### PR TITLE
Constructors in not-patterns are symbolized properly

### DIFF
--- a/src/boot/mexpr.ml
+++ b/src/boot/mexpr.ml
@@ -496,7 +496,14 @@ let rec symbolize (env : (ident * sym) list) (t : tm) =
        let (patEnv, l) = sPat patEnv l in
        let (patEnv, r) = sPat patEnv r
        in (patEnv, PatOr(fi, l, r))
-    | PatNot _ as p -> (patEnv, p) (* NOTE(vipa): names in a not-pattern do not matter since they will never bind (it should be an error to bind a name inside a not-pattern, but we're not doing that kind of static checks yet *)
+    | PatNot(fi, p) ->
+       let (_, p) = sPat patEnv p in
+        (* NOTE(vipa): new names in a not-pattern do not matter since they will
+         * never bind (it should probably be an error to bind a name inside a
+         * not-pattern, but we're not doing that kind of static checks yet.
+         * Note that we still need to run symbolize though, constructors must
+         * refer to the right symbol. *)
+       (patEnv, PatNot(fi, p))
   in
   match t with
   | TmVar(fi,x,_) -> TmVar(fi,x,findsym fi (IdVar(sid_of_ustring x)) env)

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -156,6 +156,9 @@ utest match K2 2 with K1 a | K2 a | K3 a then a else 0 with 2 in
 utest match K3 3 with K1 a | K2 a | K3 a then a else 0 with 3 in
 utest match (true, true) with (true, a) & !(_, true) then a else false with false in
 utest match (true, false) with (true, a) & !(_, true) then a else false with false in
+utest match (1, 2) with (a, _) & b then (a, b) else (0, (0, 0)) with (1, (1, 2)) in
+utest match Some true with a & !(None ()) then a else Some false with Some true in
+utest match None () with a & !(None ()) then a else Some false with Some false in
 
 -- Matching with never terms
 let x = true in


### PR DESCRIPTION
This fixes the bug mentioned in #111. The issue was that `symbolize` was never run on the contents of a not-pattern. I incorrectly thought this wasn't required, since no introduced names in a not-pattern are ever used, but symbolize additionally assigns the correct symbol to constructors, which do matter even inside a not-pattern.