### PR TITLE
Preparation for MExpr type lifting

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -311,64 +311,37 @@ let rec map_tm f = function
 
 (* Returns the info field from a term *)
 let tm_info = function
-  | TmVar (fi, _, _) ->
-      fi
-  | TmLam (fi, _, _, _, _) ->
-      fi
-  | TmClos (fi, _, _, _, _) ->
-      fi
-  | TmLet (fi, _, _, _, _, _) ->
-      fi
-  | TmType (fi, _, _, _, _) ->
-      fi
-  | TmRecLets (fi, _, _) ->
-      fi
-  | TmApp (fi, _, _) ->
-      fi
-  | TmConst (fi, _) ->
-      fi
-  | TmFix fi ->
-      fi
-  | TmSeq (fi, _) ->
-      fi
-  | TmRecord (fi, _) ->
-      fi
-  | TmRecordUpdate (fi, _, _, _) ->
-      fi
-  | TmCondef (fi, _, _, _, _) ->
-      fi
-  | TmConapp (fi, _, _, _) ->
-      fi
-  | TmMatch (fi, _, _, _, _) ->
-      fi
-  | TmUse (fi, _, _) ->
-      fi
-  | TmUtest (fi, _, _, _, _) ->
-      fi
+  | TmVar (fi, _, _)
+  | TmLam (fi, _, _, _, _)
+  | TmClos (fi, _, _, _, _)
+  | TmLet (fi, _, _, _, _, _)
+  | TmType (fi, _, _, _, _)
+  | TmRecLets (fi, _, _)
+  | TmApp (fi, _, _)
+  | TmConst (fi, _)
+  | TmFix fi
+  | TmSeq (fi, _)
+  | TmRecord (fi, _)
+  | TmRecordUpdate (fi, _, _, _)
+  | TmCondef (fi, _, _, _, _)
+  | TmConapp (fi, _, _, _)
+  | TmMatch (fi, _, _, _, _)
+  | TmUse (fi, _, _)
+  | TmUtest (fi, _, _, _, _)
   | TmNever fi ->
       fi
 
 let pat_info = function
-  | PatNamed (fi, _) ->
-      fi
-  | PatSeqTot (fi, _) ->
-      fi
-  | PatSeqEdge (fi, _, _, _) ->
-      fi
-  | PatRecord (fi, _) ->
-      fi
-  | PatCon (fi, _, _, _) ->
-      fi
-  | PatInt (fi, _) ->
-      fi
-  | PatChar (fi, _) ->
-      fi
-  | PatBool (fi, _) ->
-      fi
-  | PatAnd (fi, _, _) ->
-      fi
-  | PatOr (fi, _, _) ->
-      fi
+  | PatNamed (fi, _)
+  | PatSeqTot (fi, _)
+  | PatSeqEdge (fi, _, _, _)
+  | PatRecord (fi, _)
+  | PatCon (fi, _, _, _)
+  | PatInt (fi, _)
+  | PatChar (fi, _)
+  | PatBool (fi, _)
+  | PatAnd (fi, _, _)
+  | PatOr (fi, _, _)
   | PatNot (fi, _) ->
       fi
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -154,27 +154,42 @@ and program = Program of include_ list * top list * tm
 
 (* Terms in MExpr *)
 and tm =
-  | TmVar of info * ustring * Symb.t (* Variable *)
-  | TmLam of info * ustring * Symb.t * ty * tm (* Lambda abstraction *)
-  | TmLet of info * ustring * Symb.t * ty * tm * tm (* Let *)
-  | TmType of info * ustring * Symb.t * ty * tm (* Type let *)
-  | TmRecLets of info * (info * ustring * Symb.t * ty * tm) list * tm (* Recursive lets *)
-  | TmApp of info * tm * tm (* Application *)
-  | TmConst of info * const (* Constant *)
-  | TmSeq of info * tm Mseq.t (* Sequence *)
-  | TmRecord of info * tm Record.t (* Record *)
-  | TmRecordUpdate of info * tm * ustring * tm (* Record update *)
-  | TmCondef of info * ustring * Symb.t * ty * tm (* Constructor definition *)
-  | TmConapp of info * ustring * Symb.t * tm (* Constructor application *)
-  | TmMatch of info * tm * pat * tm * tm (* Match data *)
-  | TmUse of info * ustring * tm (* Use a language *)
-  | TmUtest of info * tm * tm * tm option * tm (* Unit testing *)
-  | TmNever of info (* Never term *)
+  (* Variable *)
+  | TmVar of info * ustring * Symb.t
+  (* Lambda abstraction *)
+  | TmLam of info * ustring * Symb.t * ty * tm
+  (* Let *)
+  | TmLet of info * ustring * Symb.t * ty * tm * tm
+  (* Type let *)
+  | TmType of info * ustring * Symb.t * ty * tm
+  (* Recursive lets *)
+  | TmRecLets of info * (info * ustring * Symb.t * ty * tm) list * tm
+  (* Application *)
+  | TmApp of info * tm * tm
+  (* Constant *)
+  | TmConst of info * const
+  (* Sequence *)
+  | TmSeq of info * tm Mseq.t
+  (* Record *)
+  | TmRecord of info * tm Record.t
+  (* Record update *)
+  | TmRecordUpdate of info * tm * ustring * tm
+  (* Constructor definition *)
+  | TmCondef of info * ustring * Symb.t * ty * tm
+  (* Constructor application *)
+  | TmConapp of info * ustring * Symb.t * tm
+  (* Match data *)
+  | TmMatch of info * tm * pat * tm * tm
+  (* Use a language *)
+  | TmUse of info * ustring * tm
+  (* Unit testing *)
+  | TmUtest of info * tm * tm * tm option * tm
+  (* Never term *)
+  | TmNever of info
   (* Only part of the runtime system *)
   | TmClos of info * ustring * Symb.t * tm * env Lazy.t (* Closure *)
+  (* Fix point *)
   | TmFix of info
-
-(* Fix point *)
 
 (* Kind of pattern name *)
 and patName =
@@ -185,44 +200,64 @@ and patName =
 
 (* Patterns *)
 and pat =
-  | PatNamed of info * patName (* Named, capturing wildcard *)
-  | PatSeqTot of info * pat Mseq.t (* Exact sequence patterns *)
-  | PatSeqEdge of info * pat Mseq.t * patName * pat Mseq.t (* Sequence edge patterns *)
-  | PatRecord of info * pat Record.t (* Record pattern *)
-  | PatCon of info * ustring * Symb.t * pat (* Constructor pattern *)
-  | PatInt of info * int (* Int pattern *)
-  | PatChar of info * int (* Char pattern *)
-  | PatBool of info * bool (* Boolean pattern *)
-  | PatAnd of info * pat * pat (* And pattern *)
-  | PatOr of info * pat * pat (* Or pattern *)
+  (* Named, capturing wildcard *)
+  | PatNamed of info * patName
+  (* Exact sequence patterns *)
+  | PatSeqTot of info * pat Mseq.t
+  (* Sequence edge patterns *)
+  | PatSeqEdge of info * pat Mseq.t * patName * pat Mseq.t
+  (* Record pattern *)
+  | PatRecord of info * pat Record.t
+  (* Constructor pattern *)
+  | PatCon of info * ustring * Symb.t * pat
+  (* Int pattern *)
+  | PatInt of info * int
+  (* Char pattern *)
+  | PatChar of info * int
+  (* Boolean pattern *)
+  | PatBool of info * bool
+  (* And pattern *)
+  | PatAnd of info * pat * pat
+  (* Or pattern *)
+  | PatOr of info * pat * pat
+  (* Not pattern *)
   | PatNot of info * pat
-
-(* Not pattern *)
 
 (* Types *)
 and ty =
-  | TyUnknown of info (* Unknown type *)
-  | TyBool of info (* Boolean type *)
-  | TyInt of info (* Int type *)
-  | TyFloat of info (* Floating-point type *)
-  | TyChar of info (* Character type *)
-  | TyArrow of info * ty * ty (* Function type *)
-  | TySeq of info * ty (* Sequence type *)
-  | TyRecord of info * ty Record.t (* Record type *)
-  | TyVariant of info * (ustring * Symb.t * ty) list (* Variant type *)
-  | TyVar of info * ustring * Symb.t (* Type variables *)
+  (* Unknown type *)
+  | TyUnknown of info
+  (* Boolean type *)
+  | TyBool of info
+  (* Int type *)
+  | TyInt of info
+  (* Floating-point type *)
+  | TyFloat of info
+  (* Character type *)
+  | TyChar of info
+  (* Function type *)
+  | TyArrow of info * ty * ty
+  (* Sequence type *)
+  | TySeq of info * ty
+  (* Record type *)
+  | TyRecord of info * ty Record.t
+  (* Variant type *)
+  | TyVariant of info * (ustring * Symb.t * ty) list
+  (* Type variables *)
+  | TyVar of info * ustring * Symb.t
+  (* Type application, currently only used for documenation purposes *)
   | TyApp of info * ty * ty
-
-(* Type application, currently only used for documenation purposes *)
 
 (* Kind of identifier *)
 and ident =
-  | IdVar of sid (* A variable identifier *)
-  | IdCon of sid (* A constructor identifier *)
-  | IdType of sid (* A type identifier *)
+  (* A variable identifier *)
+  | IdVar of sid
+  (* A constructor identifier *)
+  | IdCon of sid
+  (* A type identifier *)
+  | IdType of sid
+  (* A label identifier *)
   | IdLabel of sid
-
-(* A label identifier *)
 
 let tmUnit = TmRecord (NoInfo, Record.empty)
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -242,7 +242,7 @@ and ty =
   (* Record type *)
   | TyRecord of info * ty Record.t
   (* Variant type *)
-  | TyVariant of info * (ustring * Symb.t * ty) list
+  | TyVariant of info * (ustring * Symb.t) list
   (* Type variables *)
   | TyVar of info * ustring * Symb.t
   (* Type application, currently only used for documenation purposes *)

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -205,10 +205,11 @@ and ty =
   | TyChar (* Character type *)
   | TyArrow of ty * ty (* Function type *)
   | TySeq of ty (* Sequence type *)
-  | TyTuple of ty list (* Tuple type *)
+  | TyTuple of ty list (* Tuple type *) (* TODO: Remove? Subsumed by record *)
   | TyRecord of (ustring * ty) list (* Record type *)
-  | TyCon of ustring (* Type constructor *)
+  | TyCon of ustring (* Type constructor *) (* TODO: TyVar + TyLam instead? *)
   | TyApp of (ty * ty)
+  (* TODO: Add TyVariant, so that the meaning of "type Type in" can be parsed as "type Type = TyVariant { types = []} in" *)
 
 (* Type constructor application *)
 

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -823,7 +823,7 @@ let findsym fi id env =
       | IdCon x ->
           (x, "constructor")
       | IdType x ->
-          (x, "type")
+          (x, "type variable")
       | IdLabel x ->
           (x, "label")
     in

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -250,8 +250,16 @@ mexpr:
       { $1 }
   | TYPE type_ident IN mexpr
       { $4 }
+  //    { -- Type parameters are currently ignored
+  //      let fi = mkinfo $1.i $5.i in
+  //      TmDeclTy(fi, $2.v, Symb.Helpers.nosym, $5) }
+
   | TYPE type_ident EQ ty IN mexpr
       { $6 }
+  //    { -- Type parameters are currently ignored
+  //      let fi = mkinfo $1.i $6.i in
+  //      TmLetTy(fi, $2.v, Symb.Helpers.nosym, $4, $6) }
+
   | REC lets IN mexpr
       { let fi = mkinfo $1.i $3.i in
         let lst = List.map (fun (fi,x,ty,t) -> (fi,x,Symb.Helpers.nosym,ty,t)) $2 in

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -124,11 +124,6 @@ tops:
     { $1 :: $2 }
   |
     { [] }
-  // TODO(?,?): These should matter with a type system
-  | TYPE type_ident type_params tops
-    { $4 }
-  | TYPE type_ident type_params EQ ty tops
-    { $6 }
 
 type_params:
   | type_ident type_params
@@ -141,6 +136,8 @@ top:
     { TopLang($1) }
   | toplet
     { TopLet($1) }
+  | toptype
+    { TopType($1) }
   | topRecLet
     { TopRecLet($1) }
   | topcon
@@ -152,6 +149,16 @@ toplet:
   | LET var_ident ty_op EQ mexpr
     { let fi = mkinfo $1.i $4.i in
       Let (fi, $2.v, $3, $5) }
+
+toptype:
+  | TYPE type_ident type_params
+     // Type parameters are currently ignored
+     { let fi = mkinfo $1.i $2.i in
+       Type (fi, $2.v, TyVariant (fi, [])) }
+  | TYPE type_ident type_params EQ ty
+     // Type parameters are currently ignored
+     { let fi = mkinfo $1.i (ty_info $5) in
+       Type (fi, $2.v, $5) }
 
 topRecLet:
   | REC lets END
@@ -223,7 +230,7 @@ constr_params:
   | ty
     { $1 }
   |
-    { TyUnit }
+    { tyUnit NoInfo }
 
 params:
   | LPAREN var_ident COLON ty RPAREN params
@@ -248,18 +255,14 @@ case:
 mexpr:
   | left
       { $1 }
-  | TYPE type_ident IN mexpr
-      { $4 }
-  //    { -- Type parameters are currently ignored
-  //      let fi = mkinfo $1.i $5.i in
-  //      TmDeclTy(fi, $2.v, Symb.Helpers.nosym, $5) }
-
-  | TYPE type_ident EQ ty IN mexpr
-      { $6 }
-  //    { -- Type parameters are currently ignored
-  //      let fi = mkinfo $1.i $6.i in
-  //      TmLetTy(fi, $2.v, Symb.Helpers.nosym, $4, $6) }
-
+  | TYPE type_ident type_params IN mexpr
+      // Type parameters are currently ignored
+      { let fi = mkinfo $1.i (tm_info $5) in
+        TmType(fi, $2.v, Symb.Helpers.nosym, TyVariant (fi, []), $5) }
+  | TYPE type_ident type_params EQ ty IN mexpr
+      // Type parameters are currently ignored
+      { let fi = mkinfo $1.i (tm_info $7) in
+        TmType(fi, $2.v, Symb.Helpers.nosym, $5, $7) }
   | REC lets IN mexpr
       { let fi = mkinfo $1.i $3.i in
         let lst = List.map (fun (fi,x,ty,t) -> (fi,x,Symb.Helpers.nosym,ty,t)) $2 in
@@ -448,43 +451,46 @@ ty_op:
   | COLON ty
       { $2 }
   |
-      { TyUnknown }
+      { TyUnknown NoInfo }
 
 
 ty:
   | ty_left
       { $1 }
   | ty_left ARROW ty
-      { TyArrow($1,$3) }
+      { let fi = mkinfo (ty_info $1) (ty_info $3) in
+        TyArrow(fi,$1,$3) }
 
 ty_left:
   | ty_atom
     { $1 }
   | ty_left ty_atom
-    { TyApp($1,$2) }
+    { let fi = mkinfo (ty_info $1) (ty_info $2) in
+      TyApp(fi,$1,$2) }
 
 ty_atom:
   | LPAREN RPAREN
-      { TyUnit }
+      { tyUnit (mkinfo $1.i $2.i) }
   | LPAREN ty RPAREN
       { $2 }
   | LSQUARE ty RSQUARE
-      { TySeq($2) }
+      { TySeq(mkinfo $1.i $3.i, $2) }
   | LPAREN ty COMMA ty_list RPAREN
-      { TyTuple ($2::$4) }
+      { tuplety2recordty (mkinfo $1.i $5.i) ($2::$4) }
   | LBRACKET RBRACKET
-      { TyRecord [] }
+      { tyUnit (mkinfo $1.i $2.i) }
   | LBRACKET label_tys RBRACKET
-      { TyRecord($2) }
+      { TyRecord(mkinfo $1.i $3.i, $2 |> List.fold_left
+        (fun acc (k,v) -> Record.add k v acc) Record.empty) }
   | type_ident
       {match Ustring.to_utf8 $1.v with
-       | "Unknown" -> TyUnknown
-       | "Bool"    -> TyBool
-       | "Int"     -> TyInt
-       | "Float"   -> TyFloat
-       | "Char"    -> TyChar
-       | "String"  -> TySeq(TyChar)
-       | s         -> TyCon(us s)
+       | "Unknown" -> TyUnknown $1.i
+       | "Bool"    -> TyBool $1.i
+       | "Int"     -> TyInt $1.i
+       | "Float"   -> TyFloat $1.i
+       | "Char"    -> TyChar $1.i
+       | "String"  -> TySeq($1.i,TyChar $1.i)
+       | s         -> TyVar($1.i,us s,Symb.Helpers.nosym)
       }
 
 ty_list:

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -138,12 +138,10 @@ let rec ustring_of_ty = function
       ^. Ustring.concat (us ",")
            (List.map pprint_ty_label (Record.bindings tys))
       ^. us "}"
-  | TyVariant (_, tys) -> (
-    match tys with
-    | [] ->
-        us "<>"
-    | _ ->
-        failwith "Printing of non-empty variant types not yet supported" )
+  | TyVariant (_, tys) when tys = [] ->
+      us "<>"
+  | TyVariant _ ->
+      failwith "Printing of non-empty variant types not yet supported"
   | TyVar (_, x, s) ->
       ustring_of_var x s
   | TyApp (_, ty1, ty2) ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -388,6 +388,7 @@ and print_tm fmt (prec, t) =
         Match
     | TmLam _ ->
         Lam
+    | TmConapp _
     | TmSeq _ ->
         Semicolon
     | TmApp _ ->
@@ -398,7 +399,6 @@ and print_tm fmt (prec, t) =
     | TmRecord _
     | TmRecordUpdate _
     | TmCondef _
-    | TmConapp _
     | TmUse _
     | TmUtest _
     | TmClos _

--- a/src/boot/lib/repl.ml
+++ b/src/boot/lib/repl.ml
@@ -139,7 +139,12 @@ let eval_with_envs (langs, nss, name2sym, sym2term) term =
 (* Wrap the final mexpr in a lambda application to prevent scope leak *)
 let wrap_mexpr (Program (inc, tops, tm)) =
   let lambda_wrapper =
-    TmLam (NoInfo, us "_", Symb.Helpers.nosym, TyArrow (TyInt, TyUnknown), tm)
+    TmLam
+      ( NoInfo
+      , us "_"
+      , Symb.Helpers.nosym
+      , TyArrow (NoInfo, TyInt NoInfo, TyUnknown NoInfo)
+      , tm )
   in
   let new_tm = TmApp (NoInfo, lambda_wrapper, TmConst (NoInfo, CInt 0)) in
   Program (inc, tops, new_tm)

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -34,6 +34,12 @@ let seq2assoc : AssocTraits k -> [(k,v)] -> AssocMap k v =
   lam traits. lam ls.
     foldl (lam acc. lam t. assocInsert traits t.0 t.1 acc) assocEmpty ls
 
+-- 'assoc2seq traits m' constructs a new sequence of tuples representing the association map 'm'.
+-- The order of the elements in the sequence is unspecified.
+let assoc2seq : AssocTraits k -> AssocMap k v -> [(k,v)] =
+  lam traits. lam m.
+    m
+
 -- 'assocRemove traits k m' returns a new map, where 'k' is not a key. If 'k' is
 -- not a key in 'm', the map remains unchanged after the operation.
 let assocRemove : AssocTraits k -> k -> AssocMap k v -> AssocMap k v =
@@ -152,6 +158,7 @@ let any = assocAny in
 let all = assocAll in
 let insert = assocInsert traits in
 let seq2assoc = seq2assoc traits in
+let assoc2seq = assoc2seq traits in
 let mem = assocMem traits in
 let remove = assocRemove traits in
 let keys = assocKeys traits in
@@ -190,7 +197,11 @@ utest
   then true else false
 with true in
 
-let m = seq2assoc [(1, '1'), (2, '2'), (3, '3')] in
+let seq = [(1, '1'), (2, '2'), (3, '3')] in
+let m = seq2assoc seq in
+
+utest sort (lam l. lam r. subi l.0 r.0) (assoc2seq m)
+with [(1, '1'), (2, '2'), (3, '3')] in
 
 let nextChar = lam c. int2char (addi 1 (char2int c)) in
 

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -110,6 +110,16 @@ lang LetANF = ANF + LetAst
 
 end
 
+lang TypeANF = ANF + TypeAst
+  sem isValue =
+  | TmType _ -> false
+
+  sem normalize (k : Expr -> Expr) =
+  | TmType {ident = ident, ty = ty, inexpr = m1} ->
+    TmType {ident = ident, ty = ty, inexpr = normalizeName k m1}
+
+end
+
 lang RecLetsANF = ANF + RecLetsAst
   sem isValue =
   | TmRecLets _ -> false
@@ -199,8 +209,8 @@ lang NeverANF = ANF + NeverAst
 end
 
 lang MExprANF =
-  VarANF + AppANF + FunANF + RecordANF + LetANF + RecLetsANF + ConstANF +
-  DataANF + MatchANF + UtestANF + SeqANF + NeverANF
+  VarANF + AppANF + FunANF + RecordANF + LetANF + TypeANF + RecLetsANF +
+  ConstANF + DataANF + MatchANF + UtestANF + SeqANF + NeverANF
 
 -----------
 -- TESTS --

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -93,7 +93,7 @@ let tyunknown_ = use MExprAst in
   TyUnknown ()
 
 let tyunit_ = use MExprAst in
-  TyUnit ()
+  TyRecord {fields = assocEmpty}
 
 let tyint_ = use MExprAst in
   TyInt ()
@@ -114,13 +114,15 @@ let tyseq_ = use MExprAst in
   lam ty.
   TySeq {ty = ty}
 
-let tytuple_ = use MExprAst in
-  lam tys.
-  TyTuple {tys = tys}
-
 let tyrecord_ = use MExprAst in
   lam fields.
-  TyRecord {fields = map (lam t. {ident = t.0, ty = t.1}) fields}
+  TyRecord {
+    fields = foldl (lam acc. lam b. assocInsert {eq=eqString} b.0 b.1 acc)
+               assocEmpty fields }
+
+let tytuple_ = use MExprAst in
+  lam tys.
+  tyrecord_ (mapi (lam i. lam t. (int2string i,t)) tys)
 
 let tycon_ = use MExprAst in
   lam ident.
@@ -146,6 +148,8 @@ recursive let bind_ = use MExprAst in
     TmRecLets {t with inexpr = bind_ t.inexpr expr}
   else match letexpr with TmConDef t then
     TmConDef {t with inexpr = bind_ t.inexpr expr}
+  else match letexpr with TmType t then
+    TmType {t with inexpr = bind_ t.inexpr expr}
   else
     expr -- Insert at the end of the chain
 end
@@ -172,6 +176,14 @@ let nulet_ = use MExprAst in
 let ulet_ = use MExprAst in
   lam s. lam body.
   let_ s tyunknown_ body
+
+let ntype_ = use MExprAst in
+  lam n. lam ty.
+  TmType {ident = n, ty = ty, inexpr = unit_}
+
+let type_ = use MExprAst in
+  lam s. lam ty.
+  ntype_ (nameNoSym s) ty
 
 let nreclets_ = use MExprAst in
   lam bs.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -108,7 +108,7 @@ let tychar_ = use MExprAst in
   TyChar ()
 
 let tystr_ = use MExprAst in
-  TyString ()
+  TySeq {ty = tychar_}
 
 let tyseq_ = use MExprAst in
   lam ty.
@@ -124,18 +124,17 @@ let tytuple_ = use MExprAst in
   lam tys.
   tyrecord_ (mapi (lam i. lam t. (int2string i,t)) tys)
 
-let tycon_ = use MExprAst in
-  lam ident.
-  TyCon {ident = ident}
-
 let tyapp_ = use MExprAst in
   lam lhs. lam rhs.
   TyApp {lhs = lhs, rhs = rhs}
 
-let tyvar_ = use MExprAst in
-  lam ident.
-  TyVar {ident = ident}
+let ntyvar_ = use MExprAst in
+  lam n.
+  TyVar {ident = n}
 
+let tyvar_ = use MExprAst in
+  lam s.
+  ntyvar_ (nameNoSym s)
 
 -- Terms --
 -- Methods of binding an expression into a chain of lets/reclets/condefs --

--- a/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -40,6 +40,11 @@ let tmLet = bind_ (ulet_ "y" tmLam) tmVarY in
 utest smap_Expr_Expr map2varX tmLet with bind_ (ulet_ "y" tmVarX) tmVarX in
 utest sfold_Expr_Expr fold2seq [] tmLet with [tmVarY, tmLam] in
 
+let tmTy = bind_ (type_ "X" tyint_) tmVarY in
+
+utest smap_Expr_Expr map2varX tmTy with bind_ (type_ "X" tyint_) tmVarX in
+utest sfold_Expr_Expr fold2seq [] tmTy with [tmVarY] in
+
 
 let tmRecLets = bind_ (ureclets_ [("x", tmApp), ("u", tmVarW)]) tmVarU in
 
@@ -116,6 +121,14 @@ with match_ tmVarX punit_ tmVarX tmVarX in
 utest sfold_Expr_Expr fold2seq [] tmMatch with [tmVarZ, tmVarY, tmApp] in
 
 let tmUtest = utest_ tmApp tmVarY tmVarZ in
+
+utest smap_Expr_Expr map2varX tmUtest with utest_ tmVarX tmVarX tmVarX in
+utest sfold_Expr_Expr fold2seq [] tmUtest with [tmVarZ, tmVarY, tmApp] in
+
+let tmnever = never_ in
+
+utest smap_Expr_Expr map2varX never_ with never_ in
+utest sfold_Expr_Expr fold2seq [] never_ with [] in
 
 utest smap_Expr_Expr map2varX tmUtest with utest_ tmVarX tmVarX tmVarX in
 utest sfold_Expr_Expr fold2seq [] tmUtest with [tmVarZ, tmVarY, tmApp] in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -90,6 +90,25 @@ lang LetAst = VarAst
   | TmLet t -> f (f acc t.body) t.inexpr
 end
 
+-- TODO
+lang TypeAst
+  syn Expr =
+  | TmType {ident  : Name,
+            ty     : Type,
+            inexpr : Expr,
+            fi     : Info}
+
+  sem info =
+  | TmType r -> r.fi
+
+  sem smap_Expr_Expr (f : Expr -> a) =
+  | TmType t -> TmType {t with inexpr = f t.inexpr}
+
+  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
+  | TmType t -> f acc t.inexpr
+end
+
+
 lang RecLetsAst = VarAst
   syn Expr =
   | TmRecLets {bindings : [{ident : Name,
@@ -198,7 +217,11 @@ lang NeverAst
   sem info =
   | TmNever r -> r.fi
 
-  -- TODO(dlunde,2020-09-29): smap, sfold
+  sem smap_Expr_Expr (f : Expr -> a) =
+  | TmNever _ & t -> t
+
+  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
+  | TmNever _ & t -> acc
 end
 
 ---------------
@@ -417,11 +440,6 @@ end
 -- TYPES --
 -----------
 
-lang UnitTypeAst
-  syn Type =
-  | TyUnit {} -- TODO: Remove
-end
-
 lang UnknownTypeAst
   syn Type =
   | TyUnknown {}
@@ -458,15 +476,9 @@ lang SeqTypeAst
   | TySeq {ty : Type}
 end
 
-lang TupleTypeAst
-  syn Type =
-  | TyTuple {tys : [Type]} --TODO Remove
-end
-
 lang RecordTypeAst
   syn Type =
-  | TyRecord {fields : [{ident : String,
-                         ty    : Type}]}
+  | TyRecord {fields : AssocMap String Type}
 end
 
 lang DataTypeAst
@@ -501,8 +513,8 @@ end
 lang MExprAst =
 
   -- Terms
-  VarAst + AppAst + FunAst + RecordAst + LetAst + RecLetsAst + ConstAst +
-  DataAst + MatchAst + UtestAst + SeqAst + NeverAst
+  VarAst + AppAst + FunAst + RecordAst + LetAst + TypeAst + RecLetsAst +
+  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst
 
   -- Constants
   + IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
@@ -513,6 +525,6 @@ lang MExprAst =
   BoolPat + AndPat + OrPat + NotPat
 
   -- Types
-  + FunTypeAst + UnknownTypeAst + UnitTypeAst + CharTypeAst + StringTypeAst +
-  SeqTypeAst + TupleTypeAst + RecordTypeAst + DataTypeAst + IntTypeAst +
+  + FunTypeAst + UnknownTypeAst + CharTypeAst + StringTypeAst +
+  SeqTypeAst + RecordTypeAst + DataTypeAst + IntTypeAst +
   FloatTypeAst + BoolTypeAst + AppTypeAst + TypeVarAst

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -419,7 +419,7 @@ end
 
 lang UnitTypeAst
   syn Type =
-  | TyUnit {}
+  | TyUnit {} -- TODO: Remove
 end
 
 lang UnknownTypeAst
@@ -460,7 +460,7 @@ end
 
 lang TupleTypeAst
   syn Type =
-  | TyTuple {tys : [Type]}
+  | TyTuple {tys : [Type]} --TODO Remove
 end
 
 lang RecordTypeAst
@@ -471,7 +471,7 @@ end
 
 lang DataTypeAst
   syn Type =
-  | TyCon {ident : Name}
+  | TyCon {ident : Name} --TODO: Remove and replace with TyVar
 end
 
 lang AppTypeAst
@@ -481,7 +481,12 @@ end
 
 lang StringTypeAst
   syn Type =
-  | TyString {}
+  | TyString {} --TODO: Remove
+end
+
+lang VariantTypeAst
+  syn Type =
+  | TyVariant {} -- TODO: Add
 end
 
 lang TypeVarAst

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -90,7 +90,6 @@ lang LetAst = VarAst
   | TmLet t -> f (f acc t.body) t.inexpr
 end
 
--- TODO
 lang TypeAst
   syn Expr =
   | TmType {ident  : Name,
@@ -481,9 +480,14 @@ lang RecordTypeAst
   | TyRecord {fields : AssocMap String Type}
 end
 
-lang DataTypeAst
+lang VariantTypeAst
   syn Type =
-  | TyCon {ident : Name} --TODO: Remove and replace with TyVar
+  | TyVariant {constrs : [Name]}
+end
+
+lang VarTypeAst
+  syn Type =
+  | TyVar {ident : Name}
 end
 
 lang AppTypeAst
@@ -491,20 +495,6 @@ lang AppTypeAst
   | TyApp {lhs : Type, rhs : Type}
 end
 
-lang StringTypeAst
-  syn Type =
-  | TyString {} --TODO: Remove
-end
-
-lang VariantTypeAst
-  syn Type =
-  | TyVariant {} -- TODO: Add
-end
-
-lang TypeVarAst
-  syn Type =
-  | TyVar {ident : Name}
-end
 
 ------------------------
 -- MEXPR AST FRAGMENT --
@@ -514,17 +504,17 @@ lang MExprAst =
 
   -- Terms
   VarAst + AppAst + FunAst + RecordAst + LetAst + TypeAst + RecLetsAst +
-  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst
+  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst +
 
   -- Constants
-  + IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
-  CmpIntAst + CmpFloatAst + CharAst + SymbAst + CmpSymbAst + SeqOpAst
+  IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
+  CmpIntAst + CmpFloatAst + CharAst + SymbAst + CmpSymbAst + SeqOpAst +
 
   -- Patterns
-  + NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +
-  BoolPat + AndPat + OrPat + NotPat
+  NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +
+  BoolPat + AndPat + OrPat + NotPat +
 
   -- Types
-  + FunTypeAst + UnknownTypeAst + CharTypeAst + StringTypeAst +
-  SeqTypeAst + RecordTypeAst + DataTypeAst + IntTypeAst +
-  FloatTypeAst + BoolTypeAst + AppTypeAst + TypeVarAst
+  UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
+  FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + VarTypeAst +
+  AppTypeAst

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -8,7 +8,7 @@ include "mexpr/ast-builder.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/eq.mc"
 
-lang FunCPS = FunSym + FunEq
+lang FunCPS = FunSym + FunEq + UnknownTypeSym
 
   sem cpsK (cont: Expr -> Expr) =
   | TmLam t -> cont (cpsM (TmLam t))

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -44,10 +44,12 @@ lang HoleAstPrettyPrint = HoleAst + TypePrettyPrint
   | TmHole h ->
     match pprintCode indent env h.startGuess with (env1, startStr) then
       match pprintCode indent env1 h.depth with (env2, depthStr) then
-        (env2,
-          join ["Hole (",
-                strJoin ", " [getTypeStringCode indent h.ty, startStr, depthStr],
-                ")"])
+        match getTypeStringCode indent env2 h.ty with (env3, ty) then
+          (env3,
+            join ["Hole (",
+                  strJoin ", " [ty, startStr, depthStr],
+                  ")"])
+        else never
       else never
     else never
 end

--- a/stdlib/mexpr/lift-types.mc
+++ b/stdlib/mexpr/lift-types.mc
@@ -1,0 +1,5 @@
+-- Lifts types to the top of an MExpr program.
+--
+-- NOTE(dlunde,2020-11-20)
+-- Should probably be run after type checking, since typing information is
+-- possibly lost due to our "open" variant types with condef.

--- a/stdlib/mexpr/lift-types.mc
+++ b/stdlib/mexpr/lift-types.mc
@@ -1,5 +1,1 @@
 -- Lifts types to the top of an MExpr program.
---
--- NOTE(dlunde,2020-11-20)
--- Should probably be run after type checking, since typing information is
--- possibly lost due to our "open" variant types with condef.

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -310,18 +310,10 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
     match pprintVarName env t.ident with (env,str) then
       match pprintCode (pprintIncr indent) env t.body with (env,body) then
         match pprintCode indent env t.inexpr with (env,inexpr) then
-<<<<<<< HEAD
-          let ty =
-            match t.ty with TyUnknown {} then ""
-            else concat " : " (getTypeStringCode indent t.ty)
-          in
-          (env, join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
-                      body, pprintNewline indent,
-=======
           match getTypeStringCode indent env t.ty with (env, ty) then
             let ty = if eqString ty "Unknown" then "" else concat ": " ty in
             (env,
-             join ["let ", ident, ty, " =", pprintNewline (pprintIncr indent),
+             join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
                    body, pprintNewline indent,
                    "in", pprintNewline indent,
                    inexpr])
@@ -341,12 +333,11 @@ lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmType t ->
     match pprintEnvGetStr env t.ident with (env,str) then
-      let ident = str in -- TODO(dlunde,2020-11-24): format str properly with #type
+      let ident = str in -- TODO(dlunde,2020-11-24): change to pprintTypeName
       match pprintCode indent env t.inexpr with (env,inexpr) then
         match getTypeStringCode indent env t.ty with (env, ty) then
           (env, join ["type ", ident, " =", pprintNewline (pprintIncr indent),
                       ty, pprintNewline indent,
->>>>>>> Finish type revision for interpreter (including symbolization and pretty printing)
                       "in", pprintNewline indent,
                       inexpr])
         else never
@@ -369,18 +360,10 @@ lang RecLetsPrettyPrint = PrettyPrint + RecLetsAst + UnknownTypeAst
     let f = lam env. lam bind.
       match pprintVarName env bind.ident with (env,str) then
         match pprintCode iii env bind.body with (env,body) then
-<<<<<<< HEAD
-          let ty =
-            match bind.ty with TyUnknown {} then ""
-            else concat " : " (getTypeStringCode indent bind.ty)
-          in
-          (env, join ["let ", str, ty, " =", pprintNewline iii, body])
-=======
           match getTypeStringCode indent env bind.ty with (env, ty) then
             let ty = if eqString ty "Unknown" then "" else concat ": " ty in
-            (env, join ["let ", ident, ty, " =", pprintNewline iii, body])
+            (env, join ["let ", str, ty, " =", pprintNewline iii, body])
           else never
->>>>>>> Finish type revision for interpreter (including symbolization and pretty printing)
         else never
       else never
     in
@@ -416,23 +399,12 @@ lang DataPrettyPrint = PrettyPrint + DataAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmConDef t ->
-<<<<<<< HEAD
     match pprintConName env t.ident with (env,str) then
-      let ty =
-        match t.ty with TyUnknown {} then ""
-        else concat " : " (getTypeStringCode indent t.ty)
-      in
-      match pprintCode indent env t.inexpr with (env,inexpr) then
-        (env,join ["con ", str, ty, " in", pprintNewline indent, inexpr])
-=======
-    match pprintEnvGetStr env t.ident with (env,str) then
-      let str = pprintConString str in
       match getTypeStringCode indent env t.ty with (env, ty) then
         let ty = if eqString ty "Unknown" then "" else concat ": " ty in
         match pprintCode indent env t.inexpr with (env,inexpr) then
           (env,join ["con ", str, ty, " in", pprintNewline indent, inexpr])
         else never
->>>>>>> Finish type revision for interpreter (including symbolization and pretty printing)
       else never
     else never
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -804,7 +804,7 @@ end
 lang RecordTypePrettyPrint = RecordTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyRecord t ->
-    if eqi (assocLength t.fields) 0 then "()" else
+    if eqi (assocLength t.fields) 0 then (env,"()") else
       let tuple =
         let seq = assoc2seq {eq=eqString} t.fields in
         if all (lam t. stringIsInt t.0) seq then
@@ -825,7 +825,7 @@ lang RecordTypePrettyPrint = RecordTypeAst
         else never
       else
         let f = lam env. lam _. lam v. getTypeStringCode indent env v in
-        match assocMapAccum {eq=eqString} f t.fields with (env, fields) then
+        match assocMapAccum {eq=eqString} f env t.fields with (env, fields) then
           let fields = assoc2seq {eq=eqString} fields in
           let conventry = lam entry. join [entry.0, ": ", entry.1] in
           (env,join ["{", strJoin ", " (map conventry fields), "}"])

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -126,7 +126,7 @@ with ("_BC123", gensym ()).0
 
 lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
                         + LetPrettyPrint + ConstPrettyPrint + OCamlAst
-                        + IdentifierPrettyPrint
+                        + IdentifierPrettyPrint + UnknownTypePrettyPrint
 
   sem pprintVarName (env : PprintEnv) =
   | name -> pprintEnvGetStr env (escapeName name)


### PR DESCRIPTION
### Changes
- Add type-lets to both boot and interpreter ASTs (e.g. "type String = [Char] in ...")
- Type AST updates (boot + interpreter). The boot types (interpreter ones are the same) can be found below as a basis for discussion.
```
  (* Unknown type *)
  | TyUnknown of info
  (* Boolean type *)
  | TyBool of info
  (* Int type *)
  | TyInt of info
  (* Floating-point type *)
  | TyFloat of info
  (* Character type *)
  | TyChar of info
  (* Function type *)
  | TyArrow of info * ty * ty
  (* Sequence type *)
  | TySeq of info * ty
  (* Record type *)
  | TyRecord of info * ty Record.t
  (* Variant type *)
  | TyVariant of info * (ustring * Symb.t) list
  (* Type variables *)
  | TyVar of info * ustring * Symb.t
  (* Type application, currently only used for documenation purposes *)
  | TyApp of info * ty * ty
```
- Add type symbolization (boot + interpreter)
- Add info fields to boot types.
- Add `assoc2seq` (cf. `seq2assoc` from #220)
- Improve/update pretty-printing of types in the interpreter.