### PR TITLE
Remove bash style syntax from make script

### DIFF
--- a/make
+++ b/make
@@ -55,10 +55,10 @@ runtests() {
     cd ..
     export MCORE_STDLIB='@@@'
     build/mi test stdlib)
-    if [[ -n $MI_TEST_PYTHON ]]; then
+    if [ -n "$MI_TEST_PYTHON" ]; then
         runtests_py
     fi
-    if [[ -n $MI_TEST_SUNDIALS ]]; then
+    if [ -n "$MI_TEST_SUNDIALS" ]; then
         runtests_ext
     fi
 }


### PR DESCRIPTION
Removes the bash style syntax on the if-statements for checking whether to run the sundials and/or python tests.