### PR TITLE
Add types to the MExprAst language

### DIFF
--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -244,4 +244,7 @@ lang MExprAst =
   VarAst + AppAst + FunAst + LetAst + RecLetsAst + ConstAst +
   UnitAst + UnitPat + IntAst + IntPat +
   ArithIntAst + BoolAst + BoolPat + CmpAst + CharAst + SeqAst +
-  TupleAst + TuplePat + DataAst + DataPat + MatchAst + VarPat + UtestAst
+  TupleAst + TuplePat + DataAst + DataPat + MatchAst + VarPat + UtestAst +
+  DynTypeAst + UnitTypeAst + CharTypeAst + SeqTypeAst + TupleTypeAst +
+  RecordTypeAst + DataTypeAst + ArithTypeAst + BoolTypeAst +
+  AppTypeAst


### PR DESCRIPTION
Add the language fragments for the type syntax into the `MExprAst` language. Should be included there as the pattern fragments are part of `MExprAst`.