### PR TITLE
Refine C AST

### DIFF
--- a/make
+++ b/make
@@ -57,6 +57,7 @@ runtests() {
     ../build/mi test mlang
     cd ../stdlib
     ../build/mi test mexpr
+    ../build/mi test c
     ../build/mi test ad
     ../build/mi test ext
     cd ..

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -1,86 +1,244 @@
--- AST for a subset of the C language.
+-- AST fragments for the C language.
 
 include "mexpr/ast.mc"
 
 include "name.mc"
 
+---------------
+-- TEMPLATES --
+---------------
+
+lang Expr
+  syn Expr =
+  -- Intentionally left blank
+end
+
+lang Type
+  syn Type =
+  -- Intentionally left blank
+end
+
+lang Decl
+  syn Decl =
+  -- Intentionally left blank
+end
+
+lang Stmt
+  syn Stmt =
+  -- Intentionally left blank
+end
+
+
+-------------------
+-- C EXPRESSIONS --
+-------------------
 -- Missing:
+-- * TODO Standard operators. We cannot reuse operators from mexpr (such as
+-- CAddi) since they are curried. Maybe this will change in the future?
+-- * Struct pointer access (e.g. structptr->item)
+
+lang AssgExpr
+  syn Expr =
+  | TmAssg { lhs: Expr, rhs: Expr }
+end
+
+lang AppExpr
+  syn Expr =
+  | TmApp { fun: Name, args: [Expr] }
+end
+
+lang SubScrExpr
+  syn Expr =
+  | TmSubScr { lhs: Expr, rhs: Expr }
+end
+
+lang MembExpr
+  syn Expr =
+  | TmMemb { lhs: Expr, rhs: String }
+end
+
+lang CastExpr = Type
+  syn Expr =
+  | TmCast { lhs: Type, rhs: Expr }
+end
+
+lang SizeOfExpr
+  syn Expr =
+  | TmSizeOf { arg: Expr }
+end
+
+lang SizeOfTypeExpr = Type
+  syn Expr =
+  | TmSizeOfType { arg: Type }
+end
+
+
+-------------
+-- C TYPES --
+-------------
+
+lang FunType
+  syn Type =
+  | TyFun { ret: Type, params: [Type] }
+end
+
+lang PtrType
+  syn Type =
+  | TyPtr { ty: Type }
+end
+
+lang ArrType
+  syn Type =
+  | TyArr { ty: Type, size: Int }
+end
+
+lang StructType
+  syn Type =
+  | TyStruct { id: Option Name, mem: [(Type, String)] }
+end
+
+lang UnionType
+  syn Type =
+  | TyUnion { id: Option Name, mem: [(Type, String)] }
+end
+
+lang EnumType
+  syn Type =
+  | TyEnum { id: Option Name, mem: [Name]}
+end
+
+
+--------------------
+-- C DECLARATIONS --
+--------------------
+-- Missing:
+-- * Multiple declarators within the same declaration.
+-- * Designated initializers (e.g. struct s pi = { .z = "Pi", .x = 3, .y =
+-- 3.1415 };)
 -- * Storage class specifiers (auto, register, static, extern)
 -- * Type qualifiers (const, volatile)
--- * typedef
--- * Standard operators. We cannot reuse operators from mexpr (such as CAddi) since
---   they are curried. Maybe this will change in the future?
 
-lang CExprAst = VarAst + ConstAst + IntAst + FloatAst + CharAst
-  syn Expr =
-  | TmAssg     { lhs: Expr, rhs: Expr }
-  | TmApp      { fun: Name, args: [Expr] }
-  | TmSubScr   { lhs: Expr, rhs: Expr }
-  | TmSubScr   { lhs: Expr, rhs: Expr }
-  | TmMemb     { lhs: Expr, rhs: String }
-  | TmCast     { lhs: Type, rhs: Expr }
-  | TmSize     { arg: Expr }
-  | TmSizeType { arg: Type }
-
-  -- NOTE(dlunde,2020-10-21): The below things are missing
-
-  -- Missing:
-  -- * Struct pointer access (e.g. structptr->item)
-end
-
-lang CTypeAst = CharTypeAst + IntTypeAst + FloatTypeAst + TypeVarAst
-  syn Type =
-  | TyFun { ret: Type, args: [Type] }
-  | TyPtr { to: Type }
-  | TyArr { ty: Type, size: Int }
-  | TyStruct { id: Option Name, mem: [(Type, String)] }
-  | TyUnion { id: Option Name, mem: [(Type, String)] }
-  | TEnum { id: Option Name, mem: [Name]}
-end
-
-lang CDeclAst
-  -- Missing:
-  -- * Mulitple declarators within the same declaration.
-  -- * Designated initializers (e.g. struct s pi = { .z = "Pi", .x = 3, .y =
-  -- 3.1415 };)
+lang DeclDecl = Type + Expr
   syn Decl =
-  | Decl { ty: Type, id: Option Name, init: Option Expr }
+  | DDecl { ty: Type, id: Option Name, init: Option Init }
 
+  -- NOTE(dlunde,2020-10-24): Declarations with initializers could form a
+  -- separate language fragment.
   syn Init =
   | IExpr { expr: Expr }
   | IList { inits: [Init] }
 
 end
 
-lang CStmtAst = CExprAst + CTypeAst
+lang TypeDefDecl = Type
+  syn Decl =
+  | DTypeDef { ty: Type, id: Name }
+end
+
+
+------------------
+-- C STATEMENTS --
+------------------
+-- Missing:
+-- * goto (including labeled statements)
+
+lang DeclStmt = Decl
   syn Stmt =
-  | SDecl     { decl: Decl }
-  | SIf       { cond: Expr, thn: Stmt, els: Stmt }
-  | SWhile    { cond: Expr, body: Stmt }
-  | SFor      { init: Expr, cond: Expr, after: Expr }
-  | SRet      { val: Option Expr }
-  | SExpr     { expr: Expr }
-  | SComp     { stmts: [Stmt] }
-
-  -- Missing:
-  -- * switch
-  -- * continue
-  -- * break
-  -- * do-while
-  -- * goto
+  | SDecl { decl: Decl }
 end
 
-lang CTopAst = CStmtAst + CTypeAst
+lang IfStmt = Expr
+  syn Stmt =
+  | SIf { cond: Expr, thn: Stmt, els: Stmt }
+end
+
+lang SwitchStmt
+  syn Stmt =
+  | SSwitch { cond: Expr, body: [(Int, Stmt)], default: Option Stmt }
+end
+
+lang WhileStmt
+  syn Stmt =
+  | SWhile { cond: Expr, body: Stmt }
+end
+
+lang DoWhileStmt
+  syn Stmt =
+  | SDoWhile { body: Stmt, cond: Expr }
+end
+
+lang ForStmt
+  syn Stmt =
+  | SFor { init: Expr, cond: Expr, after: Expr, body: Stmt }
+end
+
+lang ExprStmt
+  syn Stmt =
+  | SExpr { expr: Expr }
+end
+
+lang CompStmt
+  syn Stmt =
+  | SComp { stmts: [Stmt] }
+end
+
+lang RetStmt
+  syn Stmt =
+  | SRet { val: Option Expr }
+end
+
+lang ContStmt
+  syn Stmt =
+  | SCont {}
+end
+
+lang BreakStmt
+  syn Stmt =
+  | SBreak {}
+end
+
+
+-----------------
+-- C TOP-LEVEL --
+-----------------
+
+lang DeclTop
   syn Top =
-  | TDecl    { decl: Decl }
-  | TFun     { ty: Type,
-               id: Name,
-               params: [(Type, Name)],
-               body: Stmt }
+  | TDecl { decl: Decl }
 end
 
-lang CAst = CTopAst
-  syn C =
-  | CProg { tops: [Top] }
+lang FunTop
+  syn Top =
+  | TFun { ty: Type, id: Name, params: [(Type, Name)], body: Stmt }
 end
+
+lang CompTop
+  syn Top =
+  | TComp { tops: [Top] }
+end
+
+
+--------------------
+-- C AST FRAGMENT --
+--------------------
+
+lang CAst =
+
+  -- Expressions (some reuse from mexpr/ast.mc)
+  VarAst + ConstAst + IntAst + FloatAst + CharAst + AssgExpr + AppExpr +
+  SubScrExpr + MembExpr + CastExpr + SizeOfExpr + SizeOfTypeExpr +
+
+  -- Types (some reuse from mexpr/ast.mc)
+  CharTypeAst + IntTypeAst + FloatTypeAst + TypeVarAst + FunType + PtrType +
+  ArrType + StructType + UnionType + EnumType +
+
+  -- Declarations
+  DeclDecl + TypeDefDecl +
+
+  -- Statements
+  DeclStmt + IfStmt + SwitchStmt + WhileStmt + DoWhileStmt + ForStmt + ExprStmt
+  + CompStmt + RetStmt + ContStmt + BreakStmt +
+
+  -- Top-level
+  DeclTop + FunTop + CompTop
 

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -55,7 +55,7 @@ lang CAst
   | EString     { s: String }
   | EBinOp      { op: UnOp, lhs: Expr, rhs: Expr }
   | EUnOp       { op: BinOp, arg: Expr }
-  | EMember     { lhs: Expr, id: Name }
+  | EMember     { lhs: Expr, id: String }
   | ECast       { ty: Type, rhs: Expr }
   | ESizeOfType { ty: Type }
 
@@ -103,8 +103,8 @@ lang CAst
   | TyPtr { ty: Type }
   | TyFun { ret: Type, params: [Type] }
   | TyArray { ty: Type, size: Option Int }
-  | TyStruct { id: Name, mem: Option [(Type,Name)] }
-  | TyUnion { id: Name, mem: Option [(Type,Name)] }
+  | TyStruct { id: Name, mem: Option [(Type,String)] }
+  | TyUnion { id: Name, mem: Option [(Type,String)] }
   | TyEnum { id: Name, mem: Option [Name] }
 
 

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -1,29 +1,37 @@
 -- AST fragment for a subset of the C language, suitable for code generation.
 
+-- NOTE(dlunde,2020-10-29): Missing functionality (most things are probably not
+-- needed for code generation or can be expressed through other language
+-- constructs):
+-- * Labeled statements and goto
+-- * Storage class specifiers (auto, register, static, extern)
+-- * Type qualifiers (const, volatile)
+-- * Increment/decrement operators
+-- * Combined assignment operators (e.g. +=, *=)
+-- * Ternary operator (cond ? expr : expr)
+
 include "name.mc"
 
-lang CAst =
+lang CAst
 
   -------------------
   -- C EXPRESSIONS --
   -------------------
-  -- Missing:
-  -- * TODO(dlunde,2020-10-26): Many operators.
-  --
   -- NOTE(dlunde,2020-10-28): We cannot reuse operators from mexpr (such as
   -- CAddi) since they are curried. Maybe this will change in the future?
 
   syn Expr =
-  | TmVar        { id: Name }
-  | TmApp        { fun: Name, args: [Expr] }
-  | TmInt        { i: Int }
-  | TmFloat      { f: Float }
-  | TmChar       { c: Char }
-  | TmUnOp       { op: BinOp, arg: Expr }
-  | TmBinOp      { op: UnOp, lhs: Expr, rhs: Expr }
-  | TmMemb       { lhs: Expr, id: Name }
-  | TmCast       { ty: Type, rhs: Expr }
-  | TmSizeOfType { ty: Type }
+  | EVar        { id: Name }
+  | EApp        { fun: Name, args: [Expr] }
+  | EInt        { i: Int }
+  | EFloat      { f: Float }
+  | EChar       { c: Char }
+  | EString     { s: String }
+  | EUnOp       { op: BinOp, arg: Expr }
+  | EBinOp      { op: UnOp, lhs: Expr, rhs: Expr }
+  | EMemb       { lhs: Expr, id: Name }
+  | ECast       { ty: Type, rhs: Expr }
+  | ESizeOfType { ty: Type }
 
   syn BinOp =
   | OAssg {}
@@ -54,13 +62,14 @@ lang CAst =
   | ONeg {}
   | ONot {}
 
+
   -------------
   -- C TYPES --
   -------------
-
   -- We keep type expressions minimal to avoid dealing with the C type syntax.
   -- To use more complicated types, you first need to bind these to type
-  -- identifiers (see Top below).
+  -- identifiers at top-level (see below).
+
   syn Type =
   | TyIdent { id: Name }
   | TyChar {}
@@ -68,31 +77,30 @@ lang CAst =
   | TyDouble {}
   | TyVoid {}
 
-  -------------------
-  -- C DEFINITIONS --
-  -------------------
-  -- Missing:
-  -- * More storage class specifiers (auto, register, static, extern)
-  -- * Type qualifiers (const, volatile)
 
-  syn Def =
-  | DVar { ty: Type, id: Name, init: Option Init }
+  --------------------
+  -- C INITIALIZERS --
+  --------------------
 
   syn Init =
   | IExpr { expr: Expr }
   | IList { inits: [Init] }
 
+
   ------------------
   -- C STATEMENTS --
   ------------------
-  -- Missing:
-  -- * Labeled statements and goto
 
+  -- We force if, switch, and while to introduce new scopes (by setting the
+  -- body type to [Stmt] rather than Stmt). It is allowed in C to have a single
+  -- (i.e., not compound) statement as the body, but this statement is NOT
+  -- allowed to be a definition. To do this properly, we would need to separate
+  -- statements and definitions into different data types.
   syn Stmt =
-  | SDef     { def: Def }
-  | SIf      { cond: Expr, thn: Stmt, els: Stmt }
+  | SDef     { ty: Type, id: Name, init: Option Init }
+  | SIf      { cond: Expr, thn: [Stmt], els: [Stmt] }
   | SSwitch  { cond: Expr, body: [(Int, [Stmt])], default: Option [Stmt] }
-  | SWhile   { cond: Expr, body: Stmt }
+  | SWhile   { cond: Expr, body: [Stmt] }
   | SExpr    { expr: Expr }
   | SComp    { stmts: [Stmt] }
   | SRet     { val: Option Expr }
@@ -105,17 +113,17 @@ lang CAst =
   -----------------
 
   syn Top =
-  | TDef      { def: Def }
+  | TDef      { ty: Type, id: Name, init: Option Init }
+  | TFun      { ret: Type, id: Name, params: [(Type,Name)], body: [Stmt] }
   | TPtrTy    { ty: Type, id: Name }
   | TFunTy    { ret: Type, id: Name, params: [Type] }
-  | TArrTy    { ty: Type, size: Int }
-  | TStructTy { id: Name, mem: Option [Def] }
-  | TUnionTy  { id: Name, mem: Option [Def] }
+  | TArrTy    { ty: Type, id: Name, size: Option Int }
+  | TStructTy { id: Name, mem: Option [(Type,Name)] }
+  | TUnionTy  { id: Name, mem: Option [(Type,Name)] }
   | TEnumTy   { id: Name, mem: Option [Name] }
-  | TFun      { ty: Type, id: Name, params: [(Type, Name)], body: [Stmt] }
 
   syn Prog =
-  | CProg { tops: [Top] }
+  | PProg { tops: [Top] }
 
 end
 

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -28,8 +28,8 @@ lang CAst
   | EFloat      { f: Float }
   | EChar       { c: Char }
   | EString     { s: String }
-  | EUnOp       { op: BinOp, arg: Expr }
   | EBinOp      { op: UnOp, lhs: Expr, rhs: Expr }
+  | EUnOp       { op: BinOp, arg: Expr }
   | EMemb       { lhs: Expr, id: Name }
   | ECast       { ty: Type, rhs: Expr }
   | ESizeOfType { ty: Type }
@@ -102,7 +102,7 @@ lang CAst
   -- allowed to be a definition. To do this properly, we would need to separate
   -- statements and definitions into different data types.
   syn Stmt =
-  | SDef     { ty: Type, id: Name, init: Option Init }
+  | SDef     { ty: Type, id: Option Name, init: Option Init }
   | SIf      { cond: Expr, thn: [Stmt], els: [Stmt] }
   | SSwitch  { cond: Expr, body: [(Int, [Stmt])], default: Option [Stmt] }
   | SWhile   { cond: Expr, body: [Stmt] }
@@ -118,7 +118,7 @@ lang CAst
   -----------------
 
   syn Top =
-  | TDef      { ty: Type, id: Name, init: Option Init }
+  | TDef      { ty: Type, id: Option Name, init: Option Init }
   | TFun      { ret: Type, id: Name, params: [(Type,Name)], body: [Stmt] }
 
   syn Prog =

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -3,8 +3,9 @@
 -- NOTE(dlunde,2020-10-29): Missing functionality (most things are probably not
 -- needed for code generation or can be expressed through other language
 -- constructs):
+-- * Includes/module system
 -- * Labeled statements and goto
--- * Storage class specifiers (auto, register, static, extern)
+-- * Storage class specifiers (typedef, auto, register, static, extern)
 -- * Type qualifiers (const, volatile)
 -- * Increment/decrement operators
 -- * Combined assignment operators (e.g. +=, *=)
@@ -66,16 +67,20 @@ lang CAst
   -------------
   -- C TYPES --
   -------------
-  -- We keep type expressions minimal to avoid dealing with the C type syntax.
-  -- To use more complicated types, you first need to bind these to type
-  -- identifiers at top-level (see below).
 
   syn Type =
-  | TyIdent { id: Name }
+  -- TyIdent not really needed unless we add typedef
+--| TyIdent { id: Name }
   | TyChar {}
   | TyInt {}
   | TyDouble {}
   | TyVoid {}
+  | TyPtr { ty: Type }
+  | TyFun { ret: Type, params: [Type] }
+  | TyArr { ty: Type, size: Option Int }
+  | TyStruct { id: Name, mem: Option [(Type,Name)] }
+  | TyUnion { id: Name, mem: Option [(Type,Name)] }
+  | TyEnum { id: Name, mem: Option [Name] }
 
 
   --------------------
@@ -115,12 +120,6 @@ lang CAst
   syn Top =
   | TDef      { ty: Type, id: Name, init: Option Init }
   | TFun      { ret: Type, id: Name, params: [(Type,Name)], body: [Stmt] }
-  | TPtrTy    { ty: Type, id: Name }
-  | TFunTy    { ret: Type, id: Name, params: [Type] }
-  | TArrTy    { ty: Type, id: Name, size: Option Int }
-  | TStructTy { id: Name, mem: Option [(Type,Name)] }
-  | TUnionTy  { id: Name, mem: Option [(Type,Name)] }
-  | TEnumTy   { id: Name, mem: Option [Name] }
 
   syn Prog =
   | PProg { tops: [Top] }

--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -1,0 +1,233 @@
+include "ast.mc"
+
+include "mexpr/pprint.mc"
+
+-------------
+-- HELPERS --
+-------------
+
+let _par = lam str. join ["(",str,")"] in
+
+lang CPrettyPrint = CAst + PrettyPrint
+
+  -------------------
+  -- C IDENTIFIERS --
+  -------------------
+  sem printId (env: PprintEnv) =
+  -- TODO: Throw error if id is not a valid C identifier
+  | id -> pprintEnvGetStr env id
+
+
+  -------------------
+  -- C EXPRESSIONS --
+  -------------------
+
+  sem printExpr (env: PprintEnv) =
+
+  | TmVar { id = id } -> printId env id
+
+  | TmApp { fun = fun, args = args} ->
+    match prindId env fun with (env,fun) then
+      match mapAccumL printExpr env args with (env,args) then
+        (env, _par (join [fun, "(", (strJoin ", " args)], ")"))
+      else never
+    else never
+
+  | TmInt   { i = i } -> (env, int2string i)
+  | TmFloat { f = f } -> (env, float2string f)
+  | TmChar  { c = c } -> (env, ['\'', c, '\''])
+
+  | TmUnOp { op = op, arg = arg } ->
+    match printExpr env arg with (env,arg) then (env, _par (printUnOp arg op))
+    else never
+
+  | TmBinOp { op = op, lhs = lhs, rhs = rgs } ->
+    match printExpr env lhs with (env,lhs) then
+      match printExpr env rhs with (env,rhs) then
+        (env, _par (printBinOp lhs rhs op))
+      else never
+    else never
+
+  | TmMemb { lhs = lhs, id = id } ->
+    match printExpr env lhs with (env,lhs) then
+      match printId env id with (env,id)
+        (env, _par (join [lhs, ".", id]))
+      else never
+    else never
+
+  | TmCast { ty = ty, rhs = rhs } ->
+    match printType env ty with (env,ty) then
+      match printExpr env rhs with (env,rhs)
+        (env, _par (join ["(",ty,") ", rhs]))
+      else never
+    else never
+
+  | TmSizeOfType { ty = ty } ->
+    match printType env ty with (env,ty) then
+      (env, _par (join ["sizeof ", ty]))
+    else never
+
+  sem printBinOp (lhs: String) (rhs: String) =
+  | OAssg   {} -> join [lhs, " = ", rhs]
+  | OSubScr {} -> join [lhs, "[", rhs, "]"]
+  | OOr     {} -> join [lhs, " || ", rhs]
+  | OAnd    {} -> join [lhs, " && ", rhs]
+  | OEq     {} -> join [lhs, " == ", rhs]
+  | ONeq    {} -> join [lhs, " != ", rhs]
+  | OLt     {} -> join [lhs, " < ", rhs]
+  | OGt     {} -> join [lhs, " > ", rhs]
+  | OLe     {} -> join [lhs, " <= ", rhs]
+  | OGe     {} -> join [lhs, " >= ", rhs]
+  | OShiftL {} -> join [lhs, " << ", rhs]
+  | OShiftR {} -> join [lhs, " >> ", rhs]
+  | OAdd    {} -> join [lhs, " + ", rhs]
+  | OSub    {} -> join [lhs, " - ", rhs]
+  | OMul    {} -> join [lhs, " * ", rhs]
+  | ODiv    {} -> join [lhs, " / ", rhs]
+  | OMod    {} -> join [lhs, " % ", rhs]
+  | OBOr    {} -> join [lhs, " | ", rhs]
+  | OBAnd   {} -> join [lhs, " & ", rhs]
+  | OBXor   {} -> join [lhs, " ^ ", rhs]
+
+  sem printUnOp (arg: String) =
+  | OSizeOf {} -> join ["sizeof ", arg]
+  | ODeref  {} -> join ["*", arg]
+  | OAddrOf {} -> join ["&", arg]
+  | ONeg    {} -> join ["-", arg]
+  | ONot    {} -> join ["~", arg]
+
+
+  -------------
+  -- C TYPES --
+  -------------
+
+  sem printType (env: PprintEnv) =
+  | TyIdent  { id = id } -> printId env id
+  | TyChar   { }         -> (env,"char")
+  | TyInt    { }         -> (env,"int")
+  | TyDouble { }         -> (env,"double")
+  | TyVoid   { }         -> (env,"void")
+
+
+  -------------------
+  -- C DEFINITIONS --
+  -------------------
+
+  sem printDef (env: PprintEnv) =
+  | DVar { ty = ty, id = id, init = init } ->
+    match printType env ty with (env,ty) then
+      match printId env id with (env,id) then
+        let decl = join [ty, " ", id] in
+        match init with Some init then
+          match printInit env init with (env,init) then
+            (env, join [decl, " = ", init ";"])
+          else never
+        else (env, join [decl, ";"])
+      else never
+    else never
+
+  sem printInit (env: PprintEnv) =
+  | IExpr { expr = expr } -> printExpr env expr
+
+  | IList { inits = inits } ->
+    match mapAccumL printInit env inits with (env,inits) then
+      (env, join ["{ ", strJoin ", " inits, " }"])
+    else never
+
+
+  ------------------
+  -- C STATEMENTS --
+  ------------------
+
+  sem printStmt (indent : Int) (env: PprintEnv) =
+  | SDef { def = def } -> printDef env def
+
+  | SIf { cond = cond, thn = thn, els = els } ->
+    let i = indent in
+    let ii = pprintIncr i in
+    match printExpr env cond with (env,cond) then
+      match printStmt ii env thn with (env,thn) then
+        match printStmt ii env els with (env,els) then
+          (env, join ["if (", cond, ")", pprintNewline ii,
+                      thn, pprintNewline i,
+                      "else", pprintNewline ii, els])
+        else never
+      else never
+    else never
+
+  | SSwitch { cond = cond, body = body, default = default } ->
+    let i = indent in
+    let ii = pprintIncr i in
+    let iii = pprintIncr ii in
+    let iv = pprintIncr iii in
+    match printExpr env cond with (env,cond) then
+      let f = lam env. lam t.
+        match printStmt iv env t.1 with (env,t1) then (t.0, t1) else never in
+      match mapAccumL f env body with (env,body) then
+        let f = lam t.
+          join ["case ", int2string t.0, ":", pprintNewline iv, t.1] in
+        let body = strJoin (pprintNewline iii) (map f body) in
+        let str = join ["switch (", cond, ")", pprintNewline ii,
+                        "{", body] in
+        match default with Some default then
+          match printStmt iv default with (env,default) then
+            (env join [str, pprintNewline iii,
+                       "default:", pprintNewline iv,
+                       default, pprintNewline ii,
+                       "}"])
+          else never
+        else (env, join [str, pprintNewline ii, "}"])
+      else never
+    else never
+
+  | SWhile { cond = cond, body = body } ->
+    let i = indent in
+    let ii = pprintIncr i in
+    match printExpr env cond with (env,cond) then
+      match printStmt ii env body with (env,body) then
+        (env, join ["while (", cond, ")", pprintNewline ii, body])
+      else never
+    else never
+
+  | SExpr { expr = expr } ->
+    match printExpr env expr with (env,expr) then
+      (env, join [expr, ";"])
+    else never
+
+  | SComp { stmts = stmts } ->
+    let i = indent in
+    let ii = pprintIncr i in
+    match mapAccumL printStmt ii env stmts with (env,stmts) then
+      let stmts = strJoin (pprintNewline ii) stmts in
+      (env, join ["{", pprintNewline ii, stmts, pprintNewline i, "}"]
+    else never
+
+  | SRet { val = val } ->
+    match val with Some val then
+      match printExpr env val with (env,val) then
+        (env, join ["return", expr, ";"])
+      else never
+    else (env, "return;")
+
+  | SCont { } -> (env, "cont;")
+  | SBreak { } -> (env, "break;")
+
+
+  -----------------
+  -- C TOP-LEVEL --
+  -----------------
+
+  sem printTop (indent : Int) (env: PprintEnv) =
+  | TDef      { def = def } ->
+  | TPtrTy    { ty = ty, id = id} ->
+  | TFunTy    { ret = ret, id = id, params = params} ->
+  | TArrTy    { ty = ty, size = size} ->
+  | TStructTy { id = id, mem = mem} ->
+  | TUnionTy  { id = id, mem = mem} ->
+  | TEnumTy   { id = id, mem = mem} ->
+  | TFun      { ty = ty, id = id, params = params, body = body} ->
+
+  sem printProg =
+  | CProg { tops = tops} ->
+
+end

--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -567,6 +567,9 @@ let tops = [
 
 let prog = PProg { tops = tops } in
 
-let _ = printLn (printProg prog) in
+-- let _ = printLn (printProg prog) in
+
+-- Test making sure printProg does not crash
+utest geqi (length (printProg prog)) 0 with true in
 
 ()

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -435,6 +435,10 @@ end
 lang CharTypeAst
   syn Type =
   | TyChar {}
+end
+
+lang StringTypeAst
+  syn Type =
   | TyString {}
 end
 
@@ -456,10 +460,15 @@ end
 
 lang DataTypeAst
   syn Type =
-  | TyCon {ident : String}
+  | TyCon {ident : Name}
 end
 
-lang ArithTypeAst
+lang IntTypeAst
+  syn Type =
+  | TyInt {}
+end
+
+lang FloatTypeAst
   syn Type =
   | TyInt {}
 end
@@ -476,7 +485,7 @@ end
 
 lang TypeVarAst
   syn Type =
-  | TyVar {ident : String}
+  | TyVar {ident : Name}
 end
 
 ------------------------
@@ -498,6 +507,6 @@ lang MExprAst =
   BoolPat + AndPat + OrPat + NotPat
 
   -- Types
-  + FunTypeAst + DynTypeAst + UnitTypeAst + CharTypeAst + SeqTypeAst +
-  TupleTypeAst + RecordTypeAst + DataTypeAst + ArithTypeAst + BoolTypeAst +
-  AppTypeAst + TypeVarAst
+  + FunTypeAst + DynTypeAst + UnitTypeAst + CharTypeAst + StringTypeAst +
+  SeqTypeAst + TupleTypeAst + RecordTypeAst + DataTypeAst + IntTypeAst +
+  FloatTypeAst + BoolTypeAst + AppTypeAst + TypeVarAst

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -41,7 +41,7 @@ end
 lang FunAst = VarAst + AppAst
   syn Expr =
   | TmLam {ident : Name,
-           tpe   : Option,
+           tpe   : Option Type,
            body  : Expr,
            fi    : Info}
 
@@ -124,7 +124,7 @@ end
 lang DataAst
   syn Expr =
   | TmConDef {ident  : Name,
-              tpe    : Option,
+              tpe    : Option Type,
               inexpr : Expr}
   | TmConApp {ident : Name,
               body : Expr}

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -688,10 +688,11 @@ end
 -----------
 -- TODO(dlunde,2020-09-29) Update (also not up to date in boot?)
 
-lang TypePrettyPrint = FunTypeAst + DynTypeAst + UnitTypeAst + CharTypeAst +
-                       SeqTypeAst + TupleTypeAst + RecordTypeAst + DataTypeAst +
-                       ArithTypeAst + BoolTypeAst + AppTypeAst + FunAst +
-                       DataPrettyPrint + TypeVarAst
+lang TypePrettyPrint =
+  FunTypeAst + DynTypeAst + UnitTypeAst + CharTypeAst + StringTypeAst +
+  SeqTypeAst + TupleTypeAst + RecordTypeAst + DataTypeAst + IntTypeAst +
+  FloatTypeAst + BoolTypeAst + AppTypeAst + FunAst + DataPrettyPrint +
+  TypeVarAst
 
     sem getTypeStringCode (indent : Int) =
     | TyArrow t -> join ["(", getTypeStringCode indent t.from, ") -> (",

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -66,26 +66,31 @@ let pprintEnvAdd : Name -> String -> Int -> PprintEnv -> PprintEnv =
 -- Get a string for the current name. Returns both the string and a new
 -- environment.
 let pprintEnvGetStr : PprintEnv -> Name -> (PprintEnv, String) =
-lam env. lam name.
-  match pprintEnvLookup name env with Some str then (env,str)
-  else
-    let baseStr = nameGetStr name in
-    if pprintEnvFree baseStr env then (pprintEnvAdd name baseStr 1 env, baseStr)
+  lam env. lam name.
+    match pprintEnvLookup name env with Some str then (env,str)
     else
-      match env with {count = count} then
-        let start =
-          match assocLookup {eq = eqString} baseStr count
-          with Some i then i else 1 in
-        recursive let findFree : String -> Int -> (String, Int) =
-          lam baseStr. lam i.
-            let proposal = concat baseStr (int2string i) in
-            if pprintEnvFree proposal env then (proposal, i)
-            else findFree baseStr (addi i 1)
-        in
-        match findFree baseStr start with (str, i) then
-          (pprintEnvAdd name str (addi i 1) env, str)
+      let baseStr = nameGetStr name in
+      if pprintEnvFree baseStr env then (pprintEnvAdd name baseStr 1 env, baseStr)
+      else
+        match env with {count = count} then
+          let start =
+            match assocLookup {eq = eqString} baseStr count
+            with Some i then i else 1 in
+          recursive let findFree : String -> Int -> (String, Int) =
+            lam baseStr. lam i.
+              let proposal = concat baseStr (int2string i) in
+              if pprintEnvFree proposal env then (proposal, i)
+              else findFree baseStr (addi i 1)
+          in
+          match findFree baseStr start with (str, i) then
+            (pprintEnvAdd name str (addi i 1) env, str)
+          else never
         else never
-      else never
+
+-- Adds the given name to the environment (if it does not already exist)
+let pprintAddStr : PprintEnv -> Name -> PprintEnv =
+  lam env. lam name.
+    match pprintEnvGetStr env name with (env,_) then env else never
 
 ---------------------------------
 -- IDENTIFIER PARSER FUNCTIONS --

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -43,7 +43,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
 
   sem pprintCode (indent : Int) (env: PPrintEnv) =
   | TmLam {ident = id, body = b} ->
-    match pprintEnvGetStr id env with (env,str) then
+    match pprintEnvGetStr env id with (env,str) then
       let ident = pprintVarString str in
       match pprintCode (pprintIncr indent) env b with (env,body) then
         (env,join ["fun ", ident, " ->",
@@ -52,7 +52,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
     else never
   | TmRecLets {bindings = bindings, inexpr = inexpr} ->
     let lname = lam env. lam bind.
-      match pprintEnvGetStr bind.ident env with (env,str) then
+      match pprintEnvGetStr env bind.ident with (env,str) then
         (env,pprintVarString str)
       else never in
     let lbody = lam env. lam bind.


### PR DESCRIPTION
This PR revises the old C AST, and also adds pretty printing for it. Some features of C are not supported (see the notes in `c/ast.mc` for more information).

There are no unit tests in `c/pprint.mc` yet (similarly to `mexpr/pprint.mc`). I added this to [issue 208 ](https://github.com/miking-lang/miking/issues/208) as future work.

To test all the supported C features, I print the below program in `c/pprint.mc`. It compiles using `gcc`.
```
int x;
char y = 'c';
struct structty {int x1; double y1;};
int arrinit[][3] = {{1, 2, 3}, {4, 5, 6}};
char (*fun(int main1, char arg2))(int, double) {
  double x2 = 1.0e-1;
  char strinit[] = "strinit";
  struct structty s;
  union unionty {int x3; double y2;};
  enum enumty {CONST, CONST1};
  (s.x1);
  (( struct structty (*(*(*)(char))(int (double))) ) 1);
  (sizeof(struct structty (*(*(*)(char))(int (double)))));
  (x = ((-1) * 3));
  (fun(1, 'a'));
  if (2) {
    x;
    (fun(1, 'a'));
  } else {
    
  }
  switch (1) {
    case 2:
      (x = ((-1) * 3));
      break;
    case 5:
      x;
    case 7:
      (fun(1, 'a'));
      break;
    default:
      (s.x1);
  }
  while (42) {
    (fun(1, 'a'));
    {
      x;
      (s.x1);
    }
    continue;
    (s.x1);
  }
}
void noreturn() {
  return;
}
int main(int argc, char (*argv[])) {
  return 1;
}
```