### PR TITLE
Recursive lets

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -124,7 +124,7 @@ and program = Program of include_ list * top list * tm
 and tm =
 | TmVar     of info * ustring * int                                 (* Variable *)
 | TmLam     of info * ustring * ty * tm                             (* Lambda abstraction *)
-| TmClos    of info * ustring * ty * tm * env                       (* Closure *)
+| TmClos    of info * ustring * ty * tm * env Lazy.t                (* Closure *)
 | TmLet     of info * ustring * tm * tm                             (* Let *)
 | TmRecLets of info * (info * ustring * tm) list * tm               (* Recursive lets *)
 | TmApp     of info * tm * tm                                       (* Application *)

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -111,10 +111,12 @@ and decl = (* TODO: Local? *)
 
 and mlang   = Lang of info * ustring * ustring list * decl list
 and let_decl = Let of info * ustring * tm
+and rec_let_decl = RecLet of info * (info * ustring * tm) list
 and con_decl = Con of info * ustring * ty
 and top =
 | TopLang of mlang
 | TopLet  of let_decl
+| TopRecLet of rec_let_decl
 | TopCon of con_decl
 
 and include_ = Include of info * ustring

--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -30,7 +30,6 @@ let reserved_strings = [
   ("let",           fun(i) -> Parser.LET{i=i;v=()});
   ("recursive",     fun(i) -> Parser.REC{i=i;v=()});
   ("lam",           fun(i) -> Parser.LAM{i=i;v=()});
-  ("fix",           fun(i) -> Parser.FIX{i=i;v=()});
   ("in",            fun(i) -> Parser.IN{i=i;v=()});
   ("end",           fun(i) -> Parser.END{i=i;v=()});
   ("syn",           fun(i) -> Parser.SYN{i=i;v=()});

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -426,25 +426,23 @@ let rec eval env t =
   (* Variables using debruijn indices. Need to evaluate because fix point. *)
   | TmVar(_,_,n) -> eval env  (List.nth env n)
   (* Lambda and closure conversions *)
-  | TmLam(fi,x,ty,t1) -> TmClos(fi,x,ty,t1,env)
+  | TmLam(fi,x,ty,t1) -> TmClos(fi,x,ty,t1,lazy env)
   | TmClos(_,_,_,_,_) -> t
   (* Let *)
   | TmLet(_,_,t1,t2) -> eval ((eval env t1)::env) t2
   (* Recursive lets *)
   | TmRecLets(_,lst,t2) ->
-     (*
-      let t1 = match lst with | (_,_,t)::_ -> t | _ -> failwith "TEMP error" in
-      let rec t1' = (eval (t1'::env) t1) in
-      eval (t1'::env) t2
-      *)
-     let (t1,x) = match lst with | (_,x,t)::_ -> (t,x) | _ -> failwith "TEMP error" in
-     let t1' = TmApp(NoInfo, TmFix(NoInfo), TmLam(NoInfo,x,TyDyn,t1)) in
-     eval ((eval env t1')::env) t2
+     let rec env' = lazy
+       (let wraplambda = function
+          | TmLam(fi,x,ty,t1) -> TmClos(fi,x,ty,t1,env')
+          | tm -> raise_error (tm_info tm) "Right-hand side of recursive let must be a lambda"
+        in List.fold_left (fun env (_, _, rhs) -> wraplambda rhs :: env) env lst)
+     in eval (Lazy.force env') (t2)
   (* Application *)
   | TmApp(fiapp,t1,t2) ->
       (match eval env t1 with
        (* Closure application *)
-       | TmClos(_,_,_,t3,env2) -> eval ((eval env t2)::env2) t3
+       | TmClos(_,_,_,t3,env2) -> eval ((eval env t2)::Lazy.force env2) t3
        (* Constant application using the delta function *)
        | TmConst(_,c) -> delta fiapp c (eval env t2)
        (* Constructor application *)
@@ -455,7 +453,7 @@ let rec eval env t =
        (* Fix *)
        | TmFix(_) ->
          (match eval env t2 with
-         | TmClos(fi,_,_,t3,env2) as tt -> eval ((TmApp(fi,TmFix(fi),tt))::env2) t3
+         | TmClos(fi,_,_,t3,env2) as tt -> eval ((TmApp(fi,TmFix(fi),tt))::Lazy.force env2) t3
          | _ -> raise_error (tm_info t1) "Incorrect CFix")
        | _ -> raise_error fiapp "Incorrect application")
   (* Constant and fix *)

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -103,6 +103,7 @@ let lookup_lang info tops l =
   let has_name l = function
     | TopLang(Lang(_, l', _, _)) -> l = l'
     | TopLet _ -> false
+    | TopRecLet _ -> false
     | TopCon _ -> false
   in
   match List.find_opt (has_name l) tops with
@@ -117,6 +118,7 @@ let flatten_langs tops : top list =
        let lang' = List.fold_left merge_langs lang included_langs in
        TopLang lang'::flat
     | TopLet _ as let_ -> let_::flat
+    | TopRecLet _ as let_ -> let_::flat
     | TopCon _ as con -> con::flat
   in
   List.rev (List.fold_left flatten_langs' [] tops)
@@ -256,6 +258,8 @@ let insert_top_level_decls tops t =
   let insert_let top inner = match top with
     | TopLet(Let(fi, x, tm)) ->
        TmLet(fi, x, tm, inner)
+    | TopRecLet(RecLet(fi, lst)) ->
+       TmRecLets(fi, lst, inner)
     | TopCon(Con(fi, k, ty)) ->
        TmCondef(fi, k, ty, inner)
     | TopLang _ -> inner

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -49,7 +49,6 @@
 %token <unit Ast.tokendata> LET
 %token <unit Ast.tokendata> REC
 %token <unit Ast.tokendata> LAM
-%token <unit Ast.tokendata> FIX
 %token <unit Ast.tokendata> IN
 %token <unit Ast.tokendata> END
 %token <unit Ast.tokendata> SYN
@@ -115,6 +114,8 @@ top:
     { TopLang($1) }
   | toplet
     { TopLet($1) }
+  | topRecLet
+    { TopRecLet($1) }
   | topcon
     { TopCon($1) }
 
@@ -122,6 +123,11 @@ toplet:
   | LET IDENT ty_op EQ mexpr
     { let fi = mkinfo $1.i $4.i in
       Let (fi, $2.v, $5) }
+
+topRecLet:
+  | REC lets END
+    { let fi = mkinfo $1.i $3.i in
+      RecLet (fi, $2) }
 
 topcon:
   | CON IDENT ty_op
@@ -271,7 +277,6 @@ atom:
   | LPAREN RPAREN        { TmConst($1.i, Cunit) }
   | IDENT                { TmVar($1.i,$1.v,noidx) }
   | CHAR                 { TmConst($1.i, CChar(List.hd (ustring2list $1.v))) }
-  | FIX                  { TmFix($1.i) }
   | UINT                 { TmConst($1.i,CInt($1.v)) }
   | UFLOAT               { TmConst($1.i,CFloat($1.v)) }
   | TRUE                 { TmConst($1.i,CBool(true)) }

--- a/stdlib/prelude.mc
+++ b/stdlib/prelude.mc
@@ -10,6 +10,10 @@ let compose = lam f. lam g. lam x. f (g x)
 let curry = lam f. lam x. lam y. f(x, y)
 let uncurry = lam f. lam t. f t.0 t.1
 
+recursive
+  let fix = lam f. lam e. f (fix f) e
+end
+
 -- Fixpoint computation for mutual recursion. Thanks Oleg Kiselyov!
 -- (http://okmij.org/ftp/Computation/fixed-point-combinators.html)
 let fix_mutual =

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -5,55 +5,67 @@ let tail = lam s. slice s 1 (length s)
 let null = lam seq. eqi 0 (length seq)
 
 -- Maps and folds
-let map = fix (lam map. lam f. lam seq.
-  if null seq then []
-  else cons (f (head seq)) (map f (tail seq))
-)
+recursive
+  let map = lam f. lam seq.
+    if null seq then []
+    else cons (f (head seq)) (map f (tail seq))
+end
 
-let foldl = fix (lam foldl. lam f. lam acc. lam seq.
+recursive
+  let foldl = lam f. lam acc. lam seq.
     if null seq then acc
     else foldl f (f acc (head seq)) (tail seq)
-)
+end
 let foldl1 = lam f. lam l. foldl f (head l) (tail l)
 
-let foldr = fix (lam foldr. lam f. lam acc. lam seq.
+recursive
+  let foldr = lam f. lam acc. lam seq.
     if null seq
     then acc
     else f (head seq) (foldr f acc (tail seq))
-)
+end
 
 let foldr1 = lam f. lam seq. foldl1 (lam acc. lam x. f x acc) (reverse seq)
 
-let zipWith = fix (lam zipWith. lam f. lam seq1. lam seq2.
+recursive
+  let zipWith = lam f. lam seq1. lam seq2.
     if null seq1 then []
     else if null seq2 then []
     else cons (f (head seq1) (head seq2)) (zipWith f (tail seq1) (tail seq2))
-)
+end
 
 -- Predicates
-let any = fix (lam any. lam p. lam seq.
-  if null seq
-  then false
-  else or (p (head seq)) (any p (tail seq)))
+recursive
+  let any = lam p. lam seq.
+    if null seq
+    then false
+    else or (p (head seq)) (any p (tail seq))
+end
 
-let all = fix (lam all. lam p. lam seq.
-  if null seq
-  then true
-  else and (p (head seq)) (all p (tail seq)))
+recursive
+  let all = lam p. lam seq.
+    if null seq
+    then true
+    else and (p (head seq)) (all p (tail seq))
+end
 
 -- Join
 let join = lam seqs. foldl concat [] seqs
 
 -- Searching
-let filter = fix (lam filter. lam p. lam seq.
-  if null seq then []
-  else if p (head seq) then cons (head seq) (filter p (tail seq))
-  else (filter p (tail seq)))
+recursive
+  let filter = lam p. lam seq.
+    if null seq then []
+    else if p (head seq) then cons (head seq) (filter p (tail seq))
+    else (filter p (tail seq))
+end
 
-let find = fix (lam find. lam p. lam seq.
-  if null seq then None
-  else if p (head seq) then Some (head seq)
-  else find p (tail seq))
+recursive
+  let find = lam p. lam seq.
+    if null seq then None
+    else if p (head seq) then Some (head seq)
+    else find p (tail seq)
+end
 
 let partition = (lam p. lam seq.
     (filter p seq, filter (lam q. if p q then false else true) seq))

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -2,39 +2,42 @@ include "char.mc"
 include "option.mc"
 include "seq.mc"
 
-let eqstr = fix (lam eqstr. lam s1. lam s2.
-    if neqi (length s1) (length s2)
-    then false
-    else if null s1
-         then true
-         else if eqchar (head s1) (head s2)
-         then eqstr (tail s1) (tail s2)
-         else false
-)
+recursive
+  let eqstr = lam s1. lam s2.
+      if neqi (length s1) (length s2)
+      then false
+      else if null s1
+           then true
+           else if eqchar (head s1) (head s2)
+           then eqstr (tail s1) (tail s2)
+           else false
+end
 
 let string2int = lam s.
-  let string2int_rechelper = fix (lam s2i_rechelp. lam s.
+  recursive
+  let string2int_rechelper = lam s.
     let len = length s in
     let last = subi len 1 in
     if eqi len 0
     then 0
     else
       let lsd = subi (char2int (nth s last)) (char2int '0') in
-      let rest = muli 10 (s2i_rechelp (slice s 0 last)) in
+      let rest = muli 10 (string2int_rechelper (slice s 0 last)) in
       addi rest lsd
-  ) in
+  in
   if eqchar '-' (head s)
   then negi (string2int_rechelper (tail s))
   else string2int_rechelper s
 
 let int2string = lam n.
-  let int2string_rechelper = fix (lam i2s_rechelp. lam n.
+  recursive
+  let int2string_rechelper = lam n.
     if lti n 10
     then [int2char (addi n (char2int '0'))]
     else
       let d = [int2char (addi (modi n 10) (char2int '0'))] in
-      concat (i2s_rechelp (divi n 10)) d
-  ) in
+      concat (int2string_rechelper (divi n 10)) d
+  in
   if lti n 0
   then cons '-' (int2string_rechelper (negi n))
   else int2string_rechelper n
@@ -45,7 +48,8 @@ let float2string = lam arg.
   let prefixpair = if ltf arg 0.0 then ("-", negf arg) else ("", arg) in
   let prefix = prefixpair.0 in
   let val = prefixpair.1 in
-  let float2string_rechelper = fix (lam f2s_rec. lam prec. lam digits. lam v.
+  recursive
+  let float2string_rechelper = lam prec. lam digits. lam v.
     // Assume 0 <= v < 10
     if eqi prec digits then
       ""
@@ -55,18 +59,20 @@ let float2string = lam arg.
       let fstdig = floorfi v in
       let remaining = mulf (subf v (int2float fstdig)) 10.0 in
       let c = int2char (addi fstdig (char2int '0')) in
-      cons c (f2s_rec prec (addi digits 1) remaining)
-  ) in
-  let positive_exponent_pair = fix (lam pos_exp_pair. lam acc. lam v.
+      cons c (float2string_rechelper prec (addi digits 1) remaining)
+  in
+  recursive
+  let positive_exponent_pair = lam acc. lam v.
     if ltf v 10.0
     then (v, acc)
-    else pos_exp_pair (addi acc 1) (divf v 10.0)
-  ) in
-  let negative_exponent_pair = fix (lam neg_exp_pair. lam acc. lam v.
+    else positive_exponent_pair (addi acc 1) (divf v 10.0)
+  in
+  recursive
+  let negative_exponent_pair = lam acc. lam v.
     if geqf v 1.0
     then (v, acc)
-    else neg_exp_pair (addi acc 1) (mulf v 10.0)
-  ) in
+    else negative_exponent_pair (addi acc 1) (mulf v 10.0)
+  in
   let res = if eqf val 0.0 then
               "0.0"
             else if gtf val 1.0 then
@@ -86,59 +92,64 @@ let float2string = lam arg.
 // Returns an option with the index of the first occurrence of c in s. Returns
 // None if c was not found in s.
 let strIndex = lam c. lam s.
-  let strIndex_rechelper = fix (lam strIndex. lam i. lam c. lam s.
+  recursive
+  let strIndex_rechelper = lam i. lam c. lam s.
     if eqi (length s) 0
     then None
     else if eqchar c (head s)
          then Some(i)
-         else strIndex (addi i 1) c (tail s)
-  ) in
+         else strIndex_rechelper (addi i 1) c (tail s)
+  in
   strIndex_rechelper 0 c s
 
 // Returns an option with the index of the last occurrence of c in s. Returns
 // None if c was not found in s.
 let strLastIndex = lam c. lam s.
-  let strLastIndex_rechelper = fix (lam strLastIndex. lam i. lam acc. lam c. lam s.
+  recursive
+  let strLastIndex_rechelper = lam i. lam acc. lam c. lam s.
     if eqi (length s) 0 then
       if eqi acc (negi 1)
       then None
       else Some(acc)
     else
       if eqchar c (head s)
-      then strLastIndex (addi i 1) i   c (tail s)
-      else strLastIndex (addi i 1) acc c (tail s)
-  ) in
+      then strLastIndex_rechelper (addi i 1) i   c (tail s)
+      else strLastIndex_rechelper (addi i 1) acc c (tail s)
+  in
   strLastIndex_rechelper 0 (negi 1) c s
 
 // Splits s on delim
-let strSplit = fix (lam strSplit. lam delim. lam s.
-  if or (eqi (length delim) 0) (lti (length s) (length delim))
-  then cons s []
-  else if eqstr delim (slice s 0 (length delim))
-       then cons [] (strSplit delim (slice s (length delim) (length s)))
-       else let remaining = strSplit delim (tail s) in
-            cons (cons (head s) (head remaining)) (tail remaining)
-)
+recursive
+  let strSplit = lam delim. lam s.
+    if or (eqi (length delim) 0) (lti (length s) (length delim))
+    then cons s []
+    else if eqstr delim (slice s 0 (length delim))
+         then cons [] (strSplit delim (slice s (length delim) (length s)))
+         else let remaining = strSplit delim (tail s) in
+              cons (cons (head s) (head remaining)) (tail remaining)
+end
 
 // Trims s of spaces
 let strTrim = lam s.
-  let strTrim_init = fix (lam strTrim_init. lam s.
+  recursive
+  let strTrim_init = lam s.
     if eqstr s ""
     then s
     else if is_whitespace (head s)
          then strTrim_init (tail s)
          else s
-  ) in
+  in
   reverse (strTrim_init (reverse (strTrim_init s)))
 
 // Joins the strings in strs on delim
-let strJoin = fix (lam strJoin. lam delim. lam strs.
-  if eqi (length strs) 0
-  then ""
-  else if eqi (length strs) 1
-       then head strs
-       else concat (concat (head strs) delim) (strJoin delim (tail strs))
-)
+recursive
+  let strJoin = lam delim. lam strs.
+    if eqi (length strs) 0
+    then ""
+    else if eqi (length strs) 1
+         then head strs
+         else concat (concat (head strs) delim) (strJoin delim (tail strs))
+end
 
 mexpr
 

--- a/test/mexpr/letlamif.mc
+++ b/test/mexpr/letlamif.mc
@@ -32,15 +32,12 @@ let m = lam x. lam y. muli x y in
 utest if eqi (m 2 3) 6 then addi z 2 else 0 with 10 in
 
 
-// fix
-utest fix (lam x. 1) with 1 in
-
-
 // factorial function
-let fact = fix (lam fact. lam n.
+recursive
+  let fact = lam n.
     if eqi n 0 then 1
     else muli (fact (subi n 1)) n
-) in
+in
 utest fact 0 with 1 in
 utest fact 1 with 1 in
 utest fact 3 with 6 in

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -37,7 +37,8 @@ type Tree in
 con Node : (Tree,Tree) -> Tree in
 con Leaf : (Int) -> Tree in
 
-let count = fix (lam count. lam tree.
+recursive
+  let count = lam tree.
     match tree with Node t then
       let left = t.0 in
       let right = t.1 in
@@ -45,7 +46,7 @@ let count = fix (lam count. lam tree.
     else match tree with Leaf v then
       v
     else error "Unknown node"
-) in
+in
 
 let tree1 = Leaf(5) in
 utest count tree1 with 5 in

--- a/test/mexpr/reclets.mc
+++ b/test/mexpr/reclets.mc
@@ -30,4 +30,7 @@ let even = lam n.
     else odd (subi n 1)
 in
 
+utest odd 4 with false in
+utest even 4 with true in
+
 ()

--- a/test/mexpr/reclets.mc
+++ b/test/mexpr/reclets.mc
@@ -33,4 +33,17 @@ in
 utest odd 4 with false in
 utest even 4 with true in
 
+recursive
+let fax = lam f. lam e. f (fax f) e in
+
+let fact = fax (lam recur. lam n.
+  if eqi n 0
+    then 1
+    else muli n (recur (subi n 1)))
+in
+
+utest fact 0 with 1 in
+utest fact 4 with 24 in
+utest fact 5 with 120 in
+
 ()

--- a/test/mexpr/stringops.mc
+++ b/test/mexpr/stringops.mc
@@ -8,10 +8,11 @@ mexpr
 let head = lam seq. nth seq 0 in
 let tail = lam seq. slice seq 1 (length seq) in
 
-let map = fix (lam map. lam f. lam seq.
-	if eqi (length seq) 0 then []
-	else cons (f (head seq)) (map f (tail seq))
-) in
+recursive
+  let map = lam f. lam seq.
+    if eqi (length seq) 0 then []
+    else cons (f (head seq)) (map f (tail seq))
+in
 
 let eqchar = lam c1. lam c2. eqi (char2int c1) (char2int c2) in
 let ltchar = lam c1. lam c2. lti (char2int c1) (char2int c2) in
@@ -19,15 +20,16 @@ let gtchar = lam c1. lam c2. gti (char2int c1) (char2int c2) in
 let leqchar = lam c1. lam c2. leqi (char2int c1) (char2int c2) in
 let geqchar = lam c1. lam c2. geqi (char2int c1) (char2int c2) in
 
-let eqstr = fix (lam eqstr. lam s1. lam s2.
-	if neqi (length s1) (length s2)
-	then false
-	else if eqi (length s1) 0
-	     then true
-	     else if eqchar (head s1) (head s2)
-	     then eqstr (tail s1) (tail s2)
-	     else false
-) in
+recursive
+  let eqstr = lam s1. lam s2.
+    if neqi (length s1) (length s2)
+    then false
+    else if eqi (length s1) 0
+         then true
+         else if eqchar (head s1) (head s2)
+         then eqstr (tail s1) (tail s2)
+         else false
+in
 
 // Convert a character to upper case
 let char2upper = (lam c.
@@ -46,34 +48,37 @@ let char2lower = (lam c.
 let str2upper = lam s. map char2upper s in
 let str2lower = lam s. map char2lower s in
 
-// Splits the string on the entered delimiter
-let strsplit = fix (lam strsplit. lam delim. lam s.
-	if or (eqi (length delim) 0) (lti (length s) (length delim))
-	then cons s []
-	else if eqstr delim (slice s 0 (length delim))
-	     then cons [] (strsplit delim (slice s (length delim) (length s)))
-	     else let remaining = strsplit delim (tail s) in
-	          cons (cons (head s) (head remaining)) (tail remaining)
-) in
+recursive
+  // Splits the string on the entered delimiter
+  let strsplit = lam delim. lam s.
+    if or (eqi (length delim) 0) (lti (length s) (length delim))
+    then cons s []
+    else if eqstr delim (slice s 0 (length delim))
+         then cons [] (strsplit delim (slice s (length delim) (length s)))
+         else let remaining = strsplit delim (tail s) in
+              cons (cons (head s) (head remaining)) (tail remaining)
+in
 
 // Trims a string of spaces
-let strtrim_init = fix (lam strtrim_init. lam s.
-	if eqstr s ""
-	then s
-	else if eqchar (head s) ' '
-	     then strtrim_init (tail s)
-	     else s
-) in
+recursive
+  let strtrim_init = lam s.
+    if eqstr s ""
+    then s
+    else if eqchar (head s) ' '
+         then strtrim_init (tail s)
+         else s
+in
 let strtrim = lam s. reverse (strtrim_init (reverse (strtrim_init s))) in
 
-// Join a list of strings with a common delimiter
-let strjoin = fix (lam strjoin. lam delim. lam slist.
-	if eqi (length slist) 0
-	then ""
-	else if eqi (length slist) 1
-	     then head slist
-	     else concat (concat (head slist) delim) (strjoin delim (tail slist))
-) in
+recursive
+  // Join a list of strings with a common delimiter
+  let strjoin = lam delim. lam slist.
+    if eqi (length slist) 0
+    then ""
+    else if eqi (length slist) 1
+         then head slist
+         else concat (concat (head slist) delim) (strjoin delim (tail slist))
+in
 let strflatten = lam s. strjoin "" s in
 
 

--- a/test/mlang/meta.mc
+++ b/test/mlang/meta.mc
@@ -69,7 +69,7 @@ let comma_sep = sep_by (symbol ",") in
 
 -- List of reserved keywords
 let keywords =
-  ["let", "in", "if", "then", "else", "true", "false", "match", "with", "con", "lam", "fix", "utest"]
+  ["let", "in", "if", "then", "else", "true", "false", "match", "with", "con", "lam", "utest", "recursive"]
 in
 
 -- ident : Parser String
@@ -103,164 +103,173 @@ con CFloat : Float -> Const in
 con CChar : Char -> Const in
 
 -- ty : Parser Type
-let ty = fix (lam ty. lam st.
-  let tuple =
-    bind (parens (comma_sep ty)) (lam ts.
-      if null ts
-      then pure TyUnit
-      else if eqi (length ts) 1
-      then pure (head ts)
-      else pure (TyProd ts))
-  in
-  let dyn = apr (reserved "Dyn") (pure TyDyn) in
-  label "type"
-  (alt tuple dyn) st)
+recursive
+  let ty = lam st.
+    let tuple =
+      bind (parens (comma_sep ty)) (lam ts.
+        if null ts
+        then pure TyUnit
+        else if eqi (length ts) 1
+        then pure (head ts)
+        else pure (TyProd ts))
+    in
+    let dyn = apr (reserved "Dyn") (pure TyDyn) in
+    label "type"
+    (alt tuple dyn) st
 in
 
--- atom : Parser Expr
---
--- Innermost expression parser.
-let atom = fix (lam atom. lam expr. lam input.
-  let var_access =
-    let _ = debug "== Parsing var_access" in
-    fmap TmVar identifier in
-  let fix_ =
-    let _ = debug "== Parsing fix ==" in
-    apr (reserved "fix") (pure TmFix)
-  in
-  let seq =
-    let _ = debug "== Parsing seq ==" in
-    fmap TmSeq (brackets (comma_sep expr))
-  in
-  let tuple =
-    let _ = debug "== Parsing tuple ==" in
-    bind (parens (comma_sep expr)) (lam es.
-    if null es
-    then pure (TmConst CUnit)
-    else if eqi (length es) 1
-    then pure (head es)
-    else pure (TmTuple es))
-  in
-  let num =
-    let _ = debug "== Parsing num ==" in
-    fmap (lam n. TmConst (CInt n)) number
-  in
-  let float =
-    let _ = debug "== Parsing float ==" in
-    fmap (lam f. TmConst (CFloat f)) float
-  in
-  let bool =
-    let _ = debug "== Parsing bool ==" in
-    alt (apr (reserved "true")  (pure (TmConst (CBool true))))
-        (apr (reserved "false") (pure (TmConst (CBool false))))
-  in
-  let str_lit =
-    let _ = debug "== Parsing string ==" in
-    fmap TmSeq string_lit
-  in
-  let chr_lit =
-    let _ = debug "== Parsing character ==" in
-    fmap (lam c. TmConst (CChar c)) char_lit
-  in
-    label "atomic expression"
-    (alt var_access
-    (alt fix_
-    (alt seq
-    (alt tuple
-    (alt (try float)
-    (alt num
-    (alt bool
-    (alt str_lit char_lit)))))))) input)
-in
+recursive
+  -- atom : Parser Expr
+  --
+  -- Innermost expression parser.
+  let atom = lam input.
+    let var_access =
+      let _ = debug "== Parsing var_access" in
+      fmap TmVar identifier in
+    let seq =
+      let _ = debug "== Parsing seq ==" in
+      fmap TmSeq (brackets (comma_sep expr))
+    in
+    let tuple =
+      let _ = debug "== Parsing tuple ==" in
+      bind (parens (comma_sep expr)) (lam es.
+      if null es
+      then pure (TmConst CUnit)
+      else if eqi (length es) 1
+      then pure (head es)
+      else pure (TmTuple es))
+    in
+    let num =
+      let _ = debug "== Parsing num ==" in
+      fmap (lam n. TmConst (CInt n)) number
+    in
+    let float =
+      let _ = debug "== Parsing float ==" in
+      fmap (lam f. TmConst (CFloat f)) float
+    in
+    let bool =
+      let _ = debug "== Parsing bool ==" in
+      alt (apr (reserved "true")  (pure (TmConst (CBool true))))
+          (apr (reserved "false") (pure (TmConst (CBool false))))
+    in
+    let str_lit =
+      let _ = debug "== Parsing string ==" in
+      fmap TmSeq string_lit
+    in
+    let chr_lit =
+      let _ = debug "== Parsing character ==" in
+      fmap (lam c. TmConst (CChar c)) char_lit
+    in
+      label "atomic expression"
+      (alt var_access
+      (alt seq
+      (alt tuple
+      (alt (try float)
+      (alt num
+      (alt bool
+      (alt str_lit char_lit))))))) input
 
--- left : Parser Expr
---
--- Left recursive expressions, i.e. function application
--- and tuple projection.
-let left = lam expr.
-  let atom_or_proj =
-    bind (atom expr) (lam a.
-    bind (many (apr (symbol ".") number)) (lam is.
-    if null is
-    then pure a
-    else pure (foldl (curry TmProj) a is)))
-  in
-  bind (many1 atom_or_proj) (lam as.
-  pure (foldl1 (curry TmApp) as))
-in
-
--- expr: Parser Expr
---
--- Main expression parser.
-let expr = fix (lam expr. lam st.
-  let let_ =
-    let _ = debug "== Parsing let ==" in
-    bind (reserved "let") (lam _.
-    bind identifier (lam x.
-    bind (symbol "=") (lam _.
-    bind expr (lam e.
-    bind (reserved "in") (lam _.
-    bind expr (lam body.
-    pure (TmLet(x, e, body))))))))
-  in
-  let lam_ =
-    let _ = debug "== Parsing lam ==" in
-    bind (reserved "lam") (lam _.
-    bind identifier (lam x.
-    bind (optional (apr (symbol ":") ty)) (lam t.
-    bind (symbol ".") (lam _.
-    bind expr (lam e.
-    pure (TmLam(x, t, e)))))))
-  in
-  let if_ =
-    let _ = debug "== Parsing if ==" in
-    bind (reserved "if") (lam _.
-    bind expr (lam cnd.
-    bind (reserved "then") (lam _.
-    bind expr (lam thn.
-    bind (reserved "else") (lam _.
-    bind expr (lam els.
-    pure (TmIf(cnd, thn, els))))))))
-  in
-  let match_ =
-    let _ = debug "== Parsing match ==" in
-    bind (reserved "match") (lam _.
-    bind expr (lam e.
-    bind (reserved "with") (lam _.
-    bind identifier (lam k.
-    bind (optional identifier) (lam x.
-    bind (reserved "then") (lam _.
-    bind expr (lam thn.
-    bind (reserved "else") (lam _.
-    bind expr (lam els.
-    pure (TmMatch(e, k, x, thn, els)))))))))))
-  in
-  let con_ =
-    let _ = debug "== Parsing con ==" in
-    bind (reserved "con") (lam _.
-    bind identifier (lam k.
-    bind (optional (apr (symbol ":") ty)) (lam t.
-    bind (reserved "in") (lam _.
-    bind expr (lam body.
-    pure (TmConDef(k, t, body)))))))
-  in
-  let utest_ =
-    let _ = debug "== Parsing utest ==" in
-    bind (reserved "utest") (lam _.
-    bind expr (lam e1.
-    bind (reserved "with") (lam _.
-    bind expr (lam e2.
-    bind (reserved "in") (lam _.
-    bind expr (lam body.
-    pure (TmUtest(e1, e2, body))))))))
-  in
-  label "expression"
-  (alt (left expr)
-  (alt let_
-  (alt lam_
-  (alt if_
-  (alt match_
-  (alt con_ utest_)))))) st)
+  -- expr: Parser Expr
+  --
+  -- Main expression parser.
+  let expr = lam st.
+    -- left : Parser Expr
+    --
+    -- Left recursive expressions, i.e. function application
+    -- and tuple projection.
+    let left =
+      let atom_or_proj =
+        bind atom (lam a.
+        bind (many (apr (symbol ".") number)) (lam is.
+        if null is
+        then pure a
+        else pure (foldl (curry TmProj) a is)))
+      in
+      bind (many1 atom_or_proj) (lam as.
+      pure (foldl1 (curry TmApp) as))
+    in
+    let letbinding =
+      let _ = debug "== Parsing letbinding ==" in
+      bind (reserved "let") (lam _.
+      bind identifier (lam x.
+      bind (symbol "=") (lam _.
+      bind expr (lam e.
+      pure (x, e)))))
+    in
+    let reclets =
+      let _ = debug "== Parsing recursive lets ==" in
+      bind (reserved "recursive") (lam _.
+      bind (many1 letbinding) (lam bindings.
+      bind (reserved "in") (lam _.
+      bind expr (lam body.
+      pure (TmRecLets(bindings, body))))))
+    in
+    let let_ =
+      let _ = debug "== Parsing let ==" in
+      bind letbinding (lam binding.
+      bind (reserved "in") (lam _.
+      bind expr (lam body.
+      pure (TmLet(binding.0, binding.1, body)))))
+    in
+    let lam_ =
+      let _ = debug "== Parsing lam ==" in
+      bind (reserved "lam") (lam _.
+      bind identifier (lam x.
+      bind (optional (apr (symbol ":") ty)) (lam t.
+      bind (symbol ".") (lam _.
+      bind expr (lam e.
+      pure (TmLam(x, t, e)))))))
+    in
+    let if_ =
+      let _ = debug "== Parsing if ==" in
+      bind (reserved "if") (lam _.
+      bind expr (lam cnd.
+      bind (reserved "then") (lam _.
+      bind expr (lam thn.
+      bind (reserved "else") (lam _.
+      bind expr (lam els.
+      pure (TmIf(cnd, thn, els))))))))
+    in
+    let match_ =
+      let _ = debug "== Parsing match ==" in
+      bind (reserved "match") (lam _.
+      bind expr (lam e.
+      bind (reserved "with") (lam _.
+      bind identifier (lam k.
+      bind (optional identifier) (lam x.
+      bind (reserved "then") (lam _.
+      bind expr (lam thn.
+      bind (reserved "else") (lam _.
+      bind expr (lam els.
+      pure (TmMatch(e, k, x, thn, els)))))))))))
+    in
+    let con_ =
+      let _ = debug "== Parsing con ==" in
+      bind (reserved "con") (lam _.
+      bind identifier (lam k.
+      bind (optional (apr (symbol ":") ty)) (lam t.
+      bind (reserved "in") (lam _.
+      bind expr (lam body.
+      pure (TmConDef(k, t, body)))))))
+    in
+    let utest_ =
+      let _ = debug "== Parsing utest ==" in
+      bind (reserved "utest") (lam _.
+      bind expr (lam e1.
+      bind (reserved "with") (lam _.
+      bind expr (lam e2.
+      bind (reserved "in") (lam _.
+      bind expr (lam body.
+      pure (TmUtest(e1, e2, body))))))))
+    in
+    label "expression"
+    (alt left
+    (alt reclets
+    (alt let_
+    (alt lam_
+    (alt if_
+    (alt match_
+    (alt con_ utest_))))))) st
 in
 
 -- program : Parser Expr

--- a/test/mlang/parser.mc
+++ b/test/mlang/parser.mc
@@ -246,11 +246,13 @@ let label = lam l. lam p. lam st.
 -- many : Parser a -> Parser [a]
 --
 -- Parse zero or more occurrences of a parser.
-let many = fix (lam many. lam p.
-  bind (alt (bind p (lam v. pure [v])) (pure [])) (lam hd.
-  if null hd
-  then pure []
-  else bind (many p) (lam tl. pure (concat hd tl))))
+recursive
+  let many = lam p.
+    bind (alt (bind p (lam v. pure [v])) (pure [])) (lam hd.
+    if null hd
+    then pure []
+    else bind (many p) (lam tl. pure (concat hd tl)))
+end
 
 -- many1 : Parser a -> Parser [a]
 --
@@ -297,19 +299,21 @@ let lex_number = fmap string2int (many1 (satisfy is_digit "digit"))
 -- lex_string : String -> Parser String
 --
 -- Parse a specific string.
-let lex_string = fix (lam lex_string. lam s.
-  if null s
-  then pure ""
-  else
-    let c = head s in
-    let cs = tail s in
-    label (concat "'" (concat s "'")) (
-      try ( -- This 'try' makes the parser consume the whole string or nothing
-        bind (lex_char c) (lam _.
-        bind (lex_string cs) (lam _.
-        pure (cons c cs)))
-      ))
-)
+recursive
+  let lex_string = lam s.
+    if null s
+    then pure ""
+    else
+      let c = head s in
+      let cs = tail s in
+      label (concat "'" (concat s "'")) (
+        try ( -- This 'try' makes the parser consume the whole string or nothing
+          bind (lex_char c) (lam _.
+          bind (lex_string cs) (lam _.
+          pure (cons c cs)))
+        ))
+end
+
 
 -- Parser Char
 --


### PR DESCRIPTION
Adds full mutual recursion to the OCaml interpreter (including the top-level), as well as the interpreter in `mexpr.mc`. It also adds a few constants to `mexpr.mc`, since they were needed for the test case.