### PR TITLE
Top level utests

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -122,11 +122,13 @@ and mlang   = Lang of info * ustring * ustring list * decl list
 and let_decl = Let of info * ustring * tm
 and rec_let_decl = RecLet of info * (info * ustring * tm) list
 and con_decl = Con of info * ustring * ty
+and utest_top = Utest of info * tm * tm
 and top =
 | TopLang of mlang
 | TopLet  of let_decl
 | TopRecLet of rec_let_decl
 | TopCon of con_decl
+| TopUtest of utest_top
 
 and include_ = Include of info * ustring
 and program = Program of include_ list * top list * tm

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -113,9 +113,13 @@ let rec merge_includes root visited = function
        includes
        |> List.filter_map (parse_include root)
      in
+     let not_test = function
+       | TopUtest(_) -> false
+       | _ -> true
+     in
      let included_tops =
        included
-       |> List.map (function Program(_ ,tops, _) -> tops)
+       |> List.map (function Program(_ ,tops, _) -> List.filter not_test tops)
        |> List.concat
      in
      Program(includes, included_tops@tops, tm)

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -164,7 +164,7 @@ let data_to_lang info name includes {inters; syns}: mlang =
   Lang(info, name, includes, List.rev_append syns inters)
 
 let flatten_lang (prev_langs: lang_data Record.t): top -> lang_data Record.t * top = function
-  | (TopLet _ | TopRecLet _ | TopCon _) as top -> (prev_langs, top)
+  | (TopLet _ | TopRecLet _ | TopCon _ | TopUtest _) as top -> (prev_langs, top)
   | TopLang(Lang(info, name, includes, _) as lang) ->
      let self_data = compute_lang_data lang in
      let included_data = List.map (lookup_lang info prev_langs) includes in
@@ -354,6 +354,9 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
      in (nss, (wrap :: stack))
   | TopCon(Con(fi, id, ty)) ->
      let wrap tm' = TmCondef(fi, empty_mangle id, nosym, ty, tm')
+     in (nss, (wrap :: stack))
+  | TopUtest(Utest(fi, lhs, rhs)) ->
+     let wrap tm' = TmUtest(fi, lhs, rhs, tm')
      in (nss, (wrap :: stack))
 
 let desugar_post_flatten_with_nss nss (Program (_, tops, t)) =

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -137,6 +137,8 @@ top:
     { TopRecLet($1) }
   | topcon
     { TopCon($1) }
+  | toputest
+    { TopUtest($1) }
 
 toplet:
   | LET var_ident ty_op EQ mexpr
@@ -152,6 +154,11 @@ topcon:
   | CON con_ident ty_op
     { let fi = mkinfo $1.i $2.i in
       Con (fi, $2.v, $3) }
+
+toputest:
+  | UTEST mexpr WITH mexpr
+      { let fi = mkinfo $1.i (tm_info $4) in
+        Utest (fi,$2,$4) }
 
 mlang:
   | LANG ident lang_includes lang_body

--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -14,12 +14,31 @@ let char2upper = lam c.
   then (int2char (subi (char2int c) 32))
   else c
 
+utest char2upper 'a' with 'A'
+utest char2upper '0' with '0'
+utest char2upper 'A' with 'A'
+
 let char2lower = lam c.
   if and (geqchar c 'A') (leqchar c 'Z')
   then (int2char (addi (char2int c) 32))
   else c
 
+utest char2lower 'a' with 'a'
+utest char2lower '0' with '0'
+utest char2lower 'A' with 'a'
+
+-- Character predicates
 let is_whitespace = lam c. any (eqchar c) [' ', '\n', '\t', '\r']
+
+utest is_whitespace ' ' with true
+utest is_whitespace '	' with true
+utest is_whitespace '
+' with true
+utest is_whitespace 'a' with false
+utest is_whitespace '\n' with true
+utest is_whitespace '\t' with true
+utest is_whitespace '\r' with true
+utest is_whitespace '\'' with false
 
 let is_lower_alpha = lam c.
   and (leqi (char2int 'a') (char2int c)) (leqi (char2int c) (char2int 'z'))
@@ -29,52 +48,31 @@ let is_upper_alpha = lam c.
 
 let is_alpha = lam c. or (is_lower_alpha c) (is_upper_alpha c)
 
+utest is_alpha 'a' with true
+utest is_alpha 'm' with true
+utest is_alpha 'z' with true
+utest is_alpha '`' with false
+utest is_alpha '{' with false
+utest is_alpha 'A' with true
+utest is_alpha 'M' with true
+utest is_alpha 'Z' with true
+utest is_alpha '@' with false
+utest is_alpha '[' with false
+
 let is_digit = lam c.
   and (leqi (char2int '0') (char2int c)) (leqi (char2int c) (char2int '9'))
+
+utest is_digit '0' with true
+utest is_digit '5' with true
+utest is_digit '9' with true
+utest is_digit '/' with false
+utest is_digit ':' with false
 
 let is_alphanum = lam c.
   or (is_alpha c) (is_digit c)
 
-mexpr
-
-utest char2upper 'a' with 'A' in
-utest char2upper '0' with '0' in
-utest char2upper 'A' with 'A' in
-
-utest char2lower 'a' with 'a' in
-utest char2lower '0' with '0' in
-utest char2lower 'A' with 'a' in
-
-utest is_whitespace ' ' with true in
-utest is_whitespace '	' with true in
-utest is_whitespace '
-' with true in
-utest is_whitespace 'a' with false in
-utest is_whitespace '\n' with true in
-utest is_whitespace '\t' with true in
-utest is_whitespace '\r' with true in
-utest is_whitespace '\'' with false in
-
-utest is_alpha 'a' with true in
-utest is_alpha 'm' with true in
-utest is_alpha 'z' with true in
-utest is_alpha '`' with false in
-utest is_alpha '{' with false in
-utest is_alpha 'A' with true in
-utest is_alpha 'M' with true in
-utest is_alpha 'Z' with true in
-utest is_alpha '@' with false in
-utest is_alpha '[' with false in
-
-utest is_digit '0' with true in
-utest is_digit '5' with true in
-utest is_digit '9' with true in
-utest is_digit '/' with false in
-utest is_digit ':' with false in
-
-utest is_alphanum '0' with true in
-utest is_alphanum '9' with true in
-utest is_alphanum 'A' with true in
-utest is_alphanum 'z' with true in
-utest is_alphanum '_' with false in
-()
+utest is_alphanum '0' with true
+utest is_alphanum '9' with true
+utest is_alphanum 'A' with true
+utest is_alphanum 'z' with true
+utest is_alphanum '_' with false

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -4,29 +4,25 @@ let inf = divf 1.0 0.0
 let maxf = lam r. lam l. if gtf r l then r else l
 let minf = lam r. lam l. if ltf r l then r else l
 
+utest maxf 0. 0. with 0.
+utest maxf 1. 0. with 1.
+utest maxf 0. 1. with 1.
+
+utest minf 0. 0. with 0.
+utest minf 1. 0. with 0.
+utest minf 0. 1. with 0.
+
 -- Int stuff
 
 let maxi = lam r. lam l. if gti r l then r else l
 let mini = lam r. lam l. if lti r l then r else l
 
-mexpr
+utest maxi 0 0 with 0
+utest maxi 1 0 with 1
+utest maxi 0 1 with 1
 
-utest maxf 0. 0. with 0. in
-utest maxf 1. 0. with 1. in
-utest maxf 0. 1. with 1. in
+utest mini 0 0 with 0
+utest mini 1 0 with 0
+utest mini 0 1 with 0
 
-utest minf 0. 0. with 0. in
-utest minf 1. 0. with 0. in
-utest minf 0. 1. with 0. in
-
-utest maxi 0 0 with 0 in
-utest maxi 1 0 with 1 in
-utest maxi 0 1 with 1 in
-
-utest mini 0 0 with 0 in
-utest mini 1 0 with 0 in
-utest mini 0 1 with 0 in
-
-utest addi 1 (negi 1) with 0 in
-
-()
+utest addi 1 (negi 1) with 0

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -33,6 +33,11 @@ let string2int = lam s.
   then negi (string2int_rechelper (tail s))
   else string2int_rechelper s
 
+utest string2int "5" with 5
+utest string2int "25" with 25
+utest string2int "314159" with 314159
+utest string2int "-314159" with (negi 314159)
+
 let int2string = lam n.
   recursive
   let int2string_rechelper = lam n.
@@ -45,6 +50,11 @@ let int2string = lam n.
   if lti n 0
   then cons '-' (int2string_rechelper (negi n))
   else int2string_rechelper n
+
+utest int2string 5 with "5"
+utest int2string 25 with "25"
+utest int2string 314159 with "314159"
+utest int2string (negi 314159) with "-314159"
 
 // A naive float2string implementation that only formats in standard form
 let float2string = lam arg.
@@ -96,6 +106,10 @@ let float2string = lam arg.
   in
   concat prefix res
 
+utest float2string 5.0e+25 with "5.0e+25"
+utest float2string (negf 5.0e+25) with "-5.0e+25"
+utest float2string (5.0e-5) with "5.0e-5"
+utest float2string (negf 5.0e-5) with "-5.0e-5"
 
 // Returns an option with the index of the first occurrence of c in s. Returns
 // None if c was not found in s.
@@ -109,6 +123,13 @@ let strIndex = lam c. lam s.
          else strIndex_rechelper (addi i 1) c (tail s)
   in
   strIndex_rechelper 0 c s
+
+utest strIndex '%' "a % 5" with Some(2)
+utest strIndex '%' "a & 5" with None ()
+utest strIndex 'w' "Hello, world!" with Some(7)
+utest strIndex 'w' "Hello, World!" with None ()
+utest strIndex 'o' "Hello, world!" with Some(4)
+utest strIndex '@' "Some @TAG@" with Some(5)
 
 // Returns an option with the index of the last occurrence of c in s. Returns
 // None if c was not found in s.
@@ -126,6 +147,13 @@ let strLastIndex = lam c. lam s.
   in
   strLastIndex_rechelper 0 (negi 1) c s
 
+utest strLastIndex '%' "a % 5" with Some(2)
+utest strLastIndex '%' "a & 5" with None ()
+utest strLastIndex 'w' "Hello, world!" with Some(7)
+utest strLastIndex 'w' "Hello, World!" with None ()
+utest strLastIndex 'o' "Hello, world!" with Some(8)
+utest strLastIndex '@' "Some @TAG@" with Some(9)
+
 // Splits s on delim
 recursive
   let strSplit = lam delim. lam s.
@@ -136,6 +164,12 @@ recursive
          else let remaining = strSplit delim (tail s) in
               cons (cons (head s) (head remaining)) (tail remaining)
 end
+
+utest strSplit "ll" "Hello" with ["He", "o"]
+utest strSplit "ll" "Hellallllo" with ["He", "a", "", "o"]
+utest strSplit "" "Hello" with ["Hello"]
+utest strSplit "lla" "Hello" with ["Hello"]
+utest strSplit "Hello" "Hello" with ["", ""]
 
 // Trims s of spaces
 let strTrim = lam s.
@@ -149,6 +183,10 @@ let strTrim = lam s.
   in
   reverse (strTrim_init (reverse (strTrim_init s)))
 
+utest strTrim " aaaa   " with "aaaa"
+utest strTrim "   bbbbb  bbb " with "bbbbb  bbb"
+utest strTrim "ccccc c\t   \n" with "ccccc c"
+
 // Joins the strings in strs on delim
 recursive
   let strJoin = lam delim. lam strs.
@@ -159,50 +197,7 @@ recursive
          else concat (concat (head strs) delim) (strJoin delim (tail strs))
 end
 
-mexpr
-
-utest string2int "5" with 5 in
-utest string2int "25" with 25 in
-utest string2int "314159" with 314159 in
-utest string2int "-314159" with (negi 314159) in
-
-utest int2string 5 with "5" in
-utest int2string 25 with "25" in
-utest int2string 314159 with "314159" in
-utest int2string (negi 314159) with "-314159" in
-
-utest float2string 5.0e+25 with "5.0e+25" in
-utest float2string (negf 5.0e+25) with "-5.0e+25" in
-utest float2string (5.0e-5) with "5.0e-5" in
-utest float2string (negf 5.0e-5) with "-5.0e-5" in
-
-utest strIndex '%' "a % 5" with Some(2) in
-utest strIndex '%' "a & 5" with None () in
-utest strIndex 'w' "Hello, world!" with Some(7) in
-utest strIndex 'w' "Hello, World!" with None () in
-utest strIndex 'o' "Hello, world!" with Some(4) in
-utest strIndex '@' "Some @TAG@" with Some(5) in
-
-utest strLastIndex '%' "a % 5" with Some(2) in
-utest strLastIndex '%' "a & 5" with None () in
-utest strLastIndex 'w' "Hello, world!" with Some(7) in
-utest strLastIndex 'w' "Hello, World!" with None () in
-utest strLastIndex 'o' "Hello, world!" with Some(8) in
-utest strLastIndex '@' "Some @TAG@" with Some(9) in
-
-utest strSplit "ll" "Hello" with ["He", "o"] in
-utest strSplit "ll" "Hellallllo" with ["He", "a", "", "o"] in
-utest strSplit "" "Hello" with ["Hello"] in
-utest strSplit "lla" "Hello" with ["Hello"] in
-utest strSplit "Hello" "Hello" with ["", ""] in
-
-utest strTrim " aaaa   " with "aaaa" in
-utest strTrim "   bbbbb  bbb " with "bbbbb  bbb" in
-utest strTrim "ccccc c\t   \n" with "ccccc c" in
-
-utest strJoin "--" ["water", "tea", "coffee"] with "water--tea--coffee" in
-utest strJoin "--" [] with "" in
-utest strJoin "--" ["coffee"] with "coffee" in
-utest strJoin "water" ["coffee", "tea"] with "coffeewatertea" in
-
-()
+utest strJoin "--" ["water", "tea", "coffee"] with "water--tea--coffee"
+utest strJoin "--" [] with ""
+utest strJoin "--" ["coffee"] with "coffee"
+utest strJoin "water" ["coffee", "tea"] with "coffeewatertea"


### PR DESCRIPTION
This adds MLang top level utests, and moves some of the utests in the standard library to be next to the function they are testing.
Note that using top level utests is not quite as convenient as mexpr utests, as you cannot reuse a value across several utests without defining it in the top level.