### PR TITLE
Add Either library

### DIFF
--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -1,7 +1,7 @@
 -- Miking is licensed under the MIT license.
 -- Copyright (C) David Broman. See file LICENSE.txt
 --
--- The library defines the Either type and its two constructors: Left & Right.
+-- This library defines the Either type and its two constructors: Left & Right.
 
 include "option.mc"
 include "seq.mc"

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -3,6 +3,7 @@
 --
 -- The library defines the Either type and its two constructors: Left & Right.
 
+include "option.mc"
 include "seq.mc"
 
 type Either a b
@@ -86,3 +87,23 @@ let eitherFromRight: b -> Either a b -> b = lam v. lam e.
 
 utest eitherFromRight 0 (Left "foo") with 0
 utest eitherFromRight 0 (Right 42) with 42
+
+
+let eitherGetLeft: Either a b -> Option a = lam e.
+  match e with Left content then
+    Some content
+  else
+    None ()
+
+utest eitherGetLeft (Left "foo") with Some "foo"
+utest eitherGetLeft (Right 42) with None ()
+
+
+let eitherGetRight: Either a b -> Option b = lam e.
+  match e with Right content then
+    Some content
+  else
+    None ()
+
+utest eitherGetRight (Left "foo") with None ()
+utest eitherGetRight (Right 42) with Some 42

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -242,7 +242,7 @@ utest eitherIsRight (Right (Left 1)) with true
 --  *
 --  * .return The Left case value or the default value.
 -- -*
-let eitherFromLeft: a -> Either a b -> a = lam v. lam e. eitherEither (lam x. x) (lam _. v)
+let eitherFromLeft: a -> Either a b -> a = lam v. eitherEither (lam x. x) (lam _. v)
 
 utest eitherFromLeft "a" (Right 5) with "a"
 utest eitherFromLeft "a" (Left "foo") with "foo"
@@ -256,7 +256,7 @@ utest eitherFromLeft "a" (Left "foo") with "foo"
 --  *
 --  * .return The Right case value or the default value.
 -- -*
-let eitherFromRight: b -> Either a b -> b = lam v. lam e. eitherEither (lam _. v) (lam x. x)
+let eitherFromRight: b -> Either a b -> b = lam v. eitherEither (lam _. v) (lam x. x)
 
 utest eitherFromRight 0 (Left "foo") with 0
 utest eitherFromRight 0 (Right 42) with 42

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -11,6 +11,23 @@ con Left: a -> Either a b
 con Right: b -> Either a b
 
 
+let eitherEq: (a -> c -> Bool) -> (b -> d -> Bool) -> Either a b -> Either c d -> Bool =
+  lam eql. lam eqr. lam e1. lam e2.
+  match (e1,e2) with (Left c1, Left c2) then
+    eql c1 c2
+  else match (e1,e2) with (Right c1, Right c2) then
+    eqr c1 c2
+  else
+    false
+
+utest eitherEq eqi eqi (Left 100) (Left 100) with true
+utest eitherEq eqi eqi (Left 100) (Left 33) with false
+utest eitherEq eqi eqi (Left 100) (Right 100) with false
+utest eitherEq eqi eqi (Right 4321) (Right 4321) with true
+utest eitherEq eqi eqi (Right 4321) (Right 1) with false
+utest eitherEq eqi eqi (Right 4321) (Left 4321) with false
+
+
 let eitherEither: (a -> c) -> (b -> c) -> Either a b -> c =
   lam lf. lam rf. lam e.
   match e with Left content then
@@ -35,23 +52,13 @@ utest eitherBiMap (addi 1) (cons 'a') (Left 2) with Left 3
 utest eitherBiMap (addi 1) (cons 'a') (Right "choo") with Right "achoo"
 
 
-let eitherMapLeft: (a -> c) -> Either a b -> Either c b = lam f. lam e.
-  match e with Left content then
-    Left (f content)
-  else match e with Right content then
-    Right content
-  else never
+let eitherMapLeft: (a -> c) -> Either a b -> Either c b = lam f. eitherBiMap f (lam x. x)
 
 utest eitherMapLeft (cons 'a') (Right 5) with Right 5
 utest eitherMapLeft (cons 'a') (Left "choo") with Left "achoo"
 
 
-let eitherMapRight: (b -> c) -> Either a b -> Either a c = lam f. lam e.
-  match e with Left content then
-    Left content
-  else match e with Right content then
-    Right (f content)
-  else never
+let eitherMapRight: (b -> c) -> Either a b -> Either a c = lam f. eitherBiMap (lam x. x) f
 
 utest eitherMapRight (addi 2) (Right 40) with Right 42
 utest eitherMapRight (addi 2) (Left "foo") with Left "foo"

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -23,6 +23,42 @@ utest eitherEither (eqi 1) (eqf 0.5) (Left 2) with false
 utest eitherEither (eqi 1) (eqf 0.5) (Right 0.5) with true
 
 
+let eitherBiMap: (a -> c) -> (b -> d) -> Either a b -> Either c d =
+  lam lf. lam rf. lam e.
+  match e with Left content then
+    Left (lf content)
+  else match e with Right content then
+    Right (rf content)
+  else never
+
+utest eitherBiMap (addi 1) (cons 'a') (Left 2) with Left 3
+utest eitherBiMap (addi 1) (cons 'a') (Right "choo") with Right "achoo"
+
+
+let eitherMapLeft: (a -> c) -> Either a b -> Either c b = lam f. lam e.
+  match e with Left content then
+    Left (f content)
+  else match e with Right content then
+    -- just returning e here is most likely not type safe
+    Right content
+  else never
+
+utest eitherMapLeft (cons 'a') (Right 5) with Right 5
+utest eitherMapLeft (cons 'a') (Left "choo") with Left "achoo"
+
+
+let eitherMapRight: (b -> c) -> Either a b -> Either a c = lam f. lam e.
+  match e with Left content then
+    -- just returning e here is most likely not type safe
+    Left content
+  else match e with Right content then
+    Right (f content)
+  else never
+
+utest eitherMapRight (addi 2) (Right 40) with Right 42
+utest eitherMapRight (addi 2) (Left "foo") with Left "foo"
+
+
 let eitherPartition: [Either a b] -> ([a],[b]) = lam es.
   foldl (lam acc. lam e.
     match e with Left content then

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -1,0 +1,88 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- The library defines the Either type and its two constructors: Left & Right.
+
+include "seq.mc"
+
+type Either a b
+con Left: a -> Either a b
+con Right: b -> Either a b
+
+
+let eitherEither: (a -> c) -> (b -> c) -> Either a b -> c =
+  lam lf. lam rf. lam e.
+  match e with Left content then
+    lf content
+  else match e with Right content then
+    rf content
+  else never
+
+utest eitherEither (eqi 1) (eqf 0.5) (Left 2) with false
+utest eitherEither (eqi 1) (eqf 0.5) (Right 0.5) with true
+
+
+let eitherPartition: [Either a b] -> ([a],[b]) = lam es.
+  foldl (lam acc. lam e.
+    match e with Left content then
+      (snoc acc.0 content, acc.1)
+    else match e with Right content then
+      (acc.0, snoc acc.1 content)
+    else never
+  ) ([],[]) es
+
+utest eitherPartition [] with ([], [])
+utest eitherPartition [Left 1, Right "foo", Right "bar", Left 42] with ([1,42], ["foo", "bar"])
+utest eitherPartition [Right 5.0, Right 1.0, Left "42"] with (["42"], [5.0, 1.0])
+
+
+let eitherLefts: [Either a b] -> [a] = lam es. (eitherPartition es).0
+
+utest eitherLefts [] with []
+utest eitherLefts [Right 1, Right 5] with []
+utest eitherLefts [Right 1, Left "c", Right 5, Left "a"] with ["c", "a"]
+
+
+let eitherRights: [Either a b] -> [b] = lam es. (eitherPartition es).1
+
+utest eitherRights [] with []
+utest eitherRights [Left "1", Left "5"] with []
+utest eitherRights [Right 1, Left "3", Right 5, Left "1"] with [1, 5]
+
+
+let eitherIsLeft: Either a b -> Bool = lam e.
+  match e with Left _ then true else false
+
+utest eitherIsLeft (Left 5) with true
+utest eitherIsLeft (Left "a") with true
+utest eitherIsLeft (Right "a") with false
+utest eitherIsLeft (Right (Left 1)) with false
+
+
+let eitherIsRight: Either a b -> Bool = lam e.
+  match e with Right _ then true else false
+
+utest eitherIsRight (Left 5) with false
+utest eitherIsRight (Left "a") with false
+utest eitherIsRight (Right "a") with true
+utest eitherIsRight (Right (Left 1)) with true
+
+
+let eitherFromLeft: a -> Either a b -> a = lam v. lam e.
+  match e with Left content then
+    content
+  else
+    v
+
+utest eitherFromLeft "a" (Right 5) with "a"
+utest eitherFromLeft "a" (Left "foo") with "foo"
+
+
+let eitherFromRight: b -> Either a b -> b = lam v. lam e.
+  match e with Right content then
+    content
+  else
+    v
+
+utest eitherFromRight 0 (Left "foo") with 0
+utest eitherFromRight 0 (Right 42) with 42

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -38,13 +38,13 @@ utest eitherEq eqi eqi (Right 4321) (Right 1) with false
 utest eitherEq eqi eqi (Right 4321) (Left 4321) with false
 
 --  *-
---  * .brief Case analysis of an Either type to extract its value
+--  * .brief Case analysis of an Either type to extract its value.
 --  *
 --  * .lam[lf] How a Left value should be extracted
 --  * .lam[rf] How a Right value should be extracted
 --  * .lam[e] The Either value to have have its value extracted
 --  *
---  * .return The value that was extracted from the case analysis
+--  * .return The value that was extracted from the case analysis.
 -- -*
 let eitherEither: (a -> c) -> (b -> c) -> Either a b -> c =
   lam lf. lam rf. lam e.
@@ -57,7 +57,16 @@ let eitherEither: (a -> c) -> (b -> c) -> Either a b -> c =
 utest eitherEither (eqi 1) (eqf 0.5) (Left 2) with false
 utest eitherEither (eqi 1) (eqf 0.5) (Right 0.5) with true
 
-
+--  *-
+--  * .brief Maps a function onto an either value, one function for each case.
+--  *
+--  * .lam[lf] The Left mapping function
+--  * .lam[rf] The Right mapping function
+--  * .lam[e] The Either value to map a function on
+--  *
+--  * .return The map result as an Either type, concealing which case that was
+--  *         actually mapped on.
+-- -*
 let eitherBiMap: (a -> c) -> (b -> d) -> Either a b -> Either c d =
   lam lf. lam rf. lam e.
   match e with Left content then
@@ -69,19 +78,45 @@ let eitherBiMap: (a -> c) -> (b -> d) -> Either a b -> Either c d =
 utest eitherBiMap (addi 1) (cons 'a') (Left 2) with Left 3
 utest eitherBiMap (addi 1) (cons 'a') (Right "choo") with Right "achoo"
 
-
+--  *-
+--  * .brief Maps a function onto the Left value if that is the Either case.
+--  *
+--  * .lam[f] The mapping function
+--  * .lam[e] The Either value to map a function on
+--  *
+--  * .return The map result as an Either type, in the Left case containing
+--  *         the mapped value and in the Right case staying the same.
+-- -*
 let eitherMapLeft: (a -> c) -> Either a b -> Either c b = lam f. eitherBiMap f (lam x. x)
 
 utest eitherMapLeft (cons 'a') (Right 5) with Right 5
 utest eitherMapLeft (cons 'a') (Left "choo") with Left "achoo"
 
-
+--  *-
+--  * .brief Maps a function onto the Right value if that is the Either case.
+--  *
+--  * .lam[f] The mapping function
+--  * .lam[e] The Either value to map a function on
+--  *
+--  * .return The map result as an Either type, in the Right case containing
+--  *         the mapped value and in the Left case staying the same.
+-- -*
 let eitherMapRight: (b -> c) -> Either a b -> Either a c = lam f. eitherBiMap (lam x. x) f
 
 utest eitherMapRight (addi 2) (Right 40) with Right 42
 utest eitherMapRight (addi 2) (Left "foo") with Left "foo"
 
-
+--  *-
+--  * .brief If the input Either is the Left case, then its value is applied as
+--  *        the argument to the passed function.
+--  *
+--  * .lam[e] The Either value whose Left case will be bound as input
+--  * .lam[bf] The function to have the Left value applied to
+--  *
+--  * .return If the Either argument is a Left case, the result of binding its
+--  *         value to the passed function. If it is the Right case, then it is
+--  *         returned as is.
+-- -*
 let eitherBindLeft: Either a b -> (a -> Either c b) -> Either c b =
   lam e. lam bf.
   match e with Left content then
@@ -94,7 +129,17 @@ utest eitherBindLeft (Left "a") (lam s. Left (head s)) with Left 'a'
 utest eitherBindLeft (Left "a") (lam _. Right 42) with Right 42
 utest eitherBindLeft (Right 42) (lam s. Left (head s)) with Right 42
 
-
+--  *-
+--  * .brief If the input Either is the Right case, then its value is applied
+--  *        as the argument to the passed function.
+--  *
+--  * .lam[e] The Either value whose Right case will be bound as input
+--  * .lam[bf] The function to have the Right value applied to
+--  *
+--  * .return If the Either argument is a Right case, the result of binding its
+--  *         value to the passed function. If it is the Left case, then it is
+--  *         returned as is.
+-- -*
 let eitherBindRight: Either a b -> (b -> Either a c) -> Either a c =
   lam e. lam bf.
   match e with Left content then
@@ -107,7 +152,16 @@ utest eitherBindRight (Left "a") (lam i. Right [int2char i]) with Left "a"
 utest eitherBindRight (Right 10) (lam i. Right [int2char i]) with Right "\n"
 utest eitherBindRight (Right 11) (lam _. Left "c") with Left "c"
 
-
+--  *-
+--  * .brief Partitions a list of Eithers into the Left case values and the
+--  *        Right case values.
+--  *
+--  * .lam[es] List of Either values to partition
+--  *
+--  * .return A tuple with the first element containing the Left values and the
+--  *         second element containing the Right values, preserving order in
+--  *         relation to the input list.
+-- -*
 let eitherPartition: [Either a b] -> ([a],[b]) = lam es.
   foldl (lam acc. lam e.
     match e with Left content then
@@ -121,21 +175,41 @@ utest eitherPartition [] with ([], [])
 utest eitherPartition [Left 1, Right "foo", Right "bar", Left 42] with ([1,42], ["foo", "bar"])
 utest eitherPartition [Right 5.0, Right 1.0, Left "42"] with (["42"], [5.0, 1.0])
 
-
+--  *-
+--  * .brief Extracts the Left values from a list of Eithers.
+--  *
+--  * .lam[es] List of Eithers whose Left values to extract
+--  *
+--  * .return The extracted Left values, appearing in the same order as in the
+--  *         input list.
+-- -*
 let eitherLefts: [Either a b] -> [a] = lam es. (eitherPartition es).0
 
 utest eitherLefts [] with []
 utest eitherLefts [Right 1, Right 5] with []
 utest eitherLefts [Right 1, Left "c", Right 5, Left "a"] with ["c", "a"]
 
-
+--  *-
+--  * .brief Extracts the Right values from a list of Eithers.
+--  *
+--  * .lam[es] List of Eithers whose Right values to extract
+--  *
+--  * .return The extracted Right values, appearing in the same order as in the
+--  *         input list.
+-- -*
 let eitherRights: [Either a b] -> [b] = lam es. (eitherPartition es).1
 
 utest eitherRights [] with []
 utest eitherRights [Left "1", Left "5"] with []
 utest eitherRights [Right 1, Left "3", Right 5, Left "1"] with [1, 5]
 
-
+--  *-
+--  * .brief Checks whether the entered Either value is the Left case.
+--  *
+--  * .lam[e] The Either value to check
+--  *
+--  * .return True iff the Either value is the Left case.
+-- -*
 let eitherIsLeft: Either a b -> Bool = lam e.
   match e with Left _ then true else false
 
@@ -144,7 +218,13 @@ utest eitherIsLeft (Left "a") with true
 utest eitherIsLeft (Right "a") with false
 utest eitherIsLeft (Right (Left 1)) with false
 
-
+--  *-
+--  * .brief Checks whether the entered Either value is the Right case.
+--  *
+--  * .lam[e] The Either value to check
+--  *
+--  * .return True iff the Either value is the Right case.
+-- -*
 let eitherIsRight: Either a b -> Bool = lam e.
   match e with Right _ then true else false
 
@@ -153,27 +233,42 @@ utest eitherIsRight (Left "a") with false
 utest eitherIsRight (Right "a") with true
 utest eitherIsRight (Right (Left 1)) with true
 
-
-let eitherFromLeft: a -> Either a b -> a = lam v. lam e.
-  match e with Left content then
-    content
-  else
-    v
+--  *-
+--  * .brief Extracts the Left case value from an Either or returns the passed
+--  *        default value.
+--  *
+--  * .lam[v] The default value
+--  * .lam[e] The Either value to check
+--  *
+--  * .return The Left case value or the default value.
+-- -*
+let eitherFromLeft: a -> Either a b -> a = lam v. lam e. eitherEither (lam x. x) (lam _. v)
 
 utest eitherFromLeft "a" (Right 5) with "a"
 utest eitherFromLeft "a" (Left "foo") with "foo"
 
-
-let eitherFromRight: b -> Either a b -> b = lam v. lam e.
-  match e with Right content then
-    content
-  else
-    v
+--  *-
+--  * .brief Extracts the Right case value from an Either or returns the passed
+--  *        default value.
+--  *
+--  * .lam[v] The default value
+--  * .lam[e] The Either value to check
+--  *
+--  * .return The Right case value or the default value.
+-- -*
+let eitherFromRight: b -> Either a b -> b = lam v. lam e. eitherEither (lam _. v) (lam x. x)
 
 utest eitherFromRight 0 (Left "foo") with 0
 utest eitherFromRight 0 (Right 42) with 42
 
-
+--  *-
+--  * .brief Extracts the Left case value as an Option.
+--  *
+--  * .lam[e] The Either value to extract
+--  *
+--  * .return In the Left case, an Option containing the Left value is
+--  *         returned. Otherwise `None ()` is returned.
+-- -*
 let eitherGetLeft: Either a b -> Option a = lam e.
   match e with Left content then
     Some content
@@ -183,7 +278,14 @@ let eitherGetLeft: Either a b -> Option a = lam e.
 utest eitherGetLeft (Left "foo") with Some "foo"
 utest eitherGetLeft (Right 42) with None ()
 
-
+--  *-
+--  * .brief Extracts the Right case value as an Option.
+--  *
+--  * .lam[e] The Either value to extract
+--  *
+--  * .return In the Right case, an Option containing the Right value is
+--  *         returned. Otherwise `None ()` is returned.
+-- -*
 let eitherGetRight: Either a b -> Option b = lam e.
   match e with Right content then
     Some content

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -39,7 +39,6 @@ let eitherMapLeft: (a -> c) -> Either a b -> Either c b = lam f. lam e.
   match e with Left content then
     Left (f content)
   else match e with Right content then
-    -- just returning e here is most likely not type safe
     Right content
   else never
 
@@ -49,7 +48,6 @@ utest eitherMapLeft (cons 'a') (Left "choo") with Left "achoo"
 
 let eitherMapRight: (b -> c) -> Either a b -> Either a c = lam f. lam e.
   match e with Left content then
-    -- just returning e here is most likely not type safe
     Left content
   else match e with Right content then
     Right (f content)
@@ -57,6 +55,32 @@ let eitherMapRight: (b -> c) -> Either a b -> Either a c = lam f. lam e.
 
 utest eitherMapRight (addi 2) (Right 40) with Right 42
 utest eitherMapRight (addi 2) (Left "foo") with Left "foo"
+
+
+let eitherBindLeft: Either a b -> (a -> Either c b) -> Either c b =
+  lam e. lam bf.
+  match e with Left content then
+    bf content
+  else match e with Right content then
+    Right content
+  else never
+
+utest eitherBindLeft (Left "a") (lam s. Left (head s)) with Left 'a'
+utest eitherBindLeft (Left "a") (lam _. Right 42) with Right 42
+utest eitherBindLeft (Right 42) (lam s. Left (head s)) with Right 42
+
+
+let eitherBindRight: Either a b -> (b -> Either a c) -> Either a c =
+  lam e. lam bf.
+  match e with Left content then
+    Left content
+  else match e with Right content then
+    bf content
+  else never
+
+utest eitherBindRight (Left "a") (lam i. Right [int2char i]) with Left "a"
+utest eitherBindRight (Right 10) (lam i. Right [int2char i]) with Right "\n"
+utest eitherBindRight (Right 11) (lam _. Left "c") with Left "c"
 
 
 let eitherPartition: [Either a b] -> ([a],[b]) = lam es.

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -10,7 +10,17 @@ type Either a b
 con Left: a -> Either a b
 con Right: b -> Either a b
 
-
+--  *-
+--  * .brief Checks equality between two Either values.
+--  *
+--  * .lam[eql] Function that checks left equality
+--  * .lam[eqr] Function that checks right equality
+--  * .lam[e1] Either value to be compared
+--  * .lam[e2] The other Either value to be compared
+--  *
+--  * .return Whether e1 and e2 are equal based on the provided equaliy
+--  *         functions.
+-- -*
 let eitherEq: (a -> c -> Bool) -> (b -> d -> Bool) -> Either a b -> Either c d -> Bool =
   lam eql. lam eqr. lam e1. lam e2.
   match (e1,e2) with (Left c1, Left c2) then
@@ -27,7 +37,15 @@ utest eitherEq eqi eqi (Right 4321) (Right 4321) with true
 utest eitherEq eqi eqi (Right 4321) (Right 1) with false
 utest eitherEq eqi eqi (Right 4321) (Left 4321) with false
 
-
+--  *-
+--  * .brief Case analysis of an Either type to extract its value
+--  *
+--  * .lam[lf] How a Left value should be extracted
+--  * .lam[rf] How a Right value should be extracted
+--  * .lam[e] The Either value to have have its value extracted
+--  *
+--  * .return The value that was extracted from the case analysis
+-- -*
 let eitherEither: (a -> c) -> (b -> c) -> Either a b -> c =
   lam lf. lam rf. lam e.
   match e with Left content then


### PR DESCRIPTION
Adds an Either library to stdlib. I know that @andersthune was supposed to start on this, but I need it for the refactoring that I am doing on #162. Feels better to put this as a separate PR instead of including it there.

This is more or less a rip-off from https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-Either.html

Will add documentation to functions before the meeting on Tuesday.