### PR TITLE
Type updates and cleanup

### DIFF
--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -151,7 +151,7 @@ top:
 toplet:
   | LET var_ident ty_op EQ mexpr
     { let fi = mkinfo $1.i $4.i in
-      Let (fi, $2.v, $5) }
+      Let (fi, $2.v, $3, $5) }
 
 topRecLet:
   | REC lets END
@@ -254,11 +254,11 @@ mexpr:
       { $6 }
   | REC lets IN mexpr
       { let fi = mkinfo $1.i $3.i in
-        let lst = List.map (fun (fi,x,t) -> (fi,x,Symb.Helpers.nosym,t)) $2 in
+        let lst = List.map (fun (fi,x,ty,t) -> (fi,x,Symb.Helpers.nosym,ty,t)) $2 in
          TmRecLets(fi,lst,$4) }
   | LET var_ident ty_op EQ mexpr IN mexpr
       { let fi = mkinfo $1.i $6.i in
-        TmLet(fi,$2.v,Symb.Helpers.nosym,$5,$7) }
+        TmLet(fi,$2.v,Symb.Helpers.nosym,$3,$5,$7) }
   | LAM var_ident ty_op DOT mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
         TmLam(fi,$2.v,Symb.Helpers.nosym,$3,$5) }
@@ -284,10 +284,10 @@ mexpr:
 lets:
   | LET var_ident ty_op EQ mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
-        [(fi, $2.v, $5)] }
+        [(fi, $2.v, $3, $5)] }
   | LET var_ident ty_op EQ mexpr lets
       { let fi = mkinfo $1.i (tm_info $5) in
-        (fi, $2.v, $5)::$6 }
+        (fi, $2.v, $3, $5)::$6 }
 
 
 left:
@@ -401,11 +401,11 @@ pat_atom:
       { let fi = mkinfo (fst $1) (fst $5) in
         let l = $1 |> snd |> Mseq.Helpers.of_list in
         let r = $5 |> snd |> Mseq.Helpers.of_list in
-        PatSeqEdg(fi, l, snd $3, r) }
+        PatSeqEdge(fi, l, snd $3, r) }
   | patseq CONCAT name
-      { PatSeqEdg(mkinfo (fst $1) (fst $3), $1 |> snd |> Mseq.Helpers.of_list, snd $3, Mseq.empty) }
+      { PatSeqEdge(mkinfo (fst $1) (fst $3), $1 |> snd |> Mseq.Helpers.of_list, snd $3, Mseq.empty) }
   | name CONCAT patseq
-      { PatSeqEdg(mkinfo (fst $1) (fst $3), Mseq.empty, snd $1, $3 |> snd |> Mseq.Helpers.of_list) }
+      { PatSeqEdge(mkinfo (fst $1) (fst $3), Mseq.empty, snd $1, $3 |> snd |> Mseq.Helpers.of_list) }
   | LPAREN pat RPAREN
       { $2 }
   | LPAREN pat COMMA pat_list RPAREN
@@ -440,7 +440,7 @@ ty_op:
   | COLON ty
       { $2 }
   |
-      { TyDyn }
+      { TyUnknown }
 
 
 ty:
@@ -470,13 +470,13 @@ ty_atom:
       { TyRecord($2) }
   | type_ident
       {match Ustring.to_utf8 $1.v with
-       | "Dyn"    -> TyDyn
-       | "Bool"   -> TyBool
-       | "Int"    -> TyInt
-       | "Float"  -> TyFloat
-       | "Char"   -> TyChar
-       | "String" -> TySeq(TyChar)
-       | s        -> TyCon(us s)
+       | "Unknown" -> TyUnknown
+       | "Bool"    -> TyBool
+       | "Int"     -> TyInt
+       | "Float"   -> TyFloat
+       | "Char"    -> TyChar
+       | "String"  -> TySeq(TyChar)
+       | s         -> TyCon(us s)
       }
 
 ty_list:

--- a/src/boot/lib/repl.ml
+++ b/src/boot/lib/repl.ml
@@ -139,7 +139,7 @@ let eval_with_envs (langs, nss, name2sym, sym2term) term =
 (* Wrap the final mexpr in a lambda application to prevent scope leak *)
 let wrap_mexpr (Program (inc, tops, tm)) =
   let lambda_wrapper =
-    TmLam (NoInfo, us "_", Symb.Helpers.nosym, TyArrow (TyInt, TyDyn), tm)
+    TmLam (NoInfo, us "_", Symb.Helpers.nosym, TyArrow (TyInt, TyUnknown), tm)
   in
   let new_tm = TmApp (NoInfo, lambda_wrapper, TmConst (NoInfo, CInt 0)) in
   Program (inc, tops, new_tm)

--- a/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -35,17 +35,17 @@ utest smap_Expr_Expr map2varX tmLam with ulam_ "x" tmVarX in
 utest sfold_Expr_Expr fold2seq [] tmLam with [tmApp] in
 
 
-let tmLet = bind_ (let_ "y" tmLam) tmVarY in
+let tmLet = bind_ (ulet_ "y" tmLam) tmVarY in
 
-utest smap_Expr_Expr map2varX tmLet with bind_ (let_ "y" tmVarX) tmVarX in
+utest smap_Expr_Expr map2varX tmLet with bind_ (ulet_ "y" tmVarX) tmVarX in
 utest sfold_Expr_Expr fold2seq [] tmLet with [tmVarY, tmLam] in
 
 
-let tmRecLets = bind_ (reclets_ [("x", tmApp), ("u", tmVarW)]) tmVarU in
+let tmRecLets = bind_ (ureclets_ [("x", tmApp), ("u", tmVarW)]) tmVarU in
 
 utest smap_Expr_Expr map2varX tmRecLets
 with
-bind_ (reclets_ [("x", tmVarX), ("u", tmVarX)])
+bind_ (ureclets_ [("x", tmVarX), ("u", tmVarX)])
   tmVarX
 in
 utest sfold_Expr_Expr fold2seq [] tmRecLets with [tmVarU, tmVarW, tmApp] in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -41,7 +41,7 @@ end
 lang FunAst = VarAst + AppAst
   syn Expr =
   | TmLam {ident : Name,
-           tpe   : Option Type,
+           ty    : Type,
            body  : Expr,
            fi    : Info}
 
@@ -75,6 +75,7 @@ end
 lang LetAst = VarAst
   syn Expr =
   | TmLet {ident  : Name,
+           ty     : Type,
            body   : Expr,
            inexpr : Expr,
 	   fi     : Info}
@@ -92,6 +93,7 @@ end
 lang RecLetsAst = VarAst
   syn Expr =
   | TmRecLets {bindings : [{ident : Name,
+                            ty    : Type,
                             body  : Expr}],
                inexpr   : Expr}
 
@@ -124,7 +126,7 @@ end
 lang DataAst
   syn Expr =
   | TmConDef {ident  : Name,
-              tpe    : Option Type,
+              ty     : Type,
               inexpr : Expr}
   | TmConApp {ident : Name,
               body : Expr}
@@ -286,15 +288,15 @@ type PatName
 con PName     : Name -> PatName
 con PWildcard : ()   -> PatName
 
-lang VarPat
+lang NamedPat
   syn Pat =
-  | PVar {ident : PatName}
+  | PNamed {ident : PatName}
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PVar p -> PVar p
+  | PNamed p -> PNamed p
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PVar _ -> acc
+  | PNamed _ -> acc
 end
 
 lang SeqTotPat
@@ -414,53 +416,20 @@ end
 -----------
 -- TYPES --
 -----------
--- TODO(dlunde,2020-09-29): Update (also not up to date in boot?)
-
-lang FunTypeAst
-  syn Type =
-  | TyArrow {from : Type,
-             to   : Type}
-end
-
-lang DynTypeAst
-  syn Type =
-  | TyDyn {}
-end
 
 lang UnitTypeAst
   syn Type =
   | TyUnit {}
 end
 
-lang CharTypeAst
+lang UnknownTypeAst
   syn Type =
-  | TyChar {}
+  | TyUnknown {}
 end
 
-lang StringTypeAst
+lang BoolTypeAst
   syn Type =
-  | TyString {}
-end
-
-lang SeqTypeAst
-  syn Type =
-  | TySeq {tpe : Type}
-end
-
-lang TupleTypeAst
-  syn Type =
-  | TyProd {tpes : [Type]}
-end
-
-lang RecordTypeAst
-  syn Type =
-  | TyRecord {tpes : [{ident : String,
-                       tpe   : Type}]}
-end
-
-lang DataTypeAst
-  syn Type =
-  | TyCon {ident : Name}
+  | TyBool {}
 end
 
 lang IntTypeAst
@@ -470,17 +439,49 @@ end
 
 lang FloatTypeAst
   syn Type =
-  | TyInt {}
+  | TyFloat {}
 end
 
-lang BoolTypeAst
+lang CharTypeAst
   syn Type =
-  | TyBool {}
+  | TyChar {}
+end
+
+lang FunTypeAst
+  syn Type =
+  | TyArrow {from : Type,
+             to   : Type}
+end
+
+lang SeqTypeAst
+  syn Type =
+  | TySeq {ty : Type}
+end
+
+lang TupleTypeAst
+  syn Type =
+  | TyTuple {tys : [Type]}
+end
+
+lang RecordTypeAst
+  syn Type =
+  | TyRecord {fields : [{ident : String,
+                         ty    : Type}]}
+end
+
+lang DataTypeAst
+  syn Type =
+  | TyCon {ident : Name}
 end
 
 lang AppTypeAst
   syn Type =
   | TyApp {lhs : Type, rhs : Type}
+end
+
+lang StringTypeAst
+  syn Type =
+  | TyString {}
 end
 
 lang TypeVarAst
@@ -503,10 +504,10 @@ lang MExprAst =
   CmpIntAst + CmpFloatAst + CharAst + SymbAst + CmpSymbAst + SeqOpAst
 
   -- Patterns
-  + VarPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +
+  + NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +
   BoolPat + AndPat + OrPat + NotPat
 
   -- Types
-  + FunTypeAst + DynTypeAst + UnitTypeAst + CharTypeAst + StringTypeAst +
+  + FunTypeAst + UnknownTypeAst + UnitTypeAst + CharTypeAst + StringTypeAst +
   SeqTypeAst + TupleTypeAst + RecordTypeAst + DataTypeAst + IntTypeAst +
   FloatTypeAst + BoolTypeAst + AppTypeAst + TypeVarAst

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -43,7 +43,7 @@ lang FunCPS = FunSym + FunEq
   | TmLam t ->
     let k = nameSym "k" in
     let kvar = nvar_ k in
-    nlam_ t.ident t.tpe (nulam_ k (cpsC kvar t.body))
+    nlam_ t.ident t.ty (nulam_ k (cpsC kvar t.body))
 
 end
 

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -298,14 +298,16 @@ end
 
 
 -- Parsing of a lambda
-lang FunParser = ExprParser + IdentParser + KeywordUtils + FunAst 
+lang FunParser =
+  ExprParser + IdentParser + KeywordUtils + FunAst + UnknownTypeAst
+
   sem nextIdent (p: Pos) (xs: String) =
   | "lam" ->
     let r = eatWSAC (advanceCol p 3) xs in
     let r2 = parseIdent false r.pos r.str in
     let r3 = matchKeyword "." r2.pos r2.str  in
     let e = parseExprMain r3.pos 0 r3.str in
-    {val = TmLam {ident = nameNoSym r2.val, tpe = None (),
+    {val = TmLam {ident = nameNoSym r2.val, ty = TyUnknown {},
                   body = e.val, fi = makeInfo p e.pos},
      pos = e.pos, str = e.str}
     -- TODO (David, 2020-09-27): Add parsing of type     
@@ -313,7 +315,8 @@ end
 
 
 -- Parsing let expressions
-lang LetParser = ExprParser + IdentParser + KeywordUtils + LetAst
+lang LetParser =
+  ExprParser + IdentParser + KeywordUtils + LetAst + UnknownTypeAst
   sem nextIdent (p: Pos) (xs: String) =
   | "let" ->
     let r = eatWSAC (advanceCol p 3) xs in
@@ -322,7 +325,7 @@ lang LetParser = ExprParser + IdentParser + KeywordUtils + LetAst
     let e1 = parseExprMain r3.pos 0 r3.str in
     let r4 = matchKeyword "in" e1.pos e1.str in
     let e2 = parseExprMain r4.pos 0 r4.str in
-    {val = TmLet {ident = nameNoSym r2.val, body = e1.val,
+    {val = TmLet {ident = nameNoSym r2.val, ty = TyUnknown {}, body = e1.val,
                   inexpr = e2.val, fi = makeInfo p e2.pos},
      pos = e2.pos, str = e2.str}
 end

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -113,20 +113,20 @@ let charLiteral = char_ 'c' in
 let fun = ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) in
 
 let testLet =
-  bindall_ [let_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)]
+  bindall_ [ulet_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)]
 in
 
 let testRec =
   bind_
-    (reclets_add "foo" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
+    (ureclets_add "foo" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
       reclets_empty)
     (app_ (var_ "foo") (int_ 1))
 in
 
 let mutRec =
   bind_
-    (reclets_add "foo" (ulam_ "x" (app_ (var_ "bar") (var_ "x")))
-      (reclets_add "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
+    (ureclets_add "foo" (ulam_ "x" (app_ (var_ "bar") (var_ "x")))
+      (ureclets_add "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
          reclets_empty))
     (app_ (var_ "foo") (int_ 1))
 in


### PR DESCRIPTION
- Add type annotations to lets and recursive lets in the interpreter and boot.
- Renamed `PatSeqEdg` to `PatSeqEdge` in boot (to match the interpreter).
- Replaced `TyDyn` with `TyUnknown` in the interpreter and boot.
- Replaced the `tpe` abbreviation for types with `ty` in the interpreter.
- Renamed `PVar` to `PNamed` in the interpreter to match boot.
- Other minor cleanup.

To discuss:
- I removed the type annotation on closures in boot (it was already removed in the interpreter), since this is not relevant at runtime?