### PR TITLE
Refactor option.mc

### DIFF
--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -14,9 +14,8 @@ let mapLookupOpt = lam eq. lam k. lam seq. findAssoc (eq k) seq
 -- Value binded to k in seq, if no such binding in seq then an error occurs.
 -- Equality defined by eq.
 let mapLookup = lam eq. lam k. lam seq.
-  optionMapOrElse (mapLookupOpt eq k seq)
-                  (lam _. error "Element not found")
-                  (lam x. x)
+  optionGetOrElse (lam _. error "Element not found")
+                  (mapLookupOpt eq k seq)
 
 -- True if k is bound in seq, else false.
 -- Equality defined by eq.
@@ -25,9 +24,9 @@ let mapMem = lam eq. lam k. lam seq.
 
 -- Binds v to k in seq, where equality defined by eq.
 let mapInsert = lam eq. lam k. lam v. lam seq.
-  optionMapOrElse (index ( lam t. eq k t.0) seq)
-                  (lam _. cons (k,v) seq)
+  optionMapOrElse (lam _. cons (k,v) seq)
                   (lam i. set seq i (k,v))
+                  (index (lam t. eq k t.0) seq)
 
 -- Updates seq by applying f to the value bound by k.
 -- Equality defined by eq.

--- a/stdlib/matrix.mc
+++ b/stdlib/matrix.mc
@@ -93,7 +93,7 @@ let matrixIndex = lam pred. lam mtx.
     if eqi i d.0 then None ()
     else
       let j = index pred (head rs) in
-      if optionIsSome j then optionMap j (lam j. (i, j))
+      if optionIsSome j then optionMap (lam j. (i, j)) j
       else work (addi i 1) (tail rs)
   in
   work 0 mtx

--- a/stdlib/maxmatch.mc
+++ b/stdlib/maxmatch.mc
@@ -80,9 +80,8 @@ let isMatch = lam x. neqi x (negi 1)
 let isPerfectMatch = all isMatch
 
 let findNonCovered = lam x.
-  optionMapOrElse (index (lam x. not (isMatch x)) x)
-                  (lam _. error "All nodes are covered")
-                  identity
+  optionGetOrElse (lam _. error "All nodes are covered")
+                  (index (lam x. not (isMatch x)) x)
 
 -- lu[u] + lv[v] - w[u][v]
 let slackVal = lam u. lam v. lam state.

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -3,120 +3,120 @@ type Option
 con Some : Dyn -> Option
 con None : () -> Option
 
--- Returns `true` if the option is a `Some` value.
-let optionIsSome: Option -> Bool = lam o.
-  match o with Some _ then
-    true
-  else
-    false
-
--- Returns `true` if the option is a `None` value.
-let optionIsNone: Option -> Bool = lam o.
-  match o with None () then
-    true
-  else
-    false
-
--- Returns `true` if the option contains a value which
--- satisfies the specified predicate.
-let optionContains: Option -> (a -> Bool) -> Bool = lam o. lam p.
-  match o with Some t then
-    p t
-  else
-    false
-
 -- Applies a function to the contained value (if any).
-let optionMap: Option -> (a -> a) -> Option = lam o. lam f.
+let optionMap: (a -> b) -> Option -> Option = lam f. lam o.
   match o with Some t then
-    Some(f t)
-  else
-    None ()
-
--- Applies a function to the contained value (if any),
--- or returns the provided default (if not).
-let optionMapOr: Option -> a -> (a -> a) -> a = lam o. lam d. lam f.
-  match o with Some t then
-    f t
-  else
-    d
-
--- Applies a function to the contained value (if any),
--- or computes a default (if not).
-let optionMapOrElse: Option -> (Unit -> a) -> (a -> a) -> a = lam o. lam d. lam f.
-  match o with Some t then
-    f t
-  else
-    d ()
-
--- Returns `None` if either option is `None`, otherwise returns
--- the first option.
-let optionAnd: Option -> Option -> Option = lam o1. lam o2.
-  match o1 with Some _ then
-    match o2 with Some _ then
-      o1
-    else
-      None ()
-  else
-    None ()
-
--- Returns `None` if the option is `None`, otherwise calls the
--- specified function on the wrapped value and returns the result.
-let optionFlatMap: Option -> (a -> Option) -> Option = lam o. lam f.
-  match o with Some t then
-    f t
-  else
-    None ()
-
--- Filters the contained value (if any) using the specified predicate.
-let optionFilter: Option -> (a -> a) -> Option = lam o. lam p.
-  match o with Some t then
-    if p t then
-      o
-    else
-      None ()
-  else
-    None ()
-
--- Returns the first option if it contains a value, otherwise returns
--- the second option.
-let optionOr: Option -> Option -> Option = lam o1. lam o2.
-  match o1 with Some _ then
-    o1
-  else
-    o2
-
--- Returns the option if it contains a value, otherwise calls the specified
--- function and returns the result.
-let optionOrElse: Option -> (Unit -> Option) -> Option = lam o. lam f.
-  match o with Some _ then
-    o
-  else
-    f ()
-
--- If exactly one option is `Some`, that option is returned,
--- otherwise returns `None`.
-let optionXor: Option -> Option -> Option = lam o1. lam o2.
-  match o1 with Some _ then
-    match o2 with None () then
-      o1
-    else
-      None ()
-  else match o1 with None () then
-    match o2 with Some _ then
-      o2
-    else
-      None ()
+    Some (f t)
   else
     None ()
 
 -- Converts from `Option<Option<T>>` to `Option<T>`
-let optionFlatten: Option -> Option = lam o.
+let optionJoin: Option -> Option = lam o.
+    match o with Some t then
+      t
+    else
+      None ()
+
+-- Returns `None` if the option is `None`, otherwise calls the
+-- specified function on the wrapped value and returns the result.
+let optionBind: Option -> (a -> Option) -> Option = lam o. lam f.
+    optionJoin (optionMap f o)
+
+-- Try to retrieve the contained value, or compute a default value
+let optionGetOrElse: (Unit -> a) -> Option -> a = lam d. lam o.
   match o with Some t then
     t
+  else
+    d ()
+
+-- Try to retrieve the contained value, or fallback to a default value
+let optionGetOr: a -> Option -> a = lam d.
+  optionGetOrElse (lam _. d)
+
+-- Applies a function to the contained value (if any),
+-- or computes a default (if not).
+let optionMapOrElse: (Unit -> b) -> (a -> b) -> Option -> b = lam d. lam f. lam o.
+  optionGetOrElse d (optionMap f o)
+
+-- Applies a function to the contained value (if any),
+-- or returns the provided default (if not).
+let optionMapOr: b -> (a -> b) -> Option -> b = lam d. lam f. lam o.
+  optionGetOr d (optionMap f o)
+
+-- Returns `true` if the option contains a value which
+-- satisfies the specified predicate.
+let optionContains: Option -> (a -> Bool) -> Bool = lam o. lam p.
+  optionMapOr false p o
+
+-- Returns `true` if the option is a `Some` value.
+let optionIsSome: Option -> Bool = lam o. optionContains o (lam _. true)
+
+-- Returns `true` if the option is a `None` value.
+let optionIsNone: Option -> Bool = lam o. not (optionIsSome o)
+
+-- Returns `None` if either option is `None`, otherwise returns
+-- the first option.
+let optionAnd: Option -> Option -> Option = lam o1. lam o2.
+  match (o1, o2) with (Some _, Some _) then
+    o1
+  else
+    None ()
+
+-- Filters the contained value (if any) using the specified predicate.
+let optionFilter: (a -> Bool) -> Option -> Option = lam p. lam o.
+    if optionContains o p then
+      o
+    else
+      None ()
+
+-- Returns the option if it contains a value, otherwise calls the specified
+-- function and returns the result.
+let optionOrElse: (Unit -> Option) -> Option -> Option = lam f. lam o.
+  optionGetOrElse f (optionMap (lam x. Some x) o)
+
+-- Returns the first option if it contains a value, otherwise returns
+-- the second option.
+let optionOr: Option -> Option -> Option = lam o1. lam o2.
+  optionOrElse (lam _. o2) o1
+
+-- If exactly one option is `Some`, that option is returned,
+-- otherwise returns `None`.
+let optionXor: Option -> Option -> Option = lam o1. lam o2.
+  match (o1, o2) with (Some _, None ()) then
+    o1
+  else match (o1, o2) with (None (), Some _) then
+    o2
   else
     None ()
 
 mexpr
+
+  utest optionMap (addi 1) (None ()) with (None ()) in
+  utest optionMap (addi 1) (Some 1) with (Some 2) in
+
+  utest optionJoin (Some (Some 1)) with (Some 1) in
+  utest optionJoin (Some (None ())) with (None ()) in
+  utest optionJoin (None ()) with (None ()) in
+
+  utest optionBind (None ()) (lam t. Some (addi 1 t)) with (None ()) in
+  utest optionBind (Some 1) (lam t. Some (addi 1 t)) with (Some 2) in
+  utest optionBind (Some 1) (lam _. None ()) with (None ()) in
+
+  utest optionGetOrElse (lam _. 3) (Some 1) with 1 in
+  utest optionGetOrElse (lam _. 3) (None ()) with 3 in
+
+  utest optionGetOr 3 (Some 1) with 1 in
+  utest optionGetOr 3 (None ()) with 3 in
+
+  utest optionMapOrElse (lam _. 3) (addi 1) (Some 1) with 2 in
+  utest optionMapOrElse (lam _. 3) (addi 1) (None ()) with 3 in
+
+  utest optionMapOr 3 (addi 1) (Some 1) with 2 in
+  utest optionMapOr 3 (addi 1) (None ()) with 3 in
+
+  utest optionContains (Some 1) (eqi 1) with true in
+  utest optionContains (Some 2) (eqi 1) with false in
+  utest optionContains (None ()) (eqi 1) with false in
 
   utest optionIsNone (None ()) with true in
   utest optionIsNone (Some 1) with false in
@@ -124,47 +124,26 @@ mexpr
   utest optionIsSome (Some 1) with true in
   utest optionIsSome (None ()) with false in
 
-  utest optionContains (Some 1) (lam t. eqi t 1) with true in
-  utest optionContains (Some 2) (lam t. eqi t 1) with false in
-  utest optionContains (None ()) (lam t. eqi t 1) with false in
-
-  utest optionMap (None ()) (lam t. addi t 1) with (None ()) in
-  utest optionMap (Some 1) (lam t. addi t 1) with (Some 2) in
-
-  utest optionFlatMap (None ()) (lam t. Some (addi t 1)) with (None ()) in
-  utest optionFlatMap (Some 1) (lam t. Some (addi t 1)) with (Some 2) in
-  utest optionFlatMap (Some 1) (lam t. None ()) with (None ()) in
-
-  utest optionMapOr (Some 1) 3 (lam t. addi t 1) with 2 in
-  utest optionMapOr (None ()) 3 (lam t. addi t 1) with 3 in
-
-  utest optionMapOrElse (Some 1) (lam _. 3) (lam t. addi t 1) with 2 in
-  utest optionMapOrElse (None ()) (lam _. 3) (lam t. addi t 1) with 3 in
-
   utest optionAnd (Some 1) (Some 2) with (Some 1) in
   utest optionAnd (Some 1) (None ()) with (None ()) in
   utest optionAnd (None ()) (Some 1) with (None ()) in
   utest optionAnd (None ()) (None ()) with (None ()) in
 
-  utest optionFilter (Some 1) (lam t. eqi t 1) with (Some 1) in
-  utest optionFilter (Some 1) (lam t. eqi t 2) with (None ()) in
-  utest optionFilter (None ()) (lam t. eqi t 2) with (None ()) in
+  utest optionFilter (eqi 1) (Some 1) with (Some 1) in
+  utest optionFilter (eqi 2) (Some 1) with (None ()) in
+  utest optionFilter (eqi 2) (None ()) with (None ()) in
 
   utest optionOr (Some 1) (Some 2) with (Some 1) in
   utest optionOr (Some 1) (None ()) with (Some 1) in
   utest optionOr (None ()) (Some 2) with (Some 2) in
   utest optionOr (None ()) (None ()) with (None ()) in
 
-  utest optionOrElse (Some 1) (lam _. Some 2) with (Some 1) in
-  utest optionOrElse (None ()) (lam _. Some 2) with (Some 2) in
+  utest optionOrElse (lam _. Some 2) (Some 1) with (Some 1) in
+  utest optionOrElse (lam _. Some 2) (None ()) with (Some 2) in
 
   utest optionXor (Some 1) (Some 2) with (None ()) in
   utest optionXor (Some 1) (None ()) with (Some 1) in
   utest optionXor (None ()) (Some 2) with (Some 2) in
   utest optionXor (None ()) (None ()) with (None ()) in
-
-  utest optionFlatten (Some (Some 1)) with (Some 1) in
-  utest optionFlatten (Some (None ())) with (None ()) in
-  utest optionFlatten (None ()) with (None ()) in
 
   ()

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -130,9 +130,8 @@ let minOpt = lam cmp. lam seq.
 let maxOpt = lam cmp. minOpt (lam l. lam r. cmp r l)
 
 let min = lam cmp. lam seq.
-  optionMapOrElse (minOpt cmp seq)
-                  (lam _. error "Undefined")
-                  (lam x. x)
+  optionGetOrElse (lam _. error "Undefined")
+                  (minOpt cmp seq)
 
 let max = lam cmp. min (lam l. lam r. cmp r l)
 

--- a/test/mlang/nestedpatterns.mc
+++ b/test/mlang/nestedpatterns.mc
@@ -86,7 +86,7 @@ lang LexDecimal = LexBase
   sem lex =
   | (['0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ _) & str ->
     match lex_int "" str with (n, rest) then
-      optionMap (lex rest) (cons (IntTok n))
+      optionMap (cons (IntTok n)) (lex rest)
     else never
 
   sem lex_int (prev_digits : [Char]) =
@@ -108,7 +108,7 @@ lang LexBinary = LexBase
   sem lex =
   | (['0', 'b', '0' | '1'] ++ _) & ([_, _] ++ str) ->
     match lex_binary "" str with (n, rest) then
-      optionMap (lex rest) (cons (BinaryIntTok n))
+      optionMap (cons (BinaryIntTok n)) (lex rest)
     else never
 
   sem lex_binary (prev_digits : [Char]) =


### PR DESCRIPTION
This pull request refactors `option.mc`.

- Fix parameter orders: `optionMap` and `optionFilter` now take the function first, and `optionMapOr` and co. take the default value first. This enables smoother composition of these functions and conforms with convention in other languages.
- Rename `optionFlatten` to `optionJoin` and `optionFlatMap` to `optionBind` for consistency with the rest of the stdlib.
- Implement functions in terms of each other.
- Add utility functions `optionGetOrElse` and `optionGetOr` (with `optionGetOrElse f o` corresponding to `optionMapOrElse f identity o`).

These changes may be breaking for users of the library.