### PR TITLE
Repl improvements and kernel preparations

### DIFF
--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -9,172 +9,11 @@
    only implements a subset of the Ragnar language.
 *)
 
-
-open Ustring.Op
 open Printf
 open Ast
-open Msg
-open Mexpr
-open Pprint
+open Eval
 open Repl
-
-module Option = BatOption
-
-(* Standard lib default local path on unix (used by make install) *)
-let stdlib_loc_unix =
-  match Sys.getenv_opt "HOME" with
-  | Some home -> home ^ "/.local/lib/mcore/stdlib"
-  | None -> "@@@"
-
-let stdlib_loc =
-  match Sys.getenv_opt "MCORE_STDLIB" with
-  | Some path -> path
-  | None ->
-    if Sys.os_type = "Unix" &&
-       Sys.file_exists stdlib_loc_unix
-    then stdlib_loc_unix
-    else "@@@"
-
-let default_includes =
-  let prelude = [Include(NoInfo, us"prelude.mc")] in
-  match Sys.getenv_opt "MCORE_STDLIB" with
-  | Some "@@@" -> [] (* Needed for test of stdlib *)
-  | Some _ -> prelude
-  | None ->
-    if Sys.os_type = "Unix" &&
-       Sys.file_exists stdlib_loc_unix
-    then prelude
-    else []
-
-let prog_argv = ref []          (* Argv for the program that is executed *)
-
-(* Debug printing after parse*)
-let debug_after_parse t =
-  if !enable_debug_after_parse then
-    (printf "\n-- After parsing (only mexpr part) --\n";
-     uprint_endline (ustring_of_program t);
-     t)
-  else t
-
-(* Debug printing after symbolize transformation *)
-let debug_after_symbolize t =
-  if !enable_debug_after_symbolize then
-    (printf "\n-- After symbolize --\n";
-     uprint_endline (ustring_of_tm ~margin:80 t);
-     t)
-  else t
-
-(* Debug mlang to mexpr transform *)
-let debug_after_mlang t =
-  if !enable_debug_after_mlang then
-    (printf "\n-- After mlang --\n";
-     uprint_endline (ustring_of_tm ~margin:80 t);
-     t)
-  else t
-
-(* Keep track of which files have been parsed to avoid double includes *)
-let parsed_files = ref []
-
-(* Open a file and parse it into an MCore program *)
-let parse_mcore_file filename =
-  let tablength = 8 in
-  let fs1 = open_in filename in
-  let p =
-    Lexer.init (us filename) tablength;
-    fs1 |> Ustring.lexing_from_channel
-    |> Parser.main Lexer.main |> debug_after_parse
-  in
-  close_in fs1; (parsed_files := filename::!parsed_files); p
-
-(* Parse and merge all files included from a program, given the
-   path of the "root program". Raise an error if a loop is
-   detected. *)
-let rec merge_includes root visited = function
-  | Program(includes, tops, tm) ->
-     let rec parse_include root = function
-       | Include(info, path) as inc ->
-          let filename = Filename.concat root (Ustring.to_utf8 path) |> Utils.normalize_path in
-          if List.mem filename visited
-          then raise_error info ("Cycle detected in included files: " ^ filename)
-          else if List.mem filename !parsed_files
-          then None (* File already included *)
-          else
-            if Sys.file_exists filename then
-              parse_mcore_file filename |>
-              merge_includes (Filename.dirname filename) (filename::visited) |>
-              Option.some
-            else if root != stdlib_loc &&
-                    Sys.file_exists @@
-                      Filename.concat stdlib_loc (Ustring.to_utf8 path)
-            then parse_include stdlib_loc inc
-            else raise_error info ("No such file: \"" ^ filename ^ "\"")
-     in
-     let included =
-       includes
-       |> List.filter_map (parse_include root)
-     in
-     let not_test = function
-       | TopUtest(_) -> false
-       | _ -> true
-     in
-     let included_tops =
-       included
-       |> List.map (function Program(_ ,tops, _) -> List.filter not_test tops)
-       |> List.concat
-     in
-     Program(includes, included_tops@tops, tm)
-
-let add_prelude = function
-  | Program(includes, tops, tm) -> Program(default_includes@includes, tops, tm)
-
-(* Main function for evaluation a function. Performs lexing, parsing
-   and evaluation. Does not perform any type checking *)
-let evalprog filename  =
-  (* Make sure the filename is an absolute path, otherwise the duplicate file detection won't work *)
-  let filename =
-    if Filename.is_relative filename
-    then Filename.concat (Sys.getcwd ()) filename
-    else filename in
-  if !utest then printf "%s: " filename;
-  utest_fail_local := 0;
-  begin try
-    let parsed = parse_mcore_file filename in
-    (parsed
-     |> add_prelude
-     |> merge_includes (Filename.dirname filename) [filename]
-     |> Mlang.flatten
-     |> Mlang.desugar_post_flatten
-     |> debug_after_mlang
-     |> Mexpr.symbolize builtin_name2sym
-     |> debug_after_symbolize
-     |> Mexpr.eval builtin_sym2term
-     |> fun _ -> ())
-    with
-    | Lexer.Lex_error m ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
-    | Error m ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
-    | Parsing.Parse_error ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n"
-  (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())))
-  end; parsed_files := [];
-  if !utest && !utest_fail_local = 0 then printf " OK\n" else printf "\n"
-
+open Mexpr
 
 (* Define the file slash, to make it platform independent *)
 let sl = if Sys.win32 then "\\" else "/"
@@ -213,53 +52,15 @@ let testprog lst =
       printf "ERROR! %d successful tests and %d failed tests.\n\n"
         (!utest_ok) (!utest_fail)
 
-(* Run the MCore REPL *)
-let runrepl _ =
-  let repl_merge_includes = merge_includes (Sys.getcwd ()) [] in
-  (* Wrap the final mexpr in a lambda application to prevent scope leak *)
-  let repl_wrap_mexpr (Program(inc, tops, tm)) =
-    let lambda_wrapper = TmLam(NoInfo, us"_", nosym, TyArrow(TyInt,TyDyn), tm) in
-    let new_tm = TmApp(NoInfo, lambda_wrapper, TmConst(NoInfo, CInt(0))) in
-    Program(inc, tops, new_tm) in
-  let rec read_eval_print envs =
-    try
-      let (Program(_,_,tm)) as ast = read_user_input () in
-      let prog = ast
-        |> repl_merge_includes
-        |> repl_wrap_mexpr in
-      let (new_envs, result) = eval_with_envs envs prog in
-      begin
-        if tm = tmUnit then
-          flush stdout
-        else
-          uprint_endline (ustring_of_tm result)
-      end;
-      read_eval_print new_envs
-    with e ->
-      begin
-        match e with
-        | Lexer.Lex_error m -> uprint_endline (message2str m)
-        | Parsing.Parse_error -> uprint_endline (message2str (Lexer.parse_error_message ()))
-        | Error m -> uprint_endline (message2str m)
-        | Sys.Break -> ()
-        | End_of_file -> exit 0
-        | _ -> print_endline @@ Printexc.to_string e
-      end;
-      read_eval_print envs
-  in
-  let initial_term = Program([],[],TmConst(NoInfo,CInt(0)))
-                     |> add_prelude
-                     |> repl_merge_includes in
-  let builtin_envs = (Record.empty, Mlang.USMap.empty, builtin_name2sym, builtin_sym2term) in
-  let initial_envs, _ = eval_with_envs builtin_envs initial_term in
-  print_welcome_message ();
-  read_eval_print initial_envs
-
 (* Run program *)
 let runprog name lst =
     (* TODO prog_argv is never used anywhere *)
     prog_argv := lst;
     evalprog name
+
+(* Run the REPL *)
+let runrepl _ =
+    start_repl ()
 
 (* Print out main menu *)
 let usage_msg = "Usage: mi [run|repl|test] <files>\n\nOptions:"

--- a/src/boot/eval.ml
+++ b/src/boot/eval.ml
@@ -1,0 +1,169 @@
+
+(*
+   Miking is licensed under the MIT license.
+   Copyright (C) David Broman. See file LICENSE.txt
+*)
+
+open Ustring.Op
+open Printf
+open Ast
+open Pprint
+open Msg
+open Mexpr
+
+module Option = BatOption
+
+(* Standard lib default local path on unix (used by make install) *)
+let stdlib_loc_unix =
+  match Sys.getenv_opt "HOME" with
+  | Some home -> home ^ "/.local/lib/mcore/stdlib"
+  | None -> "@@@"
+
+let default_includes =
+  let prelude = [Include(NoInfo, us"prelude.mc")] in
+  match Sys.getenv_opt "MCORE_STDLIB" with
+  | Some "@@@" -> [] (* Needed for test of stdlib *)
+  | Some _ -> prelude
+  | None ->
+    if Sys.os_type = "Unix" &&
+       Sys.file_exists stdlib_loc_unix
+    then prelude
+    else []
+
+let stdlib_loc =
+  match Sys.getenv_opt "MCORE_STDLIB" with
+  | Some path -> path
+  | None ->
+    if Sys.os_type = "Unix" &&
+       Sys.file_exists stdlib_loc_unix
+    then stdlib_loc_unix
+    else "@@@"
+
+let prog_argv : string list ref = ref []          (* Argv for the program that is executed *)
+
+(* Debug printing after parse*)
+let debug_after_parse t =
+  if !enable_debug_after_parse then
+    (printf "\n-- After parsing (only mexpr part) --\n";
+     uprint_endline (ustring_of_program t);
+     t)
+  else t
+
+(* Debug printing after symbolize transformation *)
+let debug_after_symbolize t =
+  if !enable_debug_after_symbolize then
+    (printf "\n-- After symbolize --\n";
+     uprint_endline (ustring_of_tm ~margin:80 t);
+     t)
+  else t
+
+(* Debug mlang to mexpr transform *)
+let debug_after_mlang t =
+  if !enable_debug_after_mlang then
+    (printf "\n-- After mlang --\n";
+     uprint_endline (ustring_of_tm ~margin:80 t);
+     t)
+  else t
+
+(* Keep track of which files have been parsed to avoid double includes *)
+let parsed_files = ref []
+
+(* Open a file and parse it into an MCore program *)
+let parse_mcore_file filename =
+  let tablength = 8 in
+  let fs1 = open_in filename in
+  let p =
+    Lexer.init (us filename) tablength;
+    fs1 |> Ustring.lexing_from_channel
+    |> Parser.main Lexer.main |> debug_after_parse
+  in
+  close_in fs1; (parsed_files := filename::!parsed_files); p
+
+(* Parse and merge all files included from a program, given the
+   path of the "root program". Raise an error if a loop is
+   detected. *)
+let rec merge_includes root visited = function
+  | Program(includes, tops, tm) ->
+     let rec parse_include root = function
+       | Include(info, path) as inc ->
+          let filename = Filename.concat root (Ustring.to_utf8 path) |> Utils.normalize_path in
+          if List.mem filename visited
+          then raise_error info ("Cycle detected in included files: " ^ filename)
+          else if List.mem filename !parsed_files
+          then None (* File already included *)
+          else
+            if Sys.file_exists filename then
+              parse_mcore_file filename |>
+              merge_includes (Filename.dirname filename) (filename::visited) |>
+              Option.some
+            else if root != stdlib_loc &&
+                    Sys.file_exists @@
+                      Filename.concat stdlib_loc (Ustring.to_utf8 path)
+            then parse_include stdlib_loc inc
+            else raise_error info ("No such file: \"" ^ filename ^ "\"")
+     in
+     let included =
+       includes
+       |> List.filter_map (parse_include root)
+     in
+     let not_test = function
+       | TopUtest(_) -> false
+       | _ -> true
+     in
+     let included_tops =
+       included
+       |> List.map (function Program(_ ,tops, _) -> List.filter not_test tops)
+       |> List.concat
+     in
+     Program(includes, included_tops@tops, tm)
+
+let add_prelude = function
+  | Program(includes, tops, tm) -> Program(default_includes@includes, tops, tm)
+
+(* Main function for evaluation a function. Performs lexing, parsing
+   and evaluation. Does not perform any type checking *)
+let evalprog filename  =
+  (* Make sure the filename is an absolute path, otherwise the duplicate file detection won't work *)
+  let filename =
+    if Filename.is_relative filename
+    then Filename.concat (Sys.getcwd ()) filename
+    else filename in
+  if !utest then printf "%s: " filename;
+  utest_fail_local := 0;
+  begin try
+    let parsed = parse_mcore_file filename in
+    (parsed
+     |> add_prelude
+     |> merge_includes (Filename.dirname filename) [filename]
+     |> Mlang.flatten
+     |> Mlang.desugar_post_flatten
+     |> debug_after_mlang
+     |> Mexpr.symbolize builtin_name2sym
+     |> debug_after_symbolize
+     |> Mexpr.eval builtin_sym2term
+     |> fun _ -> ())
+    with
+    | Lexer.Lex_error m ->
+      if !utest then (
+        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
+        utest_fail := !utest_fail + 1;
+        utest_fail_local := !utest_fail_local + 1)
+      else
+        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
+    | Error m ->
+      if !utest then (
+        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
+        utest_fail := !utest_fail + 1;
+        utest_fail_local := !utest_fail_local + 1)
+      else
+        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
+    | Parsing.Parse_error ->
+      if !utest then (
+        printf "\n%s" (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())));
+        utest_fail := !utest_fail + 1;
+        utest_fail_local := !utest_fail_local + 1)
+      else
+        fprintf stderr "%s\n"
+  (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())))
+  end; parsed_files := [];
+  if !utest && !utest_fail_local = 0 then printf " OK\n" else printf "\n"

--- a/src/boot/eval.ml
+++ b/src/boot/eval.ml
@@ -120,6 +120,13 @@ let rec merge_includes root visited = function
 let add_prelude = function
   | Program(includes, tops, tm) -> Program(default_includes@includes, tops, tm)
 
+let error_to_ustring e =
+  match e with
+  | Lexer.Lex_error m -> message2str m
+  | Parsing.Parse_error -> message2str (Lexer.parse_error_message ())
+  | Error m -> message2str m
+  | _ -> us(Printexc.to_string e)
+
 (* Main function for evaluation a function. Performs lexing, parsing
    and evaluation. Does not perform any type checking *)
 let evalprog filename  =
@@ -143,27 +150,13 @@ let evalprog filename  =
      |> Mexpr.eval builtin_sym2term
      |> fun _ -> ())
     with
-    | Lexer.Lex_error m ->
+    | (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->
+      let error_string = Ustring.to_utf8 (error_to_ustring e) in
       if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
+        printf "\n%s" error_string;
         utest_fail := !utest_fail + 1;
         utest_fail_local := !utest_fail_local + 1)
       else
-        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
-    | Error m ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str m));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n" (Ustring.to_utf8 (Msg.message2str m))
-    | Parsing.Parse_error ->
-      if !utest then (
-        printf "\n%s" (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())));
-        utest_fail := !utest_fail + 1;
-        utest_fail_local := !utest_fail_local + 1)
-      else
-        fprintf stderr "%s\n"
-  (Ustring.to_utf8 (Msg.message2str (Lexer.parse_error_message())))
+        fprintf stderr "%s\n" error_string
   end; parsed_files := [];
   if !utest && !utest_fail_local = 0 then printf " OK\n" else printf "\n"

--- a/src/boot/py-skel/pyffi.ml
+++ b/src/boot/py-skel/pyffi.ml
@@ -2,3 +2,4 @@
 let externals = []
 let arity () = failwith "This should not happen!"
 let delta _ _ _ _ _ = failwith "This should not happen!"
+let is_none _ = false

--- a/src/boot/py/pyffi.ml
+++ b/src/boot/py/pyffi.ml
@@ -71,6 +71,9 @@ let rec python_to_val fi obj =
   | t ->
     raise_error fi ("The supplied python value with type " ^ Py.Type.name t ^
       " cannot be converted to an MCore value")
+let is_none = function
+  | PyObject(v) -> v = Py.none
+  | _ -> false
 
 let fail_constapp f v fi = raise_error fi
                           ("Incorrect application. function: "

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -200,6 +200,7 @@ let keywords_and_identifiers () =
   |> USSet.to_seq
   |> List.of_seq
   |> List.map Ustring.to_utf8
+  |> (@) keywords
 
 let get_matches s = s
   |> BatPervasives.flip BatString.starts_with

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -24,12 +24,11 @@ let followup_prompt = " | "
 
 let no_line_edit = ref false
 
-let history_dir =
+let history_file =
   if not !no_line_edit then
-    try Sys.getenv "HOME" ^ "/.mcore"
+    try Sys.getenv "HOME" ^ "/.mcore_history"
     with Not_found -> failwith "$HOME is needed to save history, but it is unset. Either set it, or disable line editing with --no-line-edit"
   else "@@@"
-let history_file = sprintf "%s/repl_history" history_dir
 
 (* Try to parse a string received by the REPL into an MCore AST *)
 let parse_mcore_string filename parse_fun str =
@@ -219,8 +218,6 @@ let completion_callback line_so_far ln_completions =
 
 let init_linenoise () =
   if not !no_line_edit then (
-    if not (Sys.file_exists history_dir && Sys.is_directory history_dir) then
-      Unix.mkdir history_dir 0o755;
     LNoise.set_completion_callback completion_callback;
     LNoise.history_load ~filename:history_file |> ignore)
 

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -126,13 +126,14 @@ let wrap_mexpr (Program(inc, tops, tm)) =
 
 let repl_merge_includes = merge_includes (Sys.getcwd ()) []
 
-let repl_envs =
-  let initial_term = Program([],[],TmConst(NoInfo,CInt(0)))
-                     |> add_prelude
-                     |> repl_merge_includes in
-  let builtin_envs = (Record.empty, Mlang.USMap.empty, builtin_name2sym, builtin_sym2term) in
-  let initial_envs, _ = eval_with_envs builtin_envs initial_term in
-  ref initial_envs
+let repl_envs = ref (Record.empty, Mlang.USMap.empty, builtin_name2sym, builtin_sym2term)
+
+let initialize_envs () =
+  let initial_envs, _ = Program([],[],TmConst(NoInfo,CInt(0)))
+                        |> add_prelude
+                        |> repl_merge_includes
+                        |> eval_with_envs !repl_envs in
+  repl_envs := initial_envs
 
 let repl_eval_ast prog =
   let new_envs, result = prog
@@ -168,4 +169,5 @@ let start_repl () =
       read_eval_print ()
   in
   print_welcome_message ();
+  initialize_envs ();
   read_eval_print ()

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -165,12 +165,9 @@ let start_repl () =
     with e ->
       begin
         match e with
-        | Lexer.Lex_error m -> uprint_endline (message2str m)
-        | Parsing.Parse_error -> uprint_endline (message2str (Lexer.parse_error_message ()))
-        | Error m -> uprint_endline (message2str m)
         | Sys.Break -> ()
         | End_of_file -> exit 0
-        | _ -> print_endline @@ Printexc.to_string e
+        | _ -> uprint_endline @@ error_to_ustring e
       end;
       read_eval_print ()
   in

--- a/src/boot/repl.ml
+++ b/src/boot/repl.ml
@@ -24,8 +24,10 @@ let followup_prompt = " | "
 let no_line_edit = ref false
 
 let history_dir =
-  try Sys.getenv "HOME" ^ "/.mcore"
-  with Not_found -> failwith "$HOME is needed to save history, but it is unset. Either set it, or disable line editing with --no-line-edit"
+  if not !no_line_edit then
+    try Sys.getenv "HOME" ^ "/.mcore"
+    with Not_found -> failwith "$HOME is needed to save history, but it is unset. Either set it, or disable line editing with --no-line-edit"
+  else "@@@"
 let history_file = sprintf "%s/repl_history" history_dir
 
 (* Try to parse a string received by the REPL into an MCore AST *)


### PR DESCRIPTION
This PR was extracted from #120.

This pull request restructures the REPL code and adds several new features to it. It also changes a few things needed for the Jupyter kernel.
- Refactor the REPL code and restructure files to allow the REPL functions to be called from other modules (like the Jupyter kernel). This includes moving a large part of `boot.ml` to a new file called `eval.ml`.
- Add a variable to control how program output is printed
- Make the REPL not print unit or None values
- Add persistent history to the REPL
- Add autocompletion to the REPL

