### PR TITLE
Changed scope of functions in pprint.mc

### DIFF
--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -55,7 +55,7 @@ lang VarEval = VarAst
     match _evalLookup ident ctx.env with Some t then
       eval ctx t
     else
-      error (concat "Unknown variable: " (varString ident))
+      error (concat "Unknown variable: " (pprintVarString ident))
 end
 
 lang AppEval = AppAst

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -21,8 +21,6 @@ let pprintNewline = lam indent. concat "\n" (pprintSpacing indent)
 -- Increment [indent] by 2
 let pprintIncr = lam indent. addi indent 2
 
-let symbolDelim = "'"
-
 ---------------------------------
 -- PRETTY PRINTING ENVIRONMENT --
 ---------------------------------

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -302,9 +302,6 @@ lang MExprSym =
   + VarPatSym + SeqTotPatSym + SeqEdgePatSym + RecordPatSym + DataPatSym +
   IntPatSym + CharPatSym + BoolPatSym + AndPatSym + OrPatSym + NotPatSym
 
-  -- Debugging
-  + MExprPrettyPrint
-
 -----------
 -- TESTS --
 -----------
@@ -312,9 +309,11 @@ lang MExprSym =
 -- of symbols, so we are just evaluating the below for errors. Unit
 -- testing in eval.mc also implicitly covers symbolizeExpr.
 
+lang TestLang = MExprSym + MExprPrettyPrint
+
 mexpr
 
-use MExprSym in
+use TestLang in
 
 let base = (ulam_ "x" (ulam_ "y" (app_ (var_ "x") (var_ "y")))) in
 


### PR DESCRIPTION
This PR changes the scope (i.e. name) of some functions in `pprint.mc`. Some of these functions will be used in the ocaml pprint language fragment. One function (`varString`) was already used in `eval.mc`. Other functions are exposed since they are naturally exposed as a group (e.g. pprint environment manipulation functions and identifier parser functions). 

I also removed the `MExprPrettyPrint` language fragment from the `MExpSym` language fragment. This inhibited you from constructing a new language from `MExprPrettyPrint` fragments and at same time include `MExpSym`.