### PR TITLE
Change snake_case function names to camelCase

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -76,12 +76,12 @@ and const =
 | Cfloorfi
 | Cceilfi
 | Croundfi
-| CInt2float
-| CString2float
+| Cint2float
+| Cstring2float
 (* MCore intrinsic: characters *)
 | CChar    of int
-| CChar2int
-| CInt2char
+| Cchar2int
+| Cint2char
 (* MCore intrinsic: sequences *)
 | CmakeSeq of int option
 | Clength
@@ -113,7 +113,7 @@ and const =
 | CSymb of int
 | Cgensym
 | Ceqsym of int option
-| CSym2hash
+| Csym2hash
 (* External functions TODO(?,?): Should not be part of core language *)
 | CExt of Extast.ext
 | CSd of Sdast.ext

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -43,8 +43,8 @@ let builtin =
    ("ltf",f(Cltf(None)));("leqf",f(Cleqf(None)));("gtf",f(Cgtf(None)));("geqf",f(Cgeqf(None)));
    ("eqf",f(Ceqf(None)));("neqf",f(Cneqf(None)));
    ("floorfi", f(Cfloorfi)); ("ceilfi", f(Cceilfi)); ("roundfi", f(Croundfi));
-   ("int2float", f(CInt2float)); ("string2float", f(CString2float));
-   ("char2int",f(CChar2int));("int2char",f(CInt2char));
+   ("int2float", f(Cint2float)); ("string2float", f(Cstring2float));
+   ("char2int",f(Cchar2int));("int2char",f(Cint2char));
    ("makeSeq",f(CmakeSeq(None))); ("length",f(Clength));("concat",f(Cconcat(None)));
    ("get",f(Cget(None)));("set",f(Cset(None,None)));
    ("cons",f(Ccons(None)));("snoc",f(Csnoc(None)));
@@ -63,7 +63,7 @@ let builtin =
    ("fileExists", f(CfileExists)); ("deleteFile", f(CdeleteFile));
    ("error",f(Cerror));
    ("exit",f(Cexit));
-   ("eqsym", f(Ceqsym(None))); ("gensym", f(Cgensym)); ("sym2hash", f(CSym2hash));
+   ("eqsym", f(Ceqsym(None))); ("gensym", f(Cgensym)); ("sym2hash", f(Csym2hash));
    ("randIntU", f(CrandIntU(None))); ("randSetSeed", f(CrandSetSeed));
    ("wallTimeMs",f(CwallTimeMs)); ("sleepMs",f(CsleepMs));
   ]
@@ -120,12 +120,12 @@ let arity = function
   | Cfloorfi    -> 1
   | Cceilfi     -> 1
   | Croundfi    -> 1
-  | CInt2float  -> 1
-  | CString2float -> 1
+  | Cint2float  -> 1
+  | Cstring2float -> 1
   (* MCore intrinsic: characters *)
   | CChar(_)    -> 0
-  | CChar2int   -> 1
-  | CInt2char   -> 1
+  | Cchar2int   -> 1
+  | Cint2char   -> 1
   (* MCore intrinsic: sequences *)
   | CmakeSeq(None)    -> 2 | CmakeSeq(Some(_)) -> 1
   | Clength           -> 1
@@ -155,7 +155,7 @@ let arity = function
   | Cgensym       -> 1
   | Ceqsym(None)    -> 2
   | Ceqsym(Some(_)) -> 1
-  | CSym2hash     -> 1
+  | Csym2hash     -> 1
   (* Python intrinsics *)
   | CPy v   -> Pyffi.arity v
   (* Sundials intrinsics *)
@@ -321,7 +321,7 @@ let delta eval env fi c v  =
     | Cneqf(None),TmConst(fi,CFloat(v)) -> TmConst(fi,Cneqf(Some(v)))
     | Cneqf(Some(v1)),TmConst(fi,CFloat(v2)) -> TmConst(fi,CBool(v1 <> v2))
     | Cneqf(None),_ | Cneqf(Some(_)),_  -> fail_constapp fi
-    | CString2float,TmSeq(fi,s) ->
+    | Cstring2float,TmSeq(fi,s) ->
         let to_char = function
           | TmConst(_, CChar(c)) -> c
           | _ -> fail_constapp fi
@@ -331,7 +331,7 @@ let delta eval env fi c v  =
                 |> Ustring.from_uchars |> Ustring.to_utf8
         in
         TmConst(fi, CFloat(Float.of_string f))
-    | CString2float,_ -> fail_constapp fi
+    | Cstring2float,_ -> fail_constapp fi
 
     | Cfloorfi,TmConst(fi,CFloat(v)) -> TmConst(fi,CInt(Float.floor v |> int_of_float))
     | Cfloorfi,_ -> fail_constapp fi
@@ -342,17 +342,17 @@ let delta eval env fi c v  =
     | Croundfi,TmConst(fi,CFloat(v)) -> TmConst(fi,CInt(Float.round v |> int_of_float))
     | Croundfi,_ -> fail_constapp fi
 
-    | CInt2float,TmConst(fi,CInt(v)) -> TmConst(fi,CFloat(float_of_int v))
-    | CInt2float,_ -> fail_constapp fi
+    | Cint2float,TmConst(fi,CInt(v)) -> TmConst(fi,CFloat(float_of_int v))
+    | Cint2float,_ -> fail_constapp fi
 
     (* MCore intrinsic: characters *)
     | CChar(_),_ -> fail_constapp fi
 
-    | CChar2int,TmConst(fi,CChar(v)) -> TmConst(fi,CInt(v))
-    | CChar2int,_ -> fail_constapp fi
+    | Cchar2int,TmConst(fi,CChar(v)) -> TmConst(fi,CInt(v))
+    | Cchar2int,_ -> fail_constapp fi
 
-    | CInt2char,TmConst(fi,CInt(v)) -> TmConst(fi,CChar(v))
-    | CInt2char,_ -> fail_constapp fi
+    | Cint2char,TmConst(fi,CInt(v)) -> TmConst(fi,CChar(v))
+    | Cint2char,_ -> fail_constapp fi
 
     (* MCore intrinsic: sequences *)
     | CmakeSeq(None),TmConst(fi,CInt(v)) -> TmConst(fi,CmakeSeq(Some(v)))
@@ -474,8 +474,8 @@ let delta eval env fi c v  =
     | Ceqsym(None), TmConst(fi,CSymb(id)) -> TmConst(fi, Ceqsym(Some(id)))
     | Ceqsym(Some(id)), TmConst(fi,CSymb(id')) -> TmConst(fi, CBool(id == id'))
     | Ceqsym(_),_ -> fail_constapp fi
-    | CSym2hash, TmConst(fi,CSymb(id)) -> TmConst(fi, CInt(id))
-    | CSym2hash,_ -> fail_constapp fi
+    | Csym2hash, TmConst(fi,CSymb(id)) -> TmConst(fi, CInt(id))
+    | Csym2hash,_ -> fail_constapp fi
 
     (* Python intrinsics *)
     | CPy v, t -> Pyffi.delta eval env fi v t

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -196,13 +196,13 @@ let rec print_const fmt = function
   | Cfloorfi       -> fprintf fmt "floorfi"
   | Cceilfi        -> fprintf fmt "ceilfi"
   | Croundfi       -> fprintf fmt "roundfi"
-  | CInt2float     -> fprintf fmt "int2float"
-  | CString2float  -> fprintf fmt "string2float"
+  | Cint2float     -> fprintf fmt "int2float"
+  | Cstring2float  -> fprintf fmt "string2float"
 
   (* MCore intrinsic: characters *)
   | CChar(v)  -> fprintf fmt "%s" (lit_of_uchar v)
-  | CChar2int -> fprintf fmt "char2int"
-  | CInt2char -> fprintf fmt "int2char"
+  | Cchar2int -> fprintf fmt "char2int"
+  | Cint2char -> fprintf fmt "int2char"
 
   (* MCore intrinsic: sequences *)
   | CmakeSeq(_) -> fprintf fmt "makeseq"
@@ -238,7 +238,7 @@ let rec print_const fmt = function
   | CSymb(id) -> fprintf fmt "symb(%d)" id
   | Cgensym   -> fprintf fmt "gensym"
   | Ceqsym(_)   -> fprintf fmt "eqsym"
-  | CSym2hash  -> fprintf fmt "sym2hash"
+  | Csym2hash  -> fprintf fmt "sym2hash"
 
   (* Python intrinsics *)
   | CPy(v) -> fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -189,7 +189,7 @@ utest (lookup 1 mapm, lookup 2 mapm, lookup 3 mapm)
 with (Some '2', Some '3', Some '4') in
 
 utest fold (lam acc. lam k. lam v. addi acc k) 0 m with 6 in
-utest fold (lam acc. lam k. lam v. and acc (is_digit v)) true m with true in
+utest fold (lam acc. lam k. lam v. and acc (isDigit v)) true m with true in
 
 utest foldOption (lam acc. lam k. lam v. Some (addi acc k)) 0 m with Some 6 in
 utest foldOption (lam acc. lam k. lam v. if eqi k 4 then None () else Some acc)

--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -25,51 +25,51 @@ utest char2lower '0' with '0'
 utest char2lower 'A' with 'a'
 
 -- Character predicates
-let is_whitespace = lam c. any (eqChar c) [' ', '\n', '\t', '\r']
+let isWhitespace = lam c. any (eqChar c) [' ', '\n', '\t', '\r']
 
-utest is_whitespace ' ' with true
-utest is_whitespace '	' with true
-utest is_whitespace '
+utest isWhitespace ' ' with true
+utest isWhitespace '	' with true
+utest isWhitespace '
 ' with true
-utest is_whitespace 'a' with false
-utest is_whitespace '\n' with true
-utest is_whitespace '\t' with true
-utest is_whitespace '\r' with true
-utest is_whitespace '\'' with false
+utest isWhitespace 'a' with false
+utest isWhitespace '\n' with true
+utest isWhitespace '\t' with true
+utest isWhitespace '\r' with true
+utest isWhitespace '\'' with false
 
-let is_lower_alpha = lam c.
+let isLowerAlpha = lam c.
   and (leqi (char2int 'a') (char2int c)) (leqi (char2int c) (char2int 'z'))
 
-let is_upper_alpha = lam c.
+let isUpperAlpha = lam c.
   and (leqi (char2int 'A') (char2int c)) (leqi (char2int c) (char2int 'Z'))
 
-let is_alpha = lam c. or (is_lower_alpha c) (is_upper_alpha c)
+let isAlpha = lam c. or (isLowerAlpha c) (isUpperAlpha c)
 
-utest is_alpha 'a' with true
-utest is_alpha 'm' with true
-utest is_alpha 'z' with true
-utest is_alpha '`' with false
-utest is_alpha '{' with false
-utest is_alpha 'A' with true
-utest is_alpha 'M' with true
-utest is_alpha 'Z' with true
-utest is_alpha '@' with false
-utest is_alpha '[' with false
+utest isAlpha 'a' with true
+utest isAlpha 'm' with true
+utest isAlpha 'z' with true
+utest isAlpha '`' with false
+utest isAlpha '{' with false
+utest isAlpha 'A' with true
+utest isAlpha 'M' with true
+utest isAlpha 'Z' with true
+utest isAlpha '@' with false
+utest isAlpha '[' with false
 
-let is_digit = lam c.
+let isDigit = lam c.
   and (leqi (char2int '0') (char2int c)) (leqi (char2int c) (char2int '9'))
 
-utest is_digit '0' with true
-utest is_digit '5' with true
-utest is_digit '9' with true
-utest is_digit '/' with false
-utest is_digit ':' with false
+utest isDigit '0' with true
+utest isDigit '5' with true
+utest isDigit '9' with true
+utest isDigit '/' with false
+utest isDigit ':' with false
 
-let is_alphanum = lam c.
-  or (is_alpha c) (is_digit c)
+let isAlphanum = lam c.
+  or (isAlpha c) (isDigit c)
 
-utest is_alphanum '0' with true
-utest is_alphanum '9' with true
-utest is_alphanum 'A' with true
-utest is_alphanum 'z' with true
-utest is_alphanum '_' with false
+utest isAlphanum '0' with true
+utest isAlphanum '9' with true
+utest isAlphanum 'A' with true
+utest isAlphanum 'z' with true
+utest isAlphanum '_' with false

--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -10,9 +10,9 @@ con JsonBool   : Bool                    -> JsonValue
 con JsonNull   : ()                      -> JsonValue
 
 
-let with_ws = wrappedIn spaces spaces
+let withWs = wrappedIn spaces spaces
 
-let list_or_spaces = lam left. lam right. lam elem.
+let listOrSpaces = lam left. lam right. lam elem.
   (wrappedIn left right
     (apr spaces
          (sepBy (lexChar ',') elem)))
@@ -45,15 +45,15 @@ recursive
 -- These functions are all eta expanded, because recursive lets must begin with a lambda.
 let jsonMember = lam x.
   let makeMember = lam k. lam v. (k, v) in
-  (liftA2 makeMember (apl (with_ws lexStringLit) (lexChar ':')) jsonValue) x
+  (liftA2 makeMember (apl (withWs lexStringLit) (lexChar ':')) jsonValue) x
 
 let jsonObject = lam x.
   fmap (lam x. JsonObject x)
-  (list_or_spaces (lexChar '{') (lexChar '}') jsonMember) x
+  (listOrSpaces (lexChar '{') (lexChar '}') jsonMember) x
 
 let jsonArray = lam x.
   fmap (lam x. JsonArray x)
-  (list_or_spaces (lexChar '[') (lexChar ']') jsonValue) x
+  (listOrSpaces (lexChar '[') (lexChar ']') jsonValue) x
 
 -- jsonValue : Parser JsonValue
 --
@@ -68,7 +68,7 @@ let jsonValue = lam x.
     , jsonNull
     ]
   in
-  (with_ws (foldr1 alt jsonValues)) x
+  (withWs (foldr1 alt jsonValues)) x
 end
 
 -- parseJson : String -> Option

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -48,15 +48,15 @@ let parserStr = lam str. lam prefix. lam cond.
 
 -- Constructor string parser translation
 let conString = lam str.
-  parserStr str "#con" (lam str. is_upper_alpha (head str))
+  parserStr str "#con" (lam str. isUpperAlpha (head str))
 
 -- Variable string parser translation
 let varString = lam str.
-  parserStr str "#var" (lam str. is_lower_alpha (head str))
+  parserStr str "#var" (lam str. isLowerAlpha (head str))
 
 -- Label string parser translation for records
 let labelString = lam str.
-  parserStr str "#label" (lam str. is_lower_alpha (head str))
+  parserStr str "#label" (lam str. isLowerAlpha (head str))
 
 let _ppLookupName = assocLookup {eq = nameEqSym}
 let _ppLookupStr = assocLookup {eq = eqString}

--- a/stdlib/parser-combinators.mc
+++ b/stdlib/parser-combinators.mc
@@ -415,7 +415,7 @@ with "Parse error at 1:1: Unexpected 'b'. Expected 'a'"
 -- lexDigits : Parser String
 --
 -- Parse a sequence of digits
-let lexDigits = many1 (satisfy is_digit "digit")
+let lexDigits = many1 (satisfy isDigit "digit")
 
 -- lexNumber : Parser Int
 --
@@ -527,12 +527,12 @@ with "Parse error at 1:3: Unexpected end of input. Expected exponent or decimals
 -- spaces : Parser ()
 --
 -- Parse zero or more whitespace characters.
-let spaces = void (many (satisfy is_whitespace "whitespace"))
+let spaces = void (many (satisfy isWhitespace "whitespace"))
 
 -- spaces1 : Parser ()
 --
 -- Parse one or more whitespace characters.
-let spaces1 = void (many1 (satisfy is_whitespace "whitespace"))
+let spaces1 = void (many1 (satisfy isWhitespace "whitespace"))
 
 utest testParser spaces "   abc"
 with Success ((), ("abc", {file = "", row = 1, col = 4}))
@@ -608,7 +608,7 @@ let symbol = string in
 --
 -- Check if a character is valid in an identifier.
 let isValidChar = lam c.
-  or (is_alphanum c) (eqChar c '_')
+  or (isAlphanum c) (eqChar c '_')
 in
 
 -- reserved : String -> Parser String
@@ -633,7 +633,7 @@ in
 -- of reserved keywords.
 let identifier =
   let validId =
-    bind (satisfy (lam c. or (is_alpha c) (eqChar '_' c)) "valid identifier") (lam c.
+    bind (satisfy (lam c. or (isAlpha c) (eqChar '_' c)) "valid identifier") (lam c.
     bind (token (many (satisfy isValidChar ""))) (lam cs.
     pure (cons c cs)))
   in

--- a/stdlib/prelude.mc
+++ b/stdlib/prelude.mc
@@ -18,7 +18,7 @@ end
 
 -- Fixpoint computation for mutual recursion. Thanks Oleg Kiselyov!
 -- (http://okmij.org/ftp/Computation/fixed-point-combinators.html)
-let fix_mutual =
+let fixMutual =
   lam l. fix (lam self. lam l. map (lam li. lam x. li (self l) x) l) l
 
 -- Printing stuff

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -91,26 +91,26 @@ let float2string = lam arg.
       cons c (float2string_rechelper prec (addi digits 1) remaining)
   in
   recursive
-  let positive_exponent_pair = lam acc. lam v.
+  let positiveExponentPair = lam acc. lam v.
     if ltf v 10.0
     then (v, acc)
-    else positive_exponent_pair (addi acc 1) (divf v 10.0)
+    else positiveExponentPair (addi acc 1) (divf v 10.0)
   in
   recursive
-  let negative_exponent_pair = lam acc. lam v.
+  let negativeExponentPair = lam acc. lam v.
     if geqf v 1.0
     then (v, acc)
-    else negative_exponent_pair (addi acc 1) (mulf v 10.0)
+    else negativeExponentPair (addi acc 1) (mulf v 10.0)
   in
   let res = if eqf val 0.0 then
               "0.0"
             else if gtf val 1.0 then
-              let pospair = positive_exponent_pair 0 val in
+              let pospair = positiveExponentPair 0 val in
               let retstr = float2string_rechelper precision 0 (pospair.0) in
               let decimals = cons (head retstr) (cons '.' (tail retstr)) in
               concat decimals (concat "e+" (int2string pospair.1))
             else
-              let pospair = negative_exponent_pair 0 val in
+              let pospair = negativeExponentPair 0 val in
               let retstr = float2string_rechelper precision 0 (pospair.0) in
               let decimals = cons (head retstr) (cons '.' (tail retstr)) in
               concat decimals (concat "e-" (int2string pospair.1))
@@ -188,7 +188,7 @@ let strTrim = lam s.
   let strTrim_init = lam s.
     if eqString s ""
     then s
-    else if is_whitespace (head s)
+    else if isWhitespace (head s)
          then strTrim_init (tail s)
          else s
   in

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -94,7 +94,7 @@ lang StrFormatBase
         -- A valid format: %(...)X
         -- Where X represents any alpha char and (...) represents any
         -- sequence of non-alpha chars.
-        let found_idx = index is_alpha s in
+        let found_idx = index isAlpha s in
         match found_idx with Some i then
           let fmtstr = slice s 0 (addi i 1) in
           let remaining = slice s (addi i 1) (length s) in


### PR DESCRIPTION
Some of these name changes might be controversial (for instance `gensym` -> `genSym`). I have tried to be as consistent as possible, but I may have missed something.

Edit: The changes to the conversion names are now undone, so the PR only updates snake-cased names to camel case.