### PR TITLE
Map intrinsics

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -124,6 +124,7 @@ and const =
   | CMap of map
   | CmapEmpty
   | CmapInsert of tm option * tm option
+  | CmapLookup of tm option
   (* External functions TODO(?,?): Should not be part of core language *)
   | CExt of Extast.ext
   | CSd of Sdast.ext

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -121,7 +121,8 @@ and const =
   | CMap of (tm -> tm -> int) * Obj.t
   | CmapEmpty
   | CmapInsert of tm option * tm option
-  | CmapLookup of tm option
+  | CmapFind of tm option
+  | CmapMem of tm option
   | CmapAny of (tm -> tm -> bool) option
   (* External functions TODO(?,?): Should not be part of core language *)
   | CExt of Extast.ext

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -34,8 +34,11 @@ let utest_fail_local = ref 0 (* Counts local failed tests for one file *)
 (* Map type for record implementation *)
 module Record = Map.Make (Ustring)
 
+(* Type for built-in maps: a tuple module * map object *)
+type map = Obj.t * (module Map.S) * Obj.t
+
 (* Evaluation environment *)
-type env = (Symb.t * tm) list
+and env = (Symb.t * tm) list
 
 and const =
   (* MCore intrinsic: Boolean constant and operations. See test/mexpr/bool.mc *)
@@ -117,6 +120,10 @@ and const =
   | Cref
   | CmodRef of tm ref option
   | CdeRef
+  (* Map intrinsics *)
+  | CMap of map
+  | CmapEmpty
+  | CmapInsert of tm option * tm option
   (* External functions TODO(?,?): Should not be part of core language *)
   | CExt of Extast.ext
   | CSd of Sdast.ext

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -118,6 +118,7 @@ and const =
   | CmodRef of tm ref option
   | CdeRef
   (* Map intrinsics *)
+  (* NOTE(Linnea, 2021-01-27): Obj.t denotes the type of the internal map (I was so far unable to express it properly) *)
   | CMap of (tm -> tm -> int) * Obj.t
   | CmapEmpty
   | CmapInsert of tm option * tm option

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -34,11 +34,8 @@ let utest_fail_local = ref 0 (* Counts local failed tests for one file *)
 (* Map type for record implementation *)
 module Record = Map.Make (Ustring)
 
-(* Type for built-in maps: a tuple module * map object *)
-type map = Obj.t * (module Map.S) * Obj.t
-
 (* Evaluation environment *)
-and env = (Symb.t * tm) list
+type env = (Symb.t * tm) list
 
 and const =
   (* MCore intrinsic: Boolean constant and operations. See test/mexpr/bool.mc *)
@@ -121,10 +118,11 @@ and const =
   | CmodRef of tm ref option
   | CdeRef
   (* Map intrinsics *)
-  | CMap of map
+  | CMap of (tm -> tm -> int) * Obj.t
   | CmapEmpty
   | CmapInsert of tm option * tm option
   | CmapLookup of tm option
+  | CmapAny of (tm -> tm -> bool) option
   (* External functions TODO(?,?): Should not be part of core language *)
   | CExt of Extast.ext
   | CSd of Sdast.ext

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -347,27 +347,27 @@ let arity = function
       1
   (* Map intrinsics *)
   | CMap _ ->
-    0
+      0
   | CmapEmpty ->
-    1
+      1
   | CmapInsert (None, None) ->
-    3
+      3
   | CmapInsert (Some _, None) ->
-    2
+      2
   | CmapInsert (_, Some _) ->
-    1
+      1
   | CmapFind None ->
-    2
+      2
   | CmapFind (Some _) ->
-    1
+      1
   | CmapAny None ->
-    2
+      2
   | CmapAny (Some _) ->
-    1
+      1
   | CmapMem None ->
-    2
+      2
   | CmapMem (Some _) ->
-    1
+      1
   (* Python intrinsics *)
   | CPy v ->
       Pyffi.arity v
@@ -805,71 +805,82 @@ let delta eval env fi c v =
   | CdeRef, _ ->
       fail_constapp fi
   | CMap _, _ ->
-    fail_constapp fi
+      fail_constapp fi
   | CmapEmpty, cmp ->
-    let compare (x : tm) (y : tm) =
-      let app = TmApp(fi, TmApp(fi, cmp, x), y) in
-      match eval env app with
-      | TmConst(_, CInt(i)) -> i
-      | _ -> fail_constapp fi
-    in let module Ord = struct
-         type t = tm
-         let compare = compare
-       end
-    in let module MapModule = Map.Make(Ord) in
-    TmConst(fi, CMap(compare, Obj.repr MapModule.empty))
+      let compare x y =
+        let app = TmApp (fi, TmApp (fi, cmp, x), y) in
+        match eval env app with
+        | TmConst (_, CInt i) ->
+            i
+        | _ ->
+            fail_constapp fi
+      in
+      let module Ord = struct
+        type t = tm
+
+        let compare = compare
+      end in
+      let module MapModule = Map.Make (Ord) in
+      TmConst (fi, CMap (compare, Obj.repr MapModule.empty))
   | CmapInsert (None, None), key ->
-    TmConst(fi, CmapInsert (Some key, None))
+      TmConst (fi, CmapInsert (Some key, None))
   | CmapInsert (Some key, None), v ->
-    TmConst(fi, CmapInsert (Some key, Some v))
-  | CmapInsert (Some k, Some v), TmConst(_, CMap(cmp, m)) ->
-    let module Ord = struct
-      type t = tm
-      let compare = cmp
-    end
-    in let module MapModule = Map.Make(Ord) in
-    let m = MapModule.add k v (Obj.obj m) in
-    TmConst(fi, CMap(cmp, Obj.repr m))
+      TmConst (fi, CmapInsert (Some key, Some v))
+  | CmapInsert (Some k, Some v), TmConst (_, CMap (cmp, m)) ->
+      let module Ord = struct
+        type t = tm
+
+        let compare = cmp
+      end in
+      let module MapModule = Map.Make (Ord) in
+      let m = MapModule.add k v (Obj.obj m) in
+      TmConst (fi, CMap (cmp, Obj.repr m))
   | CmapInsert (Some _, Some _), _ | CmapInsert (None, Some _), _ ->
-    fail_constapp fi
+      fail_constapp fi
   | CmapFind None, t ->
-    TmConst(fi, CmapFind(Some t))
-  | CmapFind (Some k), TmConst(_, CMap(cmp, mp)) ->
-    let module Ord = struct
-      type t = tm
-      let compare = cmp
-    end
-    in let module MapModule = Map.Make(Ord) in
-    MapModule.find k (Obj.obj mp)
+      TmConst (fi, CmapFind (Some t))
+  | CmapFind (Some k), TmConst (_, CMap (cmp, mp)) ->
+      let module Ord = struct
+        type t = tm
+
+        let compare = cmp
+      end in
+      let module MapModule = Map.Make (Ord) in
+      MapModule.find k (Obj.obj mp)
   | CmapFind (Some _), _ ->
-    fail_constapp fi
+      fail_constapp fi
   | CmapAny None, p ->
-    let pred (x : tm) (y : tm) =
-      let app = TmApp(fi, TmApp(fi, p, x), y) in
-      match eval env app with
-      | TmConst(_, CBool(b)) -> b
-      | _ -> fail_constapp fi
-    in TmConst(fi, CmapAny(Some pred))
-  | CmapAny (Some p), TmConst(_, CMap(cmp, m)) ->
-    let module Ord = struct
-      type t = tm
-      let compare = cmp
-    end
-    in let module MapModule = Map.Make(Ord) in
-    TmConst(fi, CBool(MapModule.exists p (Obj.obj m)))
-  | CmapAny(Some _), _ ->
-    fail_constapp fi
+      let pred x y =
+        let app = TmApp (fi, TmApp (fi, p, x), y) in
+        match eval env app with
+        | TmConst (_, CBool b) ->
+            b
+        | _ ->
+            fail_constapp fi
+      in
+      TmConst (fi, CmapAny (Some pred))
+  | CmapAny (Some p), TmConst (_, CMap (cmp, m)) ->
+      let module Ord = struct
+        type t = tm
+
+        let compare = cmp
+      end in
+      let module MapModule = Map.Make (Ord) in
+      TmConst (fi, CBool (MapModule.exists p (Obj.obj m)))
+  | CmapAny (Some _), _ ->
+      fail_constapp fi
   | CmapMem None, key ->
-    TmConst(fi, CmapMem(Some key))
-  | CmapMem (Some k), TmConst(_, CMap(cmp, m)) ->
-    let module Ord = struct
-      type t = tm
-      let compare = cmp
-    end
-    in let module MapModule = Map.Make(Ord) in
-    TmConst(fi, CBool(MapModule.mem k (Obj.obj m)))
+      TmConst (fi, CmapMem (Some key))
+  | CmapMem (Some k), TmConst (_, CMap (cmp, m)) ->
+      let module Ord = struct
+        type t = tm
+
+        let compare = cmp
+      end in
+      let module MapModule = Map.Make (Ord) in
+      TmConst (fi, CBool (MapModule.mem k (Obj.obj m)))
   | CmapMem (Some _), _ ->
-    fail_constapp fi
+      fail_constapp fi
   (* Python intrinsics *)
   | CPy v, t ->
       Pyffi.delta eval env fi v t

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -377,10 +377,12 @@ let rec print_const fmt = function
     fprintf fmt "mapEmpty"
   | CmapInsert _ ->
     fprintf fmt "mapInsert"
-  | CmapLookup _ ->
+  | CmapFind _ ->
     fprintf fmt "mapLookup"
   | CmapAny _ ->
     fprintf fmt "mapAny"
+  | CmapMem _ ->
+    fprintf fmt "mapMem"
   (* Python intrinsics *)
   | CPy v ->
       fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -370,6 +370,13 @@ let rec print_const fmt = function
       fprintf fmt "modref"
   | CdeRef ->
       fprintf fmt "deref"
+  (* Map intrinsics *)
+  | CMap _ ->
+    fprintf fmt "map"
+  | CmapEmpty ->
+    fprintf fmt "mapEmpty"
+  | CmapInsert _ ->
+    fprintf fmt "mapInsert"
   (* Python intrinsics *)
   | CPy v ->
       fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -377,6 +377,8 @@ let rec print_const fmt = function
     fprintf fmt "mapEmpty"
   | CmapInsert _ ->
     fprintf fmt "mapInsert"
+  | CmapLookup _ ->
+    fprintf fmt "mapLookup"
   (* Python intrinsics *)
   | CPy v ->
       fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -372,17 +372,17 @@ let rec print_const fmt = function
       fprintf fmt "deref"
   (* Map intrinsics *)
   | CMap _ ->
-    fprintf fmt "map"
+      fprintf fmt "map"
   | CmapEmpty ->
-    fprintf fmt "mapEmpty"
+      fprintf fmt "mapEmpty"
   | CmapInsert _ ->
-    fprintf fmt "mapInsert"
+      fprintf fmt "mapInsert"
   | CmapFind _ ->
-    fprintf fmt "mapLookup"
+      fprintf fmt "mapLookup"
   | CmapAny _ ->
-    fprintf fmt "mapAny"
+      fprintf fmt "mapAny"
   | CmapMem _ ->
-    fprintf fmt "mapMem"
+      fprintf fmt "mapMem"
   (* Python intrinsics *)
   | CPy v ->
       fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -379,6 +379,8 @@ let rec print_const fmt = function
     fprintf fmt "mapInsert"
   | CmapLookup _ ->
     fprintf fmt "mapLookup"
+  | CmapAny _ ->
+    fprintf fmt "mapAny"
   (* Python intrinsics *)
   | CPy v ->
       fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -12,7 +12,11 @@ let ltChar = lam c1. lam c2. lti (char2int c1) (char2int c2)
 let gtChar = lam c1. lam c2. gti (char2int c1) (char2int c2)
 let leqChar = lam c1. lam c2. leqi (char2int c1) (char2int c2)
 let geqChar = lam c1. lam c2. geqi (char2int c1) (char2int c2)
+let cmpChar = lam c1. lam c2. subi (char2int c1) (char2int c2)
 
+utest cmpChar 'a' 'a' with 0
+utest cmpChar 'a' 'A' with 32
+utest cmpChar '\t' '\n' with subi 0 1
 
 -- Escape characters
 let _escapes = [

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -3,6 +3,8 @@
 --
 -- Defines auxiliary functions for the map intrinsics.
 
+include "option.mc"
+
 let mapLookup : k -> Map k v -> Option v =
   lam k. lam m.
     match mapMem k m with false then None ()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -1,0 +1,26 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Defines auxiliary functions for the map intrinsics.
+
+let mapLookup : k -> Map k v -> Option v =
+  lam k. lam m.
+    match mapMem k m with false then None ()
+    else Some (mapFind k m)
+
+mexpr
+
+let m = mapEmpty subi in
+
+utest mapLookup 1 m with None () in
+
+let m = mapInsert 1 "1" m in
+let m = mapInsert 2 "2" m in
+let m = mapInsert 3 "3" m in
+
+utest mapLookup 1 m with Some "1" in
+utest mapLookup 2 m with Some "2" in
+utest mapLookup 3 m with Some "3" in
+utest mapLookup 4 m with None () in
+
+()

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -156,7 +156,7 @@ end
 -- OPT(vipa, 2020-12-03): This is quadratic, no?
 let bindall_ = use MExprAst in
   lam exprs.
-  foldl1 bind_ exprs
+  foldr1 bind_ exprs
 
 let unit_ = use MExprAst in
   TmRecord {bindings = assocEmpty}

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -153,7 +153,6 @@ recursive let bind_ = use MExprAst in
     expr -- Insert at the end of the chain
 end
 
--- OPT(vipa, 2020-12-03): This is quadratic, no?
 let bindall_ = use MExprAst in
   lam exprs.
   foldr1 bind_ exprs

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -4,6 +4,7 @@ include "option.mc"
 include "seq.mc"
 include "string.mc"
 include "name.mc"
+include "map.mc"
 
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
@@ -38,19 +39,19 @@ type PprintEnv = {
 
 -- TODO(dlunde,2020-09-29) Make it possible to debug the actual symbols
 
-let pprintEnvEmpty = {nameMap = assocEmpty, count = assocEmpty}
+let pprintEnvEmpty = {nameMap = mapEmpty nameCmp, count = mapEmpty cmpString}
 
 -- Look up the string associated with a name in the environment
 let pprintEnvLookup : Name -> PprintEnv -> Option String = lam name. lam env.
   match env with { nameMap = nameMap } then
-    assocLookup {eq = nameEq} name nameMap
+    mapLookup name nameMap
   else never
 
 -- Check if a string is free in the environment.
 let pprintEnvFree : String -> PprintEnv -> Bool = lam str. lam env.
   match env with { nameMap = nameMap } then
     let f = lam _. lam v. eqString str v in
-    not (assocAny f nameMap)
+    not (mapAny f nameMap)
   else never
 
 -- Add a binding to the environment
@@ -58,8 +59,8 @@ let pprintEnvAdd : Name -> String -> Int -> PprintEnv -> PprintEnv =
   lam name. lam str. lam i. lam env.
     match env with {nameMap = nameMap, count = count} then
       let baseStr = nameGetStr name in
-      let count = assocInsert {eq = eqString} baseStr i count in
-      let nameMap = assocInsert {eq = nameEq} name str nameMap in
+      let count = mapInsert baseStr i count in
+      let nameMap = mapInsert name str nameMap in
       {nameMap = nameMap, count = count}
     else never
 
@@ -74,7 +75,7 @@ let pprintEnvGetStr : PprintEnv -> Name -> (PprintEnv, String) =
       else
         match env with {count = count} then
           let start =
-            match assocLookup {eq = eqString} baseStr count
+            match mapLookup baseStr count
             with Some i then i else 1 in
           recursive let findFree : String -> Int -> (String, Int) =
             lam baseStr. lam i.

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -150,8 +150,8 @@ let _s = gensym ()
 utest nameGetSym (nameNoSym "foo") with None ()
 utest nameGetSym (nameSetSym (nameNoSym "foo") _s) with Some _s
 
--- TODO(Linnea, 2021-01-26): This is not a total ordering since symbols are not
--- ordered.
+-- NOTE(Linnea, 2021-01-26): This function is temporarily added for performance
+-- experiments. It is not a total ordering since symbols are not ordered.
 -- 'nameCmp n1 n2' compares two names lexicographically.
 let nameCmp : Name -> Name -> Int =
   lam n1. lam n2.
@@ -160,9 +160,9 @@ let nameCmp : Name -> Name -> Int =
     else if and (nameHasSym n1) (nameHasSym n2) then
       subi (sym2hash (optionGetOrElse (lam _. error "Expected symbol") (nameGetSym n1)))
            (sym2hash (optionGetOrElse (lam _. error "Expected symbol") (nameGetSym n2)))
+    else if (nameHasSym n1) then subi 0 1
+    else if (nameHasSym n2) then 1
     else
-      let _ = printLn "Name missing symbol" in
-      -- TODO(Linnea, 2021-01-26): perhaps always consider having symbol as smaller, or else not transitive
       cmpString (nameGetStr n1) (nameGetStr n2)
 
 let _s1 = gensym ()
@@ -172,3 +172,5 @@ utest nameCmp (nameSetSym (nameNoSym "foo") _s1) (nameSetSym (nameNoSym "foo") _
 utest nameCmp (nameSetSym (nameNoSym "foo") _s2) (nameSetSym (nameNoSym "foo") _s1) with 1
 utest nameCmp (nameNoSym "foo") (nameNoSym "foo") with 0
 utest nameCmp (nameNoSym "a") (nameNoSym "A") with 32
+utest nameCmp (nameSetSym (nameNoSym "foo") _s1) (nameNoSym "foo") with subi 0 1
+utest nameCmp (nameNoSym "foo") (nameSetSym (nameNoSym "foo") _s1) with 1

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -149,3 +149,26 @@ let nameGetSym : Name -> Option Symbol =
 let _s = gensym ()
 utest nameGetSym (nameNoSym "foo") with None ()
 utest nameGetSym (nameSetSym (nameNoSym "foo") _s) with Some _s
+
+-- TODO(Linnea, 2021-01-26): This is not a total ordering since symbols are not
+-- ordered.
+-- 'nameCmp n1 n2' compares two names lexicographically.
+let nameCmp : Name -> Name -> Int =
+  lam n1. lam n2.
+    if nameEq n1 n2 then
+      0
+    else if and (nameHasSym n1) (nameHasSym n2) then
+      subi (sym2hash (optionGetOrElse (lam _. error "Expected symbol") (nameGetSym n1)))
+           (sym2hash (optionGetOrElse (lam _. error "Expected symbol") (nameGetSym n2)))
+    else
+      let _ = printLn "Name missing symbol" in
+      -- TODO(Linnea, 2021-01-26): perhaps always consider having symbol as smaller, or else not transitive
+      cmpString (nameGetStr n1) (nameGetStr n2)
+
+let _s1 = gensym ()
+let _s2 = gensym ()
+utest nameCmp (nameSetSym (nameNoSym "foo") _s1) (nameSetSym (nameNoSym "foo") _s1) with 0
+utest nameCmp (nameSetSym (nameNoSym "foo") _s1) (nameSetSym (nameNoSym "foo") _s2) with (subi 0 1)
+utest nameCmp (nameSetSym (nameNoSym "foo") _s2) (nameSetSym (nameNoSym "foo") _s1) with 1
+utest nameCmp (nameNoSym "foo") (nameNoSym "foo") with 0
+utest nameCmp (nameNoSym "a") (nameNoSym "A") with 32

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -59,6 +59,35 @@ utest gtString "x" "y" with false
 utest gtString "yx" "y" with true
 utest gtString "xy" "y" with false
 
+-- String comparison giving a total ordering of strings.
+-- cmpString s1 s2 returns >0 or <0 if s1 lexicographically
+-- greater respectively smaller than s2, else 0.
+recursive
+  let cmpString: String -> String -> Int = lam s1. lam s2.
+    if and (null s1) (null s2) then
+      0
+    else if null s1 then
+      subi 0 1
+    else if null s2 then
+      1
+    else
+      let d = cmpChar (head s1) (head s2) in
+      match d with 0 then
+        cmpString (tail s1) (tail s2)
+      else d
+end
+
+utest cmpString "" "" with 0
+utest cmpString "Hello" "Hello" with 0
+utest
+  match gti (cmpString "a" "") 0 with true then true else false
+  with true
+utest
+  match lti (cmpString "aa" "aaa") 0 with true then true else false
+  with true
+utest
+  match lti (cmpString "aaa" "aab") 0 with true then true else false
+  with true
 
 let str2upper = lam s. map char2upper s
 let str2lower = lam s. map char2lower s

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -7,10 +7,6 @@ include "../../stdlib/string.mc"
 
 mexpr
 
--- TODO
--- mapAny
--- mapMem
-
 -- Int map
 let m = mapEmpty subi in
 

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -3,49 +3,48 @@
 --
 -- Map intrinstics
 
-include "../../stdlib/string.mc"
-
 mexpr
 
 -- Int map
 let m = mapEmpty subi in
 
-let m = mapInsert 1 "1" m in
-let m = mapInsert 2 "2" m in
-let m = mapInsert 3 "3" m in
-let m = mapInsert 4 "4" m in
-let m = mapInsert 4 "5" m in
+let m = mapInsert 1 '1' m in
+let m = mapInsert 2 '2' m in
+let m = mapInsert 3 '3' m in
+let m = mapInsert 4 '4' m in
+let m = mapInsert 4 '5' m in
 
-utest mapFind 1 m with "1" in
-utest mapFind 2 m with "2" in
-utest mapFind 3 m with "3" in
-utest mapFind 4 m with "5" in
+utest mapFind 1 m with '1' in
+utest mapFind 2 m with '2' in
+utest mapFind 3 m with '3' in
+utest mapFind 4 m with '5' in
 
 utest mapMem 1 m with true in
 utest mapMem 42 m with false in
 
 utest mapAny (lam k. lam v. eqi 1 k) m with true in
-utest mapAny (lam k. lam v. eqString "5" v) m with true in
-utest mapAny (lam k. lam v. eqString "4" v) m with false in
+utest mapAny (lam k. lam v. eqi (char2int '5') (char2int v)) m with true in
+utest mapAny (lam k. lam v. eqi (char2int '4') (char2int v)) m with false in
 
--- String-int tuple map
+-- Int tuple map
 let cmpTuple = lam t1. lam t2.
-  let sDiff = cmpString t1.0 t2.0 in
-  match sDiff with 0 then
+  let d = subi t1.0 t2.0 in
+  match d with 0 then
     subi t1.1 t2.1
-  else sDiff
+  else d
 in
 
 let m = mapEmpty cmpTuple in
 
-let m = mapInsert ("1", 1) 1 m in
-let m = mapInsert ("1", 2) 2 m in
-let m = mapInsert ("Hello", 42) 3 m in
-let m = mapInsert ("Hello!", 42) 4 m in
+let m = mapInsert (1, 1) 1 m in
+let m = mapInsert (1, 1) 2 m in
+let m = mapInsert (1, 2) 2 m in
+let m = mapInsert (2, 42) 3 m in
+let m = mapInsert (3, 42) 4 m in
 
-utest mapFind ("1", 1) m with 1 in
-utest mapFind ("1", 2) m with 2 in
-utest mapFind ("Hello", 42) m with 3 in
-utest mapFind ("Hello!", 42) m with 4 in
+utest mapFind (1, 1) m with 2 in
+utest mapFind (1, 2) m with 2 in
+utest mapFind (2, 42) m with 3 in
+utest mapFind (3, 42) m with 4 in
 
 ()

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -1,0 +1,51 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Map intrinstics
+
+include "../../stdlib/string.mc"
+
+mexpr
+
+-- TODO
+-- mapAny
+
+-- Int map
+let m = mapEmpty subi in
+
+let m = mapInsert 1 "1" m in
+let m = mapInsert 2 "2" m in
+let m = mapInsert 3 "3" m in
+let m = mapInsert 4 "4" m in
+let m = mapInsert 4 "5" m in
+
+utest mapLookup 1 m with "1" in
+utest mapLookup 2 m with "2" in
+utest mapLookup 3 m with "3" in
+utest mapLookup 4 m with "5" in
+
+utest mapAny (lam k. lam v. eqi 1 k) m with true in
+utest mapAny (lam k. lam v. eqString "5" v) m with true in
+utest mapAny (lam k. lam v. eqString "4" v) m with false in
+
+-- String-int tuple map
+let cmpTuple = lam t1. lam t2.
+  let sDiff = cmpString t1.0 t2.0 in
+  match sDiff with 0 then
+    subi t1.1 t2.1
+  else sDiff
+in
+
+let m = mapEmpty cmpTuple in
+
+let m = mapInsert ("1", 1) 1 m in
+let m = mapInsert ("1", 2) 2 m in
+let m = mapInsert ("Hello", 42) 3 m in
+let m = mapInsert ("Hello!", 42) 4 m in
+
+utest mapLookup ("1", 1) m with 1 in
+utest mapLookup ("1", 2) m with 2 in
+utest mapLookup ("Hello", 42) m with 3 in
+utest mapLookup ("Hello!", 42) m with 4 in
+
+()

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -9,6 +9,7 @@ mexpr
 
 -- TODO
 -- mapAny
+-- mapMem
 
 -- Int map
 let m = mapEmpty subi in
@@ -19,10 +20,13 @@ let m = mapInsert 3 "3" m in
 let m = mapInsert 4 "4" m in
 let m = mapInsert 4 "5" m in
 
-utest mapLookup 1 m with "1" in
-utest mapLookup 2 m with "2" in
-utest mapLookup 3 m with "3" in
-utest mapLookup 4 m with "5" in
+utest mapFind 1 m with "1" in
+utest mapFind 2 m with "2" in
+utest mapFind 3 m with "3" in
+utest mapFind 4 m with "5" in
+
+utest mapMem 1 m with true in
+utest mapMem 42 m with false in
 
 utest mapAny (lam k. lam v. eqi 1 k) m with true in
 utest mapAny (lam k. lam v. eqString "5" v) m with true in
@@ -43,9 +47,9 @@ let m = mapInsert ("1", 2) 2 m in
 let m = mapInsert ("Hello", 42) 3 m in
 let m = mapInsert ("Hello!", 42) 4 m in
 
-utest mapLookup ("1", 1) m with 1 in
-utest mapLookup ("1", 2) m with 2 in
-utest mapLookup ("Hello", 42) m with 3 in
-utest mapLookup ("Hello!", 42) m with 4 in
+utest mapFind ("1", 1) m with 1 in
+utest mapFind ("1", 2) m with 2 in
+utest mapFind ("Hello", 42) m with 3 in
+utest mapFind ("Hello!", 42) m with 4 in
 
 ()


### PR DESCRIPTION
This PR adds map intrinsics using the OCaml `Map` module in an attempt to speed up `pprint.mc`, which heavily relies on map operations.

* The last status of the performance issues was that using hashmaps in `pprint.mc` gave a much better performance than using assoc maps. However, there was a bug in my implementation (`assocAny` and `hashmapAny` had different signatures), which resulted in variable names not getting unique strings after all. This means that the performance was far from as good as I thought: ~11 s (and not 4 s as I thought) on the example program.
* The runtime using the intrinsics in this PR is ~4 s, that is, what we thought we had already achieved using hashmaps.
* This PR has been marked as a draft because:
   1) It contains some hacky elements, most notably the type of the internal map is `Obj.t` in the AST.
   2) The OCaml `Map` module requires a total ordering of the keys, and since the keys are names in `pprint.mc`, we need a total ordering of symbols, which we currently don’t have. However, just for the sake of experimentation, I used `sym2hash` to implement a comparison function.

Hopefully, this PR can at least lead to a discussion of the next steps in fixing the performance issues.