### PR TITLE
Add conversion between float and int

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -68,6 +68,10 @@ and const =
 | Cgeqf    of float option
 | Ceqf     of float option
 | Cneqf    of float option
+| Cfloorfi
+| Cceilfi
+| Croundfi
+| CInt2float
 (* MCore intrinsic: characters *)
 | CChar    of int
 | CChar2int

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -25,6 +25,8 @@ let builtin =
    ("divf",Cdivf(None));("negf",Cnegf);
    ("ltf",Cltf(None));("leqf",Cleqf(None));("gtf",Cgtf(None));("geqf",Cgeqf(None));
    ("eqf",Ceqf(None));("neqf",Cneqf(None));
+   ("floorfi", Cfloorfi); ("ceilfi", Cceilfi); ("roundfi", Croundfi);
+   ("int2float", CInt2float);
    ("char2int",CChar2int);("int2char",CInt2char);
    ("makeseq",Cmakeseq(None)); ("length",Clength);("concat",Cconcat(None));
    ("nth",Cnth(None)); ("cons",Ccons(None));
@@ -80,6 +82,10 @@ let arity = function
   | Cgeqf(None) -> 2  | Cgeqf(Some(_)) -> 1
   | Ceqf(None)  -> 2  | Ceqf(Some(_))  -> 1
   | Cneqf(None) -> 2  | Cneqf(Some(_)) -> 1
+  | Cfloorfi    -> 1
+  | Cceilfi     -> 1
+  | Croundfi    -> 1
+  | CInt2float  -> 1
   (* MCore intrinsic: characters *)
   | CChar(_)    -> 0
   | CChar2int   -> 1
@@ -240,6 +246,18 @@ let delta fi c v  =
     | Cneqf(None),TmConst(fi,CFloat(v)) -> TmConst(fi,Cneqf(Some(v)))
     | Cneqf(Some(v1)),TmConst(fi,CFloat(v2)) -> TmConst(fi,CBool(v1 <> v2))
     | Cneqf(None),t | Cneqf(Some(_)),t  -> fail_constapp (tm_info t)
+
+    | Cfloorfi,TmConst(fi,CFloat(v)) -> TmConst(fi,CInt(Float.floor v |> int_of_float))
+    | Cfloorfi,t -> fail_constapp (tm_info t)
+
+    | Cceilfi,TmConst(fi,CFloat(v)) -> TmConst(fi,CInt(Float.ceil v |> int_of_float))
+    | Cceilfi,t -> fail_constapp (tm_info t)
+
+    | Croundfi,TmConst(fi,CFloat(v)) -> TmConst(fi,CInt(Float.round v |> int_of_float))
+    | Croundfi,t -> fail_constapp (tm_info t)
+
+    | CInt2float,TmConst(fi,CInt(v)) -> TmConst(fi,CFloat(float_of_int v))
+    | CInt2float,t -> fail_constapp (tm_info t)
 
     (* MCore intrinsic: characters *)
     | CChar(_),t -> fail_constapp (tm_info t)

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -96,6 +96,10 @@ let rec pprint_const c =
   | Ceqf(Some(v)) -> us(sprintf "eqf(%f)" v)
   | Cneqf(None) -> us"neqf"
   | Cneqf(Some(v)) -> us(sprintf "neqf(%f)" v)
+  | Cfloorfi -> us"floorfi"
+  | Cceilfi -> us"ceilfi"
+  | Croundfi -> us"roundfi"
+  | CInt2float -> us"int2float"
   (* MCore intrinsic: characters *)
   | CChar(v) -> us"'" ^. list2ustring [v] ^. us"'"
   | CChar2int -> us"char2int"

--- a/test/mexpr/float.mc
+++ b/test/mexpr/float.mc
@@ -48,6 +48,39 @@ utest divf 6.0 3.0 with 2.0 in
 utest eqf (subf 3.0 5.0) (negf 2.0) with true in
 utest eqf (subf 3.0 5.0) (negf 3.0) with false in
 
+// Float-to-Int conversions
+utest floorfi 0.0 with 0 in
+utest floorfi 3.8 with 3 in
+utest floorfi 3.0 with 3 in
+utest floorfi 2.999 with 2 in
+utest floorfi (negf 1.75) with negi 2 in
+utest floorfi (negf 1.25) with negi 2 in
+utest floorfi (negf 0.975) with negi 1 in
+
+utest ceilfi 0.0 with 0 in
+utest ceilfi 7.3 with 8 in
+utest ceilfi 7.75 with 8 in
+utest ceilfi 8.0 with 8 in
+utest ceilfi 8.001 with 9 in
+utest ceilfi (negf 5.0) with negi 5 in
+utest ceilfi (negf 5.75) with negi 5 in
+utest ceilfi (negf 6.25) with negi 6 in
+
+utest roundfi 0.0 with 0 in
+utest roundfi 1.0 with 1 in
+utest roundfi 1.25 with 1 in
+utest roundfi 1.5 with 2 in
+utest roundfi 0.75 with 1 in
+utest roundfi (negf 2.4) with negi 2 in
+utest roundfi (negf 2.0) with negi 2 in
+utest roundfi (negf 2.5) with negi 3 in
+
+// Int-to-Float conversion
+utest int2float 0 with 0.0 in
+utest int2float 1 with 1.0 in
+utest int2float 17 with 17.0 in
+utest int2float (negi 10) with negf 10.0 in
+
 // powf3 x = x^3
 let powf3 = lam x. mulf x (mulf x x) in
 let taxicab2_1 = addf (powf3 1.0) (powf3 12.0) in


### PR DESCRIPTION
Adds conversion expressions for int-to-float and for float-to-int. The mnemonic for the float-to-int conversions (`floorfi`/`ceilfi`/`roundfi`) is
 - `%fi`: Performs `%` on a **f**loat and returns an **i**nt.