### PR TITLE
Constructors as functions

### DIFF
--- a/src/boot/ast.ml
+++ b/src/boot/ast.ml
@@ -143,7 +143,7 @@ and tm =
 | TmRecord  of info * tm Record.t                                   (* Record *)
 | TmRecordUpdate of info * tm * ustring * tm                        (* Record update *)
 | TmCondef  of info * ustring * sym * ty * tm                       (* Constructor definition *)
-| TmConapp  of info * ustring * sym * tm                            (* Constructor application *)
+| TmConapp  of info * ustring * sym * tm option                     (* Constructor application *)
 | TmMatch   of info * tm * pat * tm * tm                            (* Match data *)
 | TmUse     of info * ustring * tm                                  (* Use a language *)
 | TmUtest   of info * tm * tm * tm                                  (* Unit testing *)
@@ -223,7 +223,7 @@ let rec map_tm f = function
   | TmRecord(fi,r) -> f (TmRecord(fi,Record.map (map_tm f) r))
   | TmRecordUpdate(fi,r,l,t) -> f (TmRecordUpdate(fi,map_tm f r,l,map_tm f t))
   | TmCondef(fi,x,s,ty,t1) -> f (TmCondef(fi,x,s,ty,map_tm f t1))
-  | TmConapp(fi,k,s,t) -> f (TmConapp(fi,k,s,t))
+  | TmConapp _ as t -> f t
   | TmMatch(fi,t1,p,t2,t3) ->
     f (TmMatch(fi,map_tm f t1,p,map_tm f t2,map_tm f t3))
   | TmUse(fi,l,t1) -> f (TmUse(fi,l,map_tm f t1))

--- a/src/boot/mlang.ml
+++ b/src/boot/mlang.ml
@@ -248,7 +248,7 @@ let rec desugar_tm nss env =
      in TmRecLets(fi, List.map (fun (fi, name, s, e) -> (fi, empty_mangle name, s, desugar_tm nss env' e)) bindings, desugar_tm nss env' body)
   | TmCondef(fi, name, s, ty, body) ->
      TmCondef(fi, empty_mangle name, s, ty, desugar_tm nss (delete_con env name) body)
-  | TmConapp(fi,x,s,t) -> TmConapp(fi,resolve_con env x,s,desugar_tm nss env t)
+  | TmConapp(fi,x,s,_) -> TmConapp(fi,resolve_con env x,s,None)
   | (TmClos _) as tm -> tm
   (* Both introducing and referencing *)
   | TmMatch(fi, target, pat, thn, els) ->

--- a/src/boot/parser.mly
+++ b/src/boot/parser.mly
@@ -275,9 +275,6 @@ left:
   | left atom
       { let fi = mkinfo (tm_info $1) (tm_info $2) in
         TmApp(fi,$1,$2) }
-  | con_ident atom
-      { let fi = mkinfo $1.i (tm_info $2) in
-        TmConapp(fi,$1.v,nosym,$2) }
 
 
 atom:
@@ -292,7 +289,8 @@ atom:
   | LPAREN mexpr COMMA RPAREN
       { TmRecord(mkinfo $1.i $4.i, Record.singleton (us "0") $2) }
   | LPAREN RPAREN        { TmRecord($1.i, Record.empty) }
-  | var_ident                { TmVar($1.i,$1.v,nosym) }
+  | var_ident            { TmVar($1.i,$1.v,nosym) }
+  | con_ident            { TmConapp($1.i,$1.v,nosym,None) }
   | CHAR                 { TmConst($1.i, CChar(List.hd (ustring2list $1.v))) }
   | UINT                 { TmConst($1.i,CInt($1.v)) }
   | UFLOAT               { TmConst($1.i,CFloat($1.v)) }

--- a/src/boot/pprint.ml
+++ b/src/boot/pprint.ml
@@ -354,9 +354,13 @@ and print_tm' fmt t = match t with
     fprintf fmt "@[<hov 0>con %s:%s in@ %a@]"
       str ty print_tm (Match, t)
 
-  | TmConapp(_,x,sym,t) ->
+  | TmConapp(_,x,sym,opt) ->
     let str = string_of_ustring (ustring_of_var x sym) in
-     fprintf fmt "%s %a" str print_tm (Atom ,t)
+    begin
+      match opt with
+      | None -> fprintf fmt "%s" str
+      | Some(t) -> fprintf fmt "%s %a" str print_tm (Atom, t)
+    end
 
   (* If expressions *)
   | TmMatch(_,t1,PatBool(_,true),t2,t3) ->

--- a/stdlib/mexpr/mcore_parser.mc
+++ b/stdlib/mexpr/mcore_parser.mc
@@ -162,7 +162,7 @@ recursive
   let ty = lam st.
     let app_or_atom =
       bind (many1 ty_atom) (lam ts.
-      pure (foldl1 (curry (lam x. TyApp x)) ts))
+      pure (foldl1 (curry TyApp) ts))
     in
     let arrow_or_ty =
       bind app_or_atom (lam lt.
@@ -182,10 +182,10 @@ recursive
   let atom = lam st.
     let var_access =
       let _ = debug "== Parsing var_access" in
-      fmap (lam x. TmVar x) identifier in
+      fmap TmVar identifier in
     let seq =
       let _ = debug "== Parsing seq ==" in
-      fmap (lam x. TmSeq x) (brackets (comma_sep expr))
+      fmap TmSeq (brackets (comma_sep expr))
     in
     let tuple =
       let _ = debug "== Parsing tuple ==" in
@@ -198,11 +198,11 @@ recursive
     in
     let num =
       let _ = debug "== Parsing num ==" in
-      fmap (lam n. TmConst (CInt n)) number
+      fmap (compose TmConst CInt) number
     in
     let float =
       let _ = debug "== Parsing float ==" in
-      fmap (lam f. TmConst (CFloat f)) float
+      fmap (compose TmConst CFloat) float
     in
     let bool =
       let _ = debug "== Parsing bool ==" in
@@ -212,11 +212,11 @@ recursive
     let str_lit =
       let _ = debug "== Parsing string ==" in
       bind string_lit (lam s.
-      pure (TmSeq (map (lam c. TmConst (CChar c)) s)))
+      pure (TmSeq (map (compose TmConst CChar) s)))
     in
     let chr_lit =
       let _ = debug "== Parsing character ==" in
-      fmap (lam c. TmConst (CChar c)) char_lit
+      fmap (compose TmConst CChar) char_lit
     in
       label "atomic expression"
       (alt var_access
@@ -241,10 +241,10 @@ recursive
         bind (many (apr (symbol ".") number)) (lam is.
         if null is
         then pure a
-        else pure (foldl (curry (lam x. TmProj x)) a is)))
+        else pure (foldl (curry TmProj) a is)))
       in
       bind (many1 atom_or_proj) (lam as.
-      pure (foldl1 (curry (lam x. TmApp x)) as))
+      pure (foldl1 (curry TmApp) as))
     in
     let letbinding =
       let _ = debug "== Parsing letbinding ==" in

--- a/stdlib/mexpr/meta.mc
+++ b/stdlib/mexpr/meta.mc
@@ -140,7 +140,7 @@ recursive
   let ty = lam st.
     let app_or_atom =
       bind (many1 ty_atom) (lam ts.
-      pure (foldl1 (curry (lam x. TyApp x)) ts))
+      pure (foldl1 (curry TyApp) ts))
     in
     let arrow_or_ty =
       bind app_or_atom (lam lt.
@@ -160,10 +160,10 @@ recursive
   let atom = lam st.
     let var_access =
       let _ = debug "== Parsing var_access" in
-      fmap (lam x. TmVar x) identifier in
+      fmap TmVar identifier in
     let seq =
       let _ = debug "== Parsing seq ==" in
-      fmap (lam x. TmSeq x) (brackets (comma_sep expr))
+      fmap TmSeq (brackets (comma_sep expr))
     in
     let tuple =
       let _ = debug "== Parsing tuple ==" in
@@ -176,11 +176,11 @@ recursive
     in
     let num =
       let _ = debug "== Parsing num ==" in
-      fmap (lam n. TmConst (CInt n)) number
+      fmap (compose TmConst CInt) number
     in
     let float =
       let _ = debug "== Parsing float ==" in
-      fmap (lam f. TmConst (CFloat f)) float
+      fmap (compose TmConst CFloat) float
     in
     let bool =
       let _ = debug "== Parsing bool ==" in
@@ -190,11 +190,11 @@ recursive
     let str_lit =
       let _ = debug "== Parsing string ==" in
       bind string_lit (lam s.
-      pure (TmSeq (map (lam c. TmConst (CChar c)) s)))
+      pure (TmSeq (map (compose TmConst CChar) s)))
     in
     let chr_lit =
       let _ = debug "== Parsing character ==" in
-      fmap (lam c. TmConst (CChar c)) char_lit
+      fmap (compose TmConst CChar) char_lit
     in
       label "atomic expression"
       (alt var_access
@@ -219,10 +219,10 @@ recursive
         bind (many (apr (symbol ".") number)) (lam is.
         if null is
         then pure a
-        else pure (foldl (curry (lam x. TmProj x)) a is)))
+        else pure (foldl (curry TmProj) a is)))
       in
       bind (many1 atom_or_proj) (lam as.
-      pure (foldl1 (curry (lam x. TmApp x)) as))
+      pure (foldl1 (curry TmApp) as))
     in
     let letbinding =
       let _ = debug "== Parsing letbinding ==" in

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -72,7 +72,7 @@ let optionFilter: (a -> Bool) -> Option -> Option = lam p. lam o.
 -- Returns the option if it contains a value, otherwise calls the specified
 -- function and returns the result.
 let optionOrElse: (Unit -> Option) -> Option -> Option = lam f. lam o.
-  optionGetOrElse f (optionMap (lam x. Some x) o)
+  optionGetOrElse f (optionMap Some o)
 
 -- Returns the first option if it contains a value, otherwise returns
 -- the second option.

--- a/stdlib/parser.mc
+++ b/stdlib/parser.mc
@@ -86,7 +86,7 @@ let fmap = lam f. lam p. lam st.
 -- Parser is an applicative functor
 
 -- pure : a -> Parser a
-let pure = lam v. lam st. Success(v, st)
+let pure = curry Success
 
 -- ap : Parser (a -> b) -> Parser a -> Parser b
 let ap = lam pf. lam p. lam st.
@@ -265,7 +265,7 @@ let many1 = lam p.
 
 -- optional : Parser a -> Parser (Option a)
 let optional = lam p.
-  alt (fmap (lam x. Some x) p) (pure (None()))
+  alt (fmap Some p) (pure (None()))
 
 -- wrapped_in : Parser l -> Parser r -> Parser a -> Parser a
 --


### PR DESCRIPTION
This pull request makes data constructors behave like first-class functions. This enables code such as 

```ocaml
map Foo [1,2,3]
```

where before, you had to use

```ocaml
map (lam x. Foo x) [1,2,3]
```

I don't know whether this change is wanted, but this is something which has been annoying me, and I don't see any particular downsides in changing it.