### PR TITLE
Change constructor handling in boot and MExpr

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -146,7 +146,7 @@ and tm =
 | TmRecord  of info * tm Record.t                                   (* Record *)
 | TmRecordUpdate of info * tm * ustring * tm                        (* Record update *)
 | TmCondef  of info * ustring * sym * ty * tm                       (* Constructor definition *)
-| TmConsym  of info * ustring * sym * tm option                     (* Constructor symbol *)
+| TmConapp  of info * ustring * sym * tm                            (* Constructor application *)
 | TmMatch   of info * tm * pat * tm * tm                            (* Match data *)
 | TmUse     of info * ustring * tm                                  (* Use a language *)
 | TmUtest   of info * tm * tm * tm                                  (* Unit testing *)
@@ -201,6 +201,12 @@ and vartype =
 | VarTm    of ustring
 
 
+(* Kind of indentifier *)
+and identkind =
+| IdentVar   (* A variable identifier *)
+| IdentCon   (* A constructor identifier *)
+| IdentAny   (* Any of the above *)
+
 let tmUnit = TmRecord(NoInfo,Record.empty)
 
 (* Value -1 means that there is no symbol yet assigned *)
@@ -223,7 +229,7 @@ let rec map_tm f = function
   | TmRecord(fi,r) -> f (TmRecord(fi,Record.map (map_tm f) r))
   | TmRecordUpdate(fi,r,l,t) -> f (TmRecordUpdate(fi,map_tm f r,l,map_tm f t))
   | TmCondef(fi,x,s,ty,t1) -> f (TmCondef(fi,x,s,ty,map_tm f t1))
-  | TmConsym(fi,k,s,ot) -> f (TmConsym(fi,k,s,Option.map (map_tm f) ot))
+  | TmConapp(fi,k,s,t) -> f (TmConapp(fi,k,s,t))
   | TmMatch(fi,t1,p,t2,t3) ->
     f (TmMatch(fi,map_tm f t1,p,map_tm f t2,map_tm f t3))
   | TmUse(fi,l,t1) -> f (TmUse(fi,l,map_tm f t1))
@@ -245,7 +251,7 @@ let tm_info = function
   | TmRecord(fi,_) -> fi
   | TmRecordUpdate(fi,_,_,_) -> fi
   | TmCondef(fi,_,_,_,_) -> fi
-  | TmConsym(fi,_,_,_) -> fi
+  | TmConapp(fi,_,_,_) -> fi
   | TmMatch(fi,_,_,_,_) -> fi
   | TmUse(fi,_,_) -> fi
   | TmUtest(fi,_,_,_) -> fi

--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -196,16 +196,14 @@ and ty =
 | TyRecord of (ustring * ty) list                 (* Record type *)
 | TyCon    of ustring                             (* Type constructor *)
 
-(* Variable type *)
-and vartype =
-| VarTm    of ustring
 
+(* Kind of identifier *)
+and ident =
+| IdVar   of sid    (* A variable identifier *)
+| IdCon   of sid    (* A constructor identifier *)
+| IdType  of sid    (* A type identifier *)
+| IdLabel of sid    (* A label identifier *)
 
-(* Kind of indentifier *)
-and identkind =
-| IdentVar   (* A variable identifier *)
-| IdentCon   (* A constructor identifier *)
-| IdentAny   (* Any of the above *)
 
 let tmUnit = TmRecord(NoInfo,Record.empty)
 

--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -115,7 +115,7 @@ let mkid s =
     let f = Hashtbl.find str_tab s in f (mkinfo_fast s)
   with Not_found ->
     let s2 = Ustring.from_utf8 s in
-    Parser.IDENT {i=mkinfo_ustring s2; v=s2}
+    Parser.LC_IDENT {i=mkinfo_ustring s2; v=s2}
 
 (* String handling *)
 let string_buf = Buffer.create 80
@@ -184,18 +184,21 @@ rule main = parse
   | ident | symtok as s
       { mkid s }
   | uident as s
-      { Parser.IDENT{i=mkinfo_fast s; v=Ustring.from_utf8 s} }  (* UIDENT *)
+      { Parser.UC_IDENT{i=mkinfo_fast s; v= Ustring.from_utf8 s} }
   | '\'' (utf8 as c) '\''
       { let s = Ustring.from_utf8 c in
         Parser.CHAR{i=mkinfo_ustring (us"'" ^. s ^. us"'"); v=s}}
-  | '#' (("ident") as ident) '"'
+  | '#' (("con" | "type" | "var" | "label") as ident) '"'
        { Buffer.reset string_buf ;  parsestring lexbuf;
 	 let s = Ustring.from_utf8 (Buffer.contents string_buf) in
-         let esc_s = Ustring.convert_escaped_chars s in
+         let id = Ustring.convert_escaped_chars s  in
          let fi = mkinfo_ustring (s ^. us"  #" ^. us(ident)) in
 	 let rval = (match ident with
-            | "var" -> Parser.IDENT{i=fi; v=esc_s}
-            | _ -> Parser.IDENT{i=fi; v=esc_s})  (* UIDENT *)
+            | "con"   -> Parser.CON_IDENT{i=fi; v=id}
+            | "type"  -> Parser.TYPE_IDENT{i=fi; v=id}
+            | "var"   -> Parser.VAR_IDENT{i=fi; v=id}
+            | "label" -> Parser.LABEL_IDENT{i=fi; v=id}
+            | _ -> failwith "Cannot happen")
          in
 	 add_colno 3; colcount_fast ident; rval}
   | '"'

--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -188,7 +188,7 @@ rule main = parse
   | '\'' (utf8 as c) '\''
       { let s = Ustring.from_utf8 c in
         Parser.CHAR{i=mkinfo_ustring (us"'" ^. s ^. us"'"); v=s}}
-  | '#' (("con" | "type" | "var") as ident) '"'
+  | '#' (("ident") as ident) '"'
        { Buffer.reset string_buf ;  parsestring lexbuf;
 	 let s = Ustring.from_utf8 (Buffer.contents string_buf) in
          let esc_s = Ustring.convert_escaped_chars s in

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -53,7 +53,7 @@ let builtin =
   |> List.map (fun (x,t) -> (x,gensym(),t))
 
 (* Mapping name to symbol *)
-let builtin_name2sym = List.map (fun (x,s,_) -> (us x,s)) builtin
+let builtin_name2sym = List.map (fun (x,s,_) -> (us x,(IdentVar,s))) builtin
 
 (* Mapping sym to term *)
 let builtin_sym2term = List.map (fun (_,s,t) -> (s,t)) builtin
@@ -434,16 +434,23 @@ let rec val_equal v1 v2 =
   | TmSeq(_,s1), TmSeq(_,s2) -> Mseq.equal val_equal s1 s2
   | TmRecord(_,r1), TmRecord(_,r2) -> Record.equal (fun t1 t2 -> val_equal t1 t2) r1 r2
   | TmConst(_,c1),TmConst(_,c2) -> c1 = c2
-  | TmConsym(_,_,sym1,None),TmConsym(_,_,sym2,None) ->sym1 = sym2
-  | TmConsym(_,_,sym1,Some(v1)),TmConsym(_,_,sym2,Some(v2)) -> sym1 = sym2 && val_equal v1 v2
+  | TmConapp(_,_,sym1,v1),TmConapp(_,_,sym2,v2) -> sym1 = sym2 && val_equal v1 v2
   | _ -> false
 
 
-(* Add symbol associations between lambdas, patterns, and variables *)
+type identType
+
+(* Add symbol associations between lambdas, patterns, and variables. The function also
+   constructs TmConapp terms from the combination of variables and function applications.  *)
 let rec symbolize env t =
-  let findsym fi x kind env = try List.assoc x env
-    with Not_found -> raise_error fi ("Unknown " ^ kind ^ " '" ^ Ustring.to_utf8 x ^ "'")
+  let findsymkind fi x kind env =
+    let str_of_kind x = match x with IdentVar -> "variable" | IdentCon -> "constructor" | IdentAny -> "identifier" in
+    let (kind_found,sym) = try List.assoc x env
+      with Not_found -> raise_error fi ("Unknown " ^ str_of_kind kind ^ " '" ^ Ustring.to_utf8 x ^ "'")
+    in if kind = IdentAny || kind_found = kind then (kind_found,sym)
+       else raise_error fi ("Expected a " ^ str_of_kind kind ^ " but found a " ^ str_of_kind kind_found ^ ".")
   in
+  let findsym fi x kind env = findsymkind fi x kind env |> snd in
   (* add_name is only called in sPat and it reuses previously generated symbols.
    * This is imperative for or-patterns, since both branches should give the same symbols,
    * e.g., [a] | [a, _] should give the same symbol to both "a"s.
@@ -451,70 +458,75 @@ let rec symbolize env t =
    * in a pattern in other cases. In particular, this means that, e.g., the pattern
    * [a, a] assigns the same symbol to both "a"s, which may or may not be desirable. Which
    * introduced binding gets used then depends on what try_match does for the pattern. *)
-  let add_name x env =
-    match List.assoc_opt x env with
-    | Some s -> (env, s)
-    | None -> let s = gensym() in ((x,s)::env, s) in
-  let rec s_pat_sequence env pats =
+  let add_name x patEnv =
+    match List.assoc_opt x patEnv with
+    | Some (_,s) -> (patEnv, s)
+    | None -> let s = gensym() in ((x,(IdentVar,s))::patEnv, s) in
+  let rec s_pat_sequence env patEnv pats =
     Mseq.fold_right
-      (fun p (env, ps) -> let (env, p) = sPat env p in (env, Mseq.cons p ps))
+      (fun p (patEnv, ps) -> let (patEnv, p) = sPat env patEnv p in (patEnv, Mseq.cons p ps))
       pats
-      (env, Mseq.empty)
-  and sPat patEnv = function
+      (patEnv, Mseq.empty)
+  and sPat env patEnv = function
     | PatNamed(fi,NameStr(x,_)) -> let (patEnv, s) = add_name x patEnv in (patEnv, PatNamed(fi,NameStr(x,s)))
     | PatNamed(_,NameWildcard) as pat -> (patEnv, pat)
     | PatSeqTot(fi, pats) ->
-       let (patEnv, pats) = s_pat_sequence patEnv pats
+       let (patEnv, pats) = s_pat_sequence env patEnv pats
        in (patEnv, PatSeqTot(fi, pats))
     | PatSeqEdg(fi, l, x, r) ->
-       let (patEnv, l) = s_pat_sequence patEnv l in
+       let (patEnv, l) = s_pat_sequence env patEnv l in
        let (patEnv, x) = match x with
          | NameWildcard -> (patEnv, NameWildcard)
-         | NameStr(x, _) -> let s = gensym() in ((x,s)::patEnv, NameStr(x, s)) in
-       let (patEnv, r) = s_pat_sequence patEnv r
+         | NameStr(x, _) -> let s = gensym() in ((x,(IdentVar,s))::patEnv, NameStr(x, s)) in
+       let (patEnv, r) = s_pat_sequence env patEnv r
        in (patEnv, PatSeqEdg(fi, l, x, r))
     | PatRecord(fi, pats) ->
        let patEnv = ref patEnv in
-       let pats = Record.map (fun p -> let (patEnv', p) = sPat !patEnv p in patEnv := patEnv'; p) pats
+       let pats = Record.map (fun p -> let (patEnv', p) = sPat env !patEnv p in patEnv := patEnv'; p) pats
        in (!patEnv, PatRecord(fi, pats))
-    | PatCon(fi,cx,_,p) ->
-       let cxId = findsym fi cx "constructor" env in
-       let (patEnv, p) = sPat patEnv p
-       in (patEnv,PatCon(fi,cx,cxId,p))
+    | PatCon(fi,x,_,p) ->
+       let s = findsym fi x IdentCon env in
+       let (patEnv, p) = sPat env patEnv p
+       in (patEnv,PatCon(fi,x,s,p))
     | PatInt _ as p -> (patEnv,p)
     | PatChar _ as p -> (patEnv,p)
     | PatBool _ as p -> (patEnv,p)
     | PatUnit _ as p -> (patEnv,p)
     | PatAnd(fi, l, r) ->
-       let (patEnv, l) = sPat patEnv l in
-       let (patEnv, r) = sPat patEnv r
+       let (patEnv, l) = sPat env patEnv l in
+       let (patEnv, r) = sPat env patEnv r
        in (patEnv, PatAnd(fi, l, r))
     | PatOr(fi, l, r) ->
-       let (patEnv, l) = sPat patEnv l in
-       let (patEnv, r) = sPat patEnv r
+       let (patEnv, l) = sPat env patEnv l in
+       let (patEnv, r) = sPat env patEnv r
        in (patEnv, PatOr(fi, l, r))
     | PatNot _ as p -> (patEnv, p) (* NOTE(vipa): names in a not-pattern do not matter since they will never bind (it should be an error to bind a name inside a not-pattern, but we're not doing that kind of static checks yet *)
   in
   match t with
-  | TmVar(fi,x,_) -> TmVar(fi,x,findsym fi x "variable" env)
-  | TmLam(fi,x,_,ty,t1) -> let s = gensym() in TmLam(fi,x,s,ty,symbolize ((x,s)::env) t1)
+  | TmVar(fi,x,_) -> TmVar(fi,x,findsym fi x IdentVar env)
+  | TmLam(fi,x,_,ty,t1) -> let s = gensym() in TmLam(fi,x,s,ty,symbolize ((x,(IdentVar,s))::env) t1)
   | TmClos(_,_,_,_,_,_) -> failwith "Closures should not be available."
-  | TmLet(fi,x,_,t1,t2) -> let s = gensym() in TmLet(fi,x,s,symbolize env t1,symbolize ((x,s)::env) t2)
+  | TmLet(fi,x,_,t1,t2) -> let s = gensym() in TmLet(fi,x,s,symbolize env t1,symbolize ((x,(IdentVar,s))::env) t2)
   | TmRecLets(fi,lst,tm) ->
-     let env2 = List.fold_left (fun env (_,x,_,_) -> let s = gensym() in (x,s)::env) env lst in
-     TmRecLets(fi,List.map (fun (fi,x,_,t) -> (fi,x,findsym fi x "variable" env2, symbolize env2 t))
+     let env2 = List.fold_left (fun env (_,x,_,_) -> let s = gensym() in (x,(IdentVar,s))::env) env lst in
+     TmRecLets(fi,List.map (fun (fi,x,_,t) -> (fi,x,findsym fi x IdentVar env2, symbolize env2 t))
        lst, symbolize env2 tm)
+  | TmApp(fi1,(TmVar(fi2,x,_) as t1), t2) ->
+    let (kind,s) = findsymkind fi2 x IdentAny  env in
+    (match kind with
+     | IdentVar -> TmApp(fi1,symbolize env t1, symbolize env t2)
+     | IdentCon -> TmConapp(fi1,x,s,symbolize env t2)
+     | IdentAny -> failwith "Cannot be in the environment")
   | TmApp(fi,t1,t2) -> TmApp(fi,symbolize env t1,symbolize env t2)
   | TmConst(_,_) -> t
   | TmFix(_) -> t
   | TmSeq(fi,tms) -> TmSeq(fi,Mseq.map (symbolize env) tms)
   | TmRecord(fi,r) -> TmRecord(fi,Record.map (symbolize env) r)
   | TmRecordUpdate(fi,t1,l,t2) -> TmRecordUpdate(fi,symbolize env t1,l,symbolize env t2)
-  | TmCondef(fi,x,_,ty,t) -> let s = gensym() in TmCondef(fi,x,s,ty,symbolize ((x,s)::env) t)
-  | TmConsym(fi,x,sym,tmop) ->
-     TmConsym(fi,x,sym,match tmop with | None -> None | Some(t) -> Some(symbolize env t))
+  | TmCondef(fi,x,_,ty,t) -> let s = gensym() in TmCondef(fi,x,s,ty,symbolize ((x,(IdentCon,s))::env) t)
+  | TmConapp(fi,_,_,_) -> raise_error fi ("Construct is used without application")
   | TmMatch(fi,t1,p,t2,t3) ->
-     let (matchedEnv, p) = sPat [] p in
+     let (matchedEnv, p) = sPat env [] p in
      TmMatch(fi,symbolize env t1,p,symbolize (matchedEnv @ env) t2,symbolize env t3)
   | TmUse(fi,l,t) -> TmUse(fi,l,symbolize env t)
   | TmUtest(fi,t1,t2,tnext)
@@ -565,10 +577,9 @@ let rec try_match env value pat =
          in Record.merge merge_f vs pats
             |> (fun merged -> Record.fold (fun _ f env -> f env) merged (Some env))
       | _ -> None)
-  | PatCon(_,_,cxId,p) ->
-     (match value, List.assoc cxId env with
-      | TmConsym(_,_,sym1,Some v), TmConsym(_,_,sym2,_)
-           when sym1 = sym2 -> try_match env v p
+  | PatCon(_,_,s1,p) ->
+     (match value with
+      | TmConapp(_,_,s2,v) when s1 = s2 -> try_match env v p
       | _ -> None)
   | PatInt(_, i) ->
      (match value with
@@ -623,11 +634,6 @@ let rec eval (env : (sym * tm) list) (t : tm) =
        | TmClos(_,_,s,_,t3,env2) -> eval ((s,eval env t2)::Lazy.force env2) t3
        (* Constant application using the delta function *)
        | TmConst(_,c) -> delta eval env fiapp c (eval env t2)
-       (* Constructor application *)
-       | TmConsym(fi,x,sym,None) -> TmConsym(fi,x,sym,Some(eval env t2))
-       | TmConsym(_,x,_,Some(_)) ->
-          raise_error fiapp ("Cannot apply constructor '" ^ Ustring.to_utf8 x ^
-                               "' more than once")
        (* Fix *)
        | TmFix(_) ->
          (match eval env t2 with
@@ -654,8 +660,8 @@ let rec eval (env : (sym * tm) list) (t : tm) =
          raise_error fi ("Cannot update the term. The term is not a record: "
                          ^ Ustring.to_utf8 (ustring_of_tm v)))
   (* Data constructors and match *)
-  | TmCondef(fi,x,s,_,t) -> eval ((s,TmConsym(fi,x,s,None))::env) t
-  | TmConsym(_,_,_,_) as tm -> tm
+  | TmCondef(_,_,_,_,t) -> eval env t
+  | TmConapp(fi,x,s,t) -> TmConapp(fi,x,s,eval env t)
   | TmMatch(_,t1,p,t2,t3) ->
      (match try_match env (eval env t1) p with
       | Some env -> eval env t2

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -200,7 +200,8 @@ let resolve_id {normals; _} ident =
   | Some(ident') -> ident'
   | None -> empty_mangle ident
 
-(* TODO(vipa): this function is here since the current implementation has variables and constructors in the same namespace, it should be replaced by correct uses of resolve_id and resolve_con *)
+(* TODO(vipa): this function is here since the current implementation has variables and constructors in the same namespace, it should be replaced by correct uses of resolve_id and resolve_con
+   I am not sure what this is doing now, and if we can remove it. *)
 let resolve_id_or_con {constructors; normals} ident =
   match USMap.find_opt ident normals with
   | Some ident' -> ident'
@@ -219,7 +220,6 @@ let rec desugar_tm nss env =
   in function
   (* Referencing things *)
   | TmVar(fi, name, i) -> TmVar(fi, resolve_id_or_con env name, i)
-  | (TmConsym _) as tm -> tm
   (* Introducing things *)
   | TmLam(fi, name, s, ty, body) ->
      TmLam(fi, empty_mangle name, s, ty, desugar_tm nss (delete_id_and_con env name) body)
@@ -230,6 +230,7 @@ let rec desugar_tm nss env =
      in TmRecLets(fi, List.map (fun (fi, name, s, e) -> (fi, empty_mangle name, s, desugar_tm nss env' e)) bindings, desugar_tm nss env' body)
   | TmCondef(fi, name, s, ty, body) ->
      TmCondef(fi, empty_mangle name, s, ty, desugar_tm nss (delete_id_and_con env name) body)
+  | TmConapp(fi,x,s,t) -> TmConapp(fi,x,s,desugar_tm nss env t)
   | (TmClos _) as tm -> tm
   (* Both introducing and referencing *)
   | TmMatch(fi, target, pat, thn, els) ->

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -214,7 +214,7 @@ cases:
   |
     { [] }
 case:
-  | BAR con_ident ARROW mexpr
+  | BAR var_ident ARROW mexpr
     { let fi = mkinfo $1.i $3.i in
       (VarPattern (fi, $2.v), $4) }
   | BAR con_ident binder ARROW mexpr

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -1,3 +1,4 @@
+
 /*
    Miking is licensed under the MIT license.
    Copyright (C) David Broman. See file LICENSE.txt
@@ -26,11 +27,19 @@
 
 /* Misc tokens */
 %token EOF
-%token <Ustring.ustring Ast.tokendata> IDENT
+
+/* Use the non-terminals 'con_ident', 'var_ident', 'type_ident', and 'ident' instead of the below */
+%token <Ustring.ustring Ast.tokendata> CON_IDENT
+%token <Ustring.ustring Ast.tokendata> VAR_IDENT
+%token <Ustring.ustring Ast.tokendata> TYPE_IDENT
+%token <Ustring.ustring Ast.tokendata> LABEL_IDENT
+%token <Ustring.ustring Ast.tokendata> UC_IDENT  /* An identifier that starts with an upper-case letter */
+%token <Ustring.ustring Ast.tokendata> LC_IDENT  /* An identifier that starts with "_" or a lower-case letter */
 %token <Ustring.ustring Ast.tokendata> STRING
 %token <Ustring.ustring Ast.tokendata> CHAR
 %token <int Ast.tokendata> UINT
 %token <float Ast.tokendata> UFLOAT
+
 
 /* Keywords */
 %token <unit Ast.tokendata> IF
@@ -108,9 +117,9 @@ tops:
   |
     { [] }
   // TODO: These should matter with a type system
-  | TYPE IDENT tops
+  | TYPE type_ident tops
     { $3 }
-  | TYPE IDENT EQ ty tops
+  | TYPE type_ident EQ ty tops
     { $5 }
 
 top:
@@ -124,7 +133,7 @@ top:
     { TopCon($1) }
 
 toplet:
-  | LET IDENT ty_op EQ mexpr
+  | LET var_ident ty_op EQ mexpr
     { let fi = mkinfo $1.i $4.i in
       Let (fi, $2.v, $5) }
 
@@ -134,12 +143,12 @@ topRecLet:
       RecLet (fi, $2) }
 
 topcon:
-  | CON IDENT ty_op
+  | CON con_ident ty_op
     { let fi = mkinfo $1.i $2.i in
       Con (fi, $2.v, $3) }
 
 mlang:
-  | LANG IDENT lang_includes lang_body
+  | LANG ident lang_includes lang_body
     { let fi = if List.length $3 > 0 then
                  mkinfo $1.i (List.nth $3 (List.length $3 - 1)).i
                else
@@ -153,9 +162,9 @@ lang_includes:
   |
     { [] }
 lang_list:
-  | IDENT ADD lang_list
+  | ident ADD lang_list
     { $1 :: $3 }
-  | IDENT
+  | ident
     { [$1] }
 
 lang_body:
@@ -169,10 +178,10 @@ decls:
   |
     { [] }
 decl:
-  | SYN IDENT EQ constrs
+  | SYN type_ident EQ constrs
     { let fi = mkinfo $1.i $3.i in
       Data (fi, $2.v, $4) }
-  | SEM IDENT params EQ cases
+  | SEM var_ident params EQ cases
     { let fi = mkinfo $1.i $4.i in
       Inter (fi, $2.v, $3, $5) }
 
@@ -182,7 +191,7 @@ constrs:
   |
     { [] }
 constr:
-  | BAR IDENT constr_params
+  | BAR con_ident constr_params
     { let fi = mkinfo $1.i $2.i in
       CDecl(fi, $2.v, $3) }
 
@@ -193,7 +202,7 @@ constr_params:
     { TyUnit }
 
 params:
-  | LPAREN IDENT COLON ty RPAREN params
+  | LPAREN var_ident COLON ty RPAREN params
     { let fi = mkinfo $1.i $5.i in
       Param (fi, $2.v, $4) :: $6 }
   |
@@ -205,16 +214,16 @@ cases:
   |
     { [] }
 case:
-  | BAR IDENT ARROW mexpr
+  | BAR con_ident ARROW mexpr
     { let fi = mkinfo $1.i $3.i in
       (VarPattern (fi, $2.v), $4) }
-  | BAR IDENT binder ARROW mexpr
+  | BAR con_ident binder ARROW mexpr
     { let fi = mkinfo $1.i $4.i in
       (ConPattern (fi, $2.v, $3), $5)}
 binder:
-  | LPAREN IDENT RPAREN
+  | LPAREN var_ident RPAREN
     { $2.v }
-  | IDENT
+  | var_ident
     { $1.v }
 
 /// Expression language ///////////////////////////////
@@ -224,30 +233,30 @@ binder:
 mexpr:
   | left
       { $1 }
-  | TYPE IDENT IN mexpr
+  | TYPE type_ident IN mexpr
       { $4 }
-  | TYPE IDENT EQ ty IN mexpr
+  | TYPE type_ident EQ ty IN mexpr
       { $6 }
   | REC lets IN mexpr
       { let fi = mkinfo $1.i $3.i in
         let lst = List.map (fun (fi,x,t) -> (fi,x,0,t)) $2 in
          TmRecLets(fi,lst,$4) }
-  | LET IDENT ty_op EQ mexpr IN mexpr
+  | LET var_ident ty_op EQ mexpr IN mexpr
       { let fi = mkinfo $1.i $6.i in
         TmLet(fi,$2.v,0,$5,$7) }
-  | LAM IDENT ty_op DOT mexpr
+  | LAM var_ident ty_op DOT mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
         TmLam(fi,$2.v,0,$3,$5) }
   | IF mexpr THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $6) in
         TmMatch(fi,$2,PatBool(NoInfo,true),$4,$6) }
-  | CON IDENT ty_op IN mexpr
+  | CON con_ident ty_op IN mexpr
       { let fi = mkinfo $1.i $4.i in
         TmCondef(fi,$2.v,0,$3,$5)}
   | MATCH mexpr WITH pat THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $8) in
          TmMatch(fi,$2,$4,$6,$8) }
-  | USE IDENT IN mexpr
+  | USE ident IN mexpr
       { let fi = mkinfo $1.i $3.i in
         TmUse(fi,$2.v,$4) }
   | UTEST mexpr WITH mexpr IN mexpr
@@ -255,10 +264,10 @@ mexpr:
         TmUtest(fi,$2,$4,$6) }
 
 lets:
-  | LET IDENT ty_op EQ mexpr
+  | LET var_ident ty_op EQ mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
         [(fi, $2.v, $5)] }
-  | LET IDENT ty_op EQ mexpr lets
+  | LET var_ident ty_op EQ mexpr lets
       { let fi = mkinfo $1.i (tm_info $5) in
         (fi, $2.v, $5)::$6 }
 
@@ -269,6 +278,9 @@ left:
   | left atom
       { let fi = mkinfo (tm_info $1) (tm_info $2) in
         TmApp(fi,$1,$2) }
+  | con_ident atom
+      { let fi = mkinfo $1.i (tm_info $2) in
+        TmConapp(fi,$1.v,nosym,$2) }
 
 
 atom:
@@ -281,7 +293,7 @@ atom:
       { if List.length $2 = 1 then List.hd $2
         else tuple2record (mkinfo $1.i $3.i) $2 }
   | LPAREN RPAREN        { TmRecord($1.i, Record.empty) }
-  | IDENT                { TmVar($1.i,$1.v,nosym) }
+  | var_ident                { TmVar($1.i,$1.v,nosym) }
   | CHAR                 { TmConst($1.i, CChar(List.hd (ustring2list $1.v))) }
   | UINT                 { TmConst($1.i,CInt($1.v)) }
   | UFLOAT               { TmConst($1.i,CFloat($1.v)) }
@@ -296,13 +308,13 @@ atom:
       { TmRecord(mkinfo $1.i $3.i, $2 |> List.fold_left
         (fun acc (k,v) -> Record.add k v acc) Record.empty) }
   | LBRACKET RBRACKET    { TmRecord(mkinfo $1.i $2.i, Record.empty)}
-  | LBRACKET mexpr WITH IDENT EQ mexpr RBRACKET
+  | LBRACKET mexpr WITH var_ident EQ mexpr RBRACKET
       { TmRecordUpdate(mkinfo $1.i $7.i, $2, $4.v, $6) }
 
 proj_label:
   | UINT
     { ($1.i, ustring_of_int $1.v) }
-  | IDENT
+  | label_ident
     { ($1.i,$1.v) }
 
 
@@ -314,9 +326,9 @@ seq:
       { $1::$3 }
 
 labels:
-  | IDENT EQ mexpr
+  | label_ident EQ mexpr
     {[($1.v, $3)]}
-  | IDENT EQ mexpr COMMA labels
+  | label_ident EQ mexpr COMMA labels
     {($1.v, $3)::$5}
 
 pats:
@@ -334,14 +346,14 @@ patseq:
       { ($1.i, List.map (fun x -> PatChar($1.i,x)) (ustring2list $1.v)) }
 
 pat_labels:
-  | IDENT EQ pat
+  | label_ident EQ pat
     {[($1.v, $3)]}
-  | IDENT EQ pat COMMA pat_labels
+  | label_ident EQ pat COMMA pat_labels
     {($1.v, $3)::$5}
 
 
 name:
-  | IDENT
+  | var_ident
       { if $1.v =. us"_"
         then ($1.i, NameWildcard)
         else ($1.i, NameStr($1.v,0)) }
@@ -361,7 +373,7 @@ pat_atom:
       { PatNamed(fst $1, snd $1) }
   | NOT pat_atom
       { PatNot(mkinfo $1.i (pat_info $2), $2) }
-  | IDENT pat_atom
+  | con_ident pat_atom
       { PatCon(mkinfo $1.i (pat_info $2), $1.v, nosym, $2) }
   | patseq
       { PatSeqTot($1 |> fst, $1 |> snd |> Mseq.of_list) }
@@ -431,7 +443,7 @@ ty_atom:
       { TyRecord [] }
   | LBRACKET label_tys RBRACKET
       { TyRecord($2) }
-  | IDENT
+  | type_ident
       {match Ustring.to_utf8 $1.v with
        | "Dyn"    -> TyDyn
        | "Bool"   -> TyBool
@@ -449,7 +461,30 @@ ty_list:
     { [$1] }
 
 label_tys:
-  | IDENT COLON ty
+  | label_ident COLON ty
     {[($1.v, $3)]}
-  | IDENT COLON ty COMMA label_tys
+  | label_ident COLON ty COMMA label_tys
     {($1.v, $3)::$5}
+
+
+/// Identifiers ///////////////////////////////
+
+ident:
+  | UC_IDENT {$1}
+  | LC_IDENT {$1}
+
+var_ident:
+  | LC_IDENT {$1}
+  | VAR_IDENT {$1}
+
+con_ident:
+  | UC_IDENT {$1}
+  | CON_IDENT {$1}
+
+type_ident:
+  | ident {$1}
+  | TYPE_IDENT {$1}
+
+label_ident:
+  | ident {$1}
+  | LABEL_IDENT {$1}

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -257,7 +257,7 @@ and print_tm fmt (prec, t) =
     | TmVar _    | TmRecLets _
     | TmConst _  | TmRecord _
     | TmRecordUpdate _
-    | TmCondef _ | TmConsym _
+    | TmCondef _ | TmConapp _
     | TmUse _    | TmUtest _
     | TmClos _   | TmFix _
     | TmNever _                        -> Atom
@@ -352,12 +352,9 @@ and print_tm' fmt t = match t with
     fprintf fmt "@[<hov 0>con %s:%s in@ %a@]"
       str ty print_tm (Match, t)
 
-  | TmConsym(_,x,sym,tmop) ->
+  | TmConapp(_,x,sym,t) ->
     let str = string_of_ustring (ustring_of_var x sym) in
-    (match tmop with
-     (* TODO Atom precedence too conservative? *)
-     | Some(t) -> fprintf fmt "%s %a" str print_tm (Atom ,t)
-     | None -> fprintf fmt "%s" str)
+     fprintf fmt "%s %a" str print_tm (Atom ,t)
 
   (* If expressions *)
   | TmMatch(_,t1,PatBool(_,true),t2,t3) ->

--- a/src/boot/ustring.ml
+++ b/src/boot/ustring.ml
@@ -272,6 +272,8 @@ struct
 
   let ustring_of_sid i = Hashtbl.find symtab2 i
 
+  let string_of_sid i = ustring_of_sid i |> to_utf8
+
   let usid s = sid_of_ustring (us s)
 
   let ustring_of_bool b = if b then us"true" else us"false"

--- a/src/boot/ustring.mli
+++ b/src/boot/ustring.mli
@@ -145,6 +145,9 @@ sig
       If the string identifier has not been defined, exception
       [Not_found] is raised *)
 
+  val string_of_sid : sid -> string
+  (** Returns the UTF8-encoded ocaml string of a [sid] *)
+
   val usid : string -> sid
   (** Expression [sid s] returns a unique string identifier of string [s].
       Same as expression [sid_of_ustring (us s)] *)

--- a/stdlib/ext/sundials.mc
+++ b/stdlib/ext/sundials.mc
@@ -1,8 +1,8 @@
 type SResf = SArray -> SArray -> Float -> SArray -> ()
 
-let IDA_SUCCESS = 0
-let IDA_ROOTS_FOUND = 2
-let IDA_STOP_TIME_REACHED = 1
+let idaRCSuccess = 0
+let idaRCRootsFound = 2
+let idaRCStopTimeReached = 1
 
 let noroots = (0, lam _. error "Called noroots")
 

--- a/stdlib/matrix.mc
+++ b/stdlib/matrix.mc
@@ -68,36 +68,36 @@ let matrixMul = matrixMul addi muli in
 
 utest matrixConst (2,3) 0 with [[0,0,0],[0,0,0]] in
 
-let A = [[1,3],[2,4]] in
+let matA = [[1,3],[2,4]] in
 
-utest matrixIsMatrix A with true in
+utest matrixIsMatrix matA with true in
 utest matrixIsMatrix [] with false in
 utest matrixIsMatrix [[]] with false in
 utest matrixIsMatrix [[1, 2], [1]] with false in
 
-utest matrixGet A 0 0 with 1 in
-utest matrixGet A 1 0 with 2 in
-utest matrixGet A 0 1 with 3 in
-utest matrixGet A 1 1 with 4 in
+utest matrixGet matA 0 0 with 1 in
+utest matrixGet matA 1 0 with 2 in
+utest matrixGet matA 0 1 with 3 in
+utest matrixGet matA 1 1 with 4 in
 
-let C = matrixConst (2,2) 0 in
-let B = matrixSet C 0 0 1 in
-let B = matrixSet B 1 0 2 in
-let B = matrixSet B 0 1 3 in
-let B = matrixSet B 1 1 4 in
+let matC = matrixConst (2,2) 0 in
+let matB = matrixSet matC 0 0 1 in
+let matB = matrixSet matB 1 0 2 in
+let matB = matrixSet matB 0 1 3 in
+let matB = matrixSet matB 1 1 4 in
 
-utest B with A in
-utest matrixAdd A B with [[2,6],[4,8]] in
+utest matB with matA in
+utest matrixAdd matA matB with [[2,6],[4,8]] in
 
 utest matrixMapij (lam i. lam j. lam _. (i, j)) (matrixConst (2,2) (0,0))
 with [[(0,0),(0,1)],[(1,0),(1,1)]] in
 
-utest matrixSMul 3 A with [[3,9],[6,12]] in
+utest matrixSMul 3 matA with [[3,9],[6,12]] in
 
-utest matrixSize A with (2,2) in
+utest matrixSize matA with (2,2) in
 
-utest matrixTr (matrixTr A) with A in
-utest matrixTr A with [[1,2], [3,4]] in
+utest matrixTr (matrixTr matA) with matA in
+utest matrixTr matA with [[1,2], [3,4]] in
 utest matrixTr [[1,2,3], [4,5,6]] with [[1,4], [2,5], [3,6]] in
 
 utest matrixMul [[1]] [[1]] with [[1]] in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -22,7 +22,7 @@ let fresh : String -> Env -> String = lam var. lam env.
   else
     recursive let find_free = lam n.
       let new = concat var (int2string n) in
-      match lookup new env with None then
+      match lookup new env with None () then
         new
       else
         find_free (addi n 1)

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -608,7 +608,7 @@ utest eval {env = []} appFst with TmConst {val = CBool {val = true}} in
 let unit = TmConst {val = CUnit ()} in
 
 let dataDecl = TmConDef {ident = "Foo",
-                         tpe = None,
+                         tpe = None(),
                          inexpr = TmMatch {target = TmApp {lhs = TmVar {ident = "Foo"},
                                                            rhs = TmTuple {tms = [unit, unit]}},
                                            pat = PCon {ident = "Foo",

--- a/stdlib/mexpr/meta.mc
+++ b/stdlib/mexpr/meta.mc
@@ -106,7 +106,7 @@ recursive
     let tuple =
       bind (parens (comma_sep ty)) (lam ts.
         if null ts
-        then pure TyUnit
+        then pure (TyUnit())
         else if eqi (length ts) 1
         then pure (head ts)
         else pure (TyProd ts))
@@ -115,14 +115,14 @@ recursive
       bind (brackets ty) (lam t.
       pure (TySeq t))
     in
-    let dyn = apr (reserved "Dyn") (pure TyDyn) in
+    let dyn = apr (reserved "Dyn") (pure (TyDyn())) in
     let primitive =
-      (alt (apr (reserved "Int") (pure TyInt))
-      (alt (apr (reserved "Bool") (pure TyBool))
-      (alt (apr (reserved "Float") (pure TyFloat))
-      (apr (reserved "Char") (pure TyChar)))))
+      (alt (apr (reserved "Int") (pure (TyInt())))
+      (alt (apr (reserved "Bool") (pure (TyBool())))
+      (alt (apr (reserved "Float") (pure (TyFloat())))
+      (apr (reserved "Char") (pure (TyChar()))))))
     in
-    let string = apr (reserved "String") (pure (TySeq(TyChar))) in
+    let string = apr (reserved "String") (pure (TySeq(TyChar()))) in
     let datatype =
       bind (satisfy is_upper_alpha "Uppercase character") (lam c.
       bind (token (many (satisfy is_valid_char ""))) (lam cs.
@@ -140,7 +140,7 @@ recursive
   let ty = lam st.
     let app_or_atom =
       bind (many1 ty_atom) (lam ts.
-      pure (foldl1 (curry TyApp) ts))
+      pure (foldl1 (curry (lam x. TyApp x)) ts))
     in
     let arrow_or_ty =
       bind app_or_atom (lam lt.
@@ -160,16 +160,16 @@ recursive
   let atom = lam st.
     let var_access =
       let _ = debug "== Parsing var_access" in
-      fmap TmVar identifier in
+      fmap (lam x. TmVar x) identifier in
     let seq =
       let _ = debug "== Parsing seq ==" in
-      fmap TmSeq (brackets (comma_sep expr))
+      fmap (lam x. TmSeq x) (brackets (comma_sep expr))
     in
     let tuple =
       let _ = debug "== Parsing tuple ==" in
       bind (parens (comma_sep expr)) (lam es.
       if null es
-      then pure (TmConst CUnit)
+      then pure (TmConst (CUnit{}))
       else if eqi (length es) 1
       then pure (head es)
       else pure (TmTuple es))
@@ -219,10 +219,10 @@ recursive
         bind (many (apr (symbol ".") number)) (lam is.
         if null is
         then pure a
-        else pure (foldl (curry TmProj) a is)))
+        else pure (foldl (curry (lam x. TmProj x)) a is)))
       in
       bind (many1 atom_or_proj) (lam as.
-      pure (foldl1 (curry TmApp) as))
+      pure (foldl1 (curry (lam x. TmApp x)) as))
     in
     let letbinding =
       let _ = debug "== Parsing letbinding ==" in
@@ -324,14 +324,14 @@ let program = apl (apr ws (apr (reserved "mexpr") expr)) end_of_input in
 
 -- TODO: Define remaining built-ins
 let builtins =
-    [("not", TmConst CNot)
-    ,("and", TmConst CAnd)
-    ,("or", TmConst COr)
-    ,("addi", TmConst CAddi)
-    ,("subi", TmConst CSubi)
-    ,("muli", TmConst CMuli)
-    ,("eqi", TmConst CEqi)
-    ,("lti", TmConst CLti)
+    [("not", TmConst (CNot{}))
+    ,("and", TmConst (CAnd{}))
+    ,("or", TmConst (COr{}))
+    ,("addi", TmConst (CAddi{}))
+    ,("subi", TmConst (CSubi{}))
+    ,("muli", TmConst (CMuli{}))
+    ,("eqi", TmConst (CEqi{}))
+    ,("lti", TmConst (CLti{}))
 ] in
 
 if or (eqstr (get argv 1) "test") (lti (length argv) 3) then

--- a/stdlib/parser.mc
+++ b/stdlib/parser.mc
@@ -265,7 +265,7 @@ let many1 = lam p.
 
 -- optional : Parser a -> Parser (Option a)
 let optional = lam p.
-  alt (fmap Some p) (pure None)
+  alt (fmap (lam x. Some x) p) (pure (None()))
 
 -- wrapped_in : Parser l -> Parser r -> Parser a -> Parser a
 --

--- a/test/ext/sundials/sundials.mc
+++ b/test/ext/sundials/sundials.mc
@@ -25,7 +25,7 @@ let resf = lam t. lam y. lam yp. lam r.
 in
 let s = idaInitDense tol resf noroots 0. y yp in
 utest idaCalcICYY s y 0.001 with () in
-utest idaSolveNormal s 10. y yp with (10., IDA_SUCCESS) in
+utest idaSolveNormal s 10. y yp with (10., idaRCSuccess) in
 
 let jacf = lam t. lam c. lam y. lam yp. lam m.
   let _ = sMatrixDenseSet m 0 0 c in
@@ -38,9 +38,9 @@ let rootf = lam t. lam _. lam _. lam g.
 in
 let s = idaInitDenseJac tol jacf resf (1, rootf) 0. y yp in
 utest idaCalcICYY s y 0.001 with () in
-utest idaSolveNormal s 10. y yp with (5., IDA_ROOTS_FOUND) in
+utest idaSolveNormal s 10. y yp with (5., idaRCRootsFound) in
 utest idaReinit s 5. y yp with () in
-utest idaSolveNormal s 10. y yp with (10., IDA_SUCCESS) in
+utest idaSolveNormal s 10. y yp with (10., idaRCSuccess) in
 
 utest idaGetDky s y (subf (idaGetCurrentTime s) (idaGetLastStep s)) 0 with () in
 utest idaGetDky s yp (subf (idaGetCurrentTime s) (idaGetLastStep s)) 1 with () in

--- a/test/mexpr/ident.mc
+++ b/test/mexpr/ident.mc
@@ -17,5 +17,12 @@ utest #ident"Foo" with Foo in
 utest #ident"*9^/\nhi" with #ident"*9^/\nhi" in
 utest #ident"*9^/\nhi" with 8 in
 
+type Bar in
+con f : (Int,Int) -> Bar in
+con F : (Int,String) -> Bar in
+
+utest match f(5,2) with f(x,y) then (y,x) else (0,0) with (2,5) in
+utest match F(3,"a") with F(x,y) then (y,x) else ("b",0) with ("a",3) in
+utest match F(3,"a") with f(x,y) then (y,x) else (0,0) with (0,0) in
 
 ()

--- a/test/mexpr/ident.mc
+++ b/test/mexpr/ident.mc
@@ -1,18 +1,21 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
-// Test general handling of integers
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test general handling of integers
 
 mexpr
 
-
+-- Testing variables
 let foo = 5 in
-let Foo = 5 in
-let #var"*9^/\nhi" = 8 in
-utest #var"foo" with foo in
-utest #type"Foo" with Foo in
-utest #con"Foo" with Foo in
-utest #var"*9^/\nhi" with #var"*9^/\nhi" in
+let Foo = 7 in
+let #ident"*9^/\nhi" = 8 in
+
+utest #ident"foo" with foo in
+utest #ident"Foo" with Foo in
+utest #ident"Foo" with 7 in
+utest #ident"Foo" with Foo in
+utest #ident"*9^/\nhi" with #ident"*9^/\nhi" in
+utest #ident"*9^/\nhi" with 8 in
 
 
 ()

--- a/test/mexpr/ident.mc
+++ b/test/mexpr/ident.mc
@@ -7,22 +7,20 @@ mexpr
 
 -- Testing variables
 let foo = 5 in
-let Foo = 7 in
-let #ident"*9^/\nhi" = 8 in
+let #var"Foo" = 7 in
+let #var"*9^/\nhi" = 8 in
 
-utest #ident"foo" with foo in
-utest #ident"Foo" with Foo in
-utest #ident"Foo" with 7 in
-utest #ident"Foo" with Foo in
-utest #ident"*9^/\nhi" with #ident"*9^/\nhi" in
-utest #ident"*9^/\nhi" with 8 in
+utest #var"foo" with foo in
+utest #var"Foo" with 7 in
+utest #var"*9^/\nhi" with #var"*9^/\nhi" in
+utest #var"*9^/\nhi" with 8 in
 
 type Bar in
-con f : (Int,Int) -> Bar in
-con F : (Int,String) -> Bar in
+con F : (Int,Int) -> Bar in
+con #con"f" : (Int,String) -> Bar in
 
-utest match f(5,2) with f(x,y) then (y,x) else (0,0) with (2,5) in
-utest match F(3,"a") with F(x,y) then (y,x) else ("b",0) with ("a",3) in
-utest match F(3,"a") with f(x,y) then (y,x) else (0,0) with (0,0) in
+utest match F(5,2) with F(x,y) then (y,x) else (0,0) with (2,5) in
+utest match #con"f"(3,"a") with #con"f"(x,y) then (y,x) else ("b",0) with ("a",3) in
+utest match #con"f"(3,"a") with F(x,y) then (y,x) else (0,0) with (0,0) in
 
 ()

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -9,17 +9,20 @@ mexpr
 utest () with () in
 utest () with {} in
 
--- Constructor with and without arguments
+-- Constructor with arguments
 con K1 in
 con K2 in
 con K3 in
-utest K1 with K1 in
-utest match K1 with K1 then 1 else 0 with 1 in
 utest K2() with K2() in
 utest match K2() with K2 a then a else () with () in
 utest K3("k",100) with K3("k",100) in
 utest match K2("k",100) with K2 x then x.0 else "a" with "k" in
 
+-- Constructor can start with either lower or upper case
+con c1 in
+con C1 in
+utest c1() with c1() in
+utest C1() with C1() in
 
 -- Matching two constructors
 con Foo in

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -18,15 +18,11 @@ utest match K2() with K2 a then a else () with () in
 utest K3("k",100) with K3("k",100) in
 utest match K2("k",100) with K2 x then x.0 else "a" with "k" in
 
--- Constructor can start with either lower or upper case
-con c1 in
-con C1 in
-utest c1() with c1() in
-utest C1() with C1() in
 
 -- Matching two constructors
 con Foo in
 con Bar in
+
 let f = lam x.
    match x with Foo t then
      let s = t.0 in

--- a/test/mlang/catchall.mc
+++ b/test/mlang/catchall.mc
@@ -5,7 +5,7 @@ lang Nat
 
   sem is_zero =
   | Z _ -> true
-  | n -> false
+  | S _ -> false
 
   sem pred =
   | Z _ -> Z ()
@@ -19,10 +19,10 @@ end
 mexpr
 
 use Nat in
-let Z = Z () in
-utest is_zero Z with true in
-utest is_zero (S Z) with false in
-utest pred Z with Z in
-utest pred (S Z) with Z in
-utest plus (S (S Z)) (S Z) with S (S (S Z)) in
+let z = Z () in
+utest is_zero z with true in
+utest is_zero (S z) with false in
+utest pred z with z in
+utest pred (S z) with z in
+utest plus (S (S z)) (S z) with S (S (S z)) in
 ()

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -50,7 +50,7 @@ lang User
     use Arith in
     eval (Add (Num 1, Num 2))
   sem bump (x : Dyn) =
-  | Unit -> addi x 1
+  | Unit _ -> addi x 1
 end
 
 lang A


### PR DESCRIPTION
This PR changes the way constructors are handled in MExpr. Everything is in the implementation, and the basic use of MExpr from a syntax point of view has not changed. The implementation is so far only in boot. Before, constructors created new symbols on the fly, during evaluation. Now, a unique symbol is created statically in the `TmConaef` term. As part of the `symbolize` transformation, a new term `TmConapp` is created from a combination of a variable and a function application. That is, syntactically constructor applications are still seen as function applications, but a transformation step before evaluation makes the translation to `TmConapp`. This also means that constructors are not first class, you need to apply the constructor directly and you cannot pass it as a value. If you would like to get this effect, you can always wrap the constructor in a lambda.

As a consequence, variables and constructors live in the same name space and there is no limitation of the names (both constructors and lambda variables can have lower and upper case identifiers). Hence, I have removed #var and #con and replaced it with #ident. We can for instance write `#ident"foo"` instead of `foo`. We can also use any non-standard string as an identifier, e.g `#ident"7*/1@ a1A" is also an identifier.   