### PR TITLE
REPL improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Before you can use the Miking system, you need to install
 [OPAM](https://opam.ocaml.org/) package manager.
 
 
-After the installation, you need to install the `opam` packages `dune` and `batteries` by running the following:
+After the installation, you need to install the `opam` packages `dune`, `batteries`, and `linenoise` by running the following:
 
 ```
-opam install dune batteries
+opam install dune batteries linenoise
 ```
 
 To compile and run the test suite, execute:
@@ -51,20 +51,20 @@ make install
 This will install the interpreter to `$HOME/.local/bin` and the standard library to `$HOME/.local/lib/mcore/stdlib`, according to the [systemd file system hierarchy overview](https://www.freedesktop.org/software/systemd/man/file-hierarchy.html).
 
 The Miking interpreter also features a simple REPL.
+The REPL allows interactively executing fragments of MCore code.
+Both toplevel definitions and expressions can be evaluated.
+
 To start the REPL (assuming that the interpreter is installed in the path), run
 
 ```
 mi repl
 ```
 
-The REPL allows interactively executing fragments of MCore code.
-Both toplevel definitions and expressions can be evaluated.
-To exit the REPL, use Ctrl-C or Ctrl-D.
-
 The following is an example interaction with the REPL.
 
 ```
 Welcome to the MCore REPL!
+Type :h for help or :q to quit.
 >> let x = 5
 ()
 >> let y = 10 in

--- a/README.md
+++ b/README.md
@@ -57,19 +57,18 @@ To start the REPL (assuming that the interpreter is installed in the path), run
 mi repl
 ```
 
-The REPL allows executing fragments of MCore code. The syntax is the
-same as when writing a regular program, meaning that to evaluate an
-expression, you need to prepend it with `mexpr`. End your commands
-using `;;`. To exit the REPL, use Ctrl-C or Ctrl-D.
+The REPL allows interactively executing fragments of MCore code.
+Both toplevel definitions and expressions can be evaluated.
+To exit the REPL, use Ctrl-C or Ctrl-D.
 
 The following is an example interaction with the REPL.
 
 ```
 Welcome to the MCore REPL!
->> let x = 5;;
+>> let x = 5
 ()
->> mexpr let y = 10 in
- | addi x y;;
+>> let y = 10 in
+ | addi x y
 15
 >>
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The following is an example interaction with the REPL.
 Welcome to the MCore REPL!
 Type :h for help or :q to quit.
 >> let x = 5
-()
 >> let y = 10 in
  | addi x y
 15

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -253,7 +253,7 @@ let handle_command str =
    be extended to a valid expression *)
 let rec read_until_complete is_mexpr input =
   let new_acc () = sprintf "%s\n%s" input (read_input followup_prompt) in
-  let parse_fun = if is_mexpr then Parser.prog_mexpr else Parser.main in
+  let parse_fun = if is_mexpr then Parser.main_mexpr else Parser.main in
   match parse_mcore_string parse_fun input with
     | Ok ast -> ast
     | Error "" -> read_until_complete is_mexpr (new_acc ())
@@ -279,7 +279,7 @@ let read_multiline first_line =
     match parse_mcore_string Parser.main lines with
     | Ok ast -> Some ast
     | Error _ ->
-      match lines |> parse_mcore_string Parser.prog_mexpr with
+      match lines |> parse_mcore_string Parser.main_mexpr with
       | Ok ast -> Some ast
       | Error _ -> raise Parsing.Parse_error
   else

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -75,10 +75,9 @@ let debug_after_mlang t =
 (* Keep track of which files have been parsed to avoid double includes *)
 let parsed_files = ref []
 
-let tablength = 8
-
 (* Open a file and parse it into an MCore program *)
 let parse_mcore_file filename =
+  let tablength = 8 in
   let fs1 = open_in filename in
   let p =
     Lexer.init (us filename) tablength;

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -268,14 +268,13 @@ let rec read_until_complete is_mexpr input =
 let read_multiline first_line =
   let rec read_until_end acc =
     let line = read_input followup_prompt in
-    let first, last = Utils.split_at (String.length line - 2) line in
-    match last with
-    | ":}" -> sprintf "%s\n%s" acc first
-    | _ -> read_until_end (sprintf "%s\n%s" acc line)
+    match line with
+    | ":}" -> acc
+    | _ -> read_until_end (line :: acc)
   in
-  let first, last = Utils.split_at 2 first_line in
-  if first = ":{" then
-    let lines = read_until_end last in
+  if first_line = ":{" then
+    let lines = List.fold_right (fun x a -> sprintf "%s\n%s" a x)
+                                (read_until_end []) "" in
     match parse_mcore_string Parser.main lines with
     | Ok ast -> Some ast
     | Error _ ->

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -253,7 +253,7 @@ let rec read_until_complete added_mexpr input =
       if added_mexpr then
         raise Parsing.Parse_error
       else
-        read_until_complete true ("mexpr " ^ input)
+        read_until_complete true (sprintf "mexpr %s" input)
 
 (* Read and parse a multiline expression, that is an expression enclosed in
   :{ and :}. Returns None if the first line does not start with :{ *)
@@ -267,9 +267,13 @@ let read_multiline first_line =
   in
   let first, last = Utils.split_at 2 first_line in
   if first = ":{" then
-    match last |> read_until_end |> parse_mcore_string with
+    let lines = read_until_end last in
+    match parse_mcore_string lines with
     | Ok ast -> Some ast
-    | Error _ -> raise Parsing.Parse_error
+    | Error _ ->
+      match lines |> sprintf "mexpr %s" |> parse_mcore_string with
+      | Ok ast -> Some ast
+      | Error _ -> raise Parsing.Parse_error
   else
     None
 

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -219,12 +219,17 @@ let parse_mcore_string parse_fun str =
 let initial_prompt = ">> "
 let followup_prompt = " | "
 
+let no_line_edit = ref false
+
 let read_input prompt =
-  match LNoise.linenoise prompt with
-    | None -> raise End_of_file
-    | Some str ->
-      LNoise.history_add str |> ignore;
-      String.trim str
+  if !no_line_edit then
+    (print_string prompt; read_line ())
+  else
+    match LNoise.linenoise prompt with
+      | None -> raise End_of_file
+      | Some str ->
+        LNoise.history_add str |> ignore;
+        String.trim str
 
 let print_welcome_message () =
   print_endline "Welcome to the MCore REPL!";
@@ -378,6 +383,9 @@ let main =
 
     "--full-pattern", Arg.Set(Patterns.pat_example_gives_complete_pattern),
     " Make the pattern analysis in mlang print full patterns instead of partial ones.";
+
+    "--no-line-edit", Arg.Set(no_line_edit),
+    " Disable line editing funcionality in the REPL.";
 
   ] in
 

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -224,15 +224,25 @@ let read_input prompt =
       LNoise.history_add str |> ignore;
       String.trim str
 
+let print_welcome_message () =
+  print_endline "Welcome to the MCore REPL!";
+  print_endline "Type :h for help or :q to quit."
+
 let handle_command str =
-  let help_message = "No help for you!" in
+  let help_message =
+{|  Commands available from the prompt:
+
+   <statement>                 evaluate <statement>
+   :{\n ..lines.. \n:}\n       multiline command
+   :q                          exit the REPL
+   :h                          display this message|} in
   match str with
     | ":q" -> exit 0
     | ":h" -> print_endline help_message; true
     | _ -> false
 
 (* Read and parse a toplevel or mexpr expression. Continues to read input
-   until a valid expression is formed. Returns Error if the expression cannot
+   until a valid expression is formed. Raises Parse_error if the expression cannot
    be extended to a valid expression *)
 let rec read_until_complete added_mexpr input =
   let new_acc () = sprintf "%s\n%s" input (read_input followup_prompt) in
@@ -313,7 +323,7 @@ let runrepl _ =
   let builtin_envs = (Record.empty, Mlang.USMap.empty, builtin_name2sym, builtin_sym2term) in
   let initial_envs, _ = eval_with_envs builtin_envs initial_term in
   linenoise_init ();
-  print_endline "Welcome to the MCore REPL!";
+  print_welcome_message ();
   read_eval_print initial_envs
 
 (* Run program *)

--- a/src/boot/dune-boot
+++ b/src/boot/dune-boot
@@ -5,5 +5,5 @@
 
 (executable
  (name boot)
- (libraries batteries str)
+ (libraries batteries str linenoise)
 )

--- a/src/boot/dune-boot-ext
+++ b/src/boot/dune-boot-ext
@@ -5,5 +5,5 @@
 
 (executable
  (name boot)
- (libraries batteries str sundialsml)
+ (libraries batteries str linenoise sundialsml)
 )

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -85,10 +85,10 @@
 %token <unit Ast.tokendata> CONCAT        /* "++"  */
 
 %start main
-%start prog_mexpr
+%start main_mexpr
 
 %type <Ast.program> main
-%type <Ast.program> prog_mexpr
+%type <Ast.program> main_mexpr
 
 %%
 
@@ -96,7 +96,7 @@ main:
   | includes tops mexpr_opt EOF
     { Program ($1, $2, $3) }
 
-prog_mexpr:
+main_mexpr:
   | mexpr EOF
     { Program ([], [], $1) }
 

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -85,14 +85,20 @@
 %token <unit Ast.tokendata> CONCAT        /* "++"  */
 
 %start main
+%start prog_mexpr
 
 %type <Ast.program> main
+%type <Ast.program> prog_mexpr
 
 %%
 
 main:
   | includes tops mexpr_opt EOF
     { Program ($1, $2, $3) }
+
+prog_mexpr:
+  | mexpr EOF
+    { Program ([], [], $1) }
 
 includes:
   | include_ includes

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -1,0 +1,111 @@
+
+(*
+   Miking is licensed under the MIT license.
+   Copyright (C) David Broman. See file LICENSE.txt
+
+   repl.ml contains most of the MCore REPL functionality. It is built upon the
+   bootstrap interpreter. Uses linenoise.
+*)
+
+
+open Ustring.Op
+open Printf
+
+let initial_prompt = ">> "
+let followup_prompt = " | "
+
+let no_line_edit = ref false
+
+module Option = BatOption
+
+
+(* Try to parse a string received by the REPL into an MCore AST *)
+let parse_mcore_string parse_fun str =
+  let repl_tablength = 8 in
+  Lexer.init (us"REPL") repl_tablength;
+  let lexbuf = Lexing.from_string str in
+  try Ok (parse_fun Lexer.main lexbuf)
+  with Parsing.Parse_error -> Error (Lexing.lexeme lexbuf)
+
+let read_input prompt =
+  if !no_line_edit then
+    (print_string prompt; read_line ())
+  else
+    match LNoise.linenoise prompt with
+      | None -> raise End_of_file
+      | Some str ->
+        LNoise.history_add str |> ignore;
+        String.trim str
+
+let print_welcome_message () =
+  print_endline "Welcome to the MCore REPL!";
+  print_endline "Type :h for help or :q to quit."
+
+let handle_command str =
+  let help_message =
+{|  Commands available from the prompt:
+
+   <statement>                 evaluate <statement>
+   :{\n ..lines.. \n:}\n       multiline command
+   :q                          exit the REPL
+   :h                          display this message|} in
+  match str with
+    | ":q" -> exit 0
+    | ":h" -> print_endline help_message; true
+    | _ -> false
+
+(* Read and parse a toplevel or mexpr expression. Continues to read input
+   until a valid expression is formed. Raises Parse_error if the expression
+   cannot be extended to a valid expression *)
+let rec read_until_complete is_mexpr input =
+  let new_acc () = sprintf "%s\n%s" input (read_input followup_prompt) in
+  let parse_fun = if is_mexpr then Parser.main_mexpr else Parser.main in
+  match parse_mcore_string parse_fun input with
+    | Ok ast -> ast
+    | Error "" -> read_until_complete is_mexpr (new_acc ())
+    | Error _ ->
+      if is_mexpr then
+        raise Parsing.Parse_error
+      else
+        read_until_complete true input
+
+(* Read and parse a multiline expression (:{\n ..lines.. \n:}).
+   Returns None if the first line is not ":{" *)
+let read_multiline first_line =
+  let rec read_until_end acc =
+    let line = read_input followup_prompt in
+    match line with
+    | ":}" -> acc
+    | _ -> read_until_end (line :: acc)
+  in
+  if first_line = ":{" then
+    let lines = List.fold_right (fun x a -> sprintf "%s\n%s" a x)
+                                (read_until_end []) "" in
+    match parse_mcore_string Parser.main lines with
+    | Ok ast -> Some ast
+    | Error _ ->
+      match parse_mcore_string Parser.main_mexpr lines with
+      | Ok ast -> Some ast
+      | Error _ -> raise Parsing.Parse_error
+  else
+    None
+
+(* Read input from the user and respond accordingly depending on if it is a
+   command, the beginning of a multiline statement or a normal expression *)
+let rec read_user_input () =
+  let first_line = read_input initial_prompt in
+  if handle_command first_line then
+    read_user_input ()
+  else
+    Option.default_delayed (fun _ -> read_until_complete false first_line)
+                           (read_multiline first_line)
+
+(* Evaluate a term given existing environments.
+   Returns updated environments along with evaluation result.
+*)
+let eval_with_envs (langs, nss, name2sym, sym2term) term =
+  let new_langs, flattened = Mlang.flatten_with_env langs term in
+  let new_nss, desugared = Mlang.desugar_post_flatten_with_nss nss flattened in
+  let new_name2sym, symbolized = Mexpr.symbolize_toplevel name2sym desugared in
+  let new_sym2term, result = Mexpr.eval_toplevel sym2term symbolized in
+  ((new_langs, new_nss, new_name2sym, new_sym2term), result)

--- a/src/boot/utils.ml
+++ b/src/boot/utils.ml
@@ -154,6 +154,9 @@ let normalize_path p =
      |> recur
      |> String.concat Filename.dir_sep
 
+let split_at idx str =
+  let open BatString in
+  (slice ~last:idx str, slice ~first:idx str)
 
 module Int =
 struct

--- a/src/boot/utils.ml
+++ b/src/boot/utils.ml
@@ -154,9 +154,6 @@ let normalize_path p =
      |> recur
      |> String.concat Filename.dir_sep
 
-let split_at idx str =
-  let open BatString in
-  (slice ~last:idx str, slice ~first:idx str)
 
 module Int =
 struct


### PR DESCRIPTION
This pull request improves the REPL:
- Add history and line editing
- Remove need for semicolons and `mexpr`
- Fix bug where local bindings leaked into global scope
- Fix error message row numbers
- Add exit and help commands

In addition, the REPL code has been moved to its own module. As the line editing complicates communicating with the REPL using python's `pexpect`, the flag `--no-line-edit` has also been added, which makes the REPL use the old basic input mode.

The line editing relies on the OCaml library `linenoise`, which has been added as a dependency.