### PR TITLE
Added new term 'never' and removed CRecord in boot.

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -151,6 +151,7 @@ and tm =
 | TmMatch   of info * tm * pat * tm * tm                            (* Match data *)
 | TmUse     of info * ustring * tm                                  (* Use a language *)
 | TmUtest   of info * tm * tm * tm                                  (* Unit testing *)
+| TmNever   of info                                                 (* Never term *)
 (* Only part of the runtime system *)
 | TmClos    of info * ustring * ty * tm * env Lazy.t                (* Closure *)
 | TmFix     of info                                                 (* Fix point *)
@@ -234,6 +235,7 @@ let rec map_tm f = function
     f (TmMatch(fi,map_tm f t1,p,map_tm f t2,map_tm f t3))
   | TmUse(fi,l,t1) -> f (TmUse(fi,l,map_tm f t1))
   | TmUtest(fi,t1,t2,tnext) -> f (TmUtest(fi,map_tm f t1,map_tm f t2,map_tm f tnext))
+  | TmNever(_) as t -> f t
 
 
 (* Returns the info field from a term *)
@@ -256,6 +258,7 @@ let tm_info = function
   | TmMatch(fi,_,_,_,_) -> fi
   | TmUse(fi,_,_) -> fi
   | TmUtest(fi,_,_,_) -> fi
+  | TmNever(fi) -> fi
 
 let pat_info = function
   | PatNamed(fi,_) -> fi

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -89,8 +89,6 @@ and const =
 | Csnoc    of (tm Mseq.t) option
 | CsplitAt of (tm Mseq.t) option
 | Creverse
-(* MCore intrinsic: records *)
-| CRecord of tm Record.t
 (* MCore debug and I/O intrinsics *)
 | Cprint
 | Cdprint
@@ -143,7 +141,7 @@ and tm =
 | TmConst   of info * const                                         (* Constant *)
 | TmSeq     of info * tm Mseq.t                                     (* Sequence *)
 | TmTuple   of info * tm list                                       (* Tuple *)
-| TmRecord  of info * (ustring * tm) list                           (* Record *)
+| TmRecord  of info * tm Record.t                                   (* Record *)
 | TmProj    of info * tm * label                                    (* Projection of a tuple or record *)
 | TmRecordUpdate of info * tm * ustring * tm                        (* Record update *)
 | TmCondef  of info * ustring * ty * tm                             (* Constructor definition *)
@@ -224,9 +222,9 @@ let rec map_tm f = function
   | TmApp(fi,t1,t2) -> f (TmApp(fi,map_tm f t1,map_tm f t2))
   | TmConst(_,_) as t -> f t
   | TmFix(_) as t -> f t
-  | TmSeq(fi, tms) -> f (TmSeq(fi,Mseq.map (map_tm f) tms))
+  | TmSeq(fi,tms) -> f (TmSeq(fi,Mseq.map (map_tm f) tms))
   | TmTuple(fi,tms) -> f (TmTuple(fi,List.map (map_tm f) tms))
-  | TmRecord(fi, r) -> f (TmRecord(fi,List.map (function (l, t) -> (l, map_tm f t)) r))
+  | TmRecord(fi,r) -> f (TmRecord(fi,Record.map (map_tm f) r))
   | TmProj(fi,t1,l) -> f (TmProj(fi,map_tm f t1,l))
   | TmRecordUpdate(fi,r,l,t) -> f (TmRecordUpdate(fi,map_tm f r,l,map_tm f t))
   | TmCondef(fi,x,ty,t1) -> f (TmCondef(fi,x,ty,map_tm f t1))

--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -37,6 +37,7 @@ let reserved_strings = [
   ("use",           fun(i) -> Parser.USE{i=i;v=()});
   ("mexpr",         fun(i) -> Parser.MEXPR{i=i;v=()});
   ("include",       fun(i) -> Parser.INCLUDE{i=i;v=()});
+  ("never",         fun(i) -> Parser.NEVER{i=i;v=()});
 
 
   (* v *)

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -497,7 +497,8 @@ let rec debruijn env t =
      TmMatch(fi,debruijn env t1,p,debruijn matchedEnv t2,debruijn env t3)
   | TmUse(fi,l,t) -> TmUse(fi,l,debruijn env t)
   | TmUtest(fi,t1,t2,tnext)
-     -> TmUtest(fi,debruijn env t1,debruijn env t2,debruijn env tnext)
+    -> TmUtest(fi,debruijn env t1,debruijn env t2,debruijn env tnext)
+  | TmNever(_) -> t
 
 
 let rec tryMatch env value pat =
@@ -658,3 +659,4 @@ let rec eval env t =
         utest_fail_local := !utest_fail_local + 1)
      end;
     eval env tnext
+  | TmNever(fi) -> raise_error fi "Reached a never term, which should be impossible in a well-typed program."

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -264,11 +264,10 @@ let rec desugar_tm nss env =
   | TmApp(fi, a, b) -> TmApp(fi, desugar_tm nss env a, desugar_tm nss env b)
   | TmSeq(fi, tms) -> TmSeq(fi, Mseq.map (desugar_tm nss env) tms)
   | TmTuple(fi, tms) -> TmTuple(fi, List.map (desugar_tm nss env) tms)
-  | TmRecord(fi, tms) -> TmRecord(fi, List.map (desugar_tm nss env |> map_right) tms)
+  | TmRecord(fi, r) -> TmRecord(fi, Record.map (desugar_tm nss env) r)
   | TmProj(fi, tm, lab) -> TmProj(fi, desugar_tm nss env tm, lab)
   | TmRecordUpdate(fi, a, lab, b) -> TmRecordUpdate(fi, desugar_tm nss env a, lab, desugar_tm nss env b)
   | TmUtest(fi, a, b, body) -> TmUtest(fi, desugar_tm nss env a, desugar_tm nss env b, desugar_tm nss env body)
-  | TmConst(fi, CRecord record) -> TmConst(fi, CRecord (Record.map (desugar_tm nss env) record))
   | TmNever(fi) -> TmNever(fi)
   (* Non-recursive *)
   | (TmConst _ | TmFix _ ) as tm -> tm

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -269,6 +269,7 @@ let rec desugar_tm nss env =
   | TmRecordUpdate(fi, a, lab, b) -> TmRecordUpdate(fi, desugar_tm nss env a, lab, desugar_tm nss env b)
   | TmUtest(fi, a, b, body) -> TmUtest(fi, desugar_tm nss env a, desugar_tm nss env b, desugar_tm nss env body)
   | TmConst(fi, CRecord record) -> TmConst(fi, CRecord (Record.map (desugar_tm nss env) record))
+  | TmNever(fi) -> TmNever(fi)
   (* Non-recursive *)
   | (TmConst _ | TmFix _ ) as tm -> tm
 

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -52,6 +52,7 @@
 %token <unit Ast.tokendata> USE
 %token <unit Ast.tokendata> MEXPR
 %token <unit Ast.tokendata> INCLUDE
+%token <unit Ast.tokendata> NEVER
 
 %token <unit Ast.tokendata> EQ            /* "="   */
 %token <unit Ast.tokendata> ARROW         /* "->"  */
@@ -277,6 +278,7 @@ atom:
   | UFLOAT               { TmConst($1.i,CFloat($1.v)) }
   | TRUE                 { TmConst($1.i,CBool(true)) }
   | FALSE                { TmConst($1.i,CBool(false)) }
+  | NEVER                { TmNever($1.i) }
   | STRING               { TmSeq($1.i, Mseq.map (fun x -> TmConst($1.i,CChar(x)))
                                                   (Mseq.of_ustring $1.v)) }
   | LSQUARE seq RSQUARE  { TmSeq(mkinfo $1.i $3.i, Mseq.of_list $2) }

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -283,8 +283,10 @@ atom:
                                                   (Mseq.of_ustring $1.v)) }
   | LSQUARE seq RSQUARE  { TmSeq(mkinfo $1.i $3.i, Mseq.of_list $2) }
   | LSQUARE RSQUARE      { TmSeq(mkinfo $1.i $2.i, Mseq.empty) }
-  | LBRACKET labels RBRACKET    { TmRecord(mkinfo $1.i $3.i, $2)}
-  | LBRACKET RBRACKET    { TmRecord(mkinfo $1.i $2.i, [])}
+  | LBRACKET labels RBRACKET
+      { TmRecord(mkinfo $1.i $3.i, $2 |> List.fold_left
+        (fun acc (k,v) -> Record.add k v acc) Record.empty) }
+  | LBRACKET RBRACKET    { TmRecord(mkinfo $1.i $2.i, Record.empty)}
   | LBRACKET mexpr WITH IDENT EQ mexpr RBRACKET
       { TmRecordUpdate(mkinfo $1.i $7.i, $2, $4.v, $6) }
 

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -256,7 +256,8 @@ and print_tm fmt (prec, t) =
     | TmProj _   | TmRecordUpdate _
     | TmCondef _ | TmConsym _
     | TmUse _    | TmUtest _
-    | TmClos _   | TmFix _             -> Atom
+    | TmClos _   | TmFix _
+    | TmNever _                        -> Atom
   in
 
   if paren then
@@ -409,6 +410,7 @@ and print_tm' fmt t = match t with
       print_tm (Lam, t1)
 
   | TmFix _ -> fprintf fmt "fix"
+  | TmNever _ -> fprintf fmt "never"
 
 (** Print an environment on the given formatter. *)
 and print_env fmt env =
@@ -467,4 +469,3 @@ let ustring_of_env ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix e =
 let ustring_of_program tml =
   match tml with
   | Program(_,_,t) -> ustring_of_tm t
-

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -210,11 +210,6 @@ let rec print_const fmt = function
   | CsplitAt(_) -> fprintf fmt "splitAt"
   | Creverse    -> fprintf fmt "reverse"
 
-  (* MCore records *)
-  | CRecord(r) ->
-    let contents = Record.fold (fun l v ack -> (l, v)::ack) r [] in
-    print_record fmt contents
-
   (* MCore debug and stdio intrinsics *)
   | Cprint        -> fprintf fmt "print"
   | Cdprint       -> fprintf fmt "dprint"
@@ -321,7 +316,9 @@ and print_tm' fmt t = match t with
     let inner = List.map print tms in
     fprintf fmt "(@[<hov 0>%a@])" concat (Comma,inner)
 
-  | TmRecord(_,r) -> print_record fmt r
+  | TmRecord(_,r) ->
+    let contents = Record.fold (fun l v ack -> (l, v)::ack) r [] in
+    print_record fmt contents
 
   | TmProj(_,t,l) ->
     let l = match l with

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -97,6 +97,14 @@ utest match (1,[["a","b"],["c"]],76) with (1,b++[a],76) then (a,b) else [] with 
 utest match (1,[["a","b"],["c"]],76) with (1,b++[["c"]],76) then b else [] with [["a","b"]] in
 
 
+-- Matching with never terms
+let x = true in
+utest match x with true then "true" else
+      match x with false then "false" else
+      never
+with "true" in
+
+
 
 
 


### PR DESCRIPTION
This PR makes two changes boot.

It adds a new term TmNever that should be inserted in places that cannot happen for a well-typed programs. For instance, in the end of a sequence of match expressions that exhaustively matches all cases.

The constant CRecord is removed in boot. Instead, the record term (and its value) is stored in TmRecord. This is the same procedure that was done for TmSeq before.