### PR TITLE
Alpha equivalence for MExpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ end
 ```
 
 <!--
-NOTE: The following text needs to be updated since we now have
+NOTE(?,?): The following text needs to be updated since we now have
 nested patterns, even for MLang.
 
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -112,7 +112,7 @@ and const =
 (* MCore Symbols *)
 | CSymb of int
 | Cgensym
-| Ceqs of int option
+| Ceqsym of int option
 | CSym2hash
 (* External functions TODO: Should not be part of core language *)
 | CExt of Extast.ext

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -114,7 +114,7 @@ and const =
 | Cgensym
 | Ceqsym of int option
 | CSym2hash
-(* External functions TODO: Should not be part of core language *)
+(* External functions TODO(?,?): Should not be part of core language *)
 | CExt of Extast.ext
 | CSd of Sdast.ext
 | CPy of tm Pyast.ext
@@ -122,7 +122,7 @@ and const =
 (* Terms in MLang *)
 and cdecl   = CDecl   of info * ustring * ty
 and param   = Param   of info * ustring * ty
-and decl = (* TODO: Local? *)
+and decl = (* TODO(?,?): Local? *)
 | Data     of info * ustring * cdecl list
 | Inter    of info * ustring * param list * (pat * tm) list
 

--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -13,7 +13,7 @@
   open Msg
   exception Lex_error of Msg.message
 
-(* TODO: Remove unused keywords *)
+(* TODO(?,?): Remove unused keywords *)
 let reserved_strings = [
   (* Keywords *)
   ("if",            fun(i) -> Parser.IF{i=i;v=()});

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -67,7 +67,7 @@ let builtin =
    ("randIntU", f(CrandIntU(None))); ("randSetSeed", f(CrandSetSeed));
    ("wallTimeMs",f(CwallTimeMs)); ("sleepMs",f(CsleepMs));
   ]
-  (* Append external functions TODO: Should not be part of core language *)
+  (* Append external functions TODO(?,?): Should not be part of core language *)
   @ Ext.externals
   (* Append sundials intrinsics *)
   @ Sd.externals
@@ -160,7 +160,7 @@ let arity = function
   | CPy v   -> Pyffi.arity v
   (* Sundials intrinsics *)
   | CSd v   -> Sd.arity v
-  (* External functions TODO: Should not be part of core language *)
+  (* External functions TODO(?,?): Should not be part of core language *)
   | CExt v  -> Ext.arity v
   (* MCore intrinsic: random numbers *)
   | CrandIntU(None)    -> 2

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -63,7 +63,7 @@ let builtin =
    ("fileExists", f(CfileExists)); ("deleteFile", f(CdeleteFile));
    ("error",f(Cerror));
    ("exit",f(Cexit));
-   ("eqs", f(Ceqs(None))); ("gensym", f(Cgensym)); ("sym2hash", f(CSym2hash));
+   ("eqsym", f(Ceqsym(None))); ("gensym", f(Cgensym)); ("sym2hash", f(CSym2hash));
    ("randIntU", f(CrandIntU(None))); ("randSetSeed", f(CrandSetSeed));
    ("wallTimeMs",f(CwallTimeMs)); ("sleepMs",f(CsleepMs));
   ]
@@ -153,8 +153,8 @@ let arity = function
   (* MCore symbols *)
   | CSymb(_)      -> 0
   | Cgensym       -> 1
-  | Ceqs(None)    -> 2
-  | Ceqs(Some(_)) -> 1
+  | Ceqsym(None)    -> 2
+  | Ceqsym(Some(_)) -> 1
   | CSym2hash     -> 1
   (* Python intrinsics *)
   | CPy v   -> Pyffi.arity v
@@ -471,9 +471,9 @@ let delta eval env fi c v  =
     | CSymb(_),_ -> fail_constapp fi
     | Cgensym, TmRecord(fi,x) when Record.is_empty x -> TmConst(fi, CSymb(gen_symid()))
     | Cgensym,_ -> fail_constapp fi
-    | Ceqs(None), TmConst(fi,CSymb(id)) -> TmConst(fi, Ceqs(Some(id)))
-    | Ceqs(Some(id)), TmConst(fi,CSymb(id')) -> TmConst(fi, CBool(id == id'))
-    | Ceqs(_),_ -> fail_constapp fi
+    | Ceqsym(None), TmConst(fi,CSymb(id)) -> TmConst(fi, Ceqsym(Some(id)))
+    | Ceqsym(Some(id)), TmConst(fi,CSymb(id')) -> TmConst(fi, CBool(id == id'))
+    | Ceqsym(_),_ -> fail_constapp fi
     | CSym2hash, TmConst(fi,CSymb(id)) -> TmConst(fi, CInt(id))
     | CSym2hash,_ -> fail_constapp fi
 

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -134,7 +134,7 @@ let merge_lang_data {inters = i1; syns = s1} {inters = i2; syns = s2}: lang_data
          Some {data with subsets; cases = List.rev_append c2 c1} in
   {inters = Record.merge merge_inter i1 i2; syns = Record.merge merge_syn s1 s2}
 
-(* TODO(vipa): this is likely fairly low hanging fruit when it comes to optimization *)
+(* TODO(vipa,?): this is likely fairly low hanging fruit when it comes to optimization *)
 let topo_sort (eq: 'a -> 'a -> bool) (edges: ('a * 'a) list) (vertices: 'a list) =
   let rec recur rev_order edges vertices =
     match List.find_opt (fun v -> List.exists (fun (_, t) -> eq v t) edges |> not) vertices with
@@ -199,7 +199,7 @@ let translate_cases f target cases =
                |> Mseq.of_ustring)
   in
   let no_match =
-    let_ (us"_") nosym   (* TODO: we should probably have a special sort for let with wildcards *)
+    let_ (us"_") nosym   (* TODO(?,?): we should probably have a special sort for let with wildcards *)
       (app (TmConst (NoInfo, Cdprint)) target)
       (app (TmConst (NoInfo, Cerror)) (TmSeq(NoInfo, msg)))
   in
@@ -327,8 +327,8 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
      let ns = List.fold_left add_decl previous_ns decls in
      (* wrap in "con"s *)
      let wrap_con ty_name (CDecl(fi, cname, ty)) tm =
-       TmCondef(fi, mangle cname, nosym, TyArrow(ty, TyCon ty_name), tm) in (* TODO(vipa): the type will likely be incorrect once we start doing product extensions of constructors *)
-     let wrap_data decl tm = match decl with (* TODO(vipa): this does not declare the type itself *)
+       TmCondef(fi, mangle cname, nosym, TyArrow(ty, TyCon ty_name), tm) in (* TODO(vipa,?): the type will likely be incorrect once we start doing product extensions of constructors *)
+     let wrap_data decl tm = match decl with (* TODO(vipa,?): this does not declare the type itself *)
        | Data(_, name, cdecls) -> List.fold_right (wrap_con name) cdecls tm
        | _ -> tm in
      (* translate "Inter"s into (info * ustring * tm) *)

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -123,7 +123,7 @@ tops:
     { $1 :: $2 }
   |
     { [] }
-  // TODO: These should matter with a type system
+  // TODO(?,?): These should matter with a type system
   | TYPE type_ident type_params tops
     { $4 }
   | TYPE type_ident type_params EQ ty tops
@@ -417,7 +417,7 @@ pat_atom:
   | LBRACKET pat_labels RBRACKET
       { PatRecord(mkinfo $1.i $3.i, $2 |> List.fold_left
                   (fun acc (k,v) -> Record.add k v acc) Record.empty) }
-  | UINT /* TODO: enable matching against negative ints */
+  | UINT /* TODO(?,?): enable matching against negative ints */
       { PatInt($1.i, $1.v) }
   | CHAR
       { PatChar($1.i, List.hd (ustring2list $1.v)) }

--- a/src/boot/lib/patterns.ml
+++ b/src/boot/lib/patterns.ml
@@ -30,7 +30,7 @@ type simple_con =
 
 module SimpleConOrd = struct
   type t = simple_con
-  (* NOTE: I can't just use the polymorphic compare in the standard library
+  (* NOTE(?,?): I can't just use the polymorphic compare in the standard library
    * since ustring has internal mutation that would be visible to it, but
    * shouldn't affect the result *)
   let compare a b = match a, b with

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -31,15 +31,15 @@ let ustring_of_var x s =
 (** Create a string from a uchar, as it would appear in a string literal. *)
 let lit_of_uchar c =
   let str = match (string_of_ustring (Ustring.from_uchars [|c|])) with
-    (* TODO This is a temporary fix for newlines only. How do we do this
+    (* TODO(dlunde,?): This is a temporary fix for newlines only. How do we do this
        properly? *)
     | "\n" -> "\\n"
     | str -> str in
   Printf.sprintf "'%s'" str
 
 (** Convert pattern to ustring.
- *  TODO Precedence
- *  TODO Use Format module printing *)
+ *  TODO(dlunde,?): Precedence
+ *  TODO(dlunde,?): Use Format module printing *)
 let ustring_of_pat p =
   let rec ppp pat =
     let ppSeq s =
@@ -82,8 +82,8 @@ let ustring_of_pat p =
   in ppp p
 
 (** Convert type to ustring.
- *  TODO Precedence
- *  TODO Use Format module printing *)
+ *  TODO(dlunde,?): Precedence
+ *  TODO(dlunde,?): Use Format module printing *)
 let rec ustring_of_ty = function
   | TyUnit  -> us"()"
   | TyDyn   -> us"Dyn"
@@ -111,7 +111,7 @@ type sep =
   | Comma
 
 (** Function for concatenating a list of fprintf calls using a given separator.
- *  TODO Possible to simply use Format.pp_print_list? *)
+ *  TODO(dlunde,?) Possible to simply use Format.pp_print_list? *)
 let rec concat fmt (sep, ls) = match ls with
   | []  -> ()
   | [f] -> f fmt
@@ -130,8 +130,8 @@ type prec =
   | Atom
 
 (** Print a constant on the given formatter
- *  TODO Precendece?
- *  TODO Break hints? *)
+ *  TODO(dlunde,?): Precendece?
+ *  TODO(dlunde,?): Break hints? *)
 let rec print_const fmt = function
 
   (* MCore Intrinsic Booleans *)
@@ -244,7 +244,7 @@ let rec print_const fmt = function
   | CPy(v) -> fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))
   (* Sundials intrinsics *)
   | CSd(v) -> fprintf fmt "%s" (string_of_ustring (Sdpprint.pprint v))
-  (* External pprint TODO: Should not be part of core language *)
+  (* External pprint TODO(?,?):: Should not be part of core language *)
   | CExt(v) -> fprintf fmt "%s" (string_of_ustring (Extpprint.pprint v))
 
 (** Pretty print a record *)
@@ -357,7 +357,7 @@ and print_tm' fmt t = match t with
 
   | TmRecordUpdate(_,t1,l,t2) ->
     let l = string_of_ustring l in
-    (* TODO The below Atom precedences can probably be made less conservative *)
+    (* TODO(?,?): The below Atom precedences can probably be made less conservative *)
     fprintf fmt "{%a with %s = %a}"
       print_tm (Atom, t1)
       l
@@ -489,24 +489,24 @@ let ustr_formatter_print
   flush_str_formatter () |> us
 
 (** Convert terms to strings.
- *  TODO Messy with optional arguments passing. Alternatives? *)
+ *  TODO(dlunde,?): Messy with optional arguments passing. Alternatives? *)
 let ustring_of_tm ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix t =
   ustr_formatter_print ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix
     print_tm (Match, t)
 
 (** Converting constants to strings.
- *  TODO Messy with optional arguments passing. Alternatives? *)
+ *  TODO(dlunde,?): Messy with optional arguments passing. Alternatives? *)
 let ustring_of_const ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix c =
   ustr_formatter_print ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix
     print_const c
 
 (** Converting environments to strings.
- *  TODO Messy with optional arguments passing. Alternatives? *)
+ *  TODO(dlunde,?): Messy with optional arguments passing. Alternatives? *)
 let ustring_of_env ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix e =
   ustr_formatter_print ?symbol ?indent ?max_indent ?margin ?max_boxes ?prefix
     print_env e
 
-(** TODO: Print mlang part as well. *)
+(** TODO(dlunde,?): Print mlang part as well. *)
 let ustring_of_program tml =
   match tml with
   | Program(_,_,t) -> ustring_of_tm t

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -237,7 +237,7 @@ let rec print_const fmt = function
   (* MCore Symbols *)
   | CSymb(id) -> fprintf fmt "symb(%d)" id
   | Cgensym   -> fprintf fmt "gensym"
-  | Ceqs(_)   -> fprintf fmt "eqs"
+  | Ceqsym(_)   -> fprintf fmt "eqsym"
   | CSym2hash  -> fprintf fmt "sym2hash"
 
   (* Python intrinsics *)

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -54,7 +54,7 @@ let testprog lst =
 
 (* Run program *)
 let runprog name lst =
-    (* TODO prog_argv is never used anywhere *)
+    (* TODO(?,?): prog_argv is never used anywhere *)
     prog_argv := lst;
     evalprog name
 

--- a/src/main/mi.mc
+++ b/src/main/mi.mc
@@ -36,7 +36,7 @@ let commandsMap = [
 let parseOptions = lam xs.
   (foldl (lam acc. lam s1.
     match acc with (options,lst) then
-      match findAssoc (lam s2. eqstr s1 s2) optionsMap with Some f
+      match findAssoc (lam s2. eqString s1 s2) optionsMap with Some f
       then (f options, lst)
       else match s1 with "--" ++ _
            then  [printLn (concat "Unknown option " s1), exit 1]
@@ -47,6 +47,6 @@ let parseOptions = lam xs.
 
 -- Main: find and run the correct command. See commandsMap above.
 if lti (length argv) 2 then print menu else
-  match findAssoc (lam s. eqstr (get argv 1) s) commandsMap with Some cmd
+  match findAssoc (lam s. eqString (get argv 1) s) commandsMap with Some cmd
   then cmd (parseOptions argv)
   else [printLn (join ["Unknown command '", get argv 1, "'"]), exit 1]

--- a/stdlib/ad/dualnum-symb.mc
+++ b/stdlib/ad/dualnum-symb.mc
@@ -22,7 +22,7 @@ type Term = ([Eps], Float)
 con DualNum : [Term] -> DualNum
 con Num : Float -> DualNum -- we separate out real numbers
 
-let memq = lam s. any (lam x. eqs x s)
+let memq = lam s. any (lam x. eqsym x s)
 let some = any
 
 let findIf = lam p. lam seq.
@@ -32,7 +32,7 @@ let findIf = lam p. lam seq.
 let removeIf = lam p. filter (lam x. not (p x))
 
 let removeq : Eps -> [Eps] =
-lam s. lam ss. filter (lam x. not (eqs x s)) ss
+lam s. lam ss. filter (lam x. not (eqsym x s)) ss
 
 let terms : DualNum -> [Term] =
 lam p. match p with Num f then [([], f)] else

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -103,14 +103,13 @@ let assocFold : AssocTraits k -> (acc -> k -> v -> acc)
   lam _. lam f. lam acc. lam m.
     foldl (lam acc. lam t. f acc t.0 t.1) acc m
 
--- 'assocFoldOption traits f acc m' folds over 'm' using function 'f' and accumulator
+-- 'assocFoldlM traits f acc m' folds over 'm' using function 'f' and accumulator
 -- 'acc'. The folding stops immediately if 'f' returns 'None ()'.
 -- IMPORTANT: The folding order is unspecified.
-let assocFoldOption : AssocTraits k -> (acc -> k -> v -> Option acc)
+let assocFoldlM : AssocTraits k -> (acc -> k -> v -> Option acc)
                         -> acc -> AssocMap k v -> Option acc =
   lam _. lam f. lam acc. lam m.
-    -- TODO Replace with optionFoldlM when available
-    foldOption (lam acc. lam t. f acc t.0 t.1) acc m
+    optionFoldlM (lam acc. lam t. f acc t.0 t.1) acc m
 
 -- 'assocMapAccum traits f acc m' simultaneously performs a map (over values)
 -- and fold over 'm' using function 'f' and accumulator 'acc'.
@@ -151,7 +150,7 @@ let keys = assocKeys traits in
 let values = assocValues traits in
 let map = assocMap traits in
 let fold = assocFold traits in
-let foldOption = assocFoldOption traits in
+let foldOption = assocFoldlM traits in
 let mapAccum = assocMapAccum traits in
 let mergePreferLeft = assocMergePreferLeft traits in
 let mergePreferRight = assocMergePreferRight traits in

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -16,7 +16,7 @@ let assocEmpty : AssocMap k v =
 
 -- 'assocLength m' returns the number of key-value pairs in m
 let assocLength : AssocMap k v -> Int =
-  lam m. length m
+  length
 
 -- 'assocInsert traits k v m' returns a new map, where the key-value pair
 -- ('k','v') is stored. If 'k' is already a key in 'm', its old value will be
@@ -103,7 +103,7 @@ let assocFold : AssocTraits k -> (acc -> k -> v -> acc)
   lam _. lam f. lam acc. lam m.
     foldl (lam acc. lam t. f acc t.0 t.1) acc m
 
--- 'assocFold traits f acc m' folds over 'm' using function 'f' and accumulator
+-- 'assocFoldOption traits f acc m' folds over 'm' using function 'f' and accumulator
 -- 'acc'. The folding stops immediately if 'f' returns 'None ()'.
 -- IMPORTANT: The folding order is unspecified.
 let assocFoldOption : AssocTraits k -> (acc -> k -> v -> Option acc)

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -169,8 +169,8 @@ utest lookupOrElse (lam _. 42) 1 m with '1' in
 utest lookupOrElse (lam _. 42) 2 m with '2' in
 utest lookupOrElse (lam _. 42) 3 m with '3' in
 utest lookupPred (eqi 2) m with Some '2' in
-utest any (lam k. lam v. eqchar v '2') m with true in
-utest any (lam k. lam v. eqchar v '4') m with false in
+utest any (lam k. lam v. eqChar v '2') m with true in
+utest any (lam k. lam v. eqChar v '4') m with false in
 utest all (lam k. lam v. gti k 0) m with true in
 utest all (lam k. lam v. gti k 1) m with false in
 utest

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -103,6 +103,15 @@ let assocFold : AssocTraits k -> (acc -> k -> v -> acc)
   lam _. lam f. lam acc. lam m.
     foldl (lam acc. lam t. f acc t.0 t.1) acc m
 
+-- 'assocFold traits f acc m' folds over 'm' using function 'f' and accumulator
+-- 'acc'. The folding stops immediately if 'f' returns 'None ()'.
+-- IMPORTANT: The folding order is unspecified.
+let assocFoldOption : AssocTraits k -> (acc -> k -> v -> Option acc)
+                        -> acc -> AssocMap k v -> Option acc =
+  lam _. lam f. lam acc. lam m.
+    -- TODO Replace with optionFoldlM when available
+    foldOption (lam acc. lam t. f acc t.0 t.1) acc m
+
 -- 'assocMapAccum traits f acc m' simultaneously performs a map (over values)
 -- and fold over 'm' using function 'f' and accumulator 'acc'.
 -- IMPORTANT: The folding order is unspecified.
@@ -142,6 +151,7 @@ let keys = assocKeys traits in
 let values = assocValues traits in
 let map = assocMap traits in
 let fold = assocFold traits in
+let foldOption = assocFoldOption traits in
 let mapAccum = assocMapAccum traits in
 let mergePreferLeft = assocMergePreferLeft traits in
 let mergePreferRight = assocMergePreferRight traits in
@@ -181,6 +191,14 @@ with (Some '2', Some '3', Some '4') in
 
 utest fold (lam acc. lam k. lam v. addi acc k) 0 m with 6 in
 utest fold (lam acc. lam k. lam v. and acc (is_digit v)) true m with true in
+
+utest foldOption (lam acc. lam k. lam v. Some (addi acc k)) 0 m with Some 6 in
+utest foldOption (lam acc. lam k. lam v. if eqi k 4 then None () else Some acc)
+        true m
+with Some true in
+utest foldOption (lam acc. lam k. lam v. if eqi k 2 then None () else Some acc)
+        true m
+with None () in
 
 let mapaccm = mapAccum (lam acc. lam k. lam v. (addi acc k, nextChar v)) 0 m in
 utest (mapaccm.0, (lookup 1 mapaccm.1, lookup 2 mapaccm.1, lookup 3 mapaccm.1))

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -12,7 +12,11 @@ type AssocTraits k = {eq : k -> k -> Bool}
 
 -- 'assocEmpty' is an empty associate map
 let assocEmpty : AssocMap k v =
-   []
+  []
+
+-- 'assocLength m' returns the number of key-value pairs in m
+let assocLength : AssocMap k v -> Int =
+  lam m. length m
 
 -- 'assocInsert traits k v m' returns a new map, where the key-value pair
 -- ('k','v') is stored. If 'k' is already a key in 'm', its old value will be
@@ -64,6 +68,12 @@ let assocLookupPred : (k -> Bool) -> AssocMap k v -> Option v =
 let assocAny : (k -> v -> Bool) -> AssocMap k v -> Bool =
   lam p. lam m.
     any (lam t. p t.0 t.1) m
+
+-- 'assocAll p m' returns true if all (k,v) pair in the map satisfies
+-- the predicate 'p'.
+let assocAll : (k -> v -> Bool) -> AssocMap k v -> Bool =
+  lam p. lam m.
+    all (lam t. p t.0 t.1) m
 
 -- 'assocMem traits k m' returns true if 'k' is a key in 'm', else false.
 let assocMem : AssocTraits k -> k -> AssocMap k v -> Bool =
@@ -119,10 +129,12 @@ mexpr
 
 let traits = {eq = eqi} in
 
+let length = assocLength in
 let lookup = assocLookup traits in
 let lookupOrElse = assocLookupOrElse traits in
 let lookupPred = assocLookupPred in
 let any = assocAny in
+let all = assocAll in
 let insert = assocInsert traits in
 let mem = assocMem traits in
 let remove = assocRemove traits in
@@ -139,6 +151,7 @@ let m = insert 1 '1' m in
 let m = insert 2 '2' m in
 let m = insert 3 '3' m in
 
+utest length m with 3 in
 utest lookup 1 m with Some '1' in
 utest lookup 2 m with Some '2' in
 utest lookup 3 m with Some '3' in
@@ -149,6 +162,8 @@ utest lookupOrElse (lam _. 42) 3 m with '3' in
 utest lookupPred (eqi 2) m with Some '2' in
 utest any (lam k. lam v. eqchar v '2') m with true in
 utest any (lam k. lam v. eqchar v '4') m with false in
+utest all (lam k. lam v. gti k 0) m with true in
+utest all (lam k. lam v. gti k 1) m with false in
 utest
   match keys m with [1,2,3] | [1,3,2] | [2,1,3] | [2,3,1] | [3,1,2] | [3,2,1]
   then true else false

--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -54,9 +54,9 @@ utest xnor false false with true
 
 
 -- Boolean equality
-let eqb = lam b1. lam b2. or (and b1 b2) (and (not b1) (not b2))
-utest eqb false false with true
-utest eqb false true  with false
-utest eqb true  false with false
-utest eqb true  true  with true
+let eqBool = lam b1. lam b2. or (and b1 b2) (and (not b1) (not b2))
+utest eqBool false false with true
+utest eqBool false true  with false
+utest eqBool true  false with false
+utest eqBool true  true  with true
 

--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -51,3 +51,12 @@ utest xnor true true with true
 utest xnor true false with false
 utest xnor false true with false
 utest xnor false false with true
+
+
+-- Boolean equality
+let eqb = lam b1. lam b2. or (and b1 b2) (and (not b1) (not b2))
+utest eqb false false with true
+utest eqb false true  with false
+utest eqb true  false with false
+utest eqb true  true  with true
+

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -7,17 +7,17 @@ lang CExprAst = VarAst + ConstAst + IntAst + FloatAst + CharAst
     | TmAssg { lhs: Expr, rhs: Expr }
     | TmApp { fun: String, args: [Expr] }
 
-    -- TODO Many other things missing, for instance:
+    -- TODO(dlunde,2020-09-29): Many other things missing, for instance:
     -- * Operators. We cannot reuse operators from mexpr (such as CAddi) since
     --   they are curried. Maybe this will change in the future?
     -- * Pointers
     -- * Arrays
-    -- * Unions (NOTE: not tagged unions, aka variants)
+    -- * Unions (NOTE(dlunde,2020-09-29): not tagged unions, aka variants)
     -- * Enums (variants with only nullary constructors)
     -- * Structs (should be reusable if we decompose RecordAst a bit)
 end
 
--- TODO Types (Some reuse from mexpr should be possible after some refactoring)
+-- TODO(dlunde,2020-09-29): Types (Some reuse from mexpr should be possible after some refactoring)
 lang CTypeAst
 
 lang CStmtAst = CExprAst + CTypeAst

--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -1,16 +1,13 @@
 include "seq.mc"
 
-let eqchar = lam c1. lam c2. eqi (char2int c1) (char2int c2)
-let neqchar = lam c1. lam c2. neqi (char2int c1) (char2int c2)
-let ltchar = lam c1. lam c2. lti (char2int c1) (char2int c2)
-let gtchar = lam c1. lam c2. gti (char2int c1) (char2int c2)
-let leqchar = lam c1. lam c2. leqi (char2int c1) (char2int c2)
-let geqchar = lam c1. lam c2. geqi (char2int c1) (char2int c2)
-let show_char = lam c. concat "'" (concat [c] "'")
+let eqChar = lam c1. lam c2. eqi (char2int c1) (char2int c2)
+let leqChar = lam c1. lam c2. leqi (char2int c1) (char2int c2)
+let geqChar = lam c1. lam c2. geqi (char2int c1) (char2int c2)
+let showChar = lam c. concat "'" (concat [c] "'")
 
 -- Character conversion
 let char2upper = lam c.
-  if and (geqchar c 'a') (leqchar c 'z')
+  if and (geqChar c 'a') (leqChar c 'z')
   then (int2char (subi (char2int c) 32))
   else c
 
@@ -19,7 +16,7 @@ utest char2upper '0' with '0'
 utest char2upper 'A' with 'A'
 
 let char2lower = lam c.
-  if and (geqchar c 'A') (leqchar c 'Z')
+  if and (geqChar c 'A') (leqChar c 'Z')
   then (int2char (addi (char2int c) 32))
   else c
 
@@ -28,7 +25,7 @@ utest char2lower '0' with '0'
 utest char2lower 'A' with 'a'
 
 -- Character predicates
-let is_whitespace = lam c. any (eqchar c) [' ', '\n', '\t', '\r']
+let is_whitespace = lam c. any (eqChar c) [' ', '\n', '\t', '\r']
 
 utest is_whitespace ' ' with true
 utest is_whitespace '	' with true

--- a/stdlib/dfa.mc
+++ b/stdlib/dfa.mc
@@ -54,7 +54,7 @@ let states = [0,1,2] in
 let transitions = [(0,1,'1'),(1,1,'1'),(1,2,'0'),(2,2,'0'),(2,1,'1')] in
 let startState = 0 in
 let acceptStates = [2] in
-let newDfa = dfaConstr states transitions startState acceptStates eqi eqchar in
+let newDfa = dfaConstr states transitions startState acceptStates eqi eqChar in
 utest eqi startState newDfa.startState with true in
 utest setEqual eqi acceptStates newDfa.acceptStates with true in
 utest (digraphHasVertices states newDfa.graph) with true in

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -304,7 +304,7 @@ utest digraphHasEdges [(2,1,l1),(3,1,l2),(1,3,l3)] gRev with true in
 utest digraphCountVertices gRev with 3 in
 utest digraphCountEdges gRev with 3 in
 
--- TODO: successor/predeccessor
+-- TODO(?,?): successor/predeccessor
 
 let g = digraphUnion (digraphAddVertex 1 empty) (digraphAddVertex 2 empty) in
 

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -246,7 +246,7 @@ let l2 = gensym () in
 let l3 = gensym () in
 let l4 = gensym () in
 
-let empty = digraphEmpty eqi eqs in
+let empty = digraphEmpty eqi eqsym in
 
 utest digraphVertices empty with [] in
 utest digraphEdges empty with [] in

--- a/stdlib/eq-paths.mc
+++ b/stdlib/eq-paths.mc
@@ -35,7 +35,7 @@ let eqPaths : Digraph -> a -> Int -> [a] -> [[a]] =
 
 mexpr
 -- To construct test graphs
-let empty = digraphEmpty eqi eqchar in
+let empty = digraphEmpty eqi eqChar in
 let fromList = lam vs. foldl (lam g. lam v. digraphAddVertex v g) empty vs in
 let addEdges = lam g. lam es. foldl (lam acc. lam e. digraphAddEdge e.0 e.1 e.2 acc) g es in
 

--- a/stdlib/eq-paths.mc
+++ b/stdlib/eq-paths.mc
@@ -52,7 +52,7 @@ let i = 'i' in
 let j = 'j' in
 
 let samePaths = lam p1. lam p2.
-  setEqual eqstr p1 p2 in
+  setEqual eqString p1 p2 in
 
 -- Graph with one node
 -- ┌─────┐

--- a/stdlib/graph.mc
+++ b/stdlib/graph.mc
@@ -66,7 +66,7 @@ let graphUnion = digraphUnion
 
 mexpr
 
-let empty = graphEmpty eqi eqs in
+let empty = graphEmpty eqi eqsym in
 
 utest graphEdges empty with [] in
 utest graphVertices empty with [] in
@@ -104,14 +104,14 @@ let g1 = graphAddEdge 1 2 l1 g in
 utest graphNeighbors 1 g1 with [2] in
 utest graphIsAdjecent 2 1 g1 with true in
 utest graphIsAdjecent 1 2 g1 with true in
-utest any (eqs l1) (graphLabels 1 2 g1) with true in
-utest any (eqs l1) (graphLabels 1 2 g1) with true in
+utest any (eqsym l1) (graphLabels 1 2 g1) with true in
+utest any (eqsym l1) (graphLabels 1 2 g1) with true in
 
 let l3 = gensym () in
 let g2 = graphAddEdge 3 2 l3 g1 in
 utest graphIsAdjecent 2 3 g2 with true in
 utest graphIsAdjecent 3 2 g2 with true in
-utest any (eqs l3) (graphLabels 3 2 g2) with true in
+utest any (eqsym l3) (graphLabels 3 2 g2) with true in
 
 let l2 = gensym () in
 let g3 = graphUnion (graphAddVertex 1 empty) (graphAddVertex 2 empty) in

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -44,7 +44,7 @@ let hashmapStrTraits : HashMapTraits =
       let newhash = addi (addi (muli hash 32) hash) (char2int (head s)) in
       djb2 newhash (tail s)
   in
-  {eq = eqstr, hashfn = djb2 5381}
+  {eq = eqString, hashfn = djb2 5381}
 
 -- 'hashmapInsert traits k v hm' returns a new hashmap, where the key-value pair
 -- ('k', 'v') is stored. If 'k' is already a key in 'hm', its old value will be
@@ -190,7 +190,7 @@ utest m.nelems with 2 in
 utest mem "bar" m with true in
 utest lookup "bar" m with Some ("bbb") in
 utest lookupOrElse (lam _. 42) "bar" m with "bbb" in
-utest lookupPred (eqstr "bar") m with Some "bbb" in
+utest lookupPred (eqString "bar") m with Some "bbb" in
 utest
   match keys m with ["foo", "bar"] | ["bar", "foo"]
   then true else false

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -3,7 +3,7 @@
 --
 -- A simple generic hashmap library.
 --
--- TODO:
+-- TODO(?,?):
 --  - Resizing of buckets.
 --  - Conversion to and from association lists.
 --
@@ -49,7 +49,7 @@ let hashmapStrTraits : HashMapTraits =
 -- 'hashmapInsert traits k v hm' returns a new hashmap, where the key-value pair
 -- ('k', 'v') is stored. If 'k' is already a key in 'hm', its old value will be
 -- overwritten.
--- [NOTE]
+-- [NOTE(?,?)]
 --   The insertion uses a recursion that is not tail-recursive.
 let hashmapInsert : HashMapTraits -> k -> v -> HashMap -> HashMap =
   lam traits. lam key. lam value. lam hm.
@@ -76,7 +76,7 @@ let hashmapInsert : HashMapTraits -> k -> v -> HashMap -> HashMap =
 
 -- 'hashmapRemove traits k hm' returns a new hashmap, where 'k' is not a key. If
 -- 'k' is not a key in 'hm', the map remains unchanged after the operation.
--- [NOTE]
+-- [NOTE(?,?)]
 --   The removal uses a recursion that is not tail-recursive.
 let hashmapRemove : HashMapTraits -> k -> HashMap -> HashMap =
   lam traits. lam key. lam hm.
@@ -130,7 +130,7 @@ let hashmapLookupOrElse : HashMapTraits -> k -> HashMap -> v =
 -- 'hashmapLookupPred p hm' returns the value of a key that satisfies the
 -- predicate 'p'. If several keys satisfies 'p', the one that happens to be
 -- found first is returned.
--- [NOTE]
+-- [NOTE(?,?)]
 --   Linear complexity.
 let hashmapLookupPred : (k -> Bool) -> HashMap -> OptionV =
   lam p. lam hm.

--- a/stdlib/local-search.mc
+++ b/stdlib/local-search.mc
@@ -158,7 +158,7 @@ let es = [("Uppsala", "Stockholm", 80), ("Stockholm", "Uppsala", 90),
           ("Stockholm", "Gothenburg", 40), ("Gothenburg", "Stockholm", 65),
           ("Kiruna", "Gothenburg", 111), ("Gothenburg", "Kiruna", 321)] in
 
-let g = digraphAddEdges es (digraphAddVertices vs (digraphEmpty eqstr eqi)) in
+let g = digraphAddEdges es (digraphAddVertices vs (digraphEmpty eqString eqi)) in
 
 -- Define initial solution
 let initTour = [("Uppsala", "Kiruna", 10),
@@ -178,8 +178,8 @@ let neighbours = lam g. lam state.
   let tour = curSol.0 in
 
   let tourHasEdge = lam v1. lam v2.
-    any (lam e. or (and (eqstr v1 e.0) (eqstr v2 e.1))
-                   (and (eqstr v1 e.1) (eqstr v2 e.0))) tour in
+    any (lam e. or (and (eqString v1 e.0) (eqString v2 e.1))
+                   (and (eqString v1 e.1) (eqString v2 e.0))) tour in
 
   -- Find replacing edges for 'e12' and 'e34'
   let exchange = lam e12. lam e34.

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -79,10 +79,10 @@ lang RecordANF = ANF + RecordAst
       (lam acc. lam k. lam e.
          (lam bs.
             normalizeName
-              (lam v. acc (assocInsert {eq=eqstr} k v bs))
+              (lam v. acc (assocInsert {eq=eqString} k v bs))
               e))
     in
-    (assocFold {eq=eqstr} f acc bindings) assocEmpty
+    (assocFold {eq=eqString} f acc bindings) assocEmpty
 
   | TmRecordUpdate {rec = rec, key = key, value = value} ->
     normalizeName

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -41,7 +41,12 @@ let pcon_ = use MExprAst in
 
 let prec_ = use MExprAst in
   lam bindings.
-  PRecord {bindings = bindings}
+  PRecord {
+    bindings =
+      foldl
+        (lam acc. lam b. assocInsert {eq=eqstr} b.0 b.1 acc)
+        assocEmpty bindings
+    }
 
 let ptuple_ = use MExprAst in
   lam ps.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -254,12 +254,6 @@ let if_ = use MExprAst in
   lam cond. lam thn. lam els.
   TmMatch {target = cond, pat = ptrue_, thn = thn, els = els}
 
-let and_ = use MExprAst in
-  lam a. lam b. if_ a b false
-
-let or_ = use MExprAst in
-  lam a. lam b. if_ a true b
-
 let match_ = use MExprAst in
   lam target. lam pat. lam thn. lam els.
   TmMatch {target = target, pat = pat, thn = thn, els = els}
@@ -478,3 +472,11 @@ let null_ = use MExprAst in
 let reverse_ = use MExprAst in
   lam s.
   appf1_ (const_ (CReverse ())) s
+
+-- Short circuit logical expressions
+let and_ = use MExprAst in
+  lam a. lam b. if_ a b false_
+
+let or_ = use MExprAst in
+  lam a. lam b. if_ a true_ b
+

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -254,6 +254,12 @@ let if_ = use MExprAst in
   lam cond. lam thn. lam els.
   TmMatch {target = cond, pat = ptrue_, thn = thn, els = els}
 
+let and_ = use MExprAst in
+  lam a. lam b. if_ a b false
+
+let or_ = use MExprAst in
+  lam a. lam b. if_ a true b
+
 let match_ = use MExprAst in
   lam target. lam pat. lam thn. lam els.
   TmMatch {target = target, pat = pat, thn = thn, els = els}

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -44,7 +44,7 @@ let prec_ = use MExprAst in
   PRecord {
     bindings =
       foldl
-        (lam acc. lam b. assocInsert {eq=eqstr} b.0 b.1 acc)
+        (lam acc. lam b. assocInsert {eq=eqString} b.0 b.1 acc)
         assocEmpty bindings
     }
 
@@ -267,7 +267,7 @@ let record_ = use MExprAst in
   TmRecord {
     bindings =
       foldl
-        (lam acc. lam b. assocInsert {eq=eqstr} b.0 b.1 acc)
+        (lam acc. lam b. assocInsert {eq=eqString} b.0 b.1 acc)
         assocEmpty bindings
     }
 
@@ -431,7 +431,7 @@ let eqf_ = use MExprAst in
 
 let eqs_ = use MExprAst in
   lam s1. lam s2.
-  appf2_ (const_ (CEqs ())) s1 s2
+  appf2_ (const_ (CEqsym ())) s1 s2
 
 let ltf_ = use MExprAst in
   lam a. lam b.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -257,6 +257,7 @@ end
 type PatName
 con PName     : Name -> PatName
 con PWildcard : ()   -> PatName
+
 lang VarPat
   syn Pat =
   | PVar {ident : PatName}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -52,12 +52,12 @@ lang RecordAst
                     value : Expr}
 
   sem smap_Expr_Expr (f : Expr -> a) =
-  | TmRecord t -> TmRecord {bindings = assocMap {eq=eqstr} f t.bindings}
+  | TmRecord t -> TmRecord {bindings = assocMap {eq=eqString} f t.bindings}
   | TmRecordUpdate t -> TmRecordUpdate {{t with rec = f t.rec}
                                            with value = f t.value}
 
   sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
-  | TmRecord t -> assocFold {eq=eqstr} (lam acc. lam _k. lam v. f acc v) acc t.bindings
+  | TmRecord t -> assocFold {eq=eqString} (lam acc. lam _k. lam v. f acc v) acc t.bindings
   | TmRecordUpdate t -> f (f acc t.rec) t.value
 end
 
@@ -233,7 +233,7 @@ end
 
 lang CmpSymbAst = SymbAst + BoolAst
   syn Const =
-  | CEqs {}
+  | CEqsym {}
 end
 
 -- TODO Remove constants no longer available in boot?
@@ -296,10 +296,10 @@ lang RecordPat
   | PRecord {bindings : AssocMap String Pat}
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PRecord b -> PRecord {b with bindings = assocMap {eq=eqstr} (lam b. (b.0, f b.1)) b.bindings}
+  | PRecord b -> PRecord {b with bindings = assocMap {eq=eqString} (lam b. (b.0, f b.1)) b.bindings}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PRecord {bindings = bindings} -> assocFold {eq=eqstr} (lam acc. lam _k. lam v. f acc v) acc bindings
+  | PRecord {bindings = bindings} -> assocFold {eq=eqString} (lam acc. lam _k. lam v. f acc v) acc bindings
 end
 
 lang DataPat = DataAst

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -168,7 +168,7 @@ lang NeverAst
   syn Expr =
   | TmNever {}
 
-  -- TODO smap, sfold?
+  -- TODO(dlunde,2020-09-29): smap, sfold
 end
 
 ---------------
@@ -206,7 +206,7 @@ end
 lang BoolAst = ConstAst
   syn Const =
   | CBool {val : Bool}
-  | CNot {} -- TODO dlunde 2020-09-29: This constant does not exist in boot. Remove?
+  | CNot {} -- TODO(dlunde,2020-09-29): This constant does not exist in boot. Remove?
 end
 
 lang CmpIntAst = IntAst + BoolAst
@@ -236,7 +236,7 @@ lang CmpSymbAst = SymbAst + BoolAst
   | CEqsym {}
 end
 
--- TODO Remove constants no longer available in boot?
+-- TODO(dlunde,2020-09-29): Remove constants no longer available in boot?
 lang SeqOpAst = SeqAst
   syn Const =
   | CGet {}
@@ -383,7 +383,7 @@ end
 -----------
 -- TYPES --
 -----------
--- TODO Update (also not up to date in boot?)
+-- TODO(dlunde,2020-09-29): Update (also not up to date in boot?)
 
 lang FunTypeAst
   syn Type =

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -206,7 +206,7 @@ end
 lang BoolAst = ConstAst
   syn Const =
   | CBool {val : Bool}
-  | CNot {}
+  | CNot {} -- TODO dlunde 2020-09-29: This constant does not exist in boot. Remove?
 end
 
 lang CmpIntAst = IntAst + BoolAst

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -1,7 +1,7 @@
 -- This file contains proof-of-concept functions for CPS transformation of the
 -- basic lambda calculus subset of MExpr. It is based on
 -- http://matt.might.net/articles/cps-conversion/.
--- TODO dlunde 2020-09-25: Add full support for MExpr when stable.
+-- TODO(dlunde,2020-09-25): Add full support for MExpr when stable.
 
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
@@ -55,6 +55,6 @@ let idc = symbolize (ulam_ "x" (ulam_ "k" (app_ (var_ "k") (var_ "x")))) in
 
 utest cpsM id with idc using eqExpr in
 
--- TODO dlunde 2020-09-25: Add more test cases
+-- TODO(dlunde,2020-09-25): Add more test cases
 
 ()

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -53,7 +53,7 @@ use FunCPS in
 let id = symbolize (ulam_ "x" (var_ "x")) in
 let idc = symbolize (ulam_ "x" (ulam_ "k" (app_ (var_ "k") (var_ "x")))) in
 
-utest cpsM id with idc using eqexpr in
+utest cpsM id with idc using eqExpr in
 
 -- TODO dlunde 2020-09-25: Add more test cases
 

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -1,13 +1,14 @@
 -- This file contains proof-of-concept functions for CPS transformation of the
 -- basic lambda calculus subset of MExpr. It is based on
 -- http://matt.might.net/articles/cps-conversion/.
--- TODO Add full support for MExpr when stable.
+-- TODO dlunde 2020-09-25: Add full support for MExpr when stable.
 
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/symbolize.mc"
+include "mexpr/eq.mc"
 
-lang FunCPS = FunSym
+lang FunCPS = FunSym + FunEq
 
   sem cpsK (cont: Expr -> Expr) =
   | TmLam t -> cont (cpsM (TmLam t))
@@ -49,15 +50,11 @@ end
 mexpr
 use FunCPS in
 
-let _s = symbolize assocEmpty in
+let id = symbolizeMExpr (ulam_ "x" (var_ "x")) in
+let idc = symbolizeMExpr (ulam_ "x" (ulam_ "k" (app_ (var_ "k") (var_ "x")))) in
 
-let id = _s (ulam_ "x" (var_ "x")) in
+utest cpsM id with idc using eqmexpr in
 
--- TODO This is currently not working since the symbols differ between the LHS
--- and RHS. Implement equality check between terms that takes care of symbols?
--- utest cpsM id
--- with _s (ulam_ "x" (ulam_ "k" (app_ (var_ "k") (var_ "x")))) in
-
--- TODO Add more test cases
+-- TODO dlunde 2020-09-25: Add more test cases
 
 ()

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -50,10 +50,10 @@ end
 mexpr
 use FunCPS in
 
-let id = symbolizeMExpr (ulam_ "x" (var_ "x")) in
-let idc = symbolizeMExpr (ulam_ "x" (ulam_ "k" (app_ (var_ "k") (var_ "x")))) in
+let id = symbolize (ulam_ "x" (var_ "x")) in
+let idc = symbolize (ulam_ "x" (ulam_ "k" (app_ (var_ "k") (var_ "x")))) in
 
-utest cpsM id with idc using eqmexpr in
+utest cpsM id with idc using eqexpr in
 
 -- TODO dlunde 2020-09-25: Add more test cases
 

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -575,7 +575,7 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
 
 end
 
--- TODO dlunde 2020-09-29: Why does the include order matter here? If I place
+-- TODO(dlunde,2020-09-29): Why does the include order matter here? If I place
 -- MExprPrettyPrint first, I get a pattern matching error.
 lang PPrintLang = LAppPrettyPrint + LHoleAstPrettyPrint + MExprPrettyPrint
 let expr2str = use PPrintLang in

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -154,7 +154,7 @@ lang Ast2CallGraph = LetAst + FunAst + RecLetsAst + LAppAst
   sem toCallGraph =
   | arg ->
     let vs = findVertices arg in
-    let gempty = digraphAddVertex _top (digraphEmpty _eqn eqs) in
+    let gempty = digraphAddVertex _top (digraphEmpty _eqn eqsym) in
     let gvs = foldl (lam g. lam v. digraphAddVertex v g) gempty vs in
     findEdges gvs _top arg
 
@@ -373,7 +373,7 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
 
     -- Lookup the value for a decision point in a given call context
     -- let lookup = lam callCtx. lam id.
-    --   let entries = filter (lam t. eqs t.0 id) lookupTable in
+    --   let entries = filter (lam t. eqsym t.0 id) lookupTable in
     --   let entriesSuffix = filter (lam t. isSuffix eqi t.1 callCtx) entries in
     --   let cmp = lam t1. lam t2. subi (length t1.1) (length t2.1) in
     --   max cmp entriesSuffix
@@ -383,7 +383,7 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
       let entries = nameSym "entries" in
       let entriesSuffix = nameSym "entriesSuffix" in
       let entriesLongestSuffix = nameSym "entriesLongestSuffix" in
-      let eqs = nameSym "eqs" in
+      let eqsym = nameSym "eqsym" in
       let cmp = nameSym "cmp" in
       let y = nameSym "y" in
       let t = nameSym "t" in
@@ -397,10 +397,10 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
               appf2_ (nvar_ _filter)
                      (nulam_ t (eqs_ (nvar_ id) (drecordproj_ "id" (nvar_ t))))
                      (nvar_ _lookupTable)),
-          nlet_ eqs (nulam_ x (nulam_ y (eqs_ (nvar_ x) (nvar_ y)))),
+          nlet_ eqsym (nulam_ x (nulam_ y (eqs_ (nvar_ x) (nvar_ y)))),
           nlet_ entriesSuffix
                (appf2_ (nvar_ _filter)
-                       (nulam_ t (appf3_ (nvar_ _isSuffix) (nvar_ eqs) (drecordproj_ "path" (nvar_ t)) (nvar_ _callCtx)))
+                       (nulam_ t (appf3_ (nvar_ _isSuffix) (nvar_ eqsym) (drecordproj_ "path" (nvar_ t)) (nvar_ _callCtx)))
                        (nvar_ entries)),
           nlet_ cmp
             (nulam_ t1 (nulam_ t2
@@ -645,12 +645,12 @@ let callGraphTests = lam ast. lam strVs. lam strEdgs.
     digraphAddEdges
       (map (lam t. (nameGetStr t.0, nameGetStr t.1, t.2)) (digraphEdges ng))
       (digraphAddVertices (map nameGetStr (digraphVertices ng))
-                          (digraphEmpty eqstr eqs))
+                          (digraphEmpty eqString eqsym))
   in
   let g = toCallGraph (labelApps (symbolize ast)) in
   let sg = toStr g in
 
-  utest setEqual eqstr strVs (digraphVertices sg) with true in
+  utest setEqual eqString strVs (digraphVertices sg) with true in
 
   let es = digraphEdges sg in
   utest length es with length strEdgs in

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -29,7 +29,7 @@ lang HoleAst
   | TmHole {tp : Type,
             startGuess : Expr,
             depth : Int}
-  sem symbolize (env : Env) =
+  sem symbolizeExpr (env : Env) =
 end
 
 lang HoleAstPrettyPrint = HoleAst + TypePrettyPrint
@@ -55,7 +55,7 @@ lang LHoleAst = HoleAst
              startGuess : Expr,
              depth : Int}
 
-  sem symbolize (env : Env) =
+  sem symbolizeExpr (env : Env) =
   | LTmHole h -> LTmHole h
 
   sem fromTmHole =
@@ -108,8 +108,8 @@ lang LAppAst = AppAst
     fromAppAst (TmApp {lhs = labelApps t.lhs, rhs = labelApps t.rhs})
   | tm -> smap_Expr_Expr labelApps tm
 
-  sem symbolize (env : Env) =
-  | TmLApp t -> fromAppAst (symbolize env (toAppAst (TmLApp t)))
+  sem symbolizeExpr (env : Env) =
+  | TmLApp t -> fromAppAst (symbolizeExpr env (toAppAst (TmLApp t)))
 end
 
 lang LAppEval = LAppAst + AppEval
@@ -575,7 +575,9 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
 
 end
 
-lang PPrintLang = MExprPrettyPrint + LAppPrettyPrint + LHoleAstPrettyPrint
+-- TODO dlunde 2020-09-29: Why does the include order matter here? If I place
+-- MExprPrettyPrint first, I get a pattern matching error.
+lang PPrintLang = LAppPrettyPrint + LHoleAstPrettyPrint + MExprPrettyPrint
 let expr2str = use PPrintLang in
   lam expr.
     match
@@ -599,7 +601,7 @@ let evalE = lam expr. lam expected.
   if evalEnabled then eval {env = []} expr else expected in
 
 -- Shorthand for symbolize
-let symbolize = symbolize assocEmpty in
+let symbolize = symbolizeExpr assocEmpty in
 
 -- Prettyprinting
 let pprint = lam ast.

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -309,7 +309,7 @@ end
 lang CharEq = CharAst
   sem eqConst (lhs : Const) =
   | CChar {val = v2} ->
-    match lhs with CChar {val = v1} then eqchar v1 v2 else false
+    match lhs with CChar {val = v1} then eqChar v1 v2 else false
 end
 
 lang SymbEq = SymbAst
@@ -413,7 +413,7 @@ lang CharPatEq = CharPat
   sem eqPat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
   | PChar {val = c2} ->
     match lhs with PChar {val = c1} then
-      if eqchar c1 c2 then Some (free,patEnv) else None ()
+      if eqChar c1 c2 then Some (free,patEnv) else None ()
     else None ()
 end
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -270,3 +270,65 @@ end
 --------------
 -- PATTERNS --
 --------------
+
+lang SeqTotPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- TODO
+end
+
+lang SeqEdgPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- TODO
+end
+
+lang RecordPatEq = RecordPat
+  sem eqpat (env : Env) (lhs : Pat) =
+  | PRecord {bindings = bs2} ->
+    match lhs with PRecord {bindings = bs1} then
+      if eqi (assocLength bs1) (assocLength bs2) then
+        assocFoldOption {eq=eqstr}
+          (lam env. lam k1. lam p1.
+             match assocLookup {eq=eqstr} k1 bs2 with Some p2 then
+               eqpat env p1 p2
+             else None ())
+          env bs1
+      else None ()
+    else None ()
+end
+
+lang DataPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- | PCon {ident  : Name,
+  --         subpat : Pat}
+end
+
+lang IntPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- | PInt {val : Int}
+end
+
+lang CharPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- | PChar {val : Char}
+end
+
+lang BoolPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- | PBool {val : Bool}
+end
+
+lang AndPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- TODO
+end
+
+lang OrPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- TODO
+end
+
+lang NotPatEq
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- TODO
+end
+

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -67,8 +67,20 @@ let _eqCheck : Name -> Name -> NameEnv -> NameEnv -> Option NameEnv =
 -- TERMS --
 -----------
 
-lang VarEq = VarAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+-- Convenience fragment containing the function eqexpr. Should be included in
+-- all fragments below.
+lang Eq
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
+  -- Intentionally left blank
+
+  sem eqexpr (e1: Expr) =
+  | e2 ->
+    let empty = {varEnv = biEmpty, conEnv = biEmpty} in
+    match eqexprh empty empty e1 e2 with Some _ then true else false
+end
+
+lang VarEq = Eq + VarAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmVar {ident = i2} ->
     match lhs with TmVar {ident = i1} then
       match (env,free) with ({varEnv = varEnv},{varEnv = freeVarEnv}) then
@@ -79,37 +91,37 @@ lang VarEq = VarAst
     else None ()
 end
 
-lang AppEq = AppAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang AppEq = Eq + AppAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmApp {lhs = rl, rhs = rr} ->
     match lhs with TmApp {lhs = ll, rhs = lr} then
-      match eqexpr env free ll rl with Some free then
-        eqexpr env free lr rr
+      match eqexprh env free ll rl with Some free then
+        eqexprh env free lr rr
       else None ()
     else None ()
 end
 
-lang FunEq = FunAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang FunEq = Eq + FunAst + VarEq + AppEq
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   -- NOTE dlunde 2020-09-26: The type annotation is currently ignored.
   | TmLam {ident = i2, body = b2} ->
     match env with {varEnv = varEnv} then
       match lhs with TmLam {ident = i1, body = b1} then
         let varEnv = biInsert (i1,i2) varEnv in
-        eqexpr {env with varEnv = varEnv} free b1 b2
+        eqexprh {env with varEnv = varEnv} free b1 b2
       else None ()
     else never
 end
 
-lang RecordEq = RecordAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang RecordEq = Eq + RecordAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmRecord {bindings = bs2} ->
     match lhs with TmRecord {bindings = bs1} then
       if eqi (assocLength bs1) (assocLength bs2) then
         assocFoldlM {eq=eqstr}
           (lam free. lam k1. lam v1.
             match assocLookup {eq=eqstr} k1 bs2 with Some v2 then
-              eqexpr env free v1 v2
+              eqexprh env free v1 v2
             else None ())
           free bs1
       else None ()
@@ -118,28 +130,28 @@ lang RecordEq = RecordAst
   | TmRecordUpdate {rec = r2, key = k2, value = v2} ->
     match lhs with TmRecordUpdate {rec = r1, key = k1, value = v1} then
       if eqstr k1 k2 then
-        match eqexpr env free r1 r2 with Some free then
-          eqexpr env free v1 v2
+        match eqexprh env free r1 r2 with Some free then
+          eqexprh env free v1 v2
         else None ()
       else None ()
     else None ()
 end
 
-lang LetEq = LetAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang LetEq = Eq + LetAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmLet {ident = i2, body = b2, inexpr = ie2} ->
     match lhs with TmLet {ident = i1, body = b1, inexpr = ie1} then
-      match eqexpr env free b1 b2 with Some free then
+      match eqexprh env free b1 b2 with Some free then
         match env with {varEnv = varEnv} then
           let varEnv = biInsert (i1,i2) varEnv in
-          eqexpr {env with varEnv = varEnv} free ie1 ie2
+          eqexprh {env with varEnv = varEnv} free ie1 ie2
         else never
       else None ()
     else None ()
 end
 
-lang RecLetsEq = RecLetsAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang RecLetsEq = Eq + RecLetsAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmRecLets {bindings = bs2} ->
     -- NOTE dlunde 2020-09-25: This requires the bindings to occur in the same
     -- order. Do we want to allow equality of differently ordered (but equal)
@@ -156,32 +168,32 @@ lang RecLetsEq = RecLetsAst
           in
           let env = {env with varEnv = varEnv} in
           optionFoldlM
-            (lam free. lam t. eqexpr env free (t.0).body (t.1).body)
+            (lam free. lam t. eqexprh env free (t.0).body (t.1).body)
             free bszip
         else None ()
       else None ()
     else never
 end
 
-lang ConstEq = ConstAst
+lang ConstEq = Eq + ConstAst
   sem eqconst (lhs : Const) =
   -- Intentionally left blank
 
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmConst {val = v2} ->
     match lhs with TmConst {val = v1} then
       if eqconst v1 v2 then Some free else None ()
     else None ()
 end
 
-lang DataEq = DataAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang DataEq = Eq + DataAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   -- Type annotation ignored here as well
   | TmConDef {ident = i2, inexpr = ie2} ->
     match env with {conEnv = conEnv} then
       match lhs with TmConDef {ident = i1, inexpr = ie1} then
         let conEnv = biInsert (i1,i2) conEnv in
-        eqexpr {env with conEnv = conEnv} free ie1 ie2
+        eqexprh {env with conEnv = conEnv} free ie1 ie2
       else None ()
     else never
 
@@ -189,24 +201,24 @@ lang DataEq = DataAst
     match lhs with TmConApp {ident = i1, body = b1} then
       match (env,free) with ({conEnv = conEnv},{conEnv = freeConEnv}) then
         match _eqCheck i1 i2 conEnv freeConEnv with Some freeConEnv then
-          eqexpr env {free with conEnv = freeConEnv} b1 b2
+          eqexprh env {free with conEnv = freeConEnv} b1 b2
         else None ()
       else never
     else None ()
 end
 
-lang MatchEq = MatchAst
+lang MatchEq = Eq + MatchAst
   sem eqpat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
   -- Intentionally left blank
 
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmMatch {target = t2, pat = p2, thn = thn2, els = els2} ->
     match lhs with TmMatch {target = t1, pat = p1, thn = thn1, els = els1} then
-      match eqexpr env free t1 t2 with Some free then
-        match eqexpr env free els1 els2 with Some free then
+      match eqexprh env free t1 t2 with Some free then
+        match eqexprh env free els1 els2 with Some free then
           match eqpat env free biEmpty p1 p2 with Some (free,patEnv) then
             match env with {varEnv = varEnv} then
-              eqexpr {env with varEnv = biMergePreferRight varEnv patEnv}
+              eqexprh {env with varEnv = biMergePreferRight varEnv patEnv}
                 free thn1 thn2
             else never
           else None ()
@@ -216,31 +228,31 @@ lang MatchEq = MatchAst
 
 end
 
-lang UtestEq = UtestAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang UtestEq = Eq + UtestAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmUtest {test = t2, expected = e2, next = n2} ->
     match lhs with TmUtest {test = t1, expected = e1, next = n1} then
-      match eqexpr env free t1 t2 with Some free then
-        match eqexpr env free e1 e2 with Some free then
-          eqexpr env free n1 n2
+      match eqexprh env free t1 t2 with Some free then
+        match eqexprh env free e1 e2 with Some free then
+          eqexprh env free n1 n2
         else None ()
       else None ()
     else None ()
 end
 
-lang SeqEq = SeqAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang SeqEq = Eq + SeqAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmSeq {tms = ts2} ->
     match lhs with TmSeq {tms = ts1} then
       if eqi (length ts1) (length ts2) then
         let z = zipWith (lam t1. lam t2. (t1,t2)) ts1 ts2 in
-        optionFoldlM (lam free. lam tp. eqexpr env free tp.0 tp.1) free z
+        optionFoldlM (lam free. lam tp. eqexprh env free tp.0 tp.1) free z
       else None ()
     else None ()
 end
 
-lang NeverEq = NeverAst
-  sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
+lang NeverEq = Eq + NeverAst
+  sem eqexprh (env : Env) (free : Env) (lhs : Expr) =
   | TmNever _ -> match lhs with TmNever _ then Some free else None ()
 end
 
@@ -448,14 +460,7 @@ lang MExprEq =
   + VarPatEq + SeqTotPatEq + SeqEdgPatEq + RecordPatEq + DataPatEq + IntPatEq +
   CharPatEq + BoolPatEq + AndPatEq + OrPatEq + NotPatEq
 
----------------------------
--- CONVENIENCE FUNCTIONS --
----------------------------
-
-let eqmexpr = use MExprEq in
-  lam e1. lam e2.
-    let empty = {varEnv = biEmpty, conEnv = biEmpty} in
-    match eqexpr empty empty e1 e2 with Some _ then true else false
+end
 
 -----------
 -- TESTS --
@@ -468,26 +473,26 @@ use MExprEq in
 -- Simple variables
 let v1 = var_ "x" in
 let v2 = var_ "y" in
-utest v1 with v2 using eqmexpr in
-utest eqmexpr (int_ 1) v1 with false in
+utest v1 with v2 using eqexpr in
+utest eqexpr (int_ 1) v1 with false in
 
 -- Variables are equal as long as they occur in the same positions
 let v3 = app_ (var_ "x") (var_ "y") in
 let v4 = app_ (var_ "y") (var_ "x") in
 let v5e = app_ (var_ "x") (var_ "x") in
-utest v3 with v4 using eqmexpr in
-utest eqmexpr v3 v5e with false in
+utest v3 with v4 using eqexpr in
+utest eqexpr v3 v5e with false in
 
 -- Lambdas
 let lam1 = ulam_ "x" v1 in
 let lam2 = ulam_ "y" v2 in
-utest lam1 with lam2 using eqmexpr in
-utest eqmexpr (int_ 1) lam2 with false in
+utest lam1 with lam2 using eqexpr in
+utest eqexpr (int_ 1) lam2 with false in
 
 let lamNested1 = ulam_ "x" (ulam_ "y" (app_ (var_ "x") (var_ "y"))) in
 let lamNested2 = ulam_ "x" (ulam_ "x" (app_ (var_ "x") (var_ "x"))) in
-utest eqmexpr lamNested1 lamNested2 with false in
-utest eqmexpr lamNested2 lamNested1 with false in
+utest eqexpr lamNested1 lamNested2 with false in
+utest eqexpr lamNested2 lamNested1 with false in
 
 let lamNested21 = ulam_ "x" (ulam_ "y" (ulam_ "x" (var_ "x"))) in
 let lamNested22 = ulam_ "x" (ulam_ "y" (ulam_ "y" (var_ "y"))) in
@@ -495,14 +500,14 @@ let lamNested23 =
   ulam_ "x" (ulam_ "y" (ulam_ "x" (app_ (var_ "x") (var_ "y")))) in
 let lamNested24 =
   ulam_ "x" (ulam_ "y" (ulam_ "y" (app_ (var_ "y") (var_ "y")))) in
-utest lamNested21 with lamNested22 using eqmexpr in
-utest eqmexpr lamNested23 lamNested24 with false in
+utest lamNested21 with lamNested22 using eqexpr in
+utest eqexpr lamNested23 lamNested24 with false in
 
 -- Applications
 let a1 = app_ lam1 lam2 in
 let a2 = app_ lam2 lam1 in
-utest a1 with a2 using eqmexpr in
-utest eqmexpr a1 lam1 with false in
+utest a1 with a2 using eqexpr in
+utest eqexpr a1 lam1 with false in
 
 -- Records
 let r1 = record_ [("a",lam1), ("b",a1), ("c",a2)] in
@@ -510,44 +515,44 @@ let r2 = record_ [("b",a1), ("a",lam2), ("c",a2)] in
 let r3e = record_ [("a",lam1), ("b",a1), ("d",a2)] in
 let r4e = record_ [("a",lam1), ("b",a1), ("c",lam2)] in
 let r5e = record_ [("a",lam1), ("b",a1), ("c",a2), ("d",lam2)] in
-utest r1 with r2 using eqmexpr in
-utest eqmexpr r1 r3e with false in
-utest eqmexpr r1 r4e with false in
-utest eqmexpr r1 r5e with false in
+utest r1 with r2 using eqexpr in
+utest eqexpr r1 r3e with false in
+utest eqexpr r1 r4e with false in
+utest eqexpr r1 r5e with false in
 
 let ru1 = recordupdate_ r1 "b" lam1 in
 let ru2 = recordupdate_ r2 "b" lam2 in
 let ru3e = recordupdate_ r3e "b" lam2 in
 let ru4e = recordupdate_ r2 "c" lam2 in
-utest ru1 with ru2 using eqmexpr in
-utest eqmexpr ru1 ru3e with false in
-utest eqmexpr ru1 ru4e with false in
+utest ru1 with ru2 using eqexpr in
+utest eqexpr ru1 ru3e with false in
+utest eqexpr ru1 ru4e with false in
 
 -- Let and recursive let
 let let1 = bind_ (let_ "x" lam1) a1 in
 let let2 = bind_ (let_ "y" lam2) a2 in
 let let3e = bind_ (let_ "x" (int_ 1)) a1 in
 let let4e = bind_ (let_ "x" lam2) lam1 in
-utest let1 with let2 using eqmexpr in
-utest eqmexpr let1 let3e with false in
-utest eqmexpr let1 let4e with false in
+utest let1 with let2 using eqexpr in
+utest eqexpr let1 let3e with false in
+utest eqexpr let1 let4e with false in
 
 let rlet1 = reclets_ [("x", a1), ("y", lam1)] in
 let rlet2 = reclets_ [("x", a2), ("y", lam2)] in
 let rlet3 = reclets_ [("y", a2), ("x", lam2)] in
 let rlet4e = reclets_ [("y", lam1), ("x", a1)] in -- Order matters
-utest rlet1 with rlet2 using eqmexpr in
-utest rlet1 with rlet3 using eqmexpr in
-utest eqmexpr rlet1 rlet4e with false in
+utest rlet1 with rlet2 using eqexpr in
+utest rlet1 with rlet3 using eqexpr in
+utest eqexpr rlet1 rlet4e with false in
 
 -- Constants
 let c1 = (int_ 1) in
 let c2 = (int_ 2) in
 let c3 = (true_) in
 
-utest c1 with c1 using eqmexpr in
-utest eqmexpr c1 c2 with false in
-utest eqmexpr c1 c3 with false in
+utest c1 with c1 using eqexpr in
+utest eqexpr c1 c2 with false in
+utest eqexpr c1 c3 with false in
 
 -- Constructors can have different names, but they must be used in the same
 -- positions.
@@ -560,8 +565,8 @@ let cda2 =
 let cd3e =
   bind_ (ucondef_ "App")
     (app_ (conapp_ "App2" (int_ 1)) (conapp_ "Other2" (int_ 2))) in
-utest cda1 with cda2 using eqmexpr in
-utest eqmexpr cda1 cd3e with false in
+utest cda1 with cda2 using eqexpr in
+utest eqexpr cda1 cd3e with false in
 
 -- Match and patterns
 let m1 = match_ c1 (pint_ 1) cda1 rlet1 in
@@ -569,47 +574,47 @@ let m2 = match_ c1 (pint_ 1) cda2 rlet2 in
 let m3e = match_ rlet1 (pint_ 1) cda2 rlet2 in
 let m4e = match_ c1 (pint_ 1) c1 rlet2 in
 let m5e = match_ c1 (pint_ 1) cda2 cda1 in
-utest m1 with m2 using eqmexpr in
-utest eqmexpr m1 m3e with false in
-utest eqmexpr m1 m4e with false in
-utest eqmexpr m1 m5e with false in
+utest m1 with m2 using eqexpr in
+utest eqexpr m1 m3e with false in
+utest eqexpr m1 m4e with false in
+utest eqexpr m1 m5e with false in
 
 let pgen = lam p. match_ (int_ 1) p (int_ 2) (int_ 3) in
 let pvar1 = pvar_ "x" in
 let pvar2 = pvar_ "y" in
-utest pgen pvar1 with pgen pvar2 using eqmexpr in
-utest eqmexpr (pgen pvar1) (pgen (pint_ 1)) with false in
+utest pgen pvar1 with pgen pvar2 using eqexpr in
+utest eqexpr (pgen pvar1) (pgen (pint_ 1)) with false in
 
 let prec1 = prec_ [("a",pvar1), ("b",pvar2), ("c",pvar1)] in
 let prec2 = prec_ [("a",pvar2), ("b",pvar1), ("c",pvar2)] in
 let prec3e = prec_ [("a",pvar2), ("b",pvar2), ("c",pvar1)] in
 let prec4e = prec_ [("a",pvar2), ("b",pvar2), ("c",pvar1)] in
-utest pgen prec1 with pgen prec2 using eqmexpr in
-utest eqmexpr (pgen prec1) (pgen prec3e) with false in
+utest pgen prec1 with pgen prec2 using eqexpr in
+utest eqexpr (pgen prec1) (pgen prec3e) with false in
 
 let pdata1 = pcon_ "Const1" (pcon_ "Const2" prec1) in
 let pdata2 = pcon_ "Const2" (pcon_ "Const1" prec1) in
 let pdata3e = pcon_ "Const1" (pcon_ "Const1" prec1) in
-utest pgen pdata1 with pgen pdata2 using eqmexpr in
-utest eqmexpr (pgen pdata1) (pgen pdata3e) with false in
+utest pgen pdata1 with pgen pdata2 using eqexpr in
+utest eqexpr (pgen pdata1) (pgen pdata3e) with false in
 
 let pint1 = pint_ 1 in
 let pint2 = pint_ 1 in
 let pint3e = pint_ 2 in
-utest pgen pint1 with pgen pint2 using eqmexpr in
-utest eqmexpr (pgen pint1) (pgen pint3e) with false in
+utest pgen pint1 with pgen pint2 using eqexpr in
+utest eqexpr (pgen pint1) (pgen pint3e) with false in
 
 let pchar1 = pchar_ 'a' in
 let pchar2 = pchar_ 'a' in
 let pchar3e = pchar_ 'b' in
-utest pgen pchar1 with pgen pchar2 using eqmexpr in
-utest eqmexpr (pgen pchar1) (pgen pchar3e) with false in
+utest pgen pchar1 with pgen pchar2 using eqexpr in
+utest eqexpr (pgen pchar1) (pgen pchar3e) with false in
 
 let pbool1 = ptrue_ in
 let pbool2 = ptrue_ in
 let pbool3e = pfalse_ in
-utest pgen pbool1 with pgen pbool2 using eqmexpr in
-utest eqmexpr (pgen pbool1) (pgen pbool3e) with false in
+utest pgen pbool1 with pgen pbool2 using eqexpr in
+utest eqexpr (pgen pbool1) (pgen pbool3e) with false in
 
 -- Utest
 let ut1 = utest_ lam1 lam2 v3 in
@@ -617,26 +622,26 @@ let ut2 = utest_ lam2 lam1 v4 in
 let ut3e = utest_ v5e lam2 v3 in
 let ut4e = utest_ lam1 v5e v3 in
 let ut5e = utest_ lam1 lam2 v5e in
-utest ut1 with ut2 using eqmexpr in
-utest eqmexpr ut1 ut3e with false in
-utest eqmexpr ut1 ut4e with false in
-utest eqmexpr ut1 ut5e with false in
+utest ut1 with ut2 using eqexpr in
+utest eqexpr ut1 ut3e with false in
+utest eqexpr ut1 ut4e with false in
+utest eqexpr ut1 ut5e with false in
 
 -- Sequences
 let s1 = seq_ [lam1, lam2, v3] in
 let s2 = seq_ [lam2, lam1, v4] in
 let s3e = seq_ [lam1, v5e, v3] in
-utest s1 with s2 using eqmexpr in
-utest eqmexpr s1 s3e with false in
+utest s1 with s2 using eqexpr in
+utest eqexpr s1 s3e with false in
 
 -- Never
-utest never_ with never_ using eqmexpr in
-utest eqmexpr never_ true_ with false in
+utest never_ with never_ using eqexpr in
+utest eqexpr never_ true_ with false in
 
 -- Symbolized (and partially symbolized) terms are also supported.
-let sm = symbolizeMExpr in
-utest sm lamNested21 with sm lamNested22 using eqmexpr in
-utest lamNested21 with sm lamNested22 using eqmexpr in
-utest eqmexpr (sm lamNested23) (sm lamNested24) with false in
+let sm = symbolize in
+utest sm lamNested21 with sm lamNested22 using eqexpr in
+utest lamNested21 with sm lamNested22 using eqexpr in
+utest eqexpr (sm lamNested23) (sm lamNested24) with false in
 
 ()

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -12,68 +12,56 @@ include "mexpr/symbolize.mc"
 -- ENVIRONMENT --
 -----------------
 
--- The environment used throughout equality checking must be bijective. We use
--- double assocMaps to check this.
-type NameEnv = (AssocMap Name Name, AssocMap Name Name)
+-- The environment used throughout equality checking is a bijective map.
+type BiNameMap = [(Name,Name)]
 
-let _eqEmptyNameEnv = (assocEmpty, assocEmpty)
+let biEmpty = []
+
+-- 'biInsert (i1,i2) bmap' inserts (i1,i2) in bmap, maintaining bijectivity
+-- (destructive).
+let biInsert : (Name,Name) -> BiNameMap -> BiNameMap =
+  lam i. lam bmap.
+    let p = (lam n. if nameEq i.0 n.0 then false else not (nameEq i.1 n.1)) in
+    cons i (filter p bmap)
+
+-- 'biMergePreferRight bmapl bmapr' inserts all elements of bmapr into bmapl
+-- (destructive).
+let biMergePreferRight : BiNameMap -> BiNameMap -> BiNameMap =
+  lam bmapl. lam bmapr.
+    foldl (lam bmap. lam i. biInsert i bmap) bmapl bmapr
+
+-- 'biLookup (i1,i2) bmap' retrieves either (i1,y) or (x,i2) from bmap
+-- (unspecified which), if such an entry exists. If not, returns
+-- None ().
+let biLookup : (Name,Name) -> BiNameMap -> Option (Name,Name) =
+  lam i. lam bmap.
+    let pred = (lam n. if nameEq i.0 n.0 then true else nameEq i.1 n.1) in
+    find pred bmap
 
 type Env = {
-  varEnv : NameEnv,
-  conEnv : NameEnv
+  varEnv : BiNameMap,
+  conEnv : BiNameMap
 }
 
-let _eqUpdateEnv : NameEnv -> NameEnv -> NameEnv =
-  lam old. lam new.
-    let m = assocMergePreferRight {eq=nameEq} in
-    (m old.0 new.0, m old.1 new.1)
-
-let _eqInsert : Name -> Name -> NameEnv -> NameEnv =
-  lam i1. lam i2. lam env.
-    let t1 = assocInsert {eq = nameEq} i1 i2 env.0 in
-    let t2 = assocInsert {eq = nameEq} i2 i1 env.1 in
-    (t1,t2)
-
--- Returns Some true if the mapping exists and is consistent, Some false if the
--- mapping does not exist, and None () if the mapping exists but is
--- inconsistent (the environment is found to not be bijective).
-let _eqCheckEnv : Name -> Name -> NameEnv -> Option Bool =
-  lam i1. lam i2. lam env.
-    let m = (assocLookup {eq = nameEq} i1 env.0,
-             assocLookup {eq = nameEq} i2 env.1) in
-
-    -- Binding exists in both directions
-    match m with (Some v2, Some v1) then
-      if and (nameEq i1 v1) (nameEq i2 v2) then
-        Some true -- Bindings are consistent
-      else None () -- Bindings are inconsistent
-
-    -- Binding exists only in one direction (inconsistent)
-    else match m with (Some _, None ()) | (None (), Some _) then
-      None ()
-
-    -- Binding is completely missing (consistent)
-    else match m with (None (), None ()) then
-      Some false
-    else never
-
--- Checks if i1 <-> i2 exists in either the bound or free environments (bound
--- takes precedence). If so, return the given free environment. If the mapping
--- does not exist, add it to the free environment and return this updated
--- environment. If the mapping is found to be inconsistent, return None ().
-let _eqCheckEnvs : Name -> Name -> NameEnv -> NameEnv -> Option NameEnv =
+-- Checks if the mapping (i1,i2) exists in either the bound or free
+-- environments (bound takes precedence). If so, return the given free
+-- environment. If (i1,i2) is inconsistent with either environment, return None
+-- (). If i1 (lhs) or i2 (rhs) does not exist in any environment, return the
+-- free environment with (i1,i2) added.
+let _eqCheck : Name -> Name -> NameEnv -> NameEnv -> Option NameEnv =
   lam i1. lam i2. lam env. lam free.
-    let lenv = _eqCheckEnv i1 i2 env in
-    match lenv with Some true then Some free -- Consistent bound name exists
-    else match lenv with Some false then
-      let lfree = _eqCheckEnv i1 i2 free in
-      match lfree with Some true then Some free -- Consistent free name exists
-      else match lfree with Some false then
-        Some (_eqInsert i1 i2 free) -- New free variable encountered
-      else match lfree with None () then None () -- Inconsistent bindings
-      else never
-    else match lenv with None () then None () -- Inconsistent bindings
-    else never
+    match biLookup (i1,i2) env with Some (n1,n2) then
+      if and (nameEq i1 n1) (nameEq i2 n2) then Some free -- Match in env
+      else None () -- i1<->i2 is not consistent with env
+    else match biLookup (i1,i2) free with Some (n1,n2) then
+      if and (nameEq i1 n1) (nameEq i2 n2) then Some free -- Match in free
+      else None () -- i1<->i2 is not consistent with free
+    else
+      -- Here, we know that neither i1 (lhs) nor i2 (rhs) exists in free.
+      -- Hence, the below insert is non-destructive (which makes sense, since
+      -- unbound variables cannot shadow one another).
+      Some (biInsert (i1,i2) free)
+
 
 -----------
 -- TERMS --
@@ -82,10 +70,9 @@ let _eqCheckEnvs : Name -> Name -> NameEnv -> NameEnv -> Option NameEnv =
 lang VarEq = VarAst
   sem eqexpr (env : Env) (free : Env) (lhs : Expr) =
   | TmVar {ident = i2} ->
-
     match lhs with TmVar {ident = i1} then
       match (env,free) with ({varEnv = varEnv},{varEnv = freeVarEnv}) then
-        match _eqCheckEnvs i1 i2 varEnv freeVarEnv with Some freeVarEnv then
+        match _eqCheck i1 i2 varEnv freeVarEnv with Some freeVarEnv then
           Some {free with varEnv = freeVarEnv}
         else None ()
       else never
@@ -108,7 +95,7 @@ lang FunEq = FunAst
   | TmLam {ident = i2, body = b2} ->
     match env with {varEnv = varEnv} then
       match lhs with TmLam {ident = i1, body = b1} then
-        let varEnv = _eqInsert i1 i2 varEnv in
+        let varEnv = biInsert (i1,i2) varEnv in
         eqexpr {env with varEnv = varEnv} free b1 b2
       else None ()
     else never
@@ -144,7 +131,7 @@ lang LetEq = LetAst
     match lhs with TmLet {ident = i1, body = b1, inexpr = ie1} then
       match eqexpr env free b1 b2 with Some free then
         match env with {varEnv = varEnv} then
-          let varEnv = _eqInsert i1 i2 varEnv in
+          let varEnv = biInsert (i1,i2) varEnv in
           eqexpr {env with varEnv = varEnv} free ie1 ie2
         else never
       else None ()
@@ -164,11 +151,12 @@ lang RecLetsEq = RecLetsAst
           let varEnv =
             foldl
               (lam varEnv. lam t.
-                 _eqInsert (t.0).ident (t.1).ident varEnv)
+                 biInsert ((t.0).ident,(t.1).ident) varEnv)
               varEnv bszip
           in
           let env = {env with varEnv = varEnv} in
-          optionFoldlM (lam free. lam t. eqexpr env free (t.0).body (t.1).body)
+          optionFoldlM
+            (lam free. lam t. eqexpr env free (t.0).body (t.1).body)
             free bszip
         else None ()
       else None ()
@@ -192,7 +180,7 @@ lang DataEq = DataAst
   | TmConDef {ident = i2, inexpr = ie2} ->
     match env with {conEnv = conEnv} then
       match lhs with TmConDef {ident = i1, inexpr = ie1} then
-        let conEnv = _eqInsert i1 i2 conEnv in
+        let conEnv = biInsert (i1,i2) conEnv in
         eqexpr {env with conEnv = conEnv} free ie1 ie2
       else None ()
     else never
@@ -200,7 +188,7 @@ lang DataEq = DataAst
   | TmConApp {ident = i2, body = b2} ->
     match lhs with TmConApp {ident = i1, body = b1} then
       match (env,free) with ({conEnv = conEnv},{conEnv = freeConEnv}) then
-        match _eqCheckEnvs i1 i2 conEnv freeConEnv with Some freeConEnv then
+        match _eqCheck i1 i2 conEnv freeConEnv with Some freeConEnv then
           eqexpr env {free with conEnv = freeConEnv} b1 b2
         else None ()
       else never
@@ -216,11 +204,9 @@ lang MatchEq = MatchAst
     match lhs with TmMatch {target = t1, pat = p1, thn = thn1, els = els1} then
       match eqexpr env free t1 t2 with Some free then
         match eqexpr env free els1 els2 with Some free then
-          match eqpat env free _eqEmptyNameEnv p1 p2 with Some (free,patEnv) then
+          match eqpat env free biEmpty p1 p2 with Some (free,patEnv) then
             match env with {varEnv = varEnv} then
-              eqexpr
-                { env with
-                  varEnv = _eqUpdateEnv varEnv patEnv }
+              eqexpr {env with varEnv = biMergePreferRight varEnv patEnv}
                 free thn1 thn2
             else never
           else None ()
@@ -345,22 +331,21 @@ end
 
 let _eqpatname : NameEnv -> NameEnv -> PatName -> PatName -> Option NameEnv =
   lam penv. lam free. lam p1. lam p2.
-
-    match (p1,p2) with (PName n1,PName n2) then
-      let lpenv = _eqCheckEnv n1 n2 penv in
-      match lpenv with Some true then Some (free,penv)
-      else match lpenv with Some false then
-        Some (free, _eqInsert n1 n2 penv)
-      else match lpenv with None () then None ()
-      else never
+    match (p1,p2) with (PName i1,PName i2) then
+      match biLookup (i1,i2) penv with Some (n1,n2) then
+        if and (nameEq i1 n1) (nameEq i2 n2) then
+          Some (free,penv) -- Match in env
+        else None () -- i1<->i2 is not consistent with penv
+      else
+        let penv = biInsert (i1,i2) penv in Some (free,penv)
 
     else match (p1,p2) with (PWildcard _,PWildcard _) then Some (free,penv)
     else None ()
 
 lang VarPatEq = VarPat
   sem eqpat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
-  | PVar p2 ->
-    match lhs with PVar p1 then
+  | PVar {ident = p2} ->
+    match lhs with PVar {ident = p1} then
       _eqpatname patEnv free p1 p2
     else None ()
 end
@@ -397,7 +382,7 @@ lang DataPatEq = DataPat
   | PCon {ident = i2, subpat = s2} ->
     match lhs with PCon {ident = i1, subpat = s1} then
       match (env,free) with ({conEnv = conEnv},{conEnv = freeConEnv}) then
-        match _eqCheckEnvs i1 i2 conEnv freeConEnv with Some freeConEnv then
+        match _eqCheck i1 i2 conEnv freeConEnv with Some freeConEnv then
           eqpat env {free with conEnv = freeConEnv} patEnv s1 s2
         else None ()
       else never
@@ -469,7 +454,7 @@ lang MExprEq =
 
 let eqmexpr = use MExprEq in
   lam e1. lam e2.
-    let empty = {varEnv = _eqEmptyNameEnv, conEnv = _eqEmptyNameEnv} in
+    let empty = {varEnv = biEmpty, conEnv = biEmpty} in
     match eqexpr empty empty e1 e2 with Some _ then true else false
 
 -----------
@@ -480,15 +465,11 @@ mexpr
 
 use MExprEq in
 
-let sm = symbolizeMExpr in
-
+-- Simple variables
 let v1 = var_ "x" in
 let v2 = var_ "y" in
 utest v1 with v2 using eqmexpr in
 utest eqmexpr (int_ 1) v1 with false in
--- TODO dlunde 2020-09-28: Symbolize does not work for open terms
--- utest sm v1 with sm v2 using eqmexpr in
--- utest eqmexpr (sm (int_ 1)) (sm v1) with false in
 
 -- Variables are equal as long as they occur in the same positions
 let v3 = app_ (var_ "x") (var_ "y") in
@@ -497,74 +478,69 @@ let v5e = app_ (var_ "x") (var_ "x") in
 utest v3 with v4 using eqmexpr in
 utest eqmexpr v3 v5e with false in
 
+-- Lambdas
 let lam1 = ulam_ "x" v1 in
 let lam2 = ulam_ "y" v2 in
 utest lam1 with lam2 using eqmexpr in
-utest sm lam1 with sm lam2 using eqmexpr in
 utest eqmexpr (int_ 1) lam2 with false in
-utest eqmexpr (sm (int_ 1)) (sm lam2) with false in
 
 let lamNested1 = ulam_ "x" (ulam_ "y" (app_ (var_ "x") (var_ "y"))) in
 let lamNested2 = ulam_ "x" (ulam_ "x" (app_ (var_ "x") (var_ "x"))) in
 utest eqmexpr lamNested1 lamNested2 with false in
-utest eqmexpr (sm lamNested1) (sm lamNested2) with false in
 utest eqmexpr lamNested2 lamNested1 with false in
-utest eqmexpr (sm lamNested2) (sm lamNested1) with false in
 
+let lamNested21 = ulam_ "x" (ulam_ "y" (ulam_ "x" (var_ "x"))) in
+let lamNested22 = ulam_ "x" (ulam_ "y" (ulam_ "y" (var_ "y"))) in
+let lamNested23 =
+  ulam_ "x" (ulam_ "y" (ulam_ "x" (app_ (var_ "x") (var_ "y")))) in
+let lamNested24 =
+  ulam_ "x" (ulam_ "y" (ulam_ "y" (app_ (var_ "y") (var_ "y")))) in
+utest lamNested21 with lamNested22 using eqmexpr in
+utest eqmexpr lamNested23 lamNested24 with false in
+
+-- Applications
 let a1 = app_ lam1 lam2 in
 let a2 = app_ lam2 lam1 in
 utest a1 with a2 using eqmexpr in
-utest sm a1 with sm a2 using eqmexpr in
 utest eqmexpr a1 lam1 with false in
-utest eqmexpr (sm a1) (sm lam1) with false in
 
+-- Records
 let r1 = record_ [("a",lam1), ("b",a1), ("c",a2)] in
 let r2 = record_ [("b",a1), ("a",lam2), ("c",a2)] in
 let r3e = record_ [("a",lam1), ("b",a1), ("d",a2)] in
 let r4e = record_ [("a",lam1), ("b",a1), ("c",lam2)] in
 let r5e = record_ [("a",lam1), ("b",a1), ("c",a2), ("d",lam2)] in
 utest r1 with r2 using eqmexpr in
-utest sm r1 with sm r2 using eqmexpr in
 utest eqmexpr r1 r3e with false in
-utest eqmexpr (sm r1) (sm r3e) with false in
 utest eqmexpr r1 r4e with false in
-utest eqmexpr (sm r1) (sm r4e) with false in
 utest eqmexpr r1 r5e with false in
-utest eqmexpr (sm r1) (sm r5e) with false in
 
 let ru1 = recordupdate_ r1 "b" lam1 in
 let ru2 = recordupdate_ r2 "b" lam2 in
 let ru3e = recordupdate_ r3e "b" lam2 in
 let ru4e = recordupdate_ r2 "c" lam2 in
 utest ru1 with ru2 using eqmexpr in
-utest sm ru1 with sm ru2 using eqmexpr in
 utest eqmexpr ru1 ru3e with false in
-utest eqmexpr (sm ru1) (sm ru3e) with false in
 utest eqmexpr ru1 ru4e with false in
-utest eqmexpr (sm ru1) (sm ru4e) with false in
 
+-- Let and recursive let
 let let1 = bind_ (let_ "x" lam1) a1 in
 let let2 = bind_ (let_ "y" lam2) a2 in
 let let3e = bind_ (let_ "x" (int_ 1)) a1 in
 let let4e = bind_ (let_ "x" lam2) lam1 in
 utest let1 with let2 using eqmexpr in
-utest sm let1 with sm let2 using eqmexpr in
 utest eqmexpr let1 let3e with false in
-utest eqmexpr (sm let1) (sm let3e) with false in
 utest eqmexpr let1 let4e with false in
-utest eqmexpr (sm let1) (sm let4e) with false in
 
 let rlet1 = reclets_ [("x", a1), ("y", lam1)] in
 let rlet2 = reclets_ [("x", a2), ("y", lam2)] in
 let rlet3 = reclets_ [("y", a2), ("x", lam2)] in
 let rlet4e = reclets_ [("y", lam1), ("x", a1)] in -- Order matters
 utest rlet1 with rlet2 using eqmexpr in
-utest sm rlet1 with sm rlet2 using eqmexpr in
 utest rlet1 with rlet3 using eqmexpr in
-utest sm rlet1 with sm rlet3 using eqmexpr in
 utest eqmexpr rlet1 rlet4e with false in
-utest eqmexpr (sm rlet1) (sm rlet4e) with false in
 
+-- Constants
 let c1 = (int_ 1) in
 let c2 = (int_ 2) in
 let c3 = (true_) in
@@ -586,5 +562,81 @@ let cd3e =
     (app_ (conapp_ "App2" (int_ 1)) (conapp_ "Other2" (int_ 2))) in
 utest cda1 with cda2 using eqmexpr in
 utest eqmexpr cda1 cd3e with false in
+
+-- Match and patterns
+let m1 = match_ c1 (pint_ 1) cda1 rlet1 in
+let m2 = match_ c1 (pint_ 1) cda2 rlet2 in
+let m3e = match_ rlet1 (pint_ 1) cda2 rlet2 in
+let m4e = match_ c1 (pint_ 1) c1 rlet2 in
+let m5e = match_ c1 (pint_ 1) cda2 cda1 in
+utest m1 with m2 using eqmexpr in
+utest eqmexpr m1 m3e with false in
+utest eqmexpr m1 m4e with false in
+utest eqmexpr m1 m5e with false in
+
+let pgen = lam p. match_ (int_ 1) p (int_ 2) (int_ 3) in
+let pvar1 = pvar_ "x" in
+let pvar2 = pvar_ "y" in
+utest pgen pvar1 with pgen pvar2 using eqmexpr in
+utest eqmexpr (pgen pvar1) (pgen (pint_ 1)) with false in
+
+let prec1 = prec_ [("a",pvar1), ("b",pvar2), ("c",pvar1)] in
+let prec2 = prec_ [("a",pvar2), ("b",pvar1), ("c",pvar2)] in
+let prec3e = prec_ [("a",pvar2), ("b",pvar2), ("c",pvar1)] in
+let prec4e = prec_ [("a",pvar2), ("b",pvar2), ("c",pvar1)] in
+utest pgen prec1 with pgen prec2 using eqmexpr in
+utest eqmexpr (pgen prec1) (pgen prec3e) with false in
+
+let pdata1 = pcon_ "Const1" (pcon_ "Const2" prec1) in
+let pdata2 = pcon_ "Const2" (pcon_ "Const1" prec1) in
+let pdata3e = pcon_ "Const1" (pcon_ "Const1" prec1) in
+utest pgen pdata1 with pgen pdata2 using eqmexpr in
+utest eqmexpr (pgen pdata1) (pgen pdata3e) with false in
+
+let pint1 = pint_ 1 in
+let pint2 = pint_ 1 in
+let pint3e = pint_ 2 in
+utest pgen pint1 with pgen pint2 using eqmexpr in
+utest eqmexpr (pgen pint1) (pgen pint3e) with false in
+
+let pchar1 = pchar_ 'a' in
+let pchar2 = pchar_ 'a' in
+let pchar3e = pchar_ 'b' in
+utest pgen pchar1 with pgen pchar2 using eqmexpr in
+utest eqmexpr (pgen pchar1) (pgen pchar3e) with false in
+
+let pbool1 = ptrue_ in
+let pbool2 = ptrue_ in
+let pbool3e = pfalse_ in
+utest pgen pbool1 with pgen pbool2 using eqmexpr in
+utest eqmexpr (pgen pbool1) (pgen pbool3e) with false in
+
+-- Utest
+let ut1 = utest_ lam1 lam2 v3 in
+let ut2 = utest_ lam2 lam1 v4 in
+let ut3e = utest_ v5e lam2 v3 in
+let ut4e = utest_ lam1 v5e v3 in
+let ut5e = utest_ lam1 lam2 v5e in
+utest ut1 with ut2 using eqmexpr in
+utest eqmexpr ut1 ut3e with false in
+utest eqmexpr ut1 ut4e with false in
+utest eqmexpr ut1 ut5e with false in
+
+-- Sequences
+let s1 = seq_ [lam1, lam2, v3] in
+let s2 = seq_ [lam2, lam1, v4] in
+let s3e = seq_ [lam1, v5e, v3] in
+utest s1 with s2 using eqmexpr in
+utest eqmexpr s1 s3e with false in
+
+-- Never
+utest never_ with never_ using eqmexpr in
+utest eqmexpr never_ true_ with false in
+
+-- Symbolized (and partially symbolized) terms are also supported.
+let sm = symbolizeMExpr in
+utest sm lamNested21 with sm lamNested22 using eqmexpr in
+utest lamNested21 with sm lamNested22 using eqmexpr in
+utest eqmexpr (sm lamNested23) (sm lamNested24) with false in
 
 ()

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -103,7 +103,7 @@ end
 
 lang FunEq = Eq + FunAst + VarEq + AppEq
   sem eqExprH (env : Env) (free : Env) (lhs : Expr) =
-  -- NOTE dlunde 2020-09-26: The type annotation is currently ignored.
+  -- NOTE(dlunde,2020-09-26): The type annotation is currently ignored.
   | TmLam {ident = i2, body = b2} ->
     match env with {varEnv = varEnv} then
       match lhs with TmLam {ident = i1, body = b1} then
@@ -153,7 +153,7 @@ end
 lang RecLetsEq = Eq + RecLetsAst
   sem eqExprH (env : Env) (free : Env) (lhs : Expr) =
   | TmRecLets {bindings = bs2} ->
-    -- NOTE dlunde 2020-09-25: This requires the bindings to occur in the same
+    -- NOTE(dlunde,2020-09-25): This requires the bindings to occur in the same
     -- order. Do we want to allow equality of differently ordered (but equal)
     -- bindings as well?
     match env with {varEnv = varEnv} then
@@ -323,7 +323,7 @@ lang CmpSymbEq = CmpSymbAst
   | CEqsym {} -> match lhs with CEqsym _ then true else false
 end
 
--- TODO Remove constants no longer available in boot?
+-- TODO(dlunde,2020-09-29): Remove constants no longer available in boot?
 lang SeqOpEq = SeqOpAst
   sem eqConst (lhs : Const) =
   | CGet {} -> match lhs with CGet _ then true else false
@@ -364,12 +364,12 @@ end
 
 lang SeqTotPatEq
   sem eqPat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
-  -- TODO
+  -- TODO(dlunde,2020-09-29)
 end
 
 lang SeqEdgPatEq
   sem eqPat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
-  -- TODO
+  -- TODO(dlunde,2020-09-29)
 end
 
 lang RecordPatEq = RecordPat
@@ -427,17 +427,17 @@ end
 
 lang AndPatEq
   sem eqPat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
-  -- TODO
+  -- TODO(dlunde,2020-09-29)
 end
 
 lang OrPatEq
   sem eqPat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
-  -- TODO
+  -- TODO(dlunde,2020-09-29)
 end
 
 lang NotPatEq
   sem eqPat (env : Env) (free : Env) (patEnv : NameEnv) (lhs : Pat) =
-  -- TODO
+  -- TODO(dlunde,2020-09-29)
 end
 
 -----------------------------

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -1,0 +1,272 @@
+-- Alpha equivalence for closed MExpr terms. Supports both non-symbolized and
+-- symbolized terms.
+
+include "name.mc"
+include "bool.mc"
+
+include "mexpr/ast.mc"
+
+-----------------
+-- ENVIRONMENT --
+-----------------
+
+type Env = {
+  varEnv : AssocMap Name Name,
+  conEnv : AssocMap Name Name
+}
+
+-----------
+-- TERMS --
+-----------
+
+lang VarEq = VarAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmVar {ident = i2} ->
+    match env with {varEnv = varEnv} then
+      match lhs with TmVar {ident = i1} then
+        match assocLookup {eq = nameEq} i1 varEnv with Some n2 then
+          nameEq i2 n2
+        else error (concat "Unbound variable in eq: " (nameGetStr i2))
+      else false
+    else never
+end
+
+lang AppEq = AppAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmApp {lhs = rl, rhs = rr} ->
+    match lhs with TmApp {lhs = ll, rhs = lr} then
+      if eqexpr env ll rl then eqexpr env lr rr else false
+    else false
+end
+
+lang FunEq = FunAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  -- The type annotation is currently ignored. TODO Add?
+  | TmLam {ident = i2, body = b2} ->
+    match env with {varEnv = varEnv, conEnv = conEnv} then
+      match lhs with TmLam {ident = i1, body = b1} then
+        let varEnv = assocInsert {eq = nameEq} i1 i2 varEnv in
+        eqexpr {varEnv = varEnv, conEnv = conEnv} b1 b2
+      else false
+    else never
+end
+
+lang RecordEq = RecordAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmRecord {bindings = bs2} ->
+    match lhs with TmRecord {bindings = bs1} then
+      if eqi (assocLength bs1) (assocLength bs2) then
+        assocAll
+          (lam k1. lam v1.
+            assocAny (lam k2. lam v2. and (eqstr k1 k2) (eqexpr env v1 v2))
+              bs2)
+          bs1
+      else false
+    else false
+
+  | TmRecordUpdate {rec = r2, key = k2, value = v2} ->
+    match lhs with TmRecordUpdate {rec = r1, key = k1, value = v1} then
+      and (and (eqexpr env r1 r2) (eqstr k1 k2)) (eqexpr env v1 v2)
+    else false
+end
+
+lang LetEq = LetAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmLet {ident = i2, body = b2, inexpr = ie2} ->
+    match env with {varEnv = varEnv, conEnv = conEnv} then
+      match lhs with TmLet {ident = i1, body = b1, inexpr = ie1} then
+        if eqexpr env b1 b2 then
+          let varEnv = assocInsert {eq = nameEq} i1 i2 varEnv in
+          eqexpr {varEnv = varEnv, conEnv = conEnv} ie1 ie2
+        else false
+      else false
+    else never
+end
+
+lang RecLetsEq = RecLetsAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmRecLets {bindings = bs2} ->
+    -- This requires the bindings to occur in the same order. TODO Do we want
+    -- to allow equality of differently ordered (but equal) bindings as well?
+    match env with {varEnv = varEnv, conEnv = conEnv} then
+      match lhs with TmRecLets {bindings = bs1} then
+        if eqi (length bs1) (length bs2) then
+          let bszip = zipWith (lam b1. lam b2. (b1, b2)) bs1 bs2 in
+          let varEnv =
+            foldl
+              (lam varEnv. lam t.
+                 assocInsert {eq = nameEq} (t.0).ident (t.1).ident varEnv)
+              varEnv bszip
+          in
+          let env = {varEnv = varEnv, conEnv = conEnv} in
+          all (lam t. eqexpr env (t.0).body (t.1).body) bszip
+        else false
+      else false
+    else never
+end
+
+lang ConstEq = ConstAst
+  sem eqconst (lhs : Const) =
+  -- Intentionally left blank
+
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmConst {val = v2} ->
+    match lhs with TmConst {val = v1} then
+      eqconst v1 v2
+    else false
+end
+
+lang DataEq = DataAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  -- Type annotation ignored here as well
+  | TmConDef {ident = i2, inexpr = ie2} ->
+    match env with {varEnv = varEnv, conEnv = conEnv} then
+      match lhs with TmConDef {ident = i1, inexpr = ie1} then
+        let conEnv = assocInsert {eq = nameEq} i1 i2 conEnv in
+        eqexpr {varEnv = varEnv, conEnv = conEnv} ie1 ie2
+      else false
+    else never
+
+  | TmConApp {ident = i2, body = b2} ->
+    match env with {varEnv = varEnv, conEnv = conEnv} then
+      match lhs with TmConApp {ident = i1, body = b1} then
+        match assocLookup {eq = nameEq} i1 conEnv with Some n2 then
+          if nameEq i2 n2 then
+            eqexpr env b1 b2
+          else false
+        else error (concat "Unbound constructor in eq: " (nameGetStr i2))
+      else false
+    else never
+
+end
+
+lang MatchEq = MatchAst
+  sem eqpat (env : Env) (lhs : Pat) =
+  -- Intentionally left blank
+
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmMatch {target = t2, pat = p2, thn = thn2, els = els2} ->
+    match lhs with TmMatch {target = t1, pat = p1, thn = thn1, els = els1} then
+      if eqexpr env t1 t2 then
+        if eqexpr env els1 els2 then
+          match eqpat env p1 p2 with Some env then
+            eqexpr env thn1 thn2
+          else false
+        else false
+      else false
+    else false
+
+end
+
+lang UtestEq = UtestAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmUtest {test = t2, expected = e2, next = n2} ->
+    match lhs with TmUtest {test = t1, expected = e1, next = n1} then
+      if eqexpr env t1 t2 then
+        if eqexpr env e1 e2 then
+          eqexpr env n1 n2
+        else false
+      else false
+    else false
+end
+
+lang SeqEq = SeqAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmSeq {tms = ts2} ->
+    match lhs with TmSeq {tms = ts1} then
+      if eqi (length ts1) (length ts2) then
+        let z = zipWith (lam t1. lam t2. (t1,t2)) ts1 ts2 in
+        all (lam tp. eqexpr env tp.0 tp.1) z
+      else false
+    else false
+end
+
+lang NeverEq = NeverAst
+  sem eqexpr (env : Env) (lhs : Expr) =
+  | TmNever _ -> match lhs with TmNever _ then true else false
+end
+
+---------------
+-- CONSTANTS --
+---------------
+
+lang IntEq = IntAst
+  sem eqconst (lhs : Const) =
+  | CInt {val = v2} -> match lhs with CInt {val = v1} then eqi v1 v2 else false
+end
+
+lang ArithEq = ArithIntAst
+  sem eqconst (lhs : Const) =
+  | CAddi {} -> match lhs with CAddi _ then true else false
+  | CSubi {} -> match lhs with CSubi _ then true else false
+  | CMuli {} -> match lhs with CMuli _ then true else false
+end
+
+lang FloatEq = FloatAst
+  sem eqconst (lhs : Const) =
+  | CFloat {val = v2} ->
+    match lhs with CFloat {val = v1} then eqf v1 v2 else false
+end
+
+lang ArithFloatEq = ArithFloatAst
+  sem eqconst (lhs : Const) =
+  | CAddf {} -> match lhs with CAddf _ then true else false
+  | CSubf {} -> match lhs with CSubf _ then true else false
+  | CMulf {} -> match lhs with CMulf _ then true else false
+  | CDivf {} -> match lhs with CDivf _ then true else false
+  | CNegf {} -> match lhs with CNegf _ then true else false
+end
+
+lang BoolEq = BoolAst
+  sem eqconst (lhs : Const) =
+  | CBool {val = v2} ->
+    match lhs with CBool {val = v1} then eqb v1 v2 else false
+  | CNot {} -> match lhs with CNot _ then true else false
+end
+
+lang CmpIntEq = CmpIntAst
+  sem eqconst (lhs : Const) =
+  | CEqi {} -> match lhs with CEqi _ then true else false
+  | CLti {} -> match lhs with CLti _ then true else false
+end
+
+lang CmpFloatEq = CmpFloatAst
+  sem eqconst (lhs : Const) =
+  | CEqf {} -> match lhs with CEqf _ then true else false
+  | CLtf {} -> match lhs with CLtf _ then true else false
+end
+
+lang CharEq = CharAst
+  sem eqconst (lhs : Const) =
+  | CChar {val = v2} ->
+    match lhs with CChar {val = v1} then eqchar v1 v2 else false
+end
+
+lang SymbEq = SymbAst
+  sem eqconst (lhs : Const) =
+  | CSymb {val = v2} ->
+    match lhs with CSymb {val = v1} then eqs v1 v2 else false
+end
+
+lang CmpSymbEq = CmpSymbAst
+  sem eqconst (lhs : Const) =
+  | CEqs {} -> match lhs with CEqs _ then true else false
+end
+
+-- TODO Remove constants no longer available in boot?
+lang SeqOpEq = SeqOpAst
+  sem eqconst (lhs : Const) =
+  | CGet {} -> match lhs with CGet _ then true else false
+  | CCons {} -> match lhs with CCons _ then true else false
+  | CSnoc {} -> match lhs with CSnoc _ then true else false
+  | CConcat {} -> match lhs with CConcat _ then true else false
+  | CLength {} -> match lhs with CLength _ then true else false
+  | CHead {} -> match lhs with CHead _ then true else false
+  | CTail {} -> match lhs with CTail _ then true else false
+  | CNull {} -> match lhs with CNull _ then true else false
+  | CReverse {} -> match lhs with CReverse _ then true else false
+end
+
+--------------
+-- PATTERNS --
+--------------

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -1,6 +1,6 @@
 -- Alpha equivalence for MExpr terms. Supports both non-symbolized and
--- symbolized terms. Also supports terms with unbound variables and
--- constructors.
+-- symbolized terms (including partially symbolized terms). Also supports terms
+-- with unbound (free) variables and constructors.
 
 include "name.mc"
 include "bool.mc"

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1,4 +1,4 @@
--- TODO: Add types
+-- TODO(?,?): Add types
 
 include "string.mc"
 include "char.mc"
@@ -201,7 +201,7 @@ lang SeqEval = SeqAst
 end
 
 lang NeverEval = NeverAst
-  --TODO
+  --TODO(?,?)
 end
 
 ---------------
@@ -411,7 +411,7 @@ lang CmpSymbEval = CmpSymbAst + ConstEval
     else error "Second argument in eqsym is not a symbol"
 end
 
--- TODO Remove constants no longer available in boot?
+-- TODO(dlunde,2020-09-29): Remove constants no longer available in boot?
 lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
   syn Const =
   | CGet2 [Expr]

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -181,7 +181,7 @@ lang MatchEval = MatchAst
   | _ -> None ()
 end
 
-lang UtestEval = UtestAst
+lang UtestEval = Eq + UtestAst
   sem eq (e1 : Expr) =
   | _ -> error "Equality not defined for expression"
 
@@ -189,7 +189,7 @@ lang UtestEval = UtestAst
   | TmUtest t ->
     let v1 = eval ctx t.test in
     let v2 = eval ctx t.expected in
-    let _ = if eqmexpr v1 v2 then print "Test passed\n" else print "Test failed\n" in
+    let _ = if eqexpr v1 v2 then print "Test passed\n" else print "Test failed\n" in
     eval ctx t.next
 end
 
@@ -595,8 +595,8 @@ end
 
 lang MExprEval =
 
-  -- Symbolize is required before eval
-  MExprSym
+  -- Symbolize is required before eval, and MExprEq is used below when testing.
+  MExprSym + MExprEq
 
   -- Terms
   + VarEval + AppEval + FunEval + FixEval + RecordEval + RecLetsEval +
@@ -623,7 +623,7 @@ use MExprEval in
 
 -- Evaluation shorthand used in tests below
 let eval =
-  lam t. eval {env = assocEmpty} (symbolize assocEmpty t) in
+  lam t. eval {env = assocEmpty} (symbolize t) in
 
 let id = ulam_ "x" (var_ "x") in
 let bump = ulam_ "x" (addi_ (var_ "x") (int_ 1)) in
@@ -713,8 +713,8 @@ let srl = bind_
 
 utest eval srl with true_ in
 
-utest eval evalAdd1 with conapp_ "Num" (int_ 3) using eqmexpr in
-utest eval evalAdd2 with conapp_ "Num" (int_ 6) using eqmexpr in
+utest eval evalAdd1 with conapp_ "Num" (int_ 3) using eqexpr in
+utest eval evalAdd2 with conapp_ "Num" (int_ 6) using eqexpr in
 
 -- Commented out to declutter test suite output
 -- let evalUTestIntInUnit = utest_ (int_ 3) (int_ 3) unit_ in
@@ -758,7 +758,7 @@ let addEvalNested = ulam_ "arg"
 
 utest eval (wrapInDecls (app_ addEvalNested (tuple_ [num (int_ 1), num (int_ 2)])))
 with conapp_ "Num" (int_ 3)
-using eqmexpr in
+using eqexpr in
 
 let recordProj =
   bind_ (let_ "myrec" (record_ [("a", int_ 10),("b", int_ 37),("c", int_ 23)]))

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -110,12 +110,12 @@ lang FixEval = FixAst + FunEval
 lang RecordEval = RecordAst
   sem eval (ctx : {env : Env}) =
   | TmRecord t ->
-    let bs = assocMap {eq=eqstr} (eval ctx) t.bindings in
+    let bs = assocMap {eq=eqString} (eval ctx) t.bindings in
     TmRecord {t with bindings = bs}
   | TmRecordUpdate u ->
     match eval ctx u.rec with TmRecord t then
-      if assocMem {eq = eqstr} u.key t.bindings then
-        TmRecord { bindings = assocInsert {eq = eqstr}
+      if assocMem {eq = eqString} u.key t.bindings then
+        TmRecord { bindings = assocInsert {eq = eqString}
                                 u.key (eval ctx u.value) t.bindings }
       else error "Key does not exist in record"
     else error "Not updating a record"
@@ -189,7 +189,7 @@ lang UtestEval = Eq + UtestAst
   | TmUtest t ->
     let v1 = eval ctx t.test in
     let v2 = eval ctx t.expected in
-    let _ = if eqexpr v1 v2 then print "Test passed\n" else print "Test failed\n" in
+    let _ = if eqExpr v1 v2 then print "Test passed\n" else print "Test failed\n" in
     eval ctx t.next
 end
 
@@ -398,17 +398,17 @@ end
 
 lang CmpSymbEval = CmpSymbAst + ConstEval
   syn Const =
-  | CEqs2 Symb
+  | CEqsym2 Symb
 
   sem delta (arg : Expr) =
-  | CEqs _ ->
+  | CEqsym _ ->
     match arg with TmConst {val = CSymb s} then
-      TmConst {val = CEqs2 s.val}
-    else error "First argument in eqs is not a symbol"
-  | CEqs2 s1 ->
+      TmConst {val = CEqsym2 s.val}
+    else error "First argument in eqsym is not a symbol"
+  | CEqsym2 s1 ->
     match arg with TmConst {val = CSymb s2} then
-      TmConst {val = CBool {val = eqs s1 s2.val}}
-    else error "Second argument in eqs is not a symbol"
+      TmConst {val = CBool {val = eqsym s1 s2.val}}
+    else error "Second argument in eqsym is not a symbol"
 end
 
 -- TODO Remove constants no longer available in boot?
@@ -516,9 +516,9 @@ lang RecordPatEval = RecordAst + RecordPat
   sem tryMatch (env : Env) (t : Expr) =
   | PRecord r ->
     match t with TmRecord {bindings = bs} then
-      assocFoldlM {eq = eqstr}
+      assocFoldlM {eq = eqString}
         (lam env. lam k. lam p.
-          match assocLookup {eq = eqstr} k bs with Some v then
+          match assocLookup {eq = eqString} k bs with Some v then
             tryMatch env v p
           else None ())
         env
@@ -713,8 +713,8 @@ let srl = bind_
 
 utest eval srl with true_ in
 
-utest eval evalAdd1 with conapp_ "Num" (int_ 3) using eqexpr in
-utest eval evalAdd2 with conapp_ "Num" (int_ 6) using eqexpr in
+utest eval evalAdd1 with conapp_ "Num" (int_ 3) using eqExpr in
+utest eval evalAdd2 with conapp_ "Num" (int_ 6) using eqExpr in
 
 -- Commented out to declutter test suite output
 -- let evalUTestIntInUnit = utest_ (int_ 3) (int_ 3) unit_ in
@@ -758,7 +758,7 @@ let addEvalNested = ulam_ "arg"
 
 utest eval (wrapInDecls (app_ addEvalNested (tuple_ [num (int_ 1), num (int_ 2)])))
 with conapp_ "Num" (int_ 3)
-using eqexpr in
+using eqExpr in
 
 let recordProj =
   bind_ (let_ "myrec" (record_ [("a", int_ 10),("b", int_ 37),("c", int_ 23)]))

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -756,10 +756,9 @@ let addEvalNested = ulam_ "arg"
     (unit_)) in
 
 
--- TODO This is currently not working because "Num" has different symbols in
--- LHS and RHS.
---   eval (wrapInDecls (app_ addEvalNested (tuple_ [num (int_ 1), num (int_ 2)])))
--- with conapp_ "Num" (int_ 3) in
+utest eval (wrapInDecls (app_ addEvalNested (tuple_ [num (int_ 1), num (int_ 2)])))
+with conapp_ "Num" (int_ 3)
+using eqmexpr in
 
 let recordProj =
   bind_ (let_ "myrec" (record_ [("a", int_ 10),("b", int_ 37),("c", int_ 23)]))

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -553,7 +553,7 @@ lang CharPatEval = CharAst + CharPat
   | PChar ch ->
     match t with TmConst c then
       match c.val with CChar ch2 then
-        if eqchar ch.val ch2.val then Some env else None ()
+        if eqChar ch.val ch2.val then Some env else None ()
       else None ()
     else None ()
 end

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -146,7 +146,7 @@
 --         let strip_prefix_helper = lam tailstr.
 --         if null tailstr
 --         then s -- String has no prefix
---         else if eqchar '_' (head tailstr)
+--         else if eqChar '_' (head tailstr)
 --              then tail tailstr
 --              else strip_prefix_helper (tail tailstr)
 --     in

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -1,4 +1,4 @@
--- TODO Needs updating, commented out for now
+-- TODO(dlunde,2020-09-29) Needs updating, commented out for now
 --
 -- -- Defines semantics for lambda lifting
 -- -- Based on the technique from the 1985 paper.
@@ -27,7 +27,7 @@
 -- --   replaced by a TmApp (..., ...) where the generated arguments are
 -- --   pre-applied on the generated identifier for the Let expression.
 --
--- -- NOTE: Assumes that bound variables are limited to the following AST nodes:
+-- -- NOTE(?,?): Assumes that bound variables are limited to the following AST nodes:
 -- --        - TmVar
 -- --        - TmApp
 -- --
@@ -580,7 +580,7 @@
 --     --| CEqi -> (state, CEqi)
 -- end
 --
--- -- TODO: Write CmpFloatLamlift
+-- -- TODO(?,?): Write CmpFloatLamlift
 --
 -- lang SeqLamlift = SeqAst + ConstLamlift
 --     sem lamlift (state : LiftState) =

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -138,7 +138,7 @@
 -- -- Returns whether the string is available in the current lambda scope
 -- let st_inLambdaScope: String -> LiftState -> Bool =
 --     lam s. lam st.
---     any (lam e. eqstr s e.ident) st.lambdarefs
+--     any (lam e. eqString s e.ident) st.lambdarefs
 --
 -- -- Strips away prefix of string if it exists
 -- let strip_prefix = lam s.
@@ -164,17 +164,17 @@
 --           lam s. lam st.
 --           let tdsm = lam td. -- tdsm: TopDefStringMatch
 --               match td with TmLet t then
---                   eqstr t.ident s
+--                   eqString t.ident s
 --               else match td with TmRecLets t then
---                   any (lam rec. eqstr rec.ident s) t.bindings
+--                   any (lam rec. eqString rec.ident s) t.bindings
 --               else match td with TmConDef t then
---                   eqstr t.ident s
+--                   eqString t.ident s
 --               else
 --                   error "Global define is not TmLet, TmRecLets, or TmConDef"
 --           in
 --           any tdsm st.globaldefs
 --       in
---       let ret = find (lam e. eqstr (e.key) x.ident) state.env.evar in
+--       let ret = find (lam e. eqString (e.key) x.ident) state.env.evar in
 --       match ret with Some t then
 --         -- Function that for all variables in an expression, that they are in
 --         -- the current scope.
@@ -239,7 +239,7 @@
 --           TmVar x
 --         else
 --           let e = head l in -- e: (name, replacement)
---           if eqstr x.ident e.ident then
+--           if eqString x.ident e.ident then
 --             e.replacement
 --           else
 --             find_replacement (tail l)
@@ -259,7 +259,7 @@
 --
 --       lamlift updatedstate t.inexpr
 --     | TmConFun t ->
---       let ret = find (lam e. eqstr (e.key) t.ident) state.env.econ in
+--       let ret = find (lam e. eqString (e.key) t.ident) state.env.econ in
 --       match ret with Some t1 then
 --         (state, t1.value)
 --       else
@@ -416,7 +416,7 @@
 --     | TmRecLets t ->
 --       -- Check that all bound identifiers are unique
 --       let bound_names = map (lam e. e.ident) t.bindings in
---       if any (lam s. neqi 1 (length (filter (eqstr s) bound_names))) bound_names
+--       if any (lam s. neqi 1 (length (filter (eqString s) bound_names))) bound_names
 --       then error "Name duplication in recursive expression"
 --       else -- continue
 --
@@ -685,7 +685,7 @@
 --       let foldret = foldl liftpats (state, []) t.pats in
 --       (foldret.0, PTuple {t with pats = foldret.1})
 --     | PCon t ->
---       let newident = find (lam e. eqstr (e.key) t.ident) state.env.econ in
+--       let newident = find (lam e. eqString (e.key) t.ident) state.env.econ in
 --       let subret = lamliftPat state t.subpat in
 --       match newident with Some t1 then
 --         match t1.value with TmConFun t2 then

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -280,7 +280,7 @@ lang RecLetsPrettyPrint = RecLetsAst
       else never in
     let lbody = lam env. lam bind.
       match pprintCode (incr (incr indent)) env bind.body with (env,str) then
-        (env,varString str)
+        (env,str)
       else never in
     match mapAccumL lname env t.bindings with (env,idents) then
       match mapAccumL lbody env t.bindings with (env,bodies) then

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -26,6 +26,7 @@ type Env = {
   nameMap: AssocMap Name String,
 
   -- Used to keep track of strings assigned to names without symbols
+  -- TODO It is probably cleaner to merge this with nameMap (see eq.mc)
   strMap: AssocMap String String,
 
   -- Count the number of occurrences of each (base) string to assist with

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -140,7 +140,16 @@ let _record2tuple = lam tm.
 -- TERMS --
 -----------
 
-lang VarPrettyPrint = VarAst
+lang PrettyPrint
+  sem pprintCode (indent : Int) (env: Env) =
+  -- Intentionally left blank
+
+  sem expr2str =
+  | expr -> match pprintCode 0 _emptyEnv expr with (_,str) then str else never
+
+end
+
+lang VarPrettyPrint = PrettyPrint + VarAst
   sem isAtomic =
   | TmVar _ -> true
 
@@ -149,7 +158,7 @@ lang VarPrettyPrint = VarAst
     match _getStr ident env with (env,str) then (env,varString str) else never
 end
 
-lang AppPrettyPrint = AppAst
+lang AppPrettyPrint = PrettyPrint + AppAst
   sem isAtomic =
   | TmApp _ -> false
 
@@ -178,7 +187,7 @@ lang AppPrettyPrint = AppAst
     else error "Impossible"
 end
 
-lang FunPrettyPrint = FunAst
+lang FunPrettyPrint = PrettyPrint + FunAst
   sem isAtomic =
   | TmLam _ -> false
 
@@ -200,7 +209,7 @@ lang FunPrettyPrint = FunAst
     else never
 end
 
-lang RecordPrettyPrint = RecordAst
+lang RecordPrettyPrint = PrettyPrint + RecordAst
   sem isAtomic =
   | TmRecord _ -> true
   | TmRecordUpdate _ -> true
@@ -243,7 +252,7 @@ lang RecordPrettyPrint = RecordAst
     else never
 end
 
-lang LetPrettyPrint = LetAst
+lang LetPrettyPrint = PrettyPrint + LetAst
   sem isAtomic =
   | TmLet _ -> false
 
@@ -265,7 +274,7 @@ lang LetPrettyPrint = LetAst
     else never
 end
 
-lang RecLetsPrettyPrint = RecLetsAst
+lang RecLetsPrettyPrint = PrettyPrint + RecLetsAst
   sem isAtomic =
   | TmRecLets _ -> false
 
@@ -296,7 +305,7 @@ lang RecLetsPrettyPrint = RecLetsAst
     else never
 end
 
-lang ConstPrettyPrint = ConstAst
+lang ConstPrettyPrint = PrettyPrint + ConstAst
   sem isAtomic =
   | TmConst _ -> true
 
@@ -307,7 +316,7 @@ lang ConstPrettyPrint = ConstAst
   | TmConst t -> (env,getConstStringCode indent t.val)
 end
 
-lang DataPrettyPrint = DataAst
+lang DataPrettyPrint = PrettyPrint + DataAst
   sem isAtomic =
   | TmConDef _ -> false
   | TmConApp _ -> false
@@ -340,7 +349,7 @@ lang DataPrettyPrint = DataAst
     else never
 end
 
-lang MatchPrettyPrint = MatchAst
+lang MatchPrettyPrint = PrettyPrint + MatchAst
   sem isAtomic =
   | TmMatch _ -> false
 
@@ -365,7 +374,7 @@ lang MatchPrettyPrint = MatchAst
     else never
 end
 
-lang UtestPrettyPrint = UtestAst
+lang UtestPrettyPrint = PrettyPrint + UtestAst
   sem isAtomic =
   | TmUtest _ -> false
 
@@ -382,7 +391,7 @@ lang UtestPrettyPrint = UtestAst
     else never
 end
 
-lang SeqPrettyPrint = SeqAst + ConstPrettyPrint + CharAst
+lang SeqPrettyPrint = PrettyPrint + SeqAst + ConstPrettyPrint + CharAst
   sem isAtomic =
   | TmSeq _ -> true
 
@@ -409,7 +418,7 @@ lang SeqPrettyPrint = SeqAst + ConstPrettyPrint + CharAst
     else never
 end
 
-lang NeverPrettyPrint = NeverAst
+lang NeverPrettyPrint = PrettyPrint + NeverAst
   sem isAtomic =
   | TmNever _ -> true
 
@@ -703,12 +712,7 @@ lang MExprPrettyPrint =
   -- Types
   + TypePrettyPrint
 
----------------------------
--- CONVENIENCE FUNCTIONS --
----------------------------
-
-let expr2str = use MExprPrettyPrint in
-  lam expr. match pprintCode 0 _emptyEnv expr with (_,str) then str else never
+end
 
 -----------
 -- TESTS --

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -26,7 +26,8 @@ type Env = {
   nameMap: AssocMap Name String,
 
   -- Used to keep track of strings assigned to names without symbols
-  -- TODO It is probably cleaner to merge this with nameMap (see eq.mc)
+  -- TODO(dlunde,2020-09-29): It is probably cleaner to merge this with nameMap
+  -- (see eq.mc)
   strMap: AssocMap String String,
 
   -- Count the number of occurrences of each (base) string to assist with
@@ -35,7 +36,7 @@ type Env = {
 
 }
 
--- TODO Make it possible to debug the actual symbols
+-- TODO(dlunde,2020-09-29) Make it possible to debug the actual symbols
 
 let _emptyEnv = {nameMap = assocEmpty, strMap = assocEmpty, count = assocEmpty}
 
@@ -657,7 +658,7 @@ end
 -----------
 -- TYPES --
 -----------
--- TODO Update (also not up to date in boot?)
+-- TODO(dlunde,2020-09-29) Update (also not up to date in boot?)
 
 lang TypePrettyPrint = FunTypeAst + DynTypeAst + UnitTypeAst + CharTypeAst + SeqTypeAst +
                        TupleTypeAst + RecordTypeAst + DataTypeAst + ArithTypeAst +

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -58,9 +58,9 @@ let labelString = lam str.
   parserStr str "#label" (lam str. is_lower_alpha (head str))
 
 let _ppLookupName = assocLookup {eq = nameEqSym}
-let _ppLookupStr = assocLookup {eq = eqstr}
+let _ppLookupStr = assocLookup {eq = eqString}
 let _ppInsertName = assocInsert {eq = nameEqSym}
-let _ppInsertStr = assocInsert {eq = eqstr}
+let _ppInsertStr = assocInsert {eq = eqString}
 
 -- Look up the string associated with a name in the environment
 let _lookup : Name -> Env -> Option String = lam name. lam env.
@@ -75,7 +75,7 @@ let _lookup : Name -> Env -> Option String = lam name. lam env.
 -- Check if a string is free in the environment.
 let _free : String -> Env -> Bool = lam str. lam env.
   match env with { nameMap = nameMap, strMap = strMap } then
-    let f = lam _. lam v. eqstr str v in
+    let f = lam _. lam v. eqString str v in
     not (or (assocAny f nameMap) (assocAny f strMap))
   else never
 
@@ -119,7 +119,7 @@ let _getStr : Name -> Env -> (Env, String) = lam name. lam env.
 let _record2tuple = lam tm.
   use RecordAst in
   match tm with TmRecord t then
-    let keys = assocKeys {eq=eqstr} t.bindings in
+    let keys = assocKeys {eq=eqString} t.bindings in
     match all stringIsInt keys with false then None () else
     let intKeys = map string2int keys in
     let sortedKeys = sort subi intKeys in
@@ -128,7 +128,7 @@ let _record2tuple = lam tm.
               (eqi (subi (length intKeys) 1) (last sortedKeys)) with true then
       -- Note: Quadratic complexity. Sorting the association list directly
       -- w.r.t. key would improve complexity to n*log(n).
-      Some (map (lam key. assocLookupOrElse {eq=eqstr}
+      Some (map (lam key. assocLookupOrElse {eq=eqString}
                             (lam _. error "Key not found")
                             (int2string key) t.bindings)
                  sortedKeys)
@@ -228,14 +228,14 @@ lang RecordPrettyPrint = PrettyPrint + RecordAst
     else
       let innerIndent = incr (incr indent) in
       match
-        assocMapAccum {eq=eqstr}
+        assocMapAccum {eq=eqString}
           (lam env. lam k. lam v.
              match pprintCode innerIndent env v with (env, str) then
                (env, join [labelString k, " =", newline innerIndent, str])
              else never)
            env t.bindings
       with (env, bindMap) then
-        let binds = assocValues {eq=eqstr} bindMap in
+        let binds = assocValues {eq=eqString} bindMap in
         let merged = strJoin (concat "," (newline (incr indent))) binds in
         (env,join ["{ ", merged, " }"])
       else never
@@ -488,7 +488,7 @@ end
 
 lang CmpSymbPrettyPrint = CmpSymbAst + ConstPrettyPrint
    sem getConstStringCode (indent : Int) =
-   | CEqs _ -> "eqs"
+   | CEqsym _ -> "eqsym"
 end
 
 lang SeqOpPrettyPrint = SeqOpAst + ConstPrettyPrint + CharAst
@@ -564,14 +564,14 @@ lang RecordPatPrettyPrint = RecordPat
   sem getPatStringCode (indent : Int) (env: Env) =
   | PRecord {bindings = bindings} ->
     match
-      assocMapAccum {eq=eqstr}
+      assocMapAccum {eq=eqString}
         (lam env. lam k. lam v.
            match getPatStringCode indent env v with (env,str) then
              (env,join [labelString k, " = ", str])
            else never)
          env bindings
     with (env,bindMap) then
-      (env,join ["{", strJoin ", " (assocValues {eq=eqstr} bindMap), "}"])
+      (env,join ["{", strJoin ", " (assocValues {eq=eqString} bindMap), "}"])
     else never
 end
 

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -1,6 +1,6 @@
 -- Symbolization of the MExpr ast.
 --
--- TODO dlunde 2020-09-25: Add support for leaving existing symbols intact when
+-- TODO(dlunde,2020-09-25): Add support for leaving existing symbols intact when
 -- running symbolize on an already partially symbolized term?
 
 include "name.mc"
@@ -14,11 +14,11 @@ include "mexpr/pprint.mc"
 ---------------------------
 -- SYMBOLIZE ENVIRONMENT --
 ---------------------------
--- NOTE dlunde 2020-09-25: The environment differs from boot, since we do not
+-- NOTE(dlunde,2020-09-25): The environment differs from boot, since we do not
 -- have access to the unique string identifiers from ustring.ml. Instead, we
 -- use strings directly.
 
--- TODO dlunde 2020-09-25: We should probably use separate environments for the
+-- TODO(dlunde,2020-09-25): We should probably use separate environments for the
 -- below instead (as in eq.mc)
 type Ident
 con IdVar   : String -> Ident

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -11,10 +11,10 @@ include "mexpr/pprint.mc"
 ---------------------------
 -- SYMBOLIZE ENVIRONMENT --
 ---------------------------
--- TODO The environment differs from boot, since we do not have access to the
+-- NOTE The environment differs from boot, since we do not have access to the
 -- unique string identifiers from ustring.ml. Instead, we use strings directly.
 
--- TODO We should probably use separate environments for the below instead (as
+-- NOTE We should probably use separate environments for the below instead (as
 -- in eq.mc)
 type Ident
 con IdVar   : String -> Ident

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -31,7 +31,7 @@ let identEq : Ident -> Ident -> Bool =
     | (IdCon   s1, IdCon   s2)
     | (IdType  s1, IdType  s2)
     | (IdLabel s1, IdLabel s2)
-    then eqstr s1 s2
+    then eqString s1 s2
     else false
 
 type Env = AssocMap Ident Name

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -14,6 +14,8 @@ include "mexpr/pprint.mc"
 -- TODO The environment differs from boot, since we do not have access to the
 -- unique string identifiers from ustring.ml. Instead, we use strings directly.
 
+-- TODO We should probably use separate environments for the below instead (as
+-- in eq.mc)
 type Ident
 con IdVar   : String -> Ident
 con IdCon   : String -> Ident

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -75,6 +75,22 @@ utest nameEqSym _t1 _t2 with false
 utest nameEqSym _t2 _t3 with false
 utest nameEqSym _t3 _t3 with true
 
+-- 'nameEq n1 n2' returns true if the symbols are equal, or if neither name has
+-- a symbol and their strings are equal. Otherwise, return false.
+-- TODO Short circuit for performance?
+let nameEq : Name -> Name -> Bool =
+  lam n1. lam n2.
+    or (nameEqSym n1 n2)
+      (and (and (not (nameHasSym n1)) (not (nameHasSym n2))) (nameEqStr n1 n2))
+
+let _t1 = nameNoSym "foo"
+let _t2 = nameSym "foo"
+let _t3 = nameSym "foo"
+utest nameEq _t1 _t1 with true
+utest nameEq _t2 _t2 with true
+utest nameEq _t1 _t2 with false
+utest nameEq _t2 _t3 with false
+utest nameEq _t3 _t3 with true
 
 -- 'nameSetNewSym n' returns a new name with a fresh symbol.
 -- The returned name contains the same string as 'n'.

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -37,7 +37,7 @@ utest _t with _t
 -- 'nameEqStr n1 n2' returns true if both names 'n1' and 'n2'
 -- contain the same string, else false.
 let nameEqStr : Name -> Name -> Bool =
-  lam n1. lam n2. eqstr n1.0 n2.0
+  lam n1. lam n2. eqString n1.0 n2.0
 
 let _t1 = nameNoSym "foo"
 let _t2 = nameSym "foo"
@@ -51,7 +51,7 @@ utest nameEqStr _t1 _t3 with false
 -- 'nameHasSym n' returns true if name 'n' has a
 -- symbol, else it returns false.
 let nameHasSym : Name -> Bool =
-  lam n. not (eqs n.1 _noSymbol)
+  lam n. not (eqsym n.1 _noSymbol)
 
 utest nameHasSym (nameSym "foo") with true
 utest nameHasSym (nameNoSym "foo") with false
@@ -63,7 +63,7 @@ utest nameHasSym (nameNoSym "foo") with false
 let nameEqSym : Name -> Name -> Bool =
   lam n1. lam n2.
     if and (nameHasSym n1) (nameHasSym n2) then
-      eqs n1.1 n2.1
+      eqsym n1.1 n2.1
     else false
 
 let _t1 = nameNoSym "foo"
@@ -141,7 +141,7 @@ utest nameGetStr (nameSym "foo") with "foo"
 -- If 'n' has no symbol, 'None' is returned.
 -- TODO: Update signature when we have polymorphic types.
 let nameGetSym : Name -> OptionSymbol =
-  lam n. if eqs n.1 _noSymbol then None () else Some n.1
+  lam n. if eqsym n.1 _noSymbol then None () else Some n.1
 
 let _s = gensym ()
 utest nameGetSym (nameNoSym "foo") with None ()

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -77,7 +77,7 @@ utest nameEqSym _t3 _t3 with true
 
 -- 'nameEq n1 n2' returns true if the symbols are equal, or if neither name has
 -- a symbol and their strings are equal. Otherwise, return false.
--- TODO Short circuit for performance?
+-- TODO dlunde 2020-09-25: Short circuit for performance?
 let nameEq : Name -> Name -> Bool =
   lam n1. lam n2.
     or (nameEqSym n1 n2)

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -77,7 +77,7 @@ utest nameEqSym _t3 _t3 with true
 
 -- 'nameEq n1 n2' returns true if the symbols are equal, or if neither name has
 -- a symbol and their strings are equal. Otherwise, return false.
--- TODO dlunde 2020-09-25: Short circuit for performance?
+-- TODO(dlunde,2020-09-25): Short circuit for performance?
 let nameEq : Name -> Name -> Bool =
   lam n1. lam n2.
     or (nameEqSym n1 n2)
@@ -139,7 +139,7 @@ utest nameGetStr (nameSym "foo") with "foo"
 
 -- 'nameGetSym n' returns optionally the symbol of name 'n'.
 -- If 'n' has no symbol, 'None' is returned.
--- TODO: Update signature when we have polymorphic types.
+-- TODO(dlunde,2020-09-29): Update signature when we have polymorphic types.
 let nameGetSym : Name -> OptionSymbol =
   lam n. if eqsym n.1 _noSymbol then None () else Some n.1
 

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -104,7 +104,7 @@ let nfaNextStates = lam from. lam graph. lam lbl.
 -- takes a path and returns whether it's accepted or not.
 let pathIsAccepted = lam path.
   if null path then false
-  else (setEqual eqchar (last path).status "accepted")
+  else (setEqual eqChar (last path).status "accepted")
 
 -- goes through the nfa, one state of the input at a time. Returns a list of {state, status, input}
 -- where status is either accepted,stuck,not accepted or neutral ("")
@@ -158,9 +158,9 @@ let transitions = [(0,1,'1'),(1,1,'1'),(1,2,'0'),(2,2,'0'),(2,1,'1')] in
 let transitions2 = [(0,1,'1'),(1,3,'1'),(1,2,'1')] in
 let startState = 0 in
 let acceptStates = [2] in
-let newNfa = nfaConstr states transitions startState acceptStates eqi eqchar in
-let newNfa2 = nfaConstr states2 transitions2 startState acceptStates eqi eqchar in
-let newNfa3 = nfaConstr states2 transitions2 startState [3] eqi eqchar in
+let newNfa = nfaConstr states transitions startState acceptStates eqi eqChar in
+let newNfa2 = nfaConstr states2 transitions2 startState acceptStates eqi eqChar in
+let newNfa3 = nfaConstr states2 transitions2 startState [3] eqi eqChar in
 utest eqi startState newNfa.startState with true in
 utest setEqual eqi acceptStates newNfa.acceptStates with true in
 utest (digraphHasVertices states newNfa.graph) with true in

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -115,7 +115,13 @@ utest optionFoldlM (lam a. lam b. if gti (addi a b) 3 then None () else Some (ad
       with Some 3
 utest optionFoldlM (lam a. lam b. if gti (addi a b) 3 then None () else Some (addi a b)) 0 [1, 2, 3]
       with None ()
-
+utest optionFoldlM (lam acc. lam x. Some (addi acc x)) 0 [1,2,3,4] with Some 10
+utest optionFoldlM (lam acc. lam x. if gti x acc then Some x else None ())
+        0 [1,2,3,4]
+with Some 4
+utest optionFoldlM (lam acc. lam x. if gti x acc then Some x else None ())
+        0 [1,2,2,4]
+with None ()
 
 -- Returns `true` if the option contains a value which
 -- satisfies the specified predicate.

--- a/stdlib/parser-combinators.mc
+++ b/stdlib/parser-combinators.mc
@@ -25,7 +25,7 @@ let showPos = lam pos.
 --
 -- Check if two positions are equal.
 let eqpos = lam pos1 : Pos. lam pos2 : Pos.
-  and (eqstr pos1.file pos2.file)
+  and (eqString pos1.file pos2.file)
   (and (eqi pos1.row pos2.row) (eqi pos1.col pos2.col))
 
 -- initPos : String -> Pos
@@ -192,7 +192,7 @@ let next = lam st.
   then fail "end of input" "" st
   else
     let c = head input in
-    let pos2 = if eqstr [c] "\n" then bumpRow pos else bumpCol pos in
+    let pos2 = if eqString [c] "\n" then bumpRow pos else bumpCol pos in
     pure c (tail input, pos2)
 
 -- Core tests
@@ -480,7 +480,7 @@ let lexStringLit =
              (apr (lexString "\\") (fmap head (lexString "\""))))
   in
   wrappedIn (lexString "\"") (lexString "\"")
-             (many (alt escaped (satisfy (lam c. not (eqstr [c] "\"")) "")))
+             (many (alt escaped (satisfy (lam c. not (eqString [c] "\"")) "")))
 
 utest testParser lexStringLit ['"','"']
 with Success ("", ("", {file = "", row = 1, col = 3}))
@@ -580,7 +580,7 @@ con If  : (Expr, Expr, Expr) -> Expr in
 -- Parse a line comment, ignoring its contents.
 let lineComment =
   void (apr (apr (lexString "--")
-                 (many (satisfy (lam c. not (eqstr "\n" [c])) "")))
+                 (many (satisfy (lam c. not (eqString "\n" [c])) "")))
             (alt (lexString "\n") endOfInput))
 in
 
@@ -639,7 +639,7 @@ let identifier =
   in
   try (
     bind validId (lam x.
-    if any (eqstr x) keywords
+    if any (eqString x) keywords
     then fail (concat (concat "keyword '" x) "'") "identifier"
     else pure x)
   )

--- a/stdlib/parser-combinators.mc
+++ b/stdlib/parser-combinators.mc
@@ -176,7 +176,7 @@ let endOfInput = lam st.
   let input = st.0 in
   if null input
   then pure () st
-  else fail (show_char (head input)) "end of input" st
+  else fail (showChar (head input)) "end of input" st
 
 utest testParser endOfInput "" with Success((), ("", initPos ""))
 
@@ -254,7 +254,7 @@ let notFollowedBy = lam p. lam st.
     let res2 = next st in
     match res2 with Success t then
       let c = t.0 in
-      fail (show_char c) "" st
+      fail (showChar c) "" st
     else res2
 
 -- satisfy : (Char -> Bool) -> String -> Parser Char
@@ -266,7 +266,7 @@ let satisfy = lam cnd. lam expected. lam st.
   bind next (lam c.
   if cnd c
   then pure c
-  else lam _ . fail (show_char c) expected st) st
+  else lam _ . fail (showChar c) expected st) st
 
 -- try : Parser a -> Parser a
 --
@@ -342,7 +342,7 @@ let sepBy = lam sep. lam p.
 -- lexChar : Char -> Parser Char
 --
 -- Parse a specific character.
-let lexChar = lam c. satisfy (eqchar c) (show_char c)
+let lexChar = lam c. satisfy (eqChar c) (showChar c)
 
 utest testParser (lexChar 'a') "ab"
 with Success ('a', ("b", {file = "", row = 1, col = 2}))
@@ -608,7 +608,7 @@ let symbol = string in
 --
 -- Check if a character is valid in an identifier.
 let isValidChar = lam c.
-  or (is_alphanum c) (eqchar c '_')
+  or (is_alphanum c) (eqChar c '_')
 in
 
 -- reserved : String -> Parser String
@@ -633,7 +633,7 @@ in
 -- of reserved keywords.
 let identifier =
   let validId =
-    bind (satisfy (lam c. or (is_alpha c) (eqchar '_' c)) "valid identifier") (lam c.
+    bind (satisfy (lam c. or (is_alpha c) (eqChar '_' c)) "valid identifier") (lam c.
     bind (token (many (satisfy isValidChar ""))) (lam cs.
     pure (cons c cs)))
   in

--- a/stdlib/parser-combinators.mc
+++ b/stdlib/parser-combinators.mc
@@ -1,5 +1,5 @@
 include "string.mc"
-include "prelude.mc" -- TODO: Should not be needed
+include "prelude.mc" -- TODO(?,?): Should not be needed
 
 -- Debug stuff
 let debugFlag = false
@@ -183,7 +183,7 @@ utest testParser endOfInput "" with Success((), ("", initPos ""))
 -- next : Parser char
 --
 -- Read next character from input stream
--- TODO: It would most likely be faster to index into
+-- TODO(?,?): It would most likely be faster to index into
 --       an array than to take the tail of a string
 let next = lam st.
   let input = st.0 in
@@ -464,7 +464,7 @@ with Success ("abcd", ("e", {file = "", row = 1, col = 5}))
 -- Parser Char
 --
 -- Parse a character literal.
--- TODO: Support escaped characters (also in OCaml parser)
+-- TODO(?,?): Support escaped characters (also in OCaml parser)
 let lexCharLit = wrappedIn (lexChar ''') (lexChar ''') next
 
 utest testParser lexCharLit "'\n'"
@@ -474,7 +474,7 @@ with Success (head "\n", ("", {file = "", row = 2, col = 2}))
 --
 -- Parse a string literal.
 let lexStringLit =
-  -- TODO: Are other escaped characters handled correctly?
+  -- TODO(?,?): Are other escaped characters handled correctly?
   let escaped =
     try (alt (apr (lexString "\\\\") (pure (head "\\")))
              (apr (lexString "\\") (fmap head (lexString "\""))))

--- a/stdlib/regex.mc
+++ b/stdlib/regex.mc
@@ -45,11 +45,11 @@ let regExPprint = lam sym2str. lam reg.
 
 -- Checks structural equivalence of two regexes.
 -- Does NOT check whether the regexes describe the same language.
-let eqr = lam eqs. lam re1. lam re2.
+let eqr = lam eqsym. lam re1. lam re2.
   recursive let eqrAux = lam re1. lam re2.
     match re1 with Epsilon () then (match re2 with Epsilon () then true else false) else
     match re1 with Empty () then (match re2 with Empty () then true else false) else
-    match re1 with Symbol a then (match re2 with Symbol b then eqs a b else false) else
+    match re1 with Symbol a then (match re2 with Symbol b then eqsym a b else false) else
     match re1 with Union (r1, r2) then
       (match re2 with Union (w1, w2) then and (eqrAux r1 w1) (eqrAux r2 w2) else false)
     else
@@ -270,7 +270,7 @@ let r3 = Concat (r1, r2) in
 let r4 = Union(Kleene(Concat(r1, r2)), Symbol(l3)) in
 let r5 = Kleene (Union(Empty (), Concat (r1, Kleene (Empty ())))) in
 
-let eqrStr = eqr eqstr in
+let eqrStr = eqr eqString in
 utest eqrStr r1 r1 with true in
 utest eqrStr r1 r2 with false in
 utest eqrStr r3 r3 with true in
@@ -290,7 +290,7 @@ let states = [1] in
 let transitions = [] in
 let startState = 1 in
 let acceptStates = [1] in
-let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqString in
 
 utest regexFromDFA dfa with Epsilon () in
 
@@ -307,7 +307,7 @@ let states = [1] in
 let transitions = [(1,1,l1), (1,1,l2)] in
 let startState = 1 in
 let acceptStates = [1] in
-let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqString in
 
 -- (l1 | l2)*
 utest regexFromDFA dfa with Kleene (Union (Symbol l1, Symbol l2)) in
@@ -329,7 +329,7 @@ let states = [1,2,3] in
 let transitions = [(1,2,l1),(3,1,l3),(1,3,l2),(1,3,l4),(1,3,l5)] in
 let startState = 1 in
 let acceptStates = [2] in
-let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqString in
 
 -- ((l2 | l4 | l5) l3)* l1
 utest regexFromDFA dfa with Concat (Kleene (Concat (Union (Union (Symbol l2, Symbol l4), Symbol l5),
@@ -354,7 +354,7 @@ let states = [1,2,3] in
 let transitions = [(1,2,l1),(3,1,l3),(1,3,l2),(1,3,l4),(1,3,l5)] in
 let startState = 1 in
 let acceptStates = [1] in
-let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqString in
 
 -- ((l2 | l4 | l5) l3)*
 utest regexFromDFA dfa with Kleene (Concat (Union (Union (Symbol l2, Symbol l4), Symbol l5),
@@ -380,7 +380,7 @@ let states = [1,2,3] in
 let transitions = [(1,2,l1),(3,1,l3),(1,3,l2),(1,3,l4),(1,3,l5)] in
 let startState = 1 in
 let acceptStates = [1,2] in
-let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqString in
 
 -- (((l2 | l4 | l5) l3)*) | ((l2 | l4 | l5) l3)* l1
 utest regexFromDFA dfa with Union (Kleene (Concat (Union (Union (Symbol l2, Symbol l4), Symbol l5), Symbol l3)),
@@ -406,7 +406,7 @@ let acceptStates = [4] in
 let startState = 1 in
 let states = [1,2,3,4] in
 let transitions = [(1,2,"a"),(2,3,"c"),(2,4,"e"),(3,2,"b"),(4,2,"d")] in
-let dfa = dfaConstr states transitions startState acceptStates eqi eqstr in
+let dfa = dfaConstr states transitions startState acceptStates eqi eqString in
 
 -- Short form: a(cb|ed)*e
 -- Actual return: a(cb)*e(d(cb)*e)*

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -88,7 +88,7 @@ utest zipWith (zipWith addi) [[1,2], [], [10, 10, 10]] [[3,4,5], [1,2], [2, 3]]
       with [[4,6], [], [12, 13]]
 utest zipWith addi [] [] with []
 
--- TODO Duplicate of optionFoldlM, remove.
+-- TODO Duplicate of optionFoldlM, remove when available.
 recursive
   let foldOption = lam f. lam acc. lam seq.
       if null seq then Some acc

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -88,15 +88,6 @@ utest zipWith (zipWith addi) [[1,2], [], [10, 10, 10]] [[3,4,5], [1,2], [2, 3]]
       with [[4,6], [], [12, 13]]
 utest zipWith addi [] [] with []
 
--- TODO Duplicate of optionFoldlM, remove when available.
-recursive
-  let foldOption = lam f. lam acc. lam seq.
-      if null seq then Some acc
-      else match f acc (head seq) with Some acc then
-        foldOption f acc (tail seq)
-      else None ()
-end
-
 utest foldOption (lam acc. lam x. Some (addi acc x)) 0 [1,2,3,4]
 with Some 10
 utest foldOption (lam acc. lam x. if gti x acc then Some x else None ())

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -88,6 +88,24 @@ utest zipWith (zipWith addi) [[1,2], [], [10, 10, 10]] [[3,4,5], [1,2], [2, 3]]
       with [[4,6], [], [12, 13]]
 utest zipWith addi [] [] with []
 
+-- TODO Duplicate of optionFoldlM, remove.
+recursive
+  let foldOption = lam f. lam acc. lam seq.
+      if null seq then Some acc
+      else match f acc (head seq) with Some acc then
+        foldOption f acc (tail seq)
+      else None ()
+end
+
+utest foldOption (lam acc. lam x. Some (addi acc x)) 0 [1,2,3,4]
+with Some 10
+utest foldOption (lam acc. lam x. if gti x acc then Some x else None ())
+        0 [1,2,3,4]
+with Some 4
+utest foldOption (lam acc. lam x. if gti x acc then Some x else None ())
+        0 [1,2,2,4]
+with None ()
+
 -- Accumulating maps
 let mapAccumL : (a -> b -> (a, c)) -> a -> [b] -> (a, [c]) =
   lam f. lam acc. lam seq.

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -88,15 +88,6 @@ utest zipWith (zipWith addi) [[1,2], [], [10, 10, 10]] [[3,4,5], [1,2], [2, 3]]
       with [[4,6], [], [12, 13]]
 utest zipWith addi [] [] with []
 
-utest foldOption (lam acc. lam x. Some (addi acc x)) 0 [1,2,3,4]
-with Some 10
-utest foldOption (lam acc. lam x. if gti x acc then Some x else None ())
-        0 [1,2,3,4]
-with Some 4
-utest foldOption (lam acc. lam x. if gti x acc then Some x else None ())
-        0 [1,2,2,4]
-with None ()
-
 -- Accumulating maps
 let mapAccumL : (a -> b -> (a, c)) -> a -> [b] -> (a, [c]) =
   lam f. lam acc. lam seq.

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -9,7 +9,7 @@ recursive
       then false
       else if null s1
            then true
-           else if eqchar (head s1) (head s2)
+           else if eqChar (head s1) (head s2)
            then eqString (tail s1) (tail s2)
            else false
 end
@@ -30,7 +30,7 @@ let string2int = lam s.
       addi rest lsd
   in
   match s with [] then 0 else
-  if eqchar '-' (head s)
+  if eqChar '-' (head s)
   then negi (string2int_rechelper (tail s))
   else string2int_rechelper s
 
@@ -129,7 +129,7 @@ let strIndex = lam c. lam s.
   let strIndex_rechelper = lam i. lam c. lam s.
     if eqi (length s) 0
     then None ()
-    else if eqchar c (head s)
+    else if eqChar c (head s)
          then Some(i)
          else strIndex_rechelper (addi i 1) c (tail s)
   in
@@ -152,7 +152,7 @@ let strLastIndex = lam c. lam s.
       then None ()
       else Some(acc)
     else
-      if eqchar c (head s)
+      if eqChar c (head s)
       then strLastIndex_rechelper (addi i 1) i   c (tail s)
       else strLastIndex_rechelper (addi i 1) acc c (tail s)
   in

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -4,13 +4,13 @@ include "seq.mc"
 include "math.mc"
 
 recursive
-  let eqstr = lam s1. lam s2.
+  let eqString = lam s1. lam s2.
       if neqi (length s1) (length s2)
       then false
       else if null s1
            then true
            else if eqchar (head s1) (head s2)
-           then eqstr (tail s1) (tail s2)
+           then eqString (tail s1) (tail s2)
            else false
 end
 
@@ -59,7 +59,7 @@ utest int2string (negi 314159) with "-314159"
 
 -- 'stringIsInt s' returns true iff 's' is a string representing an integer
 let stringIsInt: String -> Bool = lam s.
-  eqstr s (int2string (string2int s))
+  eqString s (int2string (string2int s))
 
 utest stringIsInt "" with false
 utest stringIsInt "1 " with false
@@ -170,7 +170,7 @@ recursive
   let strSplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
     then cons s []
-    else if eqstr delim (slice s 0 (length delim))
+    else if eqString delim (slice s 0 (length delim))
          then cons [] (strSplit delim (slice s (length delim) (length s)))
          else let remaining = strSplit delim (tail s) in
               cons (cons (head s) (head remaining)) (tail remaining)
@@ -186,7 +186,7 @@ utest strSplit "Hello" "Hello" with ["", ""]
 let strTrim = lam s.
   recursive
   let strTrim_init = lam s.
-    if eqstr s ""
+    if eqString s ""
     then s
     else if is_whitespace (head s)
          then strTrim_init (tail s)

--- a/test/mexpr/nestedpatterns.mc
+++ b/test/mexpr/nestedpatterns.mc
@@ -11,7 +11,7 @@ utest classify (true, false) with "two" in
 utest classify (false, true) with "three" in
 utest classify (false, false) with "four" in
 
--- TODO: in the future when we have static type checking,
+-- TODO(?,?): in the future when we have static type checking,
 -- the following expression should give a type error.
 -- utest classify (true, true, true) with "five" in
 

--- a/test/mexpr/stringops.mc
+++ b/test/mexpr/stringops.mc
@@ -21,13 +21,13 @@ let leqchar = lam c1. lam c2. leqi (char2int c1) (char2int c2) in
 let geqchar = lam c1. lam c2. geqi (char2int c1) (char2int c2) in
 
 recursive
-  let eqstr = lam s1. lam s2.
+  let eqString = lam s1. lam s2.
     if neqi (length s1) (length s2)
     then false
     else if eqi (length s1) 0
          then true
          else if eqchar (head s1) (head s2)
-         then eqstr (tail s1) (tail s2)
+         then eqString (tail s1) (tail s2)
          else false
 in
 
@@ -53,7 +53,7 @@ recursive
   let strsplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
     then cons s []
-    else if eqstr delim (slice s 0 (length delim))
+    else if eqString delim (slice s 0 (length delim))
          then cons [] (strsplit delim (slice s (length delim) (length s)))
          else let remaining = strsplit delim (tail s) in
               cons (cons (head s) (head remaining)) (tail remaining)
@@ -62,7 +62,7 @@ in
 -- Trims a string of spaces
 recursive
   let strtrim_init = lam s.
-    if eqstr s ""
+    if eqString s ""
     then s
     else if eqchar (head s) ' '
          then strtrim_init (tail s)
@@ -85,7 +85,7 @@ let strflatten = lam s. strjoin "" s in
 utest str2upper "Hello, world!" with "HELLO, WORLD!" in
 utest str2lower "Foo... BAR!" with "foo... bar!" in
 
-utest "Hello" with "Hello" using eqstr in
+utest "Hello" with "Hello" using eqString in
 utest (cons "Hello" []) with ["Hello"] in
 
 utest (strsplit "ll" "Hello") with ["He", "o"] in

--- a/test/mexpr/stringops.mc
+++ b/test/mexpr/stringops.mc
@@ -3,6 +3,8 @@
 --
 -- Test implementation of simple string operations
 
+include "char.mc"
+
 mexpr
 
 let head = lam seq. get seq 0 in
@@ -14,33 +16,27 @@ recursive
     else cons (f (head seq)) (map f (tail seq))
 in
 
-let eqchar = lam c1. lam c2. eqi (char2int c1) (char2int c2) in
-let ltchar = lam c1. lam c2. lti (char2int c1) (char2int c2) in
-let gtchar = lam c1. lam c2. gti (char2int c1) (char2int c2) in
-let leqchar = lam c1. lam c2. leqi (char2int c1) (char2int c2) in
-let geqchar = lam c1. lam c2. geqi (char2int c1) (char2int c2) in
-
 recursive
   let eqString = lam s1. lam s2.
     if neqi (length s1) (length s2)
     then false
     else if eqi (length s1) 0
          then true
-         else if eqchar (head s1) (head s2)
+         else if eqChar (head s1) (head s2)
          then eqString (tail s1) (tail s2)
          else false
 in
 
 -- Convert a character to upper case
 let char2upper = (lam c.
-	if and (geqchar c 'a') (leqchar c 'z')
+	if and (geqChar c 'a') (leqChar c 'z')
 	then (int2char (subi (char2int c) 32))
 	else c
 ) in
 
 -- Convert a character to lower case
 let char2lower = (lam c.
-	if and (geqchar c 'A') (leqchar c 'Z')
+	if and (geqChar c 'A') (leqChar c 'Z')
 	then (int2char (addi (char2int c) 32))
 	else c
 ) in
@@ -64,7 +60,7 @@ recursive
   let strtrim_init = lam s.
     if eqString s ""
     then s
-    else if eqchar (head s) ' '
+    else if eqChar (head s) ' '
          then strtrim_init (tail s)
          else s
 in

--- a/test/mexpr/symbs.mc
+++ b/test/mexpr/symbs.mc
@@ -10,17 +10,17 @@ mexpr
 let x = gensym () in
 let y = gensym () in
 
--- 'eqs s1 s2' returns true if symbol 's1' and symbol 's2'
+-- 'eqsym s1 s2' returns true if symbol 's1' and symbol 's2'
 -- are the same symbol.
 -- Symbol -> Symbol -> Bool
 let neg = lam f. lam x. lam y. not (f x y) in
-utest x with x using eqs in
-utest y with y using eqs in
-utest y with x using neg eqs in
-utest x with y using neg eqs in
+utest x with x using eqsym in
+utest y with y using eqsym in
+utest y with x using neg eqsym in
+utest x with y using neg eqsym in
 
 -- 'sym2hash s1' returns an integer representation of s1 that fulfills the
--- following criterion: eqs a b => eqi (sym2hash a) (sym2hash b)
+-- following criterion: eqsym a b => eqi (sym2hash a) (sym2hash b)
 -- No guarantees are given for the opposite direction, but a best effort is
 -- made to give 2 symbols different integer representation.
 -- Symbol -> Int

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -120,7 +120,7 @@ let _ =
 in
 
 let _ =
-  let e1 = use A in ACon{afield = 1, aextfield = 2} in -- TODO(vipa): this should break once we start typechecking product extensions of a constructor
+  let e1 = use A in ACon{afield = 1, aextfield = 2} in -- TODO(vipa,?): this should break once we start typechecking product extensions of a constructor
   let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
   utest e1 with e2 in
   ()

--- a/test/mlang/nestedpatterns.mc
+++ b/test/mlang/nestedpatterns.mc
@@ -103,7 +103,7 @@ end
 
 lang LexBinary = LexBase
   syn Tok =
-  | BinaryIntTok [Char]  -- NOTE: this should probably reuse IntTok and do conversion, but that's not relevant for this test
+  | BinaryIntTok [Char]  -- NOTE(?,?): this should probably reuse IntTok and do conversion, but that's not relevant for this test
 
   sem lex =
   | (['0', 'b', '0' | '1'] ++ _) & ([_, _] ++ str) ->

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -13,7 +13,7 @@ lang FormatInteger
 
   sem toFormat (fmtstr : String) =
   | FmtInt n ->
-    if eqstr fmtstr "%d" then
+    if eqString fmtstr "%d" then
       int2string n
     else
       error (concat "FormatInteger: toFormat: Unrecognized format: " fmtstr)
@@ -28,7 +28,7 @@ lang FormatFloat
 
   sem toFormat (fmtstr : String) =
   | FmtFloat f ->
-    if eqstr fmtstr "%f" then
+    if eqString fmtstr "%f" then
       float2string f
     else
       error (concat "FormatFloat: toFormat: Unrecognized format: " fmtstr)
@@ -43,11 +43,11 @@ lang FormatString
 
   sem toFormat (fmtstr : String) =
   | FmtStr s ->
-    if eqstr fmtstr "%s" then
+    if eqString fmtstr "%s" then
       s
-    else if eqstr fmtstr "%^s" then
+    else if eqString fmtstr "%^s" then
       str2upper s
-    else if eqstr fmtstr "%_s" then
+    else if eqString fmtstr "%_s" then
       str2lower s
     else
       error (concat "FormatString: toFormat: Unrecognized format: " fmtstr)
@@ -62,7 +62,7 @@ lang FormatChar
 
   sem toFormat (fmtstr : String) =
   | FmtChar c ->
-    if eqstr fmtstr "%c" then
+    if eqString fmtstr "%c" then
       [c]
     else
       error (concat "FormatChar: toFormat: Unrecognized format: " fmtstr)

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -82,11 +82,11 @@ lang StrFormatBase
   | s ->
     if lti (length s) 2 then
       s
-    else if eqchar '%' (head s) then
+    else if eqChar '%' (head s) then
       let c = head (tail s) in
-      if eqchar '%' c then
+      if eqChar '%' c then
         cons '%' (strFormat args (tail (tail s)))
-      else if eqchar c '*' then
+      else if eqChar c '*' then
         -- %* represents a wildcard format; The argument is converted
         -- to _some_ string.
         concat (toString (head args)) (strFormat (tail args) (tail (tail s)))


### PR DESCRIPTION
An implementation of alpha equivalence for MExpr. As an example, this enables the following:
```
utest var_ "x" with var_ "y" using eqmexpr
```
with the new `using` syntax from #172.

It is particularly useful if you are working on some type of MExpr transformation for which you want to do unit testing.