### PR TITLE
Use ANF transformation for decision points

### DIFF
--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -21,9 +21,9 @@ include "set.mc"
 include "assoc.mc"
 include "math.mc"
 
-type Digraph = { adj : AssocMap,
-                 eqv : a -> a -> Bool,
-                 eql : b -> b -> Bool }
+type Digraph v l = { adj : AssocMap v [(v,v,l)],
+                     eqv : v -> v -> Bool,
+                     eql : l -> l -> Bool }
 
 -- Returns an empty graph. Input: equality functions for vertices and labels.
 let digraphEmpty = lam eqv. lam eql.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -344,6 +344,10 @@ let recordproj_ = use MExprAst in
   lam key. lam r.
   nrecordproj_ (nameNoSym "x") key r
 
+let ntupleproj_ = use MExprAst in
+  lam name. lam i. lam t.
+  nrecordproj_ name (int2string i) t
+
 let tupleproj_ = use MExprAst in
   lam i. lam t.
   recordproj_ (int2string i) t


### PR DESCRIPTION
In this PR the decision points transformation is updated to use ANF transformation. This removes some hacky workarounds that were previously used to achieve unique symbols for some AST nodes. In addition, some cleanup and conforming to code style conventions has been done.