### PR TITLE
RFC: Support for Records

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -24,10 +24,11 @@ let utest_ok = ref 0            (* Counts the number of successful unit tests *)
 let utest_fail = ref 0          (* Counts the number of failed unit tests *)
 let utest_fail_local = ref 0    (* Counts local failed tests for one file *)
 
+(* Map type for record implementation *)
+module Record = Map.Make(Ustring)
 
 (* Evaluation environment *)
 type env = tm list
-
 
 and const =
 (* MCore intrinsic: unit - no operation *)
@@ -86,6 +87,8 @@ and const =
 | Ccons    of tm option
 | Cslice   of (tm list) option * int option
 | Creverse
+(* MCore intrinsic: records *)
+| CRecord of tm Record.t
 (* MCore debug and I/O intrinsics *)
 | Cprint
 | Cdprint
@@ -135,12 +138,18 @@ and tm =
 | TmFix     of info                                                 (* Fix point *)
 | TmSeq     of info * tm list                                       (* Sequence *)
 | TmTuple   of info * tm list                                       (* Tuple *)
-| TmProj    of info * tm * int                                      (* Projection of tuple *)
+| TmRecord  of info * (ustring * tm) list                           (* Record *)
+| TmProj    of info * tm * label                                    (* Projection of a tuple or record *)
+| TmRecordUpdate of info * tm * ustring * tm                        (* Record update *)
 | TmCondef  of info * ustring * ty * tm                             (* Constructor definition *)
 | TmConsym  of info * ustring * sym * tm option                     (* Constructor symbol *)
 | TmMatch   of info * tm * pat * tm * tm                            (* Match data *)
 | TmUse     of info * ustring * tm                                  (* Use a language *)
 | TmUtest   of info * tm * tm * tm                                  (* Unit testing *)
+
+and label =
+| LabIdx of int                                   (* Tuple index *)
+| LabStr of ustring                               (* Record label *)
 
 (* Patterns *)
 and pat =
@@ -201,7 +210,9 @@ let rec map_tm f = function
   | TmSeq(fi, tms) -> f (TmSeq(fi, List.map (map_tm f) tms))
   | TmIf(fi,t1,t2,t3) -> f (TmIf(fi,map_tm f t1,map_tm f t2,map_tm f t3))
   | TmTuple(fi,tms) -> f (TmTuple(fi,List.map (map_tm f) tms))
-  | TmProj(fi,t1,n) -> f (TmProj(fi,map_tm f t1,n))
+  | TmRecord(fi, r) -> f (TmRecord(fi, List.map (function (l, t) -> (l, map_tm f t)) r))
+  | TmProj(fi,t1,l) -> f (TmProj(fi,map_tm f t1,l))
+  | TmRecordUpdate(fi,r,l,t) -> f (TmRecordUpdate(fi,map_tm f r,l,map_tm f t))
   | TmCondef(fi,x,ty,t1) -> f (TmCondef(fi,x,ty,map_tm f t1))
   | TmConsym(fi,k,s,ot) -> f (TmConsym(fi,k,s,Option.map (map_tm f) ot))
   | TmMatch(fi,t1,p,t2,t3) ->
@@ -223,7 +234,9 @@ let tm_info = function
   | TmFix(fi) -> fi
   | TmSeq(fi,_) -> fi
   | TmTuple(fi,_) -> fi
+  | TmRecord(fi,_) -> fi
   | TmProj(fi,_,_) -> fi
+  | TmRecordUpdate(fi,_,_,_) -> fi
   | TmCondef(fi,_,_,_) -> fi
   | TmConsym(fi,_,_,_) -> fi
   | TmMatch(fi,_,_,_,_) -> fi

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -172,6 +172,7 @@ and ty =
 | TyArrow  of ty * ty                             (* Function type *)
 | TySeq    of ty                                  (* Sequence type *)
 | TyTuple  of ty list                             (* Tuple type *)
+| TyRecord of (ustring * ty) list                 (* Record type *)
 | TyCon    of ustring                             (* Type constructor *)
 
 (* Variable type *)

--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -48,6 +48,8 @@ let reserved_strings = [
   (")",             fun(i) -> Parser.RPAREN{i=i;v=()});
   ("[",             fun(i) -> Parser.LSQUARE{i=i;v=()});
   ("]",             fun(i) -> Parser.RSQUARE{i=i;v=()});
+  ("{",             fun(i) -> Parser.LBRACKET{i=i;v=()});
+  ("}",             fun(i) -> Parser.RBRACKET{i=i;v=()});
   (":",             fun(i) -> Parser.COLON{i=i;v=()});
   (",",             fun(i) -> Parser.COMMA{i=i;v=()});
   (".",             fun(i) -> Parser.DOT{i=i;v=()});

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -543,7 +543,8 @@ let rec eval env t =
          (match eval env t with
           | TmConst(fi, CRecord(r)) ->
              (try Record.find s r
-              with _ -> raise_error fi ("No label '" ^ Ustring.to_utf8 s ^ "' in record."))
+              with _ -> raise_error fi ("No label '" ^ Ustring.to_utf8 s ^
+                                        "' in record " ^ Ustring.to_utf8 (pprint_const (CRecord(r)))))
           | v ->
              raise_error fi ("Cannot project from term. The term is not a record: "
                              ^ Ustring.to_utf8 (pprintME v))))
@@ -552,7 +553,8 @@ let rec eval env t =
       | TmConst(fi, CRecord(r)) ->
          if Record.mem l r
          then TmConst(fi, CRecord(Record.add l (eval env t2) r))
-         else raise_error fi ("No label '" ^ Ustring.to_utf8 l ^ "' in record.")
+         else raise_error fi ("No label '" ^ Ustring.to_utf8 l ^
+                                        "' in record " ^ Ustring.to_utf8 (pprint_const (CRecord r)))
       | v ->
          raise_error fi ("Cannot update the term. The term is not a record: "
                          ^ Ustring.to_utf8 (pprintME v)))

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -100,6 +100,8 @@ let arity = function
   | Ccons(None)       -> 2 | Ccons(Some(_)) -> 1
   | Cslice(None,None) -> 3 | Cslice(Some(_),None) -> 2 | Cslice(_,Some(_)) -> 1
   | Creverse          -> 1
+  (* MCore intrinsic: records *)
+  | CRecord(_)        -> 0
   (* MCore debug and I/O intrinsics *)
   | Cprint            -> 1
   | Cdprint           -> 1
@@ -324,6 +326,9 @@ let delta fi c v  =
     | Creverse,TmConst(fi,CSeq(lst)) -> TmConst(fi,CSeq(List.rev lst))
     | Creverse,t -> fail_constapp (tm_info t)
 
+    (* MCore intrinsic: records *)
+    | CRecord(_),t -> fail_constapp (tm_info t)
+
     (* MCore debug and stdio intrinsics *)
     | Cprint, TmConst(fi,CSeq(lst)) ->
        uprint_string (tmlist2ustring fi lst); TmConst(NoInfo,Cunit)
@@ -380,6 +385,8 @@ let rec val_equal v1 v2 =
   | TmConst(_,CSeq(lst1)), TmConst(_,CSeq(lst2)) -> (
      List.length lst1 = List.length lst2 &&
      List.for_all (fun (x,y) -> val_equal x y) (List.combine lst1 lst2))
+  | TmConst(_,CRecord(r1)), TmConst(_,CRecord(r2)) ->
+     Record.equal val_equal r1 r2
   | TmConst(_,c1),TmConst(_,c2) -> c1 = c2
   | TmTuple(_,tms1),TmTuple(_,tms2) ->
      List.for_all (fun (x,y) -> val_equal x y) (List.combine tms1 tms2)
@@ -423,7 +430,9 @@ let rec debruijn env t =
   | TmFix(_) -> t
   | TmSeq(fi,tms) -> TmSeq(fi,List.map (debruijn env) tms)
   | TmTuple(fi,tms) -> TmTuple(fi,List.map (debruijn env) tms)
-  | TmProj(fi,t,n) -> TmProj(fi,debruijn env t,n)
+  | TmRecord(fi, r) -> TmRecord(fi,List.map (function (l, t) -> (l, debruijn env t)) r)
+  | TmProj(fi,t,l) -> TmProj(fi,debruijn env t,l)
+  | TmRecordUpdate(fi,t1,l,t2) -> TmRecordUpdate(fi,debruijn env t1,l,debruijn env t2)
   | TmCondef(fi,x,ty,t) -> TmCondef(fi,x,ty,debruijn (VarTm(x)::env) t)
   | TmConsym(fi,x,sym,tmop) ->
      TmConsym(fi,x,sym,match tmop with | None -> None | Some(t) -> Some(debruijn env t))
@@ -514,15 +523,41 @@ let rec eval env t =
   )
   (* Sequences *)
   | TmSeq(fi,tms) -> TmConst(fi,CSeq(List.map (eval env) tms))
-  (* Tuples and projection *)
-  | TmTuple(fi,tms) -> TmTuple(fi,List.map (eval env) tms)
-  | TmProj(fi,t,n) ->
-     (match eval env t with
-      | TmTuple(_,vs) -> (try List.nth vs n
-                          with _ -> raise_error fi "Tuple projection is out of bound.")
+  (* Records *)
+  | TmRecord(fi,r) ->
+     let add_mapping m = function
+       | (l, t) -> Record.add l (eval env t) m
+    in
+     TmConst(fi,CRecord(List.fold_left add_mapping Record.empty r))
+  | TmProj(fi,t,l) ->
+     (match l with
+      | LabIdx i ->
+         (match eval env t with
+          | TmTuple(fi, tms) ->
+             (try List.nth tms i
+              with _ -> raise_error fi "Tuple projection is out of bounds.")
+          | v ->
+             raise_error fi ("Cannot project from term. The term is not a tuple: "
+                             ^ Ustring.to_utf8 (pprintME v)))
+      | LabStr s ->
+         (match eval env t with
+          | TmConst(fi, CRecord(r)) ->
+             (try Record.find s r
+              with _ -> raise_error fi ("No label " ^ Ustring.to_utf8 s ^ " in record."))
+          | v ->
+             raise_error fi ("Cannot project from term. The term is not a record: "
+                             ^ Ustring.to_utf8 (pprintME v))))
+  | TmRecordUpdate(fi,t1,l,t2) ->
+     (match eval env t1 with
+      | TmConst(fi, CRecord(r)) ->
+         if Record.mem l r
+         then TmConst(fi, CRecord(Record.add l (eval env t2) r))
+         else raise_error fi ("No label " ^ Ustring.to_utf8 l ^ "in record.")
       | v ->
-         raise_error fi ("Cannot project from term. The term is not a tuple: "
+         raise_error fi ("Cannot update the term. The term is not a record: "
                          ^ Ustring.to_utf8 (pprintME v)))
+  (* Tuples *)
+  | TmTuple(fi,tms) -> TmTuple(fi,List.map (eval env) tms)
   (* Data constructors and match *)
   | TmCondef(fi,x,_,t) -> eval ((gencon fi x)::env) t
   | TmConsym(_,_,_,_) as tm -> tm

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -543,7 +543,7 @@ let rec eval env t =
          (match eval env t with
           | TmConst(fi, CRecord(r)) ->
              (try Record.find s r
-              with _ -> raise_error fi ("No label " ^ Ustring.to_utf8 s ^ " in record."))
+              with _ -> raise_error fi ("No label '" ^ Ustring.to_utf8 s ^ "' in record."))
           | v ->
              raise_error fi ("Cannot project from term. The term is not a record: "
                              ^ Ustring.to_utf8 (pprintME v))))
@@ -552,7 +552,7 @@ let rec eval env t =
       | TmConst(fi, CRecord(r)) ->
          if Record.mem l r
          then TmConst(fi, CRecord(Record.add l (eval env t2) r))
-         else raise_error fi ("No label " ^ Ustring.to_utf8 l ^ "in record.")
+         else raise_error fi ("No label '" ^ Ustring.to_utf8 l ^ "' in record.")
       | v ->
          raise_error fi ("Cannot update the term. The term is not a record: "
                          ^ Ustring.to_utf8 (pprintME v)))

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -58,10 +58,16 @@ let check_matching_constrs info constrs =
        in
        match List.find_opt matching_constr constrs with
        | Some (CDecl(_, _, ty')) ->
+(*
           if not (ty = ty')
           then raise_error info
                  ("Conflicting parameter types for constructor '"^
                   Ustring.to_utf8 c^"'")
+*)
+          let _ = ty in
+          let _ = ty' in
+          let _ = info in
+          () (* TODO: Disabled to cater for extensible records *)
        | None -> ()
   in
   List.iter check_matching_constr

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -355,6 +355,10 @@ ty_atom:
       { TySeq($2) }
   | LPAREN ty COMMA ty_list RPAREN
       { TyTuple ($2::$4) }
+  | LBRACKET RBRACKET
+      { TyRecord [] }
+  | LBRACKET label_tys RBRACKET
+      { TyRecord($2) }
   | IDENT
       {match Ustring.to_utf8 $1.v with
        | "Dyn"    -> TyDyn
@@ -365,8 +369,15 @@ ty_atom:
        | "String" -> TySeq(TyChar)
        | s        -> TyCon(us s)
       }
+
 ty_list:
   | ty COMMA ty_list
     { $1 :: $3 }
   | ty
     { [$1] }
+
+label_tys:
+  | IDENT COLON ty
+    {[($1.v, $3)]}
+  | IDENT COLON ty COMMA label_tys
+    {($1.v, $3)::$5}

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -214,9 +214,14 @@ and pprint_ty ty =
                   else us"[" ^. pprint_ty ty1 ^. us"]"
   | TyTuple tys ->
      us"(" ^. Ustring.concat (us",") (List.map pprint_ty tys) ^. us")"
+  | TyRecord tys ->
+     us"{" ^. Ustring.concat (us",") (List.map pprint_ty_label tys) ^. us"}"
   | TyCon(s) -> s
   in
     ppt ty
+
+and pprint_ty_label = function
+  | (l, ty) -> l ^. us" : " ^. pprint_ty ty
 
 (* TODO: Print mlang part as well*)
 and pprintML tml =

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -28,7 +28,6 @@ let right inside = if inside then us")" else us""
 (* Pretty print "true" or "false" *)
 let usbool x = us (if x then "true" else "false")
 
-
 (* Pretty print constants *)
 let rec pprint_const c =
   match c with
@@ -117,6 +116,10 @@ let rec pprint_const c =
   | Ccons(_) -> us"cons"
   | Cslice(_,_) -> us"slice"
   | Creverse -> us"reverse"
+  (* MCore records *)
+  | CRecord(r) ->
+     let contents = Record.fold (fun l v ack -> (l, v)::ack) r [] in
+     pprecord contents
   (* MCore debug and stdio intrinsics *)
   | Cprint -> us"print"
   | Cdprint -> us"dprint"
@@ -125,6 +128,17 @@ let rec pprint_const c =
   | CfileExists -> us"fileExists"
   | CdeleteFile -> us"deleteFile"
   | Cerror -> us"error"
+
+(* Pretty print a record *)
+and pprecord contents =
+  us"{" ^.
+    Ustring.concat (us",")
+      (List.map (function (l, v) -> l ^. us" = " ^. pprintME v) contents)
+    ^. us"}"
+
+and pplabel = function
+  | LabIdx i -> Ustring.Op.ustring_of_int i
+  | LabStr s -> s
 
 (* Pretty print a term. *)
 and pprintME t =
@@ -149,7 +163,9 @@ and pprintME t =
   | TmFix(_) -> us"fix"
   | TmSeq(_,tms) -> us"[" ^. Ustring.concat (us",") (List.map (ppt false) tms) ^. us"]"
   | TmTuple(_,tms) -> us"(" ^. Ustring.concat (us",") (List.map (ppt false) tms) ^. us")"
-  | TmProj(_,t,n) -> left inside ^. ppt false t  ^. us"." ^. ustring_of_int n ^. right inside
+  | TmRecord(_, r) -> left inside ^. pprecord r ^. right inside
+  | TmProj(_,t,l) -> left inside ^. ppt false t  ^. us"." ^. pplabel l ^. right inside
+  | TmRecordUpdate(_,t1,l,t2) -> left inside ^. ppt false t1  ^. us" with " ^. l ^. us" = " ^. ppt false t2 ^. right inside
   | TmCondef(_,s,ty,t) -> left inside ^. us"data " ^. s ^. us" " ^. pprint_ty ty ^.
                         us" in" ^. ppt false t ^. right inside
   | TmConsym(_,s,sym,tmop) -> left inside ^. s ^. us"_" ^. us(sprintf "%d" sym) ^. us" " ^.

--- a/test/mexpr/records.mc
+++ b/test/mexpr/records.mc
@@ -1,9 +1,9 @@
 mexpr
 
-let empty = {} in
+let empty : {} = {} in
 utest empty with {} in
 
-let r1 = {age = 42, name = "foobar"} in
+let r1 : {age : int, name : string} = {age = 42, name = "foobar"} in
 utest r1 with {age = 42, name = "foobar"} in
 utest r1 with {name = "foobar", age = 42} in
 
@@ -12,5 +12,7 @@ utest r1.name with "foobar" in
 
 let r2 = {r1 with age = 43} in
 utest r2 with {age = 43, name = "foobar"} in
+
+let bumpAge = lam r : {age : int}. {r with age = r.age + 1} in
 
 ()

--- a/test/mexpr/records.mc
+++ b/test/mexpr/records.mc
@@ -13,6 +13,11 @@ utest r1.name with "foobar" in
 let r2 = {r1 with age = 43} in
 utest r2 with {age = 43, name = "foobar"} in
 
-let bumpAge = lam r : {age : int}. {r with age = r.age + 1} in
+let r3 = {{r1 with age = 41} with name = "barbar"} in
+utest r3 with {age = 41, name = "barbar"} in
+
+let bumpAge = lam r : {age : int}. {r with age = addi r.age 1} in
+
+utest bumpAge r1 with r2 in
 
 ()

--- a/test/mexpr/records.mc
+++ b/test/mexpr/records.mc
@@ -1,0 +1,16 @@
+mexpr
+
+let empty = {} in
+utest empty with {} in
+
+let r1 = {age = 42, name = "foobar"} in
+utest r1 with {age = 42, name = "foobar"} in
+utest r1 with {name = "foobar", age = 42} in
+
+utest r1.age with 42 in
+utest r1.name with "foobar" in
+
+let r2 = {r1 with age = 43} in
+utest r2 with {age = 43, name = "foobar"} in
+
+()


### PR DESCRIPTION
This RFC explains the ongoing work to add records to MCore.

A record is an unordered map from labels (strings) to values:
```
let r1 = {age = 42, name = "foobar"} in
let r2 = {name = "foobar", age = 42} in
utest r1 with r2 in
...
```
Like with tuples, values are projected from a record by specifying their labels:
```
utest r1.age with 42 in
...
```
Unlike with tuples, new records can be created from existing tuples with individual tuples changed:
```
let r3 = {r2 with age = 43} in
...
```
The reason for this is to be able to support functions where the full record is not known (e.g. row polymorphism). For example, we might write a function that updates a single field but leaves the rest untouched, regardless of what these fields are:
```
let bumpAge = lam r : {age: Int, ..}. {r with age = r.age + 1} in
utest bumpAge r2 with r3 in
()
```
Note that this is not the same thing as subtyping, where the return type of `bumpAge` would necessarily be the tuple type `{age : Int}`, as there is no way to reason about the fields of a record that cannot be seen.

The details of row-polymorphism are being worked out and will be posted here when ready for scrutiny.