### PR TITLE
Nested Patterns in MExpr

### DIFF
--- a/make
+++ b/make
@@ -32,6 +32,9 @@ case $1 in
         cd test
         ../build/boot test mexpr
         ../build/boot test mlang
+        cd ..
+        unset MCORE_STDLIB
+        build/boot test stdlib
         ;;
     # Run the test suite
     pretest)

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -103,7 +103,7 @@ and sym = int
 and cdecl   = CDecl   of info * ustring * ty
 and param   = Param   of info * ustring * ty
 and pattern =
-| ConPattern of info * ustring * ustring option
+| ConPattern of info * ustring * ustring
 | VarPattern of info * ustring
 and decl = (* TODO: Local? *)
 | Data     of info * ustring * cdecl list
@@ -146,7 +146,7 @@ and tm =
 and pat =
 | PatNamed of info * ustring                      (* Named, capturing wildcard *)
 | PatTuple of info * pat list                     (* Tuple pattern *)
-| PatCon   of info * ustring * int * pat option   (* Constructor pattern *)
+| PatCon   of info * ustring * int * pat          (* Constructor pattern *)
 | PatInt   of info * int                          (* Int pattern *)
 | PatBool  of info * bool                         (* Boolean pattern *)
 | PatUnit  of info                                (* Unit pattern *)
@@ -184,6 +184,9 @@ module Option = struct
   let bind f = function
     | Some x -> f x
     | None -> None
+  let value o ~default = match o with
+    | Some x -> x
+    | None -> default
 end
 
 (* General (bottom-up) map over terms *)

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -148,6 +148,7 @@ and pat =
 | PatTuple of info * pat list                     (* Tuple pattern *)
 | PatCon   of info * ustring * int * pat          (* Constructor pattern *)
 | PatInt   of info * int                          (* Int pattern *)
+| PatChar  of info * int                          (* Char pattern *)
 | PatBool  of info * bool                         (* Boolean pattern *)
 | PatUnit  of info                                (* Unit pattern *)
 
@@ -184,9 +185,6 @@ module Option = struct
   let bind f = function
     | Some x -> f x
     | None -> None
-  let value o ~default = match o with
-    | Some x -> x
-    | None -> default
 end
 
 (* General (bottom-up) map over terms *)
@@ -237,6 +235,7 @@ let pat_info = function
   | PatTuple(fi,_) -> fi
   | PatCon(fi,_,_,_) -> fi
   | PatInt(fi,_) -> fi
+  | PatChar(fi,_) -> fi
   | PatBool(fi,_) -> fi
   | PatUnit(fi) -> fi
 

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -400,12 +400,10 @@ let rec debruijn env t =
        let go p (env,ps) = let (env,p) = dbPat env p in (env,p::ps) in
        let (env,ps) = List.fold_right go ps (env,[])
        in (env,PatTuple(fi,ps))
-    | PatCon(fi,cx,_,mp) ->
+    | PatCon(fi,cx,_,p) ->
        let cxId = find fi env 0 cx in
-       let (env, mp) = match mp with
-         | Some p -> dbPat env p |> (fun (a,b) -> (a,Some b))
-         | None -> (env, None)
-       in (env,PatCon(fi,cx,cxId,mp))
+       let (env, p) = dbPat env p
+       in (env,PatCon(fi,cx,cxId,p))
     | PatInt _ as p -> (env,p)
     | PatBool _ as p -> (env,p)
     | PatUnit _ as p -> (env,p)
@@ -443,12 +441,7 @@ let rec tryMatch env value = function
       | TmTuple(_,vs) when List.length pats = List.length vs ->
          List.fold_right2 go vs pats (Some env)
       | _ -> None)
-  | PatCon(_,_,cxId,None) ->
-     (match value, List.nth env cxId with
-      | TmConsym(_,_,sym1,None), TmConsym(_,_,sym2,_)
-           when sym1 = sym2 -> Some env
-      | _ -> None)
-  | PatCon(_,_,cxId,Some p) ->
+  | PatCon(_,_,cxId,p) ->
      (match value, List.nth env cxId with
       | TmConsym(_,_,sym1,Some v), TmConsym(_,_,sym2,_)
            when sym1 = sym2 -> tryMatch env v p

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -405,6 +405,7 @@ let rec debruijn env t =
        let (env, p) = dbPat env p
        in (env,PatCon(fi,cx,cxId,p))
     | PatInt _ as p -> (env,p)
+    | PatChar _ as p -> (env,p)
     | PatBool _ as p -> (env,p)
     | PatUnit _ as p -> (env,p)
   in
@@ -449,6 +450,10 @@ let rec tryMatch env value = function
   | PatInt(_, i) ->
      (match value with
       | TmConst(_,CInt i2) when i = i2 -> Some env
+      | _ -> None)
+  | PatChar(_, c) ->
+     (match value with
+      | TmConst(_,CChar c2) when c = c2 -> Some env
       | _ -> None)
   | PatBool(_, b) ->
      (match value with

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -393,7 +393,22 @@ let rec debruijn env t =
   let rec find fi env n x =
     (match env with
      | VarTm(y)::ee -> if y =. x then n else find fi ee (n+1) x
-     | [] -> raise_error fi ("Unknown variable '" ^ Ustring.to_utf8 x ^ "'"))
+     | [] -> raise_error fi ("Unknown variable '" ^ Ustring.to_utf8 x ^ "'")) in
+  let rec dbPat env = function
+    | PatNamed(fi,x) -> (VarTm(x)::env, PatNamed(fi,x))
+    | PatTuple(fi,ps) -> (* NOTE: this causes patterns to introduce names right-to-left, which will cause errors if a later pattern binds a name that is seen as a constructor in a pattern to the left *)
+       let go p (env,ps) = let (env,p) = dbPat env p in (env,p::ps) in
+       let (env,ps) = List.fold_right go ps (env,[])
+       in (env,PatTuple(fi,ps))
+    | PatCon(fi,cx,_,mp) ->
+       let cxId = find fi env 0 cx in
+       let (env, mp) = match mp with
+         | Some p -> dbPat env p |> (fun (a,b) -> (a,Some b))
+         | None -> (env, None)
+       in (env,PatCon(fi,cx,cxId,mp))
+    | PatInt _ as p -> (env,p)
+    | PatBool _ as p -> (env,p)
+    | PatUnit _ as p -> (env,p)
   in
   match t with
   | TmVar(fi,x,_) -> TmVar(fi,x,find fi env 0 x)
@@ -413,14 +428,43 @@ let rec debruijn env t =
   | TmCondef(fi,x,ty,t) -> TmCondef(fi,x,ty,debruijn (VarTm(x)::env) t)
   | TmConsym(fi,x,sym,tmop) ->
      TmConsym(fi,x,sym,match tmop with | None -> None | Some(t) -> Some(debruijn env t))
-  | TmMatch(fi,t1,cx,_,Some(y),t2,t3) ->
-     TmMatch(fi,debruijn env t1,cx,find fi env 0 cx,Some(y),
-             debruijn (VarTm(y)::env) t2, debruijn env t3)
-  | TmMatch(fi,t1,cx,_,None,t2,t3) ->
-     TmMatch(fi,debruijn env t1,cx,find fi env 0 cx,None, debruijn env t2, debruijn env t3)
+  | TmMatch(fi,t1,p,t2,t3) ->
+     let (matchedEnv, p) = dbPat env p in
+     TmMatch(fi,debruijn env t1,p,debruijn matchedEnv t2,debruijn env t3)
   | TmUse(fi,l,t) -> TmUse(fi,l,debruijn env t)
   | TmUtest(fi,t1,t2,tnext)
       -> TmUtest(fi,debruijn env t1,debruijn env t2,debruijn env tnext)
+
+let rec tryMatch env value = function
+  | PatNamed _ -> Some (value :: env)
+  | PatTuple(_,pats) ->
+     let go v p env = Option.bind (fun env -> tryMatch env v p) env in
+     (match value with
+      | TmTuple(_,vs) when List.length pats = List.length vs ->
+         List.fold_right2 go vs pats (Some env)
+      | _ -> None)
+  | PatCon(_,_,cxId,None) ->
+     (match value, List.nth env cxId with
+      | TmConsym(_,_,sym1,None), TmConsym(_,_,sym2,_)
+           when sym1 = sym2 -> Some env
+      | _ -> None)
+  | PatCon(_,_,cxId,Some p) ->
+     (match value, List.nth env cxId with
+      | TmConsym(_,_,sym1,Some v), TmConsym(_,_,sym2,_)
+           when sym1 = sym2 -> tryMatch env v p
+      | _ -> None)
+  | PatInt(_, i) ->
+     (match value with
+      | TmConst(_,CInt i2) when i = i2 -> Some env
+      | _ -> None)
+  | PatBool(_, b) ->
+     (match value with
+      | TmConst(_,CBool b2) when b = b2 -> Some env
+      | _ -> None)
+  | PatUnit _ ->
+     (match value with
+      | TmConst(_, Cunit) -> Some env
+      | _ -> None)
 
 
 (* Main evaluation loop of a term. Evaluates using big-step semantics *)
@@ -484,15 +528,10 @@ let rec eval env t =
   (* Data constructors and match *)
   | TmCondef(fi,x,_,t) -> eval ((gencon fi x)::env) t
   | TmConsym(_,_,_,_) as tm -> tm
-  | TmMatch(fi,t1,_,n,xop,t2,t3) ->
-     (match eval env t1, List.nth env n with
-      | TmConsym(_,_,sym1,Some(v)), TmConsym(_,_,sym2,_) ->
-         if sym1 = sym2 then eval (v::env) t2 else eval env t3
-      | TmConsym(_,_,sym1,None), TmConsym(_,_,sym2,_) ->
-         if sym1 = sym2 && xop = None then eval env t2 else eval env t3
-      | t1,t2 ->
-         let ex = Ustring.to_utf8 (pprintME t1 ^. us" with " ^. pprintME t2) in
-         raise_error fi  ("Invalid match: match " ^ ex ))
+  | TmMatch(_,t1,p,t2,t3) ->
+     (match tryMatch env (eval env t1) p with
+      | Some env -> eval env t2
+      | None -> eval env t3)
   | TmUse(fi,_,_) -> raise_error fi "A 'use' of a language was not desugared"
   (* Unit testing *)
   | TmUtest(fi,t1,t2,tnext) ->

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -173,8 +173,7 @@ let translate_cases f target cases =
   let translate_case case inner =
     match case with
     | (ConPattern (fi, k, x), handler) ->
-      TmMatch (fi, target,
-               k, -1, x, handler, inner)
+      TmMatch (fi, target, PatCon(fi, k, noidx, Option.map (fun x -> PatNamed(fi, x)) x), handler, inner)
     | (VarPattern (fi, x), handler) ->
       TmLet(fi, x, target, handler)
   in

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -173,7 +173,7 @@ let translate_cases f target cases =
   let translate_case case inner =
     match case with
     | (ConPattern (fi, k, x), handler) ->
-      TmMatch (fi, target, PatCon(fi, k, noidx, Option.map (fun x -> PatNamed(fi, x)) x), handler, inner)
+      TmMatch (fi, target, PatCon(fi, k, noidx, PatNamed(fi, x)), handler, inner)
     | (VarPattern (fi, x), handler) ->
       TmLet(fi, x, target, handler)
   in

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -298,6 +298,8 @@ pat:
         in PatTuple(fi, $2 :: $4) }
   | UINT /* TODO: enable matching against negative ints */
       { PatInt($1.i, $1.v) }
+  | CHAR
+      { PatChar($1.i, List.hd (ustring2list $1.v)) }
   | TRUE
       { PatBool($1.i, true) }
   | FALSE

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -20,10 +20,6 @@
       | (NoInfo, Info(fn,r1,c1,r2,c2)) -> Info(fn,r1,c1,r2,c2)
       | (_,_) -> NoInfo
 
-  let is_upper c =
-    let a = Ustring.get (us"A") 0 in
-    let z = Ustring.get (us"Z") 0 in
-    a <= c && c <= z
 %}
 
 /* Misc tokens */
@@ -203,13 +199,10 @@ cases:
 case:
   | BAR IDENT ARROW mexpr
     { let fi = mkinfo $1.i $3.i in
-      let c = Ustring.get $2.v 0 in
-      if is_upper c
-      then (ConPattern (fi, $2.v, None), $4)
-      else (VarPattern (fi, $2.v), $4)}
+      (VarPattern (fi, $2.v), $4) }
   | BAR IDENT binder ARROW mexpr
     { let fi = mkinfo $1.i $4.i in
-      (ConPattern (fi, $2.v, Some $3), $5)}
+      (ConPattern (fi, $2.v, $3), $5)}
 binder:
   | LPAREN IDENT RPAREN
     { $2.v }
@@ -295,12 +288,9 @@ seq:
 
 pat:
   | IDENT
-      { let str = Ustring.to_latin1 $1.v
-        in if str = String.capitalize_ascii str && str <> String.uncapitalize_ascii str
-           then PatCon($1.i, $1.v, noidx, None)
-           else PatNamed($1.i, $1.v) } /* TODO: pattern matching is currently a bit inconsistent with the rest of the language when considering constructors */
+      { PatNamed($1.i, $1.v) }
   | IDENT pat
-      { PatCon(mkinfo $1.i (pat_info $2), $1.v, noidx, Some $2) }
+      { PatCon(mkinfo $1.i (pat_info $2), $1.v, noidx, $2) }
   | LPAREN pat RPAREN
       { $2 }
   | LPAREN pat COMMA pat_list RPAREN

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -173,6 +173,7 @@ and pprintPat p =
        varDebugPrint x n ^. ppp true p ^.
        right inside
     | PatInt(_,i) -> Ustring.Op.ustring_of_int i
+    | PatChar(_,c) -> us"'" ^. list2ustring [c] ^. us"'"
     | PatBool(_,b) -> Ustring.Op.ustring_of_bool b
     | PatUnit _ -> us"()"
   in ppp false p

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -168,11 +168,9 @@ and pprintPat p =
   let rec ppp inside = function
     | PatNamed(_,x) -> x
     | PatTuple(_,ps) -> us"(" ^. Ustring.concat (us",") (List.map (ppp false) ps) ^. us")"
-    | PatCon(_,x,n,mp) ->
+    | PatCon(_,x,n,p) ->
        left inside ^.
-       varDebugPrint x n ^. (match mp with
-                             | Some p -> us" " ^. ppp true p
-                             | None -> us"") ^.
+       varDebugPrint x n ^. ppp true p ^.
        right inside
     | PatInt(_,i) -> Ustring.Op.ustring_of_int i
     | PatBool(_,b) -> Ustring.Op.ustring_of_bool b

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -156,14 +156,28 @@ and pprintME t =
                            (match tmop with
                             | Some(t) -> ppt true t
                             | None -> us"") ^. right inside
-  | TmMatch(_,t,con,_,x,then_,else_) -> left inside ^. us"match " ^. ppt false t ^.
-        us" with " ^. con ^.
-        (match x with | None -> us"" | Some(s) -> us" " ^. s) ^.
+  | TmMatch(_,t,p,then_,else_) -> left inside ^. us"match " ^. ppt false t ^.
+        us" with " ^. pprintPat p ^.
         us" then " ^. ppt false then_ ^.
         us" else " ^. ppt false else_ ^. right inside
   | TmUse(_,l,t) -> us"use " ^. l ^. us" in " ^. ppt false t
   | TmUtest(_,t1,t2,_) -> us"utest " ^. ppt false t1  ^. us" " ^. ppt false t2
   in ppt false t
+
+and pprintPat p =
+  let rec ppp inside = function
+    | PatNamed(_,x) -> x
+    | PatTuple(_,ps) -> us"(" ^. Ustring.concat (us",") (List.map (ppp false) ps) ^. us")"
+    | PatCon(_,x,n,mp) ->
+       left inside ^.
+       varDebugPrint x n ^. (match mp with
+                             | Some p -> us" " ^. ppp true p
+                             | None -> us"") ^.
+       right inside
+    | PatInt(_,i) -> Ustring.Op.ustring_of_int i
+    | PatBool(_,b) -> Ustring.Op.ustring_of_bool b
+    | PatUnit _ -> us"()"
+  in ppp false p
 
 (* Pretty prints the environment *)
 and pprint_env env =

--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -1,3 +1,5 @@
+include "seq.mc"
+
 let eqchar = lam c1. lam c2. eqi (char2int c1) (char2int c2)
 let show_char = lam c. concat "'" (concat [c] "'")
 

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -1,4 +1,4 @@
 type Option
 
 con Some : Dyn -> Option
-con None : Option
+con None : () -> Option

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -62,7 +62,7 @@ end
 
 recursive
   let find = lam p. lam seq.
-    if null seq then None
+    if null seq then None ()
     else if p (head seq) then Some (head seq)
     else find p (tail seq)
 end
@@ -108,7 +108,7 @@ utest filter (lam _. false) [3,5,234,1,43] with [] in
 utest filter (lam x. gti x 2) [3,5,234,1,43] with [3,5,234,43] in
 
 utest find (lam x. eqi x 2) [4,1,2] with Some 2 in
-utest find (lam x. lti x 1) [4,1,2] with None in
+utest find (lam x. lti x 1) [4,1,2] with None () in
 
 utest partition (lam x. gti x 3) [4,5,78,1] with ([4,5,78],[1]) in
 

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -95,7 +95,7 @@ let strIndex = lam c. lam s.
   recursive
   let strIndex_rechelper = lam i. lam c. lam s.
     if eqi (length s) 0
-    then None
+    then None ()
     else if eqchar c (head s)
          then Some(i)
          else strIndex_rechelper (addi i 1) c (tail s)
@@ -109,7 +109,7 @@ let strLastIndex = lam c. lam s.
   let strLastIndex_rechelper = lam i. lam acc. lam c. lam s.
     if eqi (length s) 0 then
       if eqi acc (negi 1)
-      then None
+      then None ()
       else Some(acc)
     else
       if eqchar c (head s)
@@ -169,16 +169,16 @@ utest float2string (5.0e-5) with "5.0e-5" in
 utest float2string (negf 5.0e-5) with "-5.0e-5" in
 
 utest strIndex '%' "a % 5" with Some(2) in
-utest strIndex '%' "a & 5" with None in
+utest strIndex '%' "a & 5" with None () in
 utest strIndex 'w' "Hello, world!" with Some(7) in
-utest strIndex 'w' "Hello, World!" with None in
+utest strIndex 'w' "Hello, World!" with None () in
 utest strIndex 'o' "Hello, world!" with Some(4) in
 utest strIndex '@' "Some @TAG@" with Some(5) in
 
 utest strLastIndex '%' "a % 5" with Some(2) in
-utest strLastIndex '%' "a & 5" with None in
+utest strLastIndex '%' "a & 5" with None () in
 utest strLastIndex 'w' "Hello, world!" with Some(7) in
-utest strLastIndex 'w' "Hello, World!" with None in
+utest strLastIndex 'w' "Hello, World!" with None () in
 utest strLastIndex 'o' "Hello, world!" with Some(8) in
 utest strLastIndex '@' "Some @TAG@" with Some(9) in
 

--- a/test/mexpr/nestedpatterns.mc
+++ b/test/mexpr/nestedpatterns.mc
@@ -10,7 +10,7 @@ utest classify (true, true) with "one" in
 utest classify (true, false) with "two" in
 utest classify (false, true) with "three" in
 utest classify (false, false) with "four" in
-utest classify Some with "five" in
+utest classify (true, true, true) with "five" in
 
 let uncurry = lam f. lam x.
   match x with (a, b) then f a b else error "bad" in
@@ -21,5 +21,7 @@ let weird = lam x.
     concat (concat a b) (concat c d)
   else error "bad" in
 utest weird (("a", "b"), ("c", "d")) with "abcd" in
+
+utest match 'a' with 'a' then true else false with true in
 
 ()

--- a/test/mexpr/nestedpatterns.mc
+++ b/test/mexpr/nestedpatterns.mc
@@ -1,0 +1,25 @@
+mexpr
+
+let classify = lam x.
+  match x with (true, true) then "one" else
+  match x with (true, false) then "two" else
+  match x with (false, true) then "three" else
+  match x with (false, false) then "four"
+  else "five" in
+utest classify (true, true) with "one" in
+utest classify (true, false) with "two" in
+utest classify (false, true) with "three" in
+utest classify (false, false) with "four" in
+utest classify Some with "five" in
+
+let uncurry = lam f. lam x.
+  match x with (a, b) then f a b else error "bad" in
+utest uncurry addi (1, 2) with 3 in
+
+let weird = lam x.
+  match x with ((a, b), (c, d)) then
+    concat (concat a b) (concat c d)
+  else error "bad" in
+utest weird (("a", "b"), ("c", "d")) with "abcd" in
+
+()

--- a/test/mlang/catchall.mc
+++ b/test/mlang/catchall.mc
@@ -1,24 +1,25 @@
 lang Nat
   syn Nat =
-  | Z
+  | Z ()
   | S Dyn
 
   sem is_zero =
-  | Z -> true
+  | Z _ -> true
   | n -> false
 
   sem pred =
-  | Z -> Z
+  | Z _ -> Z ()
   | S n -> n
 
   sem plus (n2 : Dyn) =
-  | Z -> n2
+  | Z _ -> n2
   | S n1 -> S (plus n1 n2)
 end
 
 mexpr
 
 use Nat in
+let Z = Z () in
 utest is_zero Z with true in
 utest is_zero (S Z) with false in
 utest pred Z with Z in

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -13,13 +13,13 @@ end
 
 lang Bool
   syn Expr =
-  | True
-  | False
+  | True ()
+  | False ()
   | If(Dyn, Dyn, Dyn)
 
   sem eval =
-  | True -> true
-  | False -> false
+  | True _ -> true
+  | False _ -> false
   | If t ->
     let cnd = t.0 in
     let thn = t.1 in
@@ -44,9 +44,9 @@ end
 
 lang User
   syn Unit =
-  | Unit
+  | Unit ()
   sem inspect =
-  | Unit ->
+  | Unit _ ->
     use Arith in
     eval (Add (Num 1, Num 2))
   sem bump (x : Dyn) =
@@ -73,20 +73,20 @@ in
 let _ =
   use ArithBool in
   utest eval (Add (Num 1, Num 2)) with 3 in
-  utest eval (If (True
+  utest eval (If (True ()
                  ,Num 1
                  ,Num 2)) with 1
   in
   utest eval (Add (Num 10
-                  ,If (False
+                  ,If (False ()
                       ,Num 10
                       ,Add (Num 5, (Num (negi 2)))))) with 13
   in ()
 in
 let _ =
   use User in
-  utest inspect Unit with 3 in
-  utest bump (inspect Unit) Unit with 4 in
+  utest inspect (Unit ()) with 3 in
+  utest bump (inspect (Unit ())) (Unit ()) with 4 in
   ()
 in
 let _ =

--- a/test/mlang/simple.mc
+++ b/test/mlang/simple.mc
@@ -3,12 +3,12 @@ end
 
 lang Bool
   syn Bool =
-  | True
-  | False
+  | True ()
+  | False ()
 
   sem my_not =
-  | True -> False
-  | False -> True
+  | True _ -> False ()
+  | False _ -> True ()
 end
 
 lang AlsoBool = Bool
@@ -16,38 +16,38 @@ end
 
 lang AlsoAlsoBool = AlsoBool
   sem to_bool =
-  | True -> true
-  | False -> false
+  | True _ -> true
+  | False _ -> false
 end
 
 lang Recursive
   syn Bool =
-  | True
-  | False
+  | True ()
+  | False ()
 
   sem my_not (n : Dyn) =
-  | True -> if eqi n 0 then False else my_not (subi n 1) True
-  | False -> if eqi n 0 then True else my_not (subi n 1) False
+  | True _ -> if eqi n 0 then False () else my_not (subi n 1) (True ())
+  | False _ -> if eqi n 0 then True () else my_not (subi n 1) (False ())
 end
 
 lang Mutual
   syn Bool =
-  | True
-  | False
+  | True ()
+  | False ()
 
   sem my_not (n : Dyn) =
-  | True -> if eqi n 0 then False else my_not2 (subi n 1) True
-  | False -> if eqi n 0 then True else my_not2 (subi n 1) False
+  | True _ -> if eqi n 0 then False () else my_not2 (subi n 1) (True ())
+  | False _ -> if eqi n 0 then True () else my_not2 (subi n 1) (False ())
 
   sem my_not2 (n : Dyn) =
-  | True -> if eqi n 0 then False else my_not (subi n 1) True
-  | False -> if eqi n 0 then True else my_not (subi n 1) False
+  | True _ -> if eqi n 0 then False () else my_not (subi n 1) (True ())
+  | False _ -> if eqi n 0 then True () else my_not (subi n 1) (False ())
 end
 
 lang And = Bool
   sem my_and (b1 : Dyn) =
-  | True -> b1
-  | False -> False
+  | True _ -> b1
+  | False _ -> False ()
 end
 
 mexpr
@@ -58,38 +58,38 @@ let _ =
 in
 let _ =
   use Bool in
-  utest my_not True with False in
+  utest my_not (True ()) with False () in
   ()
 in
 let _ =
   use AlsoBool in
-  utest my_not True with False in
+  utest my_not (True ()) with (False ()) in
   ()
 in
 let _ =
   use AlsoAlsoBool in
-  utest to_bool(my_not True) with false in
+  utest to_bool(my_not (True ())) with false in
   ()
 in
 let _ =
   use Recursive in
-  utest my_not 5 True with False in
+  utest my_not 5 (True ()) with False () in
   ()
 in
 let _ =
   use Mutual in
-  utest my_not 10 True with False in
-  utest my_not2 5 True with False in
-  utest my_not 42 False with True in
-  utest my_not2 1 False with True in
+  utest my_not 10 (True ()) with (False ()) in
+  utest my_not2 5 (True ()) with (False ()) in
+  utest my_not 42 (False ()) with (True ()) in
+  utest my_not2 1 (False ()) with (True ()) in
   ()
 in
 let _ =
   use And in
-  utest my_and True True with True in
-  utest my_and True False with False in
-  utest my_and False True with False in
-  utest my_and False False with False in
+  utest my_and (True ()) (True ()) with (True ()) in
+  utest my_and (True ()) (False ()) with (False ()) in
+  utest my_and (False ()) (True ()) with (False ()) in
+  utest my_and (False ()) (False ()) with (False ()) in
   ()
 in
 ()


### PR DESCRIPTION
This adds nested patterns to the OCaml interpreter and the `mexpr.mc` interpreter. Notably absent is support for nested patterns in `sem` declarations in MLang, but those have some remaining semantic questions (ordering of patterns in composition) and so won't be a part of this PR.

I also haven't yet finished updating `mcore_parser.mc` and `meta.mc`, but I wanted to get the rest looked at sooner rather than later.

As a usability note, it feels surprising when `match e with Con then ...` highlights `Con` as a constructor/type, but the semantics are equivalent with `let Con = e in ...`. It's also annoying to write `None ()` everywhere, but that's expected. As a sidenote, I believe the current implementation allows us to write
```
con None : () -> Option
let None = None ()

let map = lam f. lam o.
  match o with Some x then Some (f x) else
  match o with None _ then None else error "impossible"
```

Note that while we can't get away from using `None _` as the pattern, we can still use `None` as a value.

This gets somewhat close to the inconsistency noted in `mexpr.mc`:

```
con Foo in
let Bar = Foo in
match Foo () with Bar _ then true else false
```

This evaluates to `true` in `mexpr.ml`, but I believe it evaluates to `false` in `mexpr.mc` (both before and after this pull request) (I haven't quite had the time to construct the ast to test it yet).