### PR TITLE
Lambda Lifting: Allow for reuse of generated arguments within the same scope

### DIFF
--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -1144,7 +1144,7 @@ let example_multiuse =
           let_ "bar" (None ()) (
             lam_ "y" (None ()) (
               let xp1 =
-                let_ "xp1" (None ()) (appf2_ (var_ "addi") (var_ "y") (int_ 1))
+                let_ "xp1" (None ()) (appf2_ (var_ "addi") (var_ "x") (int_ 1))
               in
               letappend xp1 (
                 if_ (appf2_ (var_ "eqi") (var_ "x") (var_ "y"))
@@ -1154,7 +1154,8 @@ let example_multiuse =
                             (appf2_ (var_ "subi") (var_ "x") (var_ "y")))
               )
             )
-          ) in
+          )
+        in
         letappend bar (
           app_ (var_ "bar") (int_ 3)
         )


### PR DESCRIPTION
This PR makes the lambda lifting not re-generate any previously generated arguments in the same lambda/let-scope. This should make no functional difference, but it makes the transformed AST easier to understand.

The added test case `example_multiuse` looks like this before applying the genarg-fix:
```
------------------------ example_multiuse ------------------------
[>>>>  Before  <<<<]
let foo =
    lam x.
    let bar =
        lam y.
        let xp1 =
            ((addi) (x)) (1)
        in
        if ((eqi) (x)) (y) then
            ((subi) (xp1)) (x)
        else
            ((addi) (((addi) (x)) (y))) (((subi) (x)) (y))
    in
    (bar) (3)
in
(foo) (11)

[>>>>  After  <<<<]
let fun8_bar =
    lam arg7_x.
    lam arg6_x.
    lam arg5_x.
    lam arg4_x.
    lam arg2_x.
    lam arg1_y.
    let var3_xp1 =
        ((addi) (arg2_x)) (1)
    in
    if ((eqi) (arg4_x)) (arg1_y) then
        ((subi) (var3_xp1)) (arg5_x)
    else
        ((addi) (((addi) (arg6_x)) (arg1_y))) (((subi) (arg7_x)) (arg1_y))
in
let fun9_foo =
    lam arg0_x.
    ((((((fun8_bar) (arg0_x)) (arg0_x)) (arg0_x)) (arg0_x)) (arg0_x)) (3)
in
(fun9_foo) (11)
-------------------------------------------------------------------
```

After applying the genarg-fix the `example_multiuse` test case looks like this:
```
------------------------ example_multiuse ------------------------
[>>>>  Before  <<<<]
let foo =
    lam x.
    let bar =
        lam y.
        let xp1 =
            ((addi) (x)) (1)
        in
        if ((eqi) (x)) (y) then
            ((subi) (xp1)) (x)
        else
            ((addi) (((addi) (x)) (y))) (((subi) (x)) (y))
    in
    (bar) (3)
in
(foo) (11)

[>>>>  After  <<<<]
let fun4_bar =
    lam arg2_x.
    lam arg1_y.
    let var3_xp1 =
        ((addi) (arg2_x)) (1)
    in
    if ((eqi) (arg2_x)) (arg1_y) then
        ((subi) (var3_xp1)) (arg2_x)
    else
        ((addi) (((addi) (arg2_x)) (arg1_y))) (((subi) (arg2_x)) (arg1_y))
in
let fun5_foo =
    lam arg0_x.
    ((fun4_bar) (arg0_x)) (3)
in
(fun5_foo) (11)
-------------------------------------------------------------------
```
