### PR TITLE
New name and symtable libraries

### DIFF
--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -1,0 +1,128 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- The name library implements an approach to name handling
+-- where a name both has a string and a symbol representation.
+-- This library is typically used for variable handling
+-- and name binding. It is also used in the 'symtable.mc'
+-- library.
+
+include "string.mc"
+include "seq.mc"
+
+type Name = (String,Symbol)
+
+-- We use the private  _noNymbol instead of an option type
+-- for performance reason (no taggig).
+let _noSymbol = gensym()
+
+
+-- 'name x' constructs a new name with string 'x'. The
+-- returned name does not contain a symbol
+let name : String -> Name =
+  lam x. (x,_noSymbol)
+
+utest name "foo" with name "foo"
+
+
+-- 'nameSym x' constructs a new name with string 'x' together
+-- with a fresh symbol
+let nameSym : String -> Name =
+  lam x. (x,gensym())
+
+let _t = nameSym "foo"
+utest _t with _t
+
+
+-- 'nameEqSym n1 n2' returns true if both names 'n1' and 'n2'
+-- contain the same symbol or if none of them has a symbol.
+-- If not, the function returns false.
+let nameEqSym : Name -> Name -> Bool =
+  lam n1. lam n2. eqs n1.1 n2.1
+
+let _t1 = name "foo"
+let _t2 = nameSym "foo"
+let _t3 = nameSym "foo"
+utest nameEqSym _t1 _t1 with true
+utest nameEqSym _t2 _t2 with true
+utest nameEqSym _t1 _t2 with false
+utest nameEqSym _t2 _t3 with false
+
+
+-- 'nameEqStr n1 n2' returns true if both names 'n1' and 'n2'
+-- contain the same string, else false.
+let nameEqStr : Name -> Name -> Bool =
+  lam n1. lam n2. eqstr n1.0 n2.0
+
+let _t1 = name "foo"
+let _t2 = nameSym "foo"
+let _t3 = nameSym "bar"
+utest nameEqStr _t1 _t1 with true
+utest nameEqStr _t1 _t2 with true
+utest nameEqStr _t2 _t3 with false
+utest nameEqStr _t1 _t3 with false
+
+
+-- 'nameHasSym n' returns true if name 'n' has a
+-- symbol, else it returns false.
+let nameHasSym : Name -> Bool =
+  lam n. not (eqs n.1 _noSymbol)
+
+utest nameHasSym (nameSym "foo") with true
+utest nameHasSym (name "foo") with false
+
+
+-- 'nameSetNewSym n' returns a new name with a fresh symbol.
+-- The returned name contains the same string as 'n'.
+let nameSetNewSym : Name -> Name =
+  lam n. (n.0, gensym())
+
+let _t1 = name "foo"
+let _t2 = nameSym "foo"
+utest nameEqStr _t1 (nameSetNewSym _t1) with true
+utest nameEqSym _t1 (nameSetNewSym _t1) with false
+utest nameEqStr _t2 (nameSetNewSym _t2) with true
+utest nameEqSym _t2 (nameSetNewSym _t2) with false
+
+
+-- 'nameSetSym n s' returns a name with the same string as 'n'
+-- but with symbol 's'.
+let nameSetSym : Name -> Symbol -> Name =
+  lam n. lam s. (n.0,s)
+
+let _t1 = name "foo"
+let _t2 = nameSym "foo"
+let _s = gensym()
+utest nameEqSym _t2 (nameSetSym _t1 _s) with false
+utest nameEqSym (nameSetSym _t2 _s) (nameSetSym _t1 _s) with true
+
+
+-- 'nameSetStr n str' returns a new name with string 'str' and
+-- with the symbol of 'n', if it has a symbol.
+let nameSetStr : Name -> String -> Name =
+  lam n. lam str. (str,n.1)
+
+let _t1 = name "foo"
+let _t2 = nameSym "bar"
+utest nameEqStr (nameSetStr _t1 "bar") _t2 with true
+utest nameEqStr (nameSetStr _t1 "bar") _t1 with false
+utest nameEqStr (nameSetStr _t2 "foo") _t1 with true
+
+
+-- 'nameGetStr n' returns the string of name 'n'
+let nameGetStr : Name -> String =
+  lam n. n.0
+
+utest nameGetStr (name "foo") with "foo"
+utest nameGetStr (nameSym "foo") with "foo"
+
+
+-- 'nameGetSym n' returns optionally the symbol of name 'n'.
+-- If 'n' has no symbol, 'None' is returned.
+-- TODO: Update signature when we have polymorphic types.
+let nameGetSym : Name -> OptionSymbol =
+  lam n. if eqs n.1 _noSymbol then None() else Some n.1
+
+let _s = gensym()
+utest nameGetSym (name "foo") with None()
+utest nameGetSym (nameSetSym (name"foo") _s) with Some(_s)

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -10,25 +10,25 @@
 include "string.mc"
 include "seq.mc"
 
-type Name = (String,Symbol)
+type Name = (String, Symbol)
 
--- We use the private  _noNymbol instead of an option type
--- for performance reason (no taggig).
-let _noSymbol = gensym()
+-- We use the private _noNymbol instead of an option type
+-- for performance reason (no tagging).
+let _noSymbol = gensym ()
 
 
--- 'name x' constructs a new name with string 'x'. The
--- returned name does not contain a symbol
-let name : String -> Name =
-  lam x. (x,_noSymbol)
+-- 'nameNoSym x' constructs a new name with string 'x'. The
+-- returned name does not contain a symbol.
+let nameNoSym : String -> Name =
+  lam x. (x, _noSymbol)
 
-utest name "foo" with name "foo"
+utest nameNoSym "foo" with nameNoSym "foo"
 
 
 -- 'nameSym x' constructs a new name with string 'x' together
 -- with a fresh symbol
 let nameSym : String -> Name =
-  lam x. (x,gensym())
+  lam x. (x, gensym ())
 
 let _t = nameSym "foo"
 utest _t with _t
@@ -40,7 +40,7 @@ utest _t with _t
 let nameEqSym : Name -> Name -> Bool =
   lam n1. lam n2. eqs n1.1 n2.1
 
-let _t1 = name "foo"
+let _t1 = nameNoSym "foo"
 let _t2 = nameSym "foo"
 let _t3 = nameSym "foo"
 utest nameEqSym _t1 _t1 with true
@@ -54,7 +54,7 @@ utest nameEqSym _t2 _t3 with false
 let nameEqStr : Name -> Name -> Bool =
   lam n1. lam n2. eqstr n1.0 n2.0
 
-let _t1 = name "foo"
+let _t1 = nameNoSym "foo"
 let _t2 = nameSym "foo"
 let _t3 = nameSym "bar"
 utest nameEqStr _t1 _t1 with true
@@ -69,15 +69,15 @@ let nameHasSym : Name -> Bool =
   lam n. not (eqs n.1 _noSymbol)
 
 utest nameHasSym (nameSym "foo") with true
-utest nameHasSym (name "foo") with false
+utest nameHasSym (nameNoSym "foo") with false
 
 
 -- 'nameSetNewSym n' returns a new name with a fresh symbol.
 -- The returned name contains the same string as 'n'.
 let nameSetNewSym : Name -> Name =
-  lam n. (n.0, gensym())
+  lam n. (n.0, gensym ())
 
-let _t1 = name "foo"
+let _t1 = nameNoSym "foo"
 let _t2 = nameSym "foo"
 utest nameEqStr _t1 (nameSetNewSym _t1) with true
 utest nameEqSym _t1 (nameSetNewSym _t1) with false
@@ -88,11 +88,11 @@ utest nameEqSym _t2 (nameSetNewSym _t2) with false
 -- 'nameSetSym n s' returns a name with the same string as 'n'
 -- but with symbol 's'.
 let nameSetSym : Name -> Symbol -> Name =
-  lam n. lam s. (n.0,s)
+  lam n. lam s. (n.0, s)
 
-let _t1 = name "foo"
+let _t1 = nameNoSym "foo"
 let _t2 = nameSym "foo"
-let _s = gensym()
+let _s = gensym ()
 utest nameEqSym _t2 (nameSetSym _t1 _s) with false
 utest nameEqSym (nameSetSym _t2 _s) (nameSetSym _t1 _s) with true
 
@@ -100,9 +100,9 @@ utest nameEqSym (nameSetSym _t2 _s) (nameSetSym _t1 _s) with true
 -- 'nameSetStr n str' returns a new name with string 'str' and
 -- with the symbol of 'n', if it has a symbol.
 let nameSetStr : Name -> String -> Name =
-  lam n. lam str. (str,n.1)
+  lam n. lam str. (str, n.1)
 
-let _t1 = name "foo"
+let _t1 = nameNoSym "foo"
 let _t2 = nameSym "bar"
 utest nameEqStr (nameSetStr _t1 "bar") _t2 with true
 utest nameEqStr (nameSetStr _t1 "bar") _t1 with false
@@ -113,7 +113,7 @@ utest nameEqStr (nameSetStr _t2 "foo") _t1 with true
 let nameGetStr : Name -> String =
   lam n. n.0
 
-utest nameGetStr (name "foo") with "foo"
+utest nameGetStr (nameNoSym "foo") with "foo"
 utest nameGetStr (nameSym "foo") with "foo"
 
 
@@ -121,8 +121,8 @@ utest nameGetStr (nameSym "foo") with "foo"
 -- If 'n' has no symbol, 'None' is returned.
 -- TODO: Update signature when we have polymorphic types.
 let nameGetSym : Name -> OptionSymbol =
-  lam n. if eqs n.1 _noSymbol then None() else Some n.1
+  lam n. if eqs n.1 _noSymbol then None () else Some n.1
 
-let _s = gensym()
-utest nameGetSym (name "foo") with None()
-utest nameGetSym (nameSetSym (name"foo") _s) with Some(_s)
+let _s = gensym ()
+utest nameGetSym (nameNoSym "foo") with None ()
+utest nameGetSym (nameSetSym (nameNoSym "foo") _s) with Some _s

--- a/stdlib/symtable.mc
+++ b/stdlib/symtable.mc
@@ -1,0 +1,72 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- This library implements a symbol table. The
+-- implementation is based on the Name module 'name.mc'
+
+
+include "name.mc"
+include "seq.mc"
+
+type SymTable = [Name]
+
+
+-- Defines an empty symbol table
+let symtableEmpty = []
+
+
+-- 'symtableAdd n t' returns a record  '{name:Name,table:SymTable)' where
+-- field 'table' has been extended with name 'n' if it did not
+-- already exist in 't'. If the string of 'n' existed, then
+-- the returned table is the same as table 't'. In both cases,
+-- field 'name' has the string of 'n' with a unique symbol.
+let symtableAdd : Name -> SymTable -> {name: Name, table: SymTable} =
+  lam n. lam t.
+    match find (nameEqStr n) t with Some n2 then
+      {name = n2, table = t}
+    else
+      let n2 = nameSetNewSym n in
+      {name = n2, table = cons n2 t}
+
+let _r1 = symtableAdd (name "foo") []
+let _r2 = symtableAdd (name "bar") _r1.table
+let _r3 = symtableAdd (name "foo") _r2.table
+utest nameEqStr (_r1.name) (name "foo") with true
+utest nameEqStr (_r2.name) (name "bar") with true
+utest nameEqStr (_r3.name) (name "foo") with true
+utest nameEqStr (_r3.name) (name "else") with false
+
+
+-- 'symbtableMem n t' returns true if the string of 'n'
+-- exists in table 't'.
+let symtableMem : Name -> SymTable -> Bool =
+  lam n. lam t.
+    any (nameEqStr n) t
+
+utest symtableMem (name "foo") _r1.table with true
+utest symtableMem (name "foo") _r3.table with true
+utest symtableMem (name "bar") _r3.table with true
+utest symtableMem (name "else") _r3.table with false
+
+
+-- 'symtableSize t' returns the number of names in
+-- the symbol table 't'.
+let symtableSize : SymTable -> Int =
+  lam t. length t
+
+utest symtableSize symtableEmpty with 0
+utest symtableSize _r1.table with 1
+utest symtableSize _r2.table with 2
+utest symtableSize _r3.table with 2
+
+
+-- 'symtableRemove n t' returns a new table where names with strings
+-- equal to the string of 'n' are removed from 't'.
+let symtableRemove : Name -> Symtable -> Symtable =
+  lam n. lam t.
+    filter (lam n2. not (nameEqStr n n2)) t
+
+utest symtableMem (name "foo") _r3.table with true
+utest symtableMem (name "foo") (symtableRemove (name "foo") _r3.table) with false
+utest symtableSize (symtableRemove (name "foo") _r3.table) with 1
+utest symtableSize (symtableRemove (name "nothing") _r3.table) with 2

--- a/stdlib/symtable.mc
+++ b/stdlib/symtable.mc
@@ -2,7 +2,7 @@
 -- Copyright (C) David Broman. See file LICENSE.txt
 --
 -- This library implements a symbol table. The
--- implementation is based on the Name module 'name.mc'
+-- implementation is based on  module 'name.mc'.
 
 
 include "name.mc"
@@ -15,7 +15,7 @@ type SymTable = [Name]
 let symtableEmpty = []
 
 
--- 'symtableAdd n t' returns a record  '{name:Name,table:SymTable)' where
+-- 'symtableAdd n t' returns a record  '{name:Name, table:SymTable)' where
 -- field 'table' has been extended with name 'n' if it did not
 -- already exist in 't'. If the string of 'n' existed, then
 -- the returned table is the same as table 't'. In both cases,
@@ -28,13 +28,13 @@ let symtableAdd : Name -> SymTable -> {name: Name, table: SymTable} =
       let n2 = nameSetNewSym n in
       {name = n2, table = cons n2 t}
 
-let _r1 = symtableAdd (name "foo") []
-let _r2 = symtableAdd (name "bar") _r1.table
-let _r3 = symtableAdd (name "foo") _r2.table
-utest nameEqStr (_r1.name) (name "foo") with true
-utest nameEqStr (_r2.name) (name "bar") with true
-utest nameEqStr (_r3.name) (name "foo") with true
-utest nameEqStr (_r3.name) (name "else") with false
+let _r1 = symtableAdd (nameNoSym "foo") []
+let _r2 = symtableAdd (nameNoSym "bar") _r1.table
+let _r3 = symtableAdd (nameNoSym "foo") _r2.table
+utest nameEqStr (_r1.name) (nameNoSym "foo") with true
+utest nameEqStr (_r2.name) (nameNoSym "bar") with true
+utest nameEqStr (_r3.name) (nameNoSym "foo") with true
+utest nameEqStr (_r3.name) (nameNoSym "else") with false
 
 
 -- 'symbtableMem n t' returns true if the string of 'n'
@@ -43,10 +43,10 @@ let symtableMem : Name -> SymTable -> Bool =
   lam n. lam t.
     any (nameEqStr n) t
 
-utest symtableMem (name "foo") _r1.table with true
-utest symtableMem (name "foo") _r3.table with true
-utest symtableMem (name "bar") _r3.table with true
-utest symtableMem (name "else") _r3.table with false
+utest symtableMem (nameNoSym "foo") _r1.table with true
+utest symtableMem (nameNoSym "foo") _r3.table with true
+utest symtableMem (nameNoSym "bar") _r3.table with true
+utest symtableMem (nameNoSym "else") _r3.table with false
 
 
 -- 'symtableSize t' returns the number of names in
@@ -66,7 +66,7 @@ let symtableRemove : Name -> Symtable -> Symtable =
   lam n. lam t.
     filter (lam n2. not (nameEqStr n n2)) t
 
-utest symtableMem (name "foo") _r3.table with true
-utest symtableMem (name "foo") (symtableRemove (name "foo") _r3.table) with false
-utest symtableSize (symtableRemove (name "foo") _r3.table) with 1
-utest symtableSize (symtableRemove (name "nothing") _r3.table) with 2
+utest symtableMem (nameNoSym "foo") _r3.table with true
+utest symtableMem (nameNoSym "foo") (symtableRemove (nameNoSym "foo") _r3.table) with false
+utest symtableSize (symtableRemove (nameNoSym "foo") _r3.table) with 1
+utest symtableSize (symtableRemove (nameNoSym "nothing") _r3.table) with 2


### PR DESCRIPTION
This PR includes two new libraries for the Miking standard library: name.mc and symtable.mc.

The name library implements an approach to name handling where a name both has a string and a symbol representation. This library is typically used for variable handling and name binding. It is also used in the 'symtable.mc' library.

The symtable library implements a symbol table. The implementation is based on the Name module 'name.mc'
