### PR TITLE
Set prettify-symbols-alist for mcore-mode

### DIFF
--- a/emacs/mcore-mode.el
+++ b/emacs/mcore-mode.el
@@ -82,10 +82,11 @@
   '(("lam" . ?λ))
   "List of syntax to prettify for `mcore-mode'.")
 
-(add-hook 'mcore-mode-hook
-          (lambda ()
-            (mapc (lambda (pair) (push pair prettify-symbols-alist))
-                  mcore-prettify-symbols-alist)))
+(if (boundp 'prettify-symbols-alist)
+    (add-hook 'mcore-mode-hook
+              (lambda ()
+                (mapc (lambda (pair) (push pair prettify-symbols-alist))
+                      mcore-prettify-symbols-alist))))
 
 ;;;;;;;;;;;;;;;;;
 ;; compilation ;;

--- a/emacs/mcore-mode.el
+++ b/emacs/mcore-mode.el
@@ -74,6 +74,19 @@
        (modify-syntax-entry ?\n ">" synTable)
        synTable))
 
+;;;;;;;;;;;;;;
+;; prettify ;;
+;;;;;;;;;;;;;;
+
+(defvar mcore-prettify-symbols-alist
+  '(("lam" . ?λ))
+  "List of syntax to prettify for `mcore-mode'.")
+
+(add-hook 'mcore-mode-hook
+          (lambda ()
+            (mapc (lambda (pair) (push pair prettify-symbols-alist))
+                  mcore-prettify-symbols-alist)))
+
 ;;;;;;;;;;;;;;;;;
 ;; compilation ;;
 ;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Prettify symbols mode can be enabled in emacs globally
by (global-prettify-symbols-mode t) or use (prettify-symbols-mode t) in
appropriate hook. Requires Emacs >= 24.4.