### PR TITLE
Implemented more missing intrinsics in the interpreter.

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -83,13 +83,13 @@ module Symb = struct
 
   let eqsym l r = l = r
 
+  let hash s = s
+
   module Helpers = struct
     let nosym = -1
 
     let ustring_of_sym = ustring_of_int
 
     let string_of_sym s = Ustring.to_utf8 (ustring_of_sym s)
-
-    let hash s = s
   end
 end

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -93,3 +93,13 @@ module Symb = struct
     let string_of_sym s = Ustring.to_utf8 (ustring_of_sym s)
   end
 end
+
+module File = struct
+  let read f = f |> Ustring.to_utf8 |> Ustring.read_file
+
+  let write f d = Ustring.write_file (Ustring.to_utf8 f) d
+
+  let exists f = f |> Ustring.to_utf8 |> Sys.file_exists
+
+  let delete f = f |> Ustring.to_utf8 |> Sys.remove
+end

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -66,3 +66,13 @@ module Symb : sig
     val string_of_sym : t -> string
   end
 end
+
+module File : sig
+  val read : ustring -> ustring
+
+  val write : ustring -> ustring -> unit
+
+  val exists : ustring -> bool
+
+  val delete : ustring -> unit
+end

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -56,13 +56,13 @@ module Symb : sig
 
   val eqsym : t -> t -> bool
 
+  val hash : t -> int
+
   module Helpers : sig
     val nosym : t
 
     val ustring_of_sym : t -> ustring
 
     val string_of_sym : t -> string
-
-    val hash : t -> int
   end
 end

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -750,7 +750,7 @@ let delta eval env fi c v =
   | Ceqsym _, _ ->
       fail_constapp fi
   | Csym2hash, TmConst (fi, CSymb id) ->
-      TmConst (fi, CInt (Symb.Helpers.hash id))
+      TmConst (fi, CInt (Symb.hash id))
   | Csym2hash, _ ->
       fail_constapp fi
   (* Python intrinsics *)

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -707,25 +707,22 @@ let delta eval env fi c v =
       fail_constapp fi
   | CreadFile, TmSeq (fi, lst) ->
       TmSeq
-        ( fi
-        , Ustring.read_file (Ustring.to_utf8 (tmseq2ustring fi lst))
-          |> ustring2tmseq fi )
+        (fi, tmseq2ustring fi lst |> Intrinsics.File.read |> ustring2tmseq fi)
   | CreadFile, _ ->
       fail_constapp fi
   | CwriteFile None, TmSeq (fi, l) ->
       TmConst (fi, CwriteFile (Some (tmseq2ustring fi l)))
   | CwriteFile (Some fname), TmSeq (fi, lst) ->
-      Ustring.write_file (Ustring.to_utf8 fname) (tmseq2ustring fi lst) ;
+      Intrinsics.File.write fname (tmseq2ustring fi lst) ;
       tmUnit
   | CwriteFile None, _ | CwriteFile (Some _), _ ->
       fail_constapp fi
   | CfileExists, TmSeq (fi, lst) ->
-      TmConst
-        (fi, CBool (Sys.file_exists (Ustring.to_utf8 (tmseq2ustring fi lst))))
+      TmConst (fi, CBool (Intrinsics.File.exists (tmseq2ustring fi lst)))
   | CfileExists, _ ->
       fail_constapp fi
   | CdeleteFile, TmSeq (fi, lst) ->
-      Sys.remove (Ustring.to_utf8 (tmseq2ustring fi lst)) ;
+      Intrinsics.File.delete (tmseq2ustring fi lst) ;
       tmUnit
   | CdeleteFile, _ ->
       fail_constapp fi

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -535,3 +535,38 @@ let eqsym_ = use MExprAst in
 let sym2hash_ = use MExprAst in
   lam s.
   appf1_ (const_ (CSym2hash ())) s
+
+-- File operations
+let readFile_ = use MExprAst in
+  lam f. appf1_ (const_ (CFileRead ())) f
+
+let writeFile_ = use MExprAst in
+  lam f. lam d. appf2_ (const_ (CFileWrite ())) f d
+
+let fileExists_ = use MExprAst in
+  lam f. appf1_ (const_ (CFileExists ())) f
+
+let deleteFile_ = use MExprAst in
+  lam f. appf1_ (const_ (CFileDelete ())) f
+
+-- I/O operations
+let printString_ = use MExprAst in
+  lam s. app_ (const_ (CPrintString ())) s
+
+let readLine_ = use MExprAst in
+  lam u. app_ (const_ (CReadLine ())) u
+
+-- Random number generation
+let randIntU_ = use MExprAst in
+  lam lo. lam hi. appf2_ (const_ (CRandIntU ())) lo hi
+
+let randSetSeed_ = use MExprAst in
+  lam s. appf1_ (const_ (CRandSetSeed ())) s
+
+-- Error
+let error_ = use MExprAst in
+  lam s. appf1_ (const_ (CError ())) s
+
+-- Exit
+let exit_ = use MExprAst in
+  lam n. appf1_ (const_ (CExit ())) n

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -477,10 +477,6 @@ let eqf_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CEqf ())) a b
 
-let eqs_ = use MExprAst in
-  lam s1. lam s2.
-  appf2_ (const_ (CEqsym ())) s1 s2
-
 let ltf_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CLtf ())) a b
@@ -528,7 +524,14 @@ let and_ = use MExprAst in
 let or_ = use MExprAst in
   lam a. lam b. if_ a true_ b
 
--- Sym2hash
+-- Symbol operations
+let gensym_ = use MExprAst in
+  lam u. appf1_ (const_ (CGensym ())) u
+
+let eqsym_ = use MExprAst in
+  lam s1. lam s2.
+  appf2_ (const_ (CEqsym ())) s1 s2
+
 let sym2hash_ = use MExprAst in
   lam s.
   appf1_ (const_ (CSym2hash ())) s

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -527,3 +527,8 @@ let and_ = use MExprAst in
 
 let or_ = use MExprAst in
   lam a. lam b. if_ a true_ b
+
+-- Sym2hash
+let sym2hash_ = use MExprAst in
+  lam s.
+  appf1_ (const_ (CSym2hash ())) s

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -290,7 +290,6 @@ lang CmpSymbAst = SymbAst + BoolAst
   | CEqsym {}
 end
 
--- TODO(dlunde,2020-09-29): Remove constants no longer available in boot?
 lang SeqOpAst = SeqAst
   syn Const =
   | CSet {}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -281,6 +281,7 @@ end
 lang SymbAst = ConstAst
   syn Const =
   | CSymb {val : Symb}
+  | CGensym {}
   | CSym2hash {}
 end
 

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -281,6 +281,7 @@ end
 lang SymbAst = ConstAst
   syn Const =
   | CSymb {val : Symb}
+  | CSym2hash {}
 end
 
 lang CmpSymbAst = SymbAst + BoolAst

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -538,9 +538,9 @@ lang MExprAst =
   ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst +
 
   -- Constants
-  + IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
+  IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
   CmpIntAst + CmpFloatAst + CharAst + SymbAst + CmpSymbAst + SeqOpAst +
-  FileOpAst + IOAst + RandomNumberGeneratorAst + ErrorAst + ExitAst
+  FileOpAst + IOAst + RandomNumberGeneratorAst + ErrorAst + ExitAst +
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -303,6 +303,36 @@ lang SeqOpAst = SeqAst
   | CSplitAt {}
 end
 
+lang FileOpAst = ConstAst
+  syn Const =
+  | CFileRead {}
+  | CFileWrite {}
+  | CFileExists {}
+  | CFileDelete {}
+end
+
+lang IOAst = ConstAst
+  syn Const =
+  | CPrintString {}
+  | CReadLine {}
+end
+
+lang RandomNumberGeneratorAst = ConstAst
+  syn Const =
+  | CRandIntU {}
+  | CRandSetSeed {}
+end
+
+lang ExitAst = ConstAst
+  syn Const =
+  | CExit {}
+end
+
+lang ErrorAst = ConstAst
+  syn Const =
+  | CError {}
+end
+
 --------------
 -- PATTERNS --
 --------------
@@ -508,8 +538,9 @@ lang MExprAst =
   ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst +
 
   -- Constants
-  IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
+  + IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
   CmpIntAst + CmpFloatAst + CharAst + SymbAst + CmpSymbAst + SeqOpAst +
+  FileOpAst + IOAst + RandomNumberGeneratorAst + ErrorAst + ExitAst
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -401,9 +401,9 @@ lang ContextAwareHoles = Ast2CallGraph + LHoleAst + IntAst + SymbAst
         (bindall_ [
           nulet_ entries (
               appf2_ (nvar_ _filter)
-                     (nulam_ t (eqs_ (nvar_ id) (drecordproj_ "id" (nvar_ t))))
+                     (nulam_ t (eqsym_ (nvar_ id) (drecordproj_ "id" (nvar_ t))))
                      (nvar_ _lookupTable)),
-          nulet_ eqsym (nulam_ x (nulam_ y (eqs_ (nvar_ x) (nvar_ y)))),
+          nulet_ eqsym (nulam_ x (nulam_ y (eqsym_ (nvar_ x) (nvar_ y)))),
           nulet_ entriesSuffix
                (appf2_ (nvar_ _filter)
                        (nulam_ t (appf3_ (nvar_ _isSuffix) (nvar_ eqsym) (drecordproj_ "path" (nvar_ t)) (nvar_ _callCtx)))

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -595,7 +595,7 @@ end
 lang ExitEval = ExitAst + IntAst
   sem delta (arg : Expr) =
   | CExit _ ->
-    match arg with TmConst{val = CInt {val = n}} then
+    match arg with TmConst {val = CInt {val = n}} then
       exit n
     else
       error "n in exit not an integer"

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -44,6 +44,15 @@ let dtupleproj_ = use MExprAst in
   lam i. lam t.
   drecordproj_ (int2string i) t
 
+-- Converts a sequence of characters to a string
+let _seqOfCharToString = use MExprAst in
+  lam tms.
+    let f = lam c.
+      match c with TmConst {val = CChar c} then
+        c.val
+      else error "Not a character"
+    in
+    map f tms
 
 -----------
 -- TERMS --
@@ -502,6 +511,97 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     TmSeq {tms = makeSeq n arg}
 end
 
+lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst
+  syn Const =
+  | CFileWrite2 string
+
+  sem delta (arg : Expr) =
+  | CFileRead _ ->
+    match arg with TmSeq s then
+      let f = _seqOfCharToString s.tms in
+      str_ (readFile f)
+    else error "f in readFile not a sequence"
+  | CFileWrite _ ->
+    match arg with TmSeq s then
+      let f = _seqOfCharToString s.tms in
+      TmConst {val = CFileWrite2 f}
+    else error "f in writeFile not a sequence"
+  | CFileWrite2 f ->
+    match arg with TmSeq s then
+      let d = _seqOfCharToString s.tms in
+      let _ = writeFile f d in
+      unit_
+    else error "d in writeFile not a sequence"
+  | CFileExists _ ->
+    match arg with TmSeq s then
+      let f = _seqOfCharToString s.tms in
+      TmConst {val = CBool {val = fileExists f}}
+    else error "f in fileExists not a sequence"
+  | CFileDelete _ ->
+    match arg with TmSeq s then
+      let f = _seqOfCharToString s.tms in
+      let _ = deleteFile f in
+      unit_
+    else error "f in deleteFile not a sequence"
+end
+
+lang IOEval = IOAst + SeqAst
+  sem delta (arg : Expr) =
+  | CPrintString _ ->
+    match arg with TmSeq s then
+      let s = _seqOfCharToString s.tms in
+      let _ = print s in
+      unit_
+    else error "string to print is not a string"
+  | CReadLine _ ->
+    let s = readLine () in
+    TmSeq {tms = map char_ s}
+end
+
+lang RandomNumberGeneratorEval = RandomNumberGeneratorAst + IntAst
+  syn Const =
+  | CRandIntU2 Int
+
+  sem delta (arg : Expr) =
+  | CRandIntU _ ->
+    match arg with TmConst c then
+      match c.val with CInt lo then
+        TmConst {val = CRandIntU2 lo.val}
+      else error "lo in randIntU not a constant integer"
+    else error "lo in randIntU not a constant"
+  | CRandIntU2 lo ->
+    match arg with TmConst c then
+      match c.val with CInt hi then
+        TmConst {val = CInt {val = randIntU lo hi.val}}
+      else error "hi in randIntU not a constant integer"
+    else error "hi in randIntU not a constant"
+  | CRandSetSeed _ ->
+    match arg with TmConst c then
+      match c.val with CInt {val = s} then
+        TmConst {val = CInt {val = randSetSeed s}}
+      else error "s in randSetSeed not a constant integer"
+    else error "s in randSetSeed not a constant"
+end
+
+lang ErrorEval = ErrorAst + SeqAst + CharAst
+  sem delta (arg : Expr) =
+  | CError _ ->
+    match arg with TmSeq s then
+      error (_seqOfCharToString s.tms)
+    else
+      error "s in error not a sequence"
+end
+
+lang ExitEval = ExitAst + IntAst
+  sem delta (arg : Expr) =
+  | CExit _ ->
+    match arg with TmConst{val = CInt {val = n}} then
+      exit n
+    else
+      error "n in exit not an integer"
+end
+
+
 --------------
 -- PATTERNS --
 --------------
@@ -634,7 +734,8 @@ lang MExprEval =
 
   -- Constants
   + ArithIntEval + ArithFloatEval + BoolEval + CmpIntEval + CmpFloatEval +
-  SymbEval + CmpSymbEval + SeqOpEval
+  SymbEval + CmpSymbEval + SeqOpEval + FileOpEval + IOEval + ErrorEval +
+  ExitEval + RandomNumberGeneratorEval
 
   -- Patterns
   + NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +
@@ -894,7 +995,7 @@ utest eval (ltf_ (float_ 2.0) (float_ 1.0)) with false_ in
 utest eval (ltf_ (float_ 1.0) (float_ 1.0)) with false_ in
 utest eval (ltf_ (float_ 0.0) (float_ 1.0)) with true_ in
 
--- Unit tests for Symbols
+-- Unit tests for symbols
 
 -- gensym
 let s1 = eval (gensym_ unit_) in
@@ -914,7 +1015,21 @@ utest eval (eqi_ (sym2hash_ s1) (sym2hash_ s1)) with true_ in
 utest eval (eqi_ (sym2hash_ s2) (sym2hash_ s1)) with false_ in
 utest eval (eqi_ (sym2hash_ s1) (sym2hash_ s2)) with false_ in
 
--- End Unit tests for Symbols
+-- Unit tests for file operations
+let f = str_ "test_file_ops" in
+let d = str_ "$&!@" in
+utest eval (fileExists_ f) with false_ in
+utest eval (writeFile_ f d) with unit_ in
+utest eval (fileExists_ f) with true_ in
+utest eval (readFile_ f) with d in
+utest eval (deleteFile_ f) with unit_ in
+utest eval (fileExists_ f) with false_ in
+
+-- Test error
+-- let _ = eval (error_ (str_ "test error message")) in
+
+-- Test exit
+-- let _ = eval (exit_ (int_ 1)) in
 
 utest eval (match_
   (tuple_ [true_, true_])
@@ -1020,5 +1135,26 @@ utest eval (match_
   (tuple_ [var_ "a", var_ "b", var_ "c"])
   false_)
 with false_ in
+
+-- I/O operations
+-- utest eval (printString_ (str_ "Hello World")) with unit_ in
+-- utest eval (printString_ (readLine_ unit_)) with unit_ in
+
+-- Random number generation
+utest eval (bind_ (ulet_ "_" (randSetSeed_ (int_ 42)))
+                  (randIntU_ (int_ 1) (int_ 10)))
+                  with [1, 2, 3, 4, 5, 6, 7, 8, 9] using
+  lam r. lam seq.
+    match r with TmConst {val = CInt {val = n}} then
+      any (eqi n) seq
+    else false
+in
+
+utest eval (randIntU_ (int_ 0) (int_ 3)) with [0, 1, 2] using
+  lam r. lam seq.
+    match r with TmConst {val = CInt {val = n}} then
+      any (eqi n) seq
+    else false
+in
 
 ()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -400,7 +400,12 @@ lang CmpFloatEval = CmpFloatAst + ConstEval
     else error "Not comparing a constant"
 end
 
-lang SymbEval = SymbAst + ConstEval
+lang SymbEval = SymbAst + IntAst + ConstEval
+  sem delta (arg : Expr) =
+  | CSym2hash _ ->
+    match arg with TmConst {val = CSymb s} then
+      TmConst {val = CInt {val = sym2hash s.val}}
+    else error "Argument in sym2hash is not a symbol"
 end
 
 lang CmpSymbEval = CmpSymbAst + ConstEval
@@ -889,6 +894,13 @@ utest eval (ltf_ (float_ 0.0) (float_ 1.0)) with true_ in
 utest eval (eqs_ (symb_ (gensym ())) (symb_ (gensym ()))) with false_ in
 utest eval (bind_ (ulet_ "s" (symb_ (gensym ()))) (eqs_ (var_ "s") (var_ "s")))
 with true_ in
+
+-- Unit test for Symb2hash
+let s1 = symb_ (gensym ()) in
+let s2 = symb_ (gensym ()) in
+utest eval (eqi_ (sym2hash_ s1) (sym2hash_ s1)) with true_ in
+utest eval (eqi_ (sym2hash_ s2) (sym2hash_ s1)) with false_ in
+utest eval (eqi_ (sym2hash_ s1) (sym2hash_ s2)) with false_ in
 
 utest eval (match_
   (tuple_ [true_, true_])

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -40,7 +40,7 @@ let _seqOps = [
 let _seqOp = _op (_opHashMap "Boot.Intrinsics.Mseq." _seqOps)
 
 let _symbOps = [
-  "gensym".
+  "gensym",
   "eqsym",
   "hash"
 ]

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -9,6 +9,22 @@ include "mexpr/eq.mc"
 include "ocaml/compile.mc"
 include "hashmap.mc"
 
+let _opHashMap = lam prefix. lam ops.
+let mkOp = lam op.
+nameSym (join [prefix, op])
+in
+foldl (lam a. lam op. hashmapInsert hashmapStrTraits op (mkOp op) a)
+hashmapEmpty ops
+
+
+let _op = lam opHashMap. lam op.
+nvar_
+(hashmapLookupOrElse hashmapStrTraits
+  (lam _.
+    error (strJoin " " ["Operation", op, "not found"]))
+    op
+    opHashMap)
+
 let _seqOps = [
   "make",
   "empty",
@@ -22,22 +38,18 @@ let _seqOps = [
   "split_at"
 ]
 
-let _seqOpHashMap =
-  let mkOp = lam op.
-    nameSym (join ["Boot.Intrinsics.Mseq.", op])
-  in
-  foldl (lam a. lam op. hashmapInsert hashmapStrTraits op (mkOp op) a)
-        hashmapEmpty _seqOps
+let _seqOp = _op (_opHashMap "Boot.Intrinsics.Mseq." _seqOps)
 
-let _seqOp = lam op.
-  nvar_
-  (hashmapLookupOrElse hashmapStrTraits
-                       (lam _. error (strJoin " " ["Operation", op, "not found"]))
-                       op
-                       _seqOpHashMap)
+let _symbOps = [
+  "eqsym",
+  "hash"
+]
+
+let _symbOp = _op (_opHashMap "Boot.Intrinsics.Symb." _symbOps)
 
 lang OCamlGenerate = MExprAst + OCamlAst
   sem generateConst =
+  -- Sequence intrinsics
   | CMakeSeq {} -> _seqOp "make"
   | CLength {} -> _seqOp "length"
   | CCons {} -> _seqOp "cons"
@@ -46,6 +58,9 @@ lang OCamlGenerate = MExprAst + OCamlAst
   | CSet {} -> _seqOp "set"
   | CSplitAt {} -> _seqOp "split_at"
   | CReverse {} -> _seqOp "reverse"
+  -- Symbol intrinsics
+  | CEqsym {} -> _symbOp "eqsym"
+  | CSym2hash {} -> _symbOp "hash"
   | v -> TmConst { val = v }
 
   sem generate =

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -257,7 +257,7 @@ utest int_ 1 with generate thrd using sameSemantics in
 -- TODO(Oscar Eriksson, 2020-11-16) Test splitAt when we have implemented tuple
 -- projection.
 
--- TODO(Oscar Eriksson, 2020-12-30) Test symbol operations when we have
+-- TODO(Oscar Eriksson, 2020-11-30) Test symbol operations when we have
 -- implemented tuples/records.
 
 ()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -16,7 +16,6 @@ in
 foldl (lam a. lam op. hashmapInsert hashmapStrTraits op (mkOp op) a)
 hashmapEmpty ops
 
-
 let _op = lam opHashMap. lam op.
 nvar_
 (hashmapLookupOrElse hashmapStrTraits
@@ -41,6 +40,7 @@ let _seqOps = [
 let _seqOp = _op (_opHashMap "Boot.Intrinsics.Mseq." _seqOps)
 
 let _symbOps = [
+  "gensym".
   "eqsym",
   "hash"
 ]
@@ -59,6 +59,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
   | CSplitAt {} -> _seqOp "split_at"
   | CReverse {} -> _seqOp "reverse"
   -- Symbol intrinsics
+  | CGensym {} -> _symbOp "gensym"
   | CEqsym {} -> _symbOp "eqsym"
   | CSym2hash {} -> _symbOp "hash"
   | v -> TmConst { val = v }
@@ -255,5 +256,8 @@ utest int_ 1 with generate thrd using sameSemantics in
 
 -- TODO(Oscar Eriksson, 2020-11-16) Test splitAt when we have implemented tuple
 -- projection.
+
+-- TODO(Oscar Eriksson, 2020-12-30) Test symbol operations when we have
+-- implemented tuples/records.
 
 ()


### PR DESCRIPTION
This PR implements the following intrinsics in the interpreter:
- File operations
- `print` & `readLine`
- random number generation
- `exit` and `error`
- symbol operations

We have also started to implement compilation of symbols and moved the implementation of file operations into `intrinsics.ml`