### PR TITLE
Jupyter kernel

### DIFF
--- a/KERNEL_README.md
+++ b/KERNEL_README.md
@@ -54,16 +54,43 @@ and select the `MCore` kernel when creating a new notebook.
 *Note that `$HOME/.local/bin` must be included in your PATH. This should be
 done by default on most Linux distributions.*
 
+## Now you're playing with Python
+
+The MCore kernel also allows executing Python code and interacting with it from
+MCore. Use the special directive `%%python` at the top of a cell to evaluate
+Python code.
+
+You can call the functions you have defined in Python cells in normal MCore
+cells by importing and using the module `__main__`. For example, consider the
+following two cells:
+
+```python
+%%python
+def foo(x):
+  print("foo"+x)
+```
+
+```ocaml
+let x = "bar" in
+let m = pyimport "__main__" in
+pycall m "foo" (x,)
+```
+
+The final `pycall` will print `foobar` as expected.
+
 ## Plotting graphs
 
-It is possible to plot graphs with MCore using the Python library `matplotlib`.
+It is possible to plot graphs using the Python library `matplotlib`.
 The Jupyter kernel offers integration with `matplotlib` to display plots inline.
 Make sure you have `matplotlib` installed (if not, you can install it using
 `pip`). Now, when you use `matplotlib`'s plot functions in a notebook cell, the
-plots will be displayed as part of the cell's output. For example, you can try running the following in a cell:
+plots will be displayed as part of the cell's output.
+For example, you can try running the following in a cell:
 
 ```ocaml
 let plt = pyimport "matplotlib.pyplot"
 let x = [1,2,4,8]
 let _ = pycall plt "plot" (x,)
 ```
+
+Of course, the same goes for plots made using Python cells.

--- a/KERNEL_README.md
+++ b/KERNEL_README.md
@@ -1,0 +1,69 @@
+
+# MCore Jupyter Kernel
+
+In addition to the bootstrap interpreter, this repository also contains a
+[Jupyter](https://jupyter.org/) kernel for MCore which is based on the
+interpreter. The kernel is written in OCaml and directly interfaces with the
+evaluation functions of `boot`. It is focused on enabling a large amount of
+interoperability between MCore and Python.
+
+## Getting started
+
+Before using the Jupyter kernel you need to install some dependencies.
+The Jupyter kernel requires all the base dependencies of the boot interpreter,
+and the `pyml` Python bindings for OCaml. For information on how to install
+these, see [README.md](./README.md).
+
+Finally, the OCaml package `jupyter-kernel` is needed. This package needs the
+`zeromq` C library, so make sure to install it on your system first. On
+Debian-based Linux distributions, this can be done with:
+
+```bash
+sudo apt-get install libzmq3-dev
+```
+
+On macOS, you can install it using brew:
+
+```bash
+brew install zeromq
+```
+
+Once this is done, `jupyter-kernel` can be installed through `opam`, using:
+
+```bash
+opam install jupyter-kernel
+```
+
+To compile the Jupyter kernel, use the make target `kernel`:
+
+```bash
+make kernel
+```
+
+This will create the binary `build/kernel` in the root directory of the project.
+Finally, to register the kernel with Jupyter, run the following command from the
+project root.
+
+```bash
+jupyter kernelspec install src/boot/kernel --user
+```
+
+You are now ready to start using the kernel. For example, to start a new Jupyter
+notebook using the MCore kernel, go to the project root, run `jupyter notebook`
+and select the `MCore` kernel when creating a new notebook. Note that at the
+moment, **you must be in the project root when using the kernel**; this will
+change in an upcoming release.
+
+## Plotting graphs
+
+It is possible to plot graphs with MCore using the Python library `matplotlib`.
+The Jupyter kernel offers integration with `matplotlib` to display plots inline.
+Make sure you have `matplotlib` installed (if not, you can install it using
+`pip`). Now, when you use `matplotlib`'s plot functions in a notebook cell, the
+plots will be displayed as part of the cell's output. For example, you can try running the following in a cell:
+
+```ocaml
+let plt = pyimport "matplotlib.pyplot"
+let x = [1,2,4,8]
+let _ = pycall plt "plot" (x,)
+```

--- a/KERNEL_README.md
+++ b/KERNEL_README.md
@@ -7,29 +7,48 @@ interpreter. The kernel is written in OCaml and directly interfaces with the
 evaluation functions of `boot`. It is focused on enabling a large amount of
 interoperability between MCore and Python.
 
+## Jupyter basics
+
+[Jupyter](https://jupyter.org/) provides an ecosystem for writing, documenting
+and visualizing code in an interactive way. The _Jupyter Notebook_ is a
+literate programming environment for this purpose. Notebooks can contain text,
+executable code, display images and more. Notebooks provide support for many languages
+by using language-specific _kernels_, which take care of executing the user's
+code and producing output for the notebook to display.
+
+To get a quick introducion on how to use Jupyter Notebooks in general, check out
+[this tutorial](https://mybinder.org/v2/gh/ipython/ipython-in-depth/master?filepath=binder/Index.ipynb).
+https://jupyter.org/ also provides more helpful links and information.
+
+This README will explain how to get started with Jupyter Notebooks for MCore,
+and go through all the functionality of the Jupyter MCore kernel. Once you have
+installed the kernel in the next section, there is also an interactive notebook
+demonstrating MCore and the kernel's capabilities at `JupyterExample.ipynb`.
+
 ## Getting started
 
 Before using the Jupyter kernel you need to install some dependencies.
-The Jupyter kernel requires all the base dependencies of the boot interpreter,
+The Jupyter kernel requires all the base dependencies of the boot interpreter
+(`dune`, `batteries`, and `linenoise`),
 and the `pyml` Python bindings for OCaml. For information on how to install
 these, see [README.md](./README.md).
 
 Next, you will need to have Jupyter itself installed.
-Installation using pip:
+To install Jupyter using using `pip`, run the following command:
 
 ```bash
 pip install jupyter
 ```
 
-Finally, the OCaml package `jupyter-kernel` is needed. This package needs the
-`zeromq` C library, so make sure to install it on your system first. On
+Finally, the OCaml package `jupyter-kernel` is needed. This package depends on
+the `zeromq` C library, so make sure to install it on your system first. On
 Debian-based Linux distributions, this can be done with:
 
 ```bash
 sudo apt-get install libzmq3-dev
 ```
 
-On macOS, you can install it using brew:
+On macOS, it can be installed using brew:
 
 ```bash
 brew install zeromq
@@ -41,51 +60,82 @@ Once this is done, `jupyter-kernel` can be installed through `opam`, using:
 opam install jupyter-kernel
 ```
 
-Finally, to install the Jupyter kernel, use the make target `kernel-install`:
+Finally, to install the Jupyter kernel, use the make target `kernel-install`,
+by running the following command:
 
 ```bash
 make kernel-install
 ```
 
 You are now ready to start using the kernel. For example, to start a new Jupyter
-notebook using the MCore kernel run `jupyter notebook`
+Notebook using the MCore kernel, run `jupyter notebook`
 and select the `MCore` kernel when creating a new notebook.
 
 *Note that `$HOME/.local/bin` must be included in your PATH. This should be
 done by default on most Linux distributions.*
 
-## Now you're playing with Python
+## Functionality
+
+This section describes all functionality that is supported by the MCore
+Jupyter kernel.
+
+### Basic code cells
+
+The Jupyter kernel allows writing and executing code in an interactive manner.
+For example, to print the typical 'Hello world!' message, try inputting the following
+into a cell and executing it using `Shift-Enter`.
+
+```ocaml
+print "Hello world!"
+```
+
+The notebook provides syntax highlighting and autocompletion. To trigger the
+autocompletion, press `Tab` after inputting part of a word. The completions
+include both builtin functions and user-defined names.
+
+### Now you're playing with Python
 
 The MCore kernel also allows executing Python code and interacting with it from
 MCore. Use the special directive `%%python` at the top of a cell to evaluate
 Python code.
 
-You can call the functions you have defined in Python cells in normal MCore
-cells by importing and using the module `__main__`. For example, consider the
-following two cells:
+For example, the following cell defines a Python function `foo` and calls it.
 
 ```python
 %%python
 def foo(x):
   print("foo"+x)
+
+foo("bar")
 ```
 
+The running the cell will print `foobar`, as one might expect.
+
+You can call the functions you have defined in Python cells in normal MCore
+cells by using the Python intrinsics (for more information on these, see
+[README.md](./README.md) or the example notebook). A user-defined function can
+be called by importing and using the Python module `__main__`. For example,
+consider the following cell:
+
 ```ocaml
-let x = "bar" in
 let m = pyimport "__main__" in
+let x = "bar" in
 pycall m "foo" (x,)
 ```
 
-The final `pycall` will print `foobar` as expected.
+This cell will call the Python function `foo` defined above, again printing
+`foobar` as expected.
 
-## Plotting graphs
+### Plotting graphs
 
 It is possible to plot graphs using the Python library `matplotlib`.
-The Jupyter kernel offers integration with `matplotlib` to display plots inline.
-Make sure you have `matplotlib` installed (if not, you can install it using
-`pip`). Now, when you use `matplotlib`'s plot functions in a notebook cell, the
-plots will be displayed as part of the cell's output.
-For example, you can try running the following in a cell:
+The Jupyter kernel offers integration with `matplotlib` to display plots
+directly in a notebook.
+
+To use this functionality, first make sure that `matplotlib` is installed (if
+not, you can install it using `pip`). Now, when you use `matplotlib`'s plot
+functions in a notebook cell, the plots will be displayed as part of the cell's
+output. For example, you can try running the following in a cell:
 
 ```ocaml
 let plt = pyimport "matplotlib.pyplot"
@@ -93,4 +143,14 @@ let x = [1,2,4,8]
 let _ = pycall plt "plot" (x,)
 ```
 
-Of course, the same goes for plots made using Python cells.
+While this example uses the Python intrinsics, running the plot code directly in
+a Python cell would of course also work.
+
+## Interactive notebook
+
+If you followed the installation instructions above, you can try out the
+interactive example notebook, by running `jupyter notebook` in the root
+directory of the repository and opening the file `JupyterExample.ipynb` from the
+Jupyter Notebook interface. The notebook features many examples, including MCore
+basics and the Python intrinsics, demonstrating the full capabilities of the
+MCore Jupyter kernel.

--- a/KERNEL_README.md
+++ b/KERNEL_README.md
@@ -14,6 +14,13 @@ The Jupyter kernel requires all the base dependencies of the boot interpreter,
 and the `pyml` Python bindings for OCaml. For information on how to install
 these, see [README.md](./README.md).
 
+Next, you will need to have Jupyter itself installed.
+Installation using pip:
+
+```bash
+pip install jupyter
+```
+
 Finally, the OCaml package `jupyter-kernel` is needed. This package needs the
 `zeromq` C library, so make sure to install it on your system first. On
 Debian-based Linux distributions, this can be done with:
@@ -34,25 +41,18 @@ Once this is done, `jupyter-kernel` can be installed through `opam`, using:
 opam install jupyter-kernel
 ```
 
-To compile the Jupyter kernel, use the make target `kernel`:
+Finally, to install the Jupyter kernel, use the make target `kernel-install`:
 
 ```bash
-make kernel
-```
-
-This will create the binary `build/kernel` in the root directory of the project.
-Finally, to register the kernel with Jupyter, run the following command from the
-project root.
-
-```bash
-jupyter kernelspec install src/boot/kernel --user
+make kernel-install
 ```
 
 You are now ready to start using the kernel. For example, to start a new Jupyter
-notebook using the MCore kernel, go to the project root, run `jupyter notebook`
-and select the `MCore` kernel when creating a new notebook. Note that at the
-moment, **you must be in the project root when using the kernel**; this will
-change in an upcoming release.
+notebook using the MCore kernel run `jupyter notebook`
+and select the `MCore` kernel when creating a new notebook.
+
+*Note that `$HOME/.local/bin` must be included in your PATH. This should be
+done by default on most Linux distributions.*
 
 ## Plotting graphs
 

--- a/KERNEL_README.md
+++ b/KERNEL_README.md
@@ -23,7 +23,7 @@ https://jupyter.org/ also provides more helpful links and information.
 This README will explain how to get started with Jupyter Notebooks for MCore,
 and go through all the functionality of the Jupyter MCore kernel. Once you have
 installed the kernel in the next section, there is also an interactive notebook
-demonstrating MCore and the kernel's capabilities at `JupyterExample.ipynb`.
+demonstrating MCore and the kernel's capabilities at `MCoreJupyter.ipynb`.
 
 ## Getting started
 
@@ -109,7 +109,7 @@ def foo(x):
 foo("bar")
 ```
 
-The running the cell will print `foobar`, as one might expect.
+Running the cell will print `foobar`, as one might expect.
 
 You can call the functions you have defined in Python cells in normal MCore
 cells by using the Python intrinsics (for more information on these, see
@@ -150,7 +150,7 @@ a Python cell would of course also work.
 
 If you followed the installation instructions above, you can try out the
 interactive example notebook, by running `jupyter notebook` in the root
-directory of the repository and opening the file `JupyterExample.ipynb` from the
+directory of the repository and opening the file `MCoreJupyter.ipynb` from the
 Jupyter Notebook interface. The notebook features many examples, including MCore
 basics and the Python intrinsics, demonstrating the full capabilities of the
 MCore Jupyter kernel.

--- a/KERNEL_README.md
+++ b/KERNEL_README.md
@@ -16,7 +16,8 @@ executable code, display images and more. Notebooks provide support for many lan
 by using language-specific _kernels_, which take care of executing the user's
 code and producing output for the notebook to display.
 
-To get a quick introducion on how to use Jupyter Notebooks in general, check out
+To get a quick introduction on how to use Jupyter Notebooks in
+general, check out
 [this tutorial](https://mybinder.org/v2/gh/ipython/ipython-in-depth/master?filepath=binder/Index.ipynb).
 https://jupyter.org/ also provides more helpful links and information.
 
@@ -34,7 +35,7 @@ and the `pyml` Python bindings for OCaml. For information on how to install
 these, see [README.md](./README.md).
 
 Next, you will need to have Jupyter itself installed.
-To install Jupyter using using `pip`, run the following command:
+To install Jupyter using `pip`, run the following command:
 
 ```bash
 pip install jupyter

--- a/MCoreJupyter.ipynb
+++ b/MCoreJupyter.ipynb
@@ -1,0 +1,1306 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Miking\n",
+    "\n",
+    "Miking (Meta vIKING) is a meta language system for creating embedded domain-specific and general-purpose languages. Miking is not a programming language, but rather a language system for\n",
+    "creating languages and generating efficient compilers.\n",
+    "\n",
+    "## This Notebook\n",
+    "\n",
+    "This notebook gives a comprehensive introduction to the Miking language system in an interactive format. It can be seen as a complement to the main `README` intended to be easier to get started with but not covering the same depth.\n",
+    "\n",
+    "When going through the notebook, we recommend playing around with it by changing the values in code cells or trying out your own examples.\n",
+    "\n",
+    "## Table of Contents\n",
+    "1. [MCore](#MCore)\n",
+    "2. [Python Intrinsics](#Python-Intrinsics)\n",
+    "3. [Additional Notebook Features](#Notebook-Features)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MCore\n",
+    "\n",
+    "MCore (Miking Core) is the core language of the Miking system. It is\n",
+    "based on a typed Lambda Calculus (Note: the type system is under\n",
+    "development, and the current implementation is untyped).\n",
+    "\n",
+    "MCore consists of two parts:\n",
+    "\n",
+    "* **MExpr** is an MCore expression. A Miking language is always translated into an MExpr, before it is further evaluated or compiled into machine code.\n",
+    "\n",
+    "* **MLang** which is a language for defining and composing language fragments. MLang is formally translated into an MExpr.\n",
+    "\n",
+    "In Jupyter, we support both MExpr and MLang in code cells. In the following sections, we will use both without worrying too much about differentiating between the two."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Values and Function Applications\n",
+    "\n",
+    "MExpr features a number of different types of values:\n",
+    "\n",
+    "- Bool\n",
+    "- Int\n",
+    "- Char\n",
+    "- Float\n",
+    "- String\n",
+    "- Sequence\n",
+    "- Unit\n",
+    "- Record\n",
+    "- Tuple\n",
+    "- Function\n",
+    "- User-defined\n",
+    "\n",
+    "There are also a number of builtin functions that can be used. For more information on these, see [README.md](./README.md)\n",
+    "For instance, the following expression will add the two values 2 and 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "addi 2 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's print the iconic `Hello, world!` message"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print \"Hello, world!\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Let Expressions\n",
+    "\n",
+    "Expressions can be given names using `let` expressions. For instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let x = addi 1 2 in\n",
+    "eqi x 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "introduces a new name `x`. The built-in function `addi`, as we have seen, performs an addition between two integers. Note that MCore uses a call-by-value evaluation order, which means that expressions are evaluated into a value before they are applied to a function or substituted using a `let` expression. Hence, the expression `addi 1 2` is evaluated before it is substituted for `x` in the rest of the expression.\n",
+    "\n",
+    "Finally, the `eqi` builtin function is used to check that `x` is equal to 3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Top-level Definitions\n",
+    "\n",
+    "In the above example, `x` is defined only in the scope of the expression following the `in` keyword. To define a variable in the top-level scope, we can simply omit the `in` keyword:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let x = addi 1 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This lets us reuse `x` in other code cells:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "addi x 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to evaluate an expression in the same cell as a definition, you need to take some care. Simply putting one after the other won't produce the correct result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let y = addi x 10\n",
+    "\n",
+    "y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instead, either use a let binding with the `in` keyword, or use the `mexpr` keyword to separate the expression to evaluate, like this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let y = addi x 10\n",
+    "\n",
+    "mexpr\n",
+    "y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, both `x` and `y` are in the global scope."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Functions\n",
+    "\n",
+    "Functions are always defined anonymously as lambda functions. If you would like to give a function a name, a `let` expression can be used. For instance, the following program defines a function `double` that doubles the value of its argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let double = lam x. muli x 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "double 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Types can be expressed in MCore programs, but they are currently not checked. For instance, the `double` function can be written as\n",
+    "\n",
+    "```\n",
+    "let double = lam x:Int. muli x 2 in\n",
+    "```\n",
+    "\n",
+    "This means that `double` has type `Int -> Int`, which can also be expressed as part of the `let` expression.\n",
+    "\n",
+    "```\n",
+    "let double : Int -> Int = lam x. muli x 2 in\n",
+    "```\n",
+    "\n",
+    "A function with several parameters are expressed using currying, using nested lambda expressions. For instance,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let foo = lam x. lam y. addi x y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "creates a function `foo` that takes two arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foo 2 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `if` Expressions\n",
+    "\n",
+    "Conditional expressions can be expressed using `if` expressions. The program"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let x = 5 in\n",
+    "let answer = if (lti x 10) then \"yes\" else \"no\" in\n",
+    "answer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "checks if `x` is less than 10 (using the `lti` function with signature `Int -> Int -> Bool`). If it is true, the string `\"yes\"` is returned, else string `\"no\"` is returned."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Recursion\n",
+    "\n",
+    "A normal `let` expression cannot be used to define recursive functions. Instead, recursion can be defined using *recursive lets*, starting with the `recursive` keyword:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recursive\n",
+    "let fact = lam n.\n",
+    "  if eqi n 0\n",
+    "    then 1\n",
+    "    else muli n (fact (subi n 1))\n",
+    "in\n",
+    "fact 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to use a recursive let in the top-level:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recursive\n",
+    "let fact = lam n.\n",
+    "  if eqi n 0\n",
+    "    then 1\n",
+    "    else muli n (fact (subi n 1))\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fact 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recursive lets can also be used to define mutually recursive functions. For instance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recursive\n",
+    "let odd = lam n.\n",
+    "    if eqi n 1 then true\n",
+    "    else if lti n 1 then false\n",
+    "    else even (subi n 1)\n",
+    "let even = lam n.\n",
+    "    if eqi n 0 then true\n",
+    "    else if lti n 0 then false\n",
+    "    else odd (subi n 1)\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "odd 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "even 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tuples\n",
+    "\n",
+    "Product types can be expressed using tuples. An n-tuple is defined using syntax `(e_1, ..., e_n)` where `e_1` to `e_n` are MCore expressions. Extracting a value from a tuple (projection) is performed using an expression `e.n` where `e` is the expression that is evaluated into a tuple, and `n` is an integer number representing the index of an element in the tuple. The first index in a tuple is `0`.\n",
+    "\n",
+    "For instance, in the following code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let t = (addi 1 2, \"hi\", 80)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "we create a 3-tuple `t` and project out its first value. Note that the different elements of a tuple can have different types. In this case, tuple `t` has type `(Int, String, Int)`.\n",
+    "\n",
+    "Singleton tuples are also supported: `(x,)` represents a tuple with `x` as its\n",
+    "only element."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Records\n",
+    "\n",
+    "Another more general form of product types are records. A record has\n",
+    "named fields that can have different types. For instance,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{name = \"foobar\", age = 42}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "defines a record of type `{name : string, age : int}`. The order of the fields does not matter: the following would define the same record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{age = 42, name = \"foobar\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To project out a value, a dot notation may be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let r1 = {age = 42, name = \"foobar\"} in\n",
+    "r1.age"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A record type is not just a general product type in MCore, it is the only\n",
+    "product type. That is, a tuple is just *syntactic sugar* for a record. This means that the compiler encodes a tuple as a record, where the names of the fields are numbers `0`, `1`, etc. Labels can internally be any kind of string. For strings that cannot be defined as a normal identifier, the label form `#label\"x\"`\n",
+    "can be used, where `x` is the string of the label.\n",
+    "\n",
+    "The following example shows how a tuple is actually encoded as a\n",
+    "record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{#label\"0\" = true, #label\"1\" = 5}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data Types and `match` expressions\n",
+    "\n",
+    "Sum types or variant types are constructed using `con` expressions (constructor expressions). In contrast to most other functional languages, the introduction of a new data type and the introduction of constructors are separated. For instance,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type Tree\n",
+    "con Node : (Tree,Tree) -> Tree\n",
+    "con Leaf : (Int) -> Tree"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "introduces a new data type `Tree` and defines two new constructors `Node` and `Leaf`. Constructor `Leaf` takes just one argument (an integer value for the leaf) and returns a tree, whereas the `Node` constructor takes a tuple with two trees as input and constructs a new tree node.\n",
+    "\n",
+    "For instance,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let tree = Node(Node(Leaf 4, Leaf 2), Leaf 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "is a small tree named `tree`.\n",
+    "\n",
+    "Assume now that we want to count the sum of the values of all leaves in a tree. We can then write a recursive function that performs the counting:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recursive\n",
+    "  let count = lam tree.\n",
+    "    match tree with Node t then\n",
+    "      let left = t.0 in\n",
+    "      let right = t.1 in\n",
+    "      addi (count left) (count right)\n",
+    "    else match tree with Leaf v then v\n",
+    "    else error \"Unknown node\"\n",
+    "in\n",
+    "\n",
+    "count tree"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `match` expression inside the `count` function *deconstructs* data values by matching against a given constructor. For instance, the `match` expression\n",
+    "\n",
+    "```\n",
+    "match tree with Node t then expr1 else expr2\n",
+    "```\n",
+    "\n",
+    "matches the value after evaluating expression `tree` and checks if its outer most constructor is a `Node` constructor. If that is the case, the identifier `t` in expression `expr1` is bound to the tuple consisting of the node's two sub trees (recall the definition of the constructor `Node`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pattern matching\n",
+    "\n",
+    "In the previous match example, the `match` construct matched against\n",
+    "the constructor, but not against the actual data content. MExpr is\n",
+    "designed to be simple with few language construct, at the right level\n",
+    "of abstraction. If the abstraction level is too low, it is hard to\n",
+    "perform useful static analysis and code generation. As a consequence,\n",
+    "MExpr support *patterns* in `match` expressions. The `count` function\n",
+    "can be rewritten as\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recursive\n",
+    "  let count = lam tree.\n",
+    "    match tree with Node(left,right) then\n",
+    "      addi (count left) (count right)\n",
+    "    else match tree with Leaf v then v\n",
+    "    else error \"Unknown node\"\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "where the match construct matches against pattern `Node(left,right)`,\n",
+    "where `left` and `right` are pattern variables.\n",
+    "\n",
+    "Remember, however, that tuples are just syntactic sugar for records. Hence, match line\n",
+    "\n",
+    "```\n",
+    "    match tree with Node(left,right) then\n",
+    "```\n",
+    "is equivalent to the following\n",
+    "```\n",
+    "    match tree with Node {#label\"0\"=left,#label\"1\"=right} then\n",
+    "```\n",
+    "where the pattern is a *record pattern*.\n",
+    "\n",
+    "Pattern matching is the general form of deconstructing data in MExpr. Patterns can also be nested:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match {foo=7,bar={more=\"hello\"}} with {foo=_,bar={more=str}} then str else \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note also the use of *wildcard* patterns `_` (used in the `foo`\n",
+    "field), which matches any value.\n",
+    "\n",
+    "Finally, MExpr also supports more advanced patterns, including `AND` patterns (using infix notation `&`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match (1, 2) with (a, _) & b then (a, b) else (0, (0, 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`OR` patterns (using infix notation `|`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type K in\n",
+    "con K1: (Int) -> K in\n",
+    "con K2: (Int) -> K in\n",
+    "\n",
+    "match K1 1 with K1 a | K2 a then a else 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and `NOT` patterns (using the prefix notation `!`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match Some true with a & !(None ()) then a else Some false"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match None () with a & !(None ()) then a else Some false"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These are present to make it possible to translate order-dependent patterns to order-*in*dependent patterns. For example, in OCaml,\n",
+    "\n",
+    "```ocaml\n",
+    "match (opt1, opt2) with\n",
+    "| (Some a, _) -> a\n",
+    "| (_, Some a) -> a\n",
+    "| (_, _) -> 1\n",
+    "```\n",
+    "\n",
+    "is order-dependent; any change in pattern order changes which match-arm is executed. To express this in an order-independent manner we `&` every pattern with the inverse (`!`) of the union (`|`) of the previous patterns. If we pretent for a moment that OCaml supports `&` and `!` in patterns they could then be written as:\n",
+    "\n",
+    "```ocaml\n",
+    "match (opt1, opt2) with\n",
+    "| (Some a, _) -> a\n",
+    "| (_, Some a) & !(Some a, _) -> a\n",
+    "| (_, _) & !((Some a, _) | (_, Some a))-> 1\n",
+    "```\n",
+    "\n",
+    "The order can now be changed freely without affecting the semantics. In practice `&` and `!` will probably rarely be used in manually written code, while `|` is rather more useful.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sequences\n",
+    "\n",
+    "An MCore sequence is constructed using syntax `[e_1, ..., e_n]`. All elements in a sequence must have the same type. For instance, an expression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[1,3,6,7,22,3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "has type `[Int]` whereas the expression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[\"this\", \"is\", \"a\", \"test\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "has type `[String]`.\n",
+    "\n",
+    "As you may already have noticed, a string itself is actually a sequence of characters. This means that the type `String` is just an abbreviation for the sequence type `[Char]`.\n",
+    "\n",
+    "There are several operations defined for sequences, for instance, the `concat` function concatenates two sequences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "concat [1,3,5] [7,9]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or the `get` function picks out the nth element of a sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get [3,5,8,9] 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to pattern match on sequences, to either extract the *tail* of a sequence, if the first part matches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match \"foobar\" with \"fo\" ++ rest then rest else \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or the *head* of a sequence if the last part matches:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match \"foobar\" with first ++ \"bar\" then first else \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is even possible to extract the middle of a sequence, if the head and the tail matches:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "match \"foobar\" with \"fo\" ++ mid ++ \"ar\" then mid else \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, matching can be combined and nested:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match (1,[[\"a\",\"b\"],[\"c\"]],76) with (1,b++[[\"c\"]],76) then b else []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Includes\n",
+    "\n",
+    "To include code from the standard library, or from an MCore file you've written yourself, you can use the `include` keyword. This will introduce all top-level definitions from the included file into the top-level scope. The filepath to `include` can be any standard library file or a valid filepath to a user-defined file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "include \"string.mc\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, the functions from the standard library file `string.mc` can be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print (strJoin \", \" [\"Hello\", \"world!\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Language Fragments\n",
+    "\n",
+    "A language fragment contains definitions of (abstract) syntax, and\n",
+    "semantics (\"interpreters\") for that fragment. Any number of\n",
+    "language fragments can be defined in the top-level of an\n",
+    "MCore program. For example, here is a language fragment for simple\n",
+    "arithmetics:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lang Arith\n",
+    "  syn Expr =\n",
+    "  | Num Int\n",
+    "  | Add (Expr, Expr)\n",
+    "\n",
+    "  sem eval =\n",
+    "  | Num n -> Num n\n",
+    "  | Add (e1,e2) ->\n",
+    "    match eval e1 with Num n1 then\n",
+    "      match eval e2 with Num n2 then\n",
+    "        Num (addi n1 n2)\n",
+    "      else error \"Not a number\"\n",
+    "    else error \"Not a number\"\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The fragment defines a syntactic form with two cases called\n",
+    "`Expr`, and an interpreter called `eval`. An interpreter in MLang\n",
+    "is a function that is always defined by cases over its last\n",
+    "argument (here, `eval` takes only a single argument). The body of\n",
+    "a case is a regular MExpr term, which has access to the name of\n",
+    "the value (if any) carried by the current syntactic form.\n",
+    "\n",
+    "In an expression, a language fragment can be opened by\n",
+    "a `use` expression:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use Arith in\n",
+    "eval (Add (Num 2, Num 3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A `use` is translated into a series of MExpr definitions that\n",
+    "match the syntax and semantics of the specified language fragment.\n",
+    "\n",
+    "An important feature of language fragments is that they can be\n",
+    "composed to form new language fragments. As an example, we might\n",
+    "want to extend our arithmetics language with booleans and `if`\n",
+    "expressions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lang Bool\n",
+    "  syn Expr =\n",
+    "  | True()\n",
+    "  | False()\n",
+    "  | If (Expr, Expr, Expr)\n",
+    "\n",
+    "  sem eval =\n",
+    "  | True() -> True()\n",
+    "  | False() -> False()\n",
+    "  | If(cnd,thn,els) ->\n",
+    "    let cndVal = eval cnd in\n",
+    "    match cndVal with True() then eval thn\n",
+    "    else match cndVal with False() then eval els\n",
+    "    else error \"Not a boolean\"\n",
+    "end\n",
+    "\n",
+    "lang ArithBool = Arith + Bool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use ArithBool in\n",
+    "eval (Add (If (False(), Num 0, Num 5), Num 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The language fragment `ArithBool` is indistinguishable from a\n",
+    "language fragment with all the syntactic and semantic cases of\n",
+    "`Arith` and `Bool` merged. If we wanted, we could have added new\n",
+    "cases to the language composition as well, and refer to the syntax\n",
+    "and semantics of the fragments being composed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lang ArithBool = Arith + Bool\n",
+    "  syn Expr =\n",
+    "  | IsZero Expr\n",
+    "\n",
+    "  sem eval =\n",
+    "  | IsZero e ->\n",
+    "    match eval e with Num n then\n",
+    "      if eqi n 0 then True() else False()\n",
+    "    else\n",
+    "      error \"Not a number\"\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use ArithBool in\n",
+    "eval (IsZero (If (False(), Num 1, Num 0)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Python Intrinsics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An optional feature of MCore is Python intrinsics, which allow calling Python functions from MCore code. The Jupyter kernel includes these features.\n",
+    "\n",
+    "The following example shows how to use the intrinsics to sort a sequence using\n",
+    "Python's builtin `sorted` function. Before you can call a Python function, you will need to import the relevant Python module using `pyimport`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let builtins = pyimport \"builtins\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Any module in the Python path can be imported in this way. Now, `pycall` can be used to call a function from that module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let x = [5,4,2,1,3]\n",
+    "let y = pycall builtins \"sorted\" (x,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result of the `pycall` is a Python value. Python values can be passed to other Python functions, but not regular MCore functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pycall builtins \"print\" (y,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "map (addi 2) y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To recover an MCore value from a Python value, use the `pyconvert` intrinsic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let y_mcore = pyconvert y in\n",
+    "map (addi 2) y_mcore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most basic values can be converted between Python and MCore types; the main exceptions are Python classes and MCore user-defined data types. For a detailed explanation, see [the main README](./README.md)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Notebook Features\n",
+    "\n",
+    "In addition to what we've already seen, the Jupyter kernel also offers some additional features.\n",
+    "\n",
+    "### Autocompletion\n",
+    "One thing that you may not have noticed is that autocompletion is available. To get completions, use `Tab` after starting to type a name. Try it out in the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "option"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Python Cells\n",
+    "\n",
+    "The MCore kernel also allows executing Python code and interacting with it from\n",
+    "MCore. Use the special directive `%%python` at the top of a cell to evaluate\n",
+    "Python code.\n",
+    "\n",
+    "For example, the following cell defines a Python function `foo` and calls it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%python\n",
+    "def foo(x):\n",
+    "  print(\"foo\"+x)\n",
+    "\n",
+    "foo(\"bar\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can call the functions you have defined in Python cells in normal MCore\n",
+    "cells by using the Python intrinsics. A user-defined function can\n",
+    "be called by importing and using the Python module `__main__`. For example,\n",
+    "consider the following cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let m = pyimport \"__main__\" in\n",
+    "let x = \"baz\" in\n",
+    "pycall m \"foo\" (x,)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell calls the Python function `foo` defined above, printing\n",
+    "`foobaz` as expected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plotting Graphs\n",
+    "It is possible to plot graphs using the Python library `matplotlib`.\n",
+    "The Jupyter kernel offers integration with `matplotlib` to display plots\n",
+    "directly in a notebook.\n",
+    "\n",
+    "To use this functionality, first make sure that `matplotlib` is installed (if\n",
+    "not, you can install it using `pip`). Now, when you use `matplotlib`'s plot\n",
+    "functions in a notebook cell, the plots will be displayed as part of the cell's\n",
+    "output. For example, try the following cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "let plt = pyimport \"matplotlib.pyplot\"\n",
+    "let x = [1,2,4,8]\n",
+    "let _ = pycall plt \"plot\" (x,)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While this example uses the Python intrinsics, running the plot code directly in\n",
+    "a Python cell would of course also work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "MCore",
+   "language": "",
+   "name": "kernel"
+  },
+  "language_info": {
+   "codemirror_mode": "mcore",
+   "file_extension": ".mc",
+   "mimetype": "text",
+   "name": "MCore",
+   "version": "0.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ all:
 kernel:
 	@./make kernel
 
+kernel-install:
+	@./make kernel-install
+
 test:
 	@./make test
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@
 all:
 	@./make
 
+kernel:
+	@./make kernel
+
 test:
 	@./make test
 

--- a/README.md
+++ b/README.md
@@ -834,26 +834,26 @@ To install for the current user:
 MI_ENABLE_PYTHON=1 make install
 ```
 
-The following example shows how to use the intrinsics to to plot an MCore
-sequence using `matplotlib` (assuming it's installed) after sorting it.
+The following example shows how to use the intrinsics to sort a sequence using
+Python's builtin `sorted` function.
 
-```
+```ocaml
 let builtins = pyimport "builtins"
-let plt = pyimport "matplotlib.pyplot"
 
 let x = [5.,4.5,4.,1.,1.5]
 let y = pycall builtins "sorted" (x,)
-
-mexpr
-let _ = pycall plt "plot" (y,) in
-let _ = pycall plt "show" () in
-()
+let x_sorted = pyconvert y
 ```
 
 Arguments are passed to the `pycall` intrinsic using tuples.
 Note that to call Python's builtin functions, you should use the
-module `builtins`. Also note that at the moment there is no way
-to convert Python values back to MCore values.
+module `builtins`. Other modules can also be imported as long as they
+are available in the Python path. `y` in the example above is a Python value,
+which can either be passed to other Python functions, or converted back to
+an MCore sequence using the `pyconvert` builtin.
+
+[KERNEL_README.md](./KERNEL_README.md) shows some additional examples using
+the Python intrinsics, such as plotting sequences with `matplotlib`.
 
 #### Note when installing Python with brew
 `pyml` requires the shared library `libpython`. However, when using Python installed by brew on macOS, this library is not available in the paths searched by `pyml`. One way to fix this is to create a symlink to the library in `/usr/local/lib`. To find where the library is installed, use the command:

--- a/README.md
+++ b/README.md
@@ -855,6 +855,43 @@ an MCore sequence using the `pyconvert` builtin.
 [KERNEL_README.md](./KERNEL_README.md) shows some additional examples using
 the Python intrinsics, such as plotting sequences with `matplotlib`.
 
+#### Conversion between MCore and Python
+
+When calling a Python function using the `pycall` builtin, the arguments will be
+automatically converted from MCore values to Python values. Similarly, the
+opposite conversion is performed when using `pyconvert` on the result of a
+`pycall`. This section explains the details of these conversions.
+
+##### From MCore to Python
+
+| MCore type      | Python type |
+|:--------------- |:----------- |
+| Bool            | bool        |
+| Int             | int         |
+| Char            | N/A         |
+| Float           | float       |
+| [Char] (String) | str         |
+| [a]             | List        |
+| Unit            | None        |
+| Record          | Dict        |
+| Tuple (Record)  | Dict        |
+| other           | N/A         |
+
+##### From Python to MCore
+
+| Python type | MCore type      |
+|:----------- |:--------------- |
+| bool        | Bool            |
+| int         | Int             |
+| long        | Int             |
+| float       | Float           |
+| str         | [Char] (String) |
+| List        | [a]             |
+| None        | Unit            |
+| Dict        | Record          |
+| Tuple       | Tuple (Record)  |
+| other       | N/A             |
+
 #### Note when installing Python with brew
 `pyml` requires the shared library `libpython`. However, when using Python installed by brew on macOS, this library is not available in the paths searched by `pyml`. One way to fix this is to create a symlink to the library in `/usr/local/lib`. To find where the library is installed, use the command:
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Type :h for help or :q to quit.
 >>
 ```
 
+This repository also contains a Jupyter kernel for MCore. For details,
+see [KERNEL_README.md](./KERNEL_README.md).
+
 ## Editor Support
 
 It is possible to write Miking code in any editor and compile it

--- a/make
+++ b/make
@@ -71,6 +71,8 @@ install_kernel() {
     cp -f build/kernel $bin_path/mcore_kernel; chmod +x $bin_path/mcore_kernel
     cp -f src/boot/kernel/mpl_backend.py $lib_path
     jupyter-kernelspec install src/boot/kernel --user
+    jupyter-nbextension install src/boot/kernel/mcore-syntax --user --log-level=WARN
+    jupyter-nbextension enable mcore-syntax/main --user
 }
 
 # Run the test suite for sundials

--- a/make
+++ b/make
@@ -49,10 +49,10 @@ EndOfMessage
 }
 
 build_kernel() {
-  mkdir -p build
-  (cd src/boot;
-  cp kernel/dune-kernel dune
-  dune build kernel.exe && cp -f _build/default/kernel.exe ../../build/kernel)
+    mkdir -p build
+    (cd src/boot;
+    cp kernel/dune-kernel dune
+    dune build kernel.exe && cp -f _build/default/kernel.exe ../../build/kernel)
 }
 
 # Install the boot interpreter locally for the current user
@@ -62,6 +62,15 @@ install() {
     mkdir -p $bin_path $lib_path
     cp -f build/mi $bin_path/mi; chmod +x $bin_path/mi
     rm -rf $lib_path; cp -rf stdlib $lib_path
+}
+
+install_kernel() {
+    bin_path=$HOME/.local/bin/
+    lib_path=$HOME/.local/lib/mcore/kernel/
+    mkdir -p $bin_path $lib_path
+    cp -f build/kernel $bin_path/mcore_kernel; chmod +x $bin_path/mcore_kernel
+    cp -f src/boot/kernel/mpl_backend.py $lib_path
+    jupyter-kernelspec install src/boot/kernel --user
 }
 
 # Run the test suite for sundials
@@ -109,7 +118,11 @@ case $1 in
         ;;
     kernel)
         build_kernel
-    ;;
+        ;;
+    kernel-install)
+        build_kernel
+        install_kernel
+        ;;
     install)
         build
         install

--- a/make
+++ b/make
@@ -48,6 +48,13 @@ EndOfMessage
     dune build boot.exe && cp -f _build/default/boot.exe ../../build/mi)
 }
 
+build_kernel() {
+  mkdir -p build
+  (cd src/boot;
+  cp kernel/dune-kernel dune
+  dune build kernel.exe && cp -f _build/default/kernel.exe ../../build/kernel)
+}
+
 # Install the boot interpreter locally for the current user
 install() {
     bin_path=$HOME/.local/bin/
@@ -100,6 +107,9 @@ case $1 in
         build
         runtests
         ;;
+    kernel)
+        build_kernel
+    ;;
     install)
         build
         install

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -9,168 +9,10 @@
    only implements a subset of the Ragnar language.
 *)
 
-
-open Ustring.Op
 open Printf
 open Ast
-open Msg
-open Mexpr
-open Pprint
+open Eval
 open Repl
-
-module Option = BatOption
-
-(* Standard lib default local path on unix (used by make install) *)
-let stdlib_loc_unix =
-  match Sys.getenv_opt "HOME" with
-  | Some home -> home ^ "/.local/lib/mcore/stdlib"
-  | None -> "@@@"
-
-let stdlib_loc =
-  match Sys.getenv_opt "MCORE_STDLIB" with
-  | Some path -> path
-  | None ->
-    if Sys.os_type = "Unix" &&
-       Sys.file_exists stdlib_loc_unix
-    then stdlib_loc_unix
-    else "@@@"
-
-let default_includes =
-  let prelude = [Include(NoInfo, us"prelude.mc")] in
-  match Sys.getenv_opt "MCORE_STDLIB" with
-  | Some "@@@" -> [] (* Needed for test of stdlib *)
-  | Some _ -> prelude
-  | None ->
-    if Sys.os_type = "Unix" &&
-       Sys.file_exists stdlib_loc_unix
-    then prelude
-    else []
-
-let prog_argv = ref []          (* Argv for the program that is executed *)
-
-(* Debug printing after parse*)
-let debug_after_parse t =
-  if !enable_debug_after_parse then
-    (printf "\n-- After parsing (only mexpr part) --\n";
-     uprint_endline (ustring_of_program t);
-     t)
-  else t
-
-(* Debug printing after symbolize transformation *)
-let debug_after_symbolize t =
-  if !enable_debug_after_symbolize then
-    (printf "\n-- After symbolize --\n";
-     uprint_endline (ustring_of_tm ~margin:80 t);
-     t)
-  else t
-
-(* Debug mlang to mexpr transform *)
-let debug_after_mlang t =
-  if !enable_debug_after_mlang then
-    (printf "\n-- After mlang --\n";
-     uprint_endline (ustring_of_tm ~margin:80 t);
-     t)
-  else t
-
-(* Keep track of which files have been parsed to avoid double includes *)
-let parsed_files = ref []
-
-(* Open a file and parse it into an MCore program *)
-let parse_mcore_file filename =
-  let tablength = 8 in
-  let fs1 = open_in filename in
-  let p =
-    Lexer.init (us filename) tablength;
-    fs1 |> Ustring.lexing_from_channel
-    |> Parser.main Lexer.main |> debug_after_parse
-  in
-  close_in fs1; (parsed_files := filename::!parsed_files); p
-
-(* Parse and merge all files included from a program, given the
-   path of the "root program". Raise an error if a loop is
-   detected. *)
-let rec merge_includes root visited = function
-  | Program(includes, tops, tm) ->
-     let rec parse_include root = function
-       | Include(info, path) as inc ->
-          let filename = Filename.concat root (Ustring.to_utf8 path) |> Utils.normalize_path in
-          if List.mem filename visited
-          then raise_error info ("Cycle detected in included files: " ^ filename)
-          else if List.mem filename !parsed_files
-          then None (* File already included *)
-          else
-            if Sys.file_exists filename then
-              parse_mcore_file filename |>
-              merge_includes (Filename.dirname filename) (filename::visited) |>
-              Option.some
-            else if root != stdlib_loc &&
-                    Sys.file_exists @@
-                      Filename.concat stdlib_loc (Ustring.to_utf8 path)
-            then parse_include stdlib_loc inc
-            else raise_error info ("No such file: \"" ^ filename ^ "\"")
-     in
-     let included =
-       includes
-       |> List.filter_map (parse_include root)
-     in
-     let included_tops =
-       included
-       |> List.map (function Program(_ ,tops, _) -> tops)
-       |> List.concat
-     in
-     Program(includes, included_tops@tops, tm)
-
-let add_prelude = function
-  | Program(includes, tops, tm) -> Program(default_includes@includes, tops, tm)
-
-(* Main function for evaluation a function. Performs lexing, parsing
-   and evaluation. Does not perform any type checking *)
-let evalprog filename  =
-  (* Make sure the filename is an absolute path, otherwise the duplicate file detection won't work *)
-  let filename =
-    if Filename.is_relative filename
-    then Filename.concat (Sys.getcwd ()) filename
-    else filename in
-  if !utest then printf "%s: " filename;
-  utest_fail_local := 0;
-  begin try
-    let parsed = parse_mcore_file filename in
-    (parsed
-     |> add_prelude
-     |> merge_includes (Filename.dirname filename) [filename]
-     |> Mlang.flatten
-     |> Mlang.desugar_post_flatten
-     |> debug_after_mlang
-     |> Mexpr.symbolize builtin_name2sym
-     |> debug_after_symbolize
-     |> Mexpr.eval builtin_sym2term
-     |> fun _ -> ())
-    with
-    | Lexer.Lex_error m ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
-    | Error m ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
-    | Parsing.Parse_error ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n"
-  (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())))
-  end; parsed_files := [];
-  if !utest && !utest_fail_local = 0 then printf " OK\n" else printf "\n"
-
 
 (* Define the file slash, to make it platform independent *)
 let sl = if Sys.win32 then "\\" else "/"
@@ -209,53 +51,15 @@ let testprog lst =
       printf "ERROR! %d successful tests and %d failed tests.\n\n"
         (!utest_ok) (!utest_fail)
 
-(* Run the MCore REPL *)
-let runrepl _ =
-  let repl_merge_includes = merge_includes (Sys.getcwd ()) [] in
-  (* Wrap the final mexpr in a lambda application to prevent scope leak *)
-  let repl_wrap_mexpr (Program(inc, tops, tm)) =
-    let lambda_wrapper = TmLam(NoInfo, us"_", nosym, TyArrow(TyInt,TyDyn), tm) in
-    let new_tm = TmApp(NoInfo, lambda_wrapper, TmConst(NoInfo, CInt(0))) in
-    Program(inc, tops, new_tm) in
-  let rec read_eval_print envs =
-    try
-      let (Program(_,_,tm)) as ast = read_user_input () in
-      let prog = ast
-        |> repl_merge_includes
-        |> repl_wrap_mexpr in
-      let (new_envs, result) = eval_with_envs envs prog in
-      begin
-        if tm = tmUnit then
-          flush stdout
-        else
-          uprint_endline (ustring_of_tm result)
-      end;
-      read_eval_print new_envs
-    with e ->
-      begin
-        match e with
-        | Lexer.Lex_error m -> uprint_endline (message2str m)
-        | Parsing.Parse_error -> uprint_endline (message2str (Lexer.parse_error_message ()))
-        | Error m -> uprint_endline (message2str m)
-        | Sys.Break -> ()
-        | End_of_file -> exit 0
-        | _ -> print_endline @@ Printexc.to_string e
-      end;
-      read_eval_print envs
-  in
-  let initial_term = Program([],[],TmConst(NoInfo,CInt(0)))
-                     |> add_prelude
-                     |> repl_merge_includes in
-  let builtin_envs = (Record.empty, Mlang.USMap.empty, builtin_name2sym, builtin_sym2term) in
-  let initial_envs, _ = eval_with_envs builtin_envs initial_term in
-  print_welcome_message ();
-  read_eval_print initial_envs
-
 (* Run program *)
 let runprog name lst =
     (* TODO prog_argv is never used anywhere *)
     prog_argv := lst;
     evalprog name
+
+(* Run the REPL *)
+let runrepl _ =
+    start_repl ()
 
 (* Print out main menu *)
 let usage_msg = "Usage: mi [run|repl|test] <files>\n\nOptions:"

--- a/src/boot/eval.ml
+++ b/src/boot/eval.ml
@@ -1,0 +1,165 @@
+
+(*
+   Miking is licensed under the MIT license.
+   Copyright (C) David Broman. See file LICENSE.txt
+*)
+
+open Ustring.Op
+open Printf
+open Ast
+open Pprint
+open Msg
+open Mexpr
+
+module Option = BatOption
+
+(* Standard lib default local path on unix (used by make install) *)
+let stdlib_loc_unix =
+  match Sys.getenv_opt "HOME" with
+  | Some home -> home ^ "/.local/lib/mcore/stdlib"
+  | None -> "@@@"
+
+let default_includes =
+  let prelude = [Include(NoInfo, us"prelude.mc")] in
+  match Sys.getenv_opt "MCORE_STDLIB" with
+  | Some "@@@" -> [] (* Needed for test of stdlib *)
+  | Some _ -> prelude
+  | None ->
+    if Sys.os_type = "Unix" &&
+       Sys.file_exists stdlib_loc_unix
+    then prelude
+    else []
+
+let stdlib_loc =
+  match Sys.getenv_opt "MCORE_STDLIB" with
+  | Some path -> path
+  | None ->
+    if Sys.os_type = "Unix" &&
+       Sys.file_exists stdlib_loc_unix
+    then stdlib_loc_unix
+    else "@@@"
+
+let prog_argv : string list ref = ref []          (* Argv for the program that is executed *)
+
+(* Debug printing after parse*)
+let debug_after_parse t =
+  if !enable_debug_after_parse then
+    (printf "\n-- After parsing (only mexpr part) --\n";
+     uprint_endline (ustring_of_program t);
+     t)
+  else t
+
+(* Debug printing after symbolize transformation *)
+let debug_after_symbolize t =
+  if !enable_debug_after_symbolize then
+    (printf "\n-- After symbolize --\n";
+     uprint_endline (ustring_of_tm ~margin:80 t);
+     t)
+  else t
+
+(* Debug mlang to mexpr transform *)
+let debug_after_mlang t =
+  if !enable_debug_after_mlang then
+    (printf "\n-- After mlang --\n";
+     uprint_endline (ustring_of_tm ~margin:80 t);
+     t)
+  else t
+
+(* Keep track of which files have been parsed to avoid double includes *)
+let parsed_files = ref []
+
+(* Open a file and parse it into an MCore program *)
+let parse_mcore_file filename =
+  let tablength = 8 in
+  let fs1 = open_in filename in
+  let p =
+    Lexer.init (us filename) tablength;
+    fs1 |> Ustring.lexing_from_channel
+    |> Parser.main Lexer.main |> debug_after_parse
+  in
+  close_in fs1; (parsed_files := filename::!parsed_files); p
+
+(* Parse and merge all files included from a program, given the
+   path of the "root program". Raise an error if a loop is
+   detected. *)
+let rec merge_includes root visited = function
+  | Program(includes, tops, tm) ->
+     let rec parse_include root = function
+       | Include(info, path) as inc ->
+          let filename = Filename.concat root (Ustring.to_utf8 path) |> Utils.normalize_path in
+          if List.mem filename visited
+          then raise_error info ("Cycle detected in included files: " ^ filename)
+          else if List.mem filename !parsed_files
+          then None (* File already included *)
+          else
+            if Sys.file_exists filename then
+              parse_mcore_file filename |>
+              merge_includes (Filename.dirname filename) (filename::visited) |>
+              Option.some
+            else if root != stdlib_loc &&
+                    Sys.file_exists @@
+                      Filename.concat stdlib_loc (Ustring.to_utf8 path)
+            then parse_include stdlib_loc inc
+            else raise_error info ("No such file: \"" ^ filename ^ "\"")
+     in
+     let included =
+       includes
+       |> List.filter_map (parse_include root)
+     in
+     let included_tops =
+       included
+       |> List.map (function Program(_ ,tops, _) -> tops)
+       |> List.concat
+     in
+     Program(includes, included_tops@tops, tm)
+
+let add_prelude = function
+  | Program(includes, tops, tm) -> Program(default_includes@includes, tops, tm)
+
+(* Main function for evaluation a function. Performs lexing, parsing
+   and evaluation. Does not perform any type checking *)
+let evalprog filename  =
+  (* Make sure the filename is an absolute path, otherwise the duplicate file detection won't work *)
+  let filename =
+    if Filename.is_relative filename
+    then Filename.concat (Sys.getcwd ()) filename
+    else filename in
+  if !utest then printf "%s: " filename;
+  utest_fail_local := 0;
+  begin try
+    let parsed = parse_mcore_file filename in
+    (parsed
+     |> add_prelude
+     |> merge_includes (Filename.dirname filename) [filename]
+     |> Mlang.flatten
+     |> Mlang.desugar_post_flatten
+     |> debug_after_mlang
+     |> Mexpr.symbolize builtin_name2sym
+     |> debug_after_symbolize
+     |> Mexpr.eval builtin_sym2term
+     |> fun _ -> ())
+    with
+    | Lexer.Lex_error m ->
+      if !utest then (
+        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
+        utest_fail := !utest_fail + 1;
+        utest_fail_local := !utest_fail_local + 1)
+      else
+        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
+    | Error m ->
+      if !utest then (
+        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
+        utest_fail := !utest_fail + 1;
+        utest_fail_local := !utest_fail_local + 1)
+      else
+        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
+    | Parsing.Parse_error ->
+      if !utest then (
+        printf "\n%s" (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())));
+        utest_fail := !utest_fail + 1;
+        utest_fail_local := !utest_fail_local + 1)
+      else
+        fprintf stderr "%s\n"
+  (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())))
+  end; parsed_files := [];
+  if !utest && !utest_fail_local = 0 then printf " OK\n" else printf "\n"

--- a/src/boot/kernel/dune-kernel
+++ b/src/boot/kernel/dune-kernel
@@ -1,0 +1,11 @@
+(copy_files ext-skel/*)
+(copy_files py/*)
+(copy_files kernel/*)
+
+(ocamllex lexer)
+(ocamlyacc parser)
+
+(executable
+  (name kernel)
+  (libraries batteries str linenoise jupyter-kernel pyml)
+)

--- a/src/boot/kernel/kernel.json
+++ b/src/boot/kernel/kernel.json
@@ -1,3 +1,3 @@
-{"argv":["build/kernel","--connection-file", "{connection_file}"],
+{"argv":["mcore_kernel","--connection-file", "{connection_file}"],
  "display_name":"MCore"
 }

--- a/src/boot/kernel/kernel.json
+++ b/src/boot/kernel/kernel.json
@@ -1,0 +1,3 @@
+{"argv":["build/kernel","--connection-file", "{connection_file}"],
+ "display_name":"MCore"
+}

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -1,5 +1,7 @@
-open Repl
+open Ast
 open Jupyter_kernel
+open Repl
+open Ustring.Op
 
 let current_output = ref (BatIO.output_string ())
 let other_actions = ref []
@@ -106,6 +108,37 @@ let exec ~count:_ code =
                    ; Client.Kernel.actions=actions})
   with e -> Lwt.return (Error (Printexc.to_string e))
 
+let keywords = List.map fst Lexer.reserved_strings
+
+let begins_at str pos =
+  let nonword_characters = Str.regexp "[][/\\\\(),={} \n\r\x0c\t]" in
+  try Str.search_backward nonword_characters str (pos-1) + 1
+  with Not_found -> 0
+
+let get_matches s = s
+  |> BatPervasives.flip BatString.starts_with
+  |> List.filter
+
+let keywords_and_identifiers () =
+  let extract_name id =
+    let sid =
+      match id with
+      | IdVar(s) -> s
+      | IdCon(s) -> s
+      | IdType(s) -> s
+      | IdLabel(s) -> s
+    in Ustring.to_utf8 (ustring_of_sid sid)
+  in
+  let (_,_,name2sym,_) = !repl_envs in
+  keywords @ (List.map (fun x -> x |> fst |> extract_name) name2sym)
+
+let complete ~pos str =
+  let start_pos = begins_at str pos in
+  let word_to_complete = BatString.slice ~first:start_pos ~last:pos str in
+  Lwt.return { Client.Kernel.completion_matches = get_matches word_to_complete (keywords_and_identifiers ())
+             ; Client.Kernel.completion_start = start_pos
+             ; Client.Kernel.completion_end = pos}
+
 let main =
   let mcore_kernel =
     Client.Kernel.make
@@ -117,6 +150,7 @@ let main =
 for creating embedded domain-specific and general-purpose languages"
       ~init:init
       ~exec:exec
+      ~complete:complete
       () in
       let config = Client_main.mk_config ~usage:"Usage: mcore_kernel --connection-file {connection_file}" () in
       Lwt_main.run (Client_main.main ~config:config ~kernel:mcore_kernel)

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -112,7 +112,7 @@ let main =
       ~language:"MCore"
       ~language_version:[0; 1]
       ~file_extension:".mc"
-      ~codemirror_mode:"haskell"
+      ~codemirror_mode:"mcore"
       ~banner:"The core language of Miking - a meta language system
 for creating embedded domain-specific and general-purpose languages"
       ~init:init

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -10,13 +10,16 @@ let text_data_of_string str =
 let kernel_output_string str = BatIO.nwrite !current_output str
 let kernel_output_ustring ustr = ustr |> Ustring.to_utf8 |> kernel_output_string
 
+let python_init = Py.initialize ~version:3 ()
+let ocaml_module = Py.Import.add_module "ocaml"
+
 (* Set Python's sys.stdout to our own ocaml function to handle Python prints *)
-let init_py_print m =
+let init_py_print () =
   let py_ocaml_print args =
     kernel_output_string (Py.String.to_string args.(0));
     Py.none
   in
-  Py.Module.set_function m "ocaml_print" py_ocaml_print;
+  Py.Module.set_function ocaml_module "ocaml_print" py_ocaml_print;
   ignore @@ Py.Run.eval ~start:Py.File "
 import sys
 from ocaml import ocaml_print
@@ -26,29 +29,29 @@ class OCamlPrint:
 
 sys.stdout = OCamlPrint()"
 
-let init_py_mpl m =
-  ignore (Py.Run.eval ~start:Py.File "
+let init_py_mpl () =
+  ignore @@ Py.Run.eval ~start:Py.File "
 import os
-os.environ['MPLBACKEND']='module://src.boot.kernel.mpl_backend'");
+os.environ['MPLBACKEND']='module://src.boot.kernel.mpl_backend'";
   let py_ocaml_show args =
     let data = Py.String.to_string args.(0) in
     other_actions := Client.Kernel.mime ~base64:true ~ty:"image/png" data :: !other_actions;
     Py.none
   in
-  Py.Module.set_function m "ocaml_show" py_ocaml_show
+  Py.Module.set_function ocaml_module "ocaml_show" py_ocaml_show
 
 let init () =
   Mexpr.program_output := kernel_output_ustring;
-  Py.initialize ~version:3 ();
-  let m = Py.Import.add_module "ocaml" in
-  init_py_print m;
-  init_py_mpl m;
+  Py.Module.set_function ocaml_module "after_exec" (fun _ -> Py.none);
+  init_py_print ();
+  init_py_mpl ();
   Lwt.return ()
 
 let exec ~count:_ code =
   try
     let ast = parse_prog_or_mexpr code in
     let result = ast |> repl_eval_ast |> Pprint.ustring_of_tm |> Ustring.to_utf8 in
+    ignore @@ Py.Module.get_function ocaml_module "after_exec" [||];
     let new_actions =
       match BatIO.close_out !current_output with
       | "" -> !other_actions
@@ -73,5 +76,5 @@ for creating embedded domain-specific and general-purpose languages"
       ~init:init
       ~exec:exec
       () in
-      let config = Client_main.mk_config ~usage:"Usage: hello" () in
+      let config = Client_main.mk_config ~usage:"Usage: kernel --connection-file {connection_file}" () in
       Lwt_main.run (Client_main.main ~config:config ~kernel:mcore_kernel)

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -54,7 +54,7 @@ let get_python code =
     with Not_found -> ("", code)
   in
   match python_indicator with
-  | "%%%python" -> Some content
+  | "%%python" -> Some content
   | _ -> None
 
 let is_expr pycode =

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -1,15 +1,47 @@
 open Repl
 open Jupyter_kernel
 
+let current_output = ref (BatIO.output_string ())
+
+let text_data_of_string str =
+  Client.Kernel.mime ~ty:"text/plain" str
+
 let init () =
-  Lwt.return (Py.initialize ())
+  let kernel_output_string str = BatIO.nwrite !current_output str in
+  let kernel_output_ustring ustr = ustr |> Ustring.to_utf8 |> kernel_output_string in
+  Mexpr.program_output := kernel_output_ustring;
+  Py.initialize ~version:3 ();
+  let py_init_print = "
+import sys
+from ocaml import ocaml_print
+class OCamlPrint:
+    def write(self, str):
+        ocaml_print(str)
+
+sys.stdout = OCamlPrint()
+" in
+  let m = Py.Import.add_module "ocaml" in
+  let py_ocaml_print args =
+    kernel_output_string (Py.String.to_string args.(0));
+    Py.none
+  in
+  Py.Module.set_function m "ocaml_print" py_ocaml_print;
+  ignore (Py.Run.eval ~start:Py.File py_init_print);
+  Lwt.return ()
 
 let exec ~count:_ code =
   try
     let ast = parse_prog_or_mexpr code in
     let result = ast |> repl_eval_ast |> Pprint.ustring_of_tm |> Ustring.to_utf8 in
-    Lwt.return (Ok { Client.Kernel.msg=Some(result)
-                   ; Client.Kernel.actions=[]})
+    let actions = [text_data_of_string result] in
+    let new_actions =
+      match BatIO.close_out !current_output with
+      | "" -> actions
+      | s -> text_data_of_string s :: actions
+    in
+    current_output := BatIO.output_string ();
+    Lwt.return (Ok { Client.Kernel.msg=None
+                   ; Client.Kernel.actions=new_actions})
   with e -> Lwt.return (Error (Printexc.to_string e))
 
 let main =

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -1,0 +1,31 @@
+open Repl
+open Jupyter_kernel
+
+let init () =
+  Lwt.return (Py.initialize ())
+
+let exec ~count:_ code =
+  try
+    let ast = parse_prog_or_mexpr code in
+    let result = ast |> repl_eval_ast |> Pprint.ustring_of_tm |> Ustring.to_utf8 in
+    Lwt.return (Ok { Client.Kernel.msg=Some(result)
+                   ; Client.Kernel.actions=[]})
+  with e -> Lwt.return (Error (Printexc.to_string e))
+
+let main =
+  let mcore_kernel =
+    Client.Kernel.make
+      ~language:"MCore"
+      ~language_version:[0; 1]
+      ~file_extension:".mc"
+      ~codemirror_mode:"ocaml"
+      ~banner:"The core language of Miking - a meta language system
+for creating embedded domain-specific and general-purpose languages"
+      ~init:init
+      ~exec:exec
+      () in
+      let config = Client_main.mk_config ~usage:"Usage: hello" () in
+      let newstdout = open_out "redirected" in
+      Unix.dup2 (Unix.descr_of_out_channel newstdout) Unix.stdout;
+      Lwt_main.run (Client_main.main ~config:config ~kernel:mcore_kernel);
+      flush stdout;

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -11,8 +11,8 @@ let text_data_of_string str =
 let kernel_output_string str = BatIO.nwrite !current_output str
 let kernel_output_ustring ustr = ustr |> Ustring.to_utf8 |> kernel_output_string
 
-let python_init = Py.initialize ~version:3 ()
-let ocaml_module = Py.Import.add_module "ocaml"
+let _ = Py.initialize ~version:3 ()
+let ocaml_module = Py.Import.add_module "_mcore_kernel"
 
 (* Set Python's sys.stdout to our own ocaml function to handle Python prints *)
 let init_py_print () =
@@ -23,7 +23,7 @@ let init_py_print () =
   Py.Module.set_function ocaml_module "ocaml_print" py_ocaml_print;
   ignore @@ Py.Run.eval ~start:Py.File "
 import sys
-from ocaml import ocaml_print
+from _mcore_kernel import ocaml_print
 class OCamlPrint:
     def write(self, str):
         ocaml_print(str)

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -31,8 +31,9 @@ sys.stdout = OCamlPrint()"
 
 let init_py_mpl () =
   ignore @@ Py.Run.eval ~start:Py.File "
-import os
-os.environ['MPLBACKEND']='module://src.boot.kernel.mpl_backend'";
+import os, sys
+sys.path.append(os.path.expanduser('~') + '/.local/lib/mcore/kernel')
+os.environ['MPLBACKEND']='module://mpl_backend'";
   let py_ocaml_show args =
     let data = Py.String.to_string args.(0) in
     other_actions := Client.Kernel.mime ~base64:true ~ty:"image/png" data :: !other_actions;
@@ -76,5 +77,5 @@ for creating embedded domain-specific and general-purpose languages"
       ~init:init
       ~exec:exec
       () in
-      let config = Client_main.mk_config ~usage:"Usage: kernel --connection-file {connection_file}" () in
+      let config = Client_main.mk_config ~usage:"Usage: mcore_kernel --connection-file {connection_file}" () in
       Lwt_main.run (Client_main.main ~config:config ~kernel:mcore_kernel)

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -42,6 +42,7 @@ os.environ['MPLBACKEND']='module://mpl_backend'";
   Py.Module.set_function ocaml_module "ocaml_show" py_ocaml_show
 
 let init () =
+  initialize_envs ();
   Mexpr.program_output := kernel_output_ustring;
   Py.Module.set_function ocaml_module "after_exec" (fun _ -> Py.none);
   init_py_print ();
@@ -111,7 +112,7 @@ let main =
       ~language:"MCore"
       ~language_version:[0; 1]
       ~file_extension:".mc"
-      ~codemirror_mode:"ocaml"
+      ~codemirror_mode:"haskell"
       ~banner:"The core language of Miking - a meta language system
 for creating embedded domain-specific and general-purpose languages"
       ~init:init

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -2,6 +2,7 @@ open Ast
 open Jupyter_kernel
 open Repl
 open Ustring.Op
+open Eval
 
 let current_output = ref (BatIO.output_string ())
 let other_actions = ref []
@@ -106,7 +107,7 @@ let exec ~count:_ code =
     other_actions := [];
     Lwt.return (Ok { Client.Kernel.msg=result
                    ; Client.Kernel.actions=actions})
-  with e -> Lwt.return (Error (Printexc.to_string e))
+  with e -> Lwt.return (Error (error_to_ustring e |> Ustring.to_utf8))
 
 let keywords = List.map fst Lexer.reserved_strings
 

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -80,7 +80,7 @@ let eval_python code =
   else
     Py.Run.eval ~start:Py.File code
 
-let exec ~count:_ code =
+let exec ~count code =
   try
     let result =
       match get_python code with
@@ -91,7 +91,7 @@ let exec ~count:_ code =
         else
           Some(Py.Object.to_string py_val)
       | None ->
-        parse_prog_or_mexpr code
+        parse_prog_or_mexpr (Printf.sprintf "In [%d]" count) code
         |> repl_eval_ast
         |> repl_format
         |> Option.map (Ustring.to_utf8)

--- a/src/boot/kernel/kernel.ml
+++ b/src/boot/kernel/kernel.ml
@@ -2,46 +2,63 @@ open Repl
 open Jupyter_kernel
 
 let current_output = ref (BatIO.output_string ())
+let other_actions = ref []
 
 let text_data_of_string str =
   Client.Kernel.mime ~ty:"text/plain" str
 
-let init () =
-  let kernel_output_string str = BatIO.nwrite !current_output str in
-  let kernel_output_ustring ustr = ustr |> Ustring.to_utf8 |> kernel_output_string in
-  Mexpr.program_output := kernel_output_ustring;
-  Py.initialize ~version:3 ();
-  let py_init_print = "
+let kernel_output_string str = BatIO.nwrite !current_output str
+let kernel_output_ustring ustr = ustr |> Ustring.to_utf8 |> kernel_output_string
+
+(* Set Python's sys.stdout to our own ocaml function to handle Python prints *)
+let init_py_print m =
+  let py_ocaml_print args =
+    kernel_output_string (Py.String.to_string args.(0));
+    Py.none
+  in
+  Py.Module.set_function m "ocaml_print" py_ocaml_print;
+  ignore @@ Py.Run.eval ~start:Py.File "
 import sys
 from ocaml import ocaml_print
 class OCamlPrint:
     def write(self, str):
         ocaml_print(str)
 
-sys.stdout = OCamlPrint()
-" in
-  let m = Py.Import.add_module "ocaml" in
-  let py_ocaml_print args =
-    kernel_output_string (Py.String.to_string args.(0));
+sys.stdout = OCamlPrint()"
+
+let init_py_mpl m =
+  ignore (Py.Run.eval ~start:Py.File "
+import os
+os.environ['MPLBACKEND']='module://src.boot.kernel.mpl_backend'");
+  let py_ocaml_show args =
+    let data = Py.String.to_string args.(0) in
+    other_actions := Client.Kernel.mime ~base64:true ~ty:"image/png" data :: !other_actions;
     Py.none
   in
-  Py.Module.set_function m "ocaml_print" py_ocaml_print;
-  ignore (Py.Run.eval ~start:Py.File py_init_print);
+  Py.Module.set_function m "ocaml_show" py_ocaml_show
+
+let init () =
+  Mexpr.program_output := kernel_output_ustring;
+  Py.initialize ~version:3 ();
+  let m = Py.Import.add_module "ocaml" in
+  init_py_print m;
+  init_py_mpl m;
   Lwt.return ()
 
 let exec ~count:_ code =
   try
     let ast = parse_prog_or_mexpr code in
     let result = ast |> repl_eval_ast |> Pprint.ustring_of_tm |> Ustring.to_utf8 in
-    let actions = [text_data_of_string result] in
     let new_actions =
       match BatIO.close_out !current_output with
-      | "" -> actions
-      | s -> text_data_of_string s :: actions
+      | "" -> !other_actions
+      | s -> text_data_of_string s :: !other_actions
     in
+    let actions = List.rev new_actions in
     current_output := BatIO.output_string ();
-    Lwt.return (Ok { Client.Kernel.msg=None
-                   ; Client.Kernel.actions=new_actions})
+    other_actions := [];
+    Lwt.return (Ok { Client.Kernel.msg=Some(result)
+                   ; Client.Kernel.actions=actions})
   with e -> Lwt.return (Error (Printexc.to_string e))
 
 let main =
@@ -57,7 +74,4 @@ for creating embedded domain-specific and general-purpose languages"
       ~exec:exec
       () in
       let config = Client_main.mk_config ~usage:"Usage: hello" () in
-      let newstdout = open_out "redirected" in
-      Unix.dup2 (Unix.descr_of_out_channel newstdout) Unix.stdout;
-      Lwt_main.run (Client_main.main ~config:config ~kernel:mcore_kernel);
-      flush stdout;
+      Lwt_main.run (Client_main.main ~config:config ~kernel:mcore_kernel)

--- a/src/boot/kernel/mcore-syntax/main.js
+++ b/src/boot/kernel/mcore-syntax/main.js
@@ -1,0 +1,270 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: https://codemirror.net/LICENSE
+// This mode is derived from the Haskell CodeMirror mode.
+
+define(function() {
+    "use strict";
+
+    function load_ipython_extension() {
+        CodeMirror.defineMode("mcore", function(_config, modeConfig) {
+
+            function switchState(source, setState, f) {
+                setState(f);
+                return f(source, setState);
+            }
+
+            // These should all be Unicode extended, as per the Haskell 2010 report
+            var smallRE = /[a-z_]/;
+            var largeRE = /[A-Z]/;
+            var digitRE = /\d/;
+            var hexitRE = /[0-9A-Fa-f]/;
+            var octitRE = /[0-7]/;
+            var idRE = /[a-z_A-Z0-9'\xa1-\uffff]/;
+            var symbolRE = /[-!#$%&*+.\/<=>?@\\^|~:]/;
+            var specialRE = /[(),;[\]`{}]/;
+            var whiteCharRE = /[ \t\v\f]/; // newlines are handled in tokenizer
+
+            function normal(source, setState) {
+                if (source.eatWhile(whiteCharRE)) {
+                    return null;
+                }
+
+                var ch = source.next();
+                if (specialRE.test(ch)) {
+                    if (ch == '{' && source.eat('-')) {
+                        var t = "comment";
+                        if (source.eat('#')) {
+                            t = "meta";
+                        }
+                        return switchState(source, setState, ncomment(t, 1));
+                    }
+                    return null;
+                }
+
+                if (ch == '\'') {
+                    if (source.eat('\\')) {
+                        source.next();  // should handle other escapes here
+                    }
+                    else {
+                        source.next();
+                    }
+                    if (source.eat('\'')) {
+                        return "string";
+                    }
+                    return "string error";
+                }
+
+                if (ch == '"') {
+                    return switchState(source, setState, stringLiteral);
+                }
+
+                if (largeRE.test(ch)) {
+                    source.eatWhile(idRE);
+                    if (source.eat('.')) {
+                        return "qualifier";
+                    }
+                    return "variable-2";
+                }
+
+                if (smallRE.test(ch)) {
+                    source.eatWhile(idRE);
+                    return "variable";
+                }
+
+                if (digitRE.test(ch)) {
+                    if (ch == '0') {
+                        if (source.eat(/[xX]/)) {
+                            source.eatWhile(hexitRE); // should require at least 1
+                            return "integer";
+                        }
+                        if (source.eat(/[oO]/)) {
+                            source.eatWhile(octitRE); // should require at least 1
+                            return "number";
+                        }
+                    }
+                    source.eatWhile(digitRE);
+                    var t = "number";
+                    if (source.match(/^\.\d+/)) {
+                        t = "number";
+                    }
+                    if (source.eat(/[eE]/)) {
+                        t = "number";
+                        source.eat(/[-+]/);
+                        source.eatWhile(digitRE); // should require at least 1
+                    }
+                    return t;
+                }
+
+                if (ch == "." && source.eat("."))
+                    return "keyword";
+
+                if (symbolRE.test(ch)) {
+                    if (ch == '-' && source.eat(/-/)) {
+                        source.eatWhile(/-/);
+                        if (!source.eat(symbolRE)) {
+                            source.skipToEnd();
+                            return "comment";
+                        }
+                    }
+                    var t = "variable";
+                    if (ch == ':') {
+                        t = "variable-2";
+                    }
+                    source.eatWhile(symbolRE);
+                    return t;
+                }
+
+                return "error";
+            }
+
+            function ncomment(type, nest) {
+                if (nest == 0) {
+                    return normal;
+                }
+                return function(source, setState) {
+                    var currNest = nest;
+                    while (!source.eol()) {
+                        var ch = source.next();
+                        if (ch == '{' && source.eat('-')) {
+                            ++currNest;
+                        }
+                        else if (ch == '-' && source.eat('}')) {
+                            --currNest;
+                            if (currNest == 0) {
+                                setState(normal);
+                                return type;
+                            }
+                        }
+                    }
+                    setState(ncomment(type, currNest));
+                    return type;
+                };
+            }
+
+            function stringLiteral(source, setState) {
+                while (!source.eol()) {
+                    var ch = source.next();
+                    if (ch == '"') {
+                        setState(normal);
+                        return "string";
+                    }
+                    if (ch == '\\') {
+                        if (source.eol() || source.eat(whiteCharRE)) {
+                            setState(stringGap);
+                            return "string";
+                        }
+                        if (source.eat('&')) {
+                        }
+                        else {
+                            source.next(); // should handle other escapes here
+                        }
+                    }
+                }
+                setState(normal);
+                return "string error";
+            }
+
+            function stringGap(source, setState) {
+                if (source.eat('\\')) {
+                    return switchState(source, setState, stringLiteral);
+                }
+                source.next();
+                setState(normal);
+                return "error";
+            }
+
+
+            var wellKnownWords = (function() {
+                var wkw = {};
+                function setType(t) {
+                    return function () {
+                        for (var i = 0; i < arguments.length; i++)
+                            wkw[arguments[i]] = t;
+                    };
+                }
+
+                setType("keyword")(
+                    "case", "class", "data", "default", "deriving", "do", "else", "foreign",
+                    "if", "import", "in", "infix", "infixl", "infixr", "instance", "let",
+                    "module", "newtype", "of", "then", "type", "where", "_", "korv");
+
+                setType("keyword")(
+                    "\.\.", ":", "::", "=", "\\", "<-", "->", "@", "~", "=>");
+
+                setType("builtin")(
+                    "!!", "$!", "$", "&&", "+", "++", "-", ".", "/", "/=", "<", "<*", "<=",
+                    "<$>", "<*>", "=<<", "==", ">", ">=", ">>", ">>=", "^", "^^", "||", "*",
+                    "*>", "**");
+
+                setType("builtin")(
+                    "Applicative", "Bool", "Bounded", "Char", "Double", "EQ", "Either", "Enum",
+                    "Eq", "False", "FilePath", "Float", "Floating", "Fractional", "Functor",
+                    "GT", "IO", "IOError", "Int", "Integer", "Integral", "Just", "LT", "Left",
+                    "Maybe", "Monad", "Nothing", "Num", "Ord", "Ordering", "Rational", "Read",
+                    "ReadS", "Real", "RealFloat", "RealFrac", "Right", "Show", "ShowS",
+                    "String", "True");
+
+                setType("builtin")(
+                    "abs", "acos", "acosh", "all", "and", "any", "appendFile", "asTypeOf",
+                    "asin", "asinh", "atan", "atan2", "atanh", "break", "catch", "ceiling",
+                    "compare", "concat", "concatMap", "const", "cos", "cosh", "curry",
+                    "cycle", "decodeFloat", "div", "divMod", "drop", "dropWhile", "either",
+                    "elem", "encodeFloat", "enumFrom", "enumFromThen", "enumFromThenTo",
+                    "enumFromTo", "error", "even", "exp", "exponent", "fail", "filter",
+                    "flip", "floatDigits", "floatRadix", "floatRange", "floor", "fmap",
+                    "foldl", "foldl1", "foldr", "foldr1", "fromEnum", "fromInteger",
+                    "fromIntegral", "fromRational", "fst", "gcd", "getChar", "getContents",
+                    "getLine", "head", "id", "init", "interact", "ioError", "isDenormalized",
+                    "isIEEE", "isInfinite", "isNaN", "isNegativeZero", "iterate", "last",
+                    "lcm", "length", "lex", "lines", "log", "logBase", "lookup", "map",
+                    "mapM", "mapM_", "max", "maxBound", "maximum", "maybe", "min", "minBound",
+                    "minimum", "mod", "negate", "not", "notElem", "null", "odd", "or",
+                    "otherwise", "pi", "pred", "print", "product", "properFraction", "pure",
+                    "putChar", "putStr", "putStrLn", "quot", "quotRem", "read", "readFile",
+                    "readIO", "readList", "readLn", "readParen", "reads", "readsPrec",
+                    "realToFrac", "recip", "rem", "repeat", "replicate", "return", "reverse",
+                    "round", "scaleFloat", "scanl", "scanl1", "scanr", "scanr1", "seq",
+                    "sequence", "sequence_", "show", "showChar", "showList", "showParen",
+                    "showString", "shows", "showsPrec", "significand", "signum", "sin",
+                    "sinh", "snd", "span", "splitAt", "sqrt", "subtract", "succ", "sum",
+                    "tail", "take", "takeWhile", "tan", "tanh", "toEnum", "toInteger",
+                    "toRational", "truncate", "uncurry", "undefined", "unlines", "until",
+                    "unwords", "unzip", "unzip3", "userError", "words", "writeFile", "zip",
+                    "zip3", "zipWith", "zipWith3");
+
+                var override = modeConfig.overrideKeywords;
+                if (override) for (var word in override) if (override.hasOwnProperty(word))
+                    wkw[word] = override[word];
+
+                return wkw;
+            })();
+
+
+
+            return {
+                startState: function ()  { return { f: normal }; },
+                copyState:  function (s) { return { f: s.f }; },
+
+                token: function(stream, state) {
+                    var t = state.f(stream, function(s) { state.f = s; });
+                    var w = stream.current();
+                    return wellKnownWords.hasOwnProperty(w) ? wellKnownWords[w] : t;
+                },
+
+                blockCommentStart: "{-",
+                blockCommentEnd: "-}",
+                lineComment: "--"
+            };
+
+        });
+
+        CodeMirror.defineMIME(
+            "text/x-mcore",
+            {name: "MCore", mime: "text/x-mcore", mode: "mcore", ext: [".mc"]}
+        );
+    }
+
+    return {
+        load_ipython_extension: load_ipython_extension
+    };
+});

--- a/src/boot/kernel/mcore-syntax/main.js
+++ b/src/boot/kernel/mcore-syntax/main.js
@@ -13,15 +13,10 @@ define(function() {
                 return f(source, setState);
             }
 
-            // These should all be Unicode extended, as per the Haskell 2010 report
             var smallRE = /[a-z_]/;
             var largeRE = /[A-Z]/;
             var digitRE = /\d/;
-            var hexitRE = /[0-9A-Fa-f]/;
-            var octitRE = /[0-7]/;
-            var idRE = /[a-z_A-Z0-9'\xa1-\uffff]/;
-            var symbolRE = /[-!#$%&*+.\/<=>?@\\^|~:]/;
-            var specialRE = /[(),;[\]`{}]/;
+            var idRE = /[a-z_A-Z0-9]/;
             var whiteCharRE = /[ \t\v\f]/; // newlines are handled in tokenizer
 
             function normal(source, setState) {
@@ -30,24 +25,9 @@ define(function() {
                 }
 
                 var ch = source.next();
-                if (specialRE.test(ch)) {
-                    if (ch == '{' && source.eat('-')) {
-                        var t = "comment";
-                        if (source.eat('#')) {
-                            t = "meta";
-                        }
-                        return switchState(source, setState, ncomment(t, 1));
-                    }
-                    return null;
-                }
-
                 if (ch == '\'') {
-                    if (source.eat('\\')) {
-                        source.next();  // should handle other escapes here
-                    }
-                    else {
-                        source.next();
-                    }
+                    source.eat('\\');
+                    source.next();
                     if (source.eat('\'')) {
                         return "string";
                     }
@@ -60,9 +40,6 @@ define(function() {
 
                 if (largeRE.test(ch)) {
                     source.eatWhile(idRE);
-                    if (source.eat('.')) {
-                        return "qualifier";
-                    }
                     return "variable-2";
                 }
 
@@ -72,73 +49,16 @@ define(function() {
                 }
 
                 if (digitRE.test(ch)) {
-                    if (ch == '0') {
-                        if (source.eat(/[xX]/)) {
-                            source.eatWhile(hexitRE); // should require at least 1
-                            return "integer";
-                        }
-                        if (source.eat(/[oO]/)) {
-                            source.eatWhile(octitRE); // should require at least 1
-                            return "number";
-                        }
-                    }
                     source.eatWhile(digitRE);
-                    var t = "number";
-                    if (source.match(/^\.\d+/)) {
-                        t = "number";
-                    }
-                    if (source.eat(/[eE]/)) {
-                        t = "number";
-                        source.eat(/[-+]/);
-                        source.eatWhile(digitRE); // should require at least 1
-                    }
-                    return t;
+                    return "number";
                 }
 
-                if (ch == "." && source.eat("."))
-                    return "keyword";
-
-                if (symbolRE.test(ch)) {
-                    if (ch == '-' && source.eat(/-/)) {
-                        source.eatWhile(/-/);
-                        if (!source.eat(symbolRE)) {
-                            source.skipToEnd();
-                            return "comment";
-                        }
-                    }
-                    var t = "variable";
-                    if (ch == ':') {
-                        t = "variable-2";
-                    }
-                    source.eatWhile(symbolRE);
-                    return t;
+                if (ch == '-' && source.eat(/-/)) {
+                    source.skipToEnd();
+                    return "comment";
                 }
 
-                return "error";
-            }
-
-            function ncomment(type, nest) {
-                if (nest == 0) {
-                    return normal;
-                }
-                return function(source, setState) {
-                    var currNest = nest;
-                    while (!source.eol()) {
-                        var ch = source.next();
-                        if (ch == '{' && source.eat('-')) {
-                            ++currNest;
-                        }
-                        else if (ch == '-' && source.eat('}')) {
-                            --currNest;
-                            if (currNest == 0) {
-                                setState(normal);
-                                return type;
-                            }
-                        }
-                    }
-                    setState(ncomment(type, currNest));
-                    return type;
-                };
+                return null;
             }
 
             function stringLiteral(source, setState) {
@@ -148,31 +68,10 @@ define(function() {
                         setState(normal);
                         return "string";
                     }
-                    if (ch == '\\') {
-                        if (source.eol() || source.eat(whiteCharRE)) {
-                            setState(stringGap);
-                            return "string";
-                        }
-                        if (source.eat('&')) {
-                        }
-                        else {
-                            source.next(); // should handle other escapes here
-                        }
-                    }
                 }
                 setState(normal);
                 return "string error";
             }
-
-            function stringGap(source, setState) {
-                if (source.eat('\\')) {
-                    return switchState(source, setState, stringLiteral);
-                }
-                source.next();
-                setState(normal);
-                return "error";
-            }
-
 
             var wellKnownWords = (function() {
                 var wkw = {};
@@ -184,53 +83,36 @@ define(function() {
                 }
 
                 setType("keyword")(
-                    "case", "class", "data", "default", "deriving", "do", "else", "foreign",
-                    "if", "import", "in", "infix", "infixl", "infixr", "instance", "let",
-                    "module", "newtype", "of", "then", "type", "where", "_", "korv");
+                    "con",
+                    "else",
+                    "end",
+                    "fix",
+                    "if",
+                    "in",
+                    "lam",
+                    "lang",
+                    "let",
+                    "match",
+                    "recursive",
+                    "sem",
+                    "syn",
+                    "then",
+                    "type",
+                    "use",
+                    "utest",
+                    "with"
+                );
 
-                setType("keyword")(
-                    "\.\.", ":", "::", "=", "\\", "<-", "->", "@", "~", "=>");
+                setType("atom")(
+                    "false",
+                    "true"
+                );
 
-                setType("builtin")(
-                    "!!", "$!", "$", "&&", "+", "++", "-", ".", "/", "/=", "<", "<*", "<=",
-                    "<$>", "<*>", "=<<", "==", ">", ">=", ">>", ">>=", "^", "^^", "||", "*",
-                    "*>", "**");
-
-                setType("builtin")(
-                    "Applicative", "Bool", "Bounded", "Char", "Double", "EQ", "Either", "Enum",
-                    "Eq", "False", "FilePath", "Float", "Floating", "Fractional", "Functor",
-                    "GT", "IO", "IOError", "Int", "Integer", "Integral", "Just", "LT", "Left",
-                    "Maybe", "Monad", "Nothing", "Num", "Ord", "Ordering", "Rational", "Read",
-                    "ReadS", "Real", "RealFloat", "RealFrac", "Right", "Show", "ShowS",
-                    "String", "True");
-
-                setType("builtin")(
-                    "abs", "acos", "acosh", "all", "and", "any", "appendFile", "asTypeOf",
-                    "asin", "asinh", "atan", "atan2", "atanh", "break", "catch", "ceiling",
-                    "compare", "concat", "concatMap", "const", "cos", "cosh", "curry",
-                    "cycle", "decodeFloat", "div", "divMod", "drop", "dropWhile", "either",
-                    "elem", "encodeFloat", "enumFrom", "enumFromThen", "enumFromThenTo",
-                    "enumFromTo", "error", "even", "exp", "exponent", "fail", "filter",
-                    "flip", "floatDigits", "floatRadix", "floatRange", "floor", "fmap",
-                    "foldl", "foldl1", "foldr", "foldr1", "fromEnum", "fromInteger",
-                    "fromIntegral", "fromRational", "fst", "gcd", "getChar", "getContents",
-                    "getLine", "head", "id", "init", "interact", "ioError", "isDenormalized",
-                    "isIEEE", "isInfinite", "isNaN", "isNegativeZero", "iterate", "last",
-                    "lcm", "length", "lex", "lines", "log", "logBase", "lookup", "map",
-                    "mapM", "mapM_", "max", "maxBound", "maximum", "maybe", "min", "minBound",
-                    "minimum", "mod", "negate", "not", "notElem", "null", "odd", "or",
-                    "otherwise", "pi", "pred", "print", "product", "properFraction", "pure",
-                    "putChar", "putStr", "putStrLn", "quot", "quotRem", "read", "readFile",
-                    "readIO", "readList", "readLn", "readParen", "reads", "readsPrec",
-                    "realToFrac", "recip", "rem", "repeat", "replicate", "return", "reverse",
-                    "round", "scaleFloat", "scanl", "scanl1", "scanr", "scanr1", "seq",
-                    "sequence", "sequence_", "show", "showChar", "showList", "showParen",
-                    "showString", "shows", "showsPrec", "significand", "signum", "sin",
-                    "sinh", "snd", "span", "splitAt", "sqrt", "subtract", "succ", "sum",
-                    "tail", "take", "takeWhile", "tan", "tanh", "toEnum", "toInteger",
-                    "toRational", "truncate", "uncurry", "undefined", "unlines", "until",
-                    "unwords", "unzip", "unzip3", "userError", "words", "writeFile", "zip",
-                    "zip3", "zipWith", "zipWith3");
+                setType("meta")(
+                    "mexpr",
+                    "include",
+                    "never"
+                );
 
                 var override = modeConfig.overrideKeywords;
                 if (override) for (var word in override) if (override.hasOwnProperty(word))
@@ -251,8 +133,6 @@ define(function() {
                     return wellKnownWords.hasOwnProperty(w) ? wellKnownWords[w] : t;
                 },
 
-                blockCommentStart: "{-",
-                blockCommentEnd: "-}",
                 lineComment: "--"
             };
 

--- a/src/boot/kernel/mpl_backend.py
+++ b/src/boot/kernel/mpl_backend.py
@@ -1,8 +1,8 @@
 import matplotlib
-import ocaml
+import _mcore_kernel
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib._pylab_helpers import Gcf
-from ocaml import ocaml_show
+from _mcore_kernel import ocaml_show
 from io import BytesIO
 
 matplotlib.interactive(True)
@@ -40,9 +40,9 @@ def flush_figures():
 
 FigureCanvas = FigureCanvasAgg
 
-old_after_exec = ocaml.after_exec
+old_after_exec = _mcore_kernel.after_exec
 def new_after_exec():
     old_after_exec()
     flush_figures()
 
-ocaml.after_exec = lambda: new_after_exec()
+_mcore_kernel.after_exec = lambda: new_after_exec()

--- a/src/boot/kernel/mpl_backend.py
+++ b/src/boot/kernel/mpl_backend.py
@@ -1,0 +1,20 @@
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib._pylab_helpers import Gcf
+from ocaml import ocaml_show
+from io import BytesIO
+
+def show(close=None, block=None):
+    """Show all figures as PNG payloads sent to the Jupyter frontend.
+
+    Parameters
+    ----------
+    close : Not used.
+    block : Not used.
+    """
+    for figure_manager in Gcf.get_all_fig_managers():
+        fig = figure_manager.canvas.figure
+        bytes_io = BytesIO()
+        fig.canvas.print_figure(bytes_io, format='png', bbox_inches='tight')
+        ocaml_show(bytes_io.getvalue())
+
+FigureCanvas = FigureCanvasAgg

--- a/src/boot/kernel/mpl_backend.py
+++ b/src/boot/kernel/mpl_backend.py
@@ -1,20 +1,48 @@
+import matplotlib
+import ocaml
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib._pylab_helpers import Gcf
 from ocaml import ocaml_show
 from io import BytesIO
 
-def show(close=None, block=None):
+matplotlib.interactive(True)
+
+def send_fig_to_kernel(fig, fmt='png'):
+    bytes_io = BytesIO()
+    fig.canvas.print_figure(bytes_io, format=fmt, bbox_inches='tight')
+    ocaml_show(bytes_io.getvalue())
+
+def show(close=True, block=None):
     """Show all figures as PNG payloads sent to the Jupyter frontend.
 
     Parameters
     ----------
-    close : Not used.
+    close : Close figures after sending
     block : Not used.
     """
     for figure_manager in Gcf.get_all_fig_managers():
         fig = figure_manager.canvas.figure
-        bytes_io = BytesIO()
-        fig.canvas.print_figure(bytes_io, format='png', bbox_inches='tight')
-        ocaml_show(bytes_io.getvalue())
+        send_fig_to_kernel(fig)
+    if close and Gcf.get_all_fig_managers():
+        matplotlib.pyplot.close('all')
+
+show._draw_called = False
+
+def draw_if_interactive():
+    if not matplotlib.is_interactive():
+        return
+    show._draw_called = True
+
+def flush_figures():
+    if show._draw_called:
+        show(True)
+        show._draw_called = False
 
 FigureCanvas = FigureCanvasAgg
+
+old_after_exec = ocaml.after_exec
+def new_after_exec():
+    old_after_exec()
+    flush_figures()
+
+ocaml.after_exec = lambda: new_after_exec()

--- a/src/boot/py-skel/pyffi.ml
+++ b/src/boot/py-skel/pyffi.ml
@@ -2,3 +2,4 @@
 let externals = []
 let arity () = failwith "This should not happen!"
 let delta _ _ _ _ _ = failwith "This should not happen!"
+let is_none _ = false

--- a/src/boot/py/pyast.ml
+++ b/src/boot/py/pyast.ml
@@ -2,3 +2,4 @@ type 'a ext =
 | PyObject of Py.Object.t
 | Pyimport
 | Pycall of Py.Object.t option * string option
+| Pyconvert

--- a/src/boot/py/pyffi.ml
+++ b/src/boot/py/pyffi.ml
@@ -15,11 +15,12 @@ let mk_py fi p = TmConst(fi, CPy(p))
 
 let externals =
   let f p = mk_py NoInfo p in
-  [("pycall", f(Pycall(None,None))); ("pyimport", f(Pyimport))]
+  [("pycall", f(Pycall(None,None))); ("pyimport", f(Pyimport)); ("pyconvert", f(Pyconvert))]
 
 let arity = function
   | PyObject(_) -> 0
   | Pyimport -> 1
+  | Pyconvert -> 1
   | Pycall(None, None) -> 3 | Pycall(Some(_),None) -> 2 | Pycall(_,Some(_)) -> 1
 
 let rec val_to_python fi = function
@@ -32,7 +33,38 @@ let rec val_to_python fi = function
       try tmseq2ustring fi s |> Ustring.to_utf8 |> Py.String.of_string
       with _ -> Mseq.to_list s |> Py.List.of_list_map (val_to_python fi)
     end
+  | TmRecord(_,r) when r = Record.empty -> Py.none
+  | TmRecord(_,r) ->
+    Py.Dict.of_bindings_map
+      (fun x -> Py.String.of_string (Ustring.to_utf8 x))
+      (val_to_python fi)
+      (Record.bindings r)
   | _ -> raise_error fi "The supplied value cannot be used as a python argument"
+
+let rec python_to_val fi obj =
+  match Py.Type.get obj with
+  | Py.Type.Bool -> TmConst(fi,CBool(Py.Bool.to_bool obj))
+  | Py.Type.Int -> TmConst(fi,CInt(Py.Int.to_int obj))
+  | Py.Type.Long -> TmConst(fi,CInt(Py.Long.to_int obj))
+  | Py.Type.Float -> TmConst(fi,CFloat(Py.Float.to_float obj))
+  | Py.Type.None -> TmRecord(fi,Record.empty)
+  | Py.Type.Bytes | Py.Type.Unicode ->
+    let ustr = us (Py.String.to_string obj) in
+    TmSeq(fi,ustring2tmseq fi ustr)
+  | Py.Type.List ->
+    let lst = Py.List.to_list_map (python_to_val fi) obj in
+    TmSeq(fi,Mseq.of_list lst)
+  | Py.Type.Tuple ->
+    let lst = Py.Tuple.to_list_map (python_to_val fi) obj in
+    tuple2record fi lst
+  | Py.Type.Dict ->
+    let bindings = Py.Dict.to_bindings_string obj in
+    let mcore_bindings = List.map (fun (k,v) -> (us k, python_to_val fi v)) bindings in
+    let record = List.fold_right (fun (k,v) r -> Record.add k v r) mcore_bindings Record.empty in
+    TmRecord(fi, record)
+  | t ->
+    raise_error fi ("The supplied python value with type " ^ Py.Type.name t ^
+      " cannot be converted to an MCore value")
 
 let is_none = function
   | PyObject(v) -> v = Py.none
@@ -57,6 +89,8 @@ let delta _ _ fi c v =
     | Pyimport, TmSeq(fi, lst) ->
         mk_py fi (PyObject(Py.import (tmseq2ustring fi lst |> Ustring.to_utf8)))
     | Pyimport,_ -> fail_constapp fi
+    | Pyconvert, TmConst(fi,CPy(PyObject(obj))) -> python_to_val fi obj
+    | Pyconvert,_ -> fail_constapp fi
     | Pycall(None, None),TmConst(_,CPy(PyObject(obj))) -> mk_py fi (Pycall(Some(obj), None))
     | Pycall(None, None),_ -> fail_constapp fi
     | Pycall(Some(m), None),TmSeq(fi,lst) ->

--- a/src/boot/py/pyffi.ml
+++ b/src/boot/py/pyffi.ml
@@ -34,6 +34,10 @@ let rec val_to_python fi = function
     end
   | _ -> raise_error fi "The supplied value cannot be used as a python argument"
 
+let is_none = function
+  | PyObject(v) -> v = Py.none
+  | _ -> false
+
 let fail_constapp f v fi = raise_error fi
                           ("Incorrect application. function: "
                            ^ Ustring.to_utf8 (pprint f)

--- a/src/boot/py/pypprint.ml
+++ b/src/boot/py/pypprint.ml
@@ -1,10 +1,11 @@
 open Ustring.Op
 open Pyast
+open Printf
 
 let pprint = function
-  | PyObject(_) -> us "PyObject"
+  | PyObject(v) -> us (Py.Object.to_string v)
   | Pyimport -> us "pyimport"
   | Pycall(None,None) -> us "pycall"
-  | Pycall(Some(_),None) -> us "pycall PyObject"
-  | Pycall(Some(_),Some s) -> us "pycall PyObject " ^. us s
+  | Pycall(Some(v),None) -> us (sprintf "pycall(%s)" (Py.Object.to_string v))
+  | Pycall(Some(v),Some s) -> us (sprintf "pycall(%s, %s)" (Py.Object.to_string v) s)
   | _ -> failwith "Can't happen"

--- a/src/boot/py/pypprint.ml
+++ b/src/boot/py/pypprint.ml
@@ -5,6 +5,7 @@ open Printf
 let pprint = function
   | PyObject(v) -> us (Py.Object.to_string v)
   | Pyimport -> us "pyimport"
+  | Pyconvert -> us "pyconvert"
   | Pycall(None,None) -> us "pycall"
   | Pycall(Some(v),None) -> us (sprintf "pycall(%s)" (Py.Object.to_string v))
   | Pycall(Some(v),Some s) -> us (sprintf "pycall(%s, %s)" (Py.Object.to_string v) s)

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -200,6 +200,7 @@ let keywords_and_identifiers () =
   |> USSet.to_seq
   |> List.of_seq
   |> List.map Ustring.to_utf8
+  |> (@) keywords
 
 let get_matches s = s
   |> BatPervasives.flip BatString.starts_with

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -24,12 +24,11 @@ let followup_prompt = " | "
 
 let no_line_edit = ref false
 
-let history_dir =
+let history_file =
   if not !no_line_edit then
-    try Sys.getenv "HOME" ^ "/.mcore"
+    try Sys.getenv "HOME" ^ "/.mcore_history"
     with Not_found -> failwith "$HOME is needed to save history, but it is unset. Either set it, or disable line editing with --no-line-edit"
   else "@@@"
-let history_file = sprintf "%s/repl_history" history_dir
 
 (* Try to parse a string received by the REPL into an MCore AST *)
 let parse_mcore_string filename parse_fun str =
@@ -219,8 +218,6 @@ let completion_callback line_so_far ln_completions =
 
 let init_linenoise () =
   if not !no_line_edit then (
-    if not (Sys.file_exists history_dir && Sys.is_directory history_dir) then
-      Unix.mkdir history_dir 0o755;
     LNoise.set_completion_callback completion_callback;
     LNoise.history_load ~filename:history_file |> ignore)
 

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -126,13 +126,14 @@ let wrap_mexpr (Program(inc, tops, tm)) =
 
 let repl_merge_includes = merge_includes (Sys.getcwd ()) []
 
-let repl_envs =
-  let initial_term = Program([],[],TmConst(NoInfo,CInt(0)))
-                     |> add_prelude
-                     |> repl_merge_includes in
-  let builtin_envs = (Record.empty, Mlang.USMap.empty, builtin_name2sym, builtin_sym2term) in
-  let initial_envs, _ = eval_with_envs builtin_envs initial_term in
-  ref initial_envs
+let repl_envs = ref (Record.empty, Mlang.USMap.empty, builtin_name2sym, builtin_sym2term)
+
+let initialize_envs () =
+  let initial_envs, _ = Program([],[],TmConst(NoInfo,CInt(0)))
+                        |> add_prelude
+                        |> repl_merge_includes
+                        |> eval_with_envs !repl_envs in
+  repl_envs := initial_envs
 
 let repl_eval_ast prog =
   let new_envs, result = prog
@@ -168,4 +169,5 @@ let start_repl () =
       read_eval_print ()
   in
   print_welcome_message ();
+  initialize_envs ();
   read_eval_print ()

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -165,12 +165,9 @@ let start_repl () =
     with e ->
       begin
         match e with
-        | Lexer.Lex_error m -> uprint_endline (message2str m)
-        | Parsing.Parse_error -> uprint_endline (message2str (Lexer.parse_error_message ()))
-        | Error m -> uprint_endline (message2str m)
         | Sys.Break -> ()
         | End_of_file -> exit 0
-        | _ -> print_endline @@ Printexc.to_string e
+        | _ -> uprint_endline @@ error_to_ustring e
       end;
       read_eval_print ()
   in

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -24,8 +24,10 @@ let followup_prompt = " | "
 let no_line_edit = ref false
 
 let history_dir =
-  try Sys.getenv "HOME" ^ "/.mcore"
-  with Not_found -> failwith "$HOME is needed to save history, but it is unset. Either set it, or disable line editing with --no-line-edit"
+  if not !no_line_edit then
+    try Sys.getenv "HOME" ^ "/.mcore"
+    with Not_found -> failwith "$HOME is needed to save history, but it is unset. Either set it, or disable line editing with --no-line-edit"
+  else "@@@"
 let history_file = sprintf "%s/repl_history" history_dir
 
 (* Try to parse a string received by the REPL into an MCore AST *)


### PR DESCRIPTION
This is a large pull request adding a fully featured Jupyter kernel based on the boot interpreter. The kernel is completely optional and is described in `KERNEL_README.md`. The kernel supports a large amount of interoperability between Python and MCore, such as executing Python code directly and calling functions defined in Python cells from MCore cells. It is also able to display plots made by `matplotlib` inline in notebooks. The kernel includes autocompletion and we also bundle a notebook extension for MCore syntax highlighting.

In addition, the pull request adds the following features, which are related to the new kernel and its features.
- Conversion from python values back to MCore values using a new builtin `pyconvert`
- Autocompletion and persistent history in the REPL