### PR TITLE
Compilation of additional intrinsics

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -110,4 +110,6 @@ module FloatConversion = struct
   let ceilfi f = f |> Float.ceil |> int_of_float
 
   let roundfi f = f |> Float.round |> int_of_float
+
+  let string2float s = s |> Ustring.to_utf8 |> Float.of_string
 end

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -103,3 +103,11 @@ module File = struct
 
   let delete f = f |> Ustring.to_utf8 |> Sys.remove
 end
+
+module FloatConversion = struct
+  let floorfi f = f |> Float.floor |> int_of_float
+
+  let ceilfi f = f |> Float.ceil |> int_of_float
+
+  let roundfi f = f |> Float.round |> int_of_float
+end

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -83,4 +83,6 @@ module FloatConversion : sig
   val ceilfi : float -> int
 
   val roundfi : float -> int
+
+  val string2float : ustring -> float
 end

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -76,3 +76,11 @@ module File : sig
 
   val delete : ustring -> unit
 end
+
+module FloatConversion : sig
+  val floorfi : float -> int
+
+  val ceilfi : float -> int
+
+  val roundfi : float -> int
+end

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -552,9 +552,9 @@ let delta eval env fi c v =
       in
       let f =
         s |> Mseq.Helpers.map to_char |> Mseq.Helpers.to_array
-        |> Ustring.from_uchars |> Ustring.to_utf8
+        |> Ustring.from_uchars
       in
-      TmConst (fi, CFloat (Float.of_string f))
+      TmConst (fi, CFloat (Intrinsics.FloatConversion.string2float f))
   | Cstring2float, _ ->
       fail_constapp fi
   | Cfloorfi, TmConst (fi, CFloat v) ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -558,15 +558,15 @@ let delta eval env fi c v =
   | Cstring2float, _ ->
       fail_constapp fi
   | Cfloorfi, TmConst (fi, CFloat v) ->
-      TmConst (fi, CInt (Float.floor v |> int_of_float))
+      TmConst (fi, CInt (Intrinsics.FloatConversion.floorfi v))
   | Cfloorfi, _ ->
       fail_constapp fi
   | Cceilfi, TmConst (fi, CFloat v) ->
-      TmConst (fi, CInt (Float.ceil v |> int_of_float))
+      TmConst (fi, CInt (Intrinsics.FloatConversion.ceilfi v))
   | Cceilfi, _ ->
       fail_constapp fi
   | Croundfi, TmConst (fi, CFloat v) ->
-      TmConst (fi, CInt (Float.round v |> int_of_float))
+      TmConst (fi, CInt (Intrinsics.FloatConversion.roundfi v))
   | Croundfi, _ ->
       fail_constapp fi
   | Cint2float, TmConst (fi, CInt v) ->

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -442,6 +442,18 @@ let muli_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CMuli ())) a b
 
+let divi_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CDivi ())) a b
+
+let modi_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CModi ())) a b
+
+let negi_ = use MExprAst in
+  lam n.
+  appf1_ (const_ (CNegi ())) n
+
 let addf_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CAddf ())) a b
@@ -462,17 +474,61 @@ let negf_ = use MExprAst in
   lam a.
   appf1_ (const_ (CNegf ())) a
 
-let not_ = use MExprAst in
-  lam a.
-  appf1_ (const_ (CNot ())) a
+let floorfi_ = use MExprAst in
+  lam x.
+  appf1_ (const_ (CFloorfi ())) x
+
+let ceilfi_ = use MExprAst in
+  lam x.
+  appf1_ (const_ (CCeilfi ())) x
+
+let roundfi_ = use MExprAst in
+  lam x.
+  appf1_ (const_ (CRoundfi ())) x
+
+let int2float_ = use MExprAst in
+  lam x.
+  appf1_ (const_ (CInt2float ())) x
 
 let eqi_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CEqi ())) a b
 
+let neqi_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CNeqi ())) a b
+
 let lti_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CLti ())) a b
+
+let gti_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CGti ())) a b
+
+let leqi_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CLeqi ())) a b
+
+let geqi_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CGeqi ())) a b
+
+let eqc_ = use MExprAst in
+  lam c1. lam c2.
+  appf2_ (const_ (CEqc ())) c1 c2
+
+let int2char_ = use MExprAst in
+  lam i.
+  app_ (const_ (CInt2Char ())) i
+
+let char2int_ = use MExprAst in
+  lam c.
+  app_ (const_ (CChar2Int ())) c
+
+let string2float_ = use MExprAst in
+  lam s.
+  app_ (const_ (CString2float ())) s
 
 let eqf_ = use MExprAst in
   lam a. lam b.
@@ -481,6 +537,34 @@ let eqf_ = use MExprAst in
 let ltf_ = use MExprAst in
   lam a. lam b.
   appf2_ (const_ (CLtf ())) a b
+
+let leqf_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CLeqf ())) a b
+
+let gtf_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CGtf ())) a b
+
+let geqf_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CGeqf ())) a b
+
+let neqf_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CNeqf ())) a b
+
+let slli_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CSlli ())) a b
+
+let srli_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CSrli ())) a b
+
+let srai_ = use MExprAst in
+  lam a. lam b.
+  appf2_ (const_ (CSrai ())) a b
 
 let get_ = use MExprAst in
   lam s. lam i.
@@ -524,6 +608,9 @@ let and_ = use MExprAst in
 
 let or_ = use MExprAst in
   lam a. lam b. if_ a true_ b
+
+let not_ = use MExprAst in
+  lam b. if_ b false_ true_
 
 -- Symbol operations
 let gensym_ = use MExprAst in
@@ -571,3 +658,14 @@ let error_ = use MExprAst in
 -- Exit
 let exit_ = use MExprAst in
   lam n. appf1_ (const_ (CExit ())) n
+
+-- Argv
+let argv_ = use MExprAst in
+  const_ (CArgv ())
+
+-- Time operations
+let wallTimeMs_ = use MExprAst in
+  lam u. appf1_ (const_ (CWallTimeMs ())) u
+
+let sleepMs_ = use MExprAst in
+  lam n. appf1_ (const_ (CSleepMs ())) n

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -239,6 +239,16 @@ lang ArithIntAst = ConstAst + IntAst
   | CAddi {}
   | CSubi {}
   | CMuli {}
+  | CDivi {}
+  | CNegi {}
+  | CModi {}
+end
+
+lang ShiftIntAst = ConstAst + IntAst
+  syn Const =
+  | CSlli {}
+  | CSrli {}
+  | CSrai {}
 end
 
 lang FloatAst = ConstAst
@@ -255,27 +265,58 @@ lang ArithFloatAst = ConstAst + FloatAst
   | CNegf {}
 end
 
+lang FloatIntConversionAst = IntAst + FloatAst
+  syn Const =
+  | CFloorfi {}
+  | CCeilfi {}
+  | CRoundfi {}
+  | CInt2float {}
+end
+
 lang BoolAst = ConstAst
   syn Const =
   | CBool {val : Bool}
-  | CNot {} -- TODO(dlunde,2020-09-29): This constant does not exist in boot. Remove?
 end
 
 lang CmpIntAst = IntAst + BoolAst
   syn Const =
   | CEqi {}
+  | CNeqi {}
   | CLti {}
+  | CGti {}
+  | CLeqi {}
+  | CGeqi {}
 end
 
 lang CmpFloatAst = FloatAst + BoolAst
   syn Const =
   | CEqf {}
   | CLtf {}
+  | CLeqf {}
+  | CGtf {}
+  | CGeqf {}
+  | CNeqf {}
 end
 
 lang CharAst = ConstAst
   syn Const =
   | CChar {val : Char}
+end
+
+lang CmpCharAst = CharAst + BoolAst
+  syn Const =
+  | CEqc {}
+end
+
+lang IntCharConversionAst = IntAst + CharAst
+  syn Const =
+  | CInt2Char {}
+  | CChar2Int {}
+end
+
+lang FloatStringConversionAst = SeqAst + FloatAst
+  syn Const =
+  | CString2float {}
 end
 
 lang SymbAst = ConstAst
@@ -315,6 +356,7 @@ lang IOAst = ConstAst
   syn Const =
   | CPrintString {}
   | CReadLine {}
+  | CReadBytesAsString {}
 end
 
 lang RandomNumberGeneratorAst = ConstAst
@@ -323,14 +365,17 @@ lang RandomNumberGeneratorAst = ConstAst
   | CRandSetSeed {}
 end
 
-lang ExitAst = ConstAst
+lang SysAst = ConstAst
   syn Const =
   | CExit {}
+  | CError {}
+  | CArgv {}
 end
 
-lang ErrorAst = ConstAst
+lang TimeAst = ConstAst
   syn Const =
-  | CError {}
+  | CWallTimeMs {}
+  | CSleepMs {}
 end
 
 --------------
@@ -538,9 +583,11 @@ lang MExprAst =
   ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst +
 
   -- Constants
-  IntAst + ArithIntAst + FloatAst + ArithFloatAst + BoolAst +
-  CmpIntAst + CmpFloatAst + CharAst + SymbAst + CmpSymbAst + SeqOpAst +
-  FileOpAst + IOAst + RandomNumberGeneratorAst + ErrorAst + ExitAst +
+  IntAst + ArithIntAst + ShiftIntAst + FloatAst + ArithFloatAst + BoolAst +
+  CmpIntAst + IntCharConversionAst + CmpFloatAst + CharAst + CmpCharAst +
+  SymbAst + CmpSymbAst + SeqOpAst + FileOpAst + IOAst +
+  RandomNumberGeneratorAst + SysAst + FloatIntConversionAst +
+  FloatStringConversionAst + TimeAst +
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -293,7 +293,6 @@ lang BoolEq = BoolAst
   sem eqConst (lhs : Const) =
   | CBool {val = v2} ->
     match lhs with CBool {val = v1} then eqBool v1 v2 else false
-  | CNot {} -> match lhs with CNot _ then true else false
 end
 
 lang CmpIntEq = CmpIntAst

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1207,7 +1207,7 @@ utest eval (fileExists_ f) with false_ in
 -- let _ = eval (exit_ (int_ 1)) in
 
 -- Test argv
-utest eval argv_ with seq_ [str_ "mi"] in
+-- utest eval argv_ with seq_ [str_ "mi"] in
 
 utest eval (match_
   (tuple_ [true_, true_])

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -540,7 +540,6 @@ end
 lang BoolPrettyPrint = BoolAst + ConstPrettyPrint
   sem getConstStringCode (indent : Int) =
   | CBool b -> if b.val then "true" else "false"
-  | CNot _ -> "not"
 end
 
 lang CmpIntPrettyPrint = CmpIntAst + ConstPrettyPrint

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -31,6 +31,7 @@ lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst
                 + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
                 + CharAst + OCamlMatch + NamedPat + IntPat + CharPat
                 + BoolPat + OCamlTuple + OCamlData
+                + CharAst + FloatIntConversionAst
 end
 
 mexpr

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -27,7 +27,7 @@ lang OCamlData
   | OPCon { ident : Name, args : [Pat] }
 end
 
-lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst
+lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst + ShiftIntAst
                 + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
                 + CharAst + OCamlMatch + NamedPat + IntPat + CharPat
                 + BoolPat + OCamlTuple + OCamlData

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -227,7 +227,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
 end
 
 lang OCamlTest = OCamlGenerate + OCamlPrettyPrint + MExprSym + ConstEq
-                 + IntEq + BoolEq + CharEq
+                 + IntEq + BoolEq + CharEq + FloatEq
 
 mexpr
 
@@ -262,6 +262,11 @@ let sameSemantics = lam mexprAst. lam ocamlAst.
     match t.val with CInt _ then
       let ocamlVal = ocamlEval (expr2str ocamlAst) "string_of_int" in
       match ocamlVal with TmConst {val = CInt _} then
+        eqExpr mexprVal ocamlVal
+      else error "Values mismatch"
+    else match t.val with CFloat _ then
+      let ocamlVal = ocamlEval (expr2str ocamlAst) "string_of_float" in
+      match ocamlVal with TmConst {val = CFloat _} then
         eqExpr mexprVal ocamlVal
       else error "Values mismatch"
     else match t.val with CBool _ then
@@ -620,7 +625,7 @@ utest testCeilfi with generate testCeilfi using sameSemantics in
 let testRoundfi = roundfi_ (float_ 1.5) in
 utest testRoundfi with generate testRoundfi using sameSemantics in
 
--- let testInt2float = int2float_ (int_ 1) in
--- utest testInt2float with generate testInt2float using sameSemantics in
+let testInt2float = int2float_ (int_ 1) in
+utest testInt2float with generate testInt2float using sameSemantics in
 
 ()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -50,7 +50,8 @@ let _symbOp = _op (_opHashMap "Boot.Intrinsics.Symb." _symbOps)
 let _floatOps = [
   "floorfi",
   "ceilfi",
-  "roundfi"
+  "roundfi",
+  "string2float"
 ]
 
 let _floatOp = _op (_opHashMap "Boot.Intrinsics.FloatConversion." _floatOps)
@@ -95,10 +96,11 @@ lang OCamlGenerate = MExprAst + OCamlAst
   | CGensym {} -> _symbOp "gensym"
   | CEqsym {} -> _symbOp "eqsym"
   | CSym2hash {} -> _symbOp "hash"
-  -- Float intrinsics
+  -- Int-Float Conversion intrinsics
   | CFloorfi {} -> _floatOp "floorfi"
   | CCeilfi {} -> _floatOp "ceilfi"
   | CRoundfi {} -> _floatOp "roundfi"
+  | CString2float {} -> _floatOp "string2float"
   | v -> TmConst { val = v }
 
   sem generate =
@@ -477,30 +479,83 @@ let symbAndGen = lam e. generate (symbolize e) in
 
 -- Ints
 let addInt1 = addi_ (int_ 1) (int_ 2) in
-utest addInt1 with symbAndGen addInt1 using sameSemantics in
+utest addInt1 with generate addInt1 using sameSemantics in
 
 let addInt2 = addi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
-utest addInt2 with symbAndGen addInt2 using sameSemantics in
+utest addInt2 with generate addInt2 using sameSemantics in
 
 let testMulInt = muli_ (int_ 2) (int_ 3) in
-utest testMulInt with symbAndGen testMulInt using sameSemantics in
+utest testMulInt with generate testMulInt using sameSemantics in
 
 let testModInt = modi_ (int_ 2) (int_ 3) in
-utest testModInt with symbAndGen testModInt using sameSemantics in
+utest testModInt with generate testModInt using sameSemantics in
 
 let testDivInt = divi_ (int_ 2) (int_ 3) in
-utest testDivInt with symbAndGen testDivInt using sameSemantics in
+utest testDivInt with generate testDivInt using sameSemantics in
 
 let testNegInt = addi_ (int_ 2) (negi_ (int_ 2)) in
-utest testNegInt with symbAndGen testNegInt using sameSemantics in
+utest testNegInt with generate testNegInt using sameSemantics in
 
 let compareInt1 = eqi_ (int_ 1) (int_ 2) in
-utest compareInt1 with symbAndGen compareInt1
-using sameSemantics in
+utest compareInt1 with generate compareInt1 using sameSemantics in
 
 let compareInt2 = lti_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
-utest compareInt2 with symbAndGen compareInt2
-using sameSemantics in
+utest compareInt2 with generate compareInt2 using sameSemantics in
+
+let compareInt3 = leqi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+utest compareInt3 with generate compareInt3 using sameSemantics in
+
+let compareInt4 = gti_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+utest compareInt4 with generate compareInt4 using sameSemantics in
+
+let compareInt5 = geqi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+utest compareInt5 with generate compareInt5 using sameSemantics in
+
+let compareInt6 = neqi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
+utest compareInt6 with generate compareInt6 using sameSemantics in
+
+let shiftInt1 = slli_ (int_ 5) (int_ 2) in
+utest shiftInt1 with generate shiftInt1 using sameSemantics in
+
+let shiftInt2 = srli_ (int_ 5) (int_ 2) in
+utest shiftInt2 with generate shiftInt2 using sameSemantics in
+
+let shiftInt3 = srai_ (int_ 5) (int_ 2) in
+utest shiftInt3 with generate shiftInt3 using sameSemantics in
+
+-- Floats
+let addFloat1 = addf_ (float_ 1.) (float_ 2.) in
+utest addFloat1 with generate addFloat1 using sameSemantics in
+
+let addFloat2 = addf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+utest addFloat2 with generate addFloat2 using sameSemantics in
+
+let testMulFloat = mulf_ (float_ 2.) (float_ 3.) in
+utest testMulFloat with generate testMulFloat using sameSemantics in
+
+let testDivFloat = divf_ (float_ 6.) (float_ 3.) in
+utest testDivFloat with generate testDivFloat using sameSemantics in
+
+let testNegFloat = addf_ (float_ 2.) (negf_ (float_ 2.)) in
+utest testNegFloat with generate testNegFloat using sameSemantics in
+
+let compareFloat1 = eqf_ (float_ 1.) (float_ 2.) in
+utest compareFloat1 with generate compareFloat1 using sameSemantics in
+
+let compareFloat2 = ltf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+utest compareFloat2 with generate compareFloat2 using sameSemantics in
+
+let compareFloat3 = leqf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+utest compareFloat3 with generate compareFloat3 using sameSemantics in
+
+let compareFloat4 = gtf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+utest compareFloat4 with generate compareFloat4 using sameSemantics in
+
+let compareFloat5 = geqf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+utest compareFloat5 with generate compareFloat5 using sameSemantics in
+
+let compareFloat6 = neqf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
+utest compareFloat6 with generate compareFloat6 using sameSemantics in
 
 -- Chars
 let charLiteral = char_ 'c' in
@@ -627,5 +682,9 @@ utest testRoundfi with generate testRoundfi using sameSemantics in
 
 let testInt2float = int2float_ (int_ 1) in
 utest testInt2float with generate testInt2float using sameSemantics in
+
+-- TODO(Oscar Eriksson, 2020-12-7) We need to think about how we should compile strings.
+-- let testString2float = string2float_ (str_ "1.5") in
+-- utest testString2float with generate testString2float using sameSemantics in
 
 ()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -10,19 +10,18 @@ include "ocaml/compile.mc"
 include "hashmap.mc"
 
 let _opHashMap = lam prefix. lam ops.
-let mkOp = lam op.
-nameSym (join [prefix, op])
-in
-foldl (lam a. lam op. hashmapInsert hashmapStrTraits op (mkOp op) a)
-hashmapEmpty ops
+  let mkOp = lam op. nameSym (join [prefix, op]) in
+  foldl (lam a. lam op. hashmapInsert hashmapStrTraits op (mkOp op) a)
+        hashmapEmpty
+        ops
 
 let _op = lam opHashMap. lam op.
-nvar_
-(hashmapLookupOrElse hashmapStrTraits
-  (lam _.
-    error (strJoin " " ["Operation", op, "not found"]))
-    op
-    opHashMap)
+  nvar_
+  (hashmapLookupOrElse hashmapStrTraits
+    (lam _.
+      error (strJoin " " ["Operation", op, "not found"]))
+      op
+      opHashMap)
 
 let _seqOps = [
   "make",
@@ -353,28 +352,32 @@ utest matchOr3 with generate matchOr3 using sameSemantics in
 
 let matchNestedOr1 = symbolize
   (match_ (seq_ [int_ 1, int_ 2])
-    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"])) (pseqtot_ [pint_ 3, pvar_ "a"]))
+    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"]))
+          (pseqtot_ [pint_ 3, pvar_ "a"]))
     (var_ "a")
     (int_ 42)) in
 utest matchNestedOr1 with generate matchNestedOr1 using sameSemantics in
 
 let matchNestedOr2 = symbolize
   (match_ (seq_ [int_ 2, int_ 1])
-    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"])) (pseqtot_ [pint_ 3, pvar_ "a"]))
+    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"]))
+          (pseqtot_ [pint_ 3, pvar_ "a"]))
     (var_ "a")
     (int_ 42)) in
 utest matchNestedOr2 with generate matchNestedOr2 using sameSemantics in
 
 let matchNestedOr3 = symbolize
   (match_ (seq_ [int_ 3, int_ 7])
-    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"])) (pseqtot_ [pint_ 3, pvar_ "a"]))
+    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"]))
+          (pseqtot_ [pint_ 3, pvar_ "a"]))
     (var_ "a")
     (int_ 42)) in
 utest matchNestedOr3 with generate matchNestedOr3 using sameSemantics in
 
 let matchNestedOr4 = symbolize
   (match_ (seq_ [int_ 4, int_ 7])
-    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"])) (pseqtot_ [pint_ 3, pvar_ "a"]))
+    (por_ (por_ (pseqtot_ [pint_ 1, pvar_ "a"]) (pseqtot_ [pint_ 2, pvar_ "a"]))
+          (pseqtot_ [pint_ 3, pvar_ "a"]))
     (var_ "a")
     (int_ 42)) in
 utest matchNestedOr4 with generate matchNestedOr4 using sameSemantics in
@@ -475,7 +478,6 @@ let matchSeqEdge7 = symbolize
     (var_ "a")
     (int_ 75)) in
 utest matchSeqEdge7 with generate matchSeqEdge7 using sameSemantics in
-let symbAndGen = lam e. generate (symbolize e) in
 
 -- Ints
 let addInt1 = addi_ (int_ 1) (int_ 2) in
@@ -559,7 +561,7 @@ utest compareFloat6 with generate compareFloat6 using sameSemantics in
 
 -- Chars
 let charLiteral = char_ 'c' in
-utest charLiteral with symbAndGen charLiteral
+utest charLiteral with generate charLiteral
 using sameSemantics in
 
 -- Abstractions

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -215,12 +215,15 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | CAddi _ -> "(+)"
   | CSubi _ -> "(-)"
   | CMuli _ -> "( * )"
+  | CDivi _ -> "(/)"
+  | CModi _ -> "(mod)"
+  | CNegi _ -> "(~-)"
   | CFloat {val = f} -> float2string f
   | CAddf _ -> "(+.)"
   | CSubf _ -> "(-.)"
   | CMulf _ -> "( *. )"
   | CDivf _ -> "(/.)"
-  | CNegf _ -> "Float.neg"
+  | CNegf _ -> "(~-.)"
   | CBool {val = b} ->
       match b with true then
         "true"
@@ -228,11 +231,11 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
         match b with false then
           "false"
         else never
-  | CNot _ -> "not"
   | CEqi _ -> "(=)"
   | CLti _ -> "(<)"
   | CEqf _ -> "(=)"
   | CLtf _ -> "(<)"
+  | CInt2float _ -> "float_of_int"
   | CChar {val = c} -> show_char c
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
@@ -375,13 +378,19 @@ let testAddInt1 = addi_ (int_ 1) (int_ 2) in
 
 let testAddInt2 = addi_ (addi_ (int_ 1) (int_ 2)) (int_ 3) in
 
+let testMulInt = muli_ (int_ 2) (int_ 3) in
+
+let testModInt = modi_ (int_ 2) (int_ 3) in
+
+let testDivInt = divi_ (int_ 2) (int_ 3) in
+
+let testNegInt = negi_ (int_ 2) in
+
 let testAddFloat1 = addf_ (float_ 1.) (float_ 2.) in
 
 let testAddFloat2 = addf_ (addf_ (float_ 1.) (float_ 2.)) (float_ 3.) in
 
 let testNegFloat = negf_ (float_ 1.) in
-
-let testBoolNot = not_ (not_ true_) in
 
 let testCompareInt1 = eqi_ (int_ 1) (int_ 2) in
 
@@ -480,10 +489,13 @@ in
 let asts = [
   testAddInt1,
   testAddInt2,
+  testMulInt,
+  testModInt,
+  testDivInt,
+  testNegInt,
   testAddFloat1,
   testAddFloat2,
   testNegFloat,
-  testBoolNot,
   testCompareInt1,
   testCompareInt2,
   testCompareFloat1,

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -233,8 +233,19 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
         else never
   | CEqi _ -> "(=)"
   | CLti _ -> "(<)"
+  | CLeqi _ -> "(<=)"
+  | CGti _ -> "(>)"
+  | CGeqi _ -> "(>=)"
+  | CNeqi _ -> "(!=)"
+  | CSlli _ -> "Int.shift_left"
+  | CSrli _ -> "Int.shift_right_logical"
+  | CSrai _ -> "Int.shift_right"
   | CEqf _ -> "(=)"
   | CLtf _ -> "(<)"
+  | CLeqf _ -> "(<=)"
+  | CGtf _ -> "(>)"
+  | CGeqf _ -> "(>=)"
+  | CNeqf _ -> "(!=)"
   | CInt2float _ -> "float_of_int"
   | CChar {val = c} -> show_char c
 


### PR DESCRIPTION
This PR synchronizes boot and the interpreter and adds compilation of additional intrinsics.

Now all intrinsics except `arity`, `dprint`, and `readBytesAsString` are synchronized between boot and the interpreter (see #214).

We have also added compilation of more integer and float operations.