### PR TITLE
Changed from debruijn indicies to symbol representation of variable and pattern names in boot.

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -11,13 +11,12 @@ open Msg
 
 
 (* Debug options *)
-let enable_debug_eval = false
-let enable_debug_eval_env = false
+let enable_debug_eval_tm = ref false
+let enable_debug_eval_env = ref false
 let enable_debug_after_parse = ref false
-let enable_debug_after_debruijn = false
-let enable_debug_after_erase = false
+let enable_debug_after_symbolize = ref false
 let enable_debug_after_mlang = ref false
-
+let enable_debug_symbol_print = ref false
 
 
 let utest = ref false           (* Set to true if unit testing is enabled *)

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -203,8 +203,8 @@ and vartype =
 | VarTm    of ustring
 
 
-(* No index -1 means that de Bruijn index has not yet been assigned *)
-let noidx = -1
+(* Value -1 means that there is no symbol yet assigned *)
+let nosym = -1
 
 module Option = BatOption
 

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -13,7 +13,7 @@ open Msg
 (* Debug options *)
 let enable_debug_eval = false
 let enable_debug_eval_env = false
-let enable_debug_after_parse = false
+let enable_debug_after_parse = ref false
 let enable_debug_after_debruijn = false
 let enable_debug_after_erase = false
 let enable_debug_after_mlang = ref false

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -49,8 +49,8 @@ let prog_argv = ref []          (* Argv for the program that is executed *)
 
 (* Debug template function. Used below *)
 let debug_after_parse t =
-  if enable_debug_after_parse then
-    (printf "\n-- After parsing --\n";
+  if !enable_debug_after_parse then
+    (printf "\n-- After parsing (only mexpr part) --\n";
      uprint_endline (ustring_of_program t);
      t)
   else t
@@ -225,11 +225,14 @@ let main =
   let speclist = [
 
     (* First character in description string must be a space for alignment! *)
+    "--debug-parse", Arg.Set(enable_debug_after_parse),
+    " Enables output of parsing.";
+
     "--debug-mlang", Arg.Set(enable_debug_after_mlang),
     " Enables output of the mexpr program after mlang transformations.";
 
-    "--debruijn", Arg.Set(enable_debug_debruijn_print),
-    " Enables output of the debruijn indices of variables when printing.";
+    "--symbol", Arg.Set(enable_debug_symbol_print),
+    " Enables output of the symbols for variables when printing.";
 
   ] in
 

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -140,9 +140,9 @@ let evalprog filename  =
      |> Mlang.flatten
      |> Mlang.desugar_post_flatten
      |> debug_after_mlang
-     |> Mexpr.debruijn (builtin |> List.split |> fst |> (List.map (fun x-> VarTm(us x))))
+     |> Mexpr.symbolize builtin_name2sym
      |> debug_after_debruijn
-     |> Mexpr.eval (builtin |> List.split |> snd)
+     |> Mexpr.eval builtin_sym2term
      |> fun _ -> ())
     with
     | Lexer.Lex_error m ->

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -47,7 +47,7 @@ let default_includes =
 
 let prog_argv = ref []          (* Argv for the program that is executed *)
 
-(* Debug template function. Used below *)
+(* Debug printing after parse*)
 let debug_after_parse t =
   if !enable_debug_after_parse then
     (printf "\n-- After parsing (only mexpr part) --\n";
@@ -55,11 +55,11 @@ let debug_after_parse t =
      t)
   else t
 
-(* Debug template function. Used below *)
-let debug_after_debruijn t =
-  if enable_debug_after_debruijn  then
-    (printf "\n-- After debruijn --\n";
-     uprint_endline (ustring_of_tm t);
+(* Debug printing after symbolize transformation *)
+let debug_after_symbolize t =
+  if !enable_debug_after_symbolize then
+    (printf "\n-- After symbolize --\n";
+     uprint_endline (ustring_of_tm ~margin:80 t);
      t)
   else t
 
@@ -141,7 +141,7 @@ let evalprog filename  =
      |> Mlang.desugar_post_flatten
      |> debug_after_mlang
      |> Mexpr.symbolize builtin_name2sym
-     |> debug_after_debruijn
+     |> debug_after_symbolize
      |> Mexpr.eval builtin_sym2term
      |> fun _ -> ())
     with
@@ -231,8 +231,17 @@ let main =
     "--debug-mlang", Arg.Set(enable_debug_after_mlang),
     " Enables output of the mexpr program after mlang transformations.";
 
+    "--debug-symbolize", Arg.Set(enable_debug_after_symbolize),
+    " Enables output of the mexpr program after symbolize transformations.";
+
+    "--debug-eval-tm", Arg.Set(enable_debug_eval_tm),
+    " Enables output of terms in each eval step.";
+
+    "--debug-eval-env", Arg.Set(enable_debug_eval_env),
+    " Enables output of the environment in each eval step.";
+
     "--symbol", Arg.Set(enable_debug_symbol_print),
-    " Enables output of the symbols for variables when printing.";
+    " Enables output of symbols for variables. Affects all other debug printing.";
 
   ] in
 

--- a/src/boot/ext-skel/ext.ml
+++ b/src/boot/ext-skel/ext.ml
@@ -24,7 +24,7 @@ let delta eval env _ c v =
   let mk_app fi f v = TmApp (fi, f, v) in
 
   match c, v with
-  | EApp None, TmClos (fi, _, _, _, _) | EApp None, TmConst (fi,  _) ->
+  | EApp None, TmClos (fi, _, _, _, _, _) | EApp None, TmConst (fi,  _) ->
      mk_ext fi (EApp (Some (fun x -> eval env (mk_app NoInfo v x))))
   | EApp (Some f), _ -> (f v)
   | EApp _, t -> fail_extapp (tm_info t)

--- a/src/boot/ext/ext.ml
+++ b/src/boot/ext/ext.ml
@@ -119,7 +119,7 @@ let delta eval env fi c v =
   in
 
   match c, v with
-  | EApp None, TmClos (fi, _, _, _, _) | EApp None, TmConst (fi,  _) ->
+  | EApp None, TmClos (fi, _, _, _, _, _) | EApp None, TmConst (fi,  _) ->
      mk_ext fi (EApp (Some (fun x -> eval env (mk_app NoInfo v x))))
   | EApp (Some f), _ -> (f v)
   | EApp _,_ -> fail_extapp fi

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -14,7 +14,7 @@ open Printf
    correspond constants *)
 let builtin =
   let f c = TmConst(NoInfo,c) in
-  [("unit",f(Cunit));
+  ([("unit",f(Cunit));
    ("not",f(Cnot));("and",f(Cand(None)));("or",f(Cor(None)));
    ("addi",f(Caddi(None)));("subi",f(Csubi(None)));("muli",f(Cmuli(None)));
    ("divi",f(Cdivi(None)));("modi",f(Cmodi(None)));("negi",f(Cnegi));
@@ -49,7 +49,15 @@ let builtin =
    ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym))
   ]
   (* Append external functions TODO: Should not be part of core language *)
-  @ Ext.externals
+  @ Ext.externals)
+  |> List.map (fun (x,t) -> (x,gensym(),t))
+
+(* Mapping name to symbol *)
+let builtin_name2sym = List.map (fun (x,s,_) -> (us x,s)) builtin
+
+(* Mapping sym to term *)
+let builtin_sym2term = List.map (fun (_,s,t) -> (s,t)) builtin
+
 
 (* Returns the number of expected arguments of a constant *)
 let arity = function
@@ -438,28 +446,28 @@ let rec val_equal v1 v2 =
   | _ -> false
 
 
-(* Convert a term into de Bruijn indices. *)
-let rec debruijn env t =
-  let rec find fi env n x =
-    (match env with
-     | VarTm(y)::ee -> if y =. x then n else find fi ee (n+1) x
-     | [] -> raise_error fi ("Unknown variable '" ^ Ustring.to_utf8 x ^ "'")) in
+(* Add symbol associations between lambdas, patterns, and variables *)
+let rec symbolize env t =
+  let findsym fi x kind env = try List.assoc x env
+    with Not_found -> raise_error fi ("Unknown " ^ kind ^ " '" ^ Ustring.to_utf8 x ^ "'")
+  in
   let rec dbPat env = function
-    | PatNamed(_,NameStr(x)) as pat -> (VarTm(x)::env, pat)
+    | PatNamed(fi,NameStr(x,_)) -> let s = gensym() in ((x,s)::env, PatNamed(fi,NameStr(x,s)))
     | PatNamed(_,NameWildcard) as pat -> (env, pat)
     | PatSeq(fi,ps,seqMP) ->
        let go p (env,ps) = let (env,p) = dbPat env p in (env,Mseq.cons p ps) in
        let (env,ps) = Mseq.fold_right go ps (env,Mseq.empty) in
-       let env = (match seqMP with
-       | SeqMatchPrefix(NameStr(x)) | SeqMatchPostfix(NameStr(x)) -> VarTm(x)::env
-       | SeqMatchPrefix(NameWildcard) | SeqMatchPostfix(NameWildcard) | SeqMatchTotal -> env) in
-       (env,PatSeq(fi,ps,seqMP))
+       let (env,seqMP') = (match seqMP with
+         | SeqMatchPrefix(NameStr(x,_)) -> let s = gensym() in ((x,s)::env, SeqMatchPrefix(NameStr(x,s)))
+         | SeqMatchPostfix(NameStr(x,_)) -> let s = gensym() in ((x,s)::env, SeqMatchPostfix(NameStr(x,s)))
+         | SeqMatchPrefix(NameWildcard) | SeqMatchPostfix(NameWildcard) | SeqMatchTotal -> (env,seqMP)) in
+       (env,PatSeq(fi,ps,seqMP'))
     | PatTuple(fi,ps) -> (* NOTE: this causes patterns to introduce names right-to-left, which will cause errors if a later pattern binds a name that is seen as a constructor in a pattern to the left *)
        let go p (env,ps) = let (env,p) = dbPat env p in (env,p::ps) in
        let (env,ps) = List.fold_right go ps (env,[])
        in (env,PatTuple(fi,ps))
     | PatCon(fi,cx,_,p) ->
-       let cxId = find fi env 0 cx in
+       let cxId = findsym fi cx "constructor" env in
        let (env, p) = dbPat env p
        in (env,PatCon(fi,cx,cxId,p))
     | PatInt _ as p -> (env,p)
@@ -468,56 +476,60 @@ let rec debruijn env t =
     | PatUnit _ as p -> (env,p)
   in
   match t with
-  | TmVar(fi,x,_) -> TmVar(fi,x,find fi env 0 x)
-  | TmLam(fi,x,ty,t1) -> TmLam(fi,x,ty,debruijn (VarTm(x)::env) t1)
-  | TmClos(_,_,_,_,_) -> failwith "Closures should not be available."
-  | TmLet(fi,x,t1,t2) -> TmLet(fi,x,debruijn env t1,debruijn (VarTm(x)::env) t2)
+  | TmVar(fi,x,_) -> TmVar(fi,x,findsym fi x "variable" env)
+  | TmLam(fi,x,_,ty,t1) -> let s = gensym() in TmLam(fi,x,s,ty,symbolize ((x,s)::env) t1)
+  | TmClos(_,_,_,_,_,_) -> failwith "Closures should not be available."
+  | TmLet(fi,x,_,t1,t2) -> let s = gensym() in TmLet(fi,x,s,symbolize env t1,symbolize ((x,s)::env) t2)
   | TmRecLets(fi,lst,tm) ->
-     let env2 = List.fold_left (fun env (_,x,_) -> VarTm(x)::env) env lst in
-     TmRecLets(fi,List.map (fun (fi,s,t) -> (fi,s, debruijn env2 t)) lst, debruijn env2 tm)
-  | TmApp(fi,t1,t2) -> TmApp(fi,debruijn env t1,debruijn env t2)
+     let env2 = List.fold_left (fun env (_,x,_,_) -> let s = gensym() in (x,s)::env) env lst in
+     TmRecLets(fi,List.map (fun (fi,x,_,t) -> (fi,x,findsym fi x "variable" env2, symbolize env2 t))
+       lst, symbolize env2 tm)
+  | TmApp(fi,t1,t2) -> TmApp(fi,symbolize env t1,symbolize env t2)
   | TmConst(_,_) -> t
   | TmFix(_) -> t
-  | TmSeq(fi,tms) -> TmSeq(fi,Mseq.map (debruijn env) tms)
-  | TmTuple(fi,tms) -> TmTuple(fi,List.map (debruijn env) tms)
-  | TmRecord(fi,r) -> TmRecord(fi,Record.map (debruijn env) r)
-  | TmProj(fi,t,l) -> TmProj(fi,debruijn env t,l)
-  | TmRecordUpdate(fi,t1,l,t2) -> TmRecordUpdate(fi,debruijn env t1,l,debruijn env t2)
-  | TmCondef(fi,x,ty,t) -> TmCondef(fi,x,ty,debruijn (VarTm(x)::env) t)
+  | TmSeq(fi,tms) -> TmSeq(fi,Mseq.map (symbolize env) tms)
+  | TmTuple(fi,tms) -> TmTuple(fi,List.map (symbolize env) tms)
+  | TmRecord(fi,r) -> TmRecord(fi,Record.map (symbolize env) r)
+  | TmProj(fi,t,l) -> TmProj(fi,symbolize env t,l)
+  | TmRecordUpdate(fi,t1,l,t2) -> TmRecordUpdate(fi,symbolize env t1,l,symbolize env t2)
+  | TmCondef(fi,x,_,ty,t) -> let s = gensym() in TmCondef(fi,x,s,ty,symbolize ((x,s)::env) t)
   | TmConsym(fi,x,sym,tmop) ->
-     TmConsym(fi,x,sym,match tmop with | None -> None | Some(t) -> Some(debruijn env t))
+     TmConsym(fi,x,sym,match tmop with | None -> None | Some(t) -> Some(symbolize env t))
   | TmMatch(fi,t1,p,t2,t3) ->
      let (matchedEnv, p) = dbPat env p in
-     TmMatch(fi,debruijn env t1,p,debruijn matchedEnv t2,debruijn env t3)
-  | TmUse(fi,l,t) -> TmUse(fi,l,debruijn env t)
+     TmMatch(fi,symbolize env t1,p,symbolize matchedEnv t2,symbolize env t3)
+  | TmUse(fi,l,t) -> TmUse(fi,l,symbolize env t)
   | TmUtest(fi,t1,t2,tnext)
-    -> TmUtest(fi,debruijn env t1,debruijn env t2,debruijn env tnext)
+    -> TmUtest(fi,symbolize env t1,symbolize env t2,symbolize env tnext)
   | TmNever(_) -> t
 
 
-let rec tryMatch env value pat =
-  let go v p env = Option.bind env (fun env -> tryMatch env v p) in
-  let splitNthOrDoubleEmpty n s =
+
+let rec try_match env value pat =
+  let go v p env = Option.bind env (fun env -> try_match env v p) in
+  let split_nth_or_double_empty n s =
     if Mseq.length s == 0 then (Mseq.empty, Mseq.empty)
     else Mseq.split_at s n
   in
-  let bind fi tms env =
-    Option.bind env (fun env -> Some(TmSeq(fi,tms)::env))
+  let bind fi n tms env =
+    match n with
+    | NameStr(_,s) -> Option.bind env (fun env -> Some((s,TmSeq(fi,tms))::env))
+    | NameWildcard -> Option.bind env (fun env -> Some(env))
   in
   match pat with
-  | PatNamed(_,NameStr(_)) -> Some(value::env)
+  | PatNamed(_,NameStr(_,s)) -> Some((s,value)::env)
   | PatNamed(_,NameWildcard)-> Some(env)
   | PatSeq(_,pats,seqMP) ->
      let npats = Mseq.length pats in
      (match value,seqMP with
-      | TmSeq(fi,vs),SeqMatchPrefix(_) when npats <= Mseq.length vs ->
-         let (pre,post) = vs |> splitNthOrDoubleEmpty npats in
-         Mseq.fold_right2 go pre pats (Some env) |> bind fi post
-      | TmSeq(fi,vs),SeqMatchPostfix(_) when npats <= Mseq.length vs ->
+      | TmSeq(fi,vs),SeqMatchPrefix(n) when npats <= Mseq.length vs ->
+         let (pre,post) = vs |> split_nth_or_double_empty npats in
+         Mseq.fold_right2 go pre pats (Some env) |> bind fi n post
+      | TmSeq(fi,vs),SeqMatchPostfix(n) when npats <= Mseq.length vs ->
          let (pre,post) =
-           vs |> splitNthOrDoubleEmpty (Mseq.length vs - npats)
+           vs |> split_nth_or_double_empty (Mseq.length vs - npats)
          in
-         Mseq.fold_right2 go post pats (Some env) |> bind fi pre
+         Mseq.fold_right2 go post pats (Some env) |> bind fi n pre
       | TmSeq(_,vs),SeqMatchTotal when npats == Mseq.length vs ->
          Mseq.fold_right2 go vs pats (Some env)
       | _ -> None)
@@ -527,9 +539,9 @@ let rec tryMatch env value pat =
          List.fold_right2 go vs pats (Some env)
       | _ -> None)
   | PatCon(_,_,cxId,p) ->
-     (match value, List.nth env cxId with
+     (match value, List.assoc cxId env with
       | TmConsym(_,_,sym1,Some v), TmConsym(_,_,sym2,_)
-           when sym1 = sym2 -> tryMatch env v p
+           when sym1 = sym2 -> try_match env v p
       | _ -> None)
   | PatInt(_, i) ->
      (match value with
@@ -550,29 +562,29 @@ let rec tryMatch env value pat =
 
 
 (* Main evaluation loop of a term. Evaluates using big-step semantics *)
-let rec eval env t =
+let rec eval (env : (sym * tm) list) (t : tm) =
   debug_eval env t;
   match t with
-  (* Variables using debruijn indices. Need to evaluate because fix point. *)
-  | TmVar(_,_,n) -> eval env (List.nth env n)
+  (* Variables using symbol bindings. Need to evaluate because fix point. *)
+  | TmVar(_,_,s) -> eval env (List.assoc s env)
   (* Lambda and closure conversions *)
-  | TmLam(fi,x,ty,t1) -> TmClos(fi,x,ty,t1,lazy env)
-  | TmClos(_,_,_,_,_) -> t
+  | TmLam(fi,x,s,ty,t1) -> TmClos(fi,x,s,ty,t1,lazy env)
+  | TmClos(_,_,_,_,_,_) -> t
   (* Let *)
-  | TmLet(_,_,t1,t2) -> eval ((eval env t1)::env) t2
+  | TmLet(_,_,s,t1,t2) -> eval ((s,eval env t1)::env) t2
   (* Recursive lets *)
   | TmRecLets(_,lst,t2) ->
      let rec env' = lazy
        (let wraplambda = function
-          | TmLam(fi,x,ty,t1) -> TmClos(fi,x,ty,t1,env')
+          | TmLam(fi,x,s,ty,t1) -> TmClos(fi,x,s,ty,t1,env')
           | tm -> raise_error (tm_info tm) "Right-hand side of recursive let must be a lambda"
-        in List.fold_left (fun env (_, _, rhs) -> wraplambda rhs :: env) env lst)
+        in List.fold_left (fun env (_, _, s, rhs) -> (s, wraplambda rhs) :: env) env lst)
      in eval (Lazy.force env') (t2)
   (* Application *)
   | TmApp(fiapp,t1,t2) ->
       (match eval env t1 with
        (* Closure application *)
-       | TmClos(_,_,_,t3,env2) -> eval ((eval env t2)::Lazy.force env2) t3
+       | TmClos(_,_,s,_,t3,env2) -> eval ((s,eval env t2)::Lazy.force env2) t3
        (* Constant application using the delta function *)
        | TmConst(_,c) -> delta eval env fiapp c (eval env t2)
        (* Constructor application *)
@@ -583,7 +595,7 @@ let rec eval env t =
        (* Fix *)
        | TmFix(_) ->
          (match eval env t2 with
-         | TmClos(fi,_,_,t3,env2) as tt -> eval ((TmApp(fi,TmFix(fi),tt))::Lazy.force env2) t3
+         | TmClos(fi,_,s,_,t3,env2) as tt -> eval ((s,TmApp(fi,TmFix(fi),tt))::Lazy.force env2) t3
          | _ -> raise_error (tm_info t1) "Incorrect CFix")
        | f -> raise_error fiapp ("Incorrect application. This is not a function: "
                                  ^ Ustring.to_utf8
@@ -628,10 +640,10 @@ let rec eval env t =
   (* Tuples *)
   | TmTuple(fi,tms) -> TmTuple(fi,List.map (eval env) tms)
   (* Data constructors and match *)
-  | TmCondef(fi,x,_,t) -> eval ((gencon fi x)::env) t
+  | TmCondef(fi,x,s,_,t) -> eval ((s,TmConsym(fi,x,s,None))::env) t
   | TmConsym(_,_,_,_) as tm -> tm
   | TmMatch(_,t1,p,t2,t3) ->
-     (match tryMatch env (eval env t1) p with
+     (match try_match env (eval env t1) p with
       | Some env -> eval env t2
       | None -> eval env t3)
   | TmUse(fi,_,_) -> raise_error fi "A 'use' of a language was not desugared"

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -413,11 +413,13 @@ let delta eval env fi c v  =
 
 (* Debug function used in the eval function *)
 let debug_eval env t =
-  if enable_debug_eval then
-    (printf "\n-- eval -- \n";
-     uprint_endline (ustring_of_tm t);
-     if enable_debug_eval_env then
-        uprint_endline (ustring_of_env env))
+  if !enable_debug_eval_tm  || !enable_debug_eval_env then (
+    printf "-- eval step -- \n";
+    let env_str = if !enable_debug_eval_env then
+        us"Environment:\n" ^. (ustring_of_env ~margin:80 env) ^. us"\n" else us"" in
+    let tm_str = if !enable_debug_eval_tm then
+        us"Term:\n" ^. (ustring_of_tm ~margin:80 t) ^. us"\n" else us"" in
+    uprint_endline (env_str ^. tm_str))
   else ()
 
 (* Print out error message when a unit test fails *)

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -150,7 +150,7 @@ let flatten = function
 module AstHelpers = struct
   let var x = TmVar(NoInfo, x, -1)
   let app l r = TmApp(NoInfo, l, r)
-  let let_ x e body = TmLet(NoInfo, x, e, body)
+  let let_ x s e body = TmLet(NoInfo, x, s, e, body)
 end
 
 open AstHelpers
@@ -159,16 +159,16 @@ let translate_cases f target cases =
   let translate_case case inner =
     match case with
     | (ConPattern (fi, k, x), handler) ->
-      TmMatch (fi, target, PatCon(fi, k, noidx, PatNamed(fi, NameStr(x))), handler, inner)
+      TmMatch (fi, target, PatCon(fi, k, noidx, PatNamed(fi, NameStr(x,0))), handler, inner)
     | (VarPattern (fi, x), handler) ->
-      TmLet(fi, x, target, handler)
+      TmLet(fi, x, 0, target, handler)
   in
   let msg = Mseq.map (fun c -> TmConst(NoInfo,CChar(c)))
               ((us"No matching case for function " ^. f)
                |> Mseq.of_ustring)
   in
   let no_match =
-    let_ (us"_")
+    let_ (us"_") 0   (* TODO: we should probably have a special sort for let with wildcards *)
       (app (TmConst (NoInfo, CdebugShow)) target)
       (app (TmConst (NoInfo, Cerror)) (TmSeq(NoInfo, msg)))
   in
@@ -221,20 +221,20 @@ let rec desugar_tm nss env =
   | TmVar(fi, name, i) -> TmVar(fi, resolve_id_or_con env name, i)
   | (TmConsym _) as tm -> tm
   (* Introducing things *)
-  | TmLam(fi, name, ty, body) ->
-     TmLam(fi, empty_mangle name, ty, desugar_tm nss (delete_id_and_con env name) body)
-  | TmLet(fi, name, e, body) ->
-     TmLet(fi, empty_mangle name, desugar_tm nss env e, desugar_tm nss (delete_id_and_con env name) body)
+  | TmLam(fi, name, s, ty, body) ->
+     TmLam(fi, empty_mangle name, s, ty, desugar_tm nss (delete_id_and_con env name) body)
+  | TmLet(fi, name, s,  e, body) ->
+     TmLet(fi, empty_mangle name, s, desugar_tm nss env e, desugar_tm nss (delete_id_and_con env name) body)
   | TmRecLets(fi, bindings, body) ->
-     let env' = List.fold_left (fun env' (_, name, _) -> delete_id_and_con env' name) env bindings
-     in TmRecLets(fi, List.map (fun (fi, name, e) -> (fi, empty_mangle name, desugar_tm nss env' e)) bindings, desugar_tm nss env' body)
-  | TmCondef(fi, name, ty, body) ->
-     TmCondef(fi, empty_mangle name, ty, desugar_tm nss (delete_id_and_con env name) body)
+     let env' = List.fold_left (fun env' (_, name,_, _) -> delete_id_and_con env' name) env bindings
+     in TmRecLets(fi, List.map (fun (fi, name, s, e) -> (fi, empty_mangle name, s, desugar_tm nss env' e)) bindings, desugar_tm nss env' body)
+  | TmCondef(fi, name, s, ty, body) ->
+     TmCondef(fi, empty_mangle name, s, ty, desugar_tm nss (delete_id_and_con env name) body)
   | (TmClos _) as tm -> tm
   (* Both introducing and referencing *)
   | TmMatch(fi, target, pat, thn, els) ->
     let desugar_pname env = function
-      | NameStr(n) -> (delete_id_and_con env n, NameStr(empty_mangle n))
+      | NameStr(n,s) -> (delete_id_and_con env n, NameStr(empty_mangle n,s))
       | NameWildcard -> (env, NameWildcard) in
     let rec desugar_pat env = function
        | PatNamed(fi,name) -> name |> desugar_pname env |> map_right (fun n -> PatNamed(fi,n))
@@ -288,19 +288,19 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
      let ns = List.fold_left add_decl previous_ns decls in
      (* wrap in "con"s *)
      let wrap_con ty_name (CDecl(fi, cname, ty)) tm =
-       TmCondef(fi, mangle cname, TyArrow(ty, TyCon ty_name), tm) in (* TODO(vipa): the type will likely be incorrect once we start doing product extensions of constructors *)
+       TmCondef(fi, mangle cname, 0, TyArrow(ty, TyCon ty_name), tm) in (* TODO(vipa): the type will likely be incorrect once we start doing product extensions of constructors *)
      let wrap_data decl tm = match decl with (* TODO(vipa): this does not declare the type itself *)
        | Data(_, name, cdecls) -> List.fold_right (wrap_con name) cdecls tm
        | _ -> tm in
      (* translate "Inter"s into (info * ustring * tm) *)
      let inter_to_tm fname fi params cases =
        let target = us"__sem_target" in
-       let wrap_param (Param(fi, name, ty)) tm = TmLam(fi, name, ty, tm)
-       in TmLam(fi, target, TyDyn, translate_cases fname (var target) cases)
+       let wrap_param (Param(fi, name, ty)) tm = TmLam(fi, name, 0, ty, tm)
+       in TmLam(fi, target, 0, TyDyn, translate_cases fname (var target) cases)
           |> List.fold_right wrap_param params
           |> desugar_tm nss ns in
      let translate_inter = function
-       | Inter(fi, name, params, cases) -> Some (fi, mangle name, inter_to_tm name fi params cases)
+       | Inter(fi, name, params, cases) -> Some (fi, mangle name, 0, inter_to_tm name fi params cases)
        | _ -> None in
      (* put translated inters in a single letrec, then wrap in cons, then done *)
      let wrap tm = TmRecLets(NoInfo, List.filter_map translate_inter decls, tm)
@@ -309,13 +309,14 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
 
   (* The other tops are trivial translations *)
   | TopLet(Let(fi, id, tm)) ->
-     let wrap tm' = TmLet(fi, empty_mangle id, desugar_tm nss emptyMlangEnv tm, tm')
+     let wrap tm' = TmLet(fi, empty_mangle id, 0, desugar_tm nss emptyMlangEnv tm, tm')
      in (nss, (wrap :: stack))
   | TopRecLet(RecLet(fi, lets)) ->
-     let wrap tm' = TmRecLets(fi, List.map (fun (fi', id, tm) -> fi', empty_mangle id, desugar_tm nss emptyMlangEnv tm) lets, tm')
+    let wrap tm' = TmRecLets(fi, List.map (fun (fi', id, tm) -> (fi',
+      empty_mangle id, 0, desugar_tm nss emptyMlangEnv tm)) lets, tm')
      in (nss, (wrap :: stack))
   | TopCon(Con(fi, id, ty)) ->
-     let wrap tm' = TmCondef(fi, id, ty, tm')
+     let wrap tm' = TmCondef(fi, id, 0, ty, tm')
      in (nss, (wrap :: stack))
 
 let desugar_post_flatten (Program(_, tops, t)) =

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -226,19 +226,20 @@ mexpr:
       { $6 }
   | REC lets IN mexpr
       { let fi = mkinfo $1.i $3.i in
-         TmRecLets(fi,$2,$4) }
+        let lst = List.map (fun (fi,x,t) -> (fi,x,0,t)) $2 in
+         TmRecLets(fi,lst,$4) }
   | LET IDENT ty_op EQ mexpr IN mexpr
       { let fi = mkinfo $1.i $6.i in
-        TmLet(fi,$2.v,$5,$7) }
+        TmLet(fi,$2.v,0,$5,$7) }
   | LAM IDENT ty_op DOT mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
-        TmLam(fi,$2.v,$3,$5) }
+        TmLam(fi,$2.v,0,$3,$5) }
   | IF mexpr THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $6) in
         TmMatch(fi,$2,PatBool(NoInfo,true),$4,$6) }
   | CON IDENT ty_op IN mexpr
       { let fi = mkinfo $1.i $4.i in
-        TmCondef(fi,$2.v,$3,$5)}
+        TmCondef(fi,$2.v,0,$3,$5)}
   | MATCH mexpr WITH pat THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $8) in
          TmMatch(fi,$2,$4,$6,$8) }
@@ -255,8 +256,7 @@ lets:
         [(fi, $2.v, $5)] }
   | LET IDENT ty_op EQ mexpr lets
       { let fi = mkinfo $1.i (tm_info $5) in
-         (fi, $2.v, $5)::$6 }
-
+        (fi, $2.v, $5)::$6 }
 
 
 left:
@@ -327,7 +327,7 @@ name:
   | IDENT
       { if $1.v =. us"_"
         then PatNamed($1.i, NameWildcard)
-        else PatNamed($1.i, NameStr($1.v)) }
+        else PatNamed($1.i, NameStr($1.v,0)) }
 
 pat:
   | name
@@ -337,9 +337,9 @@ pat:
   | patseq
       { PatSeq($1 |> fst, $1 |> snd |> Mseq.of_list, SeqMatchTotal) }
   | patseq CONCAT IDENT
-      { PatSeq($1 |> fst, $1 |> snd |> Mseq.of_list, SeqMatchPrefix(NameStr($3.v))) }
+      { PatSeq($1 |> fst, $1 |> snd |> Mseq.of_list, SeqMatchPrefix(NameStr($3.v,0))) }
   | IDENT CONCAT patseq
-      { PatSeq($3 |> fst, $3 |> snd |> Mseq.of_list, SeqMatchPostfix(NameStr($1.v))) }
+      { PatSeq($3 |> fst, $3 |> snd |> Mseq.of_list, SeqMatchPostfix(NameStr($1.v,0))) }
   | LPAREN pat RPAREN
       { $2 }
   | LPAREN pat COMMA pat_list RPAREN

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -272,7 +272,7 @@ atom:
   | LPAREN seq RPAREN    { if List.length $2 = 1 then List.hd $2
                            else TmTuple(mkinfo $1.i $3.i,$2) }
   | LPAREN RPAREN        { TmConst($1.i, Cunit) }
-  | IDENT                { TmVar($1.i,$1.v,noidx) }
+  | IDENT                { TmVar($1.i,$1.v,nosym) }
   | CHAR                 { TmConst($1.i, CChar(List.hd (ustring2list $1.v))) }
   | UINT                 { TmConst($1.i,CInt($1.v)) }
   | UFLOAT               { TmConst($1.i,CFloat($1.v)) }
@@ -333,7 +333,7 @@ pat:
   | name
       { $1 }
   | IDENT pat
-      { PatCon(mkinfo $1.i (pat_info $2), $1.v, noidx, $2) }
+      { PatCon(mkinfo $1.i (pat_info $2), $1.v, nosym, $2) }
   | patseq
       { PatSeq($1 |> fst, $1 |> snd |> Mseq.of_list, SeqMatchTotal) }
   | patseq CONCAT IDENT

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -12,13 +12,13 @@ open Ast
 open Format
 open Ustring.Op
 
-(** Whether or not debruijn printin is the default (this can still be changed
+(** Whether or not symbol printin is the default (this can still be changed
  *  through optional arguments) *)
-let enable_debug_debruijn_print = ref false
+let enable_debug_symbol_print = ref false
 
-(** Global configuration for debruijn printing. Needed because of the unwieldy
+(** Global configuration for symbol printing. Needed because of the unwieldy
  *  interface to the Format module *)
-let ref_debruijn = ref false
+let ref_symbol = ref false
 
 (** Global configuration for indentation size. Needed because of the unwieldy
  *  interface to the Format module *)
@@ -28,9 +28,9 @@ let ref_indent      = ref 2
 let string_of_ustring = Ustring.to_utf8
 
 (** Create string representation of variable *)
-let ustring_of_var x n =
-  if !ref_debruijn
-  then x ^. us(sprintf "'%d" n) else x
+let ustring_of_var x s =
+  if !ref_symbol
+  then x ^. (if s == -1 then us"#" else us(sprintf "#%d" s)) else x
 
 (** Create a string from a uchar, as it would appear in a string literal. *)
 let lit_of_uchar c =
@@ -265,7 +265,8 @@ and print_tm' fmt t = match t with
 
   | TmVar(_,x,s) ->
     let print = string_of_ustring (ustring_of_var x s) in
-    fprintf fmt "%s#%d" print s
+  (*  fprintf fmt "%s#%d" print s *)
+    fprintf fmt "%s" print
 
   | TmLam(_,x,_,ty,t1) ->
     let x = string_of_ustring x in
@@ -417,7 +418,7 @@ and print_env fmt env =
 
 (** Helper function for configuring the string formatter and printing *)
 let ustr_formatter_print
-    ?(debruijn   = !enable_debug_debruijn_print)
+    ?(symbol   = !enable_debug_symbol_print)
     ?(indent     = 2)
     ?(max_indent = 68)
     ?(margin     = max_int)
@@ -426,7 +427,7 @@ let ustr_formatter_print
     printer arg =
 
   (* Configure global settings *)
-  ref_debruijn := debruijn;
+  ref_symbol := symbol;
   ref_indent   := indent;
   pp_set_margin     str_formatter margin;
   pp_set_max_indent str_formatter max_indent;
@@ -446,20 +447,20 @@ let ustr_formatter_print
 
 (** Convert terms to strings.
  *  TODO Messy with optional arguments passing. Alternatives? *)
-let ustring_of_tm ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix t =
-  ustr_formatter_print ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix
+let ustring_of_tm ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix t =
+  ustr_formatter_print ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix
     print_tm (Match, t)
 
 (** Converting constants to strings.
  *  TODO Messy with optional arguments passing. Alternatives? *)
-let ustring_of_const ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix c =
-  ustr_formatter_print ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix
+let ustring_of_const ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix c =
+  ustr_formatter_print ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix
     print_const c
 
 (** Converting environments to strings.
  *  TODO Messy with optional arguments passing. Alternatives? *)
-let ustring_of_env ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix e =
-  ustr_formatter_print ?debruijn ?indent ?max_indent ?margin ?max_boxes ?prefix
+let ustring_of_env ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix e =
+  ustr_formatter_print ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix
     print_env e
 
 (** TODO: Print mlang part as well. *)


### PR DESCRIPTION
Updated the boot interpreter to use symbols instead of debruijn indices for representing names (variable names, pattern names etc.). The rationale is two fold: (1) it is easier to implement OR-patterns, and (2) this is the pattern we will use in the MLang implementation because it simplifies program transformations.