### PR TITLE
Option utils

### DIFF
--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -33,9 +33,9 @@ utest optionBind (None ()) (lam t. Some (addi 1 t)) with (None ())
 utest optionBind (Some 1) (lam t. Some (addi 1 t)) with (Some 2)
 utest optionBind (Some 1) (lam _. None ()) with (None ())
 
--- 'optionCompose f g' composes the option-producing functions f and g into
--- a new function, which only succeeds if both f and g succeed.
-let optionCompose: (b -> Option) -> (a -> Option) -> a -> Option =
+-- 'optionCompose f g' composes the option-producing functions 'f' and 'g' into
+-- a new function, which only succeeds if both 'f' and 'g' succeed.
+let optionCompose: (b -> Option c) -> (a -> Option b) -> a -> Option c =
   lam f. lam g. lam x.
     optionBind (g x) f
 
@@ -79,7 +79,7 @@ utest optionMapOr 3 (addi 1) (None ()) with 3
 -- 'optionMapM f l' maps each element of 'l' to an option using 'f'.
 -- Then it collects the results to a new list option, which is 'Some'
 -- only if all elements of 'l' were mapped to 'Some' by 'f'.
-let optionMapM: (a -> Option) -> [a] -> Option = lam f. lam l.
+let optionMapM: (a -> Option b) -> [a] -> Option [b] = lam f. lam l.
   recursive let g = lam l. lam acc.
     match l with [hd] ++ rest then
       match f hd with Some x then

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -80,9 +80,16 @@ utest optionMapOr 3 (addi 1) (None ()) with 3
 -- Then it collects the results to a new list option, which is 'Some'
 -- only if all elements of 'l' were mapped to 'Some' by 'f'.
 let optionMapM: (a -> Option) -> [a] -> Option = lam f. lam l.
-  foldr (lam x. lam o. optionBind (f x) (lam y. optionMap (cons y) o))
-        (Some [])
-        l
+  recursive let g = lam l. lam acc.
+    match l with [hd] ++ rest then
+      match f hd with Some x then
+        g rest (snoc acc x)
+      else
+        None ()
+    else
+      Some acc
+  in
+  g l []
 
 utest optionMapM (lam x. if gti x 2 then Some x else None ()) [3, 4, 5] with Some [3, 4, 5]
 utest optionMapM (lam x. if gti x 2 then Some x else None ()) [2, 3, 4] with None ()


### PR DESCRIPTION
This PR adds two Option utility functions to `option.mc`:

- `optionCompose: (b -> Option c) -> (a -> Option b) -> a -> Option c`
- `optionMapM: (a -> Option b) -> [a] -> Option [b]`

Edit: This PR uses parametrized type signatures and should be merged after #156.