### PR TITLE
Rename 'id' to 'identity'

### DIFF
--- a/stdlib/prelude.mc
+++ b/stdlib/prelude.mc
@@ -3,7 +3,7 @@ include "seq.mc"
 include "option.mc"
 
 -- Function stuff
-let id = lam x. x
+let identity = lam x. x
 let const = lam x. lam _. x
 let apply = lam f. lam x. f x
 let compose = lam f. lam g. lam x. f (g x)
@@ -20,8 +20,8 @@ let print_ln = lam s. print (concat s "\n")
 
 mexpr
 
-utest apply id 42 with id 42 in
-utest apply (compose id (apply id)) 42 with 42 in
+utest apply identity 42 with identity 42 in
+utest apply (compose identity (apply identity)) 42 with 42 in
 
 let sum_tuple = lam t. addi t.0 t.1 in
 

--- a/test/mlang/parser.mc
+++ b/test/mlang/parser.mc
@@ -115,7 +115,7 @@ let apl = lam p1. lam p2.
 --
 -- Run two parsers, use result of second one
 let apr = lam p1. lam p2.
-  ap (fmap (const id) p1) p2
+  ap (fmap (const identity) p1) p2
 
 -- Parser is a monad
 


### PR DESCRIPTION
Free up a rather useful name for users