### PR TITLE
Mexprfix

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -163,10 +163,16 @@ and name =
 | NameStr of ustring                              (* A normal pattern name *)
 | NameWildcard                                    (* Pattern wildcard *)
 
+(* Kind of sequence matching in patterns *)
+and seqMatchType =
+| SeqMatchPrefix of name
+| SeqMatchPostfix of name
+| SeqMatchTotal
 
 (* Patterns *)
 and pat =
 | PatNamed of info * name                         (* Named, capturing wildcard *)
+| PatSeq   of info * pat list * seqMatchType      (* Sequence pattern *)
 | PatTuple of info * pat list                     (* Tuple pattern *)
 | PatCon   of info * ustring * sym * pat          (* Constructor pattern *)
 | PatInt   of info * int                          (* Int pattern *)
@@ -261,6 +267,7 @@ let tm_info = function
 
 let pat_info = function
   | PatNamed(fi,_) -> fi
+  | PatSeq(fi,_,_) -> fi
   | PatTuple(fi,_) -> fi
   | PatCon(fi,_,_,_) -> fi
   | PatInt(fi,_) -> fi

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -153,19 +153,27 @@ and tm =
 | TmFix     of info                                                 (* Fix point *)
 
 
+
 and label =
 | LabIdx of int                                   (* Tuple index *)
 | LabStr of ustring                               (* Record label *)
 
+(* Kind of pattern name *)
+and name =
+| NameStr of ustring                              (* A normal pattern name *)
+| NameWildcard                                    (* Pattern wildcard *)
+
+
 (* Patterns *)
 and pat =
-| PatNamed of info * ustring                      (* Named, capturing wildcard *)
+| PatNamed of info * name                         (* Named, capturing wildcard *)
 | PatTuple of info * pat list                     (* Tuple pattern *)
 | PatCon   of info * ustring * sym * pat          (* Constructor pattern *)
 | PatInt   of info * int                          (* Int pattern *)
 | PatChar  of info * int                          (* Char pattern *)
 | PatBool  of info * bool                         (* Boolean pattern *)
 | PatUnit  of info                                (* Unit pattern *)
+
 
 (* Types *)
 and ty =

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -140,7 +140,6 @@ and tm =
 | TmRecLets of info * (info * ustring * tm) list * tm               (* Recursive lets *)
 | TmApp     of info * tm * tm                                       (* Application *)
 | TmConst   of info * const                                         (* Constant *)
-| TmIf      of info * tm * tm * tm                                  (* If expression *)
 | TmFix     of info                                                 (* Fix point *)
 | TmSeq     of info * tm list                                       (* Sequence *)
 | TmTuple   of info * tm list                                       (* Tuple *)
@@ -218,7 +217,6 @@ let rec map_tm f = function
   | TmConst(_,_) as t -> f t
   | TmFix(_) as t -> f t
   | TmSeq(fi, tms) -> f (TmSeq(fi, List.map (map_tm f) tms))
-  | TmIf(fi,t1,t2,t3) -> f (TmIf(fi,map_tm f t1,map_tm f t2,map_tm f t3))
   | TmTuple(fi,tms) -> f (TmTuple(fi,List.map (map_tm f) tms))
   | TmRecord(fi, r) -> f (TmRecord(fi, List.map (function (l, t) -> (l, map_tm f t)) r))
   | TmProj(fi,t1,l) -> f (TmProj(fi,map_tm f t1,l))
@@ -240,7 +238,6 @@ let tm_info = function
   | TmRecLets(fi,_,_) -> fi
   | TmApp(fi,_,_) -> fi
   | TmConst(fi,_) -> fi
-  | TmIf(fi,_,_,_) -> fi
   | TmFix(fi) -> fi
   | TmSeq(fi,_) -> fi
   | TmTuple(fi,_) -> fi

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -159,19 +159,19 @@ and label =
 | LabStr of ustring                               (* Record label *)
 
 (* Kind of pattern name *)
-and name =
+and patName =
 | NameStr of ustring                              (* A normal pattern name *)
 | NameWildcard                                    (* Pattern wildcard *)
 
 (* Kind of sequence matching in patterns *)
 and seqMatchType =
-| SeqMatchPrefix of name
-| SeqMatchPostfix of name
+| SeqMatchPrefix of patName
+| SeqMatchPostfix of patName
 | SeqMatchTotal
 
 (* Patterns *)
 and pat =
-| PatNamed of info * name                         (* Named, capturing wildcard *)
+| PatNamed of info * patName                      (* Named, capturing wildcard *)
 | PatSeq   of info * pat list * seqMatchType      (* Sequence pattern *)
 | PatTuple of info * pat list                     (* Tuple pattern *)
 | PatCon   of info * ustring * sym * pat          (* Constructor pattern *)

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -79,7 +79,6 @@ and const =
 | CChar2int
 | CInt2char
 (* MCore intrinsic: sequences *)
-| CSeq     of tm list
 | Cmakeseq of int option
 | Clength
 | Cconcat  of (tm list) option
@@ -135,12 +134,10 @@ and program = Program of include_ list * top list * tm
 and tm =
 | TmVar     of info * ustring * int                                 (* Variable *)
 | TmLam     of info * ustring * ty * tm                             (* Lambda abstraction *)
-| TmClos    of info * ustring * ty * tm * env Lazy.t                (* Closure *)
 | TmLet     of info * ustring * tm * tm                             (* Let *)
 | TmRecLets of info * (info * ustring * tm) list * tm               (* Recursive lets *)
 | TmApp     of info * tm * tm                                       (* Application *)
 | TmConst   of info * const                                         (* Constant *)
-| TmFix     of info                                                 (* Fix point *)
 | TmSeq     of info * tm list                                       (* Sequence *)
 | TmTuple   of info * tm list                                       (* Tuple *)
 | TmRecord  of info * (ustring * tm) list                           (* Record *)
@@ -151,6 +148,10 @@ and tm =
 | TmMatch   of info * tm * pat * tm * tm                            (* Match data *)
 | TmUse     of info * ustring * tm                                  (* Use a language *)
 | TmUtest   of info * tm * tm * tm                                  (* Unit testing *)
+(* Only part of the runtime system *)
+| TmClos    of info * ustring * ty * tm * env Lazy.t                (* Closure *)
+| TmFix     of info                                                 (* Fix point *)
+
 
 and label =
 | LabIdx of int                                   (* Tuple index *)
@@ -260,7 +261,7 @@ let pat_info = function
   | PatUnit(fi) -> fi
 
 
-(* Converts a list of terms (typically from CSeq) to a ustring *)
+(* Converts a list of terms  to a ustring *)
 let tmlist2ustring fi lst =
   List.map (fun x ->
       match x with | TmConst(_,CChar(i)) -> i

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -138,7 +138,7 @@ let evalprog filename  =
      |> Mlang.desugar_post_flatten
      |> Mexpr.debruijn (builtin |> List.split |> fst |> (List.map (fun x-> VarTm(us x))))
      |> debug_after_debruijn
-     |> Mexpr.eval (builtin |> List.split |> snd |> List.map (fun x -> TmConst(NoInfo,x)))
+     |> Mexpr.eval (builtin |> List.split |> snd)
      |> fun _ -> ())
     with
     | Lexer.Lex_error m ->

--- a/src/boot/ext.ml
+++ b/src/boot/ext.ml
@@ -3,7 +3,7 @@ open Ast
 open Msg
 
 let externals =
-  List.map (fun x -> (fst x,  CExt (snd x)))
+  List.map (fun x -> (fst x,  TmConst(NoInfo,CExt (snd x))))
   [
     ("eapp", EApp None)
   ]

--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -42,6 +42,7 @@ let reserved_strings = [
   (* v *)
   ("=",             fun(i) -> Parser.EQ{i=i;v=()});
   ("+",             fun(i) -> Parser.ADD{i=i;v=()});
+  ("++",            fun(i) -> Parser.CONCAT{i=i;v=()});
 
   (* Symbolic Tokens *)
   ("(",             fun(i) -> Parser.LPAREN{i=i;v=()});
@@ -145,7 +146,7 @@ let uident = ucase_letter (digit | '_' | us_letter)*
 
 let symtok =  "="  | "+" |  "-" | "*"  | "/" | "%"  | "<"  | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "==" |
               "!=" | "!" | "&&" | "||" | "++"| "$"  | "("  | ")"  | "["  | "]" | "{"  | "}"  |
-              "::" | ":" | ","  | "."  | "|" | "->" | "=>"
+              "::" | ":" | ","  | "."  | "|" | "->" | "=>" | "++"
 
 
 let line_comment = "//" [^ '\013' '\010']*

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -453,7 +453,6 @@ let rec debruijn env t =
      TmRecLets(fi,List.map (fun (fi,s,t) -> (fi,s, debruijn env2 t)) lst, debruijn env2 tm)
   | TmApp(fi,t1,t2) -> TmApp(fi,debruijn env t1,debruijn env t2)
   | TmConst(_,_) -> t
-  | TmIf(fi,t1,t2,t3) -> TmIf(fi,debruijn env t1,debruijn env t2,debruijn env t3)
   | TmFix(_) -> t
   | TmSeq(fi,tms) -> TmSeq(fi,List.map (debruijn env) tms)
   | TmTuple(fi,tms) -> TmTuple(fi,List.map (debruijn env) tms)
@@ -541,13 +540,6 @@ let rec eval env t =
                                  ^ Ustring.to_utf8 (pprintME f)))
   (* Constant and fix *)
   | TmConst(_,_) | TmFix(_) -> t
-  (* If expression *)
-  | TmIf(fi,t1,t2,t3) -> (
-    match eval env t1 with
-    | TmConst(_,CBool(true)) -> eval env t2
-    | TmConst(_,CBool(false)) -> eval env t3
-    | _ -> raise_error fi "The guard of the if expression is not a boolean value"
-  )
   (* Sequences *)
   | TmSeq(fi,tms) -> TmConst(fi,CSeq(List.map (eval env) tms))
   (* Records *)

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -159,7 +159,7 @@ let translate_cases f target cases =
   let translate_case case inner =
     match case with
     | (ConPattern (fi, k, x), handler) ->
-      TmMatch (fi, target, PatCon(fi, k, noidx, PatNamed(fi, x)), handler, inner)
+      TmMatch (fi, target, PatCon(fi, k, noidx, PatNamed(fi, NameStr(x))), handler, inner)
     | (VarPattern (fi, x), handler) ->
       TmLet(fi, x, target, handler)
   in
@@ -233,7 +233,8 @@ let rec desugar_tm nss env =
   (* Both introducing and referencing *)
   | TmMatch(fi, target, pat, thn, els) ->
      let rec desugar_pat env = function
-       | PatNamed(fi, name) -> (delete_id_and_con env name, PatNamed(fi, empty_mangle name))
+       | PatNamed(fi, NameStr(name)) -> (delete_id_and_con env name, PatNamed(fi, NameStr(empty_mangle name)))
+       | PatNamed(_, NameWildcard) as pat -> (env,pat)
        | PatTuple(fi, pats) ->
           List.fold_right (fun p (env, pats) -> desugar_pat env p |> map_right (fun p -> p::pats)) pats (env, [])
           |> map_right (fun pats -> PatTuple(fi, pats))

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -169,7 +169,7 @@ let translate_cases f target cases =
   let no_match =
     let_ (us"_")
       (app (TmConst (NoInfo, CdebugShow)) target)
-      (app (TmConst (NoInfo, Cerror)) (TmConst(NoInfo, CSeq msg)))
+      (app (TmConst (NoInfo, Cerror)) (TmSeq(NoInfo, msg)))
   in
   let case_compare c1 c2 = match c1, c2 with
     | (p1, _), (p2, _) -> pattern_compare p1 p2

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -250,7 +250,6 @@ let rec desugar_tm nss env =
       | Some ns -> desugar_tm nss (merge_env_overwrite env ns) body)
   (* Simple recursions *)
   | TmApp(fi, a, b) -> TmApp(fi, desugar_tm nss env a, desugar_tm nss env b)
-  | TmIf(fi, c, th, el) -> TmIf(fi, desugar_tm nss env c, desugar_tm nss env th, desugar_tm nss env el)
   | TmSeq(fi, tms) -> TmSeq(fi, List.map (desugar_tm nss env) tms)
   | TmTuple(fi, tms) -> TmTuple(fi, List.map (desugar_tm nss env) tms)
   | TmRecord(fi, tms) -> TmRecord(fi, List.map (desugar_tm nss env |> map_right) tms)

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -306,7 +306,9 @@ labels:
 
 pat:
   | IDENT
-      { PatNamed($1.i, $1.v) }
+      { if $1.v =. us"_"
+        then PatNamed($1.i, NameWildcard)
+        else PatNamed($1.i, NameStr($1.v)) }
   | IDENT pat
       { PatCon(mkinfo $1.i (pat_info $2), $1.v, noidx, $2) }
   | LPAREN pat RPAREN

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -276,8 +276,8 @@ atom:
   | UFLOAT               { TmConst($1.i,CFloat($1.v)) }
   | TRUE                 { TmConst($1.i,CBool(true)) }
   | FALSE                { TmConst($1.i,CBool(false)) }
-  | STRING               { TmConst($1.i, CSeq(List.map (fun x -> TmConst($1.i,CChar(x)))
-                                                       (ustring2list $1.v))) }
+  | STRING               { TmSeq($1.i, List.map (fun x -> TmConst($1.i,CChar(x)))
+                                                  (ustring2list $1.v)) }
   | LSQUARE seq RSQUARE  { TmSeq(mkinfo $1.i $3.i, $2) }
   | LSQUARE RSQUARE      { TmSeq(mkinfo $1.i $2.i, []) }
   | LBRACKET labels RBRACKET    { TmRecord(mkinfo $1.i $3.i, $2)}

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -233,7 +233,7 @@ mexpr:
         TmLam(fi,$2.v,$3,$5) }
   | IF mexpr THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $6) in
-        TmIf(fi,$2,$4,$6) }
+        TmMatch(fi,$2,PatBool(NoInfo,true),$4,$6) }
   | CON IDENT ty_op IN mexpr
       { let fi = mkinfo $1.i $4.i in
         TmCondef(fi,$2.v,$3,$5)}

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -105,10 +105,6 @@ let rec pprint_const c =
   | CChar2int -> us"char2int"
   | CInt2char -> us"int2char"
   (* MCore intrinsic: sequences *)
-  | CSeq(tms) ->
-     if List.for_all (fun x -> match x with | TmConst(_,CChar(_)) -> true | _ -> false) tms
-     then us"\"" ^. tmlist2ustring NoInfo tms ^. us"\""
-     else us"[" ^. Ustring.concat (us",") (List.map pprintME tms) ^. us"]"
   | Cmakeseq(_) -> us"makeseq"
   | Clength -> us"length"
   | Cconcat(_) -> us"concat"

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -185,7 +185,8 @@ and pprintME t =
 
 and pprintPat p =
   let rec ppp inside = function
-    | PatNamed(_,x) -> x
+    | PatNamed(_,NameStr(x)) -> x
+    | PatNamed(_,NameWildcard) -> us"_"
     | PatTuple(_,ps) -> us"(" ^. Ustring.concat (us",") (List.map (ppp false) ps) ^. us")"
     | PatCon(_,x,n,p) ->
        left inside ^.

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -165,8 +165,6 @@ and pprintME t =
   | TmApp(_,t1,t2) ->
        left inside ^. ppt true t1  ^. us" " ^. ppt true t2 ^. right inside
   | TmConst(_,c) -> pprint_const c
-  | TmIf(_,t1,t2,t3) -> left inside ^. us"if " ^. ppt false t1 ^. us" then " ^.
-                          ppt false t2 ^. us" else " ^. ppt false t3 ^.right inside
   | TmFix(_) -> us"fix"
   | TmSeq(_,tms) -> us"[" ^. Ustring.concat (us",") (List.map (ppt false) tms) ^. us"]"
   | TmTuple(_,tms) -> us"(" ^. Ustring.concat (us",") (List.map (ppt false) tms) ^. us")"
@@ -179,6 +177,8 @@ and pprintME t =
                            (match tmop with
                             | Some(t) -> ppt true t
                             | None -> us"") ^. right inside
+  | TmMatch(_,t1,PatBool(_,true),t2,t3) -> left inside ^. us"if " ^. ppt false t1 ^. us" then " ^.
+                          ppt false t2 ^. us" else " ^. ppt false t3 ^.right inside
   | TmMatch(_,t,p,then_,else_) -> left inside ^. us"match " ^. ppt false t ^.
         us" with " ^. pprintPat p ^.
         us" then " ^. ppt false then_ ^.

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -58,9 +58,42 @@ let tree3 = Node(Node(Leaf(3),Node(Leaf(2),Leaf(6))),Leaf(12)) in
 utest count tree3 with 23 in
 
 
--- Matching
+-- Wildcard
 utest match (1,2,3) with (_,2,_) then true else false with true in
 utest match (1,2,3) with (_,2,x) then x else 0 with 3 in
+
+-- Matching sequences
+let s1 = [1,3,5,10] in
+utest match s1 with [1,3] then true else false with false in
+utest match s1 with [1,3,5,10] then true else false with true in
+utest match s1 with [1,3] ++ _ then true else false with true in
+utest match s1 with [2,3] ++ _ then true else false with false in
+utest match s1 with _ ++ [5,10] then true else false with true in
+utest match s1 with _ ++ [5,11] then true else false with false in
+utest match s1 with _ ++ [5,a] then a else 0 with 10 in
+utest match s1 with first ++ [1,2] then true else false with false in
+utest match s1 with [1,x] ++ rest then (x,rest) else (0,[]) with (3,[5,10]) in
+utest match s1 with first ++ [x,y] then (x,y,first) else (0,0,[]) with (5,10,[1,3]) in
+utest match s1 with first ++ [x,y,10] then (first,x,y) else ([],0,0) with ([1],3,5) in
+
+utest match "foo" with ['f','o','o'] then true else false with true in
+utest match "foo" with "foo" then true else false with true in
+utest match "foobar" with "fo" ++ rest then rest else "" with "obar" in
+utest match "foobar" with first ++ "bar" then first else "" with "foo" in
+utest match "" with first then first else "-" with "" in
+utest match "" with first then first else "-" with "" in
+utest match "" with [] then true else false with true in
+utest match "" with [] ++ rest then rest else "foo" with [] in
+utest match "" with first ++ [] then first else "foo" with [] in
+
+utest match [["a","b"],["c"]] with [a] then true else false with false in
+utest match [["a","b"],["c"]] with [a,b] then (a,b) else [] with (["a","b"],["c"]) in
+utest match (1,[["a","b"],["c"]],76) with (1,[a,b],0) then true else false with false in
+utest match (1,[["a","b"],["c"]],76) with (1,[a,b],76) then (a,b) else [] with (["a","b"],["c"]) in
+utest match (1,[["a","b"],["c"]],76) with (1,[a]++b,76) then (a,b) else [] with (["a","b"],[["c"]]) in
+utest match (1,[["a","b"],["c"]],76) with (1,b++[a],76) then (a,b) else [] with (["c"],[["a","b"]]) in
+utest match (1,[["a","b"],["c"]],76) with (1,b++[["c"]],76) then b else [] with [["a","b"]] in
+
 
 
 

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -68,6 +68,8 @@ utest match s1 with [1,3] then true else false with false in
 utest match s1 with [1,3,5,10] then true else false with true in
 utest match s1 with [1,3] ++ _ then true else false with true in
 utest match s1 with [2,3] ++ _ then true else false with false in
+utest match s1 with [1,a] ++ _ then a else 0 with 3 in
+utest match s1 with [_,a] ++ b then (a,b) else (0,[]) with (3,[5,10]) in
 utest match s1 with _ ++ [5,10] then true else false with true in
 utest match s1 with _ ++ [5,11] then true else false with false in
 utest match s1 with _ ++ [5,a] then a else 0 with 10 in

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -1,11 +1,11 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
-// Test integer primitives
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test integer primitives
 
 mexpr
 
-// Constructor with and without arguments
+-- Constructor with and without arguments
 con K1 in
 con K2 in
 con K3 in
@@ -17,7 +17,7 @@ utest K3("k",100) with K3("k",100) in
 utest match K2("k",100) with K2 x then x.0 else "a" with "k" in
 
 
-// Matching two constructors
+-- Matching two constructors
 con Foo in
 con Bar in
 let f = lam x.
@@ -32,7 +32,7 @@ utest f (Foo("a",1)) with (1, "a") in
 utest f (Bar 10) with (15, "b") in
 
 
-// Counting values in a binary tree
+-- Counting values in a binary tree
 type Tree in
 con Node : (Tree,Tree) -> Tree in
 con Leaf : (Int) -> Tree in
@@ -56,5 +56,14 @@ utest count tree2 with 9 in
 
 let tree3 = Node(Node(Leaf(3),Node(Leaf(2),Leaf(6))),Leaf(12)) in
 utest count tree3 with 23 in
+
+
+-- Matching
+utest match (1,2,3) with (_,2,_) then true else false with true in
+utest match (1,2,3) with (_,2,x) then x else 0 with 3 in
+
+
+
+
 
 ()


### PR DESCRIPTION
Refactored and added a number of things to MExpr in boot:

- Added matching of sequences in Mexpr.
- Refactored to have separate pattern wildcards.
- Removed CSeq from boot.
- Removed TmIf in boot. Replaced with match.