### PR TITLE
Replace the environment with a context and added Float arithmetic

### DIFF
--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -86,6 +86,21 @@ lang ArithIntAst = ConstAst + IntAst
 end
 
 
+lang FloatAst = ConstAst
+  syn Const =
+  | CFloat {val : Float}
+end
+
+
+lang ArithFloatAst = ConstAst + FloatAst
+  syn Const =
+  | CAddf {}
+  | CSubf {}
+  | CMulf {}
+  | CDivf {}
+  | CNegf {}
+end
+
 lang BoolAst
   syn Const =
   | CBool {val : Bool}
@@ -242,6 +257,7 @@ end
 
 lang MExprAst =
   VarAst + AppAst + FunAst + LetAst + RecLetsAst + ConstAst +
-  UnitAst + UnitPat + IntAst + IntPat +
-  ArithIntAst + BoolAst + BoolPat + CmpAst + CharAst + SeqAst +
-  TupleAst + TuplePat + DataAst + DataPat + MatchAst + VarPat + UtestAst
+  UnitAst + UnitPat + IntAst + IntPat + ArithIntAst +
+  FloatAst + ArithFloatAst + BoolAst + BoolPat + CmpAst + CharAst +
+  SeqAst + TupleAst + TuplePat + DataAst + DataPat + MatchAst + VarPat +
+  UtestAst

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -866,4 +866,24 @@ utest eval {env = []} (subf_ (float 1.) (float 2.)) with float (negf 1.) in
 utest eval {env = []} (mulf_ (float 1.) (float 2.)) with float 2. in
 utest eval {env = []} (divf_ (float 1.) (float 2.)) with float 0.5 in
 utest eval {env = []} (negf_ (float 1.)) with float (negf 1.) in
+
+utest eval {env = []} (app id (int 1)) with int 1 in
+
+utest eval {env = []} (app (lambda "x" (app (var "x") (int 1))) id)
+with int 1 in
+
+utest eval {env = []}
+           (appSeq (lambda "x" (lambda "y" (addi_ (var "x") (var "y"))))
+                   [int 1, int 2])
+with int 3 in
+
+utest eval {env = []}
+           (appSeq (lambda "x" (lambda "y" (addi_ (var "x") (int 1))))
+                   [int 1, int 2])
+with int 2 in
+
+utest eval {env = []}
+           (appSeq (lambda "x" (lambda "x" (addi_ (var "x") (int 1))))
+                   [int 1, int 2])
+with int 3 in
 ()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -802,8 +802,7 @@ let addEvalNested = lambda "arg"
     (unit)) in
 
 let tup = lam x. TmTuple {tms = x} in
-let cint = lam x. TmConst {val = CInt {val = x}} in
-utest eval {env = []} (wrapInDecls (app addEvalNested (tup [num (cint 1), num (cint 2)]))) with TmCon {ident = "Num", body = cint 3} in
+utest eval {env = []} (wrapInDecls (app addEvalNested (tup [num (int 1), num (int 2)]))) with TmCon {ident = "Num", body = int 3} in
 
 
 
@@ -826,21 +825,21 @@ in
 
 let recordProj = TmLet {ident = "myrec",
                         tpe = None (),
-                        body = recAddTups [("a", cint 10),("b", cint 37),("c", cint 23)] record_,
+                        body = recAddTups [("a", int 10),("b", int 37),("c", int 23)] record_,
                         inexpr = TmRecordProj {rec = var "myrec",
                                                key = "b"}} in
 
 let recordUpdate = TmLet {ident = "myrec",
                           tpe = None (),
-                          body = recAddTups [("a", cint 10),("b", cint 37),("c", cint 23)] record_,
-                          inexpr = TmRecordProj {rec = recordupdate_ "c" (cint 11) (var "myrec"),
+                          body = recAddTups [("a", int 10),("b", int 37),("c", int 23)] record_,
+                          inexpr = TmRecordProj {rec = recordupdate_ "c" (int 11) (var "myrec"),
                                                  key = "c"}} in
 
 -- This updates the record with a non-existent value, should this case be allowed?
 let recordUpdate2 = TmLet {ident = "myrec",
                            tpe = None (),
-                           body = recAddTups [("a", cint 10),("b", cint 37),("c", cint 23)] record_,
-                           inexpr = TmRecordProj {rec = recordupdate_ "d" (cint 1729) (var "myrec"),
+                           body = recAddTups [("a", int 10),("b", int 37),("c", int 23)] record_,
+                           inexpr = TmRecordProj {rec = recordupdate_ "d" (int 1729) (var "myrec"),
                                                   key = "d"}} in
 
 utest eval {env = []} recordProj with TmConst {val = CInt {val = 37}} in
@@ -848,8 +847,8 @@ utest eval {env = []} recordUpdate with TmConst {val = CInt {val = 11}} in
 utest eval {env = []} recordUpdate2 with TmConst {val = CInt {val = 1729}} in
 
 let evalUTestRecordInUnit = TmUtest {
-    test = recAddTups [("a", cint 10), ("b", cint 13)] record_,
-    expected = recAddTups [("b", cint 13), ("a", cint 10)] record_,
+    test = recAddTups [("a", int 10), ("b", int 13)] record_,
+    expected = recAddTups [("b", int 13), ("a", int 10)] record_,
     next = TmConst {val = CUnit ()}}
 in
 utest eval {env = []} evalUTestRecordInUnit with TmConst {val = CUnit ()} in


### PR DESCRIPTION
Changed the semantic function `eval` to pass around a context containing the environment rather than the environment by itself. I also had to change the semantic function `apply` to pass the context since it calls `eval`.