### PR TITLE
Add HashMap to stdlib

### DIFF
--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -10,8 +10,6 @@ include "math.mc"
 include "option.mc"
 include "string.mc"
 
-include "map.mc" -- REMOVE BEFORE MERGE (only used for comparison)
-
 let hashmapDefaultBucketCount = 100
 
 -- The base type of a HashMap object.
@@ -223,37 +221,5 @@ in
 let m = removeall 0 m in
 
 utest m.nelems with 0 in
-
-
-
--- BEGIN TEMPORARY TIMING TEST (Remove before merge)
---let lookupOpt = mapLookupOpt eqstr in
---let lookup = mapLookup eqstr in
---let insert = mapInsert eqstr in
---let update = mapUpdate eqstr in
---let mem = mapMem eqstr in
---
---recursive let populate = lam m. lam i.
---  if geqi i n then
---    m
---  else
---    let key = cons 'a' (int2string i) in
---    populate (insert key i m)
---             (addi i 1)
---in
---let m = populate [] 0 in
---
---utest length m with n in
---
---recursive let checkmem = lam i.
---  if geqi i n then
---    ()
---  else
---    let key = cons 'a' (int2string i) in
---    utest lookupOpt key m with Some (i) in
---    checkmem (addi i 1)
---in
---let _ = checkmem 0 in
--- END TEMPORARY TIMING TEST
 
 ()

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -193,6 +193,7 @@ recursive let populate = lam hm. lam i.
     hm
   else
     let key = cons 'a' (int2string i) in
+    utest hashmapLookupOpt key hm with None () in
     populate (hashmapInsert key i hm)
              (addi i 1)
 in
@@ -215,8 +216,9 @@ recursive let removeall = lam i. lam hm.
     hm
   else
     let key = cons 'a' (int2string i) in
-    removeall (addi i 1)
-              (hashmapRemove key hm)
+    let newHm = hashmapRemove key hm in
+    utest hashmapLookupOpt key newHm with None () in
+    removeall (addi i 1) newHm
 in
 let m = removeall 0 m in
 

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -24,13 +24,13 @@ type HashMap = {
 
 
 -- Returns an empty hashmap with a default number of buckets.
---   eqArg: A function that specifies equalities between keys in the hashmap.
---   hashfnArg: A function for computing the hash of a key value.
-let hashmapEmpty = lam eqArg. lam hashfnArg.
+--   eq: A function that specifies equalities between keys in the hashmap.
+--   hashfn: A function for computing the hash of a key value.
+let hashmapEmpty = lam eq. lam hashfn.
   {buckets = makeSeq hashmapDefaultBucketCount [],
    nelems = 0,
-   eq = eqArg,
-   hashfn = hashfnArg}
+   eq = eq,
+   hashfn = hashfn}
 
 -- An empty hashmap using strings as keys
 let hashmapStrEmpty =

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -1,0 +1,259 @@
+--
+-- A simple generic hashmap library.
+--
+-- TODO: Add support for resizing buckets.
+--
+
+include "math.mc"
+include "option.mc"
+include "string.mc"
+
+include "map.mc" -- REMOVE BEFORE MERGE (only used for comparison)
+
+let hashmapDefaultBucketCount = 400
+
+-- The base type of a HashMap object.
+--   k: Polymorphic key type
+--   v: Polymorphic value type
+type HashMap = {
+  buckets : [[{hash : Int, key : k, value : v}]],
+  nelems : Int,
+  eq : k -> k -> Bool,
+  hashfn : k -> Int
+}
+
+
+-- Returns an empty hashmap with a default number of buckets.
+--   eqArg: A function that specifies equalities between keys in the hashmap.
+--   hashfnArg: A function for computing the hash of a key value.
+let hashmapEmpty = lam eqArg. lam hashfnArg.
+  {buckets = makeSeq hashmapDefaultBucketCount [],
+   nelems = 0,
+   eq = eqArg,
+   hashfn = hashfnArg}
+
+-- An empty hashmap using strings as keys
+let hashmapStrEmpty =
+  -- An implementation of the djb2 hash function (http://www.cse.yorku.ca/~oz/hash.html)
+  recursive let djb2 = lam hash. lam s.
+    if null s then
+      hash
+    else
+      let newhash = addi (addi (muli hash 32) hash) (char2int (head s)) in
+      djb2 newhash (tail s)
+  in
+  hashmapEmpty eqstr (djb2 5381)
+
+-- Inserts a value into the hashmap
+--   key: The key to bind the value to.
+--   value: The value to be inserted.
+--   hm: The hashmap to insert the value into.
+let hashmapInsert = lam key. lam value. lam hm.
+  let hash = hm.hashfn key in
+  let idx = modi (absi hash) (length hm.buckets) in
+  let bucket = get hm.buckets idx in
+  recursive let idxfinder = lam i.
+    if geqi i (length bucket) then
+      length bucket
+    else
+      let entry = get bucket i in
+      if neqi hash entry.hash then
+        idxfinder (addi i 1)
+      else if hm.eq key entry.key then
+        i
+      else
+        idxfinder (addi i 1)
+  in
+  let bucketIdx = idxfinder 0 in
+  let entry = {hash = hash, key = key, value = value} in
+  if geqi bucketIdx (length bucket) then
+    -- Insert new entry into the bucket
+    {{hm with nelems = addi hm.nelems 1}
+         with buckets = set hm.buckets idx (cons entry bucket)}
+  else
+    -- Replace existing entry in the bucket
+    {hm with buckets = set hm.buckets idx (set bucket bucketIdx entry)}
+
+-- Removes a key-value pair from the hashmap
+--   key: The key that the value (to be removed) is bound to.
+--   hm: The hashmap to remove the pair from.
+-- [NOTE]
+--   The removal uses a recursion which is not tail-recursive.
+let hashmapRemove = lam key. lam hm.
+  let hash = hm.hashfn key in
+  let idx = modi (absi hash) (length hm.buckets) in
+  let bucket = get hm.buckets idx in
+  recursive let remover = lam seq.
+    if null seq then
+      seq
+    else
+      let entry = head seq in
+      if neqi hash entry.hash then
+        cons entry (remover (tail seq))
+      else if hm.eq key entry.key then
+        tail seq
+      else
+        cons entry (remover (tail seq))
+  in
+  let newBucket = remover bucket in
+  let newSize = subi hm.nelems (subi (length bucket) (length newBucket)) in
+  {{hm with buckets = set hm.buckets idx newBucket}
+       with nelems = newSize}
+
+-- Looks up a value in the hashmap, returning an Option type
+--   key: The key to be used in the lookup.
+--   hm: The hashmap to lookup from.
+let hashmapLookupOpt = lam key. lam hm.
+  let hash = hm.hashfn key in
+  let idx = modi (absi hash) (length hm.buckets) in
+  recursive let finder = lam seq.
+    if null seq then
+      None ()
+    else
+      let entry = head seq in
+      if neqi hash entry.hash then
+        finder (tail seq)
+      else if hm.eq key entry.key then
+        Some (entry.value)
+      else
+        finder (tail seq)
+  in
+  finder (get hm.buckets idx)
+
+-- Same as hashmapLookupOpt, but will return an error if an element was not
+-- found instead of returning an Option type.
+let hashmapLookup = lam key. lam hm.
+  optionGetOrElse (lam _. error "No element in hashmap bound to the specified key.")
+                  (hashmapLookupOpt key hm)
+
+-- Checks if a value is bound to the specified key in the hashmap.
+--   key: The key to be checked.
+--   hm: The hashmap to lookup from.
+let hashmapMem = lam key. lam hm.
+  optionIsSome (hashmapLookupOpt key hm)
+
+
+mexpr
+
+let m = hashmapStrEmpty in
+
+utest m.nelems with 0 in
+utest hashmapMem "foo" m with false in
+utest hashmapLookupOpt "foo" m with None () in
+
+let m = hashmapInsert "foo" "aaa" m in
+
+utest m.nelems with 1 in
+utest hashmapMem "foo" m with true in
+utest hashmapLookupOpt "foo" m with Some ("aaa") in
+utest hashmapLookup "foo" m with "aaa" in
+
+let m = hashmapInsert "bar" "bbb" m in
+
+utest m.nelems with 2 in
+utest hashmapMem "bar" m with true in
+utest hashmapLookupOpt "bar" m with Some ("bbb") in
+utest hashmapLookup "bar" m with "bbb" in
+
+let m = hashmapInsert "foo" "ccc" m in
+
+utest m.nelems with 2 in
+utest hashmapMem "foo" m with true in
+utest hashmapLookupOpt "foo" m with Some ("ccc") in
+utest hashmapLookup "foo" m with "ccc" in
+
+let m = hashmapRemove "foo" m in
+
+utest m.nelems with 1 in
+utest hashmapMem "foo" m with false in
+utest hashmapLookupOpt "foo" m with None () in
+
+let m = hashmapRemove "foo" m in
+
+utest m.nelems with 1 in
+utest hashmapMem "foo" m with false in
+utest hashmapLookupOpt "foo" m with None () in
+
+let m = hashmapRemove "babar" m in
+
+utest m.nelems with 1 in
+utest hashmapMem "babar" m with false in
+utest hashmapLookupOpt "babar" m with None () in
+
+let m = hashmapInsert "" "ddd" m in
+
+utest m.nelems with 2 in
+utest hashmapMem "" m with true in
+utest hashmapLookupOpt "" m with Some ("ddd") in
+utest hashmapLookup "" m with "ddd" in
+
+-- Test with collisions
+let n = addi hashmapDefaultBucketCount 10 in
+
+recursive let populate = lam hm. lam i.
+  if geqi i n then
+    hm
+  else
+    let key = cons 'a' (int2string i) in
+    populate (hashmapInsert key i hm)
+             (addi i 1)
+in
+let m = populate hashmapStrEmpty 0 in
+
+utest m.nelems with n in
+
+recursive let checkmem = lam i.
+  if geqi i n then
+    ()
+  else
+    let key = cons 'a' (int2string i) in
+    utest hashmapLookupOpt key m with Some (i) in
+    checkmem (addi i 1)
+in
+let _ = checkmem 0 in
+
+recursive let removeall = lam i. lam hm.
+  if geqi i n then
+    hm
+  else
+    let key = cons 'a' (int2string i) in
+    removeall (addi i 1)
+              (hashmapRemove key hm)
+in
+let m = removeall 0 m in
+
+utest m.nelems with 0 in
+
+
+
+-- BEGIN TEMPORARY TIMING TEST (Remove before merge)
+--let lookupOpt = mapLookupOpt eqstr in
+--let lookup = mapLookup eqstr in
+--let insert = mapInsert eqstr in
+--let update = mapUpdate eqstr in
+--let mem = mapMem eqstr in
+--
+--recursive let populate = lam m. lam i.
+--  if geqi i n then
+--    m
+--  else
+--    let key = cons 'a' (int2string i) in
+--    populate (insert key i m)
+--             (addi i 1)
+--in
+--let m = populate [] 0 in
+--
+--utest length m with n in
+--
+--recursive let checkmem = lam i.
+--  if geqi i n then
+--    ()
+--  else
+--    let key = cons 'a' (int2string i) in
+--    utest lookupOpt key m with Some (i) in
+--    checkmem (addi i 1)
+--in
+--let _ = checkmem 0 in
+-- END TEMPORARY TIMING TEST
+
+()

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -1,7 +1,9 @@
 --
 -- A simple generic hashmap library.
 --
--- TODO: Add support for resizing buckets.
+-- TODO:
+--  - Resizing of buckets.
+--  - Conversion to and from association lists.
 --
 
 include "math.mc"

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -12,7 +12,7 @@ include "string.mc"
 
 include "map.mc" -- REMOVE BEFORE MERGE (only used for comparison)
 
-let hashmapDefaultBucketCount = 400
+let hashmapDefaultBucketCount = 100
 
 -- The base type of a HashMap object.
 --   k: Polymorphic key type
@@ -190,7 +190,7 @@ utest hashmapLookupOpt "" m with Some ("ddd") in
 utest hashmapLookup "" m with "ddd" in
 
 -- Test with collisions
-let n = addi hashmapDefaultBucketCount 10 in
+let n = addi (muli hashmapDefaultBucketCount 4) 10 in
 
 recursive let populate = lam hm. lam i.
   if geqi i n then

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -70,13 +70,9 @@ let hashmapInsert = lam key. lam value. lam hm.
         cons entry (inserter (tail seq))
   in
   let newBucket = inserter bucket in
-  if gti (length newBucket) (length bucket) then
-    -- Insert new entry into the bucket
-    {{hm with nelems = addi hm.nelems 1}
-         with buckets = set hm.buckets idx newBucket}
-  else
-    -- Replace existing entry in the bucket
-    {hm with buckets = set hm.buckets idx newBucket}
+  -- If lengths differ, then an element has been inserted and we increment nelems
+  {{hm with nelems = addi hm.nelems (subi (length newBucket) (length bucket))}
+       with buckets = set hm.buckets idx newBucket}
 
 -- Removes a key-value pair from the hashmap
 --   key: The key that the value (to be removed) is bound to.

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -50,6 +50,8 @@ let hashmapStrEmpty =
 --   key: The key to bind the value to.
 --   value: The value to be inserted.
 --   hm: The hashmap to insert the value into.
+-- [NOTE]
+--   The insertion uses a recursion which is not tail-recursive.
 let hashmapInsert = lam key. lam value. lam hm.
   let hash = hm.hashfn key in
   let idx = modi (absi hash) (length hm.buckets) in

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -10,8 +10,6 @@ include "math.mc"
 include "option.mc"
 include "string.mc"
 
-let hashmapDefaultBucketCount = 100
-
 -- The base type of a HashMap object.
 --   k: Polymorphic key type
 --   v: Polymorphic value type
@@ -22,12 +20,16 @@ type HashMap = {
   hashfn : k -> Int
 }
 
+-- Private definitions
+let _hashmapDefaultBucketCount = 100
+let _hashmapBucketIdx = lam hash. lam hm. modi (absi hash) (length hm.buckets)
+
 
 -- Returns an empty hashmap with a default number of buckets.
 --   eq: A function that specifies equalities between keys in the hashmap.
 --   hashfn: A function for computing the hash of a key value.
 let hashmapEmpty = lam eq. lam hashfn.
-  {buckets = makeSeq hashmapDefaultBucketCount [],
+  {buckets = makeSeq _hashmapDefaultBucketCount [],
    nelems = 0,
    eq = eq,
    hashfn = hashfn}
@@ -52,7 +54,7 @@ let hashmapStrEmpty =
 --   The insertion uses a recursion which is not tail-recursive.
 let hashmapInsert = lam key. lam value. lam hm.
   let hash = hm.hashfn key in
-  let idx = modi (absi hash) (length hm.buckets) in
+  let idx = _hashmapBucketIdx hash hm in
   let bucket = get hm.buckets idx in
   let newEntry = {hash = hash, key = key, value = value} in
   recursive let inserter = lam seq.
@@ -79,7 +81,7 @@ let hashmapInsert = lam key. lam value. lam hm.
 --   The removal uses a recursion which is not tail-recursive.
 let hashmapRemove = lam key. lam hm.
   let hash = hm.hashfn key in
-  let idx = modi (absi hash) (length hm.buckets) in
+  let idx = _hashmapBucketIdx hash hm in
   let bucket = get hm.buckets idx in
   recursive let remover = lam seq.
     if null seq then
@@ -103,7 +105,7 @@ let hashmapRemove = lam key. lam hm.
 --   hm: The hashmap to lookup from.
 let hashmapLookupOpt = lam key. lam hm.
   let hash = hm.hashfn key in
-  let idx = modi (absi hash) (length hm.buckets) in
+  let idx = _hashmapBucketIdx hash hm in
   recursive let finder = lam seq.
     if null seq then
       None ()
@@ -186,7 +188,7 @@ utest hashmapLookupOpt "" m with Some ("ddd") in
 utest hashmapLookup "" m with "ddd" in
 
 -- Test with collisions
-let n = addi hashmapDefaultBucketCount 10 in
+let n = addi _hashmapDefaultBucketCount 10 in
 
 recursive let populate = lam hm. lam i.
   if geqi i n then

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -3,6 +3,7 @@
 let inf = divf 1.0 0.0
 let maxf = lam r. lam l. if gtf r l then r else l
 let minf = lam r. lam l. if ltf r l then r else l
+let absf = lam f. maxf f (negf f)
 
 utest maxf 0. 0. with 0.
 utest maxf 1. 0. with 1.
@@ -12,10 +13,15 @@ utest minf 0. 0. with 0.
 utest minf 1. 0. with 0.
 utest minf 0. 1. with 0.
 
+utest absf 0. with 0.
+utest absf 1. with 1.
+utest absf (negf 1.) with 1.
+
 -- Int stuff
 
 let maxi = lam r. lam l. if gti r l then r else l
 let mini = lam r. lam l. if lti r l then r else l
+let absi = lam i. maxi i (negi i)
 
 utest maxi 0 0 with 0
 utest maxi 1 0 with 1
@@ -24,5 +30,9 @@ utest maxi 0 1 with 1
 utest mini 0 0 with 0
 utest mini 1 0 with 0
 utest mini 0 1 with 0
+
+utest absi 0 with 0
+utest absi 1 with 1
+utest absi (negi 1) with 1
 
 utest addi 1 (negi 1) with 0


### PR DESCRIPTION
Adds a simple hashmap to the standard library. The measured time for the tests at the bottom of `hashmap.mc` on my machine was ~~>60s~~ ~60s for the `map.mc` association list and <5s for the hashmap. Not as much of a speedup as it probably should be, but the hashmap is at least noticably faster than the association list for when the map is large.

Update: Output from isolated timing measurements (Top is hashmap, bottom is assoc list)
```
john@obsidian:~/GitRepos/Forks/miking (hashmap)$ time mi test stdlib/hashmap.mc 
/home/john/GitRepos/Forks/miking/stdlib/hashmap.mc: ........................................................................................................................................................................................................................................................................................................................................................................................................................................................ OK
Unit testing SUCCESSFUL after executing 440 tests.


real	0m1.281s
user	0m1.272s
sys	0m0.007s
john@obsidian:~/GitRepos/Forks/miking (hashmap)$ time mi test stdlib/hashmap.mc 
/home/john/GitRepos/Forks/miking/stdlib/hashmap.mc: ....................................................................................................................................................................................................................................................................................................................................................................................................................................................... OK
Unit testing SUCCESSFUL after executing 439 tests.


real	0m58.332s
user	0m58.264s
sys	0m0.000s
```