### PR TITLE
Compile match to OCaml, except records and ADTs

### DIFF
--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -112,6 +112,11 @@ let assocMap : AssocTraits k -> (v1 -> v2) -> AssocMap k v1 -> AssocMap k v2 =
   lam _. lam f. lam m.
     map (lam t. (t.0, f t.1)) m
 
+-- 'assocMapWithKey f m' maps over the values of 'm' using function 'f', where 'f' additionally has access to the key of the value being operated upon.
+let assocMapWithKey : AssocTraits k -> (k -> v1 -> v2) -> AssocMap k v1 -> AssocMap k v2 =
+  lam _. lam f. lam m.
+    map (lam t. (t.0, f t.0 t.1)) m
+
 -- 'assocFold traits f acc m' folds over 'm' using function 'f' and accumulator
 -- 'acc'.
 -- IMPORTANT: The folding order is unspecified.
@@ -168,6 +173,7 @@ let remove = assocRemove traits in
 let keys = assocKeys traits in
 let values = assocValues traits in
 let map = assocMap traits in
+let mapWithKey = assocMapWithKey traits in
 let fold = assocFold traits in
 let foldOption = assocFoldlM traits in
 let mapAccum = assocMapAccum traits in
@@ -206,6 +212,11 @@ let m = seq2assoc seq in
 
 utest sort (lam l. lam r. subi l.0 r.0) (assoc2seq m)
 with [(1, '1'), (2, '2'), (3, '3')] in
+
+let withKeyMap = mapWithKey (lam k. lam v. (k, v)) m in
+utest lookup 1 withKeyMap with (1, '1') in
+utest lookup 2 withKeyMap with (2, '2') in
+utest lookup 3 withKeyMap with (3, '3') in
 
 let nextChar = lam c. int2char (addi 1 (char2int c)) in
 

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -103,10 +103,6 @@ let assocValues : AssocTraits k -> AssocMap k v -> [v] =
   lam _. lam m.
     map (lam t. t.1) m
 
--- 'assoc2seq traits m' returns a sequence of all pairs stored in 'm'
-let assoc2seq : AssocTraits k -> AssocMap k v -> [(k, v)] =
-    lam _. lam m. m
-
 -- 'assocMap traits f m' maps over the values of 'm' using function 'f'.
 let assocMap : AssocTraits k -> (v1 -> v2) -> AssocMap k v1 -> AssocMap k v2 =
   lam _. lam f. lam m.

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -103,6 +103,10 @@ let assocValues : AssocTraits k -> AssocMap k v -> [v] =
   lam _. lam m.
     map (lam t. t.1) m
 
+-- 'assoc2seq traits m' returns a sequence of all pairs stored in 'm'
+let assoc2seq : AssocTraits k -> AssocMap k v -> [(k, v)] =
+    lam _. lam m. m
+
 -- 'assocMap traits f m' maps over the values of 'm' using function 'f'.
 let assocMap : AssocTraits k -> (v1 -> v2) -> AssocMap k v1 -> AssocMap k v2 =
   lam _. lam f. lam m.

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -214,9 +214,9 @@ utest sort (lam l. lam r. subi l.0 r.0) (assoc2seq m)
 with [(1, '1'), (2, '2'), (3, '3')] in
 
 let withKeyMap = mapWithKey (lam k. lam v. (k, v)) m in
-utest lookup 1 withKeyMap with (1, '1') in
-utest lookup 2 withKeyMap with (2, '2') in
-utest lookup 3 withKeyMap with (3, '3') in
+utest lookup 1 withKeyMap with Some (1, '1') in
+utest lookup 2 withKeyMap with Some (2, '2') in
+utest lookup 3 withKeyMap with Some (3, '3') in
 
 let nextChar = lam c. int2char (addi 1 (char2int c)) in
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -153,6 +153,7 @@ recursive let bind_ = use MExprAst in
     expr -- Insert at the end of the chain
 end
 
+-- OPT(vipa, 2020-12-03): This is quadratic, no?
 let bindall_ = use MExprAst in
   lam exprs.
   foldl1 bind_ exprs

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1136,6 +1136,13 @@ utest eval (match_
   false_)
 with false_ in
 
+utest eval (match_
+  (tuple_ [int_ 1, int_ 2])
+  (pand_ (pvar_ "a") (ptuple_ [pvar_ "b", pint_ 2]))
+  (tuple_ [var_ "a", var_ "b"])
+  (tuple_ [tuple_ [int_ 70, int_ 72], int_ 71]))
+with tuple_ [tuple_ [int_ 1, int_ 2], int_ 1] in
+
 -- I/O operations
 -- utest eval (printString_ (str_ "Hello World")) with unit_ in
 -- utest eval (printString_ (readLine_ unit_)) with unit_ in

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -361,7 +361,7 @@ lang RecordPatSym = RecordPat
   sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
   | PRecord {bindings = bindings} ->
     match assocMapAccum {eq=eqString}
-            (lam patEnv. lam _. lam p. symbolizePat env patEnv p) env bindings
+            (lam patEnv. lam _. lam p. symbolizePat env patEnv p) patEnv bindings
     with (env,bindings) then
       (env, PRecord {bindings = bindings})
     else never

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -202,21 +202,18 @@ lang MatchSym = Sym + MatchAst
   -- nice to pass via state monad or something.  env is the
   -- environment from the outside, plus the names added thus far in
   -- the pattern patEnv is only the newly added names
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   -- Intentionally left blank
 
   sem symbolizeExpr (env : SymEnv) =
   | TmMatch {target = target, pat = pat, thn = thn, els = els} ->
-    match env with {varEnv = varEnv, conEnv = conEnv} then
-      match symbolizePat env symEnvEmpty pat
-      with ({varEnv = thnVarEnv, conEnv = thnConEnv}, pat) then
-        let m = assocMergePreferRight {eq=eqString} in
-        let thnPatEnv = {varEnv = m varEnv thnVarEnv,
-                         conEnv = m conEnv thnConEnv} in
-        TmMatch {target = symbolizeExpr env target,
-                 pat = pat, thn = symbolizeExpr thnPatEnv thn,
-                 els = symbolizeExpr env els}
-      else never
+    match symbolizePat env assocEmpty pat
+    with (thnVarEnv, pat) then
+      let m = assocMergePreferRight {eq=eqString} in
+      let thnPatEnv = {env with varEnv = m env.varEnv thnVarEnv} in
+      TmMatch {target = symbolizeExpr env target,
+               pat = pat, thn = symbolizeExpr thnPatEnv thn,
+               els = symbolizeExpr env els}
     else never
 end
 
@@ -314,26 +311,23 @@ end
 --------------
 
 let _symbolize_patname: SymEnv -> PatName -> (SymEnv, PatName) =
-  lam patEnv. lam pname.
-    match patEnv with {varEnv = varEnv} then
-      match pname with PName name then
-        if nameHasSym name then (patEnv, PName name)
-        else
-          let str = nameGetStr name in
-          let res = assocLookup {eq=eqString} str varEnv in
-          match res with Some name then (patEnv, PName name)
-          else match res with None () then
-            let name = nameSetNewSym name in
-            let varEnv = assocInsert {eq=eqString} str name varEnv in
-            let patEnv = {patEnv with varEnv = varEnv} in
-            (patEnv, PName name)
-          else never
-      else match pname with PWildcard () then (patEnv, PWildcard ())
-      else never
+  lam varEnv. lam pname.
+    match pname with PName name then
+      if nameHasSym name then (varEnv, PName name)
+      else
+        let str = nameGetStr name in
+        let res = assocLookup {eq=eqString} str varEnv in
+        match res with Some name then (varEnv, PName name)
+        else match res with None () then
+          let name = nameSetNewSym name in
+          let varEnv = assocInsert {eq=eqString} str name varEnv in
+          (varEnv, PName name)
+        else never
+    else match pname with PWildcard () then (varEnv, PWildcard ())
     else never
 
 lang NamedPatSym = NamedPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PNamed p ->
     match _symbolize_patname patEnv p.ident with (patEnv, patname) then
       (patEnv, PNamed {p with ident = patname})
@@ -341,14 +335,14 @@ lang NamedPatSym = NamedPat
 end
 
 lang SeqTotPatSym = SeqTotPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PSeqTot p ->
     let res = mapAccumL (symbolizePat env) patEnv p.pats in
     (res.0, PSeqTot {p with pats = res.1})
 end
 
 lang SeqEdgePatSym = SeqEdgePat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PSeqEdge p ->
     let preRes = mapAccumL (symbolizePat env) patEnv p.prefix in
     let midRes = _symbolize_patname preRes.0 p.middle in
@@ -358,7 +352,7 @@ lang SeqEdgePatSym = SeqEdgePat
 end
 
 lang RecordPatSym = RecordPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PRecord {bindings = bindings} ->
     match assocMapAccum {eq=eqString}
             (lam patEnv. lam _. lam p. symbolizePat env patEnv p) patEnv bindings
@@ -368,7 +362,7 @@ lang RecordPatSym = RecordPat
 end
 
 lang DataPatSym = DataPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PCon {ident = ident, subpat = subpat} ->
     match env with {conEnv = conEnv} then
       let ident =
@@ -385,22 +379,22 @@ lang DataPatSym = DataPat
 end
 
 lang IntPatSym = IntPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PInt i -> (patEnv, PInt i)
 end
 
 lang CharPatSym = CharPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PChar c -> (patEnv, PChar c)
 end
 
 lang BoolPatSym = BoolPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PBool b -> (patEnv, PBool b)
 end
 
 lang AndPatSym = AndPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PAnd p ->
     let lRes = symbolizePat env patEnv p.lpat in
     let rRes = symbolizePat env lRes.0 p.rpat in
@@ -408,7 +402,7 @@ lang AndPatSym = AndPat
 end
 
 lang OrPatSym = OrPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | POr p ->
     let lRes = symbolizePat env patEnv p.lpat in
     let rRes = symbolizePat env lRes.0 p.rpat in
@@ -416,7 +410,7 @@ lang OrPatSym = OrPat
 end
 
 lang NotPatSym = NotPat
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PNot p ->
     -- NOTE(vipa, 2020-09-23): new names in a not-pattern do not
     -- matter since they will never bind (it should probably be an

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -143,8 +143,7 @@ utest nameGetStr (nameSym "foo") with "foo"
 
 -- 'nameGetSym n' returns optionally the symbol of name 'n'.
 -- If 'n' has no symbol, 'None' is returned.
--- TODO(dlunde,2020-09-29): Update signature when we have polymorphic types.
-let nameGetSym : Name -> OptionSymbol =
+let nameGetSym : Name -> Option Symbol =
   lam n. if eqsym n.1 _noSymbol then None () else Some n.1
 
 let _s = gensym ()

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -19,10 +19,18 @@ lang OCamlTuple
   | OPTuple { pats : [Pat] }
 end
 
+lang OCamlData
+  syn Expr =
+  | OTmConApp { ident : Name, args : [Expr] }
+
+  syn Pat =
+  | OPCon { ident : Name, args : [Pat] }
+end
+
 lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst
                 + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
                 + CharAst + OCamlMatch + NamedPat + IntPat + CharPat
-                + BoolPat + OCamlTuple
+                + BoolPat + OCamlTuple + OCamlData
 end
 
 mexpr

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -11,10 +11,18 @@ lang OCamlMatch
   syn Pat =
 end
 
+lang OCamlTuple
+  syn Expr =
+  | OTmTuple { values : [Expr] }
+
+  syn Pat =
+  | OPTuple { pats : [Pat] }
+end
+
 lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst
                 + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
                 + CharAst + OCamlMatch + NamedPat + IntPat + CharPat
-                + BoolPat
+                + BoolPat + OCamlTuple
 end
 
 mexpr

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -1,9 +1,20 @@
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 
+lang OCamlMatch
+  syn Expr =
+  | OTmMatch
+    { target : Expr
+    , arms : [(Pat, Expr)]
+    }
+
+  syn Pat =
+end
+
 lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst
                 + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
-                + CharAst
+                + CharAst + OCamlMatch + NamedPat + IntPat + CharPat
+                + BoolPat
 end
 
 mexpr

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -40,7 +40,7 @@ let _runCommand : String->String->String->ExecResult =
 
 let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
   -- NOTE(vipa, 2020-12-03): Disable unused-variable warning since it's annoying to alter compilation depending on whether results are used or not
-  let dunefile = "(env (dev (flags (:standard -w -26)))) (executable (name program) (libraries batteries boot))" in
+  let dunefile = "(env (dev (flags (:standard -w -26 -w -27)))) (executable (name program) (libraries batteries boot))" in
   let td = pycall _tempfile "TemporaryDirectory" () in
   let dir = pythonGetAttr td "name" in
   let tempfile = lam f.

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -39,7 +39,8 @@ let _runCommand : String->String->String->ExecResult =
     {stdout=stdout, stderr=stderr, returncode=returncode}
 
 let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
-  let dunefile = "(executable (name program) (libraries batteries boot))" in
+  -- NOTE(vipa, 2020-12-03): Disable unused-variable warning since it's annoying to alter compilation depending on whether results are used or not
+  let dunefile = "(env (dev (flags (:standard -w -26)))) (executable (name program) (libraries batteries boot))" in
   let td = pycall _tempfile "TemporaryDirectory" () in
   let dir = pythonGetAttr td "name" in
   let tempfile = lam f.

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -38,9 +38,11 @@ let _runCommand : String->String->String->ExecResult =
     in
     {stdout=stdout, stderr=stderr, returncode=returncode}
 
-let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
-  -- NOTE(vipa, 2020-12-03): Disable unused-variable warning since it's annoying to alter compilation depending on whether results are used or not
-  let dunefile = "(env (dev (flags (:standard -w -26 -w -27)))) (executable (name program) (libraries batteries boot))" in
+let ocamlCompileWithConfig : {warnings: Bool} -> String -> {run: Program, cleanup: Unit -> Unit} = lam config. lam p.
+  let config = if config.warnings
+    then ""
+    else "(env (dev (flags (:standard -w -a)))) " in
+  let dunefile = concat config "(executable (name program) (libraries batteries boot))" in
   let td = pycall _tempfile "TemporaryDirectory" () in
   let dir = pythonGetAttr td "name" in
   let tempfile = lam f.
@@ -76,6 +78,9 @@ let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
         let _ = pycall td "cleanup" () in
         ()
   }
+
+let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} =
+  ocamlCompileWithConfig {warnings=true}
 
 mexpr
 

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -5,7 +5,6 @@ let _blt = pyimport "builtins"
 let _subprocess = pyimport "subprocess"
 let _tempfile = pyimport "tempfile"
 let _pathlib = pyimport "pathlib"
-let _shutil = pyimport "shutil"
 
 type ExecResult = {stdout: String, stderr: String, returncode: Int}
 type Program = String -> [String] -> ExecResult
@@ -28,7 +27,8 @@ let _runCommand : String->String->String->ExecResult =
     let r = pycallkw _subprocess "run" (cmd,)
             { cwd=cwd,
               input=pycall (pycall _blt "str" (stdin,)) "encode" (),
-              capture_output=true } in
+              stdout = pythonGetAttr _subprocess "PIPE",
+              stderr = pythonGetAttr _subprocess "PIPE" } in
     let returncode = pyconvert (pythonGetAttr r "returncode") in
     let stdout =
       pyconvert (pycall (pythonGetAttr r "stdout") "decode" ())
@@ -72,7 +72,7 @@ let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} = lam p.
         _runCommand command stdin (tempfile ""),
     cleanup =
       lam _.
-        let _ = pycall _shutil "rmtree" (dir,) in
+        let _ = pycall td "cleanup" () in
         ()
   }
 

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -101,7 +101,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
     match generatePat tname pat with (nameMap, wrap) then
       match _mkFinalPatExpr nameMap with (pat, expr) then
         _optMatch
-          (bind_ (nlet_ tname tyunknown_ (generate target)) (wrap (_some expr)))
+          (bind_ (nulet_ tname (generate target)) (wrap (_some expr)))
           pat
           (generate thn)
           (generate els)
@@ -449,6 +449,13 @@ let matchSeqEdge6 = symbolize
       (int_ 84))
     (int_ 75)) in
 utest matchSeqEdge6 with generate matchSeqEdge6 using sameSemantics in
+
+let matchSeqEdge7 = symbolize
+  (match_ (seq_ [int_ 1])
+    (pseqedgew_ [pvar_ "a"] [])
+    (var_ "a")
+    (int_ 75)) in
+utest matchSeqEdge7 with generate matchSeqEdge7 using sameSemantics in
 
 -- Ints
 let addInt1 = addi_ (int_ 1) (int_ 2) in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -120,6 +120,8 @@ lang OCamlGenerate = MExprAst + OCamlAst
     in (assocEmpty, wrap)
   | PInt {val = val} ->
     (assocEmpty, lam cont. _if (eqi_ (nvar_ targetName) (int_ val)) cont _none)
+  | PChar {val = val} ->
+    (assocEmpty, lam cont. _if (eqi_ (nvar_ targetName) (char_ val)) cont _none)
   | PSeqTot {pats = pats} ->
     let genOne = lam i. lam pat.
       let n = nameSym "seqElem" in
@@ -267,6 +269,20 @@ let sameSemantics = lam mexprAst. lam ocamlAst.
 in
 
 -- Match
+let matchChar1 = symbolize
+  (match_ (char_ 'a')
+    (pchar_ 'a')
+    true_
+    false_) in
+utest matchChar1 with generate matchChar1 using sameSemantics in
+
+let matchChar2 = symbolize
+  (match_ (char_ 'a')
+    (pchar_ 'b')
+    true_
+    false_) in
+utest matchChar2 with generate matchChar2 using sameSemantics in
+
 let matchSeq = symbolize
   (match_ (seq_ [int_ 1, int_ 2, int_ 3])
     (pseqtot_ [pint_ 1, pvar_ "a", pvar_ "b"])

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -97,7 +97,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
           tms
   | TmConst {val = val} -> generateConst val
   | TmMatch {target = target, pat = pat, thn = thn, els = els} ->
-    let tname = nameSym "target" in
+    let tname = nameSym "_target" in
     match generatePat tname pat with (nameMap, wrap) then
       match _mkFinalPatExpr nameMap with (pat, expr) then
         _optMatch
@@ -124,7 +124,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
     (assocEmpty, lam cont. _if (eqi_ (nvar_ targetName) (char_ val)) cont _none)
   | PSeqTot {pats = pats} ->
     let genOne = lam i. lam pat.
-      let n = nameSym "seqElem" in
+      let n = nameSym "_seqElem" in
       match generatePat n pat with (names, innerWrap) then
         let wrap = lam cont.
           bind_
@@ -145,12 +145,12 @@ lang OCamlGenerate = MExprAst + OCamlAst
     let apply = lam f. lam x. f x in
     let mergeNames = assocMergePreferRight {eq=nameEqSym} in
     let minLen = addi (length prefix) (length postfix) in
-    let preName = nameSym "prefix" in
-    let tempName = nameSym "splitTemp" in
-    let midName = nameSym "middle" in
-    let postName = nameSym "postfix" in
+    let preName = nameSym "_prefix" in
+    let tempName = nameSym "_splitTemp" in
+    let midName = nameSym "_middle" in
+    let postName = nameSym "_postfix" in
     let genOne = lam targetName. lam i. lam pat.
-      let n = nameSym "seqElem" in
+      let n = nameSym "_seqElem" in
       match generatePat n pat with (names, innerWrap) then
         let wrap = lam cont.
           bind_
@@ -179,7 +179,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
         match _mkFinalPatExpr lnames with (lpat, lexpr) then
           match _mkFinalPatExpr rnames with (_, rexpr) then  -- NOTE(vipa, 2020-12-03): the pattern is identical between the two, assuming the two branches bind exactly the same names, which they should
             let names = assocMapWithKey {eq=nameEqSym} (lam k. lam _. k) lnames in
-            let xname = nameSym "x" in
+            let xname = nameSym "_x" in
             let wrap = lam cont.
               _optMatch
                 (_optMatch
@@ -233,7 +233,7 @@ in
 let ocamlEval = lam p. lam strConvert.
   let subprocess = pyimport "subprocess" in
   let blt = pyimport "builtins" in
-    let res = ocamlCompile (join ["print_string (", strConvert, "(", p, "))"]) in
+    let res = ocamlCompileWithConfig {warnings=false} (join ["print_string (", strConvert, "(", p, "))"]) in
     let out = (res.run "" []).stdout in
     let _ = res.cleanup () in
     parseAsMExpr out

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -210,10 +210,6 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | OPCon {args = []} -> true
   | OPCon _ -> false
 
-  sem _pprintBinding (indent : Int) (env: PprintEnv) =
-  | {ident = id, body = b} ->
-    join [nameGetStr id, " = ", pprintCode indent b]
-
   sem getConstStringCode (indent : Int) =
   | CInt {val = i} -> int2string i
   | CAddi _ -> "(+)"
@@ -243,7 +239,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | OTmConApp {ident = ident, args = []} -> pprintConName env ident
   | OTmConApp {ident = ident, args = [arg]} ->
     match pprintConName env ident with (env, ident) then
-      match printParen env indent arg with (env, arg) then
+      match printParen indent env arg with (env, arg) then
         (env, join [ident, " ", arg])
       else never
     else never
@@ -283,7 +279,6 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
         else never
       else never
     else never
-  | OTmConApp {ident = ident, args = args}
   | OTmTuple {values = values} ->
     match mapAccumL (pprintCode indent) env values
     with (env, values) then
@@ -350,7 +345,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | OPCon {ident = ident, args = []} -> pprintConName env ident
   | OPCon {ident = ident, args = [arg]} ->
     match pprintConName env ident with (env, ident) then
-      match printPatParen env indent arg with (env, arg) then
+      match printPatParen indent env arg with (env, arg) then
         (env, join [ident, " ", arg])
       else never
     else never

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -207,7 +207,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
     match pprintCode ii env target with (env, target) then
       let pprintArm = lam env. lam arm. match arm with (pat, expr) then
         match getPatStringCode ii env pat with (env, pat) then
-          match pprintCode iii env expr with (env, expr) then
+          match printParen iii env expr with (env, expr) then
             (env, join [pprintNewline i, "| ", pat, " ->", pprintNewline iii, expr])
           else never
         else never
@@ -307,6 +307,15 @@ let testMatchSimple =
   OTmMatch {target = true_, arms = [armA, armB]}
 in
 
+let testMatchNested =
+  let armA = (pvar_ "a", var_ "a") in
+  let armB = (pvarw_, var_ "b") in
+  let inner = OTmMatch {target = true_, arms = [armA]} in
+  let armB = (pvar_ "b", inner) in
+  let armC = (pvar_ "c", false_) in
+  OTmMatch {target = true_, arms = [armB, armC]}
+in
+
 let asts = [
   testAddInt1,
   testAddInt2,
@@ -327,7 +336,8 @@ let asts = [
   testLetEscape,
   testRecEscape,
   testMutRecEscape,
-  testMatchSimple
+  testMatchSimple,
+  testMatchNested
 ] in
 
 let _ = map pprintProg asts in

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -6,10 +6,15 @@ include "char.mc"
 include "name.mc"
 
 let defaultIdentName = "_var"
+let defaultConName = "Con"
 
 let escapeFirstChar = lam c.
   if isLowerAlphaOrUnderscore c then c
   else '_'
+
+let escapeFirstConChar = lam c.
+  if isUpperAlpha c then c
+  else 'C'
 
 utest map escapeFirstChar "abcABC/:@_'" with "abc________"
 
@@ -30,6 +35,10 @@ let isIdentifierString = lam s.
     and (isLowerAlphaOrUnderscore hd) (all isValidChar tl)
   else
     all isLowerAlpha s
+
+let isConString = lam s.
+  if null s then false else
+  and (isUpperAlpha (head s)) (all isValidChar (tail s))
 
 utest isIdentifierString "__" with true
 utest isIdentifierString "_1" with true
@@ -74,6 +83,13 @@ let isModuleCallString = lam s.
   else
     and (all isModuleString modules) (isIdentifierString (last parts))
 
+let isModuleConString = lam s.
+  let parts = strSplit "." s in
+  let modules = init parts in
+  if null modules then false
+  else
+    and (all isModuleString modules) (isConString (last parts))
+
 utest isModuleCallString "Foo.bar" with true
 utest isModuleCallString "A.B.C.D.E.F.G.hello" with true
 utest isModuleCallString "Foo.Bar.foo" with true
@@ -92,6 +108,24 @@ utest isModuleCallString "Foo.bar.foo" with false
 utest isModuleCallString "Foo.B@r.foo" with false
 utest isModuleCallString "foo.Bar.foo" with false
 
+utest isModuleConString "Foo.Bar" with true
+utest isModuleConString "A.B.C.D.E.F.G.Hello" with true
+utest isModuleConString "Foo.Bar.Foo" with true
+utest isModuleConString "Foo.Bar.__" with false
+utest isModuleConString "Foo.Bar._a" with false
+utest isModuleConString "Foo.Bar._A" with false
+utest isModuleConString "Foo.Bar._" with false
+utest isModuleConString "Foo.Bar.a" with false
+utest isModuleConString "Foo.Bar.*" with false
+utest isModuleConString "a" with false
+utest isModuleConString "A" with false
+utest isModuleConString "_a" with false
+utest isModuleConString "Foo.@" with false
+utest isModuleConString "foo.Bar" with false
+utest isModuleConString "Foo.bar.Foo" with false
+utest isModuleConString "Foo.B@r.Foo" with false
+utest isModuleConString "foo.Bar.Foo" with false
+
 let escapeString = lam s.
   let n = length s in
   if gti n 0 then
@@ -107,6 +141,21 @@ let escapeString = lam s.
   else
     defaultIdentName
 
+let escapeConString = lam s.
+  let n = length s in
+  if gti n 0 then
+    if isModuleConString s then
+      s
+    else
+      let hd = head s in
+      let tl = tail s in
+      if or (neqi n 1) (isUpperAlpha hd) then
+        cons (escapeFirstConChar hd) (map escapeChar tl)
+      else
+        defaultConName
+  else
+    defaultConName
+
 utest escapeString "abcABC/:@_'" with "abcABC____'"
 utest escapeString "" with defaultIdentName
 utest escapeString "@" with defaultIdentName
@@ -114,8 +163,19 @@ utest escapeString "ABC123" with "_BC123"
 utest escapeString "'a/b/c" with "_a_b_c"
 utest escapeString "123" with "_23"
 
+utest escapeConString "abcABC/:@_'" with "CbcABC____'"
+utest escapeConString "" with defaultConName
+utest escapeConString "@" with defaultConName
+utest escapeConString "ABC123" with "ABC123"
+utest escapeConString "'a/b/c" with "Ca_b_c"
+utest escapeConString "123" with "C23"
+
 let escapeName = lam n.
   match n with (str,symb) then (escapeString str, symb)
+  else never
+
+let escapeConName = lam n.
+  match n with (str,symb) then (escapeConString str, symb)
   else never
 
 utest (escapeName ("abcABC/:@_'", gensym ())).0
@@ -130,6 +190,8 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
                         + NamedPatPrettyPrint + IntPatPrettyPrint
                         + CharPatPrettyPrint + BoolPatPrettyPrint
 
+  sem pprintConName (env : PprintEnv) =
+  | name -> pprintEnvGetStr env (escapeConName name)
   sem pprintVarName (env : PprintEnv) =
   | name -> pprintEnvGetStr env (escapeName name)
   sem pprintLabelString =
@@ -140,9 +202,13 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | TmRecLets _ -> false
   | OTmMatch _ -> false
   | OTmTuple _ -> true
+  | OTmConApp {args = []} -> true
+  | OTmConApp _ -> false
 
   sem patIsAtomic =
   | OPTuple _ -> true
+  | OPCon {args = []} -> true
+  | OPCon _ -> false
 
   sem _pprintBinding (indent : Int) (env: PprintEnv) =
   | {ident = id, body = b} ->
@@ -174,6 +240,19 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | CChar {val = c} -> show_char c
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
+  | OTmConApp {ident = ident, args = []} -> pprintConName env ident
+  | OTmConApp {ident = ident, args = [arg]} ->
+    match pprintConName env ident with (env, ident) then
+      match printParen env indent arg with (env, arg) then
+        (env, join [ident, " ", arg])
+      else never
+    else never
+  | OTmConApp {ident = ident, args = args} ->
+    match pprintConName env ident with (env, ident) then
+      match mapAccumL (pprintCode indent) env args with (env, args) then
+        (env, join [ident, " (", strJoin ", " args, ")"])
+      else never
+    else never
   | TmLam {ident = id, body = b} ->
     match pprintVarName env id with (env,str) then
       match pprintCode (pprintIncr indent) env b with (env,body) then
@@ -204,6 +283,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
         else never
       else never
     else never
+  | OTmConApp {ident = ident, args = args}
   | OTmTuple {values = values} ->
     match mapAccumL (pprintCode indent) env values
     with (env, values) then
@@ -266,6 +346,19 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | OPTuple {pats = pats} ->
     match mapAccumL (getPatStringCode indent) env pats with (env, pats) then
       (env, join ["(", strJoin ", " pats, ")"])
+    else never
+  | OPCon {ident = ident, args = []} -> pprintConName env ident
+  | OPCon {ident = ident, args = [arg]} ->
+    match pprintConName env ident with (env, ident) then
+      match printPatParen env indent arg with (env, arg) then
+        (env, join [ident, " ", arg])
+      else never
+    else never
+  | OPCon {ident = ident, args = args} ->
+    match pprintConName env ident with (env, ident) then
+      match mapAccumL (getPatStringCode indent) env args with (env, args) then
+        (env, join [ident, " (", strJoin ", " args, ")"])
+      else never
     else never
 end
 

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -362,9 +362,13 @@ lang TestLang = OCamlPrettyPrint + OCamlSym
 mexpr
 use TestLang in
 
+let debugPrint = false in
+
 let pprintProg = lam ast.
-  let _ = print "\n\n" in
-  print (expr2str (symbolize ast))
+  if debugPrint then
+    let _ = print "\n\n" in
+    print (expr2str (symbolize ast))
+  else ()
 in
 
 let testAddInt1 = addi_ (int_ 1) (int_ 2) in

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -4,13 +4,14 @@ include "mexpr/symbolize.mc"
 lang OCamlSym =
   VarSym + AppSym + FunSym + LetSym + RecLetsSym + ConstSym
   + NamedPatSym + IntPatSym + CharPatSym + BoolPatSym
-  + OCamlMatch + OCamlTuple + OCamlData
+  + OCamlMatch + OCamlTuple + OCamlData + UnknownTypeSym
 
   sem symbolizeExpr (env : Env) =
   | OTmMatch {target = target, arms = arms} ->
     let symbArm = lam arm. match arm with (pat, expr) then
       match symbolizePat env assocEmpty pat with (patEnv, pat) then
-        (pat, symbolizeExpr (assocMergePreferRight {eq=eqString} env patEnv) expr)
+        let thnEnv = {env with varEnv = assocMergePreferRight {eq=eqString} env.varEnv patEnv} in
+        (pat, symbolizeExpr thnEnv expr)
       else never else never in
     OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
   | OTmTuple { values = values } ->

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -4,7 +4,7 @@ include "mexpr/symbolize.mc"
 lang OCamlSym =
   VarSym + AppSym + FunSym + LetSym + RecLetsSym + ConstSym
   + NamedPatSym + IntPatSym + CharPatSym + BoolPatSym
-  + OCamlMatch + OCamlTuple
+  + OCamlMatch + OCamlTuple + OCamlData
 
   sem symbolizeExpr (env : Env) =
   | OTmMatch {target = target, arms = arms} ->
@@ -15,10 +15,12 @@ lang OCamlSym =
     OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
   | OTmTuple { values = values } ->
     OTmTuple { values = map (symbolizeExpr env) values }
+  | OTmConApp { ident = ident, args = args } -> error "We're not quite done with adt's in ocaml yet, so symbolize won't work with programs that use them (in this case OTmConApp)"
 
   sem symbolizePat (env : Env) (patEnv : Env) =
   | OPTuple { pats = pats } ->
     match mapAccumL (symbolizePat env) patEnv pats with (patEnv, pats) then
       (patEnv, OPTuple { pats = pats })
     else never
+  | OPCon _ -> error "We're not quite done with adt's in ocaml yet, so symbolize won't work with programs that use them (in this case OPCon)"
 end

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -10,7 +10,7 @@ lang OCamlSym =
   | OTmMatch {target = target, arms = arms} ->
     let symbArm = lam arm. match arm with (pat, expr) then
       match symbolizePat env assocEmpty pat with (patEnv, pat) then
-        (pat, symbolizeExpr (_symOverwrite env patEnv) expr)
+        (pat, symbolizeExpr (assocMergePreferRight {eq=eqString} env patEnv) expr)
       else never else never in
     OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
   | OTmTuple { values = values } ->

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -4,7 +4,7 @@ include "mexpr/symbolize.mc"
 lang OCamlSym =
   VarSym + AppSym + FunSym + LetSym + RecLetsSym + ConstSym
   + NamedPatSym + IntPatSym + CharPatSym + BoolPatSym
-  + OCamlMatch
+  + OCamlMatch + OCamlTuple
 
   sem symbolizeExpr (env : Env) =
   | OTmMatch {target = target, arms = arms} ->
@@ -13,4 +13,12 @@ lang OCamlSym =
         (pat, symbolizeExpr (_symOverwrite env patEnv) expr)
       else never else never in
     OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
+  | OTmTuple { values = values } ->
+    OTmTuple { values = map (symbolizeExpr env) values }
+
+  sem symbolizePat (env : Env) (patEnv : Env) =
+  | OPTuple { pats = pats } ->
+    match mapAccumL (symbolizePat env) patEnv pats with (patEnv, pats) then
+      (patEnv, OPTuple { pats = pats })
+    else never
 end

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -1,0 +1,16 @@
+include "ocaml/ast.mc"
+include "mexpr/symbolize.mc"
+
+lang OCamlSym =
+  VarSym + AppSym + FunSym + LetSym + RecLetsSym + ConstSym
+  + NamedPatSym + IntPatSym + CharPatSym + BoolPatSym
+  + OCamlMatch
+
+  sem symbolizeExpr (env : Env) =
+  | OTmMatch {target = target, arms = arms} ->
+    let symbArm = lam arm. match arm with (pat, expr) then
+      match symbolizePat env assocEmpty pat with (patEnv, pat) then
+        (pat, symbolizeExpr (_symOverwrite env patEnv) expr)
+      else never else never in
+    OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
+end

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -112,6 +112,8 @@ with (9, [2,3,4])
 utest mapAccumR (lam acc. lam x. ((cons x acc), x)) [] [1,2,3]
 with ([1,2,3], [1,2,3])
 
+let unzip : [(a, b)] -> ([a], [b]) = mapAccumL (lam l. lam p. (snoc l p.0, p.1)) []
+
 -- Predicates
 recursive
   let any = lam p. lam seq.


### PR DESCRIPTION
This PR implements a first version of pattern compilation to OCaml, and fixes some minor things I found elsewhere in the codebase while implementing. The approach is relatively simple, with the intent to support everything correctly, shortcircuit properly, and never repeat computations in a single pattern. It would not be surprising in the least if we will need to generate better code here down the road. For example, the approach here computes intermediate sequences using `split_at`, which might be unnecessarily costly in cases when the intermediate results aren't really needed (i.e., when the middle name is a wildcard).

Briefly, a match is translated to a match on an `option`, and a pattern is translated to an expression that evaluates to an `option`. For example:

```
match sequence with [a] ++ b ++ [3] then
  f a b
else
  true
```
becomes
```ocaml
(* Exact (long) generated version: *)
match
  let target =
    sequence
  in
  if
    (<)
      (Boot.Intrinsics.Mseq.length
         target)
      2
  then
    Option.None
  else
    let
      (prefix, splitTemp)
    =
      Boot.Intrinsics.Mseq.split_at
        target
        1
    in
      let
        (middle, postfix)
      =
        Boot.Intrinsics.Mseq.split_at
          splitTemp
          ((-)
             (Boot.Intrinsics.Mseq.length
                splitTemp)
             1)
      in
        let seqElem =
          Boot.Intrinsics.Mseq.get
            prefix
            0
        in
        let seqElem1 =
          Boot.Intrinsics.Mseq.get
            postfix
            0
        in
        if
          (=)
            seqElem1
            3
        then
          Option.Some (seqElem, middle)
        else
          Option.None
with
| Option.Some (a, b) ->
    (f
       a
       b)
| Option.None ->
    true

(* Or a bit more concicely: *)
open Boot.Intrinsics.Mseq in
match
  let target = sequence in
  if length target < 2
  then None
  else
    let (prefix, splitTemp) = split_at target 1 in
    let (middle, postfix) = split_at splitTemp (length splitTemp - 1) in
    let seqElem = get prefix 0 in
    let seqElem1 = get postfix 0 in
    if seqElem1 = 3 then
      Some (seqElem, middle)
    else None
with
| Some (a, b) -> f a b
| None -> true
```

The strategy for generating this stuff centers primarily around `generatePat`, which has type `Name -> Pat -> (Map Name Name, Expr -> Expr)`.

- The first argument is the name of the variable holding the value to be matched against.
- Second argument is the pattern we're compiling.
- The first return value is a mapping of names that are bound. The mapping is from name of pattern (i.e., the name that appears in the pattern itself) to name of value (i.e., the value the current pattern computed). In the example `a` and `b` are names bound by the pattern and `seqElem`, and `middle` are names of computed values.
- The second return value is the expression checking the current pattern, but in something like continuation passing style. The function takes the expression to continue with if the current pattern matches. We want this function to be linear, since dropping the argument means we don't check remaining patterns, and duplicating the argument means duplicating the code checking the rest of the pattern.

------------------------

Here's a (possibly complete) list of the other things that changed along the way, in no particular order:
- `compile.mc` now turns off two warnings for unused variables since this approach generates unused variables on wildcard patterns (and also if the AST being compiled contains unused variables, naturally). This is done because `dune` makes errors into warnings by default, thus this makes compilation fail.
- `symbolizePat` for record patterns used `env` in a location where it should have used `patEnv`. I also added a test that catches this case.
- Added an `assoc2seq` (which presently is just the identity function) to extract key-value pairs (+ tests).
- Added an `assocMapWithKey` function (+ tests).
- `pprint.mc` now also has a `printPatParen` helper, similar to `printParen` for `Expr`.
- The OCaml fragment now supports `match`, tuples & applied constructors (note that these are unrelated to those in mexpr, since the semantics are different), and patterns.
  - There is now an `ocaml/symbolize.mc` file to support these. However, since there is no construct that introduces constructors in the AST we merely error if we encounter a constructor.
- Changed `compile.mc` to not use `capture_output`, and use `cleanup` instead of `rmtree`, to be compatible with my (older) version of Python 3.
- There's now an `unzip` function in `seq.mc`.