### PR TITLE
Nested patterns in mlang

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -114,12 +114,9 @@ and const =
 (* Terms in MLang *)
 and cdecl   = CDecl   of info * ustring * ty
 and param   = Param   of info * ustring * ty
-and pattern =
-| ConPattern of info * ustring * ustring
-| VarPattern of info * ustring
 and decl = (* TODO: Local? *)
 | Data     of info * ustring * cdecl list
-| Inter    of info * ustring * param list * (pattern * tm) list
+| Inter    of info * ustring * param list * (pat * tm) list
 
 and mlang   = Lang of info * ustring * ustring list * decl list
 and let_decl = Let of info * ustring * tm
@@ -176,7 +173,6 @@ and pat =
 | PatInt    of info * int                         (* Int pattern *)
 | PatChar   of info * int                         (* Char pattern *)
 | PatBool   of info * bool                        (* Boolean pattern *)
-| PatUnit   of info                               (* Unit pattern *)
 | PatAnd    of info * pat * pat                   (* And pattern *)
 | PatOr     of info * pat * pat                   (* Or pattern *)
 | PatNot    of info * pat                         (* Not pattern *)
@@ -264,7 +260,6 @@ let pat_info = function
   | PatInt(fi,_) -> fi
   | PatChar(fi,_) -> fi
   | PatBool(fi,_) -> fi
-  | PatUnit(fi) -> fi
   | PatAnd(fi, _, _) -> fi
   | PatOr(fi, _, _) -> fi
   | PatNot(fi, _) -> fi

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -243,6 +243,9 @@ let main =
     "--symbol", Arg.Set(enable_debug_symbol_print),
     " Enables output of symbols for variables. Affects all other debug printing.";
 
+    "--full-pattern", Arg.Set(Patterns.pat_example_gives_complete_pattern),
+    " Make the pattern analysis in mlang print full patterns instead of partial ones.";
+
   ] in
 
   (* Align the command line description list *)

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -493,7 +493,6 @@ let rec symbolize (env : (ident * sym) list) (t : tm) =
     | PatInt _ as p -> (patEnv,p)
     | PatChar _ as p -> (patEnv,p)
     | PatBool _ as p -> (patEnv,p)
-    | PatUnit _ as p -> (patEnv,p)
     | PatAnd(fi, l, r) ->
        let (patEnv, l) = sPat patEnv l in
        let (patEnv, r) = sPat patEnv r
@@ -588,10 +587,6 @@ let rec try_match env value pat =
   | PatBool(_, b) ->
      (match value with
       | TmConst(_,CBool b2) when b = b2 -> Some env
-      | _ -> None)
-  | PatUnit _ ->
-     (match value with
-      | TmRecord(_,x) when x = Record.empty -> Some env
       | _ -> None)
   | PatAnd(_, l, r) -> go value r (Some env) |> go value l
   | PatOr(_, l, r) ->

--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -14,8 +14,7 @@ open Printf
    correspond constants *)
 let builtin =
   let f c = TmConst(NoInfo,c) in
-  ([("unit", tmUnit);
-   ("not",f(Cnot));("and",f(Cand(None)));("or",f(Cor(None)));
+  ([("not",f(Cnot));("and",f(Cand(None)));("or",f(Cor(None)));
    ("addi",f(Caddi(None)));("subi",f(Csubi(None)));("muli",f(Cmuli(None)));
    ("divi",f(Cdivi(None)));("modi",f(Cmodi(None)));("negi",f(Cnegi));
    ("lti",f(Clti(None)));("leqi",f(Cleqi(None)));("gti",f(Cgti(None)));("geqi",f(Cgeqi(None)));

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -65,7 +65,7 @@ type lang_data = {
     syns: (info * cdecl list) Record.t;
   }
 
-let compute_order fi ((fi1, {pos_pat = p1; neg_pat = n1; _}), (fi2, {pos_pat = p2; neg_pat = n2; _})) =
+let compute_order fi ((fi1, {pat = pat1; pos_pat = p1; neg_pat = n1; _}), (fi2, {pat = pat2; pos_pat = p2; neg_pat = n2; _})) =
   let string_of_pat pat = ustring_of_pat pat |> Ustring.to_utf8 in
   let info2str fi = info2str fi |> Ustring.to_utf8 in
   match order_query (p1, n1) (p2, n2) with
@@ -74,10 +74,13 @@ let compute_order fi ((fi1, {pos_pat = p1; neg_pat = n1; _}), (fi2, {pos_pat = p
   | Equal -> raise_error fi ("Patterns at " ^ info2str fi1 ^ " and " ^ info2str fi2 ^ " cannot be ordered by specificity; they match exactly the same values.")
   | Disjoint -> []
   | Overlapping(only1, both, only2) ->
-     "Patterns at " ^ info2str fi1 ^ " and " ^ info2str fi2 ^ " cannot be ordered by specificity (neither is more specific than the other), but the order matters; they overlap. Example:" ^
-       "\nOnly in the first: " ^ string_of_pat only1 ^
-       "\nIn both: " ^ string_of_pat both ^
-       "\nOnly in the other: " ^ string_of_pat only2
+     "Two patterns in this semantic function cannot be ordered by specificity (neither is more specific than the other), but the order matters; they overlap." ^
+       "\n  " ^ info2str fi1 ^ ": " ^ string_of_pat pat1 ^
+       "\n  " ^ info2str fi2 ^ ": " ^ string_of_pat pat2 ^
+       "\n Example:" ^
+       "\n  Only in the first: " ^ string_of_pat only1 ^
+       "\n  In both: " ^ string_of_pat both ^
+       "\n  Only in the other: " ^ string_of_pat only2
      |> raise_error fi
 
 (* Check that a single language fragment is self-consistent; it has compatible patterns,

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -171,21 +171,6 @@ let flatten_lang (prev_langs: lang_data Record.t): top -> lang_data Record.t * t
 let flatten (Program(includes, tops, e)): program =
   Program(includes, accum_map flatten_lang Record.empty tops |> snd, e)
 
-(*
-TODO
-- flatten needs to remember more info about previous languages, namely for
-  each Inter we need the DAG and normpats and stuff.
-- when we initially look at a language we construct such DAGs and error if
-  language internal patterns conflict in some way.
-- we then merge in old languages into the new one, building ever bigger DAGs
-  (and reporting concflicts). This means that when merging we only need to
-  consider the cartesian product between the two fragments, not intralanguage
-  pairs.
-- we then store the DAG(s) for use in later languages, and produce a topological
-  sort of the patterns found thus far. This topological sort is what's placed
-  in the flattened TopLang, thus translation can use that order directly.
- *)
-
 (***************
  * Translation *
  ***************)

--- a/src/boot/msg.ml
+++ b/src/boot/msg.ml
@@ -41,6 +41,11 @@ type message = id * severity * info * arguments
 exception Error of message
 
 
+let eq_info a b = match a, b with
+  | NoInfo, NoInfo -> true
+  | Info(f1, l11, c11, l21, c21), Info(f2, l12, c12, l22, c22) ->
+     l11 = l12 && c11 = c12 && l21 == l22 && c21 == c22 && f1 =. f2
+  | _ -> false
 
 
 (** [id2str id] returns the identifier string for [id], e.g.,
@@ -66,21 +71,21 @@ let info2str_startline fi =
     | Info(_,l1,_,_,_) -> l1
     | NoInfo -> assert false
 
+let info2str = function
+  | Info(filename, l1, c1, l2, c2) ->
+	   us"FILE \"" ^. filename ^. us"\" " ^.
+	     (ustring_of_int l1) ^. us":" ^.
+	     (ustring_of_int c1) ^. us"-" ^.
+	     (ustring_of_int l2) ^. us":" ^.
+	     (ustring_of_int c2)
+  | NoInfo -> us"NO INFO"
+
 (** [message2str m] returns a string representation of message [m].
     Is message is not intended to be read by humans. *)
 let message2str (id,sev,info,_)  =
-  match info with
-    | Info(filename,l1,c1,l2,c2) ->
-	begin
-	  us"FILE \"" ^. filename ^. us"\" " ^.
-	    (ustring_of_int l1) ^. us":" ^.
-	    (ustring_of_int c1) ^. us"-" ^.
-	    (ustring_of_int l2) ^. us":" ^.
-	    (ustring_of_int c2) ^. us" " ^.
-	    (severity2str sev) ^. us": " ^.
-	    (id2str id)
-        end
-    |  NoInfo -> us"NO INFO: " ^. (id2str id)
+  info2str info ^. us" " ^.
+	  (severity2str sev) ^. us": " ^.
+	  (id2str id)
 
 let raise_error fi msg =
   raise (Error (ERROR(msg),ERROR,fi,[]))

--- a/src/boot/msg.ml
+++ b/src/boot/msg.ml
@@ -44,7 +44,7 @@ exception Error of message
 let eq_info a b = match a, b with
   | NoInfo, NoInfo -> true
   | Info(f1, l11, c11, l21, c21), Info(f2, l12, c12, l22, c22) ->
-     l11 = l12 && c11 = c12 && l21 == l22 && c21 == c22 && f1 =. f2
+     l11 = l12 && c11 = c12 && l21 = l22 && c21 = c22 && f1 =. f2
   | _ -> false
 
 

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -214,17 +214,8 @@ cases:
   |
     { [] }
 case:
-  | BAR var_ident ARROW mexpr
-    { let fi = mkinfo $1.i $3.i in
-      (VarPattern (fi, $2.v), $4) }
-  | BAR con_ident binder ARROW mexpr
-    { let fi = mkinfo $1.i $4.i in
-      (ConPattern (fi, $2.v, $3), $5)}
-binder:
-  | LPAREN var_ident RPAREN
-    { $2.v }
-  | var_ident
-    { $1.v }
+  | BAR pat ARROW mexpr
+    { ($2, $4) }
 
 /// Expression language ///////////////////////////////
 

--- a/src/boot/patterns.ml
+++ b/src/boot/patterns.ml
@@ -1,0 +1,395 @@
+open Utils
+open Ast
+open Ustring.Op
+(* and pat =
+ * | PatNamed  of info * patName                     (\* Named, capturing wildcard *\)
+ * | PatSeqTot of info * pat Mseq.t                  (\* Exact sequence patterns *\)
+ * | PatSeqEdg of info * pat Mseq.t * patName * pat Mseq.t (\* Sequence edge patterns *\)
+ * | PatTuple  of info * pat list                    (\* Tuple pattern *\)
+ * | PatRecord of info * pat Record.t                (\* Record pattern *\)
+ * | PatCon    of info * ustring * sym * pat         (\* Constructor pattern *\)
+ * | PatInt    of info * int                         (\* Int pattern *\)
+ * | PatChar   of info * int                         (\* Char pattern *\)
+ * | PatBool   of info * bool                        (\* Boolean pattern *\)
+ * | PatUnit   of info                               (\* Unit pattern *\)
+ * | PatAnd    of info * pat * pat                   (\* And pattern *\)
+ * | PatOr     of info * pat * pat                   (\* Or pattern *\)
+ * | PatNot    of info * pat                         (\* Not pattern *\) *)
+
+(* NOTE: I'm pre-emptively dropping tuple and unit *)
+
+module UstringSet = Set.Make(Ustring)
+
+(* This is taken from Core: https://github.com/monadbobo/ocaml-core/blob/9c1c06e7a1af7e15b6019a325d7dbdbd4cdb4020/base/core/lib/core_list.ml#L566-L571 *)
+let concat_map l ~f =
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | hd :: tl -> aux (List.rev_append (f hd) acc) tl
+  in
+  aux [] l
+
+let rec split_at n = function
+  | x :: xs when n > 0 ->
+     let (pre, post) = split_at (n-1) xs
+     in (x :: pre, post)
+  | l -> ([], l)
+
+let repeat (n: int) (v: 'a): 'a list = List.init n (fun _ -> v)
+
+type simple_con =
+| IntCon of int
+| CharCon of int
+| BoolCon of bool
+| ConCon of ustring
+
+module SimpleConOrd = struct
+  type t = simple_con
+  (* This is a bit hacky, but I'm going with it for the moment. I would really
+   * like a persistent hashmap in ocaml. *)
+  let compare a b = Int.compare (Hashtbl.hash a) (Hashtbl.hash b)
+end
+module ConSet = Set.Make(SimpleConOrd)
+
+type simple_pat =
+| SPatInt of int
+| SPatChar of int
+| SPatBool of bool
+| SPatCon of ustring * npat
+and npat =
+| NSPat of simple_pat
+| NPatRecord of npat Record.t
+| NPatSeqTot of npat list
+| NPatSeqEdg of npat list * npat list
+| NPatNot
+  of IntSet.t option (* Some lengths -> the disallowed sequence lengths, None -> no sequences allowed *)
+     * UstringSet.t option (* Some labels -> the disallowed labels, None -> no records allowed *)
+     * ConSet.t (* The disallowed simple constructors *)
+let wildpat = NPatNot (Some IntSet.empty, Some UstringSet.empty, ConSet.empty)
+let notpat_simple c = NPatNot (Some IntSet.empty, Some UstringSet.empty, ConSet.singleton c)
+let notpat_label label = NPatNot (Some IntSet.empty, Some (UstringSet.singleton label), ConSet.empty)
+let notpat_seq_len n = NPatNot (Some (IntSet.singleton n), Some UstringSet.empty, ConSet.empty)
+let notpat_seq = NPatNot (None, Some UstringSet.empty, ConSet.empty)
+
+let simple_con_of_simple_pat = function
+  | SPatInt i -> IntCon i
+  | SPatChar c -> CharCon c
+  | SPatBool b -> BoolCon b
+  | SPatCon (c, _) -> ConCon c
+
+module NPatOrd = struct
+  type t = npat
+  let compare a b = Int.compare (Hashtbl.hash a) (Hashtbl.hash b)
+end
+module NPatSet = Set.Make(NPatOrd)
+
+type normpat = NPatSet.t
+
+let traverse (f : 'a -> 'b list) (l : 'a list): 'b list list =
+  let rec go = function
+    | [] -> [[]]
+    | x :: xs ->
+       let tails = go xs in
+       let heads = f x in
+       concat_map tails ~f:(fun tl -> List.map (fun hd -> hd::tl) heads)
+  in go l
+
+let liftA2 (f: 'a -> 'b -> 'c) (la: 'a list) (lb: 'b list): 'c list =
+  concat_map la ~f:(fun a -> List.map (f a) lb)
+
+let map2_with_extras (f: 'a -> 'b -> 'c) (extra_a: 'a) (extra_b: 'b): 'a list -> 'b list -> 'c list =
+  let rec recur la lb = match la, lb with
+    | [], [] -> []
+    | [], b :: lb -> f extra_a b :: recur [] lb
+    | a :: la, [] -> f a extra_b :: recur la []
+    | a :: la, b :: lb -> f a b :: recur la lb
+  in recur
+
+
+(* This should be more general, but I can't generalize over the element type of a set,
+ * so it's now specific to normpats. In Haskell types, the idea would be this:
+ * (a -> Set b) -> ([b] -> c) -> [a] -> Set c
+ * If we then have, e.g., f a = [1, 2], f b = [3], f c = [4, 5],
+ * then list_alts f identity [a, b, c] =
+ * #{[1, 3, 4], [1, 3, 5], [2, 3, 4], [2, 3, 5]}
+ *)
+let list_alts (f: 'a -> normpat) (constr: npat list -> npat) (l: 'a list): normpat =
+  traverse (fun a -> f a |> NPatSet.elements) l
+  |> List.map constr
+  |> NPatSet.of_list
+
+let rec list_complement (constr: npat list -> npat) (l: npat list): normpat =
+  traverse (fun p -> [NPatSet.singleton p; npat_complement p]) l (* Produce all combinations of (complement this) (don't complement this) for each element in the list. Length of this list is thus 2^(length l) *)
+  |> List.tl (* Remove the list that doesn't complement anything *)
+  (* We now have a normpat list list, where the inner list has length `length l`.
+     We want to have a npat list list, where the outermost list will be turned into
+     a normpat (after calling constr). We must thus move the multiplicity present in
+     normpat (since it's a set) up to the top-most list, which we can do using `traverse`
+     in the list monad. *)
+  |> concat_map
+       ~f:(fun np_list ->
+         traverse NPatSet.elements np_list
+         |> List.map constr)
+  |> NPatSet.of_list (* construct a normpat *)
+
+and npat_complement: npat -> normpat = function
+  | NSPat (SPatInt i) -> notpat_simple (IntCon i) |> NPatSet.singleton
+  | NSPat (SPatChar c) -> notpat_simple (CharCon c) |> NPatSet.singleton
+  | NSPat (SPatBool b) -> notpat_simple (BoolCon b) |> NPatSet.singleton
+  | NSPat (SPatCon (c, p)) ->
+     npat_complement p
+     |> NPatSet.map (fun p -> NSPat (SPatCon (c, p)))
+     |> NPatSet.add (notpat_simple (ConCon c))
+  | NPatRecord pats ->
+     let (labels, pats) =
+       Record.bindings pats
+       |> List.split in
+     let complemented_product =
+       list_complement
+         (fun pats ->
+           List.combine labels pats
+           |> List.to_seq
+           |> Record.of_seq
+           |> fun x -> NPatRecord x)
+         pats in
+     let missing_labels =
+       labels
+       |> List.map (fun label -> notpat_label label)
+       |> NPatSet.of_list
+     in NPatSet.union complemented_product missing_labels
+  | NPatSeqTot pats ->
+     list_complement (fun pats -> NPatSeqTot pats) pats
+     |> NPatSet.add (notpat_seq_len <| List.length pats)
+  | NPatSeqEdg (pre, post) ->
+     let lenPre, lenPost = List.length pre, List.length post in
+     let complemented_product =
+       list_complement
+         (fun pats -> let pre, post = split_at lenPre pats in NPatSeqEdg(pre, post))
+         (pre @ post) in
+     let allowed_lengths =
+       List.init (lenPre + lenPost)
+         (fun n -> NPatSeqTot (repeat n wildpat))
+       |> NPatSet.of_list
+     in NPatSet.union complemented_product allowed_lengths
+        |> NPatSet.add notpat_seq
+  | NPatNot (seq_lens, labels, cons) ->
+     let seqs = match seq_lens with
+       | None -> NPatSeqEdg ([], []) |> NPatSet.singleton
+       | Some seq_lens ->
+          IntSet.elements seq_lens
+          |> List.map (fun n -> NPatSeqTot (repeat n wildpat))
+          |> NPatSet.of_list in
+     let recs = match labels with
+       | None -> NPatRecord Record.empty |> NPatSet.singleton
+       | Some labels ->
+          UstringSet.elements labels
+          |> List.map (fun label -> NPatRecord (Record.singleton label wildpat))
+          |> NPatSet.of_list in
+     let cons =
+       ConSet.elements cons
+       |> List.map
+            (function
+             | IntCon i -> NSPat (SPatInt i)
+             | CharCon c -> NSPat (SPatChar c)
+             | BoolCon b -> NSPat (SPatBool b)
+             | ConCon c -> NSPat (SPatCon (c, wildpat)))
+       |> NPatSet.of_list
+     in NPatSet.union seqs recs
+        |> NPatSet.union cons
+
+and npat_intersect (a: npat) (b: npat): normpat = match a, b with
+  | NPatNot (seqs1, recs1, cons1), NPatNot (seqs2, recs2, cons2) ->
+     let seqs = match seqs1, seqs2 with
+       | None, _ | _, None -> None
+       | Some a, Some b -> Some (IntSet.union a b) in
+     let recs = match recs1, recs2 with
+       | None, _ | _, None -> None
+       | Some a, Some b -> Some (UstringSet.union a b) in
+     let cons = ConSet.union cons1 cons2
+     in NPatSet.singleton (NPatNot (seqs, recs, cons))
+  | NPatNot (_, _, cons), (NSPat sp as pat) | (NSPat sp as pat), NPatNot (_, _, cons) ->
+     if ConSet.mem (simple_con_of_simple_pat sp) cons
+     then NPatSet.empty
+     else NPatSet.singleton pat
+  | NPatNot (_, recs, _), (NPatRecord r as pat) | (NPatRecord r as pat), NPatNot (_, recs, _) ->
+     (match recs with
+      | None -> NPatSet.empty
+      | Some labels ->
+         let has_forbidden_label =
+           Record.bindings r
+           |> List.exists (fun (label, _) -> UstringSet.mem label labels)
+         in if has_forbidden_label then NPatSet.empty else NPatSet.singleton pat)
+  | NPatNot (None, _, _), (NPatSeqTot _ | NPatSeqEdg _)
+    | (NPatSeqTot _ | NPatSeqEdg _), NPatNot (None, _, _) ->
+     NPatSet.empty
+  | NPatNot (Some lens, _, _), (NPatSeqTot pats as pat)
+    | (NPatSeqTot pats as pat), NPatNot (Some lens, _, _) ->
+    if IntSet.mem (List.length pats) lens then NPatSet.empty else NPatSet.singleton pat
+  | NPatNot (Some lens, _, _), (NPatSeqEdg (pre, post) as pat)
+    | (NPatSeqEdg (pre, post) as pat), NPatNot (Some lens, _, _) ->
+     (match IntSet.max_elt_opt lens with
+      | None -> NPatSet.singleton pat
+      | Some max_forbidden_len ->
+         let min_len = List.length pre + List.length post in
+         if min_len > max_forbidden_len then NPatSet.singleton pat else
+           List.init (max_forbidden_len - min_len)
+             (fun n_extras -> NPatSeqTot (pre @ List.rev_append (repeat n_extras wildpat) post))
+           |> NPatSet.of_list
+           |> NPatSet.add (NPatSeqEdg (pre, List.rev_append (repeat (max_forbidden_len - min_len + 1) wildpat) post)))
+  | NSPat p1, NSPat p2 ->
+     (match p1, p2 with
+      | SPatInt i1, SPatInt i2 when i1 = i2 -> NPatSet.singleton a
+      | SPatChar c1, SPatChar c2 when c1 = c2 -> NPatSet.singleton a
+      | SPatBool b1, SPatBool b2 when b1 = b2 -> NPatSet.singleton a
+      | SPatCon (s1, p1), SPatCon (s2, p2) when s1 = s2 ->
+         npat_intersect p1 p2
+         |> NPatSet.map (fun p -> NSPat (SPatCon (s1, p)))
+      | _ -> NPatSet.empty)
+  | NSPat _, (NPatRecord _ | NPatSeqTot _ | NPatSeqEdg _)
+    | (NPatRecord _ | NPatSeqTot _ | NPatSeqEdg _), NSPat _ -> NPatSet.empty
+  | NPatRecord r1, NPatRecord r2 ->
+     let merge_f _ a b = match a, b with
+       | None, None -> None
+       | Some a, Some b -> Some (npat_intersect a b |> NPatSet.elements)
+       | Some a, _ | _, Some a -> Some [a] in
+     Record.merge merge_f r1 r2
+     |> Record.bindings
+     |> traverse (fun (k, vs) -> List.map (fun v -> (k, v)) vs)
+     |> List.map (fun bindings -> NPatRecord (List.to_seq bindings |> Record.of_seq))
+     |> NPatSet.of_list
+  | NPatRecord _, (NPatSeqTot _ | NPatSeqEdg _)
+    | (NPatSeqTot _ | NPatSeqEdg _), NPatRecord _ -> NPatSet.empty
+  | NPatSeqTot pats1, NPatSeqTot pats2 ->
+     if List.length pats1 <> List.length pats2 then NPatSet.empty else
+       List.map2 npat_intersect pats1 pats2
+       |> traverse NPatSet.elements
+       |> List.map (fun pats -> NPatSeqTot pats)
+       |> NPatSet.of_list
+  | NPatSeqEdg (pre1, post1), NPatSeqEdg (pre2, post2) ->
+     let intersect_with_extras = map2_with_extras npat_intersect wildpat wildpat in
+     let pre = intersect_with_extras pre1 pre2 in
+     let post = List.rev (intersect_with_extras (List.rev post1) (List.rev post2))
+     in pre @ post
+        |> traverse NPatSet.elements
+        |> List.map (fun pats -> let pre, post = split_at (List.length pre) pats in NPatSeqEdg (pre, post))
+        |> NPatSet.of_list
+  | NPatSeqEdg (pre, post), NPatSeqTot pats
+    | NPatSeqTot pats, NPatSeqEdg (pre, post) ->
+     let len_pre, len_post, len_pats = List.length pre, List.length post, List.length pats in
+     if len_pre + len_post > len_pats then NPatSet.empty else
+       pre @ repeat (len_pats - len_pre - len_post) wildpat @ post
+       |> List.map2 npat_intersect pats
+       |> traverse NPatSet.elements
+       |> List.map (fun pats -> NPatSeqTot pats)
+       |> NPatSet.of_list
+
+and normpat_complement (np: normpat): normpat =
+  NPatSet.elements np
+  |> List.map npat_complement
+  |> List.fold_left normpat_intersect (NPatSet.singleton wildpat)
+
+and normpat_intersect (a: normpat) (b: normpat): normpat =
+  liftA2 npat_intersect (NPatSet.elements a) (NPatSet.elements b)
+  |> List.fold_left NPatSet.union NPatSet.empty
+
+let normpat_subset (a: normpat) (b: normpat): bool =
+  normpat_intersect a (normpat_complement b)
+  |> NPatSet.is_empty
+
+let normpat_overlap (a: normpat) (b: normpat): bool =
+  (* This is a shortcut optimization on normpat_intersect a b |> NPatSet.is_empty |> not,
+   * lessening the minimum number of calls to npat_intersect. *)
+  liftA2 (fun a b -> (a, b)) (NPatSet.elements a) (NPatSet.elements b)
+  |> List.exists (fun (a, b) -> npat_intersect a b |> NPatSet.is_empty |> not)
+
+let rec pat_to_normpat = function
+  | PatNamed _ -> NPatSet.singleton wildpat
+  | PatSeqTot(_, pats) ->
+     Mseq.to_list pats
+     |> traverse (fun p -> pat_to_normpat p |> NPatSet.elements)
+     |> List.map (fun pats -> NPatSeqTot pats)
+     |> NPatSet.of_list
+  | PatSeqEdg(_, pre, _, post) ->
+     Mseq.concat pre post
+     |> Mseq.to_list
+     |> traverse (fun p -> pat_to_normpat p |> NPatSet.elements)
+     |> List.map (fun pats -> let pre, post = split_at (Mseq.length pre) pats in NPatSeqEdg(pre, post))
+     |> NPatSet.of_list
+  | PatRecord(_, r) ->
+     Record.bindings r
+     |> traverse (fun (k, p) ->
+            pat_to_normpat p
+            |> NPatSet.elements
+            |> List.map (fun p -> (k, p)))
+     |> List.map (fun bindings -> NPatRecord (List.to_seq bindings |> Record.of_seq))
+     |> NPatSet.of_list
+  | PatCon(_, c, _, p) ->
+     pat_to_normpat p
+     |> NPatSet.map (fun p -> NSPat (SPatCon (c, p)))
+  | PatInt(_, i) -> NPatSet.singleton (NSPat (SPatInt i))
+  | PatChar(_, c) -> NPatSet.singleton (NSPat (SPatChar c))
+  | PatBool(_, b) -> NPatSet.singleton (NSPat (SPatBool b))
+  | PatAnd(_, a, b) -> normpat_intersect (pat_to_normpat a) (pat_to_normpat b)
+  | PatOr(_, a, b) -> NPatSet.union (pat_to_normpat a) (pat_to_normpat b)
+  | PatNot(_, p) -> normpat_complement (pat_to_normpat p)
+
+let pat_example normpat =
+  let wildpat = PatNamed(NoInfo, NameWildcard) in
+  let rec npat_to_pat = function
+    | NSPat (SPatInt i) -> PatInt(NoInfo, i)
+    | NSPat (SPatChar c) -> PatChar(NoInfo, c)
+    | NSPat (SPatBool b) -> PatBool(NoInfo, b)
+    | NSPat (SPatCon (str, np)) -> PatCon(NoInfo, str, nosym, npat_to_pat np)
+    | NPatRecord r -> PatRecord(NoInfo, Record.map npat_to_pat r)
+    | NPatSeqTot nps -> PatSeqTot(NoInfo, List.map npat_to_pat nps |> Mseq.of_list)
+    | NPatSeqEdg (pre, post) ->
+       PatSeqEdg(NoInfo,
+                 List.map npat_to_pat pre |> Mseq.of_list,
+                 NameWildcard,
+                 List.map npat_to_pat post |> Mseq.of_list)
+    | NPatNot (seqs, recs, cons) ->
+       let seqs = match seqs with
+         | None -> [PatSeqEdg(NoInfo, Mseq.empty, NameWildcard, Mseq.empty)]
+         | Some lens ->
+            IntSet.elements lens
+            |> List.map (fun len -> PatSeqTot(NoInfo, repeat len wildpat |> Mseq.of_list)) in
+       let recs = match recs with
+         | None -> [PatRecord(NoInfo, Record.empty)]
+         | Some labels ->
+            UstringSet.elements labels
+            |> List.map (fun label -> PatRecord(NoInfo, Record.singleton label wildpat)) in
+       let cons =
+         ConSet.elements cons
+         |> List.map (function
+                | IntCon i -> PatInt(NoInfo, i)
+                | CharCon c -> PatChar(NoInfo, c)
+                | BoolCon b -> PatBool(NoInfo, b)
+                | ConCon str -> PatCon(NoInfo, str, nosym, wildpat)) in
+       match seqs @ recs @ cons with
+       | [] -> wildpat
+       | p::ps -> PatNot(NoInfo, List.fold_left (fun a b -> PatOr(NoInfo, a, b)) p ps)
+  in
+  (* Pick an arbitrary pattern to be our example. *)
+  match NPatSet.choose_opt normpat with
+  | None -> PatNot(NoInfo, PatNamed(NoInfo, NameWildcard))
+  | Some np -> npat_to_pat np
+
+type order_query =
+| Subset
+| Superset
+| Equal
+| Disjoint
+| Overlapping of pat * pat * pat (* examples of patterns in only left, in both, and in only right *)
+
+(* Compare the specificity order of two patterns. If you want to compare two patterns p1 and p2,
+ * pass the arguments (pat_to_normpat p1, normpat_complement (pat_to_normpat p1)) and
+ * (pat_to_normpat p2, normpat_complement (pat_to_normpat p2)). *)
+let order_query ((ap, an): normpat * normpat) ((bp, bn): normpat * normpat): order_query =
+  let a_minus_b = normpat_intersect ap bn in
+  let b_minus_a = normpat_intersect bp an in
+  if NPatSet.is_empty a_minus_b && NPatSet.is_empty b_minus_a then Equal
+  else if NPatSet.is_empty a_minus_b then Subset
+  else if NPatSet.is_empty b_minus_a then Superset
+  else
+    let overlapping = normpat_intersect ap bp in
+    if NPatSet.is_empty overlapping then Disjoint
+    else Overlapping (pat_example a_minus_b, pat_example overlapping, pat_example b_minus_a)

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -53,11 +53,11 @@ let ustring_of_pat p =
        then us"[] ++ " ^. ppName x
        else
          let rStr =
-           if Mseq.length l = 0
+           if Mseq.length r <> 0
            then us" ++ [" ^. ppSeq r ^. us"]"
            else us "" in
          let lStr =
-           if Mseq.length r = 0
+           if Mseq.length l <> 0
            then us"[" ^. ppSeq l ^. us"] ++ "
            else us""
          in lStr ^. ppName x ^. rStr

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -76,7 +76,6 @@ let ustring_of_pat p =
     | PatInt(_,i) -> Ustring.Op.ustring_of_int i
     | PatChar(_,c) -> us (lit_of_uchar c)
     | PatBool(_,b) -> ustring_of_bool b
-    | PatUnit _ -> us"()"
     | PatAnd(_, l, r) -> us"(" ^. ppp l ^. us" & " ^. ppp r ^. us")"
     | PatOr(_, l, r) -> us"(" ^. ppp l ^. us" | " ^. ppp r ^. us")"
     | PatNot(_, p) -> us"!(" ^. ppp p ^. us")"

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -31,7 +31,7 @@ let optionMap: Option -> (a -> a) -> Option = lam o. lam f.
     Some(f t)
   else
     None ()
-    
+
 -- Applies a function to the contained value (if any),
 -- or returns the provided default (if not).
 let optionMapOr: Option -> a -> (a -> a) -> a = lam o. lam d. lam f.
@@ -46,7 +46,7 @@ let optionMapOrElse: Option -> (Unit -> a) -> (a -> a) -> a = lam o. lam d. lam 
   match o with Some t then
     f t
   else
-    d unit
+    d ()
 
 -- Returns `None` if either option is `None`, otherwise returns
 -- the first option.
@@ -76,7 +76,7 @@ let optionFilter: Option -> (a -> a) -> Option = lam o. lam p.
       None ()
   else
     None ()
- 
+
 -- Returns the first option if it contains a value, otherwise returns
 -- the second option.
 let optionOr: Option -> Option -> Option = lam o1. lam o2.
@@ -84,14 +84,14 @@ let optionOr: Option -> Option -> Option = lam o1. lam o2.
     o1
   else
     o2
-  
+
 -- Returns the option if it contains a value, otherwise calls the specified
 -- function and returns the result.
 let optionOrElse: Option -> (Unit -> Option) -> Option = lam o. lam f.
   match o with Some _ then
     o
   else
-    f unit
+    f ()
 
 -- If exactly one option is `Some`, that option is returned,
 -- otherwise returns `None`.

--- a/test/mlang/nestedpatterns.mc
+++ b/test/mlang/nestedpatterns.mc
@@ -1,0 +1,57 @@
+-- lang SameBroken
+--   sem foo =
+--   | (true, _) -> true
+--   | (_, true) -> false
+-- end
+
+-- lang BrokenA
+--   sem foo =
+--   | (true, _) -> true
+-- end
+-- lang BrokenB
+--   sem foo =
+--   | (_, true) -> false
+-- end
+-- lang CombinedBroken = BrokenA + BrokenB
+
+lang CatchAll
+  sem foo =
+  | _ -> "catchall"
+end
+lang MidSpecific = CatchAll
+  sem foo =
+  | (true, _) -> "mid"
+end
+lang FullSpecific = MidSpecific
+  sem foo =
+  | (true, true) -> "spec"
+end
+
+lang OrderIndependentA
+  sem foo =
+  | _ -> "catchall"
+  | (true, _) -> "mid"
+  | (true, true) -> "spec"
+end
+lang OrderIndependentB
+  sem foo =
+  | (true, _) -> "mid"
+  | _ -> "catchall"
+  | (true, true) -> "spec"
+end
+
+mexpr
+
+utest use CatchAll in foo (true, true) with "catchall" in
+utest use MidSpecific in foo (true, true) with "mid" in
+utest use MidSpecific in foo (true, false) with "mid" in
+utest use MidSpecific in foo (false, false) with "catchall" in
+utest use FullSpecific in foo (true, true) with "spec" in
+utest use FullSpecific in foo (true, false) with "mid" in
+utest use FullSpecific in foo (false, false) with "catchall" in
+
+utest use OrderIndependentA in foo (true, true) with use OrderIndependentB in foo (true, true) in
+utest use OrderIndependentA in foo (false, false) with use OrderIndependentB in foo (false, false) in
+utest use OrderIndependentA in foo (true, false) with use OrderIndependentB in foo (true, false) in
+utest use OrderIndependentA in foo (false, true) with use OrderIndependentB in foo (false, true) in
+()


### PR DESCRIPTION
This PR changes patterns in `sem`antic functions in mlang to be the normal patterns present in mexpr. For pre-existing semantic functions this should have no externally visible change, but new ones gain additional powers.

When calling a semantic function the most specific pattern that matches the argument will dictate the arm that gets executed. Note that this means that the order of the arms in the code does not matter, ordering is determined solely by specificity. Specificity is defined as subset on the set of values a pattern can match. For example, `(true, true)` is more specific than `(true, _)` since the set of matchable values is a subset.

This also creates a new failure case for merging semantic functions: if there are two patterns that overlap, but neither is more specific than the other, then the composition fails. At present there is no way to handle this failure (e.g. by manually specifying which branch to take, or adding a new pattern that matches the intersection of the overlapping patterns) but we have thoughts on how to do this in the future.

The code that performs this analysis does not have great time complexity (this is expected, checking for redundancy in pattern matches is NP-complete). However, cases we run into in practice should still be fast, since the patterns are small, but please report slowdowns.

Additionally, and unrelated, it also removes `unit` from the initial environment of values, and `PatUnit` from patterns.