### PR TITLE
Fix error messages when running dune build.

### DIFF
--- a/make
+++ b/make
@@ -17,7 +17,7 @@ cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 
 # General function for building the project
 build() {
-    mkdir -p build 
+    mkdir -p build
     dune build 
     cp -f _build/install/default/bin/boot.mi build/mi
 }

--- a/make
+++ b/make
@@ -17,8 +17,8 @@ cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 
 # General function for building the project
 build() {
-    mkdir -p build
-    dune build -p boot
+    mkdir -p build 
+    dune build 
     cp -f _build/install/default/bin/boot.mi build/mi
 }
 

--- a/src/boot/lib/ext.ml
+++ b/src/boot/lib/ext.ml
@@ -2,7 +2,6 @@ open Extast
 open Extpprint
 open Ast
 open Msg
-open Ustring.Op
 
 let externals =
   List.map (fun x -> (fst x,  TmConst(NoInfo, CExt(snd x))))
@@ -34,7 +33,7 @@ let fail_extapp pprint f v fi = raise_error fi
      ^ Ustring.to_utf8
        (Pprint.ustring_of_tm v))
 
-let delta eval env fi c v =
+let delta _ _ fi c v =
   let fail_extapp = fail_extapp pprint c v in
   match c,v with
   (* Elementary functions *)

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -413,14 +413,14 @@ let delta eval env fi c v  =
        else TmConst(fi, CInt(rand_int_u v1 v2))
     | CrandIntU(_),_ -> fail_constapp fi
 
-    | CrandSetSeed,TmConst(fi,CInt(v)) -> rand_set_seed v; tmUnit
+    | CrandSetSeed,TmConst(_,CInt(v)) -> rand_set_seed v; tmUnit
     | CrandSetSeed,_ -> fail_constapp fi
 
     (* MCore intrinsic: time *)
     | CwallTimeMs, TmRecord(fi,x) when Record.is_empty x -> TmConst(fi, CFloat(get_wall_time_ms ()))
     | CwallTimeMs, _ -> fail_constapp fi
 
-    | CsleepMs, TmConst(fi, CInt(v)) -> sleep_ms v ; tmUnit
+    | CsleepMs, TmConst(_, CInt(v)) -> sleep_ms v ; tmUnit
     | CsleepMs, _ -> fail_constapp fi
 
     (* MCore debug and stdio intrinsics *)

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -65,12 +65,12 @@ type lang_data = {
     syns: (info * cdecl list) Record.t;
   }
 
-let spprint_inter_data ({info; cases}): ustring =
-  List.map (fun (fi, {pat}) -> us"  " ^. ustring_of_pat pat ^. us" at " ^. info2str fi) cases
+let spprint_inter_data ({info; cases; _}): ustring =
+  List.map (fun (fi, {pat; _}) -> us"  " ^. ustring_of_pat pat ^. us" at " ^. info2str fi) cases
   |> Ustring.concat (us"\n")
   |> (fun msg -> us"My location is " ^. info2str info ^. us"\n" ^. msg)
 
-let spprint_lang_data ({inters}): ustring =
+let spprint_lang_data ({inters; _}): ustring =
   Record.bindings inters
   |> List.map (fun (name, data) -> name ^. us"\n" ^. spprint_inter_data data)
   |> Ustring.concat (us"\n")

--- a/src/boot/lib/sd-skel/sd.ml
+++ b/src/boot/lib/sd-skel/sd.ml
@@ -1,7 +1,3 @@
-open Sdast
-open Ast
-open Msg
-
 let externals = []
-let arity _ = failwith "Don't call me!" 
+let arity _ = failwith "Don't call me!"
 let delta _ _ _ _ _ = failwith "Don't call me!"

--- a/src/boot/lib/sd-skel/sdpprint.ml
+++ b/src/boot/lib/sd-skel/sdpprint.ml
@@ -1,4 +1,1 @@
-open Sdast
-open Ustring.Op
-
 let pprint _ = failwith "Don't call me!"


### PR DESCRIPTION
This PR fixes some errors,  related to unused variables/modules and unmatched record labels, that occurs when running `dune build` manually in the project root. For some reason (maybe this is intentional) these errors are not reported when running `make`.