### PR TITLE
Fix printing of empty sequence

### DIFF
--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -327,18 +327,21 @@ and print_tm' fmt t = match t with
   | TmConst(_,c) -> print_const fmt c
 
   | TmSeq(fi,tms) ->
-    begin
-      try
-        tmseq2ustring fi tms
-        |> string_of_ustring
-        |> String.escaped
-        |> fprintf fmt "\"%s\""
-      with
-      | _ ->
-        let print t = (fun fmt -> fprintf fmt "%a" print_tm (App,t)) in
-        let inner = List.map print (Mseq.to_list tms) in
-        fprintf fmt "[@[<hov 0>%a@]]" concat (Comma,inner)
-    end
+    if Mseq.length tms = 0 then
+      fprintf fmt "[]"
+    else
+      begin
+        try
+          tmseq2ustring fi tms
+          |> string_of_ustring
+          |> String.escaped
+          |> fprintf fmt "\"%s\""
+        with
+        | _ ->
+          let print t = (fun fmt -> fprintf fmt "%a" print_tm (App,t)) in
+          let inner = List.map print (Mseq.to_list tms) in
+          fprintf fmt "[@[<hov 0>%a@]]" concat (Comma,inner)
+      end
 
   | TmRecord(_,r) ->
     begin


### PR DESCRIPTION
#135 accidentally made the empty sequence be prettyprinted as `""`. This PR makes the empty sequence be printed as `[]` again.