### PR TITLE
Implemented compilation function.

### DIFF
--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -72,6 +72,9 @@ let isUpperAlpha = lam c.
 
 let isAlpha = lam c. or (isLowerAlpha c) (isUpperAlpha c)
 
+let isLowerAlphaOrUnderscore = lam c.
+  or (isLowerAlpha c) (eqChar c '_')
+
 utest isAlpha 'a' with true
 utest isAlpha 'm' with true
 utest isAlpha 'z' with true
@@ -100,3 +103,25 @@ utest isAlphanum '9' with true
 utest isAlphanum 'A' with true
 utest isAlphanum 'z' with true
 utest isAlphanum '_' with false
+
+utest isLowerAlpha 'a' with true
+utest isLowerAlpha 'z' with true
+utest isLowerAlpha 'A' with false
+utest isLowerAlpha 'Z' with false
+utest isLowerAlpha '\n' with false
+utest isLowerAlpha '7' with false
+utest isLowerAlpha '_' with false
+
+utest isUpperAlpha '0' with false
+utest isUpperAlpha 'a' with false
+utest isUpperAlpha '_' with false
+utest isUpperAlpha 'X' with true
+utest isUpperAlpha 'K' with true
+utest isUpperAlpha '%' with false
+
+utest isLowerAlphaOrUnderscore '0' with false
+utest isLowerAlphaOrUnderscore 'a' with true
+utest isLowerAlphaOrUnderscore 'A' with false
+utest isLowerAlphaOrUnderscore '{' with false
+utest isLowerAlphaOrUnderscore '_' with true
+utest isLowerAlphaOrUnderscore '\n' with false

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -112,11 +112,11 @@ let pprintConString = lam str.
 
 -- Variable string parser translation
 let pprintVarString = lam str.
-  _parserStr str "#var" (lam str. isLowerAlpha (head str))
+  _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
 
 -- Label string parser translation for records
 let pprintLabelString = lam str.
-  _parserStr str "#label" (lam str. isLowerAlpha (head str))
+  _parserStr str "#label" (lam str. isLowerAlphaOrUnderscore (head str))
 
 ----------------------
 -- HELPER FUNCTIONS --

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -1,0 +1,62 @@
+include "string.mc"
+
+let _blt = pyimport "builtins"
+let _subprocess = pyimport "subprocess"
+let _tempfile = pyimport "tempfile"
+
+type Program = String -> [String] -> {stdout: String, stderr: String, returncode: Int}
+
+let writeToFile = lam str. lam filename.
+  let f = pycall _blt "open" (filename, "w+") in
+  let _ = pycallkw _subprocess "run" (["echo", str],) {stdout=f} in
+  let _ = pycall f "close" () in
+  ()
+
+let runCommand = lam cmd. lam cwd. lam exitOnFailure.
+  let r = pycallkw _subprocess "run" (cmd,) {cwd=cwd, capture_output=true} in
+  let returncode = pyconvert (pycall _blt "getattr" (r,"returncode")) in
+  let stdout =
+    pyconvert (pycall (pycall _blt "getattr" (r,"stdout")) "decode" ())
+  in
+  let stderr =
+    pyconvert (pycall (pycall _blt "getattr" (r,"stderr")) "decode" ())
+  in
+  if and (neqi returncode 0) exitOnFailure then
+    exit returncode
+  else
+    {stdout=stdout, stderr=stderr, returncode=returncode}
+
+let compile : String -> Program = lam p.
+  let symlink = lam from. lam to.
+    pycall _subprocess "run" (["ln", "-sf", from, to],)
+  in
+
+  let dunefile = "(executable (name program) (libraries batteries boot))" in
+  let td = pycall _tempfile "TemporaryDirectory" () in
+  let dir = pyconvert (pycall _blt "getattr" (td, "name")) in
+  let tempfile = lam f. strJoin "/" [dir, f] in
+
+  let _ = writeToFile p (tempfile "program.ml") in
+  let _ = writeToFile dunefile (tempfile "dune") in
+
+  let command = ["dune", "build"] in
+  let _ = runCommand command (tempfile "") true in
+
+  lam stdin. lam args.
+    let command = ["dune", "exec", "./program.exe", "--", strJoin " " args] in
+    runCommand command (tempfile "") false
+
+mexpr
+
+let run =
+  compile "print_endline (\"This is the sym: \" ^ (Boot.Intrinsics.Symb.Helpers.string_of_sym (Boot.Intrinsics.Symb.gensym ())))"
+in
+
+let run2 =
+  compile "print_endline \"Hello World!\""
+in
+
+let _ = dprint (run "" [""]) in
+let _ = dprint (run2 "" [""]) in
+let _ = dprint (run "" [""]) in
+()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -6,11 +6,12 @@ include "mexpr/parser.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/eval.mc"
 include "mexpr/eq.mc"
+include "ocaml/compile.mc"
 
-let defaultIdentName = "var"
+let defaultIdentName = "_var"
 
 let escapeFirstChar = lam c.
-  if or (isLowerAlpha c) (eqChar c '_') then c
+  if isLowerAlphaOrUnderscore c then c
   else '_'
 
 utest map escapeFirstChar "abcABC/:@_'" with "abc________"
@@ -144,18 +145,10 @@ in
 let ocamlEval = lam p. lam strConvert.
   let subprocess = pyimport "subprocess" in
   let blt = pyimport "builtins" in
-  let cmd =
-        pycall blt "str"
-               (join ["print_endline (", strConvert, "(", p, "))"],)
-  in
-  let encoded = pycall cmd "encode" () in
-  let p = pycallkw subprocess "run" (["ocaml", "-stdin"],)
-                              {input=encoded, capture_output=true}
-  in
-  let stdout =
-    pycall (pycall blt "getattr" (p,"stdout")) "decode" ()
-  in
-  parseAsMExpr (pyconvert stdout)
+    let res = compile (join ["print_string (", strConvert, "(", p, "))"]) in
+    let out = (res.run "" []).stdout in
+    let _ = res.cleanup () in
+    parseAsMExpr out
 in
 
 -- Compares evaluation of [mexprAst] as a mexpr and evaluation of

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -44,7 +44,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   sem pprintCode (indent : Int) (env: PPrintEnv) =
   | TmLam {ident = id, body = b} ->
     match pprintEnvGetStr env id with (env,str) then
-      let ident = pprintVarString str in
+      let ident = str in
       match pprintCode (pprintIncr indent) env b with (env,body) then
         (env,join ["fun ", ident, " ->",
          pprintNewline (pprintIncr indent), body])
@@ -53,11 +53,11 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | TmRecLets {bindings = bindings, inexpr = inexpr} ->
     let lname = lam env. lam bind.
       match pprintEnvGetStr env bind.ident with (env,str) then
-        (env,pprintVarString str)
+        (env, str)
       else never in
     let lbody = lam env. lam bind.
       match pprintCode (pprintIncr (pprintIncr indent)) env bind.body
-      with (env,str) then (env,pprintVarString str)
+      with (env,str) then (env, str)
       else never in
     match mapAccumL lname env bindings with (env,idents) then
       match mapAccumL lbody env bindings with (env,bodies) then

--- a/stdlib/python/python.mc
+++ b/stdlib/python/python.mc
@@ -1,0 +1,4 @@
+let _blt = pyimport "builtins"
+
+let pythonGetAttr = lam pyobj. lam attr.
+  pycall _blt "getattr" (pyobj, attr)


### PR DESCRIPTION
This PR contains a prototype implementation of a compile to OCaml function. The function `compile` takes an OCaml program as a string and returns a function with type `String -> [String] -> {stdout: String, stderr: String, returncode: Int}` which when called executes the program. The first argument is given to the program via `stdin` and the second argument is arguments passed to the program.

Behind the scenes `compile` creates a dune project in the platform specified tempdirectory via the python intrinsic. Calls to the returned run function then subsequently calls `dune exec ...` which will build and/or execute the project as necessary. To call functions from the `intrinsics.ml` it is necessary to run `dune install` in the `miking` root folder to make the `boot` library globally available on the system.

Going forward we would like to:
- Separate `intrinsics.ml` into its own library and package.
- Possibly supply the OCaml program as a OCaml AST rather than a string.
- Create the dune project using `dune init ...`.