### PR TITLE
Small bug fix in ANF and refactoring of pprint

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -268,7 +268,7 @@ let debug = false in
 let debugPrint = lam t.
   if debug then
     let _ = printLn "--- BEFORE ANF ---" in
-    let t = symbolize assocEmpty t in
+    let t = symbolize t in
     let _ = printLn (expr2str t) in
     let _ = print "\n" in
     let _ = printLn "--- AFTER ANF ---" in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -22,13 +22,8 @@ let symbolDelim = "'"
 
 type Env = {
 
-  -- Used to keep track of strings assigned to names with symbols
+  -- Used to keep track of strings assigned to names
   nameMap: AssocMap Name String,
-
-  -- Used to keep track of strings assigned to names without symbols
-  -- TODO(dlunde,2020-09-29): It is probably cleaner to merge this with nameMap
-  -- (see eq.mc)
-  strMap: AssocMap String String,
 
   -- Count the number of occurrences of each (base) string to assist with
   -- assigning unique strings.
@@ -38,7 +33,57 @@ type Env = {
 
 -- TODO(dlunde,2020-09-29) Make it possible to debug the actual symbols
 
-let _emptyEnv = {nameMap = assocEmpty, strMap = assocEmpty, count = assocEmpty}
+let _emptyEnv = {nameMap = assocEmpty, count = assocEmpty}
+
+-- Look up the string associated with a name in the environment
+let _lookup : Name -> Env -> Option String = lam name. lam env.
+  match env with { nameMap = nameMap } then
+    assocLookup {eq = nameEq} name nameMap
+  else never
+
+-- Check if a string is free in the environment.
+let _free : String -> Env -> Bool = lam str. lam env.
+  match env with { nameMap = nameMap } then
+    let f = lam _. lam v. eqString str v in
+    not (assocAny f nameMap)
+  else never
+
+-- Add a binding to the environment
+let _add : Name -> String -> Int -> Env -> Env =
+  lam name. lam str. lam i. lam env.
+    match env with {nameMap = nameMap, count = count} then
+      let baseStr = nameGetStr name in
+      let count = assocInsert {eq = eqString} baseStr i count in
+      let nameMap = assocInsert {eq = nameEq} name str nameMap in
+      {nameMap = nameMap, count = count}
+    else never
+
+-- Get a string for the current name. Returns both the string and a new
+-- environment.
+let _getStr : Name -> Env -> (Env, String) = lam name. lam env.
+  match _lookup name env with Some str then (env,str)
+  else
+    let baseStr = nameGetStr name in
+    if _free baseStr env then (_add name baseStr 1 env, baseStr)
+    else
+      match env with {count = count} then
+        let start =
+          match assocLookup {eq = eqString} baseStr count
+          with Some i then i else 1 in
+        recursive let findFree : String -> Int -> (String, Int) =
+          lam baseStr. lam i.
+            let proposal = concat baseStr (int2string i) in
+            if _free proposal env then (proposal, i)
+            else findFree baseStr (addi i 1)
+        in
+        match findFree baseStr start with (str, i) then
+          (_add name str (addi i 1) env, str)
+        else never
+      else never
+
+----------------------
+-- HELPER FUNCTIONS --
+----------------------
 
 -- Ensure string can be parsed
 let parserStr = lam str. lam prefix. lam cond.
@@ -57,67 +102,6 @@ let varString = lam str.
 -- Label string parser translation for records
 let labelString = lam str.
   parserStr str "#label" (lam str. isLowerAlpha (head str))
-
-let _ppLookupName = assocLookup {eq = nameEqSym}
-let _ppLookupStr = assocLookup {eq = eqString}
-let _ppInsertName = assocInsert {eq = nameEqSym}
-let _ppInsertStr = assocInsert {eq = eqString}
-
--- Look up the string associated with a name in the environment
-let _lookup : Name -> Env -> Option String = lam name. lam env.
-  match env with { nameMap = nameMap, strMap = strMap } then
-    match _ppLookupName name nameMap with Some str then
-      Some str
-    else match _ppLookupStr (nameGetStr name) strMap with Some str then
-      Some str
-    else None ()
-  else never
-
--- Check if a string is free in the environment.
-let _free : String -> Env -> Bool = lam str. lam env.
-  match env with { nameMap = nameMap, strMap = strMap } then
-    let f = lam _. lam v. eqString str v in
-    not (or (assocAny f nameMap) (assocAny f strMap))
-  else never
-
--- Add a binding to the environment
-let _add : Name -> String -> Int -> Env -> Env =
-  lam name. lam str. lam i. lam env.
-    let baseStr = nameGetStr name in
-    match env with {nameMap = nameMap, strMap = strMap, count = count} then
-      let count = _ppInsertStr baseStr i count in
-      if nameHasSym name then
-        let nameMap = _ppInsertName name str nameMap in
-        {nameMap = nameMap, strMap = strMap, count = count}
-      else
-        let strMap = _ppInsertStr baseStr str strMap in
-        {nameMap = nameMap, strMap = strMap, count = count}
-    else never
-
--- Get a string for the current name. Returns both the string and a new
--- environment.
-let _getStr : Name -> Env -> (Env, String) = lam name. lam env.
-  match _lookup name env with Some str then (env,str)
-  else
-    let baseStr = nameGetStr name in
-    if _free baseStr env then (_add name baseStr 1 env, baseStr)
-    else
-      match env with {count = count} then
-        let start = match _ppLookupStr baseStr count with Some i then i else 1 in
-        recursive let findFree : String -> Int -> (String, Int) =
-          lam baseStr. lam i.
-            let proposal = concat baseStr (int2string i) in
-            if _free proposal env then (proposal, i)
-            else findFree baseStr (addi i 1)
-        in
-        match findFree baseStr start with (str, i) then
-          (_add name str (addi i 1) env, str)
-        else never
-      else never
-
-----------------------
--- HELPER FUNCTIONS --
-----------------------
 
 -- Get an optional list of tuple expressions for a record. If the record does
 -- not represent a tuple, None () is returned.

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -77,11 +77,15 @@ utest nameEqSym _t3 _t3 with true
 
 -- 'nameEq n1 n2' returns true if the symbols are equal, or if neither name has
 -- a symbol and their strings are equal. Otherwise, return false.
--- TODO(dlunde,2020-09-25): Short circuit for performance?
 let nameEq : Name -> Name -> Bool =
   lam n1. lam n2.
-    or (nameEqSym n1 n2)
-      (and (and (not (nameHasSym n1)) (not (nameHasSym n2))) (nameEqStr n1 n2))
+    if nameEqSym n1 n2 then true
+    else
+      if not (nameHasSym n1) then
+        if not (nameHasSym n2) then
+          nameEqStr n1 n2
+        else false
+      else false
 
 let _t1 = nameNoSym "foo"
 let _t2 = nameSym "foo"


### PR DESCRIPTION
- Fix outdated call to symbolize in `anf.mc`.
- Refactor `pprint.mc` slightly to make it easier to extend.
- Refactor environment in `pprint.mc` slightly.
- Short circuit `nameEq`.