### PR TITLE
Setup automatic code formatting using ocamlformat.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+# Migrate to ocamlformat code style.

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+profile=ocamlformat
+margin=79

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ test-all:
 install:
 	@./make install
 
+lint:
+	@./make lint
+
+fix:
+	@./make fix
+
 clean:
 	@./make clean
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Miking
 
 Miking (Meta vIKING) is a meta language system for creating embedded domain-specific and general-purpose languages. Miking is not a programming language, but rather a language system for
@@ -943,20 +942,25 @@ ln -s /some_path/libpython*.dylib /usr/local/lib/
 The bindings should now work properly.
 
 ## Contributing
+
 1. Before making a pull request please make sure that all tests pass. Run
-   appropriate tests as described above.
+appropriate tests as described above.
 
 2. Make sure you follow the conventions declared in the
-   [wiki](https://github.com/miking-lang/miking/wiki/Conventions).
+[wiki](https://github.com/miking-lang/miking/wiki/Conventions).
 
 3. We use [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) to
-   automatically format ocaml source code. Install the package via `opam` using
-   `opam install ocamlformat`. Then you can then run `dune build @fmt` to see a
-   diff between your code and the formatted code. To promote the changes run
-   `dune promote`. To do these two steps in one run `dune build @fmt
-   --auto-promote`. If you want to, you can run `ocamlformat` in watch mode to
-   continuously format the source as you work on it with the command `dune build
-   @fmt --auto-promote -w`.
+automatically format ocaml source code. Install the package via `opam` using
+`opam install ocamlformat`. Then you can then run `dune build @fmt` to see a
+diff between your code and the formatted code. To promote the changes run `dune
+promote`. To do these two steps in one run `dune build @fmt --auto-promote`. If
+you want to, you can run `ocamlformat` in watch mode to continuously format the
+source as you work on it with the command `dune build @fmt --auto-promote -w`.
+You can also find instructions for tighter editor integration at *ocamlformat's*
+GitHub page.
+
+4. For convenience, `make lint` will run `dune build @fmt` and `make fix` will run
+`dune build @fmt --auto-promote`.
 
 ## MIT License
 Miking is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -959,8 +959,30 @@ source as you work on it with the command `dune build @fmt --auto-promote -w`.
 You can also find instructions for tighter editor integration at *ocamlformat's*
 GitHub page.
 
-4. For convenience, `make lint` will run `dune build @fmt` and `make fix` will run
-`dune build @fmt --auto-promote`.
+4. For convenience, `make lint` will run `dune build @fmt` and `make fix` will
+run `dune build @fmt --auto-promote`.
+
+### Git Blame
+
+Since automatic code formatting commits will obscure `git blame` we maintain a
+file  [.git-blame-ignore-revs](.git-blame-ignore-revs) that will contain the
+commit hashes of code formatting commits. We can then run `git blame`, ignoring
+these commits as:
+
+```
+git blame <file(s)> --ignore-revs-file .git-blame-ignore-revs
+```
+
+To make this setting persistent you can configure git like this:
+
+```
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+These instructions are adapted from
+[https://github.com/psf/black](https://github.com/psf/black). See
+[https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt)
+for documentation on the `--ignore-revs-file` option.
 
 ## MIT License
 Miking is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -942,6 +942,22 @@ ln -s /some_path/libpython*.dylib /usr/local/lib/
 
 The bindings should now work properly.
 
+## Contributing
+1. Before making a pull request please make sure that all tests pass. Run
+   appropriate tests as described above.
+
+2. Make sure you follow the conventions declared in the
+   [wiki](https://github.com/miking-lang/miking/wiki/Conventions).
+
+3. We use [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) to
+   automatically format ocaml source code. Install the package via `opam` using
+   `opam install ocamlformat`. Then you can then run `dune build @fmt` to see a
+   diff between your code and the formatted code. To promote the changes run
+   `dune promote`. To do these two steps in one run `dune build @fmt
+   --auto-promote`. If you want to, you can run `ocamlformat` in watch mode to
+   continuously format the source as you work on it with the command `dune build
+   @fmt --auto-promote -w`.
+
 ## MIT License
 Miking is licensed under the MIT license.
 

--- a/make
+++ b/make
@@ -73,7 +73,23 @@ runtests() {
     fi
 }
 
+# Lint ocaml source code
+lint () {
+    dune build @fmt
+}
+
+# lints and then fixes ocaml source code
+fix () {
+    dune build @fmt --auto-promote
+}
+
 case $1 in
+    lint)
+        lint
+        ;;
+    fix)
+        fix
+        ;;
     test)
         build
         runtests
@@ -82,6 +98,7 @@ case $1 in
         export MI_TEST_PYTHON=1
         export MI_TEST_SUNDIALS=1
         export MI_TEST_OCAML=1
+        lint
         build
         runtests
         ;;


### PR DESCRIPTION
This PR sets up automatic code formatting of OCaml source code using [ocamlformat](https://github.com/ocaml-ppx/ocamlformat). In addition, the [README.md](README.md) is updated with relevant changes to the contribution work-flow. A PR which actually migrates the code style will follow this PR.