### PR TITLE
Fix merge order dependence

### DIFF
--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -286,16 +286,16 @@ and print_tm' fmt t = match t with
   (*  fprintf fmt "%s#%d" print s *)
     fprintf fmt "%s" print
 
-  | TmLam(_,x,_,ty,t1) ->
-    let x = string_of_ustring x in
+  | TmLam(_,x,s,ty,t1) ->
+    let x = string_of_ustring (ustring_of_var x s) in
     let ty = ty |> ustring_of_ty |> string_of_ustring in
     fprintf fmt "@[<hov %d>lam %s:%s.@ %a@]"
       !ref_indent x
       ty
       print_tm (Lam, t1)
 
-  | TmLet(_,x,_,t1,t2) ->
-    let x = string_of_ustring x in
+  | TmLet(_,x,s,t1,t2) ->
+    let x = string_of_ustring (ustring_of_var x s) in
     fprintf fmt "@[<hov 0>\
                    @[<hov %d>let %s =@ %a in@]\
                    @ %a\
@@ -305,8 +305,8 @@ and print_tm' fmt t = match t with
       print_tm (Match, t2)
 
   | TmRecLets(_,lst,t2) ->
-    let print (_,x,_,t) =
-      let x = string_of_ustring x in
+    let print (_,x,s,t) =
+      let x = string_of_ustring (ustring_of_var x s) in
       (fun fmt -> fprintf fmt "@[<hov %d>let %s =@ %a@]"
           !ref_indent x print_tm (Match,t)) in
     let inner = List.map print lst in

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -65,6 +65,26 @@ end
 
 lang Overlap = ArithBool + ArithBool2 + Arith
 
+lang FooA
+  syn Val =
+  | A {}
+
+  sem foo =
+  | A _ -> "A"
+end
+
+lang FooB
+  syn Val =
+  | B {}
+
+  sem foo =
+  | B _ -> "B"
+end
+
+lang FooTrans = FooA + FooB
+
+lang FooCombined = FooA + FooTrans
+
 mexpr
 
 let _ =
@@ -123,6 +143,13 @@ let _ =
   let e1 = use A in ACon{afield = 1, aextfield = 2} in -- TODO(vipa): this should break once we start typechecking product extensions of a constructor
   let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
   utest e1 with e2 in
+  ()
+in
+
+let _ =
+  use FooCombined in
+  utest foo (A {}) with "A" in
+  utest foo (B {}) with "B" in
   ()
 in
 


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://github.com/miking-lang/miking/pull/189/files#diff-91ca39c73d626275340a6b6bc508e956R578-R580) (in #189), and probably the issue mentioned [here](https://github.com/miking-lang/miking/pull/190/files#diff-1cbc9131f0aa851151ad313dead4e210R31-R32) (in #190), though I could not reproduce the latter.

The bug arose because of an optimization I did for the `merge_inter_` function in `merge_lang_data` in `mlang.ml`. I make the assumption that if the two `sem` functions we are merging have the same `info`, then they are the same and we can just return the first `sem`. The thought here is that the `info` refers to where the function is defined, and I rather carefully make sure that the returned `sem` has the `info` from the first `sem`, not the second. This means that the copy of the `sem` function that lives in a particular language fragment (i.e., the flattened one with all cases in all its includes) will have the `info` of the `sem` that is written inside that fragment. The issue is that there might be no such `sem`, e.g., in #189 the language fragments that expose the bug look like this:

```
lang PPrintLang = MExprPrettyPrint + LAppPrettyPrint + LHoleAstPrettyPrint

lang TestLang = MExpr + ContextAwareHoles + LAppEval + PPrintLang
```

In this case the `None, Some a -> Some a` case fires, in which case the info for the `sem` function is that of the first fragment that had the function defined, in this case `MExprPrettyPrint` (which is also without its own definition, so it looks like it's defined in `VarPrettyPrint`). Somehow (I'm a little bit too lazy to track things fully) one of the other languages included in `TestLang` looks like it has a `pprintCode` defined in the same place, whereby the `pprintCode` from `PPrintLang` is never included, because it looks like it's defined at the same place, thus `TestLang` does not have cases for the decision point constructors in `pprintCode`. 

(sidenote: @lingmar, the `expr2str` between these two fragments appears to be dead code, `TestLang` contains an `expr2str` which shadows this one when it is `open`ed)

-------------------------------------------

I also leave the functions I wrote to debug this, mostly debug printing stuff (not actually called, just defined), as well as a fix in `pprint.ml` to print symbols for `let`, `lam`, and `recursive let` if `--symbol` is given.