### PR TITLE
Include the filename and line number in error prints

### DIFF
--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -368,8 +368,12 @@ let delta eval env fi c v  =
         Sys.remove (Ustring.to_utf8 (tmlist2ustring fi lst)); TmConst(NoInfo,Cunit)
     | CdeleteFile,_ -> fail_constapp fi
 
-    | Cerror, TmSeq(fi,lst) ->
-       (uprint_endline ((us"ERROR: ") ^. (tmlist2ustring fi lst)); exit 1)
+    | Cerror, TmSeq(fiseq,lst) ->
+       (let prefix = match fi with
+                     | Info(filename,l1,_,_,_) ->
+                       filename ^. us":" ^. (ustring_of_int l1) ^. us": "
+                     | NoInfo -> us""
+        in uprint_endline (prefix ^. us"ERROR: " ^. (tmlist2ustring fiseq lst)); exit 1)
     | Cerror,_ -> fail_constapp fi
     | CdebugShow,t ->
        uprint_endline ((us"EXPR: ") ^. (pprintME t)); TmConst(NoInfo,Cunit)


### PR DESCRIPTION
Adds the filename and line number of the error print to the printed message. Currently on the format `ERROR (<filename>:<line number>): <msg>`. At the moment I am having to spend a lot of time having to manually enter metadata into each error print to know where in the code it happened. Would be nice to just put in the message that describes what actually went wrong.

The format of the filename+line number metadata was what looked OK after a short moment of thinking. Comments and opinions are welcome.