### PR TITLE
Add readBytes intrinsic

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -105,6 +105,7 @@ and const =
 | Cprint
 | Cdprint
 | CreadLine
+| CreadBytes
 | CreadFile
 | CwriteFile of ustring option
 | CfileExists

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -105,7 +105,7 @@ and const =
 | Cprint
 | Cdprint
 | CreadLine
-| CreadBytes
+| CreadBytesAsString
 | CreadFile
 | CwriteFile of ustring option
 | CfileExists

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -51,7 +51,7 @@ let builtin =
    ("cons",f(Ccons(None)));("snoc",f(Csnoc(None)));
    ("splitAt",f(CsplitAt(None)));("reverse",f(Creverse));
    ("print",f(Cprint));("dprint",f(Cdprint));
-   ("readLine",f(CreadLine));("readBytes",f(CreadBytes));
+   ("readLine",f(CreadLine));("readBytesAsString",f(CreadBytesAsString));
    ("argv",TmSeq(NoInfo,argv_prog
                         |> Mseq.of_array
                         |> Mseq.map (fun s ->
@@ -142,16 +142,16 @@ let arity = function
   | CwallTimeMs       -> 1
   | CsleepMs          -> 1
   (* MCore debug and I/O intrinsics *)
-  | Cprint            -> 1
-  | Cdprint           -> 1
-  | CreadLine         -> 1
-  | CreadBytes        -> 1
-  | CreadFile         -> 1
-  | CwriteFile(None)  -> 2 | CwriteFile(Some(_)) -> 1
-  | CfileExists       -> 1
-  | CdeleteFile       -> 1
-  | Cerror            -> 1
-  | Cexit             -> 1
+  | Cprint             -> 1
+  | Cdprint            -> 1
+  | CreadLine          -> 1
+  | CreadBytesAsString -> 1
+  | CreadFile          -> 1
+  | CwriteFile(None)   -> 2 | CwriteFile(Some(_)) -> 1
+  | CfileExists        -> 1
+  | CdeleteFile        -> 1
+  | Cerror             -> 1
+  | Cexit              -> 1
   (* MCore symbols *)
   | CSymb(_)      -> 0
   | Cgensym      -> 1
@@ -441,9 +441,9 @@ let delta eval env fi c v  =
       TmSeq(fi, line |> Ustring.from_utf8 |> ustring2tmseq fi)
     | CreadLine,_ -> fail_constapp fi
 
-    | CreadBytes, TmConst(_, CInt(v)) ->
+    | CreadBytesAsString, TmConst(_, CInt(v)) ->
       if v < 0 then
-        raise_error fi "The argument to readBytes must be a positive integer"
+        raise_error fi "The argument to readBytesAsString must be a positive integer"
       else
         let str = try BatIO.nread BatIO.stdin v with BatIO.No_more_input -> "" in
         let ustr =
@@ -454,7 +454,7 @@ let delta eval env fi c v  =
           [ TmSeq(fi, ustring2tmseq fi ustr)
           ; TmConst(fi,CInt(String.length str))
           ]
-    | CreadBytes,_ -> fail_constapp fi
+    | CreadBytesAsString,_ -> fail_constapp fi
 
     | CreadFile,TmSeq(fi,lst) ->
        TmSeq(fi,Ustring.read_file (Ustring.to_utf8 (tmseq2ustring fi lst))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -229,6 +229,7 @@ let rec print_const fmt = function
   | Cprint        -> fprintf fmt "print"
   | Cdprint       -> fprintf fmt "dprint"
   | CreadLine     -> fprintf fmt "readLine"
+  | CreadBytes    -> fprintf fmt "readBytes"
   | CreadFile     -> fprintf fmt "readFile"
   | CwriteFile(_) -> fprintf fmt "writeFile"
   | CfileExists   -> fprintf fmt "fileExists"

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -226,16 +226,16 @@ let rec print_const fmt = function
   | CsleepMs -> fprintf fmt "sleepMs"
 
   (* MCore debug and stdio intrinsics *)
-  | Cprint        -> fprintf fmt "print"
-  | Cdprint       -> fprintf fmt "dprint"
-  | CreadLine     -> fprintf fmt "readLine"
-  | CreadBytes    -> fprintf fmt "readBytes"
-  | CreadFile     -> fprintf fmt "readFile"
-  | CwriteFile(_) -> fprintf fmt "writeFile"
-  | CfileExists   -> fprintf fmt "fileExists"
-  | CdeleteFile   -> fprintf fmt "deleteFile"
-  | Cerror        -> fprintf fmt "error"
-  | Cexit         -> fprintf fmt "exit"
+  | Cprint             -> fprintf fmt "print"
+  | Cdprint            -> fprintf fmt "dprint"
+  | CreadLine          -> fprintf fmt "readLine"
+  | CreadBytesAsString -> fprintf fmt "readBytesAsString"
+  | CreadFile          -> fprintf fmt "readFile"
+  | CwriteFile(_)      -> fprintf fmt "writeFile"
+  | CfileExists        -> fprintf fmt "fileExists"
+  | CdeleteFile        -> fprintf fmt "deleteFile"
+  | Cerror             -> fprintf fmt "error"
+  | Cexit              -> fprintf fmt "exit"
 
   (* MCore Symbols *)
   | CSymb(id) -> fprintf fmt "symb(%d)" id


### PR DESCRIPTION
This PR adds the intrinsic `readBytesAsString` which takes an integer `n` and reads up to `n` bytes from stdin and returns a tuple of type `(string, int)` containing the read bytes as a string and the number of bytes read.