### PR TITLE
Support for escaped characters in boot

### DIFF
--- a/src/boot/lexer.mll
+++ b/src/boot/lexer.mll
@@ -185,9 +185,10 @@ rule main = parse
       { mkid s }
   | uident as s
       { Parser.UC_IDENT{i=mkinfo_fast s; v= Ustring.from_utf8 s} }
-  | '\'' (utf8 as c) '\''
+  | '\'' ((s_escape | utf8) as c) '\''
       { let s = Ustring.from_utf8 c in
-        Parser.CHAR{i=mkinfo_ustring (us"'" ^. s ^. us"'"); v=s}}
+        let esc_s = Ustring.convert_escaped_chars s in
+        Parser.CHAR{i=mkinfo_ustring (us"'" ^. s ^. us"'"); v=esc_s}}
   | '#' (("con" | "type" | "var" | "label") as ident) '"'
        { Buffer.reset string_buf ;  parsestring lexbuf;
 	 let s = Ustring.from_utf8 (Buffer.contents string_buf) in

--- a/src/boot/ustring.ml
+++ b/src/boot/ustring.ml
@@ -722,6 +722,7 @@ let convert_escaped_chars s =
       | (true,0x5c::ss) -> 0x5c::(conv false ss)         (*  "\\" *)
       | (true,0x6E::ss) -> 0x0A::(conv false ss)         (*  "\n" *)
       | (true,0x74::ss) -> 0x09::(conv false ss)         (*  "\t" *)
+      | (true,0x72::ss) -> 0x0D::(conv false ss)         (*  "\r" *)
       | (true,_) -> raise (Invalid_argument "Ustring.convert_escaped_char")
   in
   let a2 = conv false (Array.to_list (collapse_ustring s)) in

--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -19,9 +19,7 @@ let char2lower = lam c.
   then (int2char (addi (char2int c) 32))
   else c
 
--- TODO: It would be nicer with escape codes in chars!
-let is_whitespace = lam c.
-  or (or (eqchar c ' ') (eqchar c (head "\n"))) (eqchar c (head "\t"))
+let is_whitespace = lam c. any (eqchar c) [' ', '\n', '\t', '\r']
 
 let is_lower_alpha = lam c.
   and (leqi (char2int 'a') (char2int c)) (leqi (char2int c) (char2int 'z'))
@@ -52,6 +50,10 @@ utest is_whitespace '	' with true in
 utest is_whitespace '
 ' with true in
 utest is_whitespace 'a' with false in
+utest is_whitespace '\n' with true in
+utest is_whitespace '\t' with true in
+utest is_whitespace '\r' with true in
+utest is_whitespace '\'' with false in
 
 utest is_alpha 'a' with true in
 utest is_alpha 'm' with true in

--- a/test/mexpr/string.mc
+++ b/test/mexpr/string.mc
@@ -17,9 +17,13 @@ utest "大衛·布羅曼" with "大衛·布羅曼" in
 utest char2int 'A' with 65 in         -- Char -> Int
 utest char2int 'ä' with 228 in
 utest char2int '島' with 23798 in
+utest char2int '\n' with 10 in
+utest char2int '\r' with 13 in
 utest int2char 97 with 'a' in         -- Int -> Char
 utest int2char 252 with 'ü' in
 utest int2char 28246 with '湖' in
+utest int2char 10 with '\n' in
+utest int2char 13 with '\r' in
 
 
 -- String operations


### PR DESCRIPTION
Adds support for escaped characters in boot. Also modified to `ustring.ml` to support escaped carriage return conversion as it might be useful in cases where Windows is involved.

Line 22 in `stdlib/char.mc` could have been written more compactly as
```ml
let is_whitespace = lam c. any (eqchar c) " \n\t\r"
```
but I prefer to explicitly write the characters as a sequence. (As it is now.)

Resolves #17 