### PR TITLE
[Suggestion] sym2hash intrinsic for converting a symbol to an integer

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -116,6 +116,7 @@ and const =
 | CSymb of int
 | Cgensym
 | Ceqs of int option
+| CSym2int
 (* External functions TODO: Should not be part of core language *)
 | CExt of tm Extast.ext
 | CPy of tm Pyast.ext

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -116,7 +116,7 @@ and const =
 | CSymb of int
 | Cgensym
 | Ceqs of int option
-| CSym2int
+| CSym2hash
 (* External functions TODO: Should not be part of core language *)
 | CExt of tm Extast.ext
 | CPy of tm Pyast.ext

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -64,7 +64,7 @@ let builtin =
    ("fileExists", f(CfileExists)); ("deleteFile", f(CdeleteFile));
    ("error",f(Cerror));
    ("exit",f(Cexit));
-   ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym)); ("sym2int", f(CSym2int));
+   ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym)); ("sym2hash", f(CSym2hash));
    ("randIntU", f(CrandIntU(None))); ("randSetSeed", f(CrandSetSeed));
    ("wallTimeMs",f(CwallTimeMs)); ("sleepMs",f(CsleepMs));
   ]
@@ -157,7 +157,7 @@ let arity = function
   | Cgensym      -> 1
   | Ceqs(None)    -> 2
   | Ceqs(Some(_)) -> 1
-  | CSym2int      -> 1
+  | CSym2hash      -> 1
   (* Python intrinsics *)
   | CPy v -> Pyffi.arity v
   (* External functions TODO: Should not be part of core language *)
@@ -485,8 +485,8 @@ let delta eval env fi c v  =
     | Ceqs(None), TmConst(fi,CSymb(id)) -> TmConst(fi, Ceqs(Some(id)))
     | Ceqs(Some(id)), TmConst(fi,CSymb(id')) -> TmConst(fi, CBool(id == id'))
     | Ceqs(_),_ -> fail_constapp fi
-    | CSym2int, TmConst(fi,CSymb(id)) -> TmConst(fi, CInt(id))
-    | CSym2int,_ -> fail_constapp fi
+    | CSym2hash, TmConst(fi,CSymb(id)) -> TmConst(fi, CInt(id))
+    | CSym2hash,_ -> fail_constapp fi
 
     | CPy v, t -> Pyffi.delta eval env fi v t
 

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -64,7 +64,7 @@ let builtin =
    ("fileExists", f(CfileExists)); ("deleteFile", f(CdeleteFile));
    ("error",f(Cerror));
    ("exit",f(Cexit));
-   ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym));
+   ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym)); ("sym2int", f(CSym2int));
    ("randIntU", f(CrandIntU(None))); ("randSetSeed", f(CrandSetSeed));
    ("wallTimeMs",f(CwallTimeMs)); ("sleepMs",f(CsleepMs));
   ]
@@ -157,6 +157,7 @@ let arity = function
   | Cgensym      -> 1
   | Ceqs(None)    -> 2
   | Ceqs(Some(_)) -> 1
+  | CSym2int      -> 1
   (* Python intrinsics *)
   | CPy v -> Pyffi.arity v
   (* External functions TODO: Should not be part of core language *)
@@ -484,6 +485,8 @@ let delta eval env fi c v  =
     | Ceqs(None), TmConst(fi,CSymb(id)) -> TmConst(fi, Ceqs(Some(id)))
     | Ceqs(Some(id)), TmConst(fi,CSymb(id')) -> TmConst(fi, CBool(id == id'))
     | Ceqs(_),_ -> fail_constapp fi
+    | CSym2int, TmConst(fi,CSymb(id)) -> TmConst(fi, CInt(id))
+    | CSym2int,_ -> fail_constapp fi
 
     | CPy v, t -> Pyffi.delta eval env fi v t
 

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -241,6 +241,7 @@ let rec print_const fmt = function
   | CSymb(id) -> fprintf fmt "symb(%d)" id
   | Cgensym   -> fprintf fmt "gensym"
   | Ceqs(_)   -> fprintf fmt "eqs"
+  | CSym2int  -> fprintf fmt "sym2int"
 
   (* Python intrinsics *)
   | CPy(v) -> fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -241,7 +241,7 @@ let rec print_const fmt = function
   | CSymb(id) -> fprintf fmt "symb(%d)" id
   | Cgensym   -> fprintf fmt "gensym"
   | Ceqs(_)   -> fprintf fmt "eqs"
-  | CSym2int  -> fprintf fmt "sym2int"
+  | CSym2hash  -> fprintf fmt "sym2hash"
 
   (* Python intrinsics *)
   | CPy(v) -> fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/test/mexpr/symbs.mc
+++ b/test/mexpr/symbs.mc
@@ -18,13 +18,13 @@ utest eqs y y with true in
 utest eqs y x with false in
 utest eqs x y with false in
 
--- 'sym2int s1' returns an integer representation of s1 that fulfills the
--- following criterion: eqs a b => eqi (sym2int a) (sym2int b)
+-- 'sym2hash s1' returns an integer representation of s1 that fulfills the
+-- following criterion: eqs a b => eqi (sym2hash a) (sym2hash b)
 -- No guarantees are given for the opposite direction, but a best effort is
 -- made to give 2 symbols different integer representation.
 -- Symbol -> Int
 let z = x in
-utest eqi (sym2int x) (sym2int x) with true in
-utest eqi (sym2int x) (sym2int z) with true in
+utest eqi (sym2hash x) (sym2hash x) with true in
+utest eqi (sym2hash x) (sym2hash z) with true in
 
 ()

--- a/test/mexpr/symbs.mc
+++ b/test/mexpr/symbs.mc
@@ -3,7 +3,6 @@
 --
 -- Test symbools
 
-
 mexpr
 
 -- 'gensym()' generates a new unique symbol.
@@ -18,5 +17,14 @@ utest eqs x x with true in
 utest eqs y y with true in
 utest eqs y x with false in
 utest eqs x y with false in
+
+-- 'sym2int s1' returns an integer representation of s1 that fulfills the
+-- following criterion: eqs a b => eqi (sym2int a) (sym2int b)
+-- No guarantees are given for the opposite direction, but a best effort is
+-- made to give 2 symbols different integer representation.
+-- Symbol -> Int
+let z = x in
+utest eqi (sym2int x) (sym2int x) with true in
+utest eqi (sym2int x) (sym2int z) with true in
 
 ()


### PR DESCRIPTION
This (suggestion) PR adds the ~`sym2int`~`sym2hash` intrinsic that converts a symbol to an integer. I marked this PR as a suggestion as I am unsure if this is even something that we want to have in the language, or just want in the underpinnings of the compiler. The only guarantee of this operation would be:
```
eqs s1 s2  =>  eqi (sym2hash s1) (sym2hash s2)
```
While the opposite direction might not necessarily be true, the language should make an effort for that to be true. This makes it easier for symbols to be used in data structures that relies on hashing, while not making too strict demands on symbols generated in multiple threads (for when that is implemented).

I can also see a number of cons with having this intrinsic available:
 1. _Promotes misuse._ Unexperienced users of MCore might start converting all symbols they enounter to integers for convenience, leading to bugs further along the process.
 2. _Half-hearted._ While symbols are globally unique, the integer representation of it is not. If you would like to print a sequence of symbols to the terminal, the risk is that two different symbols are printed with the same string. Instead of allowing a symbol to be represented as an integer, it could instead be converted to a globally unique string. (How this would work I do not know.)
 3. _Deprecated from conception._ While symbols probably should be hashable, that is something that the compiler should take care of using unified collection types. This is just a temporary hack to allow more efficient lookups until UC types are in place.

At least I hope that this PR can clarify what we want from symbols and what we do not want from symbols :slightly_smiling_face:

UPDATE: Changed name from `sym2int` to `sym2hash`.