### PR TITLE
Add missing parenthesis in pretty printer for TmApp

### DIFF
--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -30,7 +30,7 @@ lang AppPrettyPrint = AppAst
     | TmApp t ->
       let l = pprintCode indent t.lhs in
       let r = pprintCode indent t.rhs in
-      strJoin "" [l, " (", r, ")"]
+      strJoin "" ["(", l, ") (", r, ")"]
 end
 
 lang FunPrettyPrint = FunAst
@@ -459,6 +459,16 @@ let func_isconb =
                    (false_)))
 in
 
+-- let addone : Int -> Int = lam i : Int. (lam x : Int. addi x 1) i
+let func_addone =
+  let_ "addone" (Some (TyArrow {from = TyInt {}, to = TyInt {}})) (
+      lam_ "i" (Some (TyInt {})) (
+        app_ (lam_ "x" (Some (TyInt {})) (addi_ (var_ "x") (int_ 1)))
+             (var_ "i")
+      )
+  )
+in
+
 let sample_ast = unit_ in
 let sample_ast = letappend sample_ast func_foo in
 let sample_ast = letappend sample_ast func_factorial in
@@ -468,6 +478,7 @@ let sample_ast = letappend sample_ast func_recconcs in
 let sample_ast = letappend sample_ast func_mycona in
 let sample_ast = letappend sample_ast func_myconb in
 let sample_ast = letappend sample_ast func_isconb in
+let sample_ast = letappend sample_ast func_addone in
 
 --let _ = print "\n\n" in
 --let _ = print (pprintCode 0 sample_ast) in


### PR DESCRIPTION
Adds the parenthesis around the lhs expression in TmApp when pretty printing. It avoids an issue where the lhs expression could have a body, such as in the lambda example provided with the fix.