### PR TITLE
Mlang mangling, make language fragments share constructors

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -197,6 +197,9 @@ module Option = struct
   let bind f = function
     | Some x -> f x
     | None -> None
+  let value ~default = function
+    | Some x -> x
+    | None -> default
 end
 
 (* General (bottom-up) map over terms *)

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -53,6 +53,16 @@ lang User
   | Unit -> addi x 1
 end
 
+lang A
+  syn ATy =
+  | ACon {afield : Dyn}
+end
+
+lang AExtend = A
+  syn ATy =
+  | ACon {aextfield : Dyn}
+end
+
 lang Overlap = ArithBool + ArithBool2 + Arith
 
 mexpr
@@ -99,8 +109,21 @@ let _ =
   utest eval (Add (Num 10
                   ,If (IsZero (Add (Num 0, Num 3))
                       ,Num 10
-                      ,Add (Num 5, (Num (negi 2)))))) with 13
-  in ()
+                      ,Add (Num 5, (Num (negi 2)))))) with 13 in
+  ()
+in
+let _ =
+  let e1 = use ArithBool in If(True(), Num 1, Num 2) in
+  let e2 = use ArithBool2 in If(True(), Num 1, Num 2) in
+  utest e1 with e2 in
+  ()
+in
+
+let _ =
+  let e1 = use A in ACon{afield = 1, aextfield = 2} in // TODO(vipa): this should break once we start typechecking product extensions of a constructor
+  let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
+  utest e1 with e2 in
+  ()
 in
 
 ()

--- a/test/mlang/sharedcons.mc
+++ b/test/mlang/sharedcons.mc
@@ -1,0 +1,51 @@
+-- Remembering constructors from individual language fragments
+
+lang A
+    syn Expr =
+    | TmFoo ()
+end
+
+lang B
+    syn Expr =
+    | TmFoo ()
+end
+
+let isA = use A in lam x. match x with TmFoo () then true else false
+let isB = use B in lam x. match x with TmFoo () then true else false
+
+lang C
+    syn Expr =
+    | TmBar ()
+end
+
+lang AC = A + C
+
+mexpr
+let fooA = use A in (TmFoo ()) in
+let fooA2 = use A in (TmFoo ()) in
+let fooAC = use AC in (TmFoo ()) in
+
+utest fooA2 with fooA in
+utest fooAC with fooA in
+
+let _ = 
+  use A in
+  utest isA (TmFoo ()) with true in
+  utest isB (TmFoo ()) with false in
+  ()
+in
+
+let _ = 
+  use AC in
+  utest isA (TmFoo ()) with true in
+  utest isB (TmFoo ()) with false in
+  ()
+in
+
+let _ = 
+  use B in
+  utest isA (TmFoo ()) with false in
+  utest isB (TmFoo ()) with true in
+  ()
+in
+()


### PR DESCRIPTION
Continuation of #41, changing it so that language fragments that include other fragments reuse the same constructors, instead of creating copies.