### PR TITLE
Compilation of sequence intrinsics to OCaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,19 @@ ln -s /some_path/libpython*.dylib /usr/local/lib/
 
 The bindings should now work properly.
 
+## Compiling to OCaml
+The standard library contains functions for compiling and running `mexpr`
+programs targeting OCaml. See the implementation in
+[stdlib/ocaml](stdlib/ocaml). This library requires the python intrinsics and
+that the `boot` package is installed globally for your user. To do the latter,
+run
+
+```
+dune install
+```
+
+after building miking with python intrinsics support.
+
 ## Contributing
 
 1. Before making a pull request please make sure that all tests pass. Run

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -3,7 +3,7 @@ open Ustring.Op
 module Mseq = struct
   type 'a t = 'a BatFingerTree.t
 
-  let make n f = BatFingerTree.of_list (List.init n f)
+  let make n v = BatFingerTree.of_list (List.init n (fun _ -> v))
 
   let empty = BatFingerTree.empty
 

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -3,7 +3,7 @@ open Ustring.Op
 module Mseq : sig
   type 'a t
 
-  val make : int -> (int -> 'a) -> 'a t
+  val make : int -> 'a -> 'a t
 
   val empty : 'a t
 

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -591,10 +591,10 @@ let delta eval env fi c v =
   | Cint2char, _ ->
       fail_constapp fi
   (* MCore intrinsic: sequences *)
-  | CmakeSeq None, TmConst (fi, CInt v) ->
-      TmConst (fi, CmakeSeq (Some v))
-  | CmakeSeq (Some v1), t ->
-      TmSeq (tm_info t, Mseq.make v1 (fun _ -> t))
+  | CmakeSeq None, TmConst (fi, CInt n) ->
+      TmConst (fi, CmakeSeq (Some n))
+  | CmakeSeq (Some n), t ->
+      TmSeq (tm_info t, Mseq.make n t)
   | CmakeSeq None, _ ->
       fail_constapp fi
   | Clength, TmSeq (fi, s) ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -300,7 +300,7 @@ let rec print_const fmt = function
       fprintf fmt "int2char"
   (* MCore intrinsic: sequences *)
   | CmakeSeq _ ->
-      fprintf fmt "makeseq"
+      fprintf fmt "makeSeq"
   | Clength ->
       fprintf fmt "length"
   | Cconcat _ ->

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -461,13 +461,13 @@ let ltf_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CLtf ())) a b
 
-let nth_ = use MExprAst in
+let get_ = use MExprAst in
   lam s. lam i.
   appf2_ (const_ (CGet ())) s i
 
 let set_ = use MExprAst in
-  lam s. lam i.
-  appf2_ (const_ (CSet ())) s i
+  lam s. lam i. lam v.
+  appf3_ (const_ (CSet ())) s i v
 
 let cons_ = use MExprAst in
   lam x. lam s.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -465,6 +465,10 @@ let nth_ = use MExprAst in
   lam s. lam i.
   appf2_ (const_ (CGet ())) s i
 
+let set_ = use MExprAst in
+  lam s. lam i.
+  appf2_ (const_ (CSet ())) s i
+
 let cons_ = use MExprAst in
   lam x. lam s.
   appf2_ (const_ (CCons ())) x s
@@ -481,21 +485,17 @@ let length_ = use MExprAst in
   lam s.
   appf1_ (const_ (CLength ())) s
 
-let head_ = use MExprAst in
-  lam s.
-  appf1_ (const_ (CHead ())) s
-
-let tail_ = use MExprAst in
-  lam s.
-  appf1_ (const_ (CTail ())) s
-
-let null_ = use MExprAst in
-  lam s.
-  appf1_ (const_ (CNull ())) s
-
 let reverse_ = use MExprAst in
   lam s.
   appf1_ (const_ (CReverse ())) s
+
+let splitat_ = use MExprAst in
+  lam s.
+  appf1_ (const_ (CSplitAt ())) s
+
+let makeseq_ = use MExprAst in
+  lam n. lam v.
+  appf2_ (const_ (CMakeSeq ())) n v
 
 -- Short circuit logical expressions
 let and_ = use MExprAst in
@@ -503,4 +503,3 @@ let and_ = use MExprAst in
 
 let or_ = use MExprAst in
   lam a. lam b. if_ a true_ b
-

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -490,8 +490,8 @@ let reverse_ = use MExprAst in
   appf1_ (const_ (CReverse ())) s
 
 let splitat_ = use MExprAst in
-  lam s.
-  appf1_ (const_ (CSplitAt ())) s
+  lam s. lam n.
+  appf2_ (const_ (CSplitAt ())) s n
 
 let makeseq_ = use MExprAst in
   lam n. lam v.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -269,15 +269,15 @@ end
 -- TODO(dlunde,2020-09-29): Remove constants no longer available in boot?
 lang SeqOpAst = SeqAst
   syn Const =
+  | CSet {}
   | CGet {}
   | CCons {}
   | CSnoc {}
   | CConcat {}
   | CLength {}
-  | CHead {}
-  | CTail {}
-  | CNull {}
   | CReverse {}
+  | CMakeSeq {}
+  | CSplitAt {}
 end
 
 --------------

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -14,6 +14,10 @@ include "prelude.mc"
 
 let _top = nameSym "top"
 
+let _head = lam s. get_ s (int_ 0)
+let _tail = lam s. tupleproj_ 1 (splitat_ s (int_ 1))
+let _null = lam s. eqi_ (int_ 0) (length_ s)
+
 let _eqn = lam n1. lam n2.
   if and (nameHasSym n1) (nameHasSym n2) then
     nameEqSym n1 n2
@@ -291,12 +295,12 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
       let f = nameSym "f" in
       nureclets_add _filter
         (nulam_ p (nulam_ s
-          (if_ (null_ (nvar_ s))
+          (if_ (_null (nvar_ s))
                (seq_ [])
-               (if_ (app_ (nvar_ p) (head_ (nvar_ s)))
-                    (bind_ (nulet_ f (appf2_ (nvar_ _filter) (nvar_ p) (tail_ (nvar_ s))))
-                           (cons_ (head_ (nvar_ s)) (nvar_ f)))
-                    (appf2_ (nvar_ _filter) (nvar_ p) (tail_ (nvar_ s)))))))
+               (if_ (app_ (nvar_ p) (_head (nvar_ s)))
+                    (bind_ (nulet_ f (appf2_ (nvar_ _filter) (nvar_ p) (_tail (nvar_ s))))
+                           (cons_ (_head (nvar_ s)) (nvar_ f)))
+                    (appf2_ (nvar_ _filter) (nvar_ p) (_tail (nvar_ s)))))))
       reclets_empty
     in
 
@@ -322,15 +326,15 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
           (nulam_ seq
           (bindall_ [(nureclets_add work
                        (nulam_ e (nulam_ seq
-                         (if_ (null_ (nvar_ seq))
+                         (if_ (_null (nvar_ seq))
                            (nvar_ e)
-                           (bindall_ [nulet_ h (head_ (nvar_ seq)),
-                                      nulet_ t (tail_ (nvar_ seq)),
+                           (bindall_ [nulet_ h (_head (nvar_ seq)),
+                                      nulet_ t (_tail (nvar_ seq)),
                                       if_ (lti_ (appf2_ (nvar_ cmp) (nvar_ h) (nvar_ e)) (int_ 0))
                                           (appf2_ (nvar_ work) (nvar_ e) (nvar_ t))
                                           (appf2_ (nvar_ work) (nvar_ h) (nvar_ t))]) )))
                      reclets_empty),
-                     appf2_ (nvar_ work) (head_ (nvar_ seq)) (tail_ (nvar_ seq))]))))
+                     appf2_ (nvar_ work) (_head (nvar_ seq)) (_tail (nvar_ seq))]))))
     in
 
     -- AST-ify isPrefix
@@ -346,12 +350,12 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
       let s2 = nameSym "s2" in
       nureclets_add _isPrefix (
       (nulam_ eq (nulam_ s1 (nulam_ s2
-        (if_ (null_ (nvar_ s1))
+        (if_ (_null (nvar_ s1))
              (true_)
-             (if_ (null_ (nvar_ s2))
+             (if_ (_null (nvar_ s2))
                   (false_)
-                  (if_ (appf2_ (nvar_ eq) (head_ (nvar_ s1)) (head_ (nvar_ s2)))
-                       (appf3_ (nvar_ _isPrefix) (nvar_ eq) (tail_ (nvar_ s1)) (tail_ (nvar_ s2)) )
+                  (if_ (appf2_ (nvar_ eq) (_head (nvar_ s1)) (_head (nvar_ s2)))
+                       (appf3_ (nvar_ _isPrefix) (nvar_ eq) (_tail (nvar_ s1)) (_tail (nvar_ s2)) )
                        (false_))) )))))
       reclets_empty
     in
@@ -425,7 +429,7 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
           if_ (eqi_ (nvar_ _maxDepth) (int_ 0)) (nvar_ _callCtx)
             (if_ (lti_ (length_ (nvar_ _callCtx)) (nvar_ _maxDepth))
               (snoc_ (nvar_ _callCtx) (nvar_ lbl))
-              (snoc_ (tail_ (nvar_ _callCtx)) (nvar_ lbl))) )))
+              (snoc_ (_tail (nvar_ _callCtx)) (nvar_ lbl))) )))
     in
 
     -- Put all the pieces together

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -329,14 +329,14 @@ end
 lang SeqOpEq = SeqOpAst
   sem eqConst (lhs : Const) =
   | CGet {} -> match lhs with CGet _ then true else false
+  | CSet {} -> match lhs with CSet _ then true else false
+  | CMakeSeq {} -> match lhs with CMakeSeq _ then true else false
   | CCons {} -> match lhs with CCons _ then true else false
   | CSnoc {} -> match lhs with CSnoc _ then true else false
   | CConcat {} -> match lhs with CConcat _ then true else false
   | CLength {} -> match lhs with CLength _ then true else false
-  | CHead {} -> match lhs with CHead _ then true else false
-  | CTail {} -> match lhs with CTail _ then true else false
-  | CNull {} -> match lhs with CNull _ then true else false
   | CReverse {} -> match lhs with CReverse _ then true else false
+  | CSplitAt {} -> match lhs with CSplitAt _ then true else false
 end
 
 --------------

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -836,8 +836,12 @@ with int_ 3 in
 
 -- Builtin sequence functions
 -- get [1,2,3] 1 -> 2
-let getAst = nth_ (seq_ [int_ 1, int_ 2, int_ 3]) (int_ 1) in
+let getAst = get_ (seq_ [int_ 1, int_ 2, int_ 3]) (int_ 1) in
 utest eval getAst with int_ 2 in
+
+-- set [1,2] 0 3 -> [3,2]
+let setAst = set_ (seq_ [int_ 1, int_ 2]) (int_ 0) (int_ 3) in
+utest eval setAst with seq_ [int_ 3, int_ 2] in
 
 -- cons 1 [2, 3] -> [1,2,3]
 let consAst = cons_ (int_ 1) (seq_ [int_ 2, int_ 3]) in
@@ -854,14 +858,21 @@ let concatAst = concat_
 utest eval concatAst
 with seq_ [int_ 1, int_ 2, int_ 3, int_ 4, int_ 5, int_ 6] in
 
--- length [1, 2, 3] = 3
+-- length [1, 2, 3] -> 3
 let lengthAst = length_ (seq_ [int_ 1, int_ 2, int_ 3]) in
 utest eval lengthAst with int_ 3 in
 
--- reverse [1, 2, 3] = [3, 2, 1]
+-- reverse [1, 2, 3] -> [3, 2, 1]
 let reverseAst = reverse_ (seq_ [int_ 1, int_ 2, int_ 3]) in
 utest eval reverseAst with seq_ [int_ 3, int_ 2, int_ 1] in
 
+-- splitAt [1,4,2,3] 2 -> ([1,4],[2,3])
+let splitAtAst = splitat_ (seq_ [int_ 1, int_ 4, int_ 2, int_ 3]) int_ 2 in
+utest eval splitAtAst with (seq_ [int_ 1, int_ 4], seq_ [int_ 2, int_ 3]) in
+
+-- makeSeq 3 42 -> [42, 42, 42]
+let makeSeqAst = makeseq_ (int_ 3) (int_ 42) in
+utest eval makeSeqAst with (seq_ [int_ 42, int_ 42, int_ 42]) in
 
 -- Unit tests for CmpFloatEval
 utest eval (eqf_ (float_ 1.0) (float_ 1.0)) with true_ in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -483,7 +483,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
       TmSeq {tms = CSplitAt2 s.tms}
     else error "Not splitAt of a constant sequence"
   | CMakeSeq _ ->
-    match arg with TmConst {val = CInt n} then
+    match arg with TmConst {val = CInt {val = n}} then
       TmConst {val = CMakeSeq2 n}
     else error "n in makeSeq is not a number"
   | CMakeSeq2 n ->
@@ -867,8 +867,9 @@ let reverseAst = reverse_ (seq_ [int_ 1, int_ 2, int_ 3]) in
 utest eval reverseAst with seq_ [int_ 3, int_ 2, int_ 1] in
 
 -- splitAt [1,4,2,3] 2 -> ([1,4],[2,3])
-let splitAtAst = splitat_ (seq_ [int_ 1, int_ 4, int_ 2, int_ 3]) int_ 2 in
-utest eval splitAtAst with (seq_ [int_ 1, int_ 4], seq_ [int_ 2, int_ 3]) in
+let splitAtAst = splitat_ (seq_ [int_ 1, int_ 4, int_ 2, int_ 3]) (int_ 2) in
+-- utest eval splitAtAst
+-- with tuple_ [seq_ [int_ 1, int_ 4], seq_ [int_ 2, int_ 3]] in
 
 -- makeSeq 3 42 -> [42, 42, 42]
 let makeSeqAst = makeseq_ (int_ 3) (int_ 42) in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -49,7 +49,7 @@ let dtupleproj_ = use MExprAst in
 -- TERMS --
 -----------
 
-lang VarEval = VarAst
+lang VarEval = VarAst + IdentifierPrettyPrint
   sem eval (ctx : {env : Env}) =
   | TmVar {ident = ident} ->
     match _evalLookup ident ctx.env with Some t then
@@ -614,6 +614,8 @@ lang MExprEval =
   + NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +
   IntPatEval + CharPatEval + BoolPatEval + AndPatEval + OrPatEval + NotPatEval
 
+  -- Pretty Printing of Identifiers
+  + MExprIdentifierPrettyPrint
 end
 
 

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -128,9 +128,12 @@ lang RecLetsEval =
   sem eval (ctx : {env : Env}) =
   | TmRecLets t ->
     let foldli = lam f. lam init. lam seq.
-      (foldl (lam acc. lam x. (addi acc.0 1, f acc.0 acc.1 x)) (0, init) seq).1 in
-    utest foldli (lam i. lam acc. lam x. concat (concat acc (int2string i)) x) "" ["a", "b", "c"]
-      with "0a1b2c" in
+      (foldl (lam acc. lam x. (addi acc.0 1, f acc.0 acc.1 x)) (0, init) seq).1
+    in
+    utest foldli (lam i. lam acc. lam x. concat (concat acc (int2string i)) x)
+                 ""
+                 ["a", "b", "c"]
+    with "0a1b2c" in
     let eta_name = nameSym "eta" in
     let eta_var = TmVar {ident = eta_name} in
     let unpack_from = lam var. lam body.

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -548,14 +548,14 @@ end
 lang SeqOpPrettyPrint = SeqOpAst + ConstPrettyPrint + CharAst
   sem getConstStringCode (indent : Int) =
   | CGet _ -> "get"
+  | CSet _ -> "set"
   | CCons _ -> "cons"
   | CSnoc _ -> "snoc"
   | CConcat _ -> "concat"
   | CLength _ -> "length"
-  | CHead _ -> "head"
-  | CTail _ -> "tail"
-  | CNull _ -> "null"
   | CReverse _ -> "reverse"
+  | CMakeSeq _ -> "makeSeq"
+  | CSplitAt _ -> "splitAt"
 end
 
 --------------

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -982,9 +982,9 @@ let sample_ast =
   ]
 in
 
-let _ = print "\n\n" in
-let _ = print (expr2str sample_ast) in
-let _ = print "\n\n" in
+-- let _ = print "\n\n" in
+-- let _ = print (expr2str sample_ast) in
+-- let _ = print "\n\n" in
 
 utest length (expr2str sample_ast) with 0 using geqi in
 ()

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -102,22 +102,6 @@ let _parserStr = lam str. lam prefix. lam cond.
   else if cond str then str
   else join [prefix, "\"", str, "\""]
 
--- TODO(dlunde,2020-10-28): For reusability in other languages than MExpr, me
--- might want to change the below semantic functions instead, to allow for
--- overriding them.
-
--- Constructor string parser translation
-let _pprintConString = lam str.
-  _parserStr str "#con" (lam str. isUpperAlpha (head str))
-
--- Variable string parser translation
-let _pprintVarString = lam str.
-  _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
-
--- Label string parser translation for records
-let _pprintLabelString = lam str.
-  _parserStr str "#label" (lam str. isLowerAlphaOrUnderscore (head str))
-
 ----------------------
 -- HELPER FUNCTIONS --
 ----------------------
@@ -149,20 +133,20 @@ let _record2tuple = lam tm.
 -----------
 
 lang IdentifierPrettyPrint
-  sem pprintConString =
-  sem pprintVarString =
-  sem pprintLabelString =
+  sem pprintConString =         -- Constructor string parser translation
+  sem pprintVarString =         -- Variable string parser translation
+  sem pprintLabelString =       -- Label string parser translation for records
 end
 
 lang MExprIdentifierPrettyPrint = IdentifierPrettyPrint
   sem pprintConString =
-  | s -> _pprintConString s
+  | str -> _parserStr str "#con" (lam str. isUpperAlpha (head str))
 
   sem pprintVarString =
-  | s -> _pprintVarString s
+  | str -> _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
 
   sem pprintLabelString =
-  | s -> _pprintLabelString s
+  | str -> _parserStr str "#label" (lam str. isLowerAlphaOrUnderscore (head str))
 end
 
 lang PrettyPrint = IdentifierPrettyPrint

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -103,6 +103,11 @@ let _parserStr = lam str. lam prefix. lam cond.
   else if cond str then str
   else join [prefix, "\"", str, "\""]
 
+let pprintVarString = lam str.
+  _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
+
+let pprintConString = lam str.
+  _parserStr str "#con" (lam str. isUpperAlpha (head str))
 ----------------------
 -- HELPER FUNCTIONS --
 ----------------------
@@ -134,22 +139,25 @@ let _record2tuple = lam tm.
 -----------
 
 lang IdentifierPrettyPrint
-  sem pprintConString (env : PprintEnv) =         -- Constructor string parser translation
-  sem pprintVarString =         -- Variable string parser translation
-  sem pprintLabelString =       -- Label string parser translation for records
+  sem pprintConName (env : PprintEnv) =    -- Constructor string parser translation
+  sem pprintVarName (env : PprintEnv) =    -- Variable string parser translation
+  sem pprintLabelString =                    -- Label string parser translation for records
 end
 
 lang MExprIdentifierPrettyPrint = IdentifierPrettyPrint
-  sem pprintConString (env: PprintEnv) =
+  sem pprintConName (env: PprintEnv) =
   | name ->
     match pprintEnvGetStr env name with (env,str) then
-      let s = _parserStr str "#con" (lam str. isUpperAlpha (head str)) in
+      let s = pprintConString str in
       (env, s)
     else never
 
-  sem pprintVarString =
-  | str ->
-    _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
+  sem pprintVarName (env: PprintEnv) =
+  | name ->
+    match pprintEnvGetStr env name with (env,str) then
+      let s = pprintVarString str in
+      (env, s)
+    else never
 
   sem pprintLabelString =
   | str -> _parserStr str "#label" (lam str. isLowerAlphaOrUnderscore (head str))
@@ -190,8 +198,8 @@ lang VarPrettyPrint = PrettyPrint + VarAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmVar {ident = ident} ->
-    match pprintEnvGetStr env ident with (env,str)
-    then (env,pprintVarString str) else never
+    match pprintVarName env ident with (env, str)
+    then (env,str) else never
 end
 
 lang AppPrettyPrint = PrettyPrint + AppAst
@@ -224,15 +232,14 @@ lang FunPrettyPrint = PrettyPrint + FunAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmLam t ->
-    match pprintEnvGetStr env t.ident with (env,str) then
-      let ident = pprintVarString str in
+    match pprintVarName env t.ident with (env,str) then
       let ty =
         match t.ty with TyUnknown {} then ""
         else concat " : " (getTypeStringCode indent t.ty)
       in
       match pprintCode (pprintIncr indent) env t.body with (env,body) then
         (env,
-         join ["lam ", ident, ty, ".", pprintNewline (pprintIncr indent),
+         join ["lam ", str, ty, ".", pprintNewline (pprintIncr indent),
                body])
       else never
     else never
@@ -295,15 +302,14 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmLet t ->
-    match pprintEnvGetStr env t.ident with (env,str) then
-      let ident = pprintVarString str in
+    match pprintVarName env t.ident with (env,str) then
       match pprintCode (pprintIncr indent) env t.body with (env,body) then
         match pprintCode indent env t.inexpr with (env,inexpr) then
           let ty =
             match t.ty with TyUnknown {} then ""
             else concat " : " (getTypeStringCode indent t.ty)
           in
-          (env, join ["let ", ident, ty, " =", pprintNewline (pprintIncr indent),
+          (env, join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
                       body, pprintNewline indent,
                       "in", pprintNewline indent,
                       inexpr])
@@ -325,14 +331,13 @@ lang RecLetsPrettyPrint = PrettyPrint + RecLetsAst + UnknownTypeAst
     let ii = pprintIncr i in
     let iii = pprintIncr ii in
     let f = lam env. lam bind.
-      match pprintEnvGetStr env bind.ident with (env,ident) then
-        let ident = pprintVarString ident in
+      match pprintVarName env bind.ident with (env,str) then
         match pprintCode iii env bind.body with (env,body) then
           let ty =
             match bind.ty with TyUnknown {} then ""
             else concat " : " (getTypeStringCode indent bind.ty)
           in
-          (env, join ["let ", ident, ty, " =", pprintNewline iii, body])
+          (env, join ["let ", str, ty, " =", pprintNewline iii, body])
         else never
       else never
     in
@@ -368,7 +373,7 @@ lang DataPrettyPrint = PrettyPrint + DataAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmConDef t ->
-    match pprintConString env t.ident with (env,str) then
+    match pprintConName env t.ident with (env,str) then
       let ty =
         match t.ty with TyUnknown {} then ""
         else concat " : " (getTypeStringCode indent t.ty)
@@ -379,7 +384,7 @@ lang DataPrettyPrint = PrettyPrint + DataAst + UnknownTypeAst
     else never
 
   | TmConApp t ->
-    match pprintConString env t.ident with (env,str) then
+    match pprintConName env t.ident with (env,str) then
       match printParen (pprintIncr indent) env t.body with (env,body) then
         (env, join [str, pprintNewline (pprintIncr indent), body])
       else never
@@ -553,8 +558,8 @@ end
 lang PatNamePrettyPrint = IdentifierPrettyPrint
   sem _pprint_patname (env : PprintEnv) =
   | PName name ->
-    match pprintEnvGetStr env name with (env, str)
-    then (env, pprintVarString str) else never
+    match pprintVarName env name with (env, str)
+    then (env,str) else never
   | PWildcard () -> (env, "_")
 end
 
@@ -627,7 +632,7 @@ lang DataPatPrettyPrint = DataPat + IdentifierPrettyPrint
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
   | PCon t ->
-    match pprintConString env t.ident with (env,str) then
+    match pprintConName env t.ident with (env,str) then
       match getPatStringCode indent env t.subpat with (env,subpat) then
         let subpat = if patIsAtomic t.subpat then subpat
                      else join ["(", subpat, ")"]
@@ -943,6 +948,20 @@ let func_is123 =
   )
 in
 
+-- let var = 1 in let var1 = 2 in addi var var1
+let n1 = nameSym "var" in
+let n2 = nameSym "var" in
+let var_var =
+  bindall_ [nulet_ n1 (int_ 1), nulet_ n2 (int_ 2), addi_ (nvar_ n1) (nvar_ n2)]
+in
+
+-- let #var"" = 1 in let #var"1" = 2 in addi #var"" #var"1"
+let n1 = nameSym "" in
+let n2 = nameSym "" in
+let empty_empty =
+  bindall_ [nulet_ n1 (int_ 1), nulet_ n2 (int_ 2), addi_ (nvar_ n1) (nvar_ n2)]
+in
+
 let sample_ast =
   bindall_ [
     func_foo,
@@ -957,7 +976,9 @@ let sample_ast =
     func_addone,
     func_beginsWithBinaryDigit,
     func_pedanticIsSome,
-    func_is123
+    func_is123,
+    var_var,
+    empty_empty
   ]
 in
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -51,8 +51,7 @@ let pprintEnvFree : String -> PprintEnv -> Bool = lam str. lam env.
   match env with { nameMap = nameMap } then
     let f = lam _. lam v. eqString str v in
     not (assocAny f nameMap)
-  else
-    never
+  else never
 
 -- Add a binding to the environment
 let pprintEnvAdd : Name -> String -> Int -> PprintEnv -> PprintEnv =
@@ -141,7 +140,7 @@ let _record2tuple = lam tm.
 lang IdentifierPrettyPrint
   sem pprintConName (env : PprintEnv) =    -- Constructor string parser translation
   sem pprintVarName (env : PprintEnv) =    -- Variable string parser translation
-  sem pprintLabelString =                    -- Label string parser translation for records
+  sem pprintLabelString =                  -- Label string parser translation for records
 end
 
 lang MExprIdentifierPrettyPrint = IdentifierPrettyPrint

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -51,7 +51,8 @@ let pprintEnvFree : String -> PprintEnv -> Bool = lam str. lam env.
   match env with { nameMap = nameMap } then
     let f = lam _. lam v. eqString str v in
     not (assocAny f nameMap)
-  else never
+  else
+    never
 
 -- Add a binding to the environment
 let pprintEnvAdd : Name -> String -> Int -> PprintEnv -> PprintEnv =
@@ -140,12 +141,15 @@ end
 
 lang MExprIdentifierPrettyPrint = IdentifierPrettyPrint
   sem pprintConString (env: PprintEnv) =
-  | str ->
-    let s = _parserStr str "#con" (lam str. isUpperAlpha (head str)) in
-    pprintEnvGetStr env s
+  | name ->
+    match pprintEnvGetStr env name with (env,str) then
+      let s = _parserStr str "#con" (lam str. isUpperAlpha (head str)) in
+      (env, s)
+    else never
 
   sem pprintVarString =
-  | str -> _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
+  | str ->
+    _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
 
   sem pprintLabelString =
   | str -> _parserStr str "#label" (lam str. isLowerAlphaOrUnderscore (head str))
@@ -866,6 +870,14 @@ let func_mycona = ucondef_ "MyConA" in
 -- con #con"myConB" : (Bool, Int) in
 let func_myconb = condef_ "myConB" (tytuple_ [tybool_, tyint_]) in
 
+-- con MyConA1 in
+-- con MyConA2
+let func_mycona_mycona =
+  let n1 = nameSym "MyConA" in
+  let n2 = nameSym "MyConA" in
+  bindall_ [nucondef_ n1, nucondef_ n2]
+in
+
 -- let isconb : Bool = lam c : #con"myConB".
 --     match c with #con"myConB" (true, 17) then
 --         true
@@ -939,6 +951,7 @@ let sample_ast =
     func_recget,
     func_recconcs,
     func_mycona,
+    func_mycona_mycona,
     func_myconb,
     func_isconb,
     func_addone,

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -102,9 +102,11 @@ let _parserStr = lam str. lam prefix. lam cond.
   else if cond str then str
   else join [prefix, "\"", str, "\""]
 
+-- Variable string parser translation
 let pprintVarString = lam str.
   _parserStr str "#var" (lam str. isLowerAlphaOrUnderscore (head str))
 
+-- Constructor string parser translation
 let pprintConString = lam str.
   _parserStr str "#con" (lam str. isUpperAlpha (head str))
 ----------------------
@@ -138,8 +140,8 @@ let _record2tuple = lam tm.
 -----------
 
 lang IdentifierPrettyPrint
-  sem pprintConName (env : PprintEnv) =    -- Constructor string parser translation
-  sem pprintVarName (env : PprintEnv) =    -- Variable string parser translation
+  sem pprintConName (env : PprintEnv) =    
+  sem pprintVarName (env : PprintEnv) =
   sem pprintLabelString =                  -- Label string parser translation for records
 end
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -562,7 +562,7 @@ end
 -- PATTERNS --
 --------------
 
-lang PrettyPrintPatName = IdentifierPrettyPrint
+lang PatNamePrettyPrint = IdentifierPrettyPrint
   sem _pprint_patname (env : PprintEnv) =
   | PName name ->
     match pprintEnvGetStr env name with (env, str)
@@ -570,7 +570,7 @@ lang PrettyPrintPatName = IdentifierPrettyPrint
   | PWildcard () -> (env, "_")
 end
 
-lang NamedPatPrettyPrint = NamedPat + PrettyPrintPatName
+lang NamedPatPrettyPrint = NamedPat + PatNamePrettyPrint
   sem patIsAtomic =
   | PNamed _ -> true
 
@@ -602,7 +602,7 @@ lang SeqTotPatPrettyPrint = SeqTotPat + CharPat
   | PSeqTot {pats = pats} -> _pprint_patseq getPatStringCode indent env pats
 end
 
-lang SeqEdgePatPrettyPrint = SeqEdgePat + PrettyPrintPatName
+lang SeqEdgePatPrettyPrint = SeqEdgePat + PatNamePrettyPrint
   sem patIsAtomic =
   | PSeqEdge _ -> false
 

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -38,7 +38,7 @@ let _runCommand : String->String->String->ExecResult =
     in
     {stdout=stdout, stderr=stderr, returncode=returncode}
 
-let compile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
+let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
   let dunefile = "(executable (name program) (libraries batteries boot))" in
   let td = pycall _tempfile "TemporaryDirectory" () in
   let dir = pythonGetAttr td "name" in
@@ -69,7 +69,7 @@ let compile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
         let command =
           concat ["dune", "exec", "./program.exe", "--"] args
         in
-          _runCommand command stdin (tempfile ""),
+        _runCommand command stdin (tempfile ""),
     cleanup =
       lam _.
         let _ = pycall _shutil "rmtree" (dir,) in
@@ -79,27 +79,28 @@ let compile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
 mexpr
 
 let sym =
-  compile "print_int (Boot.Intrinsics.Mseq.length Boot.Intrinsics.Mseq.empty)"
+  ocamlCompile
+  "print_int (Boot.Intrinsics.Mseq.length Boot.Intrinsics.Mseq.empty)"
 in
 
 let hello =
-  compile "print_string \"Hello World!\""
+  ocamlCompile "print_string \"Hello World!\""
 in
 
 let echo =
-  compile "print_string (read_line ())"
+  ocamlCompile "print_string (read_line ())"
 in
 
 let args =
-  compile "print_string (Sys.argv.(1))"
+  ocamlCompile "print_string (Sys.argv.(1))"
 in
 
 let err =
-  compile "Printf.eprintf \"Hello World!\""
+  ocamlCompile "Printf.eprintf \"Hello World!\""
 in
 
 let manyargs =
-  compile "Printf.eprintf \"%s %s\" (Sys.argv.(1)) (Sys.argv.(2))"
+  ocamlCompile "Printf.eprintf \"%s %s\" (Sys.argv.(1)) (Sys.argv.(2))"
 in
 
 utest (sym.run "" []).stdout with "0" in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -73,10 +73,11 @@ let _seqOpHashMap =
         hashmapEmpty _seqOps
 
 let _seqOp = lam op.
-  nvar_ (hashmapLookupOrElse
-    hashmapStrTraits
-    (lam _. error (strJoin " " ["Operation", op, "not found"]))
-    op _seqOpHashMap)
+  nvar_
+  (hashmapLookupOrElse hashmapStrTraits
+                       (lam _. error (strJoin " " ["Operation", op, "not found"]))
+                       op
+                       _seqOpHashMap)
 
 lang OCamlGenerate = MExprAst + OCamlAst
   sem generateConst =

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -9,49 +9,6 @@ include "mexpr/eq.mc"
 include "ocaml/compile.mc"
 include "hashmap.mc"
 
-let defaultIdentName = "_var"
-
-let escapeFirstChar = lam c.
-  if isLowerAlphaOrUnderscore c then c
-  else '_'
-
-utest map escapeFirstChar "abcABC/:@_'" with "abc________"
-
-let escapeChar = lam c.
-  if or (isAlphanum c) (or (eqChar c '_') (eqChar c '\'')) then c
-  else '_'
-
-utest map escapeChar "abcABC/:@_'" with "abcABC____'"
-
-let escapeString = lam s.
-  let n = length s in
-  if gti n 0 then
-    let hd = head s in
-    let tl = tail s in
-    if or (neqi n 1) (isLowerAlpha hd) then
-      cons (escapeFirstChar hd) (map escapeChar tl)
-    else
-      defaultIdentName
-  else
-    defaultIdentName
-
-utest escapeString "abcABC/:@_'" with "abcABC____'"
-utest escapeString "" with defaultIdentName
-utest escapeString "@" with defaultIdentName
-utest escapeString "ABC123" with "_BC123"
-utest escapeString "'a/b/c" with "_a_b_c"
-utest escapeString "123" with "_23"
-
-let escapeName = lam n.
-  match n with (str,symb) then (escapeString str, symb)
-  else never
-
-utest (escapeName ("abcABC/:@_'", gensym ())).0
-with ("abcABC____'", gensym ()).0
-
-utest (escapeName ("ABC123", gensym ())).0
-with ("_BC123", gensym ()).0
-
 let _seqOps = [
   "make",
   "empty",
@@ -92,22 +49,6 @@ lang OCamlGenerate = MExprAst + OCamlAst
   | v -> TmConst { val = v }
 
   sem generate =
-  | TmVar t -> TmVar {t with ident = escapeName t.ident}
-  | TmLam t ->
-      TmLam {ident = escapeName t.ident,
-             ty = t.ty,
-             body = generate t.body}
-  | TmLet t ->
-      TmLet {ident = escapeName t.ident,
-             ty = t.ty,
-             body = generate t.body,
-             inexpr = generate t.inexpr}
-  | TmRecLets t ->
-      let bs = map (lam b. {{b with ident = escapeName b.ident}
-                               with body = generate b.body})
-                   t.bindings
-      in
-      TmRecLets {bindings = bs, inexpr = generate t.inexpr}
   | TmSeq {tms = tms} ->
     let tms = map generate tms in
     foldr (lam tm. lam a. appSeq_ (_seqOp "cons") [tm, a])
@@ -123,61 +64,6 @@ lang OCamlTest = OCamlGenerate + OCamlPrettyPrint + MExprSym + ConstEq
 mexpr
 
 use OCamlTest in
-
--- Test identifier escaping
-
--- Vars
-utest generate (var_ "abcABC/:@_'") with var_ "abcABC____'" in
-
--- Abstractions
-utest generate (ulam_ "ABC123" (ulam_ "'a/b/c" (app_ (var_ "ABC123")
-                                               (var_ "'a/b/c"))))
-with ulam_ "_BC123" (ulam_ "_a_b_c" (app_ (var_ "_BC123")
-                                          (var_ "_a_b_c")))
-in
-
--- Lets
-utest generate (ulet_ "abcABC/:@_'" (var_ "abcABC/:@_'"))
-with (ulet_ "abcABC____'" (var_ "abcABC____'")) in
-
-let testRec =
-  bind_
-    (ureclets_add "abcABC/:@_'" (ulam_ "ABC123"
-                               (app_ (var_ "abcABC/:@_'")
-                                     (var_ "ABC123")))
-      reclets_empty)
-    (app_ (var_ "abcABC/:@_'") (int_ 1))
-in
-
-let testRecExpected =
-  bind_
-    (ureclets_add "abcABC____'" (ulam_ "_BC123"
-                               (app_ (var_ "abcABC____'")
-                               (var_ "_BC123")))
-      reclets_empty)
-    (app_ (var_ "abcABC____'") (int_ 1))
-in
-
-utest generate testRec with testRecExpected in
-
-let mutRec =
-  bind_
-    (ureclets_add "'a/b/c" (ulam_ "" (app_ (var_ "123") (var_ "")))
-      (ureclets_add "123" (ulam_ "" (app_ (var_ "'a/b/c") (var_ "")))
-         reclets_empty))
-    (app_ (var_ "'a/b/c") (int_ 1))
-in
-let mutRecExpected =
-  bind_
-    (ureclets_add "_a_b_c" (ulam_ defaultIdentName (app_ (var_ "_23")
-                                             (var_ defaultIdentName)))
-      (ureclets_add "_23" (ulam_ defaultIdentName (app_ (var_ "_a_b_c")
-                                            (var_ defaultIdentName)))
-        reclets_empty))
-    (app_ (var_ "_a_b_c") (int_ 1))
-in
-
-utest generate mutRec with mutRecExpected in
 
 -- Test semantics
 

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -190,7 +190,7 @@ in
 let ocamlEval = lam p. lam strConvert.
   let subprocess = pyimport "subprocess" in
   let blt = pyimport "builtins" in
-    let res = compile (join ["print_string (", strConvert, "(", p, "))"]) in
+    let res = ocamlCompile (join ["print_string (", strConvert, "(", p, "))"]) in
     let out = (res.run "" []).stdout in
     let _ = res.cleanup () in
     parseAsMExpr out

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -5,22 +5,139 @@ include "mexpr/pprint.mc"
 include "char.mc"
 include "name.mc"
 
+let defaultIdentName = "_var"
+
+let escapeFirstChar = lam c.
+  if isLowerAlphaOrUnderscore c then c
+  else '_'
+
+utest map escapeFirstChar "abcABC/:@_'" with "abc________"
+
+let isValidChar = lam c.
+  or (isAlphanum c) (or (eqChar c '_') (eqChar c '\''))
+
+let escapeChar = lam c.
+  if isValidChar c then c else '_'
+
+utest map escapeChar "abcABC/:@_'" with "abcABC____'"
+
+let isIdentifierString = lam s.
+  let n = length s in
+  if null s then false
+  else if gti n 1 then
+    let hd = head s in
+    let tl = tail s in
+    and (isLowerAlphaOrUnderscore hd) (all isValidChar tl)
+  else
+    all isLowerAlpha s
+
+utest isIdentifierString "__" with true
+utest isIdentifierString "_1" with true
+utest isIdentifierString "_A" with true
+utest isIdentifierString "a" with true
+utest isIdentifierString "a123" with true
+utest isIdentifierString "aA" with true
+utest isIdentifierString "_" with false
+utest isIdentifierString "A" with false
+utest isIdentifierString "AA" with false
+utest isIdentifierString "__*" with false
+utest isIdentifierString "" with false
+
+let isModuleString = lam s.
+  if not (null s) then
+    if isUpperAlpha (head s) then
+      let s = cons (char2lower (head s)) (tail s) in
+      isIdentifierString s
+    else false
+  else
+    false
+
+utest isModuleString "A" with true
+utest isModuleString "ABCD" with true
+utest isModuleString "AbCd" with true
+utest isModuleString "Aa123" with true
+utest isModuleString "A_" with true
+utest isModuleString "__" with false
+utest isModuleString "a" with false
+utest isModuleString "_" with false
+utest isModuleString "aa" with false
+utest isModuleString "A*" with false
+utest isModuleString "1a" with false
+utest isModuleString "1" with false
+utest isModuleString "aA" with false
+utest isModuleString "" with false
+
+let isModuleCallString = lam s.
+  let parts = strSplit "." s in
+  let modules = init parts in
+  if null modules then false
+  else
+    and (all isModuleString modules) (isIdentifierString (last parts))
+
+utest isModuleCallString "Foo.bar" with true
+utest isModuleCallString "A.B.C.D.E.F.G.hello" with true
+utest isModuleCallString "Foo.Bar.foo" with true
+utest isModuleCallString "Foo.Bar.__" with true
+utest isModuleCallString "Foo.Bar._a" with true
+utest isModuleCallString "Foo.Bar._A" with true
+utest isModuleCallString "Foo.Bar._" with false
+utest isModuleCallString "Foo.Bar.A" with false
+utest isModuleCallString "Foo.Bar.*" with false
+utest isModuleCallString "a" with false
+utest isModuleCallString "A" with false
+utest isModuleCallString "_a" with false
+utest isModuleCallString "Foo.@" with false
+utest isModuleCallString "foo.bar" with false
+utest isModuleCallString "Foo.bar.foo" with false
+utest isModuleCallString "Foo.B@r.foo" with false
+utest isModuleCallString "foo.Bar.foo" with false
+
+let escapeString = lam s.
+  let n = length s in
+  if gti n 0 then
+    if isModuleCallString s then
+      s
+    else
+      let hd = head s in
+      let tl = tail s in
+      if or (neqi n 1) (isLowerAlpha hd) then
+        cons (escapeFirstChar hd) (map escapeChar tl)
+      else
+        defaultIdentName
+  else
+    defaultIdentName
+
+utest escapeString "abcABC/:@_'" with "abcABC____'"
+utest escapeString "" with defaultIdentName
+utest escapeString "@" with defaultIdentName
+utest escapeString "ABC123" with "_BC123"
+utest escapeString "'a/b/c" with "_a_b_c"
+utest escapeString "123" with "_23"
+
+let escapeName = lam n.
+  match n with (str,symb) then (escapeString str, symb)
+  else never
+
+utest (escapeName ("abcABC/:@_'", gensym ())).0
+with ("abcABC____'", gensym ()).0
+
+utest (escapeName ("ABC123", gensym ())).0
+with ("_BC123", gensym ()).0
+
 lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
                         + LetPrettyPrint + ConstPrettyPrint + OCamlAst
                         + IdentifierPrettyPrint
 
-  sem pprintVarString =
-  | s -> s
+  sem pprintVarName (env : PprintEnv) =
+  | name -> pprintEnvGetStr env (escapeName name)
   sem pprintLabelString =
-  | s -> s
-  sem pprintConString =
   | s -> s
 
   sem isAtomic =
   | TmLam _ -> false
   | TmRecLets _ -> false
 
-  sem _pprintBinding (indent : Int) (env: PPrintEnv) =
+  sem _pprintBinding (indent : Int) (env: PprintEnv) =
   | {ident = id, body = b} ->
     join [nameGetStr id, " = ", pprintCode indent b]
 
@@ -49,18 +166,16 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | CLtf _ -> "(<)"
   | CChar {val = c} -> show_char c
 
-  sem pprintCode (indent : Int) (env: PPrintEnv) =
+  sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmLam {ident = id, body = b} ->
-    match pprintEnvGetStr env id with (env,str) then
-      let ident = str in
+    match pprintVarName env id with (env,str) then
       match pprintCode (pprintIncr indent) env b with (env,body) then
-        (env,join ["fun ", ident, " ->",
-         pprintNewline (pprintIncr indent), body])
+        (env,join ["fun ", str, " ->", pprintNewline (pprintIncr indent), body])
       else never
     else never
   | TmRecLets {bindings = bindings, inexpr = inexpr} ->
     let lname = lam env. lam bind.
-      match pprintEnvGetStr env bind.ident with (env,str) then
+      match pprintVarName env bind.ident with (env,str) then
         (env, str)
       else never in
     let lbody = lam env. lam bind.
@@ -89,36 +204,36 @@ lang TestLang = OCamlPrettyPrint + MExprSym
 mexpr
 use TestLang in
 
-let pprintProg = lam mexprAst.
+let pprintProg = lam ast.
   let _ = print "\n\n" in
-  print (expr2str (symbolize mexprAst))
+  print (expr2str (symbolize ast))
 in
 
-let addInt1 = addi_ (int_ 1) (int_ 2) in
+let testAddInt1 = addi_ (int_ 1) (int_ 2) in
 
-let addInt2 = addi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+let testAddInt2 = addi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
 
-let addFloat1 = addf_ (float_ 1.) (float_ 2.) in
+let testAddFloat1 = addf_ (float_ 1.) (float_ 2.) in
 
-let addFloat2 = addf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+let testAddFloat2 = addf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
 
-let negFloat = negf_ (float_ 1.) in
+let testNegFloat = negf_ (float_ 1.) in
 
-let boolNot = not_ (not_ true_) in
+let testBoolNot = not_ (not_ true_) in
 
-let compareInt1 = eqi_ (int_ 1) (int_ 2) in
+let testCompareInt1 = eqi_ (int_ 1) (int_ 2) in
 
-let compareInt2 = lti_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+let testCompareInt2 = lti_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
 
-let compareFloat1 = eqf_ (float_ 1.) (float_ 2.) in
+let testCompareFloat1 = eqf_ (float_ 1.) (float_ 2.) in
 
-let compareFloat2 =
+let testCompareFloat2 =
   lti_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.)
 in
 
-let charLiteral = char_ 'c' in
+let testCharLiteral = char_ 'c' in
 
-let fun = ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) in
+let testFun = ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) in
 
 let testLet =
   bindall_ [ulet_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)]
@@ -131,7 +246,7 @@ let testRec =
     (app_ (var_ "foo") (int_ 1))
 in
 
-let mutRec =
+let testMutRec =
   bind_
     (ureclets_add "foo" (ulam_ "x" (app_ (var_ "bar") (var_ "x")))
       (ureclets_add "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
@@ -139,22 +254,53 @@ let mutRec =
     (app_ (var_ "foo") (int_ 1))
 in
 
+-- Test identifier escapingvar
+
+-- Abstractions
+let testLamEscape = (ulam_ "ABC123" (ulam_ "'a/b/c" (app_ (var_ "ABC123")
+                                                          (var_ "'a/b/c"))))
+in
+
+-- Lets
+let testLetEscape = bind_ (ulet_ "abcABC/:@_'" (int_ 1)) (var_ "abcABC/:@_'") in
+
+let testRecEscape =
+  bind_
+    (ureclets_add "abcABC/:@_'" (ulam_ "ABC123"
+                               (app_ (var_ "abcABC/:@_'")
+                                     (var_ "ABC123")))
+      reclets_empty)
+    (app_ (var_ "abcABC/:@_'") (int_ 1))
+in
+
+let testMutRecEscape =
+  bind_
+    (ureclets_add "'a/b/c" (ulam_ "" (app_ (var_ "123") (var_ "")))
+      (ureclets_add "123" (ulam_ "" (app_ (var_ "'a/b/c") (var_ "")))
+         reclets_empty))
+    (app_ (var_ "'a/b/c") (int_ 1))
+in
+
 let asts = [
-  addInt1,
-  addInt2,
-  addFloat1,
-  addFloat2,
-  negFloat,
-  boolNot,
-  compareInt1,
-  compareInt2,
-  compareFloat1,
-  compareFloat2,
-  charLiteral,
-  fun,
+  testAddInt1,
+  testAddInt2,
+  testAddFloat1,
+  testAddFloat2,
+  testNegFloat,
+  testBoolNot,
+  testCompareInt1,
+  testCompareInt2,
+  testCompareFloat1,
+  testCompareFloat2,
+  testCharLiteral,
+  testFun,
   testLet,
   testRec,
-  mutRec
+  testMutRec,
+  testLamEscape,
+  testLetEscape,
+  testRecEscape,
+  testMutRecEscape
 ] in
 
 -- let _ = map pprintProg asts in

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -7,6 +7,14 @@ include "name.mc"
 
 lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
                         + LetPrettyPrint + ConstPrettyPrint + OCamlAst
+                        + IdentifierPrettyPrint
+
+  sem pprintVarString =
+  | s -> s
+  sem pprintLabelString =
+  | s -> s
+  sem pprintConString =
+  | s -> s
 
   sem isAtomic =
   | TmLam _ -> false


### PR DESCRIPTION
In this PR we:
- Re-factored identifier pretty printing into a language fragment `IdentifierPrettyPrint`.
- Synchronized sequence intrinsics between `boot` and the interpreter. 
- Implemented compilation of sequence intrinsics. `splitAt` is not tested since we cannot yet compile tuple projection.
- Moved responsibility of pretty printing names (as defined in `name.mc`) to `IdentifierPrettyPrint`.
- Moved ocaml name-escaping from `generate.mc` to `pprint.mc` (via `IdentifierPrettyPrint`). We don't escape valid fully qualified identifiers.