### PR TITLE
Implemented ocaml pprinting of simple expressions, lambdas and lets.

### DIFF
--- a/make
+++ b/make
@@ -41,9 +41,13 @@ runtests_sundials() {
 # Run the test suite for python intrinsic tests
 runtests_py() {
     (cd test
-     ../build/mi test py/*
-     cd ../stdlib
-     ../build/mi test ocaml)
+     ../build/mi test py/*)
+}
+
+# Run the test suite for OCaml compiler
+runtests_ocaml() {
+    (cd stdlib
+     ../build/mi test ocaml/*)
 }
 
 # Run the test suite
@@ -63,6 +67,9 @@ runtests() {
     fi
     if [ -n "$MI_TEST_SUNDIALS" ]; then
         runtests_sundials
+    fi
+    if [ -n "$MI_TEST_OCAML" ]; then
+        runtests_ocaml
     fi
 }
 

--- a/make
+++ b/make
@@ -81,6 +81,7 @@ case $1 in
     test-all)
         export MI_TEST_PYTHON=1
         export MI_TEST_SUNDIALS=1
+        export MI_TEST_OCAML=1
         build
         runtests
         ;;

--- a/make
+++ b/make
@@ -18,7 +18,7 @@ cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 # General function for building the project
 build() {
     mkdir -p build
-    dune build 
+    dune build
     cp -f _build/install/default/bin/boot.mi build/mi
 }
 
@@ -53,6 +53,7 @@ runtests() {
     ../build/mi test mexpr
     ../build/mi test ad
 		../build/mi test ext
+		../build/mi test ocaml
     cd ..
     export MCORE_STDLIB='@@@'
     build/mi test stdlib)

--- a/make
+++ b/make
@@ -41,7 +41,9 @@ runtests_sundials() {
 # Run the test suite for python intrinsic tests
 runtests_py() {
     (cd test
-     ../build/mi test py/*)
+     ../build/mi test py/*
+     cd ../stdlib
+     ../build/mi test ocaml)
 }
 
 # Run the test suite
@@ -53,7 +55,6 @@ runtests() {
     ../build/mi test mexpr
     ../build/mi test ad
     ../build/mi test ext
-    ../build/mi test ocaml
     cd ..
     export MCORE_STDLIB='@@@'
     build/mi test stdlib)

--- a/make
+++ b/make
@@ -52,8 +52,8 @@ runtests() {
     cd ../stdlib
     ../build/mi test mexpr
     ../build/mi test ad
-		../build/mi test ext
-		../build/mi test ocaml
+    ../build/mi test ext
+    ../build/mi test ocaml
     cd ..
     export MCORE_STDLIB='@@@'
     build/mi test stdlib)

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -1,0 +1,9 @@
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+
+lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst + ArithFloatAst
+                + BoolAst + CmpIntAst + CmpFloatAst + CharAst
+end
+
+mexpr
+()

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -1,8 +1,9 @@
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 
-lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst + ArithFloatAst
-                + BoolAst + CmpIntAst + CmpFloatAst + CharAst
+lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst
+                + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
+                + CharAst
 end
 
 mexpr

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -1,0 +1,17 @@
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "ocaml/ast.mc"
+include "ocaml/pprint.mc"
+
+lang OCamlGenerate = MExprAst + OCamlAst
+  sem generate =
+  | t -> smap_Expr_Expr generate t
+end
+
+lang OCamlTest = OCamlGenerate + OCamlPrettyPrint
+
+mexpr
+
+use OCamlTest in
+
+generate (addi_ (int_ 1) (int_ 2))

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -212,9 +212,13 @@ utest charLiteral with generate (symbolize charLiteral)
 using sameSemantics in
 
 -- Abstractions
-let fun = ulam_ "@" (ulam_ "%" (addi_ (var_ "@") (var_ "%"))) in
-let app2fun = symbolize (appSeq_ fun [int_ 1, int_ 2]) in
-utest app2fun with generate app2fun using sameSemantics in
+let fun =
+  symbolize
+  (appSeq_
+    (ulam_ "@" (ulam_ "%" (addi_ (var_ "@") (var_ "%"))))
+    [int_ 1, int_ 2])
+in
+utest fun with generate fun using sameSemantics in
 
 let funShadowed =
   symbolize

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -3,8 +3,55 @@ include "mexpr/ast-builder.mc"
 include "ocaml/ast.mc"
 include "ocaml/pprint.mc"
 
+let escapeFirstChar = lam c.
+  if or (isLowerAlpha c) (eqChar c '_') then c
+  else '_'
+
+utest map escapeFirstChar "abcABC/:@_'" with "abc________"
+
+let escapeChar = lam c.
+  if or (isAlphanum c) (or (eqChar c '_') (eqChar c '\'')) then c
+  else '_'
+
+utest map escapeChar "abcABC/:@_'" with "abcABC____'"
+
+let escapeString = lam s.
+  if gti (length s) 0 then
+    cons (escapeFirstChar (head s)) (map escapeChar (tail s))
+  else
+    "var"
+
+utest escapeString "abcABC/:@_'" with "abcABC____'"
+utest escapeString "" with "var"
+utest escapeString "ABC123" with "_BC123"
+utest escapeString "'a/b/c" with "_a_b_c"
+utest escapeString "123" with "_23"
+
+let escapeName = lam n.
+  match n with (str,symb) then (escapeString str, symb)
+  else never
+
+utest (escapeName ("abcABC/:@_'", gensym ())).0
+with ("abcABC____'", gensym ()).0
+
+utest (escapeName ("ABC123", gensym ())).0 with ("_BC123", gensym ()).0
+
 lang OCamlGenerate = MExprAst + OCamlAst
   sem generate =
+  | TmVar t -> TmVar {t with ident = escapeName t.ident}
+  | TmLam t ->
+      TmLam {ident = escapeName t.ident,
+             tpe = t.tpe,
+             body = generate t.body}
+  | TmLet t ->
+      TmLet {ident = escapeName t.ident,
+             body = generate t.body,
+             inexpr = generate t.inexpr}
+  | TmRecLets t ->
+      let bs = map (lam b. {ident = escapeName b.ident, body = generate b.body})
+                   t.bindings
+      in
+      TmRecLets {bindings = bs, inexpr = generate t.inexpr}
   | t -> smap_Expr_Expr generate t
 end
 
@@ -14,4 +61,46 @@ mexpr
 
 use OCamlTest in
 
-generate (addi_ (int_ 1) (int_ 2))
+utest generate (var_ "abcABC/:@_'") with var_ "abcABC____'" in
+utest generate (ulam_ "ABC123" (ulam_ "'a/b/c" (app_ (var_ "ABC123")
+                                               (var_ "'a/b/c"))))
+with ulam_ "_BC123" (ulam_ "_a_b_c" (app_ (var_ "_BC123") (var_ "_a_b_c"))) in
+
+utest generate (let_ "abcABC/:@_'" (var_ "abcABC/:@_'"))
+with (let_ "abcABC____'" (var_ "abcABC____'")) in
+
+let testRec =
+  bind_
+    (reclets_add "abcABC/:@_'" (ulam_ "ABC123" (app_ (var_ "abcABC/:@_'")
+                                                     (var_ "ABC123")))
+      reclets_empty)
+    (app_ (var_ "abcABC/:@_'") (int_ 1))
+in
+
+let testRecExpected =
+  bind_
+    (reclets_add "abcABC____'" (ulam_ "_BC123" (app_ (var_ "abcABC____'")
+                                                     (var_ "_BC123")))
+      reclets_empty)
+    (app_ (var_ "abcABC____'") (int_ 1))
+in
+
+utest generate testRec with testRecExpected in
+
+let mutRec =
+  bind_
+    (reclets_add "'a/b/c" (ulam_ "" (app_ (var_ "123") (var_ "")))
+      (reclets_add "123" (ulam_ "" (app_ (var_ "'a/b/c") (var_ "")))
+         reclets_empty))
+    (app_ (var_ "'a/b/c") (int_ 1))
+in
+let mutRecExpected =
+  bind_
+    (reclets_add "_a_b_c" (ulam_ "var" (app_ (var_ "_23") (var_ "var")))
+      (reclets_add "_23" (ulam_ "var" (app_ (var_ "_a_b_c") (var_ "var")))
+        reclets_empty))
+    (app_ (var_ "_a_b_c") (int_ 1))
+in
+utest generate mutRec with mutRecExpected in
+
+()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -215,6 +215,14 @@ let fun = ulam_ "@" (ulam_ "%" (addi_ (var_ "@") (var_ "%"))) in
 let app2fun = symbolize (appSeq_ fun [int_ 1, int_ 2]) in
 utest app2fun with generate app2fun using sameSemantics in
 
+let funShadowed =
+  symbolize
+  (appSeq_
+    (ulam_ "@" (ulam_ "@" (addi_ (var_ "@") (var_ "@"))))
+    [ulam_ "@" (var_ "@"), int_ 2])
+in
+utest funShadowed with generate funShadowed using sameSemantics in
+
 -- Lets
 let testLet =
   symbolize
@@ -222,12 +230,20 @@ let testLet =
 in
 utest testLet with generate testLet using sameSemantics in
 
+let testLetShadowed =
+  symbolize
+  (bindall_ [let_ "@" (ulam_ "@" (addi_ (var_ "@") (var_ "@"))),
+             app_ (var_ "@") (int_ 1)])
+in
+utest testLetShadowed with generate testLetShadowed
+using sameSemantics in
+
 let testLetRec =
   symbolize
   (bind_
-     (reclets_add "$" (ulam_ "%" (app_ (var_ "%") (int_ 1)))
-       (reclets_add "@" (ulam_ "^" (var_ "^"))
-          reclets_empty))
+     (reclets_add "$" (ulam_ "%" (app_ (var_ "@") (int_ 1)))
+     (reclets_add "@" (ulam_ "" (var_ ""))
+     reclets_empty))
    (app_ (var_ "$") (var_ "@")))
 in
 utest testLetRec with generate testLetRec using sameSemantics in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -39,7 +39,8 @@ let escapeName = lam n.
 utest (escapeName ("abcABC/:@_'", gensym ())).0
 with ("abcABC____'", gensym ()).0
 
-utest (escapeName ("ABC123", gensym ())).0 with ("_BC123", gensym ()).0
+utest (escapeName ("ABC123", gensym ())).0
+with ("_BC123", gensym ()).0
 
 lang OCamlGenerate = MExprAst + OCamlAst
   sem generate =
@@ -53,15 +54,16 @@ lang OCamlGenerate = MExprAst + OCamlAst
              body = generate t.body,
              inexpr = generate t.inexpr}
   | TmRecLets t ->
-      let bs = map (lam b. {ident = escapeName b.ident, body = generate b.body})
+      let bs = map (lam b. {ident = escapeName b.ident,
+                            body = generate b.body})
                    t.bindings
       in
       TmRecLets {bindings = bs, inexpr = generate t.inexpr}
   | t -> smap_Expr_Expr generate t
 end
 
-lang OCamlTest = OCamlGenerate + OCamlPrettyPrint + MExprSym + ConstEq + IntEq
-                 + BoolEq + CharEq
+lang OCamlTest = OCamlGenerate + OCamlPrettyPrint + MExprSym + ConstEq
+                 + IntEq + BoolEq + CharEq
 
 mexpr
 
@@ -70,23 +72,27 @@ use OCamlTest in
 utest generate (var_ "abcABC/:@_'") with var_ "abcABC____'" in
 utest generate (ulam_ "ABC123" (ulam_ "'a/b/c" (app_ (var_ "ABC123")
                                                (var_ "'a/b/c"))))
-with ulam_ "_BC123" (ulam_ "_a_b_c" (app_ (var_ "_BC123") (var_ "_a_b_c"))) in
+with ulam_ "_BC123" (ulam_ "_a_b_c" (app_ (var_ "_BC123")
+                                          (var_ "_a_b_c")))
+in
 
 utest generate (let_ "abcABC/:@_'" (var_ "abcABC/:@_'"))
 with (let_ "abcABC____'" (var_ "abcABC____'")) in
 
 let testRec =
   bind_
-    (reclets_add "abcABC/:@_'" (ulam_ "ABC123" (app_ (var_ "abcABC/:@_'")
-                                                     (var_ "ABC123")))
+    (reclets_add "abcABC/:@_'" (ulam_ "ABC123"
+                               (app_ (var_ "abcABC/:@_'")
+                                     (var_ "ABC123")))
       reclets_empty)
     (app_ (var_ "abcABC/:@_'") (int_ 1))
 in
 
 let testRecExpected =
   bind_
-    (reclets_add "abcABC____'" (ulam_ "_BC123" (app_ (var_ "abcABC____'")
-                                                     (var_ "_BC123")))
+    (reclets_add "abcABC____'" (ulam_ "_BC123"
+                               (app_ (var_ "abcABC____'")
+                               (var_ "_BC123")))
       reclets_empty)
     (app_ (var_ "abcABC____'") (int_ 1))
 in
@@ -102,8 +108,10 @@ let mutRec =
 in
 let mutRecExpected =
   bind_
-    (reclets_add "_a_b_c" (ulam_ "var" (app_ (var_ "_23") (var_ "var")))
-      (reclets_add "_23" (ulam_ "var" (app_ (var_ "_a_b_c") (var_ "var")))
+    (reclets_add "_a_b_c" (ulam_ "var" (app_ (var_ "_23")
+                                             (var_ "var")))
+      (reclets_add "_23" (ulam_ "var" (app_ (var_ "_a_b_c")
+                                            (var_ "var")))
         reclets_empty))
     (app_ (var_ "_a_b_c") (int_ 1))
 in
@@ -117,10 +125,17 @@ in
 let ocamlEval = lam p. lam strConvert.
   let subprocess = pyimport "subprocess" in
   let blt = pyimport "builtins" in
-  let cmd = pycall blt "str" (join ["print_endline (", strConvert, "(", p, "))"],) in
+  let cmd =
+        pycall blt "str"
+               (join ["print_endline (", strConvert, "(", p, "))"],)
+  in
   let encoded = pycall cmd "encode" () in
-  let p = pycallkw subprocess "run" (["ocaml", "-stdin"],) {input=encoded, capture_output=true} in
-  let stdout = pycall (pycall blt "getattr" (p,"stdout")) "decode" () in
+  let p = pycallkw subprocess "run" (["ocaml", "-stdin"],)
+                              {input=encoded, capture_output=true}
+  in
+  let stdout =
+    pycall (pycall blt "getattr" (p,"stdout")) "decode" ()
+  in
   parseAsMExpr (pyconvert stdout)
 in
 
@@ -141,7 +156,9 @@ let sameSemantics = lam mexprAst. lam ocamlAst.
         eqExpr mexprVal ocamlVal
       else error "Values mismatch"
     else match t.val with CChar _ then
-      let ocamlVal = ocamlEval (expr2str ocamlAst) "Printf.sprintf \"'%c'\"" in
+      let ocamlVal =
+        ocamlEval (expr2str ocamlAst) "Printf.sprintf \"'%c'\""
+      in
       match ocamlVal with TmConst {val = CChar _} then
         eqExpr mexprVal ocamlVal
       else error "Values mismatch"
@@ -159,12 +176,15 @@ let boolNot = not_ (not_ true_) in
 utest boolNot with generate (symbolize boolNot) using sameSemantics in
 
 let compareInt1 = eqi_ (int_ 1) (int_ 2) in
-utest compareInt1 with generate (symbolize compareInt1) using sameSemantics in
+utest compareInt1 with generate (symbolize compareInt1)
+using sameSemantics in
 
 let compareInt2 = lti_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
-utest compareInt2 with generate (symbolize compareInt2) using sameSemantics in
+utest compareInt2 with generate (symbolize compareInt2)
+using sameSemantics in
 
 let charLiteral = char_ 'c' in
-utest charLiteral with generate (symbolize charLiteral) using sameSemantics in
+utest charLiteral with generate (symbolize charLiteral)
+using sameSemantics in
 
 ()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -34,8 +34,8 @@ let escapeString = lam s.
     defaultIdentName
 
 utest escapeString "abcABC/:@_'" with "abcABC____'"
-utest escapeString "" with "var"
-utest escapeString "@" with "var"
+utest escapeString "" with defaultIdentName
+utest escapeString "@" with defaultIdentName
 utest escapeString "ABC123" with "_BC123"
 utest escapeString "'a/b/c" with "_a_b_c"
 utest escapeString "123" with "_23"

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -7,6 +7,8 @@ include "mexpr/symbolize.mc"
 include "mexpr/eval.mc"
 include "mexpr/eq.mc"
 
+let defaultIdentName = "var"
+
 let escapeFirstChar = lam c.
   if or (isLowerAlpha c) (eqChar c '_') then c
   else '_'
@@ -20,7 +22,6 @@ let escapeChar = lam c.
 utest map escapeChar "abcABC/:@_'" with "abcABC____'"
 
 let escapeString = lam s.
-  let default = "var" in
   let n = length s in
   if gti n 0 then
     let hd = head s in
@@ -28,9 +29,9 @@ let escapeString = lam s.
     if or (neqi n 1) (isLowerAlpha hd) then
       cons (escapeFirstChar hd) (map escapeChar tl)
     else
-      default
+      defaultIdentName
   else
-    default
+    defaultIdentName
 
 utest escapeString "abcABC/:@_'" with "abcABC____'"
 utest escapeString "" with "var"
@@ -121,10 +122,10 @@ let mutRec =
 in
 let mutRecExpected =
   bind_
-    (reclets_add "_a_b_c" (ulam_ "var" (app_ (var_ "_23")
-                                             (var_ "var")))
-      (reclets_add "_23" (ulam_ "var" (app_ (var_ "_a_b_c")
-                                            (var_ "var")))
+    (reclets_add "_a_b_c" (ulam_ defaultIdentName (app_ (var_ "_23")
+                                             (var_ defaultIdentName)))
+      (reclets_add "_23" (ulam_ defaultIdentName (app_ (var_ "_a_b_c")
+                                            (var_ defaultIdentName)))
         reclets_empty))
     (app_ (var_ "_a_b_c") (int_ 1))
 in

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -1,28 +1,37 @@
 include "ocaml/ast.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/symbolize.mc"
+include "mexpr/pprint.mc"
+include "mexpr/pprint-helper.mc"
 include "char.mc"
 include "name.mc"
 
-let spacing = lam indent. makeSeq indent ' '
-let incr = lam indent. addi indent 2
-let newline = lam indent. concat "\n" (spacing indent)
+let newline = pprintHelperNewline
+let incr = pprintHelperIncr
+let getStr = pprintHelperGetStr
+let envEmpty = pprintHelperEnvEmpty
 
-lang OCamlPrettyPrint = OCamlAst
-  sem _pprintBinding (indent : Int) =
+type Env = PPrintEnv
+
+lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint + LetPrettyPrint
+                        + OCamlAst
+  sem _pprintBinding (indent : Int) (env: Env) =
   | {ident = id, body = b} ->
-    join [nameGetStr id, " = ", pprint indent b, " in"]
+    join [nameGetStr id, " = ", pprintCode indent b]
+
+  sem isAtomic =
+  | TmConst _ -> true
 
   sem pprintConst =
   | CInt {val = i} -> int2string i
-  | CAddi _ -> "+"
-  | CSubi _ -> "-"
-  | CMuli _ -> "*"
+  | CAddi _ -> "(+)"
+  | CSubi _ -> "(-)"
+  | CMuli _ -> "( * )"
   | CFloat {val = f} -> float2string f
-  | CAddf _ -> "+."
-  | CSubf _ -> "-."
-  | CMulf _ -> "*."
-  | CDivf _ -> "/."
+  | CAddf _ -> "(+.)"
+  | CSubf _ -> "(-.)"
+  | CMulf _ -> "( *. )"
+  | CDivf _ -> "(/.)"
   | CNegf _ -> "Float.neg"
   | CBool {val = b} ->
       match b with true then
@@ -32,33 +41,51 @@ lang OCamlPrettyPrint = OCamlAst
           "false"
         else never
   | CNot _ -> "not"
-  | CEqi _ -> "="
-  | CLti _ -> "<"
-  | CEqf _ -> "="
-  | CLtf _ -> "<"
+  | CEqi _ -> "(=)"
+  | CLti _ -> "(<)"
+  | CEqf _ -> "(=)"
+  | CLtf _ -> "(<)"
   | CChar {val = c} -> show_char c
 
-  sem pprint (indent : Int) =
-  | TmApp {lhs = l, rhs = r} ->
-    join ["(", pprint indent l, ")", newline (incr indent),
-          "(", pprint (incr indent) r, ")"]
-  | TmConst {val = c} -> pprintConst c
+  sem pprintCode (indent : Int) (env: Env) =
+  | TmConst {val = c} -> (env, pprintConst c)
   | TmLam {ident = id, body = b} ->
-    join ["fun ", nameGetStr id, " ->", newline (incr indent),
-          pprint (incr indent) b]
-  | TmVar {ident = name} -> nameGetStr name
-  | TmLet t ->
-    join ["let ", _pprintBinding indent t, newline (incr indent),
-          (pprint (incr indent) t.inexpr)]
+    match getStr id env with (env,str) then
+      let ident = _varString str in
+      match pprintCode (incr indent) env b with (env,body) then
+        (env,join ["fun ", ident, " ->", newline (incr indent), body])
+      else never
+    else never
   | TmRecLets {bindings = bindings, inexpr = inexpr} ->
-    let binds = map (_pprintBinding indent) bindings in
-    join ["let rec ", strJoin (join [newline indent, "and "]) binds]
+    let lname = lam env. lam bind.
+      match getStr bind.ident env with (env,str) then
+        (env,_varString str)
+      else never in
+    let lbody = lam env. lam bind.
+      match pprintCode (incr (incr indent)) env bind.body with (env,str) then
+        (env,_varString str)
+      else never in
+    match mapAccumL lname env bindings with (env,idents) then
+      match mapAccumL lbody env bindings with (env,bodies) then
+        match pprintCode indent env inexpr with (env,inexpr) then
+          let fzip = lam ident. lam body.
+            join [ident, " =", newline (incr (incr indent)), body]
+          in
+          (env,join ["let rec ", strJoin (join [newline indent, "and "])
+            (zipWith fzip idents bodies), newline indent, "in ", inexpr])
+        else never
+      else never
+    else never
 end
 
 lang TestLang = OCamlPrettyPrint + MExprSym
 
 mexpr
 use TestLang in
+
+let pprint = lam indent. lam t.
+  (pprintCode indent envEmpty t).1
+in
 
 let pprintProg = lam p.
   let _ = print "\n\n" in
@@ -92,7 +119,10 @@ let fun = ulam_ "x" (ulam_ "y" (app_ (var_ "x") (var_ "y"))) in
 let testLet = bindall_ [let_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)] in
 
 let testRec =
-  reclet_ "foo" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
+  bind_
+    (reclets_add "foo" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
+      reclets_empty)
+    (app_ (var_ "foo") (int_ 1))
 in
 
 let mutRec =

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -77,9 +77,9 @@ lang TestLang = OCamlPrettyPrint + MExprSym
 mexpr
 use TestLang in
 
-let pprintProg = lam p.
+let pprintProg = lam mexprAst.
   let _ = print "\n\n" in
-  print (expr2str (symbolize p))
+  print (expr2str (symbolize mexprAst))
 in
 
 let addInt1 = addi_ (int_ 1) (int_ 2) in
@@ -104,7 +104,7 @@ let compareFloat2 = lti_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
 
 let charLiteral = char_ 'c' in
 
-let fun = ulam_ "x" (ulam_ "y" (app_ (var_ "x") (var_ "y"))) in
+let fun = ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) in
 
 let testLet = bindall_ [let_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)] in
 
@@ -141,4 +141,6 @@ let asts = [
   mutRec
 ] in
 
-map pprintProg asts
+-- let _ = map pprintProg asts in
+
+()

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -1,0 +1,124 @@
+include "ocaml/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/symbolize.mc"
+include "char.mc"
+include "name.mc"
+
+let spacing = lam indent. makeSeq indent ' '
+let incr = lam indent. addi indent 2
+let newline = lam indent. concat "\n" (spacing indent)
+
+lang OCamlPrettyPrint = OCamlAst
+  sem _pprintBinding (indent : Int) =
+  | {ident = id, body = b} ->
+    join [nameGetStr id, " = ", pprint indent b, " in"]
+
+  sem pprintConst =
+  | CInt {val = i} -> int2string i
+  | CAddi _ -> "+"
+  | CSubi _ -> "-"
+  | CMuli _ -> "*"
+  | CFloat {val = f} -> float2string f
+  | CAddf _ -> "+."
+  | CSubf _ -> "-."
+  | CMulf _ -> "*."
+  | CDivf _ -> "/."
+  | CNegf _ -> "Float.neg"
+  | CBool {val = b} ->
+      match b with true then
+        "true"
+      else
+        match b with false then
+          "false"
+        else never
+  | CNot _ -> "not"
+  | CEqi _ -> "="
+  | CLti _ -> "<"
+  | CEqf _ -> "="
+  | CLtf _ -> "<"
+  | CChar {val = c} -> show_char c
+
+  sem pprint (indent : Int) =
+  | TmApp {lhs = l, rhs = r} ->
+    join ["(", pprint indent l, ")", newline (incr indent),
+          "(", pprint (incr indent) r, ")"]
+  | TmConst {val = c} -> pprintConst c
+  | TmLam {ident = id, body = b} ->
+    join ["fun ", nameGetStr id, " ->", newline (incr indent),
+          pprint (incr indent) b]
+  | TmVar {ident = name} -> nameGetStr name
+  | TmLet t ->
+    join ["let ", _pprintBinding indent t, newline (incr indent),
+          (pprint (incr indent) t.inexpr)]
+  | TmRecLets {bindings = bindings, inexpr = inexpr} ->
+    let binds = map (_pprintBinding indent) bindings in
+    join ["let rec ", strJoin (join [newline indent, "and "]) binds]
+end
+
+lang TestLang = OCamlPrettyPrint + MExprSym
+
+mexpr
+use TestLang in
+
+let pprintProg = lam p.
+  let _ = print "\n\n" in
+  print (pprint 0 (symbolize assocEmpty p))
+in
+
+let addInt1 = addi_ (int_ 1) (int_ 2) in
+
+let addInt2 = addi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+
+let addFloat1 = addf_ (float_ 1.) (float_ 2.) in
+
+let addFloat2 = addf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+
+let negFloat = negf_ (float_ 1.) in
+
+let boolNot = not_ (not_ true_) in
+
+let compareInt1 = eqi_ (int_ 1) (int_ 2) in
+
+let compareInt2 = lti_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+
+let compareFloat1 = eqf_ (float_ 1.) (float_ 2.) in
+
+let compareFloat2 = lti_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+
+let charLiteral = char_ 'c' in
+
+let fun = ulam_ "x" (ulam_ "y" (app_ (var_ "x") (var_ "y"))) in
+
+let testLet = bindall_ [let_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)] in
+
+let testRec =
+  reclet_ "foo" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
+in
+
+let mutRec =
+  bind_
+    (reclets_add "foo" (ulam_ "x" (app_ (var_ "bar") (var_ "x")))
+      (reclets_add "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
+         reclets_empty))
+    (app_ (var_ "foo") (int_ 1))
+in
+
+let asts = [
+  addInt1,
+  addInt2,
+  addFloat1,
+  addFloat2,
+  negFloat,
+  boolNot,
+  compareInt1,
+  compareInt2,
+  compareFloat1,
+  compareFloat2,
+  charLiteral,
+  fun,
+  testLet,
+  testRec,
+  mutRec
+] in
+
+map pprintProg asts

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -5,8 +5,8 @@ include "mexpr/pprint.mc"
 include "char.mc"
 include "name.mc"
 
-lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint + LetPrettyPrint
-                        + ConstPrettyPrint + OCamlAst
+lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
+                        + LetPrettyPrint + ConstPrettyPrint + OCamlAst
 
   sem _pprintBinding (indent : Int) (env: PPrintEnv) =
   | {ident = id, body = b} ->
@@ -100,13 +100,17 @@ let compareInt2 = lti_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
 
 let compareFloat1 = eqf_ (float_ 1.) (float_ 2.) in
 
-let compareFloat2 = lti_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+let compareFloat2 =
+  lti_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.)
+in
 
 let charLiteral = char_ 'c' in
 
 let fun = ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) in
 
-let testLet = bindall_ [let_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)] in
+let testLet =
+  bindall_ [let_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)]
+in
 
 let testRec =
   bind_

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -8,6 +8,10 @@ include "name.mc"
 lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
                         + LetPrettyPrint + ConstPrettyPrint + OCamlAst
 
+  sem isAtomic =
+  | TmLam _ -> false
+  | TmRecLets _ -> false
+
   sem _pprintBinding (indent : Int) (env: PPrintEnv) =
   | {ident = id, body = b} ->
     join [nameGetStr id, " = ", pprintCode indent b]

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -5,17 +5,14 @@ include "mexpr/pprint.mc"
 include "char.mc"
 include "name.mc"
 
-lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
-                        + LetPrettyPrint + OCamlAst
+lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint + LetPrettyPrint
+                        + ConstPrettyPrint + OCamlAst
 
   sem _pprintBinding (indent : Int) (env: PPrintEnv) =
   | {ident = id, body = b} ->
     join [nameGetStr id, " = ", pprintCode indent b]
 
-  sem isAtomic =
-  | TmConst _ -> true
-
-  sem pprintConst =
+  sem getConstStringCode (indent : Int) =
   | CInt {val = i} -> int2string i
   | CAddi _ -> "(+)"
   | CSubi _ -> "(-)"
@@ -41,7 +38,6 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | CChar {val = c} -> show_char c
 
   sem pprintCode (indent : Int) (env: PPrintEnv) =
-  | TmConst {val = c} -> (env, pprintConst c)
   | TmLam {ident = id, body = b} ->
     match pprintEnvGetStr id env with (env,str) then
       let ident = pprintVarString str in


### PR DESCRIPTION
This PR implement a language fragment and related pretty printer to generate `ocaml` code from a subset of `mexpr`. ~Currently names are not handled correctly in the pretty printer~. Currently simple expressions, abstractions, let expressions, and recursive expressions are supported. Tests covers expressions evaluating to `Int`, `Bool` and `Char` values.

Co-Authored-By: Linnea Ingmar <lingmar@kth.se>
Co-Authored-By: Lars Hummelgren <lasse.hummelgren@gmail.com>