### PR TITLE
Fix symbolize for edge patterns in boot

### DIFF
--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -555,7 +555,9 @@ let rec symbolize (env : (ident * sym) list) (t : tm) =
        let (patEnv, l) = s_pat_sequence patEnv l in
        let (patEnv, x) = match x with
          | NameWildcard -> (patEnv, NameWildcard)
-         | NameStr(x, _) -> let s = gensym() in ((IdVar(sid_of_ustring x),s)::patEnv, NameStr(x, s)) in
+         | NameStr(x, _) ->
+            let (patEnv, s) = add_name (IdVar (sid_of_ustring x)) patEnv
+            in (patEnv, NameStr(x, s)) in
        let (patEnv, r) = s_pat_sequence patEnv r
        in (patEnv, PatSeqEdg(fi, l, x, r))
     | PatRecord(fi, pats) ->

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -159,6 +159,8 @@ utest match (true, false) with (true, a) & !(_, true) then a else false with fal
 utest match (1, 2) with (a, _) & b then (a, b) else (0, (0, 0)) with (1, (1, 2)) in
 utest match Some true with a & !(None ()) then a else Some false with Some true in
 utest match None () with a & !(None ()) then a else Some false with Some false in
+utest match "abc" with ['a'] ++ s | ['b'] ++ s then s else "" with "bc" in
+utest match "bc" with ['a'] ++ s | ['b'] ++ s then s else "" with "c" in
 
 -- Matching with never terms
 let x = true in


### PR DESCRIPTION
When generating symbols for sequence edge patterns (`[] ++ s ++ []`) the symbol in the middle did not generate a symbol correctly. It always generated a new symbol, since it directly called `gensym`, instead of deferring to `add_name` which would decide on whether a new name should be generated or not. This was visible if there were two branches in a pattern (using `|`) where the second used the middle part of an edge pattern to bind something.