### PR TITLE
Add a simple string formatter written in MLang

### DIFF
--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -1,7 +1,23 @@
 include "seq.mc"
 
 let eqchar = lam c1. lam c2. eqi (char2int c1) (char2int c2)
+let neqchar = lam c1. lam c2. neqi (char2int c1) (char2int c2)
+let ltchar = lam c1. lam c2. lti (char2int c1) (char2int c2)
+let gtchar = lam c1. lam c2. gti (char2int c1) (char2int c2)
+let leqchar = lam c1. lam c2. leqi (char2int c1) (char2int c2)
+let geqchar = lam c1. lam c2. geqi (char2int c1) (char2int c2)
 let show_char = lam c. concat "'" (concat [c] "'")
+
+-- Character conversion
+let char2upper = lam c.
+  if and (geqchar c 'a') (leqchar c 'z')
+  then (int2char (subi (char2int c) 32))
+  else c
+
+let char2lower = lam c.
+  if and (geqchar c 'A') (leqchar c 'Z')
+  then (int2char (addi (char2int c) 32))
+  else c
 
 -- TODO: It would be nicer with escape codes in chars!
 let is_whitespace = lam c.
@@ -22,6 +38,14 @@ let is_alphanum = lam c.
   or (is_alpha c) (is_digit c)
 
 mexpr
+
+utest char2upper 'a' with 'A' in
+utest char2upper '0' with '0' in
+utest char2upper 'A' with 'A' in
+
+utest char2lower 'a' with 'a' in
+utest char2lower '0' with '0' in
+utest char2lower 'A' with 'a' in
 
 utest is_whitespace ' ' with true in
 utest is_whitespace '	' with true in

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -111,6 +111,30 @@ let min = lam cmp. lam seq.
 
 let max = lam cmp. min (lam l. lam r. cmp r l)
 
+-- First index in seq that satifies pred
+let index = lam pred. lam seq.
+  let index_rechelper = fix (lam index_rh. lam i. lam pred. lam seq.
+    if null seq then
+      None
+    else if pred (head seq) then
+      Some i
+    else
+      index_rh (addi i 1) pred (tail seq)
+  ) in
+  index_rechelper 0 pred seq
+
+-- Last index in seq that satifies pred
+let lastIndex = lam pred. lam seq.
+  let lastIndex_rechelper = fix (lam lastIndex_rh. lam i. lam acc. lam pred. lam seq.
+    if null seq then
+      acc
+    else if pred (head seq) then
+      lastIndex_rh (addi i 1) (Some i) pred (tail seq)
+    else
+      lastIndex_rh (addi i 1) acc pred (tail seq)
+  ) in
+  lastIndex_rechelper 0 None pred seq
+
 mexpr
 
 utest head [2,3,5] with 2 in
@@ -171,5 +195,11 @@ utest max (lam l. lam r. subi l r) [9,8,4,20,3] with Some 20 in
 
 utest unfoldr (lam b. if eqi b 10 then None () else Some (b, addi b 1)) 0
 with [0,1,2,3,4,5,6,7,8,9] in
+
+utest index (lam x. eqi (length x) 2) [[1,2,3], [1,2], [3], [1,2], [], [1]] with Some 1 in
+utest index (lam x. null x) [[1,2,3], [1,2], [3], [1,2], [], [1]] with Some 4 in
+
+utest lastIndex (lam x. eqi (length x) 2) [[1,2,3], [1,2], [3], [1,2], [], [1]] with Some 3 in
+utest lastIndex (lam x. null x) [[1,2,3], [1,2], [3], [1,2], [], [1]] with Some 4 in
 
 ()

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -113,27 +113,27 @@ let max = lam cmp. min (lam l. lam r. cmp r l)
 
 -- First index in seq that satifies pred
 let index = lam pred. lam seq.
-  let index_rechelper = fix (lam index_rh. lam i. lam pred. lam seq.
+  recursive let index_rechelper = lam i. lam pred. lam seq.
     if null seq then
-      None
+      None ()
     else if pred (head seq) then
       Some i
     else
-      index_rh (addi i 1) pred (tail seq)
-  ) in
+      index_rechelper (addi i 1) pred (tail seq)
+  in
   index_rechelper 0 pred seq
 
 -- Last index in seq that satifies pred
 let lastIndex = lam pred. lam seq.
-  let lastIndex_rechelper = fix (lam lastIndex_rh. lam i. lam acc. lam pred. lam seq.
+  recursive let lastIndex_rechelper = lam i. lam acc. lam pred. lam seq.
     if null seq then
       acc
     else if pred (head seq) then
-      lastIndex_rh (addi i 1) (Some i) pred (tail seq)
+      lastIndex_rechelper (addi i 1) (Some i) pred (tail seq)
     else
-      lastIndex_rh (addi i 1) acc pred (tail seq)
-  ) in
-  lastIndex_rechelper 0 None pred seq
+      lastIndex_rechelper (addi i 1) acc pred (tail seq)
+  in
+  lastIndex_rechelper 0 (None ()) pred seq
 
 mexpr
 

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -13,6 +13,9 @@ recursive
            else false
 end
 
+let str2upper = lam s. map char2upper s
+let str2lower = lam s. map char2lower s
+
 let string2int = lam s.
   recursive
   let string2int_rechelper = lam s.

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -4,78 +4,77 @@ include "char.mc"
 include "seq.mc"
 include "string.mc"
 
-lang TypeInteger
-	syn Type =
-	| TyInt (Int)
+lang FmtInteger
+	syn Fmt =
+	| FmtInt (Int)
 
 	sem toString =
-	| TyInt v -> int2string v
+	| FmtInt n -> int2string n
 end
 
-lang TypeFloat
-	syn Type =
-	| TyFloat (Float)
+lang FmtFloat
+	syn Fmt =
+	| FmtFloat (Float)
 
 	sem toString =
-	| TyFloat v -> float2string v
+	| FmtFloat f -> float2string f
 end
 
-lang TypeString
-	syn Type =
-	| TyStr (String)
+lang FmtString
+	syn Fmt =
+	| FmtStr (String)
 
 	sem toString =
-	| TyStr v -> v
+	| FmtStr s -> s
 end
 
-lang TypeChar
-	syn Type =
-	| TyChar (Char)
+lang FmtChar
+	syn Fmt =
+	| FmtChar (Char)
 
 	sem toString =
-	| TyChar v -> [v]
+	| FmtChar c -> [c]
 end
 
 lang StrFormatBase
-	syn Type =
-
-	syn Operand =
-	| CStrFormat (String)
+	syn Fmt =
+	-- Intentionally left blank
 
 	sem toString =
-	| _ -> error "StrFormatBase: toString: Unknown type"
+	| _ -> error "StrFormatBase: toString: Unknown Fmt"
 
-	sem eval (args : [Type]) =
-	| CStrFormat s ->
+	sem strFormat (args : [Fmt]) =
+	| s ->
 		if lti (length s) 2 then
-			s 
+			s
 		else if eqchar '%' (head s) then
 			let c = head (tail s) in
 			if eqchar '%' c then
-				cons '%' (eval args (CStrFormat (tail (tail s))))
+				cons '%' (strFormat args (tail (tail s)))
 			else if is_alpha c then
 				-- At the moment just accept any alpha char to represent a format
-				concat (toString (head args)) (eval (tail args) (CStrFormat (tail (tail s))))
+				concat (toString (head args)) (strFormat (tail args) (tail (tail s)))
 			else
-				error "StrFormatBase: eval: Unrecognized format"
+				error "StrFormatBase: strFormat: Unrecognized format"
 		else
-			cons (head s) (eval args (CStrFormat (tail s)))
+			cons (head s) (strFormat args (tail s))
 end
 
 
-lang StandardTypes = TypeInteger + TypeFloat + TypeString + TypeChar
+lang StandardFormats = FmtInteger + FmtFloat + FmtString + FmtChar
 
-lang StrFormat = StandardTypes + StrFormatBase
+lang StrFormat = StandardFormats + StrFormatBase
 
 mexpr
 
 use StrFormat in
-let sprintf = lam s. lam args. eval args (CStrFormat (s)) in
+let sprintf = lam s. lam args. strFormat args s in
 let printf = lam s. lam args. print (sprintf s args) in
 
-utest sprintf "%d + %d = %d" [TyInt(2), TyInt(3), TyInt(addi 2 3)] with "2 + 3 = 5" in
-utest sprintf "Give it %T%%" [TyInt(101)] with "Give it 101%" in
-utest sprintf "Hello, %s!" [TyStr("John Doe")] with "Hello, John Doe!" in
-utest sprintf "My initials are %c.%c." [TyChar('J'), TyChar('D')] with "My initials are J.D." in
+utest sprintf "%d + %d = %d" [FmtInt(2), FmtInt(3), FmtInt(addi 2 3)] with "2 + 3 = 5" in
+utest sprintf "Give it %T%%" [FmtInt(101)] with "Give it 101%" in
+utest sprintf "Hello, %s!" [FmtStr("John Doe")] with "Hello, John Doe!" in
+utest sprintf "My initials are %c.%c." [FmtChar('J'), FmtChar('D')] with "My initials are J.D." in
+utest sprintf "%a means %a" [FmtStr("Five"), FmtInt(5)] with "Five means 5" in
 
-printf "\n >Test Print:\n >%a/%a = %a\n" [TyInt(10), TyInt(3), TyFloat(divf (int2float 10) (int2float 3))]
+()

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -20,6 +20,22 @@ lang TypeFloat
 	| TyFloat v -> float2string v
 end
 
+lang TypeString
+	syn Type =
+	| TyStr (String)
+
+	sem toString =
+	| TyStr v -> v
+end
+
+lang TypeChar
+	syn Type =
+	| TyChar (Char)
+
+	sem toString =
+	| TyChar v -> [v]
+end
+
 lang StrFormatBase
 	syn Type =
 
@@ -46,7 +62,10 @@ lang StrFormatBase
 			cons (head s) (eval args (CStrFormat (tail s)))
 end
 
-lang StrFormat = StrFormatBase + TypeInteger + TypeFloat
+
+lang StandardTypes = TypeInteger + TypeFloat + TypeString + TypeChar
+
+lang StrFormat = StandardTypes + StrFormatBase
 
 mexpr
 
@@ -56,5 +75,7 @@ let printf = lam s. lam args. print (sprintf s args) in
 
 utest sprintf "%d + %d = %d" [TyInt(2), TyInt(3), TyInt(addi 2 3)] with "2 + 3 = 5" in
 utest sprintf "Give it %T%%" [TyInt(101)] with "Give it 101%" in
+utest sprintf "Hello, %s!" [TyStr("John Doe")] with "Hello, John Doe!" in
+utest sprintf "My initials are %c.%c." [TyChar('J'), TyChar('D')] with "My initials are J.D." in
 
 printf "\n >Test Print:\n >%a/%a = %a\n" [TyInt(10), TyInt(3), TyFloat(divf (int2float 10) (int2float 3))]

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -55,5 +55,6 @@ let sprintf = lam s. lam args. eval args (CStrFormat (s)) in
 let printf = lam s. lam args. print (sprintf s args) in
 
 utest sprintf "%d + %d = %d" [TyInt(2), TyInt(3), TyInt(addi 2 3)] with "2 + 3 = 5" in
+utest sprintf "Give it %T%%" [TyInt(101)] with "Give it 101%" in
 
 printf "\n >Test Print:\n >%a/%a = %a\n" [TyInt(10), TyInt(3), TyFloat(divf (int2float 10) (int2float 3))]

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -1,0 +1,59 @@
+// String format with MLang
+
+include "char.mc"
+include "seq.mc"
+include "string.mc"
+
+lang TypeInteger
+	syn Type =
+	| TyInt (Int)
+
+	sem toString =
+	| TyInt v -> int2string v
+end
+
+lang TypeFloat
+	syn Type =
+	| TyFloat (Float)
+
+	sem toString =
+	| TyFloat v -> float2string v
+end
+
+lang StrFormatBase
+	syn Type =
+
+	syn Operand =
+	| CStrFormat (String)
+
+	sem toString =
+	| _ -> error "StrFormatBase: toString: Unknown type"
+
+	sem eval (args : [Type]) =
+	| CStrFormat s ->
+		if lti (length s) 2 then
+			s 
+		else if eqchar '%' (head s) then
+			let c = head (tail s) in
+			if eqchar '%' c then
+				cons '%' (eval args (CStrFormat (tail (tail s))))
+			else if is_alpha c then
+				-- At the moment just accept any alpha char to represent a format
+				concat (toString (head args)) (eval (tail args) (CStrFormat (tail (tail s))))
+			else
+				error "StrFormatBase: eval: Unrecognized format"
+		else
+			cons (head s) (eval args (CStrFormat (tail s)))
+end
+
+lang StrFormat = StrFormatBase + TypeInteger + TypeFloat
+
+mexpr
+
+use StrFormat in
+let sprintf = lam s. lam args. eval args (CStrFormat (s)) in
+let printf = lam s. lam args. print (sprintf s args) in
+
+utest sprintf "%d + %d = %d" [TyInt(2), TyInt(3), TyInt(addi 2 3)] with "2 + 3 = 5" in
+
+printf "\n >Test Print:\n >%a/%a = %a\n" [TyInt(10), TyInt(3), TyFloat(divf (int2float 10) (int2float 3))]

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -45,6 +45,10 @@ lang FormatString
 	| FmtStr s ->
 		if eqstr fmtstr "%s" then
 			s
+		else if eqstr fmtstr "%^s" then
+			str2upper s
+		else if eqstr fmtstr "%_s" then
+			str2lower s
 		else
 			error (concat "FormatString: toFormat: Unrecognized format: " fmtstr)
 end
@@ -117,5 +121,7 @@ utest sprintf "Give it %d%%" [FmtInt(101)] with "Give it 101%" in
 utest sprintf "Hello, %s!" [FmtStr("John Doe")] with "Hello, John Doe!" in
 utest sprintf "My initials are %c.%c." [FmtChar('J'), FmtChar('D')] with "My initials are J.D." in
 utest sprintf "%* means %*" [FmtStr("Five"), FmtInt(5)] with "Five means 5" in
+
+utest sprintf "%s should be %_s or %^s" (makeseq 3 (FmtStr ("cAsE"))) with "cAsE should be case or CASE" in
 
 ()

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -5,104 +5,104 @@ include "seq.mc"
 include "string.mc"
 
 lang FormatInteger
-	syn Fmt =
-	| FmtInt (Int)
+  syn Fmt =
+  | FmtInt (Int)
 
-	sem toString =
-	| FmtInt n -> int2string n
+  sem toString =
+  | FmtInt n -> int2string n
 
-	sem toFormat (fmtstr : String) =
-	| FmtInt n ->
-		if eqstr fmtstr "%d" then
-			int2string n
-		else
-			error (concat "FormatInteger: toFormat: Unrecognized format: " fmtstr)
+  sem toFormat (fmtstr : String) =
+  | FmtInt n ->
+    if eqstr fmtstr "%d" then
+      int2string n
+    else
+      error (concat "FormatInteger: toFormat: Unrecognized format: " fmtstr)
 end
 
 lang FormatFloat
-	syn Fmt =
-	| FmtFloat (Float)
+  syn Fmt =
+  | FmtFloat (Float)
 
-	sem toString =
-	| FmtFloat f -> float2string f
+  sem toString =
+  | FmtFloat f -> float2string f
 
-	sem toFormat (fmtstr : String) =
-	| FmtFloat f ->
-		if eqstr fmtstr "%f" then
-			float2string f
-		else
-			error (concat "FormatFloat: toFormat: Unrecognized format: " fmtstr)
+  sem toFormat (fmtstr : String) =
+  | FmtFloat f ->
+    if eqstr fmtstr "%f" then
+      float2string f
+    else
+      error (concat "FormatFloat: toFormat: Unrecognized format: " fmtstr)
 end
 
 lang FormatString
-	syn Fmt =
-	| FmtStr (String)
+  syn Fmt =
+  | FmtStr (String)
 
-	sem toString =
-	| FmtStr s -> s
+  sem toString =
+  | FmtStr s -> s
 
-	sem toFormat (fmtstr : String) =
-	| FmtStr s ->
-		if eqstr fmtstr "%s" then
-			s
-		else if eqstr fmtstr "%^s" then
-			str2upper s
-		else if eqstr fmtstr "%_s" then
-			str2lower s
-		else
-			error (concat "FormatString: toFormat: Unrecognized format: " fmtstr)
+  sem toFormat (fmtstr : String) =
+  | FmtStr s ->
+    if eqstr fmtstr "%s" then
+      s
+    else if eqstr fmtstr "%^s" then
+      str2upper s
+    else if eqstr fmtstr "%_s" then
+      str2lower s
+    else
+      error (concat "FormatString: toFormat: Unrecognized format: " fmtstr)
 end
 
 lang FormatChar
-	syn Fmt =
-	| FmtChar (Char)
+  syn Fmt =
+  | FmtChar (Char)
 
-	sem toString =
-	| FmtChar c -> [c]
+  sem toString =
+  | FmtChar c -> [c]
 
-	sem toFormat (fmtstr : String) =
-	| FmtChar c ->
-		if eqstr fmtstr "%c" then
-			[c]
-		else
-			error (concat "FormatChar: toFormat: Unrecognized format: " fmtstr)
+  sem toFormat (fmtstr : String) =
+  | FmtChar c ->
+    if eqstr fmtstr "%c" then
+      [c]
+    else
+      error (concat "FormatChar: toFormat: Unrecognized format: " fmtstr)
 end
 
 lang StrFormatBase
-	syn Fmt =
-	-- Intentionally left blank
+  syn Fmt =
+  -- Intentionally left blank
 
-	sem toString =
-	| _ -> error "StrFormatBase: toString: Unknown Fmt"
+  sem toString =
+  | _ -> error "StrFormatBase: toString: Unknown Fmt"
 
-	sem toFormat (fmtstr : String) =
-	| _ -> error "StrFormatBase: toFormat: Unknown Fmt"
+  sem toFormat (fmtstr : String) =
+  | _ -> error "StrFormatBase: toFormat: Unknown Fmt"
 
-	sem strFormat (args : [Fmt]) =
-	| s ->
-		if lti (length s) 2 then
-			s
-		else if eqchar '%' (head s) then
-			let c = head (tail s) in
-			if eqchar '%' c then
-				cons '%' (strFormat args (tail (tail s)))
-			else if eqchar c '*' then
-				-- %* represents a wildcard format; The argument is converted
-				-- to _some_ string.
-				concat (toString (head args)) (strFormat (tail args) (tail (tail s)))
-			else
-				-- A valid format: %(...)X
-				-- Where X represents any alpha char and (...) represents any
-				-- sequence of non-alpha chars.
-				let found_idx = index is_alpha s in
-				match found_idx with Some i then
-					let fmtstr = slice s 0 (addi i 1) in
-					let remaining = slice s (addi i 1) (length s) in
-					concat (toFormat fmtstr (head args)) (strFormat (tail args) remaining)
-				else
-					error (concat "StrFormatBase: strFormat: Unrecognized format: " s)
-		else
-			cons (head s) (strFormat args (tail s))
+  sem strFormat (args : [Fmt]) =
+  | s ->
+    if lti (length s) 2 then
+      s
+    else if eqchar '%' (head s) then
+      let c = head (tail s) in
+      if eqchar '%' c then
+        cons '%' (strFormat args (tail (tail s)))
+      else if eqchar c '*' then
+        -- %* represents a wildcard format; The argument is converted
+        -- to _some_ string.
+        concat (toString (head args)) (strFormat (tail args) (tail (tail s)))
+      else
+        -- A valid format: %(...)X
+        -- Where X represents any alpha char and (...) represents any
+        -- sequence of non-alpha chars.
+        let found_idx = index is_alpha s in
+        match found_idx with Some i then
+          let fmtstr = slice s 0 (addi i 1) in
+          let remaining = slice s (addi i 1) (length s) in
+          concat (toFormat fmtstr (head args)) (strFormat (tail args) remaining)
+        else
+          error (concat "StrFormatBase: strFormat: Unrecognized format: " s)
+    else
+      cons (head s) (strFormat args (tail s))
 end
 
 

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -4,36 +4,64 @@ include "char.mc"
 include "seq.mc"
 include "string.mc"
 
-lang FmtInteger
+lang FormatInteger
 	syn Fmt =
 	| FmtInt (Int)
 
 	sem toString =
 	| FmtInt n -> int2string n
+
+	sem toFormat (fmtstr : String) =
+	| FmtInt n ->
+		if eqstr fmtstr "%d" then
+			int2string n
+		else
+			error (concat "FormatInteger: toFormat: Unrecognized format: " fmtstr)
 end
 
-lang FmtFloat
+lang FormatFloat
 	syn Fmt =
 	| FmtFloat (Float)
 
 	sem toString =
 	| FmtFloat f -> float2string f
+
+	sem toFormat (fmtstr : String) =
+	| FmtFloat f ->
+		if eqstr fmtstr "%f" then
+			float2string f
+		else
+			error (concat "FormatFloat: toFormat: Unrecognized format: " fmtstr)
 end
 
-lang FmtString
+lang FormatString
 	syn Fmt =
 	| FmtStr (String)
 
 	sem toString =
 	| FmtStr s -> s
+
+	sem toFormat (fmtstr : String) =
+	| FmtStr s ->
+		if eqstr fmtstr "%s" then
+			s
+		else
+			error (concat "FormatString: toFormat: Unrecognized format: " fmtstr)
 end
 
-lang FmtChar
+lang FormatChar
 	syn Fmt =
 	| FmtChar (Char)
 
 	sem toString =
 	| FmtChar c -> [c]
+
+	sem toFormat (fmtstr : String) =
+	| FmtChar c ->
+		if eqstr fmtstr "%c" then
+			[c]
+		else
+			error (concat "FormatChar: toFormat: Unrecognized format: " fmtstr)
 end
 
 lang StrFormatBase
@@ -43,6 +71,9 @@ lang StrFormatBase
 	sem toString =
 	| _ -> error "StrFormatBase: toString: Unknown Fmt"
 
+	sem toFormat (fmtstr : String) =
+	| _ -> error "StrFormatBase: toFormat: Unknown Fmt"
+
 	sem strFormat (args : [Fmt]) =
 	| s ->
 		if lti (length s) 2 then
@@ -51,17 +82,27 @@ lang StrFormatBase
 			let c = head (tail s) in
 			if eqchar '%' c then
 				cons '%' (strFormat args (tail (tail s)))
-			else if is_alpha c then
-				-- At the moment just accept any alpha char to represent a format
+			else if eqchar c '*' then
+				-- %* represents a wildcard format; The argument is converted
+				-- to _some_ string.
 				concat (toString (head args)) (strFormat (tail args) (tail (tail s)))
 			else
-				error "StrFormatBase: strFormat: Unrecognized format"
+				-- A valid format: %(...)X
+				-- Where X represents any alpha char and (...) represents any
+				-- sequence of non-alpha chars.
+				let found_idx = index is_alpha s in
+				match found_idx with Some i then
+					let fmtstr = slice s 0 (addi i 1) in
+					let remaining = slice s (addi i 1) (length s) in
+					concat (toFormat fmtstr (head args)) (strFormat (tail args) remaining)
+				else
+					error (concat "StrFormatBase: strFormat: Unrecognized format: " s)
 		else
 			cons (head s) (strFormat args (tail s))
 end
 
 
-lang StandardFormats = FmtInteger + FmtFloat + FmtString + FmtChar
+lang StandardFormats = FormatInteger + FormatFloat + FormatString + FormatChar
 
 lang StrFormat = StandardFormats + StrFormatBase
 
@@ -72,9 +113,9 @@ let sprintf = lam s. lam args. strFormat args s in
 let printf = lam s. lam args. print (sprintf s args) in
 
 utest sprintf "%d + %d = %d" [FmtInt(2), FmtInt(3), FmtInt(addi 2 3)] with "2 + 3 = 5" in
-utest sprintf "Give it %T%%" [FmtInt(101)] with "Give it 101%" in
+utest sprintf "Give it %d%%" [FmtInt(101)] with "Give it 101%" in
 utest sprintf "Hello, %s!" [FmtStr("John Doe")] with "Hello, John Doe!" in
 utest sprintf "My initials are %c.%c." [FmtChar('J'), FmtChar('D')] with "My initials are J.D." in
-utest sprintf "%a means %a" [FmtStr("Five"), FmtInt(5)] with "Five means 5" in
+utest sprintf "%* means %*" [FmtStr("Five"), FmtInt(5)] with "Five means 5" in
 
 ()


### PR DESCRIPTION
A simple (but verbose) implementation of string formatting in MLang. Put this in `test/mlang` instead of `stdlib` since I am not 100% about the implementation specifics but still want it "for the record".