### PR TITLE
Slightly more friendly output in error messages

### DIFF
--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -111,7 +111,10 @@ let arity = function
 
 
 
-let fail_constapp fi = raise_error fi "Incorrect application "
+let fail_constapp f v fi = raise_error fi ("Incorrect application. function: "
+                                         ^ Ustring.to_utf8 (pprint_const f)
+                                         ^ " value: "
+                                         ^ Ustring.to_utf8 (pprintME v))
 
 
 (* Evaluates a constant application. This is the standard delta function
@@ -120,6 +123,7 @@ let fail_constapp fi = raise_error fi "Incorrect application "
    The reason for this is that if-expressions return expressions
    and not values. *)
 let delta fi c v  =
+    let fail_constapp = fail_constapp c v in
     match c,v with
     (* MCore intrinsic: unit - no operation *)
     | Cunit,t -> fail_constapp (tm_info t)
@@ -457,7 +461,8 @@ let rec eval env t =
          (match eval env t2 with
          | TmClos(fi,_,_,t3,env2) as tt -> eval ((TmApp(fi,TmFix(fi),tt))::env2) t3
          | _ -> raise_error (tm_info t1) "Incorrect CFix")
-       | _ -> raise_error fiapp "Incorrect application")
+       | f -> raise_error fiapp ("Incorrect application. This is not a function: "
+                                 ^ Ustring.to_utf8 (pprintME f)))
   (* Constant and fix *)
   | TmConst(_,_) | TmFix(_) -> t
   (* If expression *)

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -152,10 +152,10 @@ and pprintME t =
   | TmProj(_,t,n) -> left inside ^. ppt false t  ^. us"." ^. ustring_of_int n ^. right inside
   | TmCondef(_,s,ty,t) -> left inside ^. us"data " ^. s ^. us" " ^. pprint_ty ty ^.
                         us" in" ^. ppt false t ^. right inside
-  | TmConsym(_,s,sym,tmop) -> left inside ^. us"con(" ^. s  ^. us(sprintf ",sym%d" sym) ^.
+  | TmConsym(_,s,sym,tmop) -> left inside ^. s ^. us"_" ^. us(sprintf "%d" sym) ^. us" " ^.
                            (match tmop with
-                            | Some(t) -> us"," ^. ppt false t ^. us")"
-                            | None -> us")") ^. right inside
+                            | Some(t) -> ppt true t
+                            | None -> us"") ^. right inside
   | TmMatch(_,t,con,_,x,then_,else_) -> left inside ^. us"match " ^. ppt false t ^.
         us" with " ^. con ^.
         (match x with | None -> us"" | Some(s) -> us" " ^. s) ^.


### PR DESCRIPTION
Some changes I made for easier debugging while working on #27. Most things should be fairly uncontroversial, except for changes in `pprintME`. I changed printing of constructors from
```
con(TmLam, sym74, (...))
```
to
```
TmLam_74 (...)
```
since it was easier to figure out a good way to pretty-print then.