### PR TITLE
Add regular expression library to stdlib

### DIFF
--- a/stdlib/dfa.mc
+++ b/stdlib/dfa.mc
@@ -2,7 +2,7 @@ include "nfa.mc"
 
 -- Represents a deterministic finite automaton.
 -- Equality and print functions are required for
--- the states (eqv,s2s) and labels (eql,l2s) for the 
+-- the states (eqv,s2s) and labels (eql,l2s) for the
 -- construct function (dfaConstr).
 
 -- States are represented by a vertex in a directed graph.
@@ -11,12 +11,11 @@ include "nfa.mc"
 
 -- transitions are represented as edges in a directed graph
 -- (digraph), where the vertices are states. All labels between two states
--- also has to be unique. 
+-- also has to be unique.
 
 -- adds syntactic sugar for DFA type
 -- DFA is based on the same data types as the NFA
 type DFA = NFA
-
 
 -- check for specific duplicate label
 recursive
@@ -32,7 +31,7 @@ end
 -- check for duplicate labels
 recursive
 let checkDuplicateLabels = lam trans. lam eqv. lam eql.
-    if(eqi (length trans) 1) then (false, (0,0))
+    if (leqi (length trans) 1) then (false, (0,0))
     else
     let first = head trans in
     let rest = tail trans in
@@ -40,13 +39,12 @@ let checkDuplicateLabels = lam trans. lam eqv. lam eql.
     else
     checkDuplicateLabels rest eqv eql
 end
-    
+
 -- constructor for the DFA
 let dfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
 	let err = checkDuplicateLabels trans eqv eql in
 	if(err.0) then error "There are duplicate labels for same state outgoing transition at"
 	else nfaConstr s trans startS accS eqv eql
-
 
 mexpr
 let states = [0,1,2] in

--- a/stdlib/dfa.mc
+++ b/stdlib/dfa.mc
@@ -20,24 +20,24 @@ type DFA = NFA
 -- check for specific duplicate label
 recursive
 let checkSpecificDuplicate = lam trans. lam rest. lam eqv. lam eql.
-    if(eqi (length rest) 0) then false
-    else
-    let first = head rest in
-    let rest = tail rest in
-    if(and (eqv first.0 trans.0) (eql first.2 trans.2)) then true
-    else checkSpecificDuplicate trans rest eqv eql
+  if(eqi (length rest) 0) then false
+  else
+  let first = head rest in
+  let rest = tail rest in
+  if(and (eqv first.0 trans.0) (eql first.2 trans.2)) then true
+  else checkSpecificDuplicate trans rest eqv eql
 end
 
 -- check for duplicate labels
 recursive
 let checkDuplicateLabels = lam trans. lam eqv. lam eql.
-    if (leqi (length trans) 1) then (false, (0,0))
-    else
-    let first = head trans in
-    let rest = tail trans in
-    if(checkSpecificDuplicate first rest eqv eql) then (true, (first.0, first.2))
-    else
-    checkDuplicateLabels rest eqv eql
+  if (leqi (length trans) 1) then (false, (0,0))
+  else
+  let first = head trans in
+  let rest = tail trans in
+  if(checkSpecificDuplicate first rest eqv eql) then (true, (first.0, first.2))
+  else
+  checkDuplicateLabels rest eqv eql
 end
 
 -- constructor for the DFA

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -46,6 +46,11 @@ let digraphEdgesTo = lam v. lam g.
                      let allEdges = digraphEdges g in
                      filter (lam tup. g.eqv v tup.1) allEdges
 
+-- Get all edges from v1 to v2
+let digraphEdgesBetween = lam v1. lam v2. lam g.
+  let fromV1 = digraphEdgesFrom v1 g in
+  filter (lam tup. g.eqv v2 tup.1) fromV1
+
 let digraphLabels = lam v1. lam v2. lam g.
     let from_v1_to_v2 = filter (lam tup. g.eqv tup.1 v2) (digraphEdgesFrom v1 g) in
     map (lam tup. tup.2) from_v1_to_v2
@@ -69,10 +74,13 @@ let digraphEdgeEq = lam g. lam e1. lam e2.
 let digraphHasEdges = lam es. lam g.
                       setIsSubsetEq (digraphEdgeEq g) es (digraphEdges g)
 
+-- Get successor nodes of v
 let digraphSuccessors = lam v. lam g.
-    distinct g.eqv (map (lam tup. tup.1) (digraphEdgesFrom v g))
+  distinct g.eqv (map (lam tup. tup.1) (digraphEdgesFrom v g))
 
--- TODO: predecessors
+-- Get predecessor nodes of v
+let digraphPredeccessors = lam v. lam g.
+  distinct g.eqv (map (lam tup. tup.0) (digraphEdgesTo v g))
 
 let digraphIsSuccessor = lam v1. lam v2. lam g.
   any (g.eqv v1) (digraphSuccessors v2 g)
@@ -183,8 +191,11 @@ let digraphPrintDot = lam g. lam v2str. lam l2str.
   let _ = print "}\n" in ()
 
 mexpr
+let l1 = gensym () in
+let l2 = gensym () in
+let l3 = gensym () in
+let l4 = gensym () in
 
--- graph tests
 let empty = digraphEmpty eqi eqs in
 
 utest digraphEdges empty with [] in
@@ -205,8 +216,6 @@ utest digraphHasVertex 3 g with true in
 utest digraphHasVertices [1, 2, 3] g with true in
 utest digraphHasVertices [3, 2] g with true in
 utest digraphHasVertices [1, 2, 3, 4] g with false in
-let l1 = gensym () in
-let l2 = gensym () in
 utest digraphEdgesFrom 1 g with [] in
 utest digraphLabels 1 2 g with [] in
 let g1 = digraphAddEdge 1 2 l2 (digraphAddEdge 1 2 l1 g) in
@@ -217,10 +226,17 @@ utest digraphHasEdges [(1, 2, l1)] g1 with true in
 let g = digraphAddVertex 1 (digraphAddVertex 2 (digraphAddVertex 3 empty)) in
 let g1 = (digraphAddEdge 1 2 l2 (digraphAddEdge 1 2 l1 g)) in
 utest digraphSuccessors 1 g1 with [2] in
+utest digraphPredeccessors 1 g1 with [] in
 utest digraphIsSuccessor 2 1 g1 with true in
 utest any (eqs l1) (digraphLabels 1 2 g1) with true in
 utest any (eqs l2) (digraphLabels 1 2 g1) with true in
 utest any (eqs l2) (digraphLabels 2 1 g1) with false in
+
+let g = digraphAddVertex 1 (digraphAddVertex 2 (digraphAddVertex 3 empty)) in
+let g = digraphAddEdge 2 3 l4 (digraphAddEdge 1 3 l3 (digraphAddEdge 1 2 l2 (digraphAddEdge 1 2 l1 g))) in
+utest digraphEdgesBetween 1 3 g with [(1,3,l3)] in
+utest match digraphEdgesBetween 1 2 g with [(1,2,l1),(1,2,l2)] | [(1,2,l2),(1,2,l1)] then true else false with true in
+utest match digraphPredeccessors 3 g with [1,2] | [2,1] then true else false with true in
 
 let l3 = gensym () in
 let g2 = digraphAddEdge 3 2 l3 g1 in

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -17,7 +17,7 @@ include "string.mc"
 
 type NFA = {
   graph: Digraph,
-  tartState: a,
+  startState: a,
   acceptStates: [a]
 }
 

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -21,7 +21,6 @@ type NFA = {
     acceptStates: [a]
 }
 
-
 -- get equality function for states
 let nfaGetEqv = lam dfa.
     dfa.graph.eqv
@@ -38,11 +37,31 @@ let nfaStates = lam nfa.
 let nfaTransitions = lam nfa.
     digraphEdges nfa.graph
 
+-- get start state of the nfa
+let getStartState = lam nfa.
+  nfa.startState
+
+-- get the accept states in the nfa
+let getAcceptStates = lam nfa.
+  nfa.acceptStates
+
+-- get all transitions from state s1 to state s2
+let getTransitionsBetween = lam s1. lam s2. lam nfa.
+    digraphEdgesBetween s1 s2 nfa.graph
+
+-- get all predecessor states to state s
+let nfaInStates = lam s. lam nfa.
+  digraphPredeccessors s nfa.graph
+
+-- get all successor states to state s
+let nfaOutStates = lam s. lam nfa.
+  digraphSuccessors s nfa.graph
+
 -- check that values are acceptable for the NFA
 let nfaCheckValues = lam trans. lam s. lam eqv. lam eql. lam accS. lam startS.
-    if not (setIsSubsetEq eqv accS s) then error "Some accepted states do not exist"
-    else if not (setMem eqv startS s) then error "The start state does not exist"
-    else true
+  if not (setIsSubsetEq eqv accS s) then error "Some accepted states do not exist"
+  else if not (setMem eqv startS s) then error "The start state does not exist"
+  else true
 
 -- States are represented by vertices in a directed graph
 let nfaAddState =  lam nfa. lam state.

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -16,26 +16,26 @@ include "string.mc"
 -- (digraph), where the vertices are states.
 
 type NFA = {
-    graph: Digraph,
-    startState: a,
-    acceptStates: [a]
+  graph: Digraph,
+  tartState: a,
+  acceptStates: [a]
 }
 
 -- get equality function for states
 let nfaGetEqv = lam dfa.
-    dfa.graph.eqv
+  dfa.graph.eqv
 
 -- get equality functions for labels
 let nfaGetEql = lam dfa.
-    dfa.graph.eql
+  dfa.graph.eql
 
 -- get all states in nfa
 let nfaStates = lam nfa.
-    digraphVertices nfa.graph
+  digraphVertices nfa.graph
 
 -- get all transitions in nfa
 let nfaTransitions = lam nfa.
-    digraphEdges nfa.graph
+  digraphEdges nfa.graph
 
 -- get start state of the nfa
 let nfaStartState = lam nfa.
@@ -47,7 +47,7 @@ let nfaAcceptStates = lam nfa.
 
 -- get all transitions from state s1 to state s2
 let nfaTransitionsBetween = lam s1. lam s2. lam nfa.
-    digraphEdgesBetween s1 s2 nfa.graph
+  digraphEdgesBetween s1 s2 nfa.graph
 
 -- get all predecessor states to state s
 let nfaInStates = lam s. lam nfa.
@@ -65,88 +65,88 @@ let nfaCheckValues = lam trans. lam s. lam eqv. lam eql. lam accS. lam startS.
 
 -- States are represented by vertices in a directed graph
 let nfaAddState =  lam nfa. lam state.
-    {
-        graph = (digraphAddVertex state nfa.graph),
-        startState = nfa.startState,
-        acceptStates = nfa.acceptStates
-    }
+  {
+    graph = (digraphAddVertex state nfa.graph),
+    startState = nfa.startState,
+    acceptStates = nfa.acceptStates
+  }
 
 -- Transitions between two states are represented by edges between vertices
 let nfaAddTransition = lam nfa. lam trans.
-    let states = nfaStates nfa in
-    let from = trans.0 in
-    let to = trans.1 in
-    let label = trans.2 in
-    {
-        graph = (digraphAddEdge from to label nfa.graph),
-        startState = nfa.startState,
-        acceptStates = nfa.acceptStates
-    }
+  let states = nfaStates nfa in
+  let from = trans.0 in
+  let to = trans.1 in
+  let label = trans.2 in
+  {
+    graph = (digraphAddEdge from to label nfa.graph),
+    startState = nfa.startState,
+    acceptStates = nfa.acceptStates
+  }
 
 -- returns true if state s is an accepted state in the nfa
 let nfaIsAcceptedState = lam s. lam nfa.
-    setMem nfa.graph.eqv s nfa.acceptStates
+  setMem nfa.graph.eqv s nfa.acceptStates
 
 -- check if there is a transition with label lbl from state s
 let nfaStateHasTransition = lam s. lam trans. lam lbl.
-    let neighbors = digraphEdgesFrom s trans in
-    --check if lbl is a label in the neighbors list
-    setMem trans.eql lbl (map (lam x. x.2) neighbors)
+  let neighbors = digraphEdgesFrom s trans in
+  --check if lbl is a label in the neighbors list
+  setMem trans.eql lbl (map (lam x. x.2) neighbors)
 
 -- get next state from state s with label lbl. Throws error if no transition is found
 let nfaNextStates = lam from. lam graph. lam lbl.
-    let neighbors = digraphEdgesFrom from graph in
-    let matches = filter (lam x. graph.eql x.2 lbl) neighbors in
-    let neighboringStates = map (lam x. x.1) matches in
-    match matches with [] then
-    error "No transition was found"
-    else neighboringStates
+  let neighbors = digraphEdgesFrom from graph in
+  let matches = filter (lam x. graph.eql x.2 lbl) neighbors in
+  let neighboringStates = map (lam x. x.1) matches in
+  match matches with [] then
+  error "No transition was found"
+  else neighboringStates
 
 -- takes a path and returns whether it's accepted or not.
 let pathIsAccepted = lam path.
-    if null path then false
-    else (setEqual eqchar (last path).status "accepted")
+  if null path then false
+  else (setEqual eqchar (last path).status "accepted")
 
 -- goes through the nfa, one state of the input at a time. Returns a list of {state, status, input}
 -- where status is either accepted,stuck,not accepted or neutral ("")
 recursive
 let nfaMakeInputPath = lam i. lam currentState. lam input. lam nfa.
-    if (eqi (length input) 0) then
-        if (nfaIsAcceptedState currentState nfa) then [{state = currentState,index = i, status = "accepted"}]
-        else [{state = currentState, index = i, status = "not accepted"}]
-    -- check if transition exists. If yes, go to next state
-    else if nfaStateHasTransition currentState nfa.graph (head input) then
-        foldl (lam path. lam elem.
-            if (pathIsAccepted path) then path
-            else
-                let config = [{state = currentState,index = i, status = ""}] in
-                join [path, config, nfaMakeInputPath (addi i 1) elem (tail input) nfa]
-        ) [] (nfaNextStates currentState nfa.graph (head input))
-    else [{state = currentState, index = i, status = "stuck"}]
+  if (eqi (length input) 0) then
+    if (nfaIsAcceptedState currentState nfa) then [{state = currentState,index = i, status = "accepted"}]
+    else [{state = currentState, index = i, status = "not accepted"}]
+  -- check if transition exists. If yes, go to next state
+  else if nfaStateHasTransition currentState nfa.graph (head input) then
+    foldl (lam path. lam elem.
+      if (pathIsAccepted path) then path
+      else
+        let config = [{state = currentState,index = i, status = ""}] in
+        join [path, config, nfaMakeInputPath (addi i 1) elem (tail input) nfa]
+    ) [] (nfaNextStates currentState nfa.graph (head input))
+  else [{state = currentState, index = i, status = "stuck"}]
 end
 
 recursive
 let nfaMakeEdgeInputPath = lam currentState. lam input. lam nfa.
-    if (eqi (length input) 0) then []
-    -- check if transition exists. If yes, go to next state
-    else if nfaStateHasTransition currentState nfa.graph (head input) then
-        foldl (lam path. lam elem.
-            join [path, [(currentState,elem)], nfaMakeEdgeInputPath elem (tail input) nfa]
-        ) [] (nfaNextStates currentState nfa.graph (head input))
-    else []
+  if (eqi (length input) 0) then []
+  -- check if transition exists. If yes, go to next state
+  else if nfaStateHasTransition currentState nfa.graph (head input) then
+    foldl (lam path. lam elem.
+      join [path, [(currentState,elem)], nfaMakeEdgeInputPath elem (tail input) nfa]
+    ) [] (nfaNextStates currentState nfa.graph (head input))
+  else []
 end
 
 -- constructor for the NFA
 let nfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
-    if nfaCheckValues trans s eqv eql accS startS then
-    let emptyDigraph = digraphEmpty eqv eql in
-    let initNfa = {
-        graph = emptyDigraph,
-        startState = startS,
-        acceptStates = accS
-    } in
-    foldl nfaAddTransition (foldl nfaAddState initNfa s) trans
-    else {}
+  if nfaCheckValues trans s eqv eql accS startS then
+  let emptyDigraph = digraphEmpty eqv eql in
+  let initNfa = {
+    graph = emptyDigraph,
+    startState = startS,
+    acceptStates = accS
+  } in
+  foldl nfaAddTransition (foldl nfaAddState initNfa s) trans
+  else {}
 
 mexpr
 let states = [0,1,2] in
@@ -169,35 +169,35 @@ utest nfaIsAcceptedState 3 newNfa with false in
 utest nfaNextStates 1 newNfa.graph '0' with [2] in
 -- Not accepted
 utest nfaMakeInputPath (negi 1) newNfa.startState "1011" newNfa with
-    [{status = "",state = 0,index = negi 1},
-    {status = "",state = 1,index = 0},
-    {status = "",state = 2,index = 1},
-    {status = "",state = 1,index = 2},
-    {status = "not accepted",state = 1,index = 3}] in
+  [{status = "",state = 0,index = negi 1},
+  {status = "",state = 1,index = 0},
+  {status = "",state = 2,index = 1},
+  {status = "",state = 1,index = 2},
+  {status = "not accepted",state = 1,index = 3}] in
 -- Accepted
 utest nfaMakeInputPath (negi 1) newNfa.startState "10110" newNfa with
-    [{status = "",state = 0,index = negi 1},
-    {status = "",state = 1,index = 0},
-    {status = "",state = 2,index = 1},
-    {status = "",state = 1,index = 2},
-    {status = "",state = 1,index = 3},
-    {status = "accepted",state = 2,index = 4}] in
+  [{status = "",state = 0,index = negi 1},
+  {status = "",state = 1,index = 0},
+  {status = "",state = 2,index = 1},
+  {status = "",state = 1,index = 2},
+  {status = "",state = 1,index = 3},
+  {status = "accepted",state = 2,index = 4}] in
 -- Invalid transition
 utest nfaMakeInputPath (negi 1) newNfa.startState "0110" newNfa with
-    [{status = "stuck",state = 0,index = negi 1}] in
+  [{status = "stuck",state = 0,index = negi 1}] in
 -- Input of length 0
 utest nfaMakeInputPath (negi 1) newNfa.startState "" newNfa with
-    [{status = "not accepted",state = 0,index = negi 1}] in
+  [{status = "not accepted",state = 0,index = negi 1}] in
 -- Accepted, after branch got stuck.
  utest nfaMakeInputPath (negi 1) newNfa2.startState "11" newNfa2 with
-    [{status = "",state = 0,index = (negi 1)},
-    {status = "",state = 1,index = 0},
-    {status = "not accepted", state = 3,index = 1},
-    {status = "",state = 1,index = 0},
-    {status = "accepted",state = 2,index = 1}] in
+  [{status = "",state = 0,index = (negi 1)},
+  {status = "",state = 1,index = 0},
+  {status = "not accepted", state = 3,index = 1},
+  {status = "",state = 1,index = 0},
+  {status = "accepted",state = 2,index = 1}] in
 -- Accepted, got accepted in the first branch (the second isn't)
 utest nfaMakeInputPath (negi 1) newNfa3.startState "11" newNfa3 with
-    [{status = "",state = 0,index = (negi 1)},
-    {status = "",state = 1,index = 0},
-    {status = "accepted",state = 3,index = 1}] in
+  [{status = "",state = 0,index = (negi 1)},
+  {status = "",state = 1,index = 0},
+  {status = "accepted",state = 3,index = 1}] in
 ()

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -38,15 +38,15 @@ let nfaTransitions = lam nfa.
     digraphEdges nfa.graph
 
 -- get start state of the nfa
-let getStartState = lam nfa.
+let nfaStartState = lam nfa.
   nfa.startState
 
 -- get the accept states in the nfa
-let getAcceptStates = lam nfa.
+let nfaAcceptStates = lam nfa.
   nfa.acceptStates
 
 -- get all transitions from state s1 to state s2
-let getTransitionsBetween = lam s1. lam s2. lam nfa.
+let nfaTransitionsBetween = lam s1. lam s2. lam nfa.
     digraphEdgesBetween s1 s2 nfa.graph
 
 -- get all predecessor states to state s

--- a/stdlib/regex.mc
+++ b/stdlib/regex.mc
@@ -1,0 +1,377 @@
+include "dfa.mc"
+include "set.mc"
+
+-- Represents basic regular expressions.
+type RegEx
+  con Empty   : ()             -> RegEx
+  con Epsilon : ()             -> RegEx
+  con Symbol  : (a)            -> RegEx
+  con Union   : (RegEx, RegEx) -> RegEx
+  con Concat  : (RegEx, RegEx) -> RegEx
+  con Kleene  : (RegEx)        -> RegEx
+
+let regEx2str = lam sym2str. lam reg.
+  recursive let pprint = lam reg.
+    match reg with Epsilon () then "(eps)" else
+    match reg with Empty () then "(empty)" else
+    match reg with Symbol (a) then sym2str a else
+    match reg with Union (r1, r2) then
+      strJoin "" ["(", pprint r1, ")|(", pprint r2, ")"] else
+    match reg with Concat (r1, r2) then
+      strJoin "" ["(", pprint r1, ") (", pprint r2, ")"] else
+    match reg with Kleene r then
+      strJoin "" ["(", pprint r, ")*"] else
+    error "Not a regExPprint of a RegEx"
+  in
+  pprint reg
+
+let regExPprint = lam sym2str. lam reg.
+  let _ = print (regEx2str sym2str reg) in
+  print "\n"
+
+-- Checks structural equivalence of two regexes.
+-- Does NOT check whether the regexes describe the same language.
+let eqr = lam eqs. lam re1. lam re2.
+  recursive let eqrAux = lam re1. lam re2.
+    match re1 with Epsilon () then (match re2 with Epsilon () then true else false) else
+    match re1 with Empty () then (match re2 with Empty () then true else false) else
+    match re1 with Symbol a then (match re2 with Symbol b then eqs a b else false) else
+    match re1 with Union (r1, r2) then
+      (match re2 with Union (w1, w2) then and (eqrAux r1 w1) (eqrAux r2 w2) else false)
+    else
+    match re1 with Concat (r1, r2) then
+      (match re2 with Concat (w1, w2) then and (eqrAux r1 w1) (eqrAux r2 w2) else false)
+    else
+    match re1 with Kleene r then (match re2 with Kleene w then eqrAux r w else false) else
+    utest re1 with [] in
+    error ("Not eqr of a RegEx")
+in eqrAux re1 re2
+
+-- Implements some basic simplification rules (not idempotent)
+recursive let simplifyS = lam reg.
+  match reg with Kleene(Empty ()) then Epsilon () else
+  match reg with Concat(Empty (), r) | Concat(r, Empty ()) then Empty () else
+  match reg with Concat(Epsilon (), r) | Concat(r, Epsilon ()) then simplifyS r else
+  match reg with Union(Empty (), r) | Union(r, Empty ()) then simplifyS r else
+
+  match reg with Symbol _ then reg else
+  match reg with Union (r1, r2) then Union (simplifyS r1, simplifyS r2) else
+  match reg with Concat (r1, r2) then Concat (simplifyS r1, simplifyS r2) else
+  match reg with Kleene r then Kleene (simplifyS r) else
+
+  error "Unknown RegEx in simplifyS"
+end
+
+-- Idempotent simplification
+recursive let simplifyD = lam eqr. lam reg.
+  let sReg = simplifyS reg in
+  -- We reached a fixpoint
+  if eqr reg sReg then reg
+  -- We might be able to simplify more
+  else simplifyD eqr sReg
+end
+
+-- Convert a DFA into a regular expression using State Elimination Method.
+-- From the book: John E. Hopcroft, Jeffrey D. Ullman (1979). Introduction
+-- to Automata Theory, Languages, and Computation.
+let regexFromDFA = lam dfa.
+  -- ** Helper functions **
+  -- Merge transitions for state pair s1 and s2
+  let pairMergeTrans = lam dfa. lam s1. lam s2.
+    let arcsBetween = getTransitionsBetween s1 s2 dfa in
+    match arcsBetween with [] then None () else
+    match arcsBetween with [t] then
+       Some (t.0, t.1, Symbol t.2)
+    else
+      let symbs = map (lam t. t.2) arcsBetween in
+      let mergedSyms = foldl (lam acc. lam s. (Union (acc, Symbol s))) (Symbol (head symbs)) (tail symbs) in
+      Some (s1, s2, mergedSyms)
+  in
+
+  -- Return the replacing transition between q and p when s is removed
+  let replaceTrans = lam dfa. lam p. lam s. lam q.
+    let psRE = (head (getTransitionsBetween p s dfa)).2 in
+    let sqRE = (head (getTransitionsBetween s q dfa)).2 in
+    -- Loop from s to s?
+    let maybeLoop = getTransitionsBetween s s dfa in
+    let isLoop = not (null maybeLoop) in
+    -- Compute Regex for p->s->q replacement
+    let psqRE = if isLoop then
+                  let ssRE = (head maybeLoop).2 in
+                  -- PS*Q
+                  Concat (psRE, Concat(Kleene(ssRE), sqRE))
+                else
+                  -- PQ
+                  Concat (psRE, sqRE)
+    in
+    -- Create regex for the p->q transition
+    let maybePQTrans = getTransitionsBetween p q dfa in
+    let finalPQReg =
+      if not (null maybePQTrans) then
+        let pqRE = (head maybePQTrans).2 in
+        Union (pqRE, psqRE)
+      else
+        psqRE
+     in (p, q, finalPQReg)
+  in
+
+  -- Eliminate state s from the DFA
+  let eliminate = lam s. lam dfa.
+    -- Compute transitions to add
+    let inStates = nfaInStates s dfa in
+    let outStates = nfaOutStates s dfa in
+    let addTrans =
+      foldl (lam acc. lam i.
+               let newTrans = map (lam o. replaceTrans dfa i s o) outStates in
+               concat acc newTrans)
+      []
+      inStates
+    in
+    -- Compute transitions to keep
+    let keepTrans = filter
+                    (lam t.
+                       let eqv = (getEqv dfa) in
+                       if eqv s t.0 then false else
+                       if eqv s t.1 then false else
+                       if and (setMem eqv t.0 inStates)
+                              (setMem eqv t.1 outStates) then false
+                       else true)
+                    (getTransitions dfa)
+    in
+    -- Keep all the states except s
+    let newStates = filter (lam st. not ((getEqv dfa) s st)) (getStates dfa) in
+    let newTrans = concat keepTrans addTrans in
+    -- Create a new dfa where s has been eliminated
+    dfaConstr newStates newTrans (getStartState dfa) (getAcceptStates dfa) (getEqv dfa) (getEql dfa)
+  in
+
+  -- Extract regex from canonical 1-state or 2-state DFA
+  let regExFromGeneric = lam dfa.
+    -- Get the symbol between from and to, or an empty regex if none exists
+    let getSymOrEmpty = lam dfa. lam from. lam to.
+      let trans = getTransitionsBetween from to dfa in
+      match trans with [] then Empty () else
+      match trans with [t] then t.2 else
+      error (strJoin ["getSymOrEmpty expected 0 or 1 transitions, was ", length trans])
+
+    in
+    -- Handle 1-state DFA
+    let generic1State = lam dfa.
+      let trans = getTransitions dfa in
+      match trans with [] then Epsilon () else
+      match trans with [t] then Kleene(t.2) else
+      error (strJoin "" ["Expected 0 or 1 transitions in 1-state DFA, not ", length trans])
+    in
+    -- Handle 2-state DFA
+    let generic2State = lam dfa.
+      let trans = getTransitions dfa in
+      match trans with [] then (error (strJoin "" ["Expected DFA with at least one transition"])) else
+      -- Start and accept state only states left
+      let p = getStartState dfa in
+      let q = match (getAcceptStates dfa) with [a] then a else error "Expected DFA with exactly one accept state" in
+      if (getEqv dfa) p q then error (strJoin "" ["Expected start state and accept state to be different"]) else
+      -- Extract the regexes from the 4 potential transitions
+      let pq = getSymOrEmpty dfa p q in
+      let qp = getSymOrEmpty dfa q p in
+      let pp = getSymOrEmpty dfa p p in
+      let qq = getSymOrEmpty dfa q q in
+      -- Construct the regex
+      let leftRE = Concat(pq, Kleene(qq)) in
+      simplifyD (getEql dfa)
+                (Concat (Kleene (Union (pp, Concat (leftRE, qp))),
+                         leftRE))
+    in
+    let nStates = length (getStates dfa) in
+    match nStates with 1 then generic1State dfa else
+    match nStates with 2 then generic2State dfa else
+    error (strJoin "" ["Expected DFA of size 1 or 2, not ", nStates, "."])
+  in
+
+  -- Get the regex from a DFA with one accept state
+  let regexOneAccept = lam dfa. lam acceptState.
+    -- Turn acceptState into the only accepting state
+    let dfa = dfaConstr (getStates dfa) (getTransitions dfa) (getStartState dfa)
+                        [acceptState] (getEqv dfa) (getEql dfa) in
+
+    let startState = getStartState dfa in
+    let toEliminate = filter
+                      (lam s. and
+                              (not ((getEqv dfa) startState s))
+                              (not ((getEqv dfa) acceptState s)))
+                      (getStates dfa) in
+    -- Eliminate states and extract regex
+    let finalDFA = foldl (lam accDFA. lam s. eliminate s accDFA)
+                   dfa
+                   toEliminate
+    in regExFromGeneric finalDFA
+  in
+
+  -- ** Actual Algorithm **
+
+  -- Step 1: Initialisation.
+  -- For every pair of states, merge the transitions between them and replace by a regex.
+  -- Established invariant: for every pair of state, there is at most one transition between them.
+  let states = getStates dfa in
+
+  -- Create the merged transitions
+  let mergedTrans = foldl (lam acc. lam s.
+                      let mergedSuccessors =
+                        map (lam s1.
+                              optionGetOrElse
+                                (lam _. error "Expected transition between states")
+                                (pairMergeTrans dfa s s1))
+                            (nfaOutStates s dfa) in
+                      concat acc mergedSuccessors)
+                    []
+                    states
+  in
+  -- Create the DFA with the merged transitions
+  let dfa = dfaConstr states mergedTrans (getStartState dfa) (getAcceptStates dfa) (getEqv dfa) (eqr (getEql dfa)) in
+
+  -- Step 2: State Elimination.
+  -- Iteratively eliminate states and replace by regexes
+  let acceptStates = getAcceptStates dfa in
+  match acceptStates with [] then Empty () else
+  match acceptStates with [a] then regexOneAccept dfa a else
+  foldl (lam acc. lam astate. Union (acc, regexOneAccept dfa astate))
+        (regexOneAccept dfa (head acceptStates))
+        (tail acceptStates)
+
+mexpr
+
+let l1 = "l1" in
+let l2 = "l2" in
+let l3 = "l3" in
+let l4 = "l4" in
+let l5 = "l5" in
+
+let r1 = Symbol l1 in
+let r2 = Symbol l2 in
+let r3 = Concat (r1, r2) in
+let r4 = Union(Kleene(Concat(r1, r2)), Symbol(l3)) in
+let r5 = Kleene (Union(Empty (), Concat (r1, Kleene (Empty ())))) in
+
+let eqrStr = eqr eqstr in
+utest eqrStr r1 r1 with true in
+utest eqrStr r1 r2 with false in
+utest eqrStr r3 r3 with true in
+utest eqrStr r3 r1 with false in
+utest eqrStr r4 r3 with false in
+utest eqrStr r4 r4 with true in
+utest eqrStr r4 (Union(Kleene(Concat(r1, r2)), Symbol(l3))) with true in
+utest eqrStr r4 (Union(Kleene(Concat(r1, r2)), Symbol(l2))) with false in
+
+utest simplifyD eqrStr r2 with r2 in
+utest simplifyD eqrStr r5 with Kleene r1 in
+
+let printDotRE = lam dfa. nfaPrintDot dfa int2string (regEx2str (lam x. x)) "LR" in
+let printDot = lam dfa. nfaPrintDot dfa int2string (lam x. x) "LR" in
+
+-- ┌───────┐  start   ╔═══╗
+-- │ start │ ───────▶ ║ 1 ║
+-- └───────┘          ╚═══╝
+let states = [1] in
+let transitions = [] in
+let startState = 1 in
+let acceptStates = [1] in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+--let _ = printDot dfa in
+
+utest regexFromDFA dfa with Epsilon () in
+
+--                        l1
+--                      ┌────┐
+--                      ▼    │
+-- ┌───────┐  start   ╔════════╗
+-- │ start │ ───────▶ ║   1    ║
+-- └───────┘          ╚════════╝
+--                      ▲ l2 │
+--                      └────┘
+--
+let states = [1] in
+let transitions = [(1,1,l1), (1,1,l2)] in
+let startState = 1 in
+let acceptStates = [1] in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+-- let _ = printDot dfa in
+
+-- (l1 | l2)*
+utest regexFromDFA dfa with Kleene (Union (Symbol l1, Symbol l2)) in
+
+--                      ┌────────────────┐
+--                      │                │
+-- ┌───────┐  start   ┌───┐  l1   ╔═══╗  │
+-- │ start │ ───────▶ │   │ ────▶ ║ 2 ║  │
+-- └───────┘          │   │       ╚═══╝  │
+--                    │   │  l3          │ l5
+--                    │ 1 │ ◀───────┐    │
+--                    │   │         │    │
+--                    │   │  l2   ┌───┐  │
+--                    │   │ ────▶ │ 3 │ ◀┘
+--                    └───┘       └───┘
+--                      │   l4      ▲
+--                      └───────────┘
+let states = [1,2,3] in
+let transitions = [(1,2,l1),(3,1,l3),(1,3,l2),(1,3,l4),(1,3,l5)] in
+let startState = 1 in
+let acceptStates = [2] in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+--let _ = printDot dfa in
+
+-- ((l2 | l4 | l5) l3)* l1
+utest regexFromDFA dfa with Concat (Kleene (Concat (Union (Union (Symbol l2, Symbol l4), Symbol l5),
+                                                    Symbol l3)),
+                                    Symbol l1) in
+
+-- Accept state same as start state
+--                      ┌────────────────┐
+--                      │                │
+-- ┌───────┐  start   ╔═══╗  l1   ┌───┐  │
+-- │ start │ ───────▶ ║   ║ ────▶ │ 2 │  │
+-- └───────┘          ║   ║       └───┘  │
+--                    ║   ║  l3          │ l4
+--                    ║ 1 ║ ◀───────┐    │
+--                    ║   ║         │    │
+--                    ║   ║  l5   ┌───┐  │
+--                    ║   ║ ────▶ │ 3 │ ◀┘
+--                    ╚═══╝       └───┘
+--                      │   l2      ▲
+--                      └───────────┘
+let states = [1,2,3] in
+let transitions = [(1,2,l1),(3,1,l3),(1,3,l2),(1,3,l4),(1,3,l5)] in
+let startState = 1 in
+let acceptStates = [1] in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+--let _ = printDot dfa in
+
+-- ((l2 | l4 | l5) l3)*
+utest regexFromDFA dfa with Kleene (Concat (Union (Union (Symbol l2, Symbol l4), Symbol l5),
+                                            Symbol l3)) in
+
+-- Several accept states
+--
+--                      ┌────────────────┐
+--                      │                │
+-- ┌───────┐  start   ╔═══╗  l1   ╔═══╗  │
+-- │ start │ ───────▶ ║   ║ ────▶ ║ 2 ║  │
+-- └───────┘          ║   ║       ╚═══╝  │
+--                    ║   ║  l3          │ l4
+--                    ║ 1 ║ ◀───────┐    │
+--                    ║   ║         │    │
+--                    ║   ║  l2   ┌───┐  │
+--                    ║   ║ ────▶ │ 3 │ ◀┘
+--                    ╚═══╝       └───┘
+--                      │   l5      ▲
+--                      └───────────┘
+--
+let states = [1,2,3] in
+let transitions = [(1,2,l1),(3,1,l3),(1,3,l2),(1,3,l4),(1,3,l5)] in
+let startState = 1 in
+let acceptStates = [1,2] in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+--let _ = printDot dfa in
+
+-- (((l2 | l4 | l5) l3)*) | ((l2 | l4 | l5) l3)* l1
+utest regexFromDFA dfa with Union (Kleene (Concat (Union (Union (Symbol l2, Symbol l4), Symbol l5), Symbol l3)),
+                                   Concat (Kleene (Concat (Union (Union (Symbol l2, Symbol l4), Symbol l5),Symbol l3)),Symbol l1)) in
+()


### PR DESCRIPTION
This PR adds regular expressions to the stdlib.

- The main point of this PR is a DFA->regular expression conversion algorithm I need in my research.
- Since the algorithm uses DFAs with regular expressions as symbols, I had to remove the `alphabet` argument for the constructor of NFAs and DFAs, making the alphabet of an NFA/DFA implicit. If this is a problem for the Miking IPM group, I can add it back and use some other workaround.
- The operators for regular expressions are concatenation, Kleene closure and union. For example:
`Kleene (Union (Concat (Symbol "a", Symbol "b"), Symbol "a"))`
represents (ab|a)*
- There isn't a lot one can do with regular expressions, except create them from a DFA and check for (structural) equivalence or regexes.
- Real equivalence is not implemented, as that would require implementing a DFA minimisation algorithm.
