### PR TITLE
Implement support for keyword arguments for Python FFI calls

### DIFF
--- a/src/boot/lib/py/pyast.ml
+++ b/src/boot/lib/py/pyast.ml
@@ -2,4 +2,5 @@ type 'a ext =
 | PyObject of Py.Object.t
 | Pyimport
 | Pycall of Py.Object.t option * string option
+| PycallKw of Py.Object.t option * string option * Py.Object.t Array.t option
 | Pyconvert

--- a/src/boot/lib/py/pyffi.ml
+++ b/src/boot/lib/py/pyffi.ml
@@ -133,13 +133,7 @@ let delta _ _ fi c v =
       Record.iter (fun k v -> Array.set argv (int_of_ustring k) (val_to_python fi v)) args;
       mk_py fi (PycallKw(Some(m), Some(s), Some(argv)))
     | PycallKw(Some(m),Some(s),Some(a)),TmRecord(fi,args) ->
-      let size_of_record = Record.cardinal args in
-      let kwargv = Array.make (size_of_record / 2) ("0", Py.Float.of_float 0.) in
-      Record.iter (fun k v ->
-          let i = int_of_ustring k in
-          if i mod 2 = 0 then
-            let next = Record.find (ustring_of_int (i + 1)) args in
-            Array.set kwargv (i / 2) (val_to_string fi v, val_to_python fi next)
-          else ()) args;
-      mk_py fi (PyObject(Py.Module.get_function_with_keywords m s a (Array.to_list kwargv)))
+      let kwargs = List.map (fun (k, v) ->
+          (Ustring.to_utf8 k, val_to_python fi v)) (Record.bindings args) in
+      mk_py fi (PyObject(Py.Module.get_function_with_keywords m s a kwargs))
     | PycallKw(_, _, _), _ -> fail_constapp fi

--- a/src/boot/lib/py/pyffi.ml
+++ b/src/boot/lib/py/pyffi.ml
@@ -15,13 +15,16 @@ let mk_py fi p = TmConst(fi, CPy(p))
 
 let externals =
   let f p = mk_py NoInfo p in
-  [("pycall", f(Pycall(None,None))); ("pyimport", f(Pyimport)); ("pyconvert", f(Pyconvert))]
+  [("pycall", f(Pycall(None,None))); ("pycallkw", f(PycallKw(None,None,None)));
+   ("pyimport", f(Pyimport)); ("pyconvert", f(Pyconvert))]
 
 let arity = function
   | PyObject(_) -> 0
   | Pyimport -> 1
   | Pyconvert -> 1
   | Pycall(None, None) -> 3 | Pycall(Some(_),None) -> 2 | Pycall(_,Some(_)) -> 1
+  | PycallKw(None, None, None) -> 4 | PycallKw(Some(_),None,None) -> 3 |
+    PycallKw(_,Some(_),None) -> 2 | PycallKw(_,_,Some _) -> 1
 
 let rec val_to_python fi = function
   | TmConst(_,CBool(v)) -> Py.Bool.of_bool v
@@ -46,6 +49,14 @@ let rec val_to_python fi = function
           (Record.bindings r)
     end
   | _ -> raise_error fi "The supplied value cannot be used as a python argument"
+
+let val_to_string fi = function
+  | TmSeq(_,s) ->
+    begin
+      try tmseq2ustring fi s |> Ustring.to_utf8
+      with _ -> raise_error fi "The supplied sequence cannot be used as a string"
+    end
+  | _ -> raise_error fi "The supplied value is not a string"
 
 let rec python_to_val fi obj =
   match Py.Type.get obj with
@@ -91,11 +102,14 @@ let delta _ _ fi c v =
   let fail_constapp fi = fail_constapp c v fi in
   match c,v with
     | PyObject(_),_ -> fail_constapp fi
+
     | Pyimport, TmSeq(fi, lst) ->
         mk_py fi (PyObject(Py.import (tmseq2ustring fi lst |> Ustring.to_utf8)))
     | Pyimport,_ -> fail_constapp fi
+
     | Pyconvert, TmConst(fi,CPy(PyObject(obj))) -> python_to_val fi obj
     | Pyconvert,_ -> fail_constapp fi
+
     | Pycall(None, None),TmConst(_,CPy(PyObject(obj))) -> mk_py fi (Pycall(Some(obj), None))
     | Pycall(None, None),_ -> fail_constapp fi
     | Pycall(Some(m), None),TmSeq(fi,lst) ->
@@ -107,3 +121,25 @@ let delta _ _ fi c v =
         Record.iter (fun k v -> Array.set argv (int_of_ustring k) (val_to_python fi v)) args;
         mk_py fi (PyObject(Py.Module.get_function m s argv))
     | Pycall(_, _), _ -> fail_constapp fi
+
+    | PycallKw(None, None, None),TmConst(_,CPy(PyObject(obj))) -> mk_py fi (PycallKw(Some(obj), None, None))
+    | PycallKw(None, None, None),_ -> fail_constapp fi
+    | PycallKw(Some(m), None, None),TmSeq(fi,lst) ->
+      mk_py fi (PycallKw(Some(m), Some(tmseq2ustring fi lst |> Ustring.to_utf8), None))
+    | PycallKw(Some(_), None, None),_ -> fail_constapp fi
+    | PycallKw(Some(m),Some(s), None),TmRecord(fi,args) ->
+      let size_of_record = Record.cardinal args in
+      let argv = Array.make size_of_record (Py.Float.of_float 0.) in
+      Record.iter (fun k v -> Array.set argv (int_of_ustring k) (val_to_python fi v)) args;
+      mk_py fi (PycallKw(Some(m), Some(s), Some(argv)))
+    | PycallKw(Some(m),Some(s),Some(a)),TmRecord(fi,args) ->
+      let size_of_record = Record.cardinal args in
+      let kwargv = Array.make (size_of_record / 2) ("0", Py.Float.of_float 0.) in
+      Record.iter (fun k v ->
+          let i = int_of_ustring k in
+          if i mod 2 = 0 then
+            let next = Record.find (ustring_of_int (i + 1)) args in
+            Array.set kwargv (i / 2) (val_to_string fi v, val_to_python fi next)
+          else ()) args;
+      mk_py fi (PyObject(Py.Module.get_function_with_keywords m s a (Array.to_list kwargv)))
+    | PycallKw(_, _, _), _ -> fail_constapp fi

--- a/src/boot/lib/py/pypprint.ml
+++ b/src/boot/lib/py/pypprint.ml
@@ -9,4 +9,15 @@ let pprint = function
   | Pycall(None,None) -> us "pycall"
   | Pycall(Some(v),None) -> us (sprintf "pycall(%s)" (Py.Object.to_string v))
   | Pycall(Some(v),Some s) -> us (sprintf "pycall(%s, %s)" (Py.Object.to_string v) s)
+  | PycallKw(None,None,None) -> us "pycallkw"
+  | PycallKw(Some(v),None,None) ->
+    us (sprintf "pycallkw(%s)" (Py.Object.to_string v))
+  | PycallKw(Some(v),Some(s),None) ->
+    us (sprintf "pycallkw(%s, %s)" (Py.Object.to_string v) s)
+  | PycallKw(Some(v),Some(s),Some(argv)) ->
+    let argv_str =
+      "[" ^
+      (String.concat ", " (Array.to_list (Array.map Py.Object.to_string argv)))
+      ^ "]" in
+    us (sprintf "pycallkw(%s, %s, %s)" (Py.Object.to_string v) s argv_str)
   | _ -> failwith "Can't happen"

--- a/test/py/python.mc
+++ b/test/py/python.mc
@@ -40,7 +40,7 @@ let none = pycall builtins "print" ("",) in
 utest pyconvert (pycall builtins "str" (none,)) with "None" in
 utest pyconvert none with () in
 
-let e = pycallkw builtins "enumerate" ([1,2,3],) ("start", 1) in
+let e = pycallkw builtins "enumerate" ([1,2,3],) {start = 1} in
 utest pyconvert (pycall builtins "list" (e,)) with [(1,1), (2,2), (3,3)] in
 
 ()

--- a/test/py/python.mc
+++ b/test/py/python.mc
@@ -39,4 +39,8 @@ utest pyconvert (pycall builtins "str" ((),)) with "None" in
 let none = pycall builtins "print" ("",) in
 utest pyconvert (pycall builtins "str" (none,)) with "None" in
 utest pyconvert none with () in
+
+let e = pycallkw builtins "enumerate" ([1,2,3],) ("start", 1) in
+utest pyconvert (pycall builtins "list" (e,)) with [(1,1), (2,2), (3,3)] in
+
 ()


### PR DESCRIPTION
This PR adds support for keyword arguments in Python FFI calls by adding the python intrinsic `pycallkw`.

Example usage:
```
let plt = pyimport "matplotlib.pyplot"
let x = [1,2,3]
```
~let _ = pycallkw plt "plot" (x,) ("linewidth", 2, "color", "green")~
```
let _ = pycallkw plt "plot" (x,) {linewidth=2, color="green"}
let _ = pycall plt "show" ()
```