### PR TITLE
Mlang mangling

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -156,7 +156,7 @@ and label =
 and pat =
 | PatNamed of info * ustring                      (* Named, capturing wildcard *)
 | PatTuple of info * pat list                     (* Tuple pattern *)
-| PatCon   of info * ustring * int * pat          (* Constructor pattern *)
+| PatCon   of info * ustring * sym * pat          (* Constructor pattern *)
 | PatInt   of info * int                          (* Int pattern *)
 | PatChar  of info * int                          (* Char pattern *)
 | PatBool  of info * bool                         (* Boolean pattern *)

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -112,9 +112,7 @@ let rec merge_includes root visited = function
      in
      let included =
        includes
-       |> List.map (parse_include root)
-       |> List.filter Option.is_some
-       |> List.map Option.get
+       |> List.filter_map (parse_include root)
      in
      let included_tops =
        included
@@ -137,7 +135,7 @@ let evalprog filename  =
      |> add_prelude
      |> merge_includes (Filename.dirname filename) [filename]
      |> Mlang.flatten
-     |> Mlang.desugar_language_uses
+     |> Mlang.desugar_post_flatten
      |> Mexpr.debruijn (builtin |> List.split |> fst |> (List.map (fun x-> VarTm(us x))))
      |> debug_after_debruijn
      |> Mexpr.eval (builtin |> List.split |> snd |> List.map (fun x -> TmConst(NoInfo,x)))


### PR DESCRIPTION
This PR changes the `mlang` to `mexpr` translation to define each fragment in a single location, then use name mangling to resolve the correct one, instead of duplicating the definition at each `use` as was done before. As part of this translation we have to resolve constructors statically, which reveals some bugs in language fragments that do not depend on all language fragments they actually need, so I also fix the ones that appeared along the way.

Presently we mangle all term level names (in a somewhat temporary way, since #31 isn't implemented, though there are TODOs for what should be fixed once that lands) and leave all other names unchanged. There is a mechanism for mangling other names, to minimize risk of collisions (see `empty_mangle` in `mlang.ml`) but it is presently the identity function. The reason for this is that mangling happens before we replace constants. To include mangling of non-language fragment names we have to start using an environment that leaves the constants unchanged, instead of an empty environment, but I ran out of time to fix that.

I believe that this deprecates #29, albeit with another potentially temporary fix.