### PR TITLE
Pretty printing tuples

### DIFF
--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -52,6 +52,10 @@ let conString = lam str.
 let varString = lam str.
   parserStr str "#var" (lam str. is_lower_alpha (head str))
 
+-- Label string parser translation for records
+let labelString = lam str.
+  parserStr str "#label" (lam str. is_lower_alpha (head str))
+
 let _ppLookupName = assocLookup {eq = nameEqSym}
 let _ppLookupStr = assocLookup {eq = eqstr}
 let _ppInsertName = assocInsert {eq = nameEqSym}
@@ -159,7 +163,7 @@ lang RecordPrettyPrint = RecordAst
         mapAccumL
           (lam env. lam r.
              match pprintCode innerIndent env r.1 with (env,str) then
-               (env, join [r.0, " =", newline innerIndent, str])
+               (env, join [labelString r.0, " =", newline innerIndent, str])
              else never)
           env t.bindings
       with (env,binds) then
@@ -170,7 +174,7 @@ lang RecordPrettyPrint = RecordAst
   | TmRecordUpdate t ->
     match pprintCode indent env t.rec with (env,rec) then
       match pprintCode indent env t.value with (env,value) then
-        (env,join ["{", rec, " with ", t.key, " = ", value, "}"])
+        (env,join ["{", rec, " with ", labelString t.key, " = ", value, "}"])
       else never
     else never
 end
@@ -422,7 +426,7 @@ lang RecordPatPrettyPrint = RecordPat
     match
       mapAccumL (lam env. lam r.
         match getPatStringCode indent env r.1 with (env,str) then
-          (env,join [r.0, " = ", str])
+          (env,join [labelString r.0, " = ", str])
         else never)
         env bindings
     with (env,binds) then

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -189,13 +189,14 @@ lang RecordPrettyPrint = RecordAst
     else
       let innerIndent = incr (incr indent) in
       match
-        mapAccumL
-          (lam env. lam r.
-             match pprintCode innerIndent env r.1 with (env,str) then
-               (env, join [labelString r.0, " =", newline innerIndent, str])
-             else never)
+        assocMapAccum {eq=eqstr}
+          (lam env. lam k. lam v.
+              match pprintCode innerIndent env v with (env, str) then
+                (env, join [labelString k, " =", newline innerIndent, str])
+              else never)
           env t.bindings
-      with (env,binds) then
+      with (env, bindMap) then
+        let binds = assocValues {eq=eqstr} bindMap in
         let merged = strJoin (concat "," (newline (incr indent))) binds in
         (env,join ["{ ", merged, " }"])
       else never

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -191,10 +191,10 @@ lang RecordPrettyPrint = RecordAst
       match
         assocMapAccum {eq=eqstr}
           (lam env. lam k. lam v.
-              match pprintCode innerIndent env v with (env, str) then
-                (env, join [labelString k, " =", newline innerIndent, str])
-              else never)
-          env t.bindings
+             match pprintCode innerIndent env v with (env, str) then
+               (env, join [labelString k, " =", newline innerIndent, str])
+             else never)
+           env t.bindings
       with (env, bindMap) then
         let binds = assocValues {eq=eqstr} bindMap in
         let merged = strJoin (concat "," (newline (incr indent))) binds in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -454,13 +454,14 @@ lang RecordPatPrettyPrint = RecordPat
   sem getPatStringCode (indent : Int) (env: Env) =
   | PRecord {bindings = bindings} ->
     match
-      mapAccumL (lam env. lam r.
-        match getPatStringCode indent env r.1 with (env,str) then
-          (env,join [labelString r.0, " = ", str])
-        else never)
-        env bindings
-    with (env,binds) then
-      (env,join ["{", strJoin ", " binds, "}"])
+      assocMapAccum {eq=eqstr}
+        (lam env. lam k. lam v.
+           match getPatStringCode indent env v with (env,str) then
+             (env,join [labelString k, " = ", str])
+           else never)
+         env bindings
+    with (env,bindMap) then
+      (env,join ["{", strJoin ", " (assocValues {eq=eqstr} bindMap), "}"])
     else never
 end
 

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -29,6 +29,7 @@ let string2int = lam s.
       let rest = muli 10 (string2int_rechelper (slice s 0 last)) in
       addi rest lsd
   in
+  match s with [] then 0 else
   if eqchar '-' (head s)
   then negi (string2int_rechelper (tail s))
   else string2int_rechelper s
@@ -55,6 +56,16 @@ utest int2string 5 with "5"
 utest int2string 25 with "25"
 utest int2string 314159 with "314159"
 utest int2string (negi 314159) with "-314159"
+
+-- 'stringIsInt s' returns true iff 's' is a string representing an integer
+let stringIsInt: String -> Bool = lam s.
+  eqstr s (int2string (string2int s))
+
+utest stringIsInt "" with false
+utest stringIsInt "1 " with false
+utest stringIsInt " 1" with false
+utest stringIsInt "1" with true
+utest stringIsInt "-1098" with true
 
 -- A naive float2string implementation that only formats in standard form
 let float2string = lam arg.


### PR DESCRIPTION
This PR updates the pretty printing for records so that:
- Keys x that are not valid identifiers are printed as #label"x".
- Records that represent tuples are printed as tuples, i.e. {#label"0" = 1, #label"1" = 2} -> (1,2).