### PR TITLE
Fancy patterns in boot

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -166,22 +166,21 @@ and patName =
 | NameStr of ustring * sym                        (* A normal pattern name *)
 | NameWildcard                                    (* Pattern wildcard *)
 
-(* Kind of sequence matching in patterns *)
-and seqMatchType =
-| SeqMatchPrefix of patName
-| SeqMatchPostfix of patName
-| SeqMatchTotal
-
 (* Patterns *)
 and pat =
-| PatNamed of info * patName                      (* Named, capturing wildcard *)
-| PatSeq   of info * pat Mseq.t * seqMatchType    (* Sequence pattern *)
-| PatTuple of info * pat list                     (* Tuple pattern *)
-| PatCon   of info * ustring * sym * pat          (* Constructor pattern *)
-| PatInt   of info * int                          (* Int pattern *)
-| PatChar  of info * int                          (* Char pattern *)
-| PatBool  of info * bool                         (* Boolean pattern *)
-| PatUnit  of info                                (* Unit pattern *)
+| PatNamed  of info * patName                     (* Named, capturing wildcard *)
+| PatSeqTot of info * pat Mseq.t                  (* Exact sequence patterns *)
+| PatSeqEdg of info * pat Mseq.t * patName * pat Mseq.t (* Sequence edge patterns *)
+| PatTuple  of info * pat list                    (* Tuple pattern *)
+| PatRecord of info * pat Record.t                (* Record pattern *)
+| PatCon    of info * ustring * sym * pat         (* Constructor pattern *)
+| PatInt    of info * int                         (* Int pattern *)
+| PatChar   of info * int                         (* Char pattern *)
+| PatBool   of info * bool                        (* Boolean pattern *)
+| PatUnit   of info                               (* Unit pattern *)
+| PatAnd    of info * pat * pat                   (* And pattern *)
+| PatOr     of info * pat * pat                   (* Or pattern *)
+| PatNot    of info * pat                         (* Not pattern *)
 
 
 (* Types *)
@@ -257,13 +256,18 @@ let tm_info = function
 
 let pat_info = function
   | PatNamed(fi,_) -> fi
-  | PatSeq(fi,_,_) -> fi
+  | PatSeqTot(fi, _) -> fi
+  | PatSeqEdg(fi, _, _, _) -> fi
   | PatTuple(fi,_) -> fi
+  | PatRecord(fi, _) -> fi
   | PatCon(fi,_,_,_) -> fi
   | PatInt(fi,_) -> fi
   | PatChar(fi,_) -> fi
   | PatBool(fi,_) -> fi
   | PatUnit(fi) -> fi
+  | PatAnd(fi, _, _) -> fi
+  | PatOr(fi, _, _) -> fi
+  | PatNot(fi, _) -> fi
 
 
 (* Converts a sequence of terms to a ustring *)

--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -56,6 +56,8 @@ let reserved_strings = [
   (",",             fun(i) -> Parser.COMMA{i=i;v=()});
   (".",             fun(i) -> Parser.DOT{i=i;v=()});
   ("|",             fun(i) -> Parser.BAR{i=i;v=()});
+  ("&",             fun(i) -> Parser.AND{i=i;v=()});
+  ("!",             fun(i) -> Parser.NOT{i=i;v=()});
   ("->",            fun(i) -> Parser.ARROW{i=i;v=()});
 
 ]
@@ -146,8 +148,8 @@ let ident = ('_'| lcase_letter) (digit | '_' | us_letter)*
 let uident = ucase_letter (digit | '_' | us_letter)*
 
 let symtok =  "="  | "+" |  "-" | "*"  | "/" | "%"  | "<"  | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "==" |
-              "!=" | "!" | "&&" | "||" | "++"| "$"  | "("  | ")"  | "["  | "]" | "{"  | "}"  |
-              "::" | ":" | ","  | "."  | "|" | "->" | "=>" | "++"
+              "!=" | "!" | "&&" | "||" | "++"| "$" | "("  | ")"  | "["  | "]" | "{"  | "}"  |
+              "::" | ":" | ","  | "."  | "&" | "|" | "->" | "=>" | "++"
 
 
 let line_comment = "//" [^ '\013' '\010']*

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -324,6 +324,12 @@ patseq:
   | STRING
       { ($1.i, List.map (fun x -> PatChar($1.i,x)) (ustring2list $1.v)) }
 
+pat_labels:
+  | IDENT EQ pat
+    {[($1.v, $3)]}
+  | IDENT EQ pat COMMA pat_labels
+    {($1.v, $3)::$5}
+
 
 name:
   | IDENT
@@ -364,6 +370,11 @@ pat_atom:
   | LPAREN pat COMMA pat_list RPAREN
       { let fi = mkinfo $1.i $5.i
         in PatTuple(fi, $2 :: $4) }
+  | LBRACKET RBRACKET
+      { PatRecord(mkinfo $1.i $2.i, Record.empty) }
+  | LBRACKET pat_labels RBRACKET
+      { PatRecord(mkinfo $1.i $3.i, $2 |> List.fold_left
+                  (fun acc (k,v) -> Record.add k v acc) Record.empty) }
   | UINT /* TODO: enable matching against negative ints */
       { PatInt($1.i, $1.v) }
   | CHAR

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -69,6 +69,8 @@
 %token <unit Ast.tokendata> COMMA         /* ","   */
 %token <unit Ast.tokendata> DOT           /* "."   */
 %token <unit Ast.tokendata> BAR           /* "|"   */
+%token <unit Ast.tokendata> AND           /* "&"   */
+%token <unit Ast.tokendata> NOT           /* "!"   */
 %token <unit Ast.tokendata> CONCAT        /* "++"  */
 
 %start main
@@ -326,20 +328,37 @@ patseq:
 name:
   | IDENT
       { if $1.v =. us"_"
-        then PatNamed($1.i, NameWildcard)
-        else PatNamed($1.i, NameStr($1.v,0)) }
+        then ($1.i, NameWildcard)
+        else ($1.i, NameStr($1.v,0)) }
 
 pat:
-  | name
+  | pat_conj BAR pat
+      { PatOr(mkinfo (pat_info $1) (pat_info $3), $1, $3) }
+  | pat_conj
       { $1 }
-  | IDENT pat
+pat_conj:
+  | pat_atom AND pat_conj
+      { PatAnd(mkinfo (pat_info $1) (pat_info $3), $1, $3)}
+  | pat_atom
+      { $1 }
+pat_atom:
+  | name
+      { PatNamed(fst $1, snd $1) }
+  | NOT pat_atom
+      { PatNot(mkinfo $1.i (pat_info $2), $2) }
+  | IDENT pat_atom
       { PatCon(mkinfo $1.i (pat_info $2), $1.v, nosym, $2) }
   | patseq
-      { PatSeq($1 |> fst, $1 |> snd |> Mseq.of_list, SeqMatchTotal) }
-  | patseq CONCAT IDENT
-      { PatSeq($1 |> fst, $1 |> snd |> Mseq.of_list, SeqMatchPrefix(NameStr($3.v,0))) }
-  | IDENT CONCAT patseq
-      { PatSeq($3 |> fst, $3 |> snd |> Mseq.of_list, SeqMatchPostfix(NameStr($1.v,0))) }
+      { PatSeqTot($1 |> fst, $1 |> snd |> Mseq.of_list) }
+  | patseq CONCAT name CONCAT patseq
+      { let fi = mkinfo (fst $1) (fst $5) in
+        let l = $1 |> snd |> Mseq.of_list in
+        let r = $5 |> snd |> Mseq.of_list in
+        PatSeqEdg(fi, l, snd $3, r) }
+  | patseq CONCAT name
+      { PatSeqEdg(mkinfo (fst $1) (fst $3), $1 |> snd |> Mseq.of_list, snd $3, Mseq.empty) }
+  | name CONCAT patseq
+      { PatSeqEdg(mkinfo (fst $1) (fst $3), Mseq.empty, snd $1, $3 |> snd |> Mseq.of_list) }
   | LPAREN pat RPAREN
       { $2 }
   | LPAREN pat COMMA pat_list RPAREN

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -69,6 +69,8 @@ utest match s1 with [1,3,5,10] then true else false with true in
 utest match s1 with [1,3] ++ _ then true else false with true in
 utest match s1 with [2,3] ++ _ then true else false with false in
 utest match s1 with [1,a] ++ _ then a else 0 with 3 in
+utest let _ = [] in match s1 with [b] ++ _ then let a = 2 in (a, b, _) else (0, 0, []) with (2, 1, []) in
+utest let _ = [] in match s1 with _ ++ [b] then let a = 2 in (a, b, _) else (0, 0, []) with (2, 10, []) in
 utest match s1 with [_,a] ++ b then (a,b) else (0,[]) with (3,[5,10]) in
 utest match s1 with _ ++ [5,10] then true else false with true in
 utest match s1 with _ ++ [5,11] then true else false with false in
@@ -77,6 +79,9 @@ utest match s1 with first ++ [1,2] then true else false with false in
 utest match s1 with [1,x] ++ rest then (x,rest) else (0,[]) with (3,[5,10]) in
 utest match s1 with first ++ [x,y] then (x,y,first) else (0,0,[]) with (5,10,[1,3]) in
 utest match s1 with first ++ [x,y,10] then (first,x,y) else ([],0,0) with ([1],3,5) in
+utest match s1 with [1] ++ mid ++ [10] then mid else [] with [3, 5] in
+utest match s1 with [1,3] ++ mid ++ [10] then mid else [] with [5] in
+utest match s1 with [a,b] ++ mid ++ [c] then (a, b, mid, c) else (0, 0, [], 0) with (1, 3, [5], 10) in
 
 utest match "foo" with ['f','o','o'] then true else false with true in
 utest match "foo" with "foo" then true else false with true in
@@ -87,6 +92,8 @@ utest match "" with first then first else "-" with "" in
 utest match "" with [] then true else false with true in
 utest match "" with [] ++ rest then rest else "foo" with [] in
 utest match "" with first ++ [] then first else "foo" with [] in
+utest match "foobar" with "fo" ++ mid ++ "ar" then mid else "" with "ob" in
+utest match "foobar" with "fob" ++ mid ++ "ar" then mid else "" with "" in
 
 utest match [["a","b"],["c"]] with [a] then true else false with false in
 utest match [["a","b"],["c"]] with [a,b] then (a,b) else [] with (["a","b"],["c"]) in
@@ -96,6 +103,13 @@ utest match (1,[["a","b"],["c"]],76) with (1,[a]++b,76) then (a,b) else [] with 
 utest match (1,[["a","b"],["c"]],76) with (1,b++[a],76) then (a,b) else [] with (["c"],[["a","b"]]) in
 utest match (1,[["a","b"],["c"]],76) with (1,b++[["c"]],76) then b else [] with [["a","b"]] in
 
+-- Matching with "&", "|", "!"
+utest match true with !_ then true else false with false in
+utest match (1, 2) with (a, _) & (_, b) then (a, b) else (0, 0) with (1, 2) in
+utest match K1 1 with K1 a | K2 a | K3 a then a else 0 with 1 in
+utest match K2 2 with K1 a | K2 a | K3 a then a else 0 with 2 in
+utest match K3 3 with K1 a | K2 a | K3 a then a else 0 with 3 in
+utest match (true, true) with (true, a) & !(_, true) then a else false with false in
 
 -- Matching with never terms
 let x = true in

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -82,6 +82,8 @@ utest match s1 with first ++ [x,y,10] then (first,x,y) else ([],0,0) with ([1],3
 utest match s1 with [1] ++ mid ++ [10] then mid else [] with [3, 5] in
 utest match s1 with [1,3] ++ mid ++ [10] then mid else [] with [5] in
 utest match s1 with [a,b] ++ mid ++ [c] then (a, b, mid, c) else (0, 0, [], 0) with (1, 3, [5], 10) in
+utest match s1 with [] ++ _ then true else false with true in
+utest match true with [] ++ _ then true else false with false in
 
 utest match "foo" with ['f','o','o'] then true else false with true in
 utest match "foo" with "foo" then true else false with true in
@@ -102,6 +104,15 @@ utest match (1,[["a","b"],["c"]],76) with (1,[a,b],76) then (a,b) else [] with (
 utest match (1,[["a","b"],["c"]],76) with (1,[a]++b,76) then (a,b) else [] with (["a","b"],[["c"]]) in
 utest match (1,[["a","b"],["c"]],76) with (1,b++[a],76) then (a,b) else [] with (["c"],[["a","b"]]) in
 utest match (1,[["a","b"],["c"]],76) with (1,b++[["c"]],76) then b else [] with [["a","b"]] in
+
+-- Matching with records
+utest match {} with {blue = _} then true else false with false in
+utest match {blue = true} with {blue = _} then true else false with true in
+utest match {blue = true} with {blue = a} then a else false with true in
+utest match {blue = (1, 2)} with {blue = {}} then true else false with false in
+utest match {blue = {red = true}} with {blue = {}} then true else false with true in
+utest match {blue = true, red = true} with {blue = _} & {red = _} then true else false with true in
+utest match {blue = true} with {blue = _} & {red = _} then true else false with false in
 
 -- Matching with "&", "|", "!"
 utest match true with !_ then true else false with false in


### PR DESCRIPTION
This PR does three things:
- It changes pre-/postfix sequence patterns into a single thing, an edge pattern, that matches both at the same time. This wasn't allowed before (e.g. `[1, 2] ++ mid ++ [3, 4]` was previously impossible), but without introducing redundancy/ambiguity in the syntax (which is what #82 essentially did). This thus replaces and closes #82.
- It adds patterns for records. `{}` matches any record, `{foo = true}` matches any record that has a field `foo` with the value `true`.
- It adds `&`, `|`, and `!` patterns, corresponding to logical "and", "or", and "not". Note that order matters for `|`, the first pattern that matches is the one that binds names. This will only matter if there is overlap, e.g., `match (1, 2) with (a, _) | (_, a) then a else never` produces `1`. Order does not matter for `&` (modulo the comment mentioned further down).

All of this is only for `boot` for the moment.

Note also the comment in `mexpr.ml` starting at line 456 (post-change, I'm not figuring out how to link it properly). It means that we more or less assume no duplicate bindings in a pattern (except for in "or"-patterns), or that we're okay with it being `try_match` that decides which binding we get. It was easier to write the function this way than to write a function that both replaced by symbols and also checked for coherence of names across `|`, and also handled shadowing in a principled way.

I would suggest that the more long term solution to shadowing inside a single pattern (i.e., not between different `match`es or `let`s, but rather inside a single `match`) is that we disallow it entirely.