### PR TITLE
Add random number generation intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ containing `utest` expressions. Please see the following files:
 
 * [Symbol intrinsics](test/mexpr/symbs.mc)
 
+* [Random number generation intrinsics](test/mexpr/random.mc)
+
 Besides the intrinsic functions, the prelude includes a number of functions defined in the MCore standard library, which can be found in the folder [stdlib](stdlib/). The main file [prelude.mc](stdlib/prelude.mc) is automatically included in all `.mc` files. Note also that the prelude file includes other files, e.g., [seq.mc](stdlib/seq.mc) and [option.mc](stdlib/option.mc). For the details of these prelude functions, please see the above files.
 
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -97,6 +97,7 @@ and const =
 | Creverse
 (* MCore intrinsic: random numbers *)
 | CrandIntU of int option
+| CrandSetSeed
 (* MCore debug and I/O intrinsics *)
 | Cprint
 | Cdprint

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -96,7 +96,7 @@ and const =
 | CsplitAt of (tm Mseq.t) option
 | Creverse
 (* MCore intrinsic: random numbers *)
-| CrandInt
+| CrandIntU
 (* MCore debug and I/O intrinsics *)
 | Cprint
 | Cdprint

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -95,6 +95,8 @@ and const =
 | Csnoc    of (tm Mseq.t) option
 | CsplitAt of (tm Mseq.t) option
 | Creverse
+(* MCore intrinsic: random numbers *)
+| CrandInt
 (* MCore debug and I/O intrinsics *)
 | Cprint
 | Cdprint

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -96,7 +96,7 @@ and const =
 | CsplitAt of (tm Mseq.t) option
 | Creverse
 (* MCore intrinsic: random numbers *)
-| CrandIntU
+| CrandIntU of int option
 (* MCore debug and I/O intrinsics *)
 | Cprint
 | Cdprint

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -64,6 +64,7 @@ let builtin =
    ("error",f(Cerror));
    ("exit",f(Cexit));
    ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym));
+   ("randInt", f(CrandInt));
   ]
   (* Append external functions TODO: Should not be part of core language *)
   @ Ext.externals
@@ -153,6 +154,8 @@ let arity = function
   | CPy v -> Pyffi.arity v
   (* External functions TODO: Should not be bart of core language *)
   | CExt v            -> Ext.arity v
+  (* MCore intrinsic: random numbers *)
+  | CrandInt          -> 1
 
 
 (* API for generating unique symbol ids *)
@@ -160,6 +163,11 @@ let symid = ref 0
 let gen_symid _ =
   symid := !symid + 1;
   !symid
+
+(* Random number generation *)
+let rand_int bound =
+  Random.self_init ();
+  Random.int bound
 
 let fail_constapp f v fi = raise_error fi ("Incorrect application. function: "
                                          ^ Ustring.to_utf8
@@ -379,6 +387,10 @@ let delta eval env fi c v  =
 
     | Creverse,TmSeq(fi,s) -> TmSeq(fi,Mseq.reverse s)
     | Creverse,_ -> fail_constapp fi
+
+    (* MCore intrinsic: random numbers *)
+    | CrandInt, TmConst(fi, CInt(v)) -> TmConst(fi, CInt(rand_int v))
+    | CrandInt,_ -> fail_constapp fi
 
     (* MCore debug and stdio intrinsics *)
     | Cprint, TmSeq(fi,lst) ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -152,7 +152,7 @@ let arity = function
   | Ceqs(Some(_)) -> 1
   (* Python intrinsics *)
   | CPy v -> Pyffi.arity v
-  (* External functions TODO: Should not be bart of core language *)
+  (* External functions TODO: Should not be part of core language *)
   | CExt v            -> Ext.arity v
   (* MCore intrinsic: random numbers *)
   | CrandIntU         -> 1

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -64,7 +64,7 @@ let builtin =
    ("error",f(Cerror));
    ("exit",f(Cexit));
    ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym));
-   ("randInt", f(CrandInt));
+   ("randIntU", f(CrandIntU));
   ]
   (* Append external functions TODO: Should not be part of core language *)
   @ Ext.externals
@@ -155,7 +155,7 @@ let arity = function
   (* External functions TODO: Should not be bart of core language *)
   | CExt v            -> Ext.arity v
   (* MCore intrinsic: random numbers *)
-  | CrandInt          -> 1
+  | CrandIntU         -> 1
 
 
 (* API for generating unique symbol ids *)
@@ -389,8 +389,8 @@ let delta eval env fi c v  =
     | Creverse,_ -> fail_constapp fi
 
     (* MCore intrinsic: random numbers *)
-    | CrandInt, TmConst(fi, CInt(v)) -> TmConst(fi, CInt(rand_int v))
-    | CrandInt,_ -> fail_constapp fi
+    | CrandIntU, TmConst(fi, CInt(v)) -> TmConst(fi, CInt(rand_int v))
+    | CrandIntU,_ -> fail_constapp fi
 
     (* MCore debug and stdio intrinsics *)
     | Cprint, TmSeq(fi,lst) ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -220,6 +220,7 @@ let rec print_const fmt = function
 
   (* MCore intrinsic: random numbers *)
   | CrandIntU(_) -> fprintf fmt "randIntU"
+  | CrandSetSeed -> fprintf fmt "randSetSeed"
 
   (* MCore debug and stdio intrinsics *)
   | Cprint        -> fprintf fmt "print"

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -219,7 +219,7 @@ let rec print_const fmt = function
   | Creverse    -> fprintf fmt "reverse"
 
   (* MCore intrinsic: random numbers *)
-  | CrandInt -> fprintf fmt "randInt"
+  | CrandIntU -> fprintf fmt "randIntU"
 
   (* MCore debug and stdio intrinsics *)
   | Cprint        -> fprintf fmt "print"

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -218,6 +218,9 @@ let rec print_const fmt = function
   | CsplitAt(_) -> fprintf fmt "splitAt"
   | Creverse    -> fprintf fmt "reverse"
 
+  (* MCore intrinsic: random numbers *)
+  | CrandInt -> fprintf fmt "randInt"
+
   (* MCore debug and stdio intrinsics *)
   | Cprint        -> fprintf fmt "print"
   | Cdprint       -> fprintf fmt "dprint"

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -219,7 +219,7 @@ let rec print_const fmt = function
   | Creverse    -> fprintf fmt "reverse"
 
   (* MCore intrinsic: random numbers *)
-  | CrandIntU -> fprintf fmt "randIntU"
+  | CrandIntU(_) -> fprintf fmt "randIntU"
 
   (* MCore debug and stdio intrinsics *)
   | Cprint        -> fprintf fmt "print"

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -1,0 +1,17 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test intrinsics for random numbers
+
+include "seq.mc"
+include "set.mc"
+
+mexpr
+
+-- 'randInt bound' generates a random number in the interval [0,bound)
+-- type: Int -> Int
+let randSeq = map (lam _. randInt 5) (makeSeq 1000 0) in
+-- With high probability all possible elements are present in the random sequence
+utest setIsSubsetEq eqi [0,1,2,3,4] randSeq with true in
+
+()

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -8,11 +8,29 @@ include "set.mc"
 
 mexpr
 
--- 'randIntU l u' generates a random number from a uniform distribution in the
--- interval [l,u)
--- type: Int -> Int
-let randSeq = map (lam _. randIntU 2 7) (makeSeq 1000 0) in
+-- randIntU l u : Int -> Int
+-- Generates a random number from a uniform distribution in the interval [l,u).
+-- Self-initializes the random generator if not already set by randSetSeed.
+
+-- randSetSeed s : Int -> ()
+-- Seeds the random generator. The same seeds generates the same sequence of numbers.
+
+-- Generate a sequence of random numbers
+let randSeq = lam lower. lam upper. lam length.
+  map (lam _. randIntU lower upper) (makeSeq length 0) in
+
 -- With high probability all possible elements are present in the random sequence
-utest setEqual eqi [2,3,4,5,6] (distinct eqi randSeq) with true in
+utest setEqual eqi [2,3,4,5,6] (distinct eqi (randSeq 2 7 1000)) with true in
+
+-- The same seed should give the same sequence of numbers
+let _ = randSetSeed 42 in
+let randSeq1 = randSeq 123 89018 100 in
+let _ = randSetSeed 42 in
+let randSeq2 = randSeq 123 89018 100 in
+utest setEqual eqi randSeq1 randSeq2 with true in
+
+-- With high probability, subsequent sequence should be different
+let randSeq3 = randSeq 123 89018 100 in
+utest setEqual eqi randSeq1 randSeq3 with false in
 
 ()

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -8,9 +8,10 @@ include "set.mc"
 
 mexpr
 
--- 'randInt bound' generates a random number in the interval [0,bound)
+-- 'randIntU bound' generates a random number from a uniform distribution in the
+-- interval [0,bound)
 -- type: Int -> Int
-let randSeq = map (lam _. randInt 5) (makeSeq 1000 0) in
+let randSeq = map (lam _. randIntU 5) (makeSeq 1000 0) in
 -- With high probability all possible elements are present in the random sequence
 utest setEqual eqi [0,1,2,3,4] (distinct eqi randSeq) with true in
 

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -12,6 +12,6 @@ mexpr
 -- type: Int -> Int
 let randSeq = map (lam _. randInt 5) (makeSeq 1000 0) in
 -- With high probability all possible elements are present in the random sequence
-utest setIsSubsetEq eqi [0,1,2,3,4] randSeq with true in
+utest setEqual eqi [0,1,2,3,4] (distinct eqi randSeq) with true in
 
 ()

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -8,11 +8,11 @@ include "set.mc"
 
 mexpr
 
--- randIntU l u : Int -> Int
--- Generates a random number from a uniform distribution in the interval [l,u).
+-- 'randIntU l u : Int -> Int'
+-- Generates a random number from a uniform distribution in the interval ['l','u').
 -- Self-initializes the random generator if not already set by randSetSeed.
 
--- randSetSeed s : Int -> ()
+-- 'randSetSeed s : Int -> Unit'
 -- Seeds the random generator. The same seeds generates the same sequence of numbers.
 
 -- Generate a sequence of random numbers

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -8,11 +8,11 @@ include "set.mc"
 
 mexpr
 
--- 'randIntU bound' generates a random number from a uniform distribution in the
--- interval [0,bound)
+-- 'randIntU l u' generates a random number from a uniform distribution in the
+-- interval [l,u)
 -- type: Int -> Int
-let randSeq = map (lam _. randIntU 5) (makeSeq 1000 0) in
+let randSeq = map (lam _. randIntU 2 7) (makeSeq 1000 0) in
 -- With high probability all possible elements are present in the random sequence
-utest setEqual eqi [0,1,2,3,4] (distinct eqi randSeq) with true in
+utest setEqual eqi [2,3,4,5,6] (distinct eqi randSeq) with true in
 
 ()


### PR DESCRIPTION
This PR adds an intrinsic function `randIntU` to boot, such that ~`randInt b`~ `randIntU a b` returns a random number between ~0~`a` (inclusive) and `b` (exclusive). 

Edit: the intrinsic `randSetSeed s` seeds the random generator, so that the same seed always generates the same sequence of numbers. If `randSetSeed` is not called, `randIntU` sets a seed automatically.