### PR TITLE
Find strongly connected component.

### DIFF
--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -213,7 +213,7 @@ utest digraphCountVertices g6 with 0 in
 
 let compsEq = setEqual (setEqual eqi) in
 
-utest  compsEq (digraphStrongConnects empty) [] with true in
+utest compsEq (digraphStrongConnects empty) [] with true in
 
 let g = foldr digraphAddVertex empty [1,2,3,4,5,6,7,8] in
 

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -112,6 +112,8 @@ let digraphUnion = lam g1. lam g2.
   in foldl (lam g. lam tup. digraphMaybeAddEdge tup.0 tup.1 tup.2 g) g3 (digraphEdges g2)
 
 -- Strongly connected components of g.
+-- From the paper: Depth-First Search and Linear Graph Algorithms, Tarjan 72.
+-- https://doi.org/10.1137/0201010
 let digraphTarjan = lam g.
   let isNone = optionIsNone in
   let min = lam l. lam r. if lti l r then l else r in

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -119,8 +119,8 @@ let digraphTarjan = lam g.
   let min = lam l. lam r. if lti l r then l else r in
   let maybeFind = mapFind g.eqv in
   let find = lam v. lam m. optionMapOrElse (maybeFind v m)
-                                       (lam _. error "undefined")
-                                       identity
+                                           (lam _. error "undefined")
+                                           identity
   in
   let add = mapAdd g.eqv in
   let mem = setMem g.eqv in
@@ -167,7 +167,7 @@ let digraphTarjan = lam g.
   in
 
   let s = foldl (lam s. lam v. if isNone (maybeFind v s.number)
-                           then strongConnect s v else s)
+                               then strongConnect s v else s)
                 {i = 0, number = [], lowlink = [], stack = [], comps = []}
                 (digraphVertices g)
   in s.comps

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -80,7 +80,7 @@ let m = update 5 (addi 3) m in
 utest lookup 1 m with 5 in
 utest lookup 4 m with 7 in
 
-utest update 1 (lam _. never) [] with [] in
+utest update 1 (lam _. error "Don't call me!") [] with [] in
 
 utest mem 1 m with true in
 utest mem 2 m with false in

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -1,0 +1,45 @@
+-- A simple library that defines map operations over sequences of tuples.
+
+include "set.mc"
+
+-- True if seq represents a map with equality defined by eq. Otherwise false.
+let mapIsMap = lam eq. lam seq.
+  setIsSet (lam x1. lam x2. eq x1.0 x2.0) seq
+
+-- Optional value binded to k in seq, if no such binding in seq then None,
+-- where equality defined by eq.
+let mapFind = lam eq. lam k. lam seq. findAssoc (eq k) seq
+
+-- Binds v to k in, seq where equality defined by eq.
+let mapAdd = lam eq. lam k. lam v. lam seq.
+  optionMapOrElse (index ( lam t. eq k t.0) seq)
+                  (lam _. cons (k,v) seq)
+                  (lam i. set seq i (k,v))
+
+mexpr
+
+let find = mapFind eqi in
+let add = mapAdd eqi in
+
+let m = [(1,'1'),(2,'2'),(3,'3')] in
+let s = snoc m (1, '1') in
+
+utest mapIsMap eqi m with true in
+utest mapIsMap eqi s with false in
+
+utest find 1 m with Some '1' in
+utest find 2 m with Some '2' in
+utest find 3 m with Some '3' in
+utest find 4 m with None () in
+
+let m = add 1 '2' m in
+let m = add 2 '3' m in
+let m = add 3 '4' m in
+let m = add 4 '5' m in
+
+utest find 1 m with Some '2' in
+utest find 2 m with Some '3' in
+utest find 3 m with Some '4' in
+utest find 4 m with Some '5' in
+
+()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -1,5 +1,6 @@
 -- A simple library that defines map operations over sequences of tuples.
 
+include "option.mc"
 include "set.mc"
 
 -- True if seq represents a map with equality defined by eq. Otherwise false.
@@ -8,18 +9,47 @@ let mapIsMap = lam eq. lam seq.
 
 -- Optional value binded to k in seq, if no such binding in seq then None,
 -- where equality defined by eq.
-let mapFind = lam eq. lam k. lam seq. findAssoc (eq k) seq
+let mapLookupOpt = lam eq. lam k. lam seq. findAssoc (eq k) seq
 
--- Binds v to k in, seq where equality defined by eq.
-let mapAdd = lam eq. lam k. lam v. lam seq.
+-- Value binded to k in seq, if no such binding in seq then an error occurs.
+-- Equality defined by eq.
+let mapLookup = lam eq. lam k. lam seq.
+  optionMapOrElse (mapLookupOpt eq k seq)
+                  (lam _. error "Element not found")
+                  (lam x. x)
+
+-- True if k is bound in seq, else false.
+-- Equality defined by eq.
+let mapMem = lam eq. lam k. lam seq.
+  optionIsSome (mapLookupOpt eq k seq)
+
+-- Binds v to k in seq, where equality defined by eq.
+let mapInsert = lam eq. lam k. lam v. lam seq.
   optionMapOrElse (index ( lam t. eq k t.0) seq)
                   (lam _. cons (k,v) seq)
                   (lam i. set seq i (k,v))
 
+-- Updates seq by applying f to the value bound by k.
+-- Equality defined by eq.
+recursive
+let mapUpdate = lam eq. lam k. lam f. lam seq.
+  if null seq then seq
+  else
+    let x = head seq in
+    let xs = tail seq in
+    if eq k x.0 then
+      cons (k, f x.1) xs
+    else
+      cons x (mapUpdate eq k f xs)
+end
+
 mexpr
 
-let find = mapFind eqi in
-let add = mapAdd eqi in
+let lookupOpt = mapLookupOpt eqi in
+let lookup = mapLookup eqi in
+let insert = mapInsert eqi in
+let update = mapUpdate eqi in
+let mem = mapMem eqi in
 
 let m = [(1,'1'),(2,'2'),(3,'3')] in
 let s = snoc m (1, '1') in
@@ -27,19 +57,34 @@ let s = snoc m (1, '1') in
 utest mapIsMap eqi m with true in
 utest mapIsMap eqi s with false in
 
-utest find 1 m with Some '1' in
-utest find 2 m with Some '2' in
-utest find 3 m with Some '3' in
-utest find 4 m with None () in
+utest lookupOpt 1 m with Some '1' in
+utest lookupOpt 2 m with Some '2' in
+utest lookupOpt 3 m with Some '3' in
+utest lookupOpt 4 m with None () in
 
-let m = add 1 '2' m in
-let m = add 2 '3' m in
-let m = add 3 '4' m in
-let m = add 4 '5' m in
+let m = insert 1 '2' m in
+let m = insert 2 '3' m in
+let m = insert 3 '4' m in
+let m = insert 4 '5' m in
 
-utest find 1 m with Some '2' in
-utest find 2 m with Some '3' in
-utest find 3 m with Some '4' in
-utest find 4 m with Some '5' in
+utest lookupOpt 1 m with Some '2' in
+utest lookupOpt 2 m with Some '3' in
+utest lookupOpt 3 m with Some '4' in
+utest lookupOpt 4 m with Some '5' in
+
+let m = [(1,3), (4,6)] in
+let m = update 1 (addi 2) m in
+let m = update 4 (addi 1) m in
+let m = update 5 (addi 3) m in
+
+utest lookup 1 m with 5 in
+utest lookup 4 m with 7 in
+
+utest update 1 (lam _. never) [] with [] in
+
+utest mem 1 m with true in
+utest mem 2 m with false in
+utest mem 3 m with false in
+utest mem 4 m with true in
 
 ()

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -21,20 +21,20 @@ let setEqual = lam eq. lam seq1. lam seq2.
 let setDiff = lam eq. lam seq1. lam seq2.
   filter (lam x1. not (setMem eq x1 seq2)) seq1
 
--- Adds element x to seq if x not already in seq, where equality is defined by
--- eq.
-let setAdd = lam eq. lam x. lam seq.
+-- Inserts element x into seq if x not already in seq,
+-- where equality is defined by eq.
+let setInsert = lam eq. lam x. lam seq.
   if setMem eq x seq then seq else snoc seq x
 
 -- The union of seq1 and seq2, where equality is defined by eq.
 let setUnion = lam eq. lam seq1. lam seq2.
-  foldr (setAdd eq) seq1 seq2
+  foldr (setInsert eq) seq1 seq2
 
 mexpr
 
 let equal = setEqual eqi in
 let diff = setDiff eqi in
-let add = setAdd eqi in
+let add = setInsert eqi in
 let union = setUnion eqi in
 let mem = setMem eqi in
 


### PR DESCRIPTION
In this PR I implement Tarjan's algorithm for finding strongly connected components in directed graphs. This is the paper: [Depth-First Search and Linear Graph Algorithms, Tarjan 72](https://doi.org/10.1137/0201010).

To implement the algorithm without mutability I use maps. Therefor, a simple and inefficient sequence based map library is also included in this PR.

The complexity of the original mutable algorithm is `O(|E|,|V|)`. If maps have `O(log(n))` insertion and lookup, this non-mutable version should be `O(log(|V|)|V|,|E|)`. However, since the maps are implemented as sequences this implementation should be `O(|V|^3,|E|)`. 