### PR TITLE
Add optional using term to utest

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -233,7 +233,7 @@ let rec map_tm f = function
     f (TmMatch(fi,map_tm f t1,p,map_tm f t2,map_tm f t3))
   | TmUse(fi,l,t1) -> f (TmUse(fi,l,map_tm f t1))
   | TmUtest(fi,t1,t2,tusing,tnext) ->
-    let tusing_mapped = Option.map (fun t -> map_tm f t) tusing in
+    let tusing_mapped = Option.map map_tm tusing in
     f (TmUtest(fi,map_tm f t1,map_tm f t2,tusing_mapped,map_tm f tnext))
   | TmNever(_) as t -> f t
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -130,7 +130,7 @@ and mlang   = Lang of info * ustring * ustring list * decl list
 and let_decl = Let of info * ustring * tm
 and rec_let_decl = RecLet of info * (info * ustring * tm) list
 and con_decl = Con of info * ustring * ty
-and utest_top = Utest of info * tm * tm
+and utest_top = Utest of info * tm * tm * tm option
 and top =
 | TopLang of mlang
 | TopLet  of let_decl
@@ -156,7 +156,7 @@ and tm =
 | TmConapp  of info * ustring * sym * tm                            (* Constructor application *)
 | TmMatch   of info * tm * pat * tm * tm                            (* Match data *)
 | TmUse     of info * ustring * tm                                  (* Use a language *)
-| TmUtest   of info * tm * tm * tm                                  (* Unit testing *)
+| TmUtest   of info * tm * tm * tm option * tm                      (* Unit testing *)
 | TmNever   of info                                                 (* Never term *)
 (* Only part of the runtime system *)
 | TmClos    of info * ustring * sym * ty * tm * env Lazy.t          (* Closure *)
@@ -232,7 +232,9 @@ let rec map_tm f = function
   | TmMatch(fi,t1,p,t2,t3) ->
     f (TmMatch(fi,map_tm f t1,p,map_tm f t2,map_tm f t3))
   | TmUse(fi,l,t1) -> f (TmUse(fi,l,map_tm f t1))
-  | TmUtest(fi,t1,t2,tnext) -> f (TmUtest(fi,map_tm f t1,map_tm f t2,map_tm f tnext))
+  | TmUtest(fi,t1,t2,tusing,tnext) ->
+    let tusing_mapped = Option.map (fun t -> map_tm f t) tusing in
+    f (TmUtest(fi,map_tm f t1,map_tm f t2,tusing_mapped,map_tm f tnext))
   | TmNever(_) as t -> f t
 
 
@@ -253,7 +255,7 @@ let tm_info = function
   | TmConapp(fi,_,_,_) -> fi
   | TmMatch(fi,_,_,_,_) -> fi
   | TmUse(fi,_,_) -> fi
-  | TmUtest(fi,_,_,_) -> fi
+  | TmUtest(fi,_,_,_,_) -> fi
   | TmNever(fi) -> fi
 
 let pat_info = function

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -233,7 +233,7 @@ let rec map_tm f = function
     f (TmMatch(fi,map_tm f t1,p,map_tm f t2,map_tm f t3))
   | TmUse(fi,l,t1) -> f (TmUse(fi,l,map_tm f t1))
   | TmUtest(fi,t1,t2,tusing,tnext) ->
-    let tusing_mapped = Option.map map_tm tusing in
+    let tusing_mapped = Option.map (map_tm f) tusing in
     f (TmUtest(fi,map_tm f t1,map_tm f t2,tusing_mapped,map_tm f tnext))
   | TmNever(_) as t -> f t
 

--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -38,6 +38,7 @@ let reserved_strings = [
   ("mexpr",         fun(i) -> Parser.MEXPR{i=i;v=()});
   ("include",       fun(i) -> Parser.INCLUDE{i=i;v=()});
   ("never",         fun(i) -> Parser.NEVER{i=i;v=()});
+  ("using",         fun(i) -> Parser.USING{i=i;v=()});
 
 
   (* v *)

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -495,14 +495,18 @@ let debug_eval env t =
   else ()
 
 (* Print out error message when a unit test fails *)
-let unittest_failed fi t1 t2=
+let unittest_failed fi t1 t2 tusing =
   uprint_endline
     (match fi with
     | Info(_,l1,_,_,_) ->
+      let using_str = (match tusing with
+        | Some t -> us"\n    Using: " ^. (ustring_of_tm t)
+        | None   -> us"") in
       us"\n ** Unit test FAILED on line " ^.
       us(string_of_int l1)
       ^.  us" **\n    LHS: " ^. (ustring_of_tm t1)
       ^.  us"\n    RHS: "    ^. (ustring_of_tm t2)
+      ^.  using_str
     | NoInfo -> us"Unit test FAILED ")
 
 
@@ -772,7 +776,7 @@ let rec eval (env : (sym * tm) list) (t : tm) =
       if equal then
         (printf "."; utest_ok := !utest_ok + 1)
       else (
-        unittest_failed fi v1 v2;
+        unittest_failed fi v1 v2 tusing;
         utest_fail := !utest_fail + 1;
         utest_fail_local := !utest_fail_local + 1)
     end;

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -304,7 +304,9 @@ let rec desugar_tm nss env =
   | TmSeq(fi, tms) -> TmSeq(fi, Mseq.map (desugar_tm nss env) tms)
   | TmRecord(fi, r) -> TmRecord(fi, Record.map (desugar_tm nss env) r)
   | TmRecordUpdate(fi, a, lab, b) -> TmRecordUpdate(fi, desugar_tm nss env a, lab, desugar_tm nss env b)
-  | TmUtest(fi, a, b, using, body) -> TmUtest(fi, desugar_tm nss env a, desugar_tm nss env b, using, desugar_tm nss env body)
+  | TmUtest(fi, a, b, using, body) ->
+    let using_desugared = Option.map (desugar_tm nss env) using in
+    TmUtest(fi, desugar_tm nss env a, desugar_tm nss env b, using_desugared, desugar_tm nss env body)
   | TmNever(fi) -> TmNever(fi)
   (* Non-recursive *)
   | (TmConst _ | TmFix _ ) as tm -> tm

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -304,7 +304,7 @@ let rec desugar_tm nss env =
   | TmSeq(fi, tms) -> TmSeq(fi, Mseq.map (desugar_tm nss env) tms)
   | TmRecord(fi, r) -> TmRecord(fi, Record.map (desugar_tm nss env) r)
   | TmRecordUpdate(fi, a, lab, b) -> TmRecordUpdate(fi, desugar_tm nss env a, lab, desugar_tm nss env b)
-  | TmUtest(fi, a, b, body) -> TmUtest(fi, desugar_tm nss env a, desugar_tm nss env b, desugar_tm nss env body)
+  | TmUtest(fi, a, b, using, body) -> TmUtest(fi, desugar_tm nss env a, desugar_tm nss env b, using, desugar_tm nss env body)
   | TmNever(fi) -> TmNever(fi)
   (* Non-recursive *)
   | (TmConst _ | TmFix _ ) as tm -> tm
@@ -355,8 +355,8 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
   | TopCon(Con(fi, id, ty)) ->
      let wrap tm' = TmCondef(fi, empty_mangle id, nosym, ty, tm')
      in (nss, (wrap :: stack))
-  | TopUtest(Utest(fi, lhs, rhs)) ->
-     let wrap tm' = TmUtest(fi, lhs, rhs, tm')
+  | TopUtest(Utest(fi, lhs, rhs, using)) ->
+     let wrap tm' = TmUtest(fi, lhs, rhs, using, tm')
      in (nss, (wrap :: stack))
 
 let desugar_post_flatten_with_nss nss (Program (_, tops, t)) =

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -64,6 +64,7 @@
 %token <unit Ast.tokendata> MEXPR
 %token <unit Ast.tokendata> INCLUDE
 %token <unit Ast.tokendata> NEVER
+%token <unit Ast.tokendata> USING
 
 %token <unit Ast.tokendata> EQ            /* "="   */
 %token <unit Ast.tokendata> ARROW         /* "->"  */
@@ -164,7 +165,10 @@ topcon:
 toputest:
   | UTEST mexpr WITH mexpr
       { let fi = mkinfo $1.i (tm_info $4) in
-        Utest (fi,$2,$4) }
+        Utest (fi,$2,$4,None) }
+  | UTEST mexpr WITH mexpr USING mexpr
+      { let fi = mkinfo $1.i (tm_info $6) in
+        Utest (fi,$2,$4,Some $6) }
 
 mlang:
   | LANG ident lang_includes lang_body
@@ -271,7 +275,10 @@ mexpr:
         TmUse(fi,$2.v,$4) }
   | UTEST mexpr WITH mexpr IN mexpr
       { let fi = mkinfo $1.i (tm_info $4) in
-        TmUtest(fi,$2,$4,$6) }
+        TmUtest(fi,$2,$4,None,$6) }
+  | UTEST mexpr WITH mexpr USING mexpr IN mexpr
+      { let fi = mkinfo $1.i (tm_info $6) in
+        TmUtest(fi,$2,$4,Some $6,$8) }
 
 lets:
   | LET var_ident ty_op EQ mexpr

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -408,7 +408,7 @@ and print_tm' fmt t = match t with
     fprintf fmt "@[<hov 0>use %s in@ %a@]"
       l print_tm (Match, t)
 
-  | TmUtest(_,t1,t2,t3) ->
+  | TmUtest(_,t1,t2,None,t4) ->
     fprintf fmt "@[<hov 0>\
                    @[<hov %d>\
                      utest@ \
@@ -422,7 +422,25 @@ and print_tm' fmt t = match t with
       !ref_indent
       print_tm (Match, t1)
       print_tm (Match, t2)
+      print_tm (Match, t4)
+
+  | TmUtest(_,t1,t2,Some t3,t4) ->
+    fprintf fmt "@[<hov 0>\
+                   @[<hov %d>\
+                     utest@ \
+                     @[<hov 0>\
+                       %a with@ \
+                       %a using@ \
+                       %a in\
+                     @]\
+                   @]\
+                   @ %a\
+                 @]"
+      !ref_indent
+      print_tm (Match, t1)
+      print_tm (Match, t2)
       print_tm (Match, t3)
+      print_tm (Match, t4)
 
   | TmClos(_,x,_,ty,t1,_) ->
     let x = string_of_ustring x in

--- a/test/mexpr/float.mc
+++ b/test/mexpr/float.mc
@@ -34,26 +34,27 @@ utest negf 2.2 with negf 2.2 in
 
 -- Floating-point operations
 -- Float -> Float -> Bool
-utest ltf 0.5 2.0 with true in           -- less than (float)
-utest ltf 2.0 0.5 with false in
-utest ltf 0.5 0.5 with false in
-utest leqf 0.5 2.0 with true in          -- less equal (float)
-utest leqf 2.0 0.5 with false in
-utest leqf 0.5 0.5 with true in
-utest gtf 7.5 0.25 with true in          -- greater than (float)
-utest gtf 0.25 7.5 with false in
-utest gtf 0.25 0.25 with false in
-utest geqf 7.5 0.25 with true in         -- greater than or equal (float)
-utest geqf 0.25 7.5 with false in
-utest geqf 0.25 0.25 with true in
-utest eqf 2.2 2.2 with true in           -- equal (float)
-utest eqf 2.2 2.3 with false in
-utest eqf (subf 3.0 5.0) (negf 2.0)
-      with true in
-utest eqf (subf 3.0 5.0) (negf 3.0)
-      with false in
-utest neqf 0.25 0.25 with false in       -- not equal (float)
-utest neqf 0.25 0.5 with true in
+let neg = lam f. lam x. lam y. not (f x y) in
+utest 0.5 with 2.0 using ltf in          -- less than (float)
+utest 2.0 with 0.5 using neg ltf in
+utest 0.5 with 0.5 using neg ltf in
+utest 0.5 with 2.0 using leqf in         -- less equal (float)
+utest 2.0 with 0.5 using neg leqf in
+utest 0.5 with 0.5 using leqf in
+utest 7.5 with 0.25 using gtf in         -- greater than (float)
+utest 0.25 with 7.5 using neg gtf in
+utest 0.25 with 0.25 using neg gtf in
+utest 7.5 with 0.25 using geqf in        -- greater than or equal (float)
+utest 0.25 with 7.5 using neg geqf in
+utest 0.25 with 0.25 using geqf in
+utest 2.2 with 2.2 using eqf in          -- equal (float)
+utest 2.2 with 2.3 using neg eqf in
+utest subf 3.0 5.0 with negf 2.0
+      using eqf in
+utest subf 3.0 5.0 with negf 3.0
+      using neg eqf in
+utest 0.25 with 0.25 using neg neqf in   -- not equal (float)
+utest 0.25 with 0.5 using neqf in
 
 
 -- Conversion from Float to Int
@@ -105,6 +106,6 @@ utest string2float "3e+2" with 300.0 in
 let powf3 = lam x. mulf x (mulf x x) in
 let taxicab2_1 = addf (powf3 1.0) (powf3 12.0) in
 let taxicab2_2 = addf (powf3 9.0) (powf3 10.0) in
-utest eqf taxicab2_1 taxicab2_2 with true in
+utest taxicab2_1 with taxicab2_2 using eqf in
 
 ()

--- a/test/mexpr/int.mc
+++ b/test/mexpr/int.mc
@@ -24,24 +24,25 @@ utest negi 1 with negi 1 in
 
 -- Integer comparison operators
 -- int -> int -> bool
-utest true with lti 4 10 in           -- Less than <
-utest false with lti 20 10 in
-utest false with lti 10 10 in
-utest true with leqi 4 10 in          -- Less than and equal <=
-utest false with leqi 20 10 in
-utest true with leqi 10 10 in
-utest true with gti 100 10 in         -- Greater than >
-utest false with gti 10 20 in
-utest false with gti 10 10 in
-utest true with geqi 100 10 in        -- Greater than and equal >=
-utest false with geqi 10 20 in
-utest true with geqi 10 10 in
-utest false with eqi 100 10 in        -- Equal =
-utest false with eqi 10 20 in
-utest true with eqi 10 10 in
-utest true with neqi 100 10 in        -- Not equal !=
-utest true with neqi 10 20 in
-utest false with neqi 10 10 in
+let neg = lam f. lam x. lam y. not (f x y) in
+utest 4 with 10 using lti in          -- Less than <
+utest 20 with 10 using neg lti in
+utest 10 with 10 using neg lti in
+utest 4 with 10 using leqi in         -- Less than or equal <=
+utest 20 with 10 using neg leqi in
+utest 10 with 10 using leqi in
+utest 100 with 10 using gti in        -- Greater than >
+utest 10 with 20 using neg gti in
+utest 10 with 10 using neg gti in
+utest 100 with 10 using geqi in       -- Greater than or equal >=
+utest 10 with 20 using neg geqi in
+utest 10 with 10 using geqi in
+utest 100 with 10 using neg eqi in    -- Equal =
+utest 10 with 20 using neg eqi in
+utest 10 with 10 using eqi in
+utest 100 with 10 using neqi in       -- Not equal !=
+utest 10 with 20 using neqi in
+utest 10 with 10 using neg neqi in
 
 -- Bit-shifting operators
 -- int -> int -> int

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -20,17 +20,18 @@ let randSeq = lam lower. lam upper. lam length.
   map (lam _. randIntU lower upper) (makeSeq length 0) in
 
 -- With high probability all possible elements are present in the random sequence
-utest setEqual eqi [2,3,4,5,6] (distinct eqi (randSeq 2 7 1000)) with true in
+utest [2,3,4,5,6] with distinct eqi (randSeq 2 7 1000) using setEqual eqi in
 
 -- The same seed should give the same sequence of numbers
 let _ = randSetSeed 42 in
 let randSeq1 = randSeq 123 89018 100 in
 let _ = randSetSeed 42 in
 let randSeq2 = randSeq 123 89018 100 in
-utest setEqual eqi randSeq1 randSeq2 with true in
+utest randSeq1 with randSeq2 using setEqual eqi in
 
 -- With high probability, subsequent sequence should be different
 let randSeq3 = randSeq 123 89018 100 in
-utest setEqual eqi randSeq1 randSeq3 with false in
+let neg = lam f. lam x. lam y. not (f x y) in
+utest randSeq1 with randSeq3 using neg (setEqual eqi) in
 
 ()

--- a/test/mexpr/stringops.mc
+++ b/test/mexpr/stringops.mc
@@ -85,7 +85,7 @@ let strflatten = lam s. strjoin "" s in
 utest str2upper "Hello, world!" with "HELLO, WORLD!" in
 utest str2lower "Foo... BAR!" with "foo... bar!" in
 
-utest (eqstr "Hello" "Hello") with true in
+utest "Hello" with "Hello" using eqstr in
 utest (cons "Hello" []) with ["Hello"] in
 
 utest (strsplit "ll" "Hello") with ["He", "o"] in

--- a/test/mexpr/symbs.mc
+++ b/test/mexpr/symbs.mc
@@ -13,10 +13,11 @@ let y = gensym () in
 -- 'eqs s1 s2' returns true if symbol 's1' and symbol 's2'
 -- are the same symbol.
 -- Symbol -> Symbol -> Bool
-utest eqs x x with true in
-utest eqs y y with true in
-utest eqs y x with false in
-utest eqs x y with false in
+let neg = lam f. lam x. lam y. not (f x y) in
+utest x with x using eqs in
+utest y with y using eqs in
+utest y with x using neg eqs in
+utest x with y using neg eqs in
 
 -- 'sym2hash s1' returns an integer representation of s1 that fulfills the
 -- following criterion: eqs a b => eqi (sym2hash a) (sym2hash b)
@@ -24,7 +25,7 @@ utest eqs x y with false in
 -- made to give 2 symbols different integer representation.
 -- Symbol -> Int
 let z = x in
-utest eqi (sym2hash x) (sym2hash x) with true in
-utest eqi (sym2hash x) (sym2hash z) with true in
+utest sym2hash x with sym2hash x using eqi in
+utest sym2hash x with sym2hash z using eqi in
 
 ()

--- a/test/mexpr/time.mc
+++ b/test/mexpr/time.mc
@@ -15,4 +15,4 @@ let t1 = wallTimeMs () in
 let _ = sleepMs 1 in
 let t2 = wallTimeMs () in
 
-utest gtf t2 t1 with true in ()
+utest t2 with t1 using gtf in ()

--- a/test/mlang/utest.mc
+++ b/test/mlang/utest.mc
@@ -1,0 +1,5 @@
+-- Top-level utest with using function
+
+utest 15 with 15 using eqi
+utest 12 with 7 using gti
+utest addi 1 5 with addi 4 2 using lam x. lam y. not (lti x y)


### PR DESCRIPTION
Adds an optional `using` argument to `utest`. This change does not affect tests using the original syntax. Example usage:

`utest 10 with 20 using lti in ()`