### PR TITLE
Decision points: allow several program entry points

### DIFF
--- a/stdlib/dfa.mc
+++ b/stdlib/dfa.mc
@@ -46,6 +46,9 @@ let dfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
 	if(err.0) then error "There are duplicate labels for same state outgoing transition at"
 	else nfaConstr s trans startS accS eqv eql
 
+-- Creat a DFA from a Digraph
+let dfaFromDigraph = nfaFromDigraph
+
 mexpr
 let states = [0,1,2] in
 let transitions = [(0,1,'1'),(1,1,'1'),(1,2,'0'),(2,2,'0'),(2,1,'1')] in

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -30,6 +30,12 @@ let digraphEmpty = lam eqv. lam eql. {adj = [], eqv = eqv, eql = eql}
 -- Get the vertices of the graph g.
 let digraphVertices = lam g. (map (lam tup. tup.0) g.adj)
 
+-- Get equivalence function for vertices.
+let digraphEqv = lam g. g.eqv
+
+-- Get equivalence function for labels.
+let digraphEql = lam g. g.eql
+
 -- Get the edges of the graph g.
 let digraphEdges = lam g.
     foldl concat []

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -27,9 +27,10 @@ type Digraph = { adj : [(a,[(a,b)])],
 -- Returns an empty graph. Input: equality functions for vertices and labels.
 let digraphEmpty = lam eqv. lam eql. {adj = [], eqv = eqv, eql = eql}
 
--- Access vertices and edges
+-- Get the vertices of the graph g.
 let digraphVertices = lam g. (map (lam tup. tup.0) g.adj)
 
+-- Get the edges of the graph g.
 let digraphEdges = lam g.
     foldl concat []
       (map
@@ -39,65 +40,82 @@ let digraphEdges = lam g.
            (map (lam tup. (v, tup.0, tup.1)) edgelist))
        g.adj)
 
+-- Get the outgoing edges from vertex v in graph g.
 let digraphEdgesFrom = lam v. lam g.
                        map (lam tup. (v, tup.0, tup.1)) (mapLookup g.eqv v g.adj)
 
+-- Get the incoming edges to vertex v in graph g.
 let digraphEdgesTo = lam v. lam g.
                      let allEdges = digraphEdges g in
                      filter (lam tup. g.eqv v tup.1) allEdges
 
--- Get all edges from v1 to v2
+-- Get all edges from v1 to v2 in graph g.
 let digraphEdgesBetween = lam v1. lam v2. lam g.
   let fromV1 = digraphEdgesFrom v1 g in
   filter (lam tup. g.eqv v2 tup.1) fromV1
 
+-- Get all labels between v1 and v2 in graph g.
 let digraphLabels = lam v1. lam v2. lam g.
     let from_v1_to_v2 = filter (lam tup. g.eqv tup.1 v2) (digraphEdgesFrom v1 g) in
     map (lam tup. tup.2) from_v1_to_v2
 
+-- Get the number of vertices in graph g.
 let digraphCountVertices = lam g. length g.adj
 
+-- Get the number of edges in graph g.
 let digraphCountEdges = lam g. length (digraphEdges g)
 
+-- Check whether g has vertex v.
 let digraphHasVertex = lam v. lam g. any (g.eqv v) (digraphVertices g)
 
+-- Check whether g has all the vertices vs.
 let digraphHasVertices = lam vs. lam g.
                          all (lam b. b) (map (lam v. digraphHasVertex v g) vs)
 
--- Edges e1 and e2 equal in graph g.
+-- Check whether edges e1 and e2 are equal in graph g.
 let digraphEdgeEq = lam g. lam e1. lam e2.
                     and (and (g.eqv e1.0 e2.0)
                              (g.eqv e1.1 e2.1))
                         (g.eql e1.2 e2.2)
 
--- Graph g contains edges es.
+-- Check whether graph g has all the edges in es.
 let digraphHasEdges = lam es. lam g.
                       setIsSubsetEq (digraphEdgeEq g) es (digraphEdges g)
 
--- Get successor nodes of v
+-- Get successor nodes of v.
 let digraphSuccessors = lam v. lam g.
   distinct g.eqv (map (lam tup. tup.1) (digraphEdgesFrom v g))
 
--- Get predecessor nodes of v
+-- Get predecessor nodes of v.
 let digraphPredeccessors = lam v. lam g.
   distinct g.eqv (map (lam tup. tup.0) (digraphEdgesTo v g))
 
+-- Check whether vertex v1 is a successor of vertex v2 in graph g.
 let digraphIsSuccessor = lam v1. lam v2. lam g.
   any (g.eqv v1) (digraphSuccessors v2 g)
 
--- Add vertices and edges
+-- Add vertex v to graph g if it doesn't already exist in g.
+-- If v exists in g and check is true, an error is thrown.
+-- If v exist in g and check is false, g stays unchanged.
 let digraphAddVertexCheck = lam v. lam g. lam check.
   if digraphHasVertex v g then
     if check then error "vertex already exists" else g
   else
     {adj = snoc g.adj (v,[]), eqv = g.eqv, eql = g.eql}
 
+-- Add a vertex to graph g. Throws an error if v already exists in g.
 let digraphAddVertex = lam v. lam g.
   digraphAddVertexCheck v g true
 
+-- Maybe add a vertex v to g. Graph stays unchanged if v already exists in g.
 let digraphMaybeAddVertex = lam v. lam g.
   digraphAddVertexCheck v g false
 
+-- Add edge e=(v1,v2,l) to graph g.
+-- If v1 or v2 do not exist in g, an error is thrown.
+-- If l exists in g and check is true, an error is thrown.
+-- If l exist in g and check is false, g stays unchanged.
+-- Otherwise, e is added to g.
 let digraphAddEdgeCheckLabel = lam v1. lam v2. lam l. lam g. lam check.
   if not (digraphHasVertices [v1, v2] g) then
     error "some vertices do not exist"
@@ -106,16 +124,32 @@ let digraphAddEdgeCheckLabel = lam v1. lam v2. lam l. lam g. lam check.
   else
     {g with adj = mapUpdate g.eqv v1 (lam es. snoc es (v2, l)) g.adj}
 
+-- Add edge e=(v1,v2,l) to g. Throws an error if l already exists in g.
 let digraphAddEdge = lam v1. lam v2. lam l. lam g.
     digraphAddEdgeCheckLabel v1 v2 l g true
 
+-- Maybe add edge e=(v1,v2,l) to g. Graph stays unchanged if l already exists in g.
 let digraphMaybeAddEdge = lam v1. lam v2. lam l. lam g.
     digraphAddEdgeCheckLabel v1 v2 l g false
 
--- Union of two graphs
+-- Add a list of vertices to a graph g.
+let digraphAddVertices = lam vs. lam g.
+  foldl (lam g. lam v. digraphAddVertex v g) g vs
+
+-- Add a list of edges to a graph g.
+let digraphAddEdges = lam es. lam g.
+  foldl (lam g. lam e. digraphAddEdge e.0 e.1 e.2 g) g es
+
+-- Create the union of two graphs.
 let digraphUnion = lam g1. lam g2.
   let g3 = foldl (lam g. lam v. digraphMaybeAddVertex v g) g1 (digraphVertices g2)
   in foldl (lam g. lam tup. digraphMaybeAddEdge tup.0 tup.1 tup.2 g) g3 (digraphEdges g2)
+
+-- Reverse the direction of graph g.
+let digraphReverse = lam g.
+  let edgesReversed = map (lam e. (e.1, e.0, e.2)) (digraphEdges g) in
+  let vs = digraphVertices g in
+  digraphAddEdges edgesReversed (digraphAddVertices vs (digraphEmpty g.eqv g.eql))
 
 -- Strongly connected components of g.
 -- From the paper: Depth-First Search and Linear Graph Algorithms, Tarjan 72.
@@ -237,6 +271,12 @@ let g = digraphAddEdge 2 3 l4 (digraphAddEdge 1 3 l3 (digraphAddEdge 1 2 l2 (dig
 utest digraphEdgesBetween 1 3 g with [(1,3,l3)] in
 utest match digraphEdgesBetween 1 2 g with [(1,2,l1),(1,2,l2)] | [(1,2,l2),(1,2,l1)] then true else false with true in
 utest match digraphPredeccessors 3 g with [1,2] | [2,1] then true else false with true in
+
+let g = digraphAddEdges [(1,2,l1),(1,3,l2),(3,1,l3)] (digraphAddVertices [1,2,3] empty) in
+let gRev = digraphReverse g in
+utest digraphHasEdges [(2,1,l1),(3,1,l2),(1,3,l3)] gRev with true in
+utest digraphCountVertices gRev with 3 in
+utest digraphCountEdges gRev with 3 in
 
 let l3 = gensym () in
 let g2 = digraphAddEdge 3 2 l3 g1 in

--- a/stdlib/eq-paths.mc
+++ b/stdlib/eq-paths.mc
@@ -114,7 +114,7 @@ let eqPaths2 = lam g. lam v. lam d. lam sStates.
   -- Equality function for paths
   let eq = lam p1. lam p2.
              and (eqi (length p1) (length p2))
-                 (all (lam t. eqchar t.0 t.1) (zipWith (lam e1. lam e2. (e1, e2)) p1 p2)) in
+                 (all (lam t. (digraphEql g) t.0 t.1) (zipWith (lam e1. lam e2. (e1, e2)) p1 p2)) in
   -- Remove duplicate paths
   let upaths = distinct eq paths in
   -- Reverse paths, making v the end path

--- a/stdlib/eq-paths.mc
+++ b/stdlib/eq-paths.mc
@@ -27,12 +27,14 @@ let callGraph2DFA = lam g. lam sStates. lam aState.
 -- Expand the regular expression as far as possible, but at most to length d
 -- Kleene closures are taken at most once
 -- TODO: Set #laps in Kleene closures as a parameter
-let regExpand: RegEx -> Int -> [[a]] = lam r. lam d.
+let regExpand: (a -> a -> bool) -> RegEx -> Int -> [[a]] =
+  lam eqsym. lam r. lam d.
   -- RegEx -> Int -> [Sym] -> [[Sym]]
   recursive let expand: RegEx -> Int -> [a] -> [[a]] =
     lam r. lam d. lam cur. lam acc.
       -- Hack: check for terminal T
-      match cur with h ++ ['T'] then cons h acc else
+      --match cur with h ++ ['T'] then cons h acc else
+      match cur with h ++ ['T'] then cons cur acc else
       match d with 0 then cons cur acc else
 
       match r with Empty () then acc else
@@ -69,35 +71,56 @@ let regExpand: RegEx -> Int -> [[a]] = lam r. lam d.
       error "Unknown RegEx in expand"
   in
   let expansion = expand r d [] [] in
-  map (lam x. match x with (h ++ ['T']) then h else x) expansion
+  -- Remove trailing terminals
+  recursive let trimTerminals = lam seq.
+    match seq with (h ++ ['T']) then trimTerminals h else seq
+  in
+  let trimmedPaths = map trimTerminals expansion in
+  -- Equality function for paths
+  let eq = lam p1. lam p2.
+    and (eqi (length p1) (length p2))
+        (all (lam t. eqsym t.0 t.1) (zipWith (lam e1. lam e2. (e1, e2)) p1 p2)) in
+  -- Remove duplicate paths
+  let upaths = distinct eq trimmedPaths in
+  upaths
 
-utest regExpand (Empty ()) 1 with []
-utest regExpand (Epsilon ()) 1 with [[]]
-utest regExpand (Symbol 'a') 1 with [['a']]
-utest regExpand (Concat (Symbol 'a', Symbol 'b')) 2 with [['a', 'b']]
-utest regExpand (Concat (Symbol 'a', Symbol 'b')) 1 with [['a']]
-utest regExpand (Concat (Symbol 'a', Concat (Symbol 'b', Symbol 'c'))) 1 with [['a']]
-utest regExpand (Concat (Symbol 'a', Concat (Symbol 'b', Symbol 'c'))) 2 with [['a','b']]
-utest regExpand (Concat (Concat (Symbol 'a', Symbol 'b'), Symbol 'c')) 2 with [['a','b']]
-utest regExpand (Concat (Concat (Symbol 'a', Symbol 'b'), Symbol 'c')) 3 with [['a','b','c']]
-utest regExpand (Kleene (Symbol 'a')) 1 with [[]]
-utest regExpand (Concat (Kleene (Symbol 'a'), Symbol 'b')) 1 with [['b']]
-utest regExpand (Concat (Kleene (Symbol 'a'), Symbol 'b')) 2 with [['b']]
-utest regExpand (Kleene (Concat (Symbol 'a', Symbol 'b'))) 5 with [[], ['a','b']]
--- (ab)*c -> c, ab
-utest regExpand (Concat (Kleene (Concat (Symbol 'a', Symbol 'b')), Symbol 'c')) 3 with [['a','b'], ['c']]
-utest regExpand (Concat (Kleene (Concat (Symbol 'a', Symbol 'b')), Symbol 'c')) 2 with [['a','b'], ['c']]
+let regExpandChar = regExpand eqchar
+utest regExpandChar (Empty ()) 1 with []
+utest regExpandChar (Epsilon ()) 1 with [[]]
+utest regExpandChar (Symbol 'a') 1 with [['a']]
+utest regExpandChar (Concat (Symbol 'a', Symbol 'b')) 2 with [['a', 'b']]
+utest regExpandChar (Concat (Symbol 'a', Symbol 'b')) 1 with [['a']]
+utest regExpandChar (Concat (Symbol 'a', Concat (Symbol 'b', Symbol 'c'))) 1 with [['a']]
+utest regExpandChar (Concat (Symbol 'a', Concat (Symbol 'b', Symbol 'c'))) 2 with [['a','b']]
+utest regExpandChar (Concat (Concat (Symbol 'a', Symbol 'b'), Symbol 'c')) 2 with [['a','b']]
+utest regExpandChar (Concat (Concat (Symbol 'a', Symbol 'b'), Symbol 'c')) 3 with [['a','b','c']]
+utest regExpandChar (Kleene (Symbol 'a')) 1 with [[]]
+utest regExpandChar (Concat (Kleene (Symbol 'a'), Symbol 'b')) 1 with [['b']]
+utest regExpandChar (Concat (Kleene (Symbol 'a'), Symbol 'b')) 2 with [['b']]
+utest regExpandChar (Kleene (Concat (Symbol 'a', Symbol 'b'))) 5 with [[], ['a','b']]
+-- (ab)*c -> c,Char ab
+utest regExpandChar (Concat (Kleene (Concat (Symbol 'a', Symbol 'b')), Symbol 'c')) 3 with [['a','b'], ['c']]
+utest regExpandChar (Concat (Kleene (Concat (Symbol 'a', Symbol 'b')), Symbol 'c')) 2 with [['a','b'], ['c']]
 
-utest regExpand (Union (Epsilon (), Symbol 'a')) 1 with [['a'], []]
-utest regExpand (Union (Symbol 'a', Symbol 'b')) 1 with [['b'], ['a']]
-utest regExpand (Union (Concat (Kleene (Concat (Symbol 'a', Symbol 'b')), Symbol 'c'),
+utest regExpandChar (Union (Epsilon (), Symbol 'a')) 1 with [['a'], []]
+utest regExpandChar (Union (Symbol 'a', Symbol 'b')) 1 with [['b'], ['a']]
+utest regExpandChar (Union (Concat (Kleene (Concat (Symbol 'a', Symbol 'b')), Symbol 'c'),
                         Concat (Concat (Symbol 'a', Symbol 'b'), Symbol 'c'))) 3 with [['a','b','c'], ['a','b'], ['c']]
+utest regExpandChar (Kleene (Concat (Symbol 'a', Symbol 'b'))) 2 with [[], ['a', 'b']]
+utest regExpandChar (Kleene ((Kleene (Concat (Symbol 'a', Symbol 'b'))))) 2 with [[], ['a', 'b']]
 
 let eqPaths2 = lam g. lam v. lam d. lam sStates.
   let re = callGraph2DFA g sStates v in
-  let paths = regExpand re d in
-  -- TODO: Remove duplicates
-  map (lam p. reverse p) paths
+--  let _ = regExPprint show_char re in
+  let paths = regExpand (digraphEql g) re d in
+  -- Equality function for paths
+  let eq = lam p1. lam p2.
+             and (eqi (length p1) (length p2))
+                 (all (lam t. eqchar t.0 t.1) (zipWith (lam e1. lam e2. (e1, e2)) p1 p2)) in
+  -- Remove duplicate paths
+  let upaths = distinct eq paths in
+  -- Reverse paths, making v the end path
+  map (lam p. reverse p) upaths
 
 -- Complexity: O(|V|^2), as for each node, we potentially visit every other
 -- node. This assumes digraphEdgesTo, isVisited and concat are constant
@@ -129,7 +152,7 @@ let eqPaths = lam g. lam v. lam d.
 
 mexpr
 -- To construct test graphs
-let empty = digraphEmpty eqi eqstr in
+let empty = digraphEmpty eqi eqchar in
 let fromList = lam vs. foldl (lam g. lam v. digraphAddVertex v g) empty vs in
 let addEdges = lam g. lam es. foldl (lam acc. lam e. digraphAddEdge e.0 e.1 e.2 acc) g es in
 
@@ -142,7 +165,7 @@ in
 
 -- To compare edges
 let eqedge = lam e1. lam e2.
-  eqstr e1 e2
+  eqchar e1 e2
 in
 
 let samePaths = lam eq. lam seq1. lam seq2.
@@ -156,140 +179,151 @@ in
 let eq = samePaths eqedge in
 
 -- Create some labels
-let l1 = "l1" in
-let l2 = "l2" in
-let l3 = "l3" in
-let l4 = "l4" in
-let l5 = "l5" in
-let l6 = "l6" in
-let l7 = "l7" in
-let l8 = "l8" in
-let l9 = "l9" in
-let l10 = "l10" in
+let a = 'a' in
+let b = 'b' in
+let c = 'c' in
+let d = 'd' in
+let e = 'e' in
+let f = 'f' in
+let g = 'g' in
+let h = 'h' in
+let i = 'i' in
+let j = 'j' in
+
 
 -- Simple chain graph
 -- ┌─────┐
 -- │  4  │
 -- └─────┘
 --   │
---   │ l3
+--   │ c
 --   ▼
 -- ┌─────┐
 -- │  3  │
 -- └─────┘
 --   │
---   │ l2
+--   │ b
 --   ▼
 -- ┌─────┐
 -- │  2  │
 -- └─────┘
 --   │
---   │ l1
+--   │ a
 --   ▼
 -- ┌─────┐
 -- │  1  │
 -- └─────┘
 let g = addEdges
         (fromList [1, 2, 3, 4])
-        [(4,3,l3),
-         (3,2,l2),
-         (2,1,l1)]
+        [(4,3,c),
+         (3,2,b),
+         (2,1,a)]
 in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
 let v = 1 in
 utest eqPaths g v 0 with [[]] in
-utest eqPaths g v 1 with [[l1]] in
-utest eqPaths g v 2 with [[l2, l1]] in
-utest eqPaths g v 3 with [[l3, l2, l1]] in
-utest eqPaths g v 4 with [[l3, l2, l1]] in
+utest eqPaths g v 1 with [[a]] in
+utest eqPaths g v 2 with [[b, a]] in
+utest eqPaths g v 3 with [[c, b, a]] in
+utest eqPaths g v 4 with [[c, b, a]] in
 
 utest eqPaths2 g v 2 [] with [] in
-utest eqPaths2 g v 2 [4] with [[l2, l1]] in
-utest eqPaths2 g v 4 [4] with [[l3, l2, l1]] in
-utest eqPaths2 g v 4 [3,4] with [[l3, l2, l1], [l2,l1]] in
-utest eq (eqPaths2 g v 4 [1,2,3,4]) [[l3, l2, l1], [l2,l1], [l1], []] with true in
+utest eqPaths2 g v 2 [4] with [[b, a]] in
+utest eqPaths2 g v 4 [4] with [[c, b, a]] in
+utest eqPaths2 g v 4 [3,4] with [[c, b, a], [b,a]] in
+utest eq (eqPaths2 g v 4 [1,2,3,4]) [[c, b, a], [b,a], [a], []] with true in
+
 
 -- Chain with several edges
 -- ┌─────┐
 -- │  4  │
 -- └─────┘
 --   │
---   │ l3
+--   │ c
 --   ▼
 -- ┌─────┐
 -- │  3  │ ─┐
 -- └─────┘  │
 --   │      │
---   │ l4   │ l2
+--   │ d   │ b
 --   ▼      │
 -- ┌─────┐  │
 -- │  2  │ ◀┘
 -- └─────┘
 --   │
---   │ l1
+--   │ a
 --   ▼
 -- ┌─────┐
 -- │  1  │
 -- └─────┘
 let g = addEdges
         (fromList [1, 2, 3, 4])
-        [(4,3,l3),
-         (3,2,l2),
-         (3,2,l4),
-         (2,1,l1)]
+        [(4,3,c),
+         (3,2,b),
+         (3,2,d),
+         (2,1,a)]
 in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
 let v = 1 in
 utest eqPaths g v 0 with [[]] in
-utest eqPaths g v 1 with [[l1]] in
+utest eqPaths g v 1 with [[a]] in
 utest samePaths eqedge (eqPaths g v 2)
-                       ([[l2, l1],
-                         [l4, l1]]) with true in
+                       ([[b, a],
+                         [d, a]]) with true in
 utest samePaths eqedge (eqPaths g v 3)
-                          ([[l3, l2, l1],
-                            [l3, l4, l1]]) with true in
+                          ([[c, b, a],
+                            [c, d, a]]) with true in
 
-utest eq (eqPaths2 g v 3 [1,2,3,4]) ([[l3,l4,l1],[l3,l2,l1],[l4,l1],[l2,l1],[l1],[]]) with true in
--- TODO: Fix this test
-utest eq (eqPaths2 g v 2 [1,2,3,4]) ([[l4,l1],[l2,l1],[l1],[]]) with true in
+utest eq (eqPaths2 g v 3 [1,2,3,4]) ([[c,d,a],[c,b,a],[d,a],[b,a],[a],[]]) with true in
+utest eq (eqPaths2 g v 2 [1,2,3,4]) ([[d,a],[b,a],[a],[]]) with true in
 
 -- Self looping graph
--- ┌───┐   l1
+-- ┌───┐   a
 -- │   │ ─────┐
 -- │ 1 │      │
 -- │   │ ◀────┘
 -- └───┘
 let g0 = addEdges
          (fromList [1])
-         [(1,1,l1)] in
+         [(1,1,a)] in
 -- let _ = digraphPrintDot g0 int2string (lam x. x) in
 
 -- Path should always be empty
 utest eqPaths g0 1 0  with [[]] in
 utest eqPaths g0 1 10 with [[]] in
 
+utest eqPaths2 g0 1 0 [1] with [[]] in
+utest eqPaths2 g0 1 1 [1] with [[]] in
+utest eqPaths2 g0 1 10 [1] with [[]] in
+
 -- Loop with two nodes (mutual recursion)
 -- ┌─────┐
 -- │  2  │ ◀┐
 -- └─────┘  │
 --   │      │
---   │ 21   │ 12
+--   │ a    │ b
 --   ▼      │
 -- ┌─────┐  │
 -- │  1  │ ─┘
 -- └─────┘
 let g = addEdges
         (fromList [1, 2])
-        [(1,2,"12"),(2,1,"21")] in
+        [(1,2,'b'),(2,1,'a')] in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
 utest eqPaths g 1 0 with [[]] in
-utest eqPaths g 1 1 with [["21"]] in
-utest eqPaths g 1 2 with [["21"]] in
-utest eqPaths g 1 3 with [["21"]] in
-utest eqPaths g 1 10 with [["21"]] in
+utest eqPaths g 1 1 with [['a']] in
+utest eqPaths g 1 2 with [['a']] in
+utest eqPaths g 1 3 with [['a']] in
+utest eqPaths g 1 10 with [['a']] in
+
+utest eqPaths2 g 1 0 [2] with [[]] in
+utest eqPaths2 g 1 1 [2] with [['a']] in
+-- Questionable result: Includes a loop
+utest eqPaths2 g 1 2 [2] with [['b','a'],['a']] in
+utest eqPaths2 g 1 2 [1,2] with [['b','a'],['a'],[]] in
 
 let foo = callGraph2DFA g [2] 1 in
 --utest foo with [] in
@@ -299,169 +333,185 @@ let foo = callGraph2DFA g [2] 1 in
 -- │  1  │
 -- └─────┘
 --   │
---   │ l1
+--   │ a
 --   ▼
 -- ┌─────┐
 -- │  2  │ ◀┐
 -- └─────┘  │
 --   │      │
---   │ l2   │ l3
+--   │ b   │ c
 --   ▼      │
 -- ┌─────┐  │
 -- │  3  │ ─┘
 -- └─────┘
 let g = addEdges
         (fromList [1, 2, 3])
-        [(1,2,l1), (3,2,l3),(2,3,l2)] in
+        [(1,2,a), (3,2,c),(2,3,b)] in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
 utest eqPaths g 2 0 with [[]] in
-utest samePaths eqedge (eqPaths g 2 1) [[l1],[l3]] with true in
-utest samePaths eqedge (eqPaths g 2 2) [[l1],[l3]] with true in
+utest samePaths eqedge (eqPaths g 2 1) [[a],[c]] with true in
+utest samePaths eqedge (eqPaths g 2 2) [[a],[c]] with true in
+
+utest eqPaths2 g 2 0 [1,2,3] with [[]] in
+-- Questionable result: cuts off at the mutual recursion
+utest eqPaths2 g 2 3 [1] with [[b,c], [a]] in
+utest eqPaths2 g 2 3 [3] with [[b,c], [c]] in
+utest eq (eqPaths2 g 2 3 [1,2,3]) [[b,c], [a], [], [c]] with true in
 
 -- Yet another mutual recursion
 --      ┌─────┐
 -- ┌──▶ │  3  │
 -- │    └─────┘
 -- │      │
--- │      │ l2
+-- │      │ b
 -- │      ▼
 -- │    ┌─────┐
--- │ l3 │  2  │ ◀┐
+-- │ c │  2  │ ◀┐
 -- │    └─────┘  │
 -- │      │      │
--- │      │ l1   │ l4
+-- │      │ a   │ d
 -- │      ▼      │
 -- │    ┌─────┐  │
 -- └─── │  1  │ ─┘
 --      └─────┘
 let g = addEdges
         (fromList [1, 2, 3])
-        [(2,1,l1), (3,2,l2), (1,3,l3), (1,2,l4)] in
+        [(2,1,a), (3,2,b), (1,3,c), (1,2,d)] in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
 utest eqPaths g 1 0 with [[]] in
-utest eqPaths g 1 1 with [[l1]] in
-utest samePaths eqedge (eqPaths g 1 2) [[l2, l1], [l1]] with true in
-utest samePaths eqedge (eqPaths g 1 3) [[l2, l1], [l1]] with true in
+utest eqPaths g 1 1 with [[a]] in
+utest samePaths eqedge (eqPaths g 1 2) [[b, a], [a]] with true in
+utest samePaths eqedge (eqPaths g 1 3) [[b, a], [a]] with true in
 
+utest eqPaths2 g 1 1 [1] with [[],[a]] in
+utest eqPaths2 g 1 5 [3] with [[d,a], [c, b, a], [b,a]] in
 
 -- Loop with three nodes
 -- ┌─────┐
 -- │  3  │ ◀┐
 -- └─────┘  │
 --   │      │
---   │ l3   │
+--   │ c   │
 --   ▼      │
 -- ┌─────┐  │
--- │  1  │  │ l2
+-- │  1  │  │ b
 -- └─────┘  │
 --   │      │
---   │ l1   │
+--   │ a   │
 --   ▼      │
 -- ┌─────┐  │
 -- │  2  │ ─┘
 -- └─────┘
 let g = addEdges
         (fromList [1, 2, 3])
-        [(1,2,l1),(2,3,l2),(3,1,l3)] in
+        [(1,2,a),(2,3,b),(3,1,c)] in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
-utest eqPaths g 1 1 with [[l3]] in
-utest eqPaths g 1 2 with [[l2, l3]] in
+utest eqPaths g 1 1 with [[c]] in
+utest eqPaths g 1 2 with [[b, c]] in
+
+utest eqPaths2 g 2 3 [3] with [[b,c,a],[c,a]] in
 
 -- Two way loop
 -- ┌─────┐
 -- │  4  │ ◀┐
 -- └─────┘  │
 --   │      │
---   │ l5   │ l4
+--   │ e    │ d
 --   ▼      │
 -- ┌───────────────────┐
 -- │         2         │
 -- └───────────────────┘
 --   │      ▲      │
---   │ l1   │ l3   │ l2
+--   │ a    │ c    │ b
 --   ▼      │      ▼
 -- ┌─────┐  │    ┌─────┐
 -- │  1  │  └─── │  3  │
 -- └─────┘       └─────┘
 let g = addEdges
         (fromList [1,2,3,4])
-        [(2,3,l2),(3,2,l3),(2,4,l4),(4,2,l5),(2,1,l1)] in
+        [(2,3,b),(3,2,c),(2,4,d),(4,2,e),(2,1,a)] in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
-utest eqPaths g 1 1 with [[l1]] in
+utest eqPaths g 1 1 with [[a]] in
 utest samePaths eqedge (eqPaths g 1 2)
-                       ([[l5, l1],
-                         [l3, l1]]) with true in
+                       ([[e, a],
+                         [c, a]]) with true in
 -- d=3 same result as d=2
 utest eqPaths g 1 3 with eqPaths g 1 2 in
 
-
+utest eqPaths2 g 1 10 [2] with [[a], [d,e,a], [b,c,a]] in
+utest eqPaths2 g 1 1 [4] with [[a]] in
+utest eqPaths2 g 1 2 [4] with [[e,a], [c,a]] in
+utest eqPaths2 g 1 3 [4] with [[e,a], [d,e,a], [b,c,a]] in
+-- TODO: blows up
+--utest eqPaths2 g 1 10 [4] with [[e,a], [d,e,a], [b,c,a]] in
+--let foo = eqPaths2 g 1 10 [2,4] in
 
 -- Chain with loops
--- ┌─────┐   l3
+-- ┌─────┐   c
 -- │     │ ─────┐
 -- │  3  │      │
 -- │     │ ◀────┘
 -- └─────┘
 --   │
---   │ l1
+--   │ a
 --   ▼
--- ┌─────┐   l2
+-- ┌─────┐   b
 -- │     │ ─────┐
 -- │  2  │      │
 -- │     │ ◀────┘
 -- └─────┘
 --   │
---   │ l4
+--   │ d
 --   ▼
 -- ┌─────┐
 -- │  1  │
 -- └─────┘
 let g = addEdges
         (fromList [1,2,3])
-        [(3,3,l3),(2,2,l2),(3,2,l1),(2,1,l4)] in
+        [(3,3,c),(2,2,b),(3,2,a),(2,1,d)] in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
-utest eqPaths g 1 2 with [[l1, l4]] in
-utest eqPaths g 1 3 with [[l1, l4]] in
+utest eqPaths g 1 2 with [[a, d]] in
+utest eqPaths g 1 3 with [[a, d]] in
 
 -- Long cycle
 --             ┌─────┐
 --             │  1  │
 --             └─────┘
 --               │
---               │ l1
+--               │ a
 --               ▼
--- ┌───┐  l8   ┌───────────────────┐
+-- ┌───┐  h   ┌───────────────────┐
 -- │ 7 │ ◀──── │         3         │
 -- └───┘       └───────────────────┘
 --               │      ▲      ▲
---               │ l4   │ l7   │ l2
+--               │ d   │ g   │ b
 --               ▼      │      │
 --             ┌─────┐  │    ┌─────┐
 --             │  4  │  │    │  2  │
 --             └─────┘  │    └─────┘
 --               │      │
---               │ l5   │
+--               │ e   │
 --               ▼      │
 --             ┌─────┐  │
 --             │  5  │  │
 --             └─────┘  │
 --               │      │
---               │ l6   │
+--               │ f   │
 --               ▼      │
 --             ┌─────┐  │
 --             │  6  │ ─┘
 --             └─────┘
 let g = addEdges
         (fromList [1,2,3,4,5,6,7])
-        [(1,3,l1), (2,3,l2), (3,4,l4), (4,5,l5), (5,6,l6), (6,3,l7), (3,7,l8)] in
+        [(1,3,a), (2,3,b), (3,4,d), (4,5,e), (5,6,f), (6,3,g), (3,7,h)] in
 -- let _ = digraphPrintDot g int2string (lam x. x) in
 
-utest samePaths eqedge (eqPaths g 7 2) [[l7, l8], [l2, l8], [l1, l8]] with true in
-utest samePaths eqedge (eqPaths g 7 10) [[l5, l6, l7, l8], [l2, l8], [l1, l8]] with true in
+--utest samePaths eqedge (eqPaths g 7 2) [[g, h], [b, h], [a, h]] with true in
+--utest samePaths eqedge (eqPaths g 7 10) [[e, f, g, h], [b, h], [a, h]] with true in
 
 ()

--- a/stdlib/eq-paths.mc
+++ b/stdlib/eq-paths.mc
@@ -13,8 +13,6 @@ include "regex.mc"
 -- It's really a graph algorithm, but very specific, and the test cases
 -- takes lots of space, so it's currently in a separate file from digraph.mc.
 
--- TODO: prove true/false: an eq. path is never a sub-path of another eq-path
-
 let rpprint = regExPprint (lam x. x)
 
 let callGraph2DFA = lam g. lam sStates. lam aState.

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -349,8 +349,27 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
                          (snoc_ (tail_ (var_ callCtxVar)) (var_ lblVarName)))))
     in
 
+    recursive let makeDummy = lam funName. lam tm. lam acc.
+      match tm with TmLam t then
+        TmLam {t with body=makeDummy funName t.body (cons t.ident acc)}
+      else
+        foldl (lam a. lam x. app_ a (var_ x)) (app_ (var_ funName) (var_ "callCtx")) acc
+    in
+    --utest makeDummy "foo" (lam_ "x" (None ()) (var_ "x")) [] with [] in
+    --utest makeDummy "foo" (lam_ "x" (None ()) (lam_ "y" (None ()) (var_ "x"))) with [] in
+
+    -- Extract dummy functions from the AST, replacing public functions
+    let dummies = dummyPublic publicFns makeDummy ltm in
+
+    utest dummies with [] in
+
     -- Rename public functions and create dummy functions for them
-    let transformed = handlePublic publicFns transformed in
+    let transformed = renamePublic publicFns (lam ident. strJoin "" [ident, "Pr"]) transformed in
+
+    let defDummies =
+      match dummies with [] then unit_
+      else bindall_ dummies
+    in
 
     -- Put all the pieces together
     bindall_ [defLookupTable,
@@ -358,44 +377,72 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
               defMaxDepth,
               defAddCall,
               defLookup,
+              defDummies,
               transformed]
 
-  -- Handle public functions
-  -- TODO: Bodies of lambdas
-  sem handlePublic (fs : [String]) =
+  -- Define dummy functions for public functions
+  sem dummyPublic (fs : [String]) (makeDummy : String -> Expr -> [String] -> Expr) =
+  | TmLet {body = TmLam lm, ident=ident, tpe=tpe, inexpr=inexpr} ->
+    let t = {body = TmLam lm, ident=ident, tpe=tpe, inexpr=inexpr} in
+    -- Public function?
+    let dummy =
+      if optionIsSome (find (eqstr t.ident) fs) then
+        let newName = strJoin "" [t.ident, "Pr"] in
+        let dummyBody = makeDummy newName t.body [] in
+        [TmLet {{t with body = dummyBody} with inexpr=unit_}]
+      else []
+    in concat dummy (dummyPublic fs makeDummy t.inexpr)
+
+  | TmRecLets t ->
+    let handleLet = lam le.
+      if optionIsSome (find (eqstr le.ident) fs) then
+        match le.body with TmLam lm then
+          let newName = strJoin "" [le.ident, "Pr"] in
+          let dummyBody = makeDummy newName le.body [] in
+          [{le with body=dummyBody}]
+        else error (strJoin "" ["Expected identifier ", le.ident, " to define a lambda."])
+      else []
+    in
+    let dummies = foldl (lam acc. lam b. concat acc (handleLet b)) [] t.bindings in
+    concat [TmRecLets {inexpr=unit_, bindings=dummies}] (dummyPublic fs makeDummy t.inexpr)
+
+  | tm -> sfold_Expr_Expr concat [] (smap_Expr_Expr (dummyPublic fs makeDummy) tm)
+
+  -- Rename functions in fs with renaming function rf
+  sem renamePublic (fs : [String]) (rf : String -> String) =
   | TmLet {body = TmLam lm, ident=ident, tpe=tpe, inexpr=inexpr} ->
     let t = {body = TmLam lm, ident=ident, tpe=tpe, inexpr=inexpr} in
     -- Public function?
     let newIdent =
       if optionIsSome (find (eqstr t.ident) fs) then
-        strJoin "" [t.ident, "Pr"]
+        rf t.ident
       else
         t.ident
     in TmLet {{{t with ident = newIdent}
-                with body = handlePublic fs t.body}
-                with inexpr = handlePublic fs t.inexpr}
+                with body = renamePublic fs rf t.body}
+                with inexpr = renamePublic fs rf t.inexpr}
 
   | TmRecLets t ->
     let handleLet = lam le.
       -- Defines a public function
       if optionIsSome (find (eqstr le.ident) fs) then
         match le.body with TmLam lm then
-          let newIdent = strJoin "" [le.ident, "Pr"] in
-          let newBody = handlePublic fs le.body in
+          let newIdent = rf le.ident in
+          let newBody = renamePublic fs rf le.body in
           {{le with ident=newIdent} with body=newBody}
         else
           error (strJoin "" ["Identifier ", le.ident, " expected to refer to a function."])
       else
         le
      in TmRecLets {{t with bindings = map handleLet t.bindings}
-                    with inexpr = handlePublic fs t.inexpr}
+                    with inexpr = renamePublic fs rf t.inexpr}
 
   | TmVar v ->
     if optionIsSome (find (eqstr v.ident) fs) then
-      TmVar {v with ident = (strJoin "" [v.ident, "Pr"])}
+      TmVar {v with ident = rf v.ident}
     else TmVar v
 
-  | tm -> smap_Expr_Expr (handlePublic fs) tm
+  | tm -> smap_Expr_Expr (renamePublic fs rf) tm
 
   -- Do some transformations (see paper for example)
   sem transform2 (fs : [String]) (prev : String) =
@@ -945,7 +992,7 @@ let _ = print "\nAST from paper\n" in
 let _ = pprint ast in
 
 let _ = print "\nTransformed AST from paper\n" in
-let tast = transform ["foo"] ast in
+let tast = transform ["foo", "bar"] ast in
 let _ = pprint tast in
 
 -- Takes ~90 s to evaluate

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -211,7 +211,7 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
         match tm with TmLam t then
           TmLam {t with body=work t.body (cons t.ident acc)}
         else
-          foldl (lam a. lam x. app_ a (var_ x)) (app_ (var_ (renameF funName)) (var_ "callCtx")) acc
+          foldl (lam a. lam x. app_ a (var_ x)) (app_ (var_ (renameF funName)) (var_ callCtxVar)) acc
       in work tm []
     in
     -- Extract dummy functions from the AST, to replace public functions

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -501,7 +501,7 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
                let hole = match t.1 with LTmHole h then h else error "Internal error" in
                let depth = match hole.depth with TmConst {val = CInt n} then n.val
                            else error "Depth must be a constant integer" in
-               let allPaths = eqPaths2 g fun depth publicFns in
+               let allPaths = eqPaths g fun depth publicFns in
                let idPathValTriples = map (lam path. (hole.id, path, hole.startGuess)) allPaths
                in concat acc idPathValTriples)
            [] functionIDPairs
@@ -532,7 +532,7 @@ mexpr
 use TestLang in
 
 -- Enable/disable printing
-let printEnabled = true in
+let printEnabled = false in
 let print = if printEnabled then print else lam x. x in
 
 let ctx = {env = []} in

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -59,6 +59,7 @@ let nfaOutStates = lam s. lam nfa.
 
 -- check that values are acceptable for the NFA
 let nfaCheckValues = lam trans. lam s. lam eqv. lam eql. lam accS. lam startS.
+<<<<<<< HEAD
   if not (setIsSubsetEq eqv accS s) then error "Some accepted states do not exist"
   else if not (setMem eqv startS s) then error "The start state does not exist"
   else true
@@ -86,6 +87,35 @@ let nfaAddTransition = lam nfa. lam trans.
 -- returns true if state s is an accepted state in the nfa
 let nfaIsAcceptedState = lam s. lam nfa.
   setMem nfa.graph.eqv s nfa.acceptStates
+=======
+    if not (setIsSubsetEq eqv accS s) then error "Some accepted states do not exist"
+        else if not (setMem eqv startS s) then error "The start state does not exist"
+        else true
+
+-- States are represented by vertices in a directed graph
+let nfaAddState =  lam nfa. lam state.
+    {
+        graph = (digraphAddVertex state nfa.graph),
+        startState = nfa.startState,
+        acceptStates = nfa.acceptStates
+    }
+
+-- Transitions between two states are represented by edges between vertices
+let nfaAddTransition = lam nfa. lam trans.
+    let states = getStates nfa in
+    let from = trans.0 in
+    let to = trans.1 in
+    let label = trans.2 in
+    {
+        graph = (digraphAddEdge from to label nfa.graph),
+        startState = nfa.startState,
+        acceptStates = nfa.acceptStates
+    }
+
+-- returns true if state s is an accepted state in the nfa
+let nfaIsAcceptedState = lam s. lam nfa.
+    setMem nfa.graph.eqv s nfa.acceptStates
+>>>>>>> DFA/NFA: Clean up whitespace and make alphabet implicit
 
 -- check if there is a transition with label lbl from state s
 let nfaStateHasTransition = lam s. lam trans. lam lbl.
@@ -138,6 +168,7 @@ end
 
 -- constructor for the NFA
 let nfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
+<<<<<<< HEAD
   if nfaCheckValues trans s eqv eql accS startS then
   let emptyDigraph = digraphEmpty eqv eql in
   let initNfa = {
@@ -147,6 +178,53 @@ let nfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
   } in
   foldl nfaAddTransition (foldl nfaAddState initNfa s) trans
   else {}
+=======
+    if nfaCheckValues trans s eqv eql accS startS then
+    let emptyDigraph = digraphEmpty eqv eql in
+    let initNfa = {
+        graph = emptyDigraph,
+        startState = startS,
+        acceptStates = accS
+    } in
+    foldl nfaAddTransition (foldl nfaAddState initNfa s) trans
+    else {}
+
+let printList = lam list.
+    map (lam x. print x) list
+
+let nfaPrintDotWithStates = lam nfa. lam v2str. lam l2str. lam direction. lam activeState.
+    let eqv = getEqv nfa in
+    let edges = getTransitions nfa in
+    let vertices = getStates nfa in
+    let _ = print "digraph {" in
+    let _ = printList ["rankdir=", direction, ";\n"] in
+    let _ = printList ["node [style=filled fillcolor=white shape=circle];"] in
+    let _ = map
+        (lam v.
+            let _ = print (v2str v) in
+            let dbl = (if (any (lam x. eqv x v) nfa.acceptStates) then "shape=doublecircle " else "") in
+            let active = match activeState with () then "" else (
+                if (eqv v activeState) then "fillcolor=darkgreen color=darkgreen fontcolor = white" else ""
+            ) in
+            printList ["[", dbl, active, "];"])
+        vertices in
+    let _ = print "start [fontcolor = white color = white];\n" in
+    let _ = printList ["start -> ", v2str nfa.startState, "[label=start];"] in
+    let eqEdge = (lam a. lam b. if and (eqv a.0 b.0) (eqv a.1 b.1) then true else false) in
+    let _ = map
+        (lam e.
+            let _ = print (v2str e.0) in
+            let _ = print " -> " in
+            let _ = print (v2str e.1) in
+            let _ = print "[label=\"" in
+            let _ = print (l2str e.2) in
+            print "\"];")
+        edges in
+    let _ = print "}\n" in ()
+
+let nfaPrintDot = lam nfa. lam v2str. lam l2str. lam direction.
+    nfaPrintDotWithStates nfa v2str l2str direction ()
+>>>>>>> DFA/NFA: Clean up whitespace and make alphabet implicit
 
 mexpr
 let states = [0,1,2] in
@@ -187,6 +265,7 @@ utest nfaMakeInputPath (negi 1) newNfa.startState "0110" newNfa with
   [{status = "stuck",state = 0,index = negi 1}] in
 -- Input of length 0
 utest nfaMakeInputPath (negi 1) newNfa.startState "" newNfa with
+<<<<<<< HEAD
   [{status = "not accepted",state = 0,index = negi 1}] in
 -- Accepted, after branch got stuck.
  utest nfaMakeInputPath (negi 1) newNfa2.startState "11" newNfa2 with
@@ -200,4 +279,19 @@ utest nfaMakeInputPath (negi 1) newNfa3.startState "11" newNfa3 with
   [{status = "",state = 0,index = (negi 1)},
   {status = "",state = 1,index = 0},
   {status = "accepted",state = 3,index = 1}] in
+=======
+    [{status = "not accepted",state = 0,index = negi 1}] in
+-- Accepted, after branch got stuck.
+ utest nfaMakeInputPath (negi 1) newNfa2.startState "11" newNfa2 with
+    [{status = "",state = 0,index = (negi 1)},
+    {status = "",state = 1,index = 0},
+    {status = "not accepted", state = 3,index = 1},
+    {status = "",state = 1,index = 0},
+    {status = "accepted",state = 2,index = 1}] in
+-- Accepted, got accepted in the first branch (the second isn't)
+utest nfaMakeInputPath (negi 1) newNfa3.startState "11" newNfa3 with
+    [{status = "",state = 0,index = (negi 1)},
+    {status = "",state = 1,index = 0},
+    {status = "accepted",state = 3,index = 1}] in
+>>>>>>> DFA/NFA: Clean up whitespace and make alphabet implicit
 ()

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -59,7 +59,6 @@ let nfaOutStates = lam s. lam nfa.
 
 -- check that values are acceptable for the NFA
 let nfaCheckValues = lam trans. lam s. lam eqv. lam eql. lam accS. lam startS.
-<<<<<<< HEAD
   if not (setIsSubsetEq eqv accS s) then error "Some accepted states do not exist"
   else if not (setMem eqv startS s) then error "The start state does not exist"
   else true
@@ -87,35 +86,6 @@ let nfaAddTransition = lam nfa. lam trans.
 -- returns true if state s is an accepted state in the nfa
 let nfaIsAcceptedState = lam s. lam nfa.
   setMem nfa.graph.eqv s nfa.acceptStates
-=======
-    if not (setIsSubsetEq eqv accS s) then error "Some accepted states do not exist"
-        else if not (setMem eqv startS s) then error "The start state does not exist"
-        else true
-
--- States are represented by vertices in a directed graph
-let nfaAddState =  lam nfa. lam state.
-    {
-        graph = (digraphAddVertex state nfa.graph),
-        startState = nfa.startState,
-        acceptStates = nfa.acceptStates
-    }
-
--- Transitions between two states are represented by edges between vertices
-let nfaAddTransition = lam nfa. lam trans.
-    let states = getStates nfa in
-    let from = trans.0 in
-    let to = trans.1 in
-    let label = trans.2 in
-    {
-        graph = (digraphAddEdge from to label nfa.graph),
-        startState = nfa.startState,
-        acceptStates = nfa.acceptStates
-    }
-
--- returns true if state s is an accepted state in the nfa
-let nfaIsAcceptedState = lam s. lam nfa.
-    setMem nfa.graph.eqv s nfa.acceptStates
->>>>>>> DFA/NFA: Clean up whitespace and make alphabet implicit
 
 -- check if there is a transition with label lbl from state s
 let nfaStateHasTransition = lam s. lam trans. lam lbl.
@@ -168,7 +138,6 @@ end
 
 -- constructor for the NFA
 let nfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
-<<<<<<< HEAD
   if nfaCheckValues trans s eqv eql accS startS then
   let emptyDigraph = digraphEmpty eqv eql in
   let initNfa = {
@@ -178,57 +147,10 @@ let nfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
   } in
   foldl nfaAddTransition (foldl nfaAddState initNfa s) trans
   else {}
-=======
-    if nfaCheckValues trans s eqv eql accS startS then
-    let emptyDigraph = digraphEmpty eqv eql in
-    let initNfa = {
-        graph = emptyDigraph,
-        startState = startS,
-        acceptStates = accS
-    } in
-    foldl nfaAddTransition (foldl nfaAddState initNfa s) trans
-    else {}
 
 -- Create an NFA from a Digraph
 let nfaFromDigraph = lam g. lam startS. lam accS.
   nfaConstr (digraphVertices g) (digraphEdges g) startS accS (digraphEqv g) (digraphEql g)
-
-let printList = lam list.
-    map (lam x. print x) list
-
-let nfaPrintDotWithStates = lam nfa. lam v2str. lam l2str. lam direction. lam activeState.
-    let eqv = getEqv nfa in
-    let edges = getTransitions nfa in
-    let vertices = getStates nfa in
-    let _ = print "digraph {" in
-    let _ = printList ["rankdir=", direction, ";\n"] in
-    let _ = printList ["node [style=filled fillcolor=white shape=circle];"] in
-    let _ = map
-        (lam v.
-            let _ = print (v2str v) in
-            let dbl = (if (any (lam x. eqv x v) nfa.acceptStates) then "shape=doublecircle " else "") in
-            let active = match activeState with () then "" else (
-                if (eqv v activeState) then "fillcolor=darkgreen color=darkgreen fontcolor = white" else ""
-            ) in
-            printList ["[", dbl, active, "];"])
-        vertices in
-    let _ = print "start [fontcolor = white color = white];\n" in
-    let _ = printList ["start -> ", v2str nfa.startState, "[label=start];"] in
-    let eqEdge = (lam a. lam b. if and (eqv a.0 b.0) (eqv a.1 b.1) then true else false) in
-    let _ = map
-        (lam e.
-            let _ = print (v2str e.0) in
-            let _ = print " -> " in
-            let _ = print (v2str e.1) in
-            let _ = print "[label=\"" in
-            let _ = print (l2str e.2) in
-            print "\"];")
-        edges in
-    let _ = print "}\n" in ()
-
-let nfaPrintDot = lam nfa. lam v2str. lam l2str. lam direction.
-    nfaPrintDotWithStates nfa v2str l2str direction ()
->>>>>>> DFA/NFA: Clean up whitespace and make alphabet implicit
 
 mexpr
 let states = [0,1,2] in
@@ -269,7 +191,6 @@ utest nfaMakeInputPath (negi 1) newNfa.startState "0110" newNfa with
   [{status = "stuck",state = 0,index = negi 1}] in
 -- Input of length 0
 utest nfaMakeInputPath (negi 1) newNfa.startState "" newNfa with
-<<<<<<< HEAD
   [{status = "not accepted",state = 0,index = negi 1}] in
 -- Accepted, after branch got stuck.
  utest nfaMakeInputPath (negi 1) newNfa2.startState "11" newNfa2 with
@@ -283,19 +204,4 @@ utest nfaMakeInputPath (negi 1) newNfa3.startState "11" newNfa3 with
   [{status = "",state = 0,index = (negi 1)},
   {status = "",state = 1,index = 0},
   {status = "accepted",state = 3,index = 1}] in
-=======
-    [{status = "not accepted",state = 0,index = negi 1}] in
--- Accepted, after branch got stuck.
- utest nfaMakeInputPath (negi 1) newNfa2.startState "11" newNfa2 with
-    [{status = "",state = 0,index = (negi 1)},
-    {status = "",state = 1,index = 0},
-    {status = "not accepted", state = 3,index = 1},
-    {status = "",state = 1,index = 0},
-    {status = "accepted",state = 2,index = 1}] in
--- Accepted, got accepted in the first branch (the second isn't)
-utest nfaMakeInputPath (negi 1) newNfa3.startState "11" newNfa3 with
-    [{status = "",state = 0,index = (negi 1)},
-    {status = "",state = 1,index = 0},
-    {status = "accepted",state = 3,index = 1}] in
->>>>>>> DFA/NFA: Clean up whitespace and make alphabet implicit
 ()

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -189,6 +189,10 @@ let nfaConstr = lam s. lam trans. lam startS. lam accS. lam eqv. lam eql.
     foldl nfaAddTransition (foldl nfaAddState initNfa s) trans
     else {}
 
+-- Create an NFA from a Digraph
+let nfaFromDigraph = lam g. lam startS. lam accS.
+  nfaConstr (digraphVertices g) (digraphEdges g) startS accS (digraphEqv g) (digraphEql g)
+
 let printList = lam list.
     map (lam x. print x) list
 

--- a/stdlib/regex.mc
+++ b/stdlib/regex.mc
@@ -67,7 +67,7 @@ recursive let simplifyS = lam reg.
   match reg with Concat(Epsilon (), r) | Concat(r, Epsilon ()) then simplifyS r else
   match reg with Union(Empty (), r) | Union(r, Empty ()) then simplifyS r else
 
-  match reg with Symbol _ then reg else
+  match reg with Empty () | Epsilon () | Symbol _ then reg else
   match reg with Union (r1, r2) then Union (simplifyS r1, simplifyS r2) else
   match reg with Concat (r1, r2) then Concat (simplifyS r1, simplifyS r2) else
   match reg with Kleene r then Kleene (simplifyS r) else

--- a/stdlib/regex.mc
+++ b/stdlib/regex.mc
@@ -43,7 +43,6 @@ let eqr = lam eqs. lam re1. lam re2.
       (match re2 with Concat (w1, w2) then and (eqrAux r1 w1) (eqrAux r2 w2) else false)
     else
     match re1 with Kleene r then (match re2 with Kleene w then eqrAux r w else false) else
-    utest re1 with [] in
     error ("Not eqr of a RegEx")
 in eqrAux re1 re2
 


### PR DESCRIPTION
This PR changes how execution path analysis is done for decision points. It now uses a regular expression that describes the possible paths in the call graph from a given set of start nodes. The main reason for these changes is working towards applying decision points on libraries, where there are many possible entry points.

Moreover, it adds:
- Some bug fixes in regex.mc
- Documentation for digraph.mc