### PR TITLE
Replace stub Option modules with module from Batteries

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -209,18 +209,7 @@ let noidx = -1
 let symno = ref 0
 let gencon fi x = symno := !symno + 1; TmConsym(fi,x,!symno,None)
 
-(* TODO: Temporary fix for hackinar installation issues *)
-module Option = struct
-  let map f = function
-    | Some x -> Some (f x)
-    | None -> None
-  let bind f = function
-    | Some x -> f x
-    | None -> None
-  let value ~default = function
-    | Some x -> x
-    | None -> default
-end
+module Option = BatOption
 
 (* General (bottom-up) map over terms *)
 let rec map_tm f = function

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -17,16 +17,7 @@ open Msg
 open Mexpr
 open Pprint
 
-(* TODO: Temporary fix for hackinar installation issues *)
-module Option = struct
-  let some x = Some x
-  let is_some = function
-    | Some _ -> true
-    | None -> false
-  let get = function
-    | Some x -> x
-    | None -> failwith "Not Some"
-end
+module Option = BatOption
 
 (* Standard lib default local path on unix (used by make install) *)
 let stdlib_loc_unix =

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -494,13 +494,13 @@ let rec debruijn env t =
 
 
 let rec tryMatch env value pat =
-  let go v p env = Option.bind (fun env -> tryMatch env v p) env in
+  let go v p env = Option.bind env (fun env -> tryMatch env v p) in
   let splitNthOrDoubleEmpty n s =
     if Mseq.length s == 0 then (Mseq.empty, Mseq.empty)
     else Mseq.split_at s n
   in
   let bind fi tms env =
-    env |> Option.bind (fun env -> Some(TmSeq(fi,tms)::env))
+    Option.bind env (fun env -> Some(TmSeq(fi,tms)::env))
   in
   match pat with
   | PatNamed(_,NameStr(_)) -> Some(value::env)

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -275,7 +275,7 @@ let rec desugar_tm nss env =
 (* add namespace to nss (overwriting) if relevant, prepend a tm -> tm function to stack, return updated tuple. Should use desugar_tm, as well as desugar both sem and syn *)
 let desugar_top (nss, (stack : (tm -> tm) list)) = function
   | TopLang (Lang(_, langName, includes, decls)) ->
-     let add_lang ns lang = USMap.find_opt lang nss |> Option.value ~default:emptyMlangEnv |> merge_env_overwrite ns in
+     let add_lang ns lang = USMap.find_opt lang nss |> Option.default emptyMlangEnv |> merge_env_overwrite ns in
      let previous_ns = List.fold_left add_lang emptyMlangEnv includes in
      (* compute the namespace *)
      let mangle str = langName ^. us"_" ^. str in


### PR DESCRIPTION
This PR removes the small `Option` modules that we wrote to make boot compile for everyone during the hackathon. It replaces the uses of `Option` by `BatOption` from Batteries Included. The new module changes the order of arguments to `bind` and uses `default` instead of our `value` (both with the same semantics as before as far as I can tell).