### PR TITLE
Change make script interpreter

### DIFF
--- a/make
+++ b/make
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 ###################################################
 #  Miking is licensed under the MIT license.
 #  Copyright (C) David Broman. See file LICENSE.txt


### PR DESCRIPTION
This PR changes the shebang of the make script to use `/bin/sh` instead of `/bin/bash`. This makes the script slightly more general as it does not rely on bash specifically. For instance, on my [Guix](https://guix.gnu.org/) system, bash is not available in `/bin/bash`, so I have to manually run `bash ./make ...` instead of using the Makefile.