### PR TITLE
Updated the syntax for multiline comments.

### DIFF
--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -69,6 +69,7 @@ let filename = ref (us"")
 let rowno = ref 1
 let colno = ref 0
 let last_info = ref NoInfo
+let nesting_level = ref 0
 let utf8strlen s = Ustring.length (Ustring.from_utf8 s)
 let newrow() =
   incr rowno;
@@ -166,9 +167,11 @@ rule main = parse
       { colcount_fast s; main lexbuf }
   | line_comment
       { main lexbuf }
-  | "/*" as s
+  | "*-" as s
       { Buffer.reset string_buf ;
-	Buffer.add_string string_buf s; section_comment lexbuf;
+	Buffer.add_string string_buf s;
+        nesting_level := 0;
+        section_comment lexbuf;
 	count_utf8 (Buffer.contents string_buf);
 	main lexbuf}
   | tab
@@ -232,10 +235,19 @@ and parsestring = parse
 
 (* Section comment *)
 and section_comment = parse
-  | "*/" as s
-      { Buffer.add_string string_buf s }
+  | "-*" as s
+      { if !nesting_level = 0 then
+          Buffer.add_string string_buf s
+        else (
+          nesting_level := !nesting_level - 1;
+          section_comment lexbuf)
+      }
+  | "*-"
+      { nesting_level := !nesting_level + 1;
+        section_comment lexbuf
+      }
   | eof
-      { let s = Ustring.from_utf8 ("/*" ^ (Buffer.contents string_buf)) in
+      { let s = Ustring.from_utf8 ("*-" ^ (Buffer.contents string_buf)) in
 	raise (Lex_error (LEX_COMMENT_NOT_TERMINATED,ERROR,
 	 	 mkinfo_ustring s, [s])) }
   | _ as c

--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -167,7 +167,7 @@ rule main = parse
       { colcount_fast s; main lexbuf }
   | line_comment
       { main lexbuf }
-  | "*-" as s
+  | "/-" as s
       { Buffer.reset string_buf ;
 	Buffer.add_string string_buf s;
         nesting_level := 0;
@@ -235,19 +235,19 @@ and parsestring = parse
 
 (* Section comment *)
 and section_comment = parse
-  | "-*" as s
+  | "-/" as s
       { if !nesting_level = 0 then
           Buffer.add_string string_buf s
         else (
           nesting_level := !nesting_level - 1;
           section_comment lexbuf)
       }
-  | "*-"
+  | "/-"
       { nesting_level := !nesting_level + 1;
         section_comment lexbuf
       }
   | eof
-      { let s = Ustring.from_utf8 ("*-" ^ (Buffer.contents string_buf)) in
+      { let s = Ustring.from_utf8 ("/-" ^ (Buffer.contents string_buf)) in
 	raise (Lex_error (LEX_COMMENT_NOT_TERMINATED,ERROR,
 	 	 mkinfo_ustring s, [s])) }
   | _ as c

--- a/test/mexpr/comments.mc
+++ b/test/mexpr/comments.mc
@@ -1,26 +1,25 @@
-*-
-* Miking is licensed under the MIT license.
-* Copyright (C) David Broman. See file LICENSE.txt
--*
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+
 
 -- This is a line comment
 
 mexpr
 
-*-
+/-
   A multiline
   comment.
--*
+-/
 
-*-
+/-
   Nested multiline comments
-  *-
+  /-
     including line comments
     -- Another comment
-  -*
--*
+  -/
+-/
 
-let x = *- multiline inside code -* 1 in
+let x = /- multiline inside code -/ 1 in
 utest x with 1 in
 
 ()

--- a/test/mexpr/comments.mc
+++ b/test/mexpr/comments.mc
@@ -1,0 +1,26 @@
+*-
+* Miking is licensed under the MIT license.
+* Copyright (C) David Broman. See file LICENSE.txt
+-*
+
+-- This is a line comment
+
+mexpr
+
+*-
+  A multiline
+  comment.
+-*
+
+*-
+  Nested multiline comments
+  *-
+    including line comments
+    -- Another comment
+  -*
+-*
+
+let x = *- multiline inside code -* 1 in
+utest x with 1 in
+
+()

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -1,7 +1,9 @@
--- Miking is licensed under the MIT license.
--- Copyright (C) David Broman. See file LICENSE.txt
---
--- Test integer primitives
+*-
+* Miking is licensed under the MIT license.
+* Copyright (C) David Broman. See file LICENSE.txt
+*
+* Test integer primitives
+-*
 
 mexpr
 

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -1,9 +1,7 @@
-*-
-* Miking is licensed under the MIT license.
-* Copyright (C) David Broman. See file LICENSE.txt
-*
-* Test integer primitives
--*
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Test integer primitives
 
 mexpr
 


### PR DESCRIPTION
I have updated the syntax for multiline comments, to support syntax
```
*- 
  Text 
-*
```
Please see the examples in file `comments.mc`.

This PR also adds support for nested multiline comments in boot. 

Also, please check out the header syntax for copyright statement etc. If we can agree on this, I will update the headers in all files in this PR.