### PR TITLE
Remove exp as mexpr intrinsic.

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -73,7 +73,6 @@ and const =
 | Cgeqf    of float option
 | Ceqf     of float option
 | Cneqf    of float option
-| Cexp
 | Cfloorfi
 | Cceilfi
 | Croundfi

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -42,7 +42,6 @@ let builtin =
    ("divf",f(Cdivf(None)));("negf",f(Cnegf));
    ("ltf",f(Cltf(None)));("leqf",f(Cleqf(None)));("gtf",f(Cgtf(None)));("geqf",f(Cgeqf(None)));
    ("eqf",f(Ceqf(None)));("neqf",f(Cneqf(None)));
-   ("exp",f(Cexp));
    ("floorfi", f(Cfloorfi)); ("ceilfi", f(Cceilfi)); ("roundfi", f(Croundfi));
    ("int2float", f(CInt2float)); ("string2float", f(CString2float));
    ("char2int",f(CChar2int));("int2char",f(CInt2char));
@@ -118,7 +117,6 @@ let arity = function
   | Cgeqf(None) -> 2  | Cgeqf(Some(_)) -> 1
   | Ceqf(None)  -> 2  | Ceqf(Some(_))  -> 1
   | Cneqf(None) -> 2  | Cneqf(Some(_)) -> 1
-  | Cexp        -> 1
   | Cfloorfi    -> 1
   | Cceilfi     -> 1
   | Croundfi    -> 1
@@ -335,9 +333,6 @@ let delta eval env fi c v  =
         TmConst(fi, CFloat(Float.of_string f))
     | CString2float,_ -> fail_constapp fi
 
-    | Cexp,TmConst(fi,CFloat(v)) -> TmConst(fi,CFloat(exp(v)))
-    | Cexp,_ -> fail_constapp fi
-
     | Cfloorfi,TmConst(fi,CFloat(v)) -> TmConst(fi,CInt(Float.floor v |> int_of_float))
     | Cfloorfi,_ -> fail_constapp fi
 
@@ -487,7 +482,7 @@ let delta eval env fi c v  =
     (* Sundials intrinsics *)
     | CSd v, t -> Sd.delta eval env fi v t
     (* Externals *)
-    | CExt v, t -> Ext.delta eval env fi v t 
+    | CExt v, t -> Ext.delta eval env fi v t
 
 
 (* Debug function used in the eval function *)

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -193,7 +193,6 @@ let rec print_const fmt = function
   | Ceqf(Some(v))  -> fprintf fmt "eqf(%f)" v
   | Cneqf(None)    -> fprintf fmt "neqf"
   | Cneqf(Some(v)) -> fprintf fmt "neqf(%f)" v
-  | Cexp           -> fprintf fmt "exp"
   | Cfloorfi       -> fprintf fmt "floorfi"
   | Cceilfi        -> fprintf fmt "ceilfi"
   | Croundfi       -> fprintf fmt "roundfi"

--- a/stdlib/local-search.mc
+++ b/stdlib/local-search.mc
@@ -8,6 +8,7 @@ include "prelude.mc"
 include "set.mc"
 include "digraph.mc"
 include "string.mc"
+include "ext/math.mc"
 
 -- 'v': polymorphic value type
 -- 'c': polymorphic cost type


### PR DESCRIPTION
As pointed out by @andersthune `exp` existed both as a `mexpr` intrinsic and external function. This PR removes the former.