### PR TITLE
Make sure filepaths handled in includes are absolute and normalized

### DIFF
--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -94,7 +94,7 @@ let rec merge_includes root visited = function
   | Program(includes, tops, tm) ->
      let rec parse_include root = function
        | Include(info, path) as inc ->
-          let filename = Filename.concat root (Ustring.to_utf8 path) in
+          let filename = Filename.concat root (Ustring.to_utf8 path) |> Utils.normalize_path in
           if List.mem filename visited
           then raise_error info ("Cycle detected in included files: " ^ filename)
           else if List.mem filename !parsed_files

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -127,6 +127,11 @@ let add_prelude = function
 (* Main function for evaluation a function. Performs lexing, parsing
    and evaluation. Does not perform any type checking *)
 let evalprog filename  =
+  (* Make sure the filename is an absolute path, otherwise the duplicate file detection won't work *)
+  let filename =
+    if Filename.is_relative filename
+    then Filename.concat (Sys.getcwd ()) filename
+    else filename in
   if !utest then printf "%s: " filename;
   utest_fail_local := 0;
   begin try

--- a/src/boot/dune-boot
+++ b/src/boot/dune-boot
@@ -5,4 +5,5 @@
 
 (executable
  (name boot)
+ (libraries str)
 )

--- a/src/boot/dune-boot-ext
+++ b/src/boot/dune-boot-ext
@@ -5,5 +5,5 @@
 
 (executable
  (name boot)
- (libraries sundialsml)
+ (libraries str sundialsml)
 )

--- a/src/boot/utils.ml
+++ b/src/boot/utils.ml
@@ -122,6 +122,37 @@ let xor b1 b2 = (b1 || b2) && (not (b1 && b2))
 let sign_extension v n =
   if ((v lsr (n-1)) land 1) = 0 then v else (-1 lsl n) lor v
 
+type 'a list_zipper =
+  | ZipLeftEnd of 'a list
+  | ZipRightEnd of 'a list
+  | Zipper of 'a list * 'a * 'a list
+
+let list_to_zipper l = ZipLeftEnd l
+
+let list_zipper_right ls = function
+  | [] -> ZipRightEnd ls
+  | x :: xs -> Zipper (ls, x, xs)
+
+let list_zip_right = function
+  | ZipLeftEnd [] -> ZipRightEnd []
+  | ZipLeftEnd (x :: xs) -> Zipper ([], x, xs)
+  | ZipRightEnd xs -> ZipRightEnd xs
+  | Zipper(ls, x, r :: rs) -> Zipper (x :: ls, r, rs)
+  | Zipper(ls, x, []) -> ZipRightEnd (x :: ls)
+
+let normalize_path p =
+  let delim = Str.regexp_string Filename.dir_sep in
+  let rec recur = function
+    | Zipper (ls, d, rs) when d = Filename.current_dir_name ->
+       list_zipper_right ls rs |> recur
+    | Zipper (l :: ls, dd, rs) when dd = Filename.parent_dir_name && l <> dd ->
+       list_zipper_right ls rs |> recur
+    | ZipRightEnd xs -> List.rev xs
+    | zipper -> list_zip_right zipper |> recur
+  in Str.split_delim delim p
+     |> list_to_zipper
+     |> recur
+     |> String.concat Filename.dir_sep
 
 
 module Int =

--- a/test/mlang/also_includes_lib.mc
+++ b/test/mlang/also_includes_lib.mc
@@ -1,3 +1,4 @@
 include "lib.mc"
 
+let alsoIncludeDecon = lam x. match x with TestCon _ then "match" else "no match"
 let triple_bump = lam n. bump(bump(bump n))

--- a/test/mlang/deplib.mc
+++ b/test/mlang/deplib.mc
@@ -1,1 +1,4 @@
 include "dep.mc"
+include "lib.mc"
+
+let depDecon = lam x. match x with TestCon _ then "match" else error "no match"

--- a/test/mlang/include.mc
+++ b/test/mlang/include.mc
@@ -1,13 +1,19 @@
 include "lib.mc"               -- Simple include
 include "deplib.mc"            -- Deep include
 include "also_includes_lib.mc" -- Ignore duplicate includes
+include "subfolder/inclib.mc"  -- even when the paths look different
 include "../mexpr/letlamif.mc" -- Include from other directory
 include "string.mc"            -- Include from standard library
 
+let decon = lam x. match x with TestCon _ then "match" else "no match"
 let double_bump = lam n. bump (bump n)
 
 mexpr
 
+utest decon (TestCon {}) with "match" in
+utest alsoIncludeDecon (TestCon {}) with "match" in
+utest depDecon (TestCon {}) with "match" in
+utest subDecon (TestCon {}) with "match" in
 utest bump 10 with 11 in
 utest double_bump 10 with 12 in
 utest triple_bump 10 with 13 in

--- a/test/mlang/lib.mc
+++ b/test/mlang/lib.mc
@@ -1,4 +1,5 @@
 let bump = addi 1
+con TestCon : TestCon
 mexpr
 utest bump 5 with 6 in
 ()

--- a/test/mlang/subfolder/inclib.mc
+++ b/test/mlang/subfolder/inclib.mc
@@ -1,0 +1,3 @@
+include "../lib.mc"
+
+let subDecon = lam x. match x with TestCon _ then "match" else "no match"


### PR DESCRIPTION
This fixes the issue mentioned in #63. The issue was that the mechanism for not including a file twice was looking solely at its path, but that path could be either relative to the current working directory of `boot` or an absolute path. If both of these are included they would be treated as different files. This PR makes sure to prepend the current working directory early on, with the hope that that'll produce a single canonical path.

Note that this doesn't work in general, e.g., in the presence of symlinks and the like. There are library functions for producing a canonical path, but they would incur an extra dependency, and this works for now at least.