### PR TITLE
Remove support for C++ style line comments

### DIFF
--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -152,8 +152,7 @@ let symtok =  "="  | "+" |  "-" | "*"  | "/" | "%"  | "<"  | "<=" | ">" | ">=" |
               "::" | ":" | ","  | "."  | "&" | "|" | "->" | "=>" | "++"
 
 
-let line_comment = "//" [^ '\013' '\010']*
-let line_comment_alt = "--" [^ '\013' '\010']*
+let line_comment = "--" [^ '\013' '\010']*
 let unsigned_integer = digit+
 let signed_integer = unsigned_integer  | '-' unsigned_integer
 let unsigned_number = unsigned_integer ('.' (unsigned_integer)?)?
@@ -165,8 +164,6 @@ rule main = parse
   | whitespace+ as s
       { colcount_fast s; main lexbuf }
   | line_comment
-      { main lexbuf }
-  | line_comment_alt
       { main lexbuf }
   | "/*" as s
       { Buffer.reset string_buf ;

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -1,39 +1,39 @@
 -- TODO Needs updating, commented out for now
 --
--- // Defines semantics for lambda lifting
--- // Based on the technique from the 1985 paper.
--- // (This will not handle partial application until a type-checker has been
--- // implemented.)
+-- -- Defines semantics for lambda lifting
+-- -- Based on the technique from the 1985 paper.
+-- -- (This will not handle partial application until a type-checker has been
+-- -- implemented.)
 --
--- // This defines the lamlift semantics which, given a state tuple, propagates
--- // the entire AST and lifts out any internal lambda expressions to the top-
--- // level.
+-- -- This defines the lamlift semantics which, given a state tuple, propagates
+-- -- the entire AST and lifts out any internal lambda expressions to the top-
+-- -- level.
 --
--- // This also defines the internal replace semantics which replaces all
--- // occurrences of an identifier with a specific expression. This is primarily
--- // used to replace the identifiers that are signalling a recursion.
+-- -- This also defines the internal replace semantics which replaces all
+-- -- occurrences of an identifier with a specific expression. This is primarily
+-- -- used to replace the identifiers that are signalling a recursion.
 --
--- // Algorithm for Let's (and anonymous lambdas):
--- // - Keep a track of all the arguments and variables (not defined functions)
--- // - When a Let expression has been fully scanned, check which variables that
--- //   where externally referenced. All the variables that were externally
--- //   referenced and are not part of the current lambda scope needs to be
--- //   generated as arguments for the current lambda as well. These arguments
--- //   will then be applied to the lifted lambda instead of the externally
--- //   referenced arguments.
--- // - For Let expressions in a recursive scope, identifiers will be replaced in
--- //   2 passes. After all the Let expressions have been scanned (just like in
--- //   the previous step), the generated identifiers potentionally need to be
--- //   replaced by a TmApp (..., ...) where the generated arguments are
--- //   pre-applied on the generated identifier for the Let expression.
+-- -- Algorithm for Let's (and anonymous lambdas):
+-- -- - Keep a track of all the arguments and variables (not defined functions)
+-- -- - When a Let expression has been fully scanned, check which variables that
+-- --   where externally referenced. All the variables that were externally
+-- --   referenced and are not part of the current lambda scope needs to be
+-- --   generated as arguments for the current lambda as well. These arguments
+-- --   will then be applied to the lifted lambda instead of the externally
+-- --   referenced arguments.
+-- -- - For Let expressions in a recursive scope, identifiers will be replaced in
+-- --   2 passes. After all the Let expressions have been scanned (just like in
+-- --   the previous step), the generated identifiers potentionally need to be
+-- --   replaced by a TmApp (..., ...) where the generated arguments are
+-- --   pre-applied on the generated identifier for the Let expression.
 --
--- // NOTE: Assumes that bound variables are limited to the following AST nodes:
--- //        - TmVar
--- //        - TmApp
--- //
--- // If an identifier is bound to a different node which itself contain
--- // identifiers, then this could lead to the lambda lifting returning an
--- // incorrect program even if the input program was correct.
+-- -- NOTE: Assumes that bound variables are limited to the following AST nodes:
+-- --        - TmVar
+-- --        - TmApp
+-- --
+-- -- If an identifier is bound to a different node which itself contain
+-- -- identifiers, then this could lead to the lambda lifting returning an
+-- -- incorrect program even if the input program was correct.
 --
 --
 -- include "ast.mc"

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -56,19 +56,19 @@ utest int2string 25 with "25"
 utest int2string 314159 with "314159"
 utest int2string (negi 314159) with "-314159"
 
-// A naive float2string implementation that only formats in standard form
+-- A naive float2string implementation that only formats in standard form
 let float2string = lam arg.
-  // Quick fix to check for infinities
+  -- Quick fix to check for infinities
   if eqf arg inf then "INFINITY" else
   if eqf arg (negf inf) then "-INFINITY" else
-  // End of quick fix
-  let precision = 7 in // Precision in number of digits
+  -- End of quick fix
+  let precision = 7 in -- Precision in number of digits
   let prefixpair = if ltf arg 0.0 then ("-", negf arg) else ("", arg) in
   let prefix = prefixpair.0 in
   let val = prefixpair.1 in
   recursive
   let float2string_rechelper = lam prec. lam digits. lam v.
-    // Assume 0 <= v < 10
+    -- Assume 0 <= v < 10
     if eqi prec digits then
       ""
     else if eqf v 0.0 then
@@ -111,8 +111,8 @@ utest float2string (negf 5.0e+25) with "-5.0e+25"
 utest float2string (5.0e-5) with "5.0e-5"
 utest float2string (negf 5.0e-5) with "-5.0e-5"
 
-// Returns an option with the index of the first occurrence of c in s. Returns
-// None if c was not found in s.
+-- Returns an option with the index of the first occurrence of c in s. Returns
+-- None if c was not found in s.
 let strIndex = lam c. lam s.
   recursive
   let strIndex_rechelper = lam i. lam c. lam s.
@@ -131,8 +131,8 @@ utest strIndex 'w' "Hello, World!" with None ()
 utest strIndex 'o' "Hello, world!" with Some(4)
 utest strIndex '@' "Some @TAG@" with Some(5)
 
-// Returns an option with the index of the last occurrence of c in s. Returns
-// None if c was not found in s.
+-- Returns an option with the index of the last occurrence of c in s. Returns
+-- None if c was not found in s.
 let strLastIndex = lam c. lam s.
   recursive
   let strLastIndex_rechelper = lam i. lam acc. lam c. lam s.
@@ -154,7 +154,7 @@ utest strLastIndex 'w' "Hello, World!" with None ()
 utest strLastIndex 'o' "Hello, world!" with Some(8)
 utest strLastIndex '@' "Some @TAG@" with Some(9)
 
-// Splits s on delim
+-- Splits s on delim
 recursive
   let strSplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
@@ -171,7 +171,7 @@ utest strSplit "" "Hello" with ["Hello"]
 utest strSplit "lla" "Hello" with ["Hello"]
 utest strSplit "Hello" "Hello" with ["", ""]
 
-// Trims s of spaces
+-- Trims s of spaces
 let strTrim = lam s.
   recursive
   let strTrim_init = lam s.
@@ -187,7 +187,7 @@ utest strTrim " aaaa   " with "aaaa"
 utest strTrim "   bbbbb  bbb " with "bbbbb  bbb"
 utest strTrim "ccccc c\t   \n" with "ccccc c"
 
-// Joins the strings in strs on delim
+-- Joins the strings in strs on delim
 recursive
   let strJoin = lam delim. lam strs.
     if eqi (length strs) 0

--- a/test/mexpr/effects.mc
+++ b/test/mexpr/effects.mc
@@ -43,10 +43,10 @@ utest fileExists file with false in
 utest if false then error "message" else 0 with 0 in
 
 
-// 'argv' contains the program arguments
+-- 'argv' contains the program arguments
 utest slice argv 1 2 with [] in
 
-// 'exit c' exits the program with error code 'c'
+-- 'exit c' exits the program with error code 'c'
 utest if true then () else exit 1 with () in
 
 ()

--- a/test/mexpr/fix.mc
+++ b/test/mexpr/fix.mc
@@ -1,11 +1,11 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
-// Test fixpoint usages
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test fixpoint usages
 
 mexpr
 
-// Separate fix-point
+-- Separate fix-point
 let fact_abs = (lam fact. lam n.
     if eqi n 0
     then 1
@@ -17,7 +17,7 @@ let fact = fix fact_abs in
 utest fact 5 with 120 in
 utest fact 0 with 1 in
 
-// Mutual recursion
+-- Mutual recursion
 let odd_abs = lam odd. lam even. lam n.
     if eqi n 1
     then true

--- a/test/mexpr/letlamif.mc
+++ b/test/mexpr/letlamif.mc
@@ -1,16 +1,16 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
-// Test string and char primitives
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test string and char primitives
 
 mexpr
 
-// lambda
+-- lambda
 utest (lam x. addi x 2) 3 with 5 in
 utest (lam x. lam y. muli x y) 3 4 with 12 in
 
 
-// let expressions
+-- let expressions
 let x = 10 in
 utest x with 10 in
 
@@ -25,14 +25,14 @@ let f2 = lam x. lam y. addi x y in
 utest f2 2 3 with 5 in
 
 
-// if expressions
+-- if expressions
 utest if true then 1 else 2 with 1 in
 let z = 8 in
 let m = lam x. lam y. muli x y in
 utest if eqi (m 2 3) 6 then addi z 2 else 0 with 10 in
 
 
-// factorial function
+-- factorial function
 recursive
   let fact = lam n.
     if eqi n 0 then 1

--- a/test/mexpr/reclets.mc
+++ b/test/mexpr/reclets.mc
@@ -1,11 +1,11 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
 
 
 mexpr
 
-// Mutual recursion
+-- Mutual recursion
 
 
 recursive

--- a/test/mexpr/stringops.mc
+++ b/test/mexpr/stringops.mc
@@ -1,7 +1,7 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
-// Test implementation of simple string operations
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test implementation of simple string operations
 
 mexpr
 
@@ -31,14 +31,14 @@ recursive
          else false
 in
 
-// Convert a character to upper case
+-- Convert a character to upper case
 let char2upper = (lam c.
 	if and (geqchar c 'a') (leqchar c 'z')
 	then (int2char (subi (char2int c) 32))
 	else c
 ) in
 
-// Convert a character to lower case
+-- Convert a character to lower case
 let char2lower = (lam c.
 	if and (geqchar c 'A') (leqchar c 'Z')
 	then (int2char (addi (char2int c) 32))
@@ -49,7 +49,7 @@ let str2upper = lam s. map char2upper s in
 let str2lower = lam s. map char2lower s in
 
 recursive
-  // Splits the string on the entered delimiter
+  -- Splits the string on the entered delimiter
   let strsplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
     then cons s []
@@ -59,7 +59,7 @@ recursive
               cons (cons (head s) (head remaining)) (tail remaining)
 in
 
-// Trims a string of spaces
+-- Trims a string of spaces
 recursive
   let strtrim_init = lam s.
     if eqstr s ""
@@ -71,7 +71,7 @@ in
 let strtrim = lam s. reverse (strtrim_init (reverse (strtrim_init s))) in
 
 recursive
-  // Join a list of strings with a common delimiter
+  -- Join a list of strings with a common delimiter
   let strjoin = lam delim. lam slist.
     if eqi (length slist) 0
     then ""

--- a/test/mexpr/tuples.mc
+++ b/test/mexpr/tuples.mc
@@ -1,11 +1,11 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
-// Test tuples
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test tuples
 
 mexpr
 
-// Tuples
+-- Tuples
 utest (1,3,10) with (1,3,10) in
 utest () with () in
 utest (2,8).1 with 8 in

--- a/test/mexpr/types.mc
+++ b/test/mexpr/types.mc
@@ -1,43 +1,43 @@
-// Miking is licensed under the MIT license.
-// Copyright (C) David Broman. See file LICENSE.txt
-//
-// Test the parsing of types
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test the parsing of types
 
 mexpr
 
-// No type in lambda
+-- No type in lambda
 let f = lam x. addi x 2 in
 utest f 5 with 7 in
 
-// Unit type
+-- Unit type
 let a:() = () in
 utest (lam x:(). 7) a with 7 in
 
-// Dynamic type
+-- Dynamic type
 let f = lam x:Dyn. x in
 utest f 5 with 5 in
 
-// Int type
+-- Int type
 let v : Int = 5 in
 let f = lam x:Int. muli x 5 in
 utest f 5 with 25 in
 
-// Float type
+-- Float type
 let v : Float = 3.33 in
 let f = lam x:Float. mulf x 10.0 in
 utest f v with 33.3 in
 
-// Bool type
+-- Bool type
 let v : Bool = true in
 utest (lam x:Bool. if x then 1 else 2) v with 1 in
 
-// Function type
+-- Function type
 let f1 : Int -> Int = lam x. addi x 1 in
 utest f1 5 with 6 in
 let f2 : Int -> Float -> Float = lam x:Int. lam y:Float. addf (int2float x) y in
 utest f2 10 17.2 with 27.2 in
 
-// Tuple type
+-- Tuple type
 let x0 : Int = 7 in
 let x1 : (Int) = (8) in
 let x2 : (Int,Float) = (7, 33.3) in
@@ -48,22 +48,22 @@ utest x2 with (7, 33.3) in
 utest x3 with (1, 2.2, 7) in
 utest (lam x:(Int,Float). x.0) (8, 13.3) with 8 in
 
-// String type
+-- String type
 let s:String = "yes" in
 utest (lam x:String. concat x x) s with "yesyes" in
 
-// Sequence type
+-- Sequence type
 let l1 : [Int] = [1,3,4,8] in
 utest (lam x:[Int]. get x 2) l1 with 4 in
 
-// Data types
+-- Data types
 type Tree in
 con Node : (Tree,Tree) -> Tree in
 con Leaf : (Int) -> Tree in
 let t : Tree = match Node(Leaf(5),Leaf(10)) with Node t then t else error "" in
 utest t.0 with Leaf(5) in
 
-// Type alias
+-- Type alias
 type Tree2 = Tree in
 
 

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -120,7 +120,7 @@ let _ =
 in
 
 let _ =
-  let e1 = use A in ACon{afield = 1, aextfield = 2} in // TODO(vipa): this should break once we start typechecking product extensions of a constructor
+  let e1 = use A in ACon{afield = 1, aextfield = 2} in -- TODO(vipa): this should break once we start typechecking product extensions of a constructor
   let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
   utest e1 with e2 in
   ()

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -1,4 +1,4 @@
-// String format with MLang
+-- String format with MLang
 
 include "char.mc"
 include "seq.mc"


### PR DESCRIPTION
Removes support for C++ style line comments as discussed in #95.

This will probably break some MCore code in other repositories. But I assume that makes it more important to get this change in as soon as possible?