### PR TITLE
Loosen seqpat restriction

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -168,8 +168,8 @@ and patName =
 
 (* Kind of sequence matching in patterns *)
 and seqMatchType =
-| SeqMatchPrefix of patName
-| SeqMatchPostfix of patName
+| SeqMatchPrefix of pat
+| SeqMatchPostfix of pat
 | SeqMatchTotal
 
 (* Patterns *)

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -514,7 +514,7 @@ let rec debruijn env t =
 
 let rec tryMatch env value pat =
   let go v p env = Option.bind env (fun env -> tryMatch env v p) in
-  let splitNthOrDoubleEmpty n s =
+  let split_at_or_double_empty n s =
     if Mseq.length s == 0 then (Mseq.empty, Mseq.empty)
     else Mseq.split_at s n
   in
@@ -525,11 +525,11 @@ let rec tryMatch env value pat =
      let npats = Mseq.length pats in
      (match value,seqMP with
       | TmSeq(fi,vs),SeqMatchPrefix(p) when npats <= Mseq.length vs ->
-         let (pre,post) = vs |> splitNthOrDoubleEmpty npats in
+         let (pre,post) = vs |> split_at_or_double_empty npats in
          Mseq.fold_right2 go pre pats (Some env)
          |> go (TmSeq(fi, post)) p
       | TmSeq(fi,vs),SeqMatchPostfix(p) when npats <= Mseq.length vs ->
-         let (pre,post) = vs |> splitNthOrDoubleEmpty (Mseq.length vs - npats) in
+         let (pre,post) = vs |> split_at_or_double_empty (Mseq.length vs - npats) in
          go (TmSeq(fi, pre)) p (Some env)
          |> Mseq.fold_right2 go post pats
       | TmSeq(_,vs),SeqMatchTotal when npats == Mseq.length vs ->

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -242,8 +242,8 @@ let rec desugar_tm nss env =
          let (env', pats') = Mseq.fold_right (fun p (env, pats) -> desugar_pat env p |> map_right
              (fun p -> Mseq.cons p pats)) pats (env, Mseq.empty) in
          let (env'',seqMT') = match seqMT with
-           | SeqMatchPrefix(n) -> n |> desugar_pname env' |> map_right (fun n -> SeqMatchPrefix(n))
-           | SeqMatchPostfix(n) -> n |> desugar_pname env' |> map_right (fun n -> SeqMatchPostfix(n))
+           | SeqMatchPrefix(p) -> p |> desugar_pat env' |> map_right (fun p -> SeqMatchPrefix(p))
+           | SeqMatchPostfix(p) -> p |> desugar_pat env' |> map_right (fun p -> SeqMatchPostfix(p))
            | SeqMatchTotal -> (env', SeqMatchTotal) in
          (env'',PatSeq(fi,pats',seqMT'))
        | PatTuple(fi, pats) ->

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -49,13 +49,12 @@ let ustring_of_pat p =
     let ppSeq s =
       s |> Mseq.to_list |> List.map ppp |> Ustring.concat (us",")
     in
-    let ppName = function NameStr(x) -> x | NameWildcard -> us"_" in
     match pat with
     | PatNamed(_,NameStr(x)) -> x
     | PatSeq(_,lst,SeqMatchPrefix(x)) ->
-      us"[" ^. ppSeq lst ^. us"] ++ " ^. ppName x
+      us"[" ^. ppSeq lst ^. us"] ++ " ^. ppp x
     | PatSeq(_,lst,SeqMatchPostfix(x)) ->
-      ppName x ^. us" ++ [" ^. ppSeq lst ^. us"]"
+      ppp x ^. us" ++ [" ^. ppSeq lst ^. us"]"
     | PatSeq(_,lst,SeqMatchTotal) -> us"[" ^. ppSeq lst ^. us"]"
     | PatNamed(_,NameWildcard) -> us"_"
     | PatTuple(_,ps) ->
@@ -467,4 +466,3 @@ let ustring_of_env ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix e =
 let ustring_of_program tml =
   match tml with
   | Program(_,_,t) -> ustring_of_tm t
-

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -69,6 +69,8 @@ utest match s1 with [1,3,5,10] then true else false with true in
 utest match s1 with [1,3] ++ _ then true else false with true in
 utest match s1 with [2,3] ++ _ then true else false with false in
 utest match s1 with [1,a] ++ _ then a else 0 with 3 in
+utest match s1 with [b] ++ _ then let a = 2 in (a, b, _) else (0, 0) with (2, 1) in
+utest match s1 with _ ++ [b] then let a = 2 in (a, b, _) else (0, 0) with (2, 10) in
 utest match s1 with [_,a] ++ b then (a,b) else (0,[]) with (3,[5,10]) in
 utest match s1 with _ ++ [5,10] then true else false with true in
 utest match s1 with _ ++ [5,11] then true else false with false in
@@ -77,6 +79,10 @@ utest match s1 with first ++ [1,2] then true else false with false in
 utest match s1 with [1,x] ++ rest then (x,rest) else (0,[]) with (3,[5,10]) in
 utest match s1 with first ++ [x,y] then (x,y,first) else (0,0,[]) with (5,10,[1,3]) in
 utest match s1 with first ++ [x,y,10] then (first,x,y) else ([],0,0) with ([1],3,5) in
+utest match s1 with [1] ++ mid ++ [10] then mid else [] with [3, 5] in
+utest match s1 with [1,3] ++ mid ++ [10] then mid else [] with [5] in
+utest match s1 with [1] ++ [3] ++ rest then rest else [] with [5, 10] in
+utest match s1 with [a,b] ++ mid ++ [c] then (a, b, mid, c) else (0, 0, [], 0) with (1, 3, [5], 10) in
 
 utest match "foo" with ['f','o','o'] then true else false with true in
 utest match "foo" with "foo" then true else false with true in

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -69,8 +69,8 @@ utest match s1 with [1,3,5,10] then true else false with true in
 utest match s1 with [1,3] ++ _ then true else false with true in
 utest match s1 with [2,3] ++ _ then true else false with false in
 utest match s1 with [1,a] ++ _ then a else 0 with 3 in
-utest match s1 with [b] ++ _ then let a = 2 in (a, b, _) else (0, 0) with (2, 1) in
-utest match s1 with _ ++ [b] then let a = 2 in (a, b, _) else (0, 0) with (2, 10) in
+utest let _ = [] in match s1 with [b] ++ _ then let a = 2 in (a, b, _) else (0, 0, []) with (2, 1, []) in
+utest let _ = [] in match s1 with _ ++ [b] then let a = 2 in (a, b, _) else (0, 0, []) with (2, 10, []) in
 utest match s1 with [_,a] ++ b then (a,b) else (0,[]) with (3,[5,10]) in
 utest match s1 with _ ++ [5,10] then true else false with true in
 utest match s1 with _ ++ [5,11] then true else false with false in


### PR DESCRIPTION
When originally implemented we placed restrictions on concat patterns: one side must be a fixed length sequence, and the other must be wildcard. This was done to prevent writing the pattern `_ ++ [1, 2, 3] ++ _` which would match any sequence that has `[1, 2, 3]` as a subsequence. This would not be obvious how to implement and it would be too fancy a thing to have in a core language.

However, this also prevents `[1, 2] ++ mid ++ [3, 4]` which is *not* particularly fancy. This PR thus loosens the restriction to the following: one side must be a fixed length sequence pattern, and the other may be any pattern.

Additionally there was a parser bug where `[1, 2] ++ _` would parse the last part as the name `_` and bind a value to it, instead of seeing it as a wildcard that doesn't bind anything. This PR fixes that as an extra bonus. It also fixes a bug that was invisible due to this parser bug: the de bruijn translation did not add anything to the environment for a non-binding wildcard pattern, but the matching function `tryMatch` did. This would make every name inside the `then` branch of a match refer to the wrong value (assuming the name was bound outside the match).