### PR TITLE
Add type annotations

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -134,9 +134,10 @@ lang RecLetsANF = ANF + RecLetsAst
   sem normalize (k : Expr -> Expr) =
   -- We do not allow lifting things outside of reclets, since they might
   -- inductively depend on what is being defined.
-  | TmRecLets {bindings = bindings, inexpr = inexpr} ->
-    let bindings = map (lam b. {b with body = normalizeTerm b.body}) bindings in
-    TmRecLets {bindings = bindings, inexpr = normalize k inexpr}
+  | TmRecLets t ->
+    let bindings = map (lam b. {b with body = normalizeTerm b.body}) t.bindings in
+    TmRecLets {{t with bindings = bindings}
+                  with inexpr = normalize k t.inexpr}
 end
 
 lang ConstANF = ANF + ConstAst
@@ -182,10 +183,10 @@ lang UtestANF = ANF + UtestAst
   | TmUtest _ -> false
 
   sem normalize (k : Expr -> Expr) =
-  | TmUtest {test = test, expected = expected, next = next} ->
-    TmUtest {test = normalizeTerm test,
-             expected = normalizeTerm expected,
-             next = normalize k next}
+  | TmUtest t ->
+    TmUtest {{{t with test = normalizeTerm t.test}
+                 with expected = normalizeTerm t.expected}
+                 with next = normalize k t.next}
 
 end
 

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -55,10 +55,11 @@ lang AppANF = ANF + AppAst
   | TmApp t -> normalizeNames k (TmApp t)
 
   sem normalizeNames (k : Expr -> Expr) =
-  | TmApp {lhs = lhs, rhs = rhs} ->
+  | TmApp t ->
     normalizeNames
-      (lam l. normalizeName (lam r. k (TmApp {lhs = l, rhs = r})) rhs)
-      lhs
+      (lam l. normalizeName (lam r. k (TmApp {{t with lhs = l}
+                                                 with rhs = r})) t.rhs)
+      t.lhs
   | t -> normalizeName k t
 
 end

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -154,12 +154,12 @@ lang DataANF = ANF + DataAst
   | TmConApp _ -> false
 
   sem normalize (k : Expr -> Expr) =
-  | TmConDef {ident = ident, ty = ty, inexpr = inexpr} ->
-    TmConDef {ident = ident, ty = ty, inexpr = normalize k inexpr}
+  | TmConDef t ->
+    TmConDef {t with inexpr = normalize k t.inexpr}
 
-  | TmConApp {ident = ident, body = body } ->
+  | TmConApp t ->
     normalizeName
-      (lam b. k (TmConApp {ident = ident, body = b})) body
+      (lam b. k (TmConApp {t with body = b})) t.body
 
 end
 

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -22,8 +22,13 @@ lang ANF = LetAst + VarAst + UnknownTypeAst
   sem bind (k : Expr -> Expr) =
   | n ->
     let ident = nameSym "t" in
-    (TmLet {ident = ident, ty = TyUnknown {},
-            body = n, inexpr = k (TmVar {ident = ident})})
+    let var = TmVar {
+      ident = ident,
+      ty = TyUnknown {},
+      fi = NoInfo {}
+    } in
+    TmLet {ident = ident, ty = TyUnknown {},
+           body = n, inexpr = k var}
 
   sem normalizeName (k : Expr -> Expr) =
   | m -> normalize (lam n. if (isValue n) then k n else bind k n) m

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -194,8 +194,8 @@ lang SeqANF = ANF + SeqAst
   | TmSeq _ -> false
 
   sem normalize (k : Expr -> Expr) =
-  | TmSeq {tms = tms} ->
-    let acc = lam ts. k (TmSeq {tms = ts}) in
+  | TmSeq t ->
+    let acc = lam ts. k (TmSeq {t with tms = ts}) in
     let f =
       (lam acc. lam e.
          (lam ts.
@@ -203,7 +203,7 @@ lang SeqANF = ANF + SeqAst
               (lam v. acc (cons v ts))
               e))
     in
-    (foldl f acc tms) []
+    (foldl f acc t.tms) []
 
 end
 

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -27,8 +27,8 @@ lang ANF = LetAst + VarAst + UnknownTypeAst
       ty = TyUnknown {},
       fi = NoInfo {}
     } in
-    TmLet {ident = ident, ty = TyUnknown {},
-           body = n, inexpr = k var}
+    TmLet {ident = ident, tyBody = TyUnknown {},
+           body = n, inexpr = k var, ty = TyUnknown {}}
 
   sem normalizeName (k : Expr -> Expr) =
   | m -> normalize (lam n. if (isValue n) then k n else bind k n) m
@@ -109,11 +109,11 @@ lang LetANF = ANF + LetAst
   | TmLet _ -> false
 
   sem normalize (k : Expr -> Expr) =
-  | TmLet {ident = ident, ty = ty, body = m1, inexpr = m2} ->
+  | TmLet t ->
     normalize
-      (lam n1. (TmLet {ident = ident, ty = ty,
-                       body = n1, inexpr = normalizeName k m2}))
-      m1
+      (lam n1. (TmLet {{t with body = n1}
+                          with inexpr = normalizeName k t.inexpr}))
+      t.body
 
 end
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -159,7 +159,7 @@ let bindall_ = use MExprAst in
   foldl1 bind_ exprs
 
 let unit_ = use MExprAst in
-  TmRecord {bindings = assocEmpty}
+  TmRecord {bindings = assocEmpty, ty = TyRecord {fields = assocEmpty}}
 
 let nlet_ = use MExprAst in
   lam n. lam ty. lam body.
@@ -311,8 +311,9 @@ let record_ = use MExprAst in
     bindings =
       foldl
         (lam acc. lam b. assocInsert {eq=eqString} b.0 b.1 acc)
-        assocEmpty bindings
-    }
+        assocEmpty bindings,
+    ty = TyUnknown {}
+  }
 
 let tuple_ = use MExprAst in
   lam tms.
@@ -354,7 +355,7 @@ let tupleproj_ = use MExprAst in
 
 let recordupdate_ = use MExprAst in
   lam rec. lam key. lam value.
-  TmRecordUpdate {rec = rec, key = key, value = value}
+  TmRecordUpdate {rec = rec, key = key, value = value, ty = TyUnknown {}}
 
 let app_ = use MExprAst in
   lam l. lam r.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -188,7 +188,7 @@ let type_ = use MExprAst in
 let nreclets_ = use MExprAst in
   lam bs.
   TmRecLets {bindings = map (lam t. {ident = t.0, ty = t.1, body = t.2}) bs,
-             inexpr = unit_}
+             inexpr = unit_, ty = TyUnknown {}}
 
 let reclets_ = use MExprAst in
   lam bs.
@@ -332,7 +332,7 @@ let record_add_bindings = lam bindings. lam record.
   foldl (lam recacc. lam b. record_add b.0 b.1 recacc) record bindings
 
 let never_ = use MExprAst in
-  TmNever {}
+  TmNever {ty = TyUnknown {}}
 
 let nrecordproj_ = use MExprAst in
   lam name. lam key. lam r.
@@ -399,7 +399,7 @@ let appf8_ = use MExprAst in
 
 let utest_ = use MExprAst in
   lam t. lam e. lam n.
-  TmUtest {test = t, expected = e, next = n}
+  TmUtest {test = t, expected = e, next = n, ty = TyUnknown {}}
 
 
 -- Ascription

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -159,7 +159,7 @@ let bindall_ = use MExprAst in
   foldl1 bind_ exprs
 
 let unit_ = use MExprAst in
-  TmRecord {bindings = assocEmpty, ty = TyRecord {fields = assocEmpty}}
+  TmRecord {bindings = assocEmpty, ty = TyUnknown {}}
 
 let nlet_ = use MExprAst in
   lam n. lam ty. lam body.
@@ -303,7 +303,7 @@ let match_ = use MExprAst in
 
 let seq_ = use MExprAst in
   lam tms.
-  TmSeq {tms = tms}
+  TmSeq {tms = tms, ty = TyUnknown {}}
 
 let record_ = use MExprAst in
   lam bindings.
@@ -429,7 +429,7 @@ let char_ = use MExprAst in
 
 let str_ = use MExprAst in
   lam s.
-  TmSeq {tms = map char_ s}
+  TmSeq {tms = map char_ s, ty = TyUnknown {}}
 
 let symb_ = use MExprAst in
   lam c.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -358,7 +358,7 @@ let recordupdate_ = use MExprAst in
 
 let app_ = use MExprAst in
   lam l. lam r.
-  TmApp {lhs = l, rhs = r}
+  TmApp {lhs = l, rhs = r, ty = TyUnknown {}}
 
 let appSeq_ = use MExprAst in
   lam f. lam seq.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -295,11 +295,11 @@ let ulams_ = use MExprAst in
 
 let if_ = use MExprAst in
   lam cond. lam thn. lam els.
-  TmMatch {target = cond, pat = ptrue_, thn = thn, els = els}
+  TmMatch {target = cond, pat = ptrue_, thn = thn, els = els, ty = TyUnknown {}}
 
 let match_ = use MExprAst in
   lam target. lam pat. lam thn. lam els.
-  TmMatch {target = target, pat = pat, thn = thn, els = els}
+  TmMatch {target = target, pat = pat, thn = thn, els = els, ty = TyUnknown {}}
 
 let seq_ = use MExprAst in
   lam tms.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -259,7 +259,7 @@ let var_ = use MExprAst in
 
 let nconapp_ = use MExprAst in
   lam n. lam b.
-  TmConApp {ident = n, body = b}
+  TmConApp {ident = n, body = b, ty = TyUnknown {}}
 
 let conapp_ = use MExprAst in
   lam s. lam b.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -267,7 +267,7 @@ let conapp_ = use MExprAst in
 
 let const_ = use MExprAst in
   lam c.
-  TmConst {val = c}
+  TmConst {val = c, ty = TyUnknown {}}
 
 let nlam_ = use MExprAst in
   lam n. lam ty. lam body.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -251,7 +251,7 @@ let ucondef_ = use MExprAst in
 
 let nvar_ = use MExprAst in
   lam n.
-  TmVar {ident = n}
+  TmVar {ident = n, ty = TyUnknown {}}
 
 let var_ = use MExprAst in
   lam s.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -163,7 +163,7 @@ let unit_ = use MExprAst in
 
 let nlet_ = use MExprAst in
   lam n. lam ty. lam body.
-  TmLet {ident = n, ty = ty, body = body, inexpr = unit_}
+  TmLet {ident = n, tyBody = ty, body = body, inexpr = unit_, ty = TyUnknown {}}
 
 let let_ = use MExprAst in
   lam s. lam ty. lam body.

--- a/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -172,7 +172,8 @@ let tmRecordC = mkTmRecordXY tmApp11C tmConst3C in
 let cInt2cChar =
 lam e. match e with TmConst t then
          match t.val with CInt i
-           then TmConst {val = CChar {val = int2char i.val}}
+           then TmConst {val = CChar {val = int2char i.val},
+                         ty = TyUnknown {}}
          else e
        else e
 in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -16,6 +16,9 @@ lang VarAst
   sem info =
   | TmVar r -> r.fi
 
+  sem withType (ty : Type) =
+  | TmVar t -> TmVar {t with ty = ty}
+
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmVar t -> TmVar t
 
@@ -29,6 +32,9 @@ lang AppAst
 
   sem info =
   | TmApp r -> r.fi
+
+  sem withType (ty : Type) =
+  | TmApp t -> TmApp {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmApp t -> TmApp {{t with lhs = f t.lhs}
@@ -49,6 +55,9 @@ lang FunAst = VarAst + AppAst
   sem info =
   | TmLam r -> r.fi
 
+  sem withType (ty : Type) =
+  | TmLam t -> TmLam {t with ty = ty}
+
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmLam t -> TmLam {t with body = f t.body}
 
@@ -64,6 +73,10 @@ lang RecordAst
                     key   : String,
                     value : Expr,
                     ty    : Type}
+
+  sem withType (ty : Type) =
+  | TmRecord t -> TmRecord {t with ty = ty}
+  | TmRecordUpdate t -> TmRecordUpdate {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmRecord t -> TmRecord {t with bindings = assocMap {eq=eqString} f t.bindings}
@@ -85,6 +98,9 @@ lang LetAst = VarAst
 
   sem info =
   | TmLet r -> r.fi
+
+  sem withType (ty : Type) =
+  | TmLet t -> TmLet {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmLet t -> TmLet {{t with body = f t.body} with inexpr = f t.inexpr}
@@ -153,6 +169,10 @@ lang DataAst
               body  : Expr,
               ty    : Type}
 
+  sem withType (ty : Type) =
+  | TmConDef t -> TmConDef {t with ty = ty}
+  | TmConApp t -> TmConApp {t with ty = ty}
+
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmConDef t -> TmConDef {t with inexpr = f t.inexpr}
   | TmConApp t -> TmConApp {t with body = f t.body}
@@ -175,6 +195,9 @@ lang MatchAst
 
   sem info =
   | TmMatch r -> r.fi
+
+  sem withType (ty : Type) =
+  | TmMatch t -> TmMatch {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmMatch t -> TmMatch {{{t with target = f t.target}
@@ -206,6 +229,9 @@ lang SeqAst
 
   sem info =
   | TmSeq r -> r.fi
+
+  sem withType (ty : Type) =
+  | TmSeq t -> TmSeq {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmSeq t -> TmSeq {t with tms = map f t.tms}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -11,7 +11,7 @@ include "mexpr/info.mc"
 
 lang VarAst
   syn Expr =
-  | TmVar {ident : Name, fi: Info}
+  | TmVar {ident : Name, ty: Type, fi: Info}
 
   sem info =
   | TmVar r -> r.fi

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -154,7 +154,14 @@ lang RecLetsAst = VarAst
   | TmRecLets {bindings : [{ident : Name,
                             ty    : Type,
                             body  : Expr}],
-               inexpr   : Expr}
+               inexpr   : Expr,
+               ty       : Type}
+
+  sem ty =
+  | TmRecLets t -> t.ty
+
+  sem withType (ty : Type) =
+  | TmRecLets t -> TmRecLets {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmRecLets t ->
@@ -247,7 +254,14 @@ lang UtestAst
   syn Expr =
   | TmUtest {test     : Expr,
              expected : Expr,
-             next     : Expr}
+             next     : Expr,
+             ty       : Type}
+
+  sem ty =
+  | TmUtest t -> t.ty
+
+  sem withType (ty : Type) =
+  | TmUtest t -> TmUtest {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmUtest t -> TmUtest {{{t with test = f t.test}
@@ -280,10 +294,16 @@ end
 
 lang NeverAst
   syn Expr =
-  | TmNever {fi: Info}
+  | TmNever {ty: Type, fi: Info}
 
   sem info =
   | TmNever r -> r.fi
+
+  sem ty =
+  | TmNever t -> t.ty
+
+  sem withType (ty : Type) =
+  | TmNever t -> TmNever {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmNever _ & t -> t

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -148,10 +148,13 @@ lang ConstAst
   syn Const =
 
   syn Expr =
-  | TmConst {val : Const, fi: Info}
+  | TmConst {val : Const, ty: Type, fi: Info}
 
   sem info =
   | TmConst r -> r.fi
+
+  sem withType (ty : Type) =
+  | TmConst t -> TmConst {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmConst t -> TmConst t

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -150,7 +150,8 @@ lang DataAst
               ty     : Type,
               inexpr : Expr}
   | TmConApp {ident : Name,
-              body : Expr}
+              body  : Expr,
+              ty    : Type}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmConDef t -> TmConDef {t with inexpr = f t.inexpr}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -104,9 +104,10 @@ end
 lang LetAst = VarAst
   syn Expr =
   | TmLet {ident  : Name,
-           ty     : Type,
+           tyBody : Type,
            body   : Expr,
            inexpr : Expr,
+           ty     : Type,
            fi     : Info}
 
   sem info =

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -202,7 +202,7 @@ end
 
 lang SeqAst
   syn Expr =
-  | TmSeq {tms : [Expr], fi: Info}
+  | TmSeq {tms : [Expr], ty: Type, fi: Info}
 
   sem info =
   | TmSeq r -> r.fi

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -16,6 +16,9 @@ lang VarAst
   sem info =
   | TmVar r -> r.fi
 
+  sem ty =
+  | TmVar t -> t.ty
+
   sem withType (ty : Type) =
   | TmVar t -> TmVar {t with ty = ty}
 
@@ -32,6 +35,9 @@ lang AppAst
 
   sem info =
   | TmApp r -> r.fi
+
+  sem ty =
+  | TmApp t -> t.ty
 
   sem withType (ty : Type) =
   | TmApp t -> TmApp {t with ty = ty}
@@ -55,6 +61,9 @@ lang FunAst = VarAst + AppAst
   sem info =
   | TmLam r -> r.fi
 
+  sem ty =
+  | TmLam t -> t.ty
+
   sem withType (ty : Type) =
   | TmLam t -> TmLam {t with ty = ty}
 
@@ -73,6 +82,10 @@ lang RecordAst
                     key   : String,
                     value : Expr,
                     ty    : Type}
+
+  sem ty =
+  | TmRecord t -> t.ty
+  | TmRecordUpdate t -> t.ty
 
   sem withType (ty : Type) =
   | TmRecord t -> TmRecord {t with ty = ty}
@@ -99,6 +112,9 @@ lang LetAst = VarAst
   sem info =
   | TmLet r -> r.fi
 
+  sem ty =
+  | TmLet t -> t.ty
+
   sem withType (ty : Type) =
   | TmLet t -> TmLet {t with ty = ty}
 
@@ -118,6 +134,12 @@ lang TypeAst
 
   sem info =
   | TmType r -> r.fi
+
+  sem ty =
+  | TmType t -> t.ty
+
+  sem withType (ty : Type) =
+  | TmType t -> TmType {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmType t -> TmType {t with inexpr = f t.inexpr}
@@ -153,6 +175,9 @@ lang ConstAst
   sem info =
   | TmConst r -> r.fi
 
+  sem ty =
+  | TmConst t -> t.ty
+
   sem withType (ty : Type) =
   | TmConst t -> TmConst {t with ty = ty}
 
@@ -171,6 +196,10 @@ lang DataAst
   | TmConApp {ident : Name,
               body  : Expr,
               ty    : Type}
+
+  sem ty =
+  | TmConDef t -> t.ty
+  | TmConApp t -> t.ty
 
   sem withType (ty : Type) =
   | TmConDef t -> TmConDef {t with ty = ty}
@@ -198,6 +227,9 @@ lang MatchAst
 
   sem info =
   | TmMatch r -> r.fi
+
+  sem ty =
+  | TmMatch t -> t.ty
 
   sem withType (ty : Type) =
   | TmMatch t -> TmMatch {t with ty = ty}
@@ -232,6 +264,9 @@ lang SeqAst
 
   sem info =
   | TmSeq r -> r.fi
+
+  sem ty =
+  | TmSeq t -> t.ty
 
   sem withType (ty : Type) =
   | TmSeq t -> TmSeq {t with ty = ty}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -165,6 +165,7 @@ lang MatchAst
              pat    : Pat,
              thn    : Expr,
              els    : Expr,
+             ty     : Type,
              fi     : Info}
 
   syn Pat =

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -58,13 +58,15 @@ end
 
 lang RecordAst
   syn Expr =
-  | TmRecord {bindings : AssocMap String Expr}
+  | TmRecord {bindings : AssocMap String Expr,
+              ty : Type}
   | TmRecordUpdate {rec   : Expr,
                     key   : String,
-                    value : Expr}
+                    value : Expr,
+                    ty    : Type}
 
   sem smap_Expr_Expr (f : Expr -> a) =
-  | TmRecord t -> TmRecord {bindings = assocMap {eq=eqString} f t.bindings}
+  | TmRecord t -> TmRecord {t with bindings = assocMap {eq=eqString} f t.bindings}
   | TmRecordUpdate t -> TmRecordUpdate {{t with rec = f t.rec}
                                            with value = f t.value}
 
@@ -79,7 +81,7 @@ lang LetAst = VarAst
            ty     : Type,
            body   : Expr,
            inexpr : Expr,
-	   fi     : Info}
+           fi     : Info}
 
   sem info =
   | TmLet r -> r.fi

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -25,13 +25,14 @@ end
 
 lang AppAst
   syn Expr =
-  | TmApp {lhs : Expr, rhs : Expr, fi: Info}
+  | TmApp {lhs : Expr, rhs : Expr, ty: Type, fi: Info}
 
   sem info =
   | TmApp r -> r.fi
 
   sem smap_Expr_Expr (f : Expr -> a) =
-  | TmApp t -> TmApp {lhs = f t.lhs, rhs = f t.rhs}
+  | TmApp t -> TmApp {{t with lhs = f t.lhs}
+                         with rhs = f t.rhs}
 
   sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
   | TmApp t -> f (f acc t.lhs) t.rhs

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -8,7 +8,7 @@ include "mexpr/ast-builder.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/eq.mc"
 
-lang FunCPS = FunSym + FunEq + UnknownTypeSym
+lang FunCPS = FunSym + FunEq + UnknownTypeSym + UnknownTypeEq
 
   sem cpsK (cont: Expr -> Expr) =
   | TmLam t -> cont (cpsM (TmLam t))

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -440,7 +440,7 @@ lang ContextAwareHoles = Ast2CallGraph + HoleAst + IntAst + SymbAst
     in
     let binds =
       foldl (lam acc. lam b. concat acc (handleLet b)) [] t.bindings
-    in concat [TmRecLets {inexpr=unit_, bindings=binds}]
+    in concat [TmRecLets {{t with inexpr=unit_} with bindings=binds}]
               (_extract p extractor t.inexpr)
 
   | tm -> sfold_Expr_Expr concat [] (smap_Expr_Expr (_extract p extractor) tm)

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -417,8 +417,7 @@ lang ContextAwareHoles = Ast2CallGraph + HoleAst + IntAst + SymbAst
   -- Consider identifier for which p is true.
   sem _extract (p : String -> Bool)
               (extractor : String -> Expr -> Expr) =
-  | TmLet {body = TmLam lm, ty = ty, ident=ident, inexpr=inexpr} ->
-    let t = {body = TmLam lm, ty = ty, ident=ident, inexpr=inexpr} in
+  | TmLet ({body = TmLam lm} & t) ->
     let res =
       if p t.ident then
         let newBody = extractor t.ident t.body in
@@ -447,8 +446,7 @@ lang ContextAwareHoles = Ast2CallGraph + HoleAst + IntAst + SymbAst
 
   -- Rename identifiers for which p is true, with renaming function rf
   sem _renameIdents (p : String -> Bool) (rf : String -> String) =
-  | TmLet {body = TmLam lm, ty = ty, ident=ident, inexpr=inexpr} ->
-    let t = {body = TmLam lm, ty = ty, ident=ident, inexpr=inexpr} in
+  | TmLet ({body = TmLam lm} & t) ->
     let newIdent =
       if p t.ident then
         rf t.ident

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -148,8 +148,8 @@ end
 
 lang LetEq = Eq + LetAst
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmLet {ident = i2, body = b2, inexpr = ie2, ty = ty2} ->
-    match lhs with TmLet {ident = i1, body = b1, inexpr = ie1, ty = ty1} then
+  | TmLet {ident = i2, body = b2, inexpr = ie2} ->
+    match lhs with TmLet {ident = i1, body = b1, inexpr = ie1} then
       match eqExprH env free b1 b2 with Some free then
         match env with {varEnv = varEnv} then
           let varEnv = biInsert (i1,i2) varEnv in

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -574,11 +574,15 @@ end
 
 lang VarTypeEq = Eq + VarTypeAst
   sem eqType (typeEnv : TypeEnv) (lhs : Type) =
-  | rhs & TyVar _ ->
+  | rhs & TyVar r ->
     match _unwrapType typeEnv lhs with Some lty then
       match _unwrapType typeEnv rhs with Some rty then
         eqType typeEnv lty rty
       else false
+    else match lhs with TyVar l then
+      nameEq l.ident r.ident
+    else false
+end
     else false
 end
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -560,6 +560,8 @@ end
 lang VariantTypeEq = Eq + VariantTypeAst
   sem eqType (typeEnv : TypeEnv) (lhs : Type) =
   | TyVariant r ->
+    -- OPT(larshum, 2021-02-05): This comparison is quadratic in the number of
+    -- constructors
     let f = lam lname.
       match find (lam rname. nameEq lname rname) r.constrs with Some _ then
         true

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -583,6 +583,12 @@ lang VarTypeEq = Eq + VarTypeAst
       nameEq l.ident r.ident
     else false
 end
+
+lang AppTypeEq = Eq + AppTypeAst
+  sem eqType (typeEnv : TypeEnv) (lhs : Type) =
+  | TyApp r ->
+    match _unwrapType typeEnv lhs with Some (TyApp l) then
+      and (eqType typeEnv l.lhs r.lhs) (eqType typeEnv l.rhs r.rhs)
     else false
 end
 
@@ -608,7 +614,7 @@ lang MExprEq =
 
   -- Types
   + UnknownTypeEq + BoolTypeEq + IntTypeEq + FloatTypeEq + CharTypeEq +
-  FunTypeEq + SeqTypeEq + RecordTypeEq + VariantTypeEq + VarTypeEq
+  FunTypeEq + SeqTypeEq + RecordTypeEq + VariantTypeEq + VarTypeEq + AppTypeEq
 end
 
 -----------
@@ -1003,6 +1009,18 @@ utest ntyvar_ t with tyint_ using eqType tyEnv1 in
 utest tyint_ with ntyvar_ t using eqType tyEnv1 in
 utest eqType tyEnv1 (ntyvar_ t) tybool_ with false in
 utest ntyvar_ t with tybool_ using eqType tyEnv2 in
+
+let tyApp1 = tyapp_ tyint_ tyint_ in
+let tyApp2 = tyapp_ (ntyvar_ t) tyint_ in
+let tyApp3 = tyapp_ tyint_ (ntyvar_ t) in
+utest tyApp1 with tyApp1 using eqType emptyEnv in
+utest tyApp2 with tyApp2 using eqType emptyEnv in
+utest tyApp3 with tyApp3 using eqType emptyEnv in
+utest tyApp1 with tyApp2 using eqType tyEnv1 in
+utest tyApp2 with tyApp3 using eqType tyEnv1 in
+utest eqType tyEnv2 tyApp1 tyApp2 with false in
+utest eqType tyEnv2 tyApp2 tyApp3 with false in
+utest eqType tyEnv2 tyApp1 tyApp3 with false in
 
 -- Utest
 let ut1 = utest_ lam1 lam2 v3 in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -124,8 +124,8 @@ lang RecordEval = RecordAst
   | TmRecordUpdate u ->
     match eval ctx u.rec with TmRecord t then
       if assocMem {eq = eqString} u.key t.bindings then
-        TmRecord { bindings = assocInsert {eq = eqString}
-                                u.key (eval ctx u.value) t.bindings }
+        TmRecord {t with bindings = assocInsert {eq = eqString}
+                                u.key (eval ctx u.value) t.bindings}
       else error "Key does not exist in record"
     else error "Not updating a record"
 end

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -238,48 +238,48 @@ lang ArithIntEval = ArithIntAst + ConstEval
 
   sem delta (arg : Expr) =
   | CAddi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CAddi2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CAddi2 n}
     else error "Not adding an integer"
   | CAddi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (addi n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = addi n1 n2}}
     else error "Not adding an integer"
   | CSubi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CSubi2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CSubi2 n}
     else error "Not substracting an integer"
   | CSubi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (subi n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = subi n1 n2}}
     else error "Not substracting an integer"
   | CMuli _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CMuli2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CMuli2 n}
     else error "Not multiplying an integer"
   | CMuli2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (muli n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = muli n1 n2}}
     else error "Not multiplying an integer"
   | CDivi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CDivi2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CDivi2 n}
     else error "Not dividing number"
   | CDivi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (divi n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = divi n1 n2}}
     else error "Not dividing with number"
   | CModi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CModi2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CModi2 n}
     else error "Not taking modulo of number"
   | CModi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (modi n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = modi n1 n2}}
     else error "Not taking modulo with number"
   | CNegi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      int_ (negi n)
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CInt {val = negi n}}
     else error "Not negating a number"
 end
 
@@ -291,28 +291,28 @@ lang ShiftIntEval = ShiftIntAst + ConstEval
 
   sem delta (arg : Expr) =
   | CSlli _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CSlli2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CSlli2 n}
     else error "Not shifting a constant integer"
   | CSlli2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (slli n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = slli n1 n2}}
     else error "Not shifting by a constant integer"
   | CSrli _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CSrli2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CSrli2 n}
     else error "Not shifting a constant integer"
   | CSrli2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (srli n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = srli n1 n2}}
     else error "Not shifting by a constant integer"
   | CSrai _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CSrai2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CSrai2 n}
     else error "Not shifting a constant integer"
   | CSrai2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      int_ (srai n1 n2)
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CInt {val = srai n1 n2}}
     else error "Not shifting by a constant integer"
 end
 
@@ -327,55 +327,55 @@ lang ArithFloatEval = ArithFloatAst + ConstEval
   | CAddf _ ->
     match arg with TmConst c then
       match c.val with CFloat f then
-        TmConst {val = CAddf2 f.val}
+        TmConst {c with val = CAddf2 f.val}
       else error "Not adding a numeric constant"
     else error "Not adding a constant"
   | CAddf2 f1 ->
     match arg with TmConst c then
       match c.val with CFloat f2 then
-        TmConst {val = CFloat {val = addf f1 f2.val}}
+        TmConst {c with val = CFloat {val = addf f1 f2.val}}
       else error "Not adding a numeric constant"
     else error "Not adding a constant"
   | CSubf _ ->
     match arg with TmConst c then
       match c.val with CFloat f then
-        TmConst {val = CSubf2 f.val}
+        TmConst {c with val = CSubf2 f.val}
       else error "Not subtracting a numeric constant"
     else error "Not subtracting a constant"
   | CSubf2 f1 ->
     match arg with TmConst c then
       match c.val with CFloat f2 then
-        TmConst {val = CFloat {val = subf f1 f2.val}}
+        TmConst {c with val = CFloat {val = subf f1 f2.val}}
       else error "Not subtracting a numeric constant"
     else error "Not subtracting a constant"
   | CMulf _ ->
     match arg with TmConst c then
       match c.val with CFloat f then
-        TmConst {val = CMulf2 f.val}
+        TmConst {c with val = CMulf2 f.val}
       else error "Not multiplying a numeric constant"
     else error "Not multiplying a constant"
   | CMulf2 f1 ->
     match arg with TmConst c then
       match c.val with CFloat f2 then
-        TmConst {val = CFloat {val = mulf f1 f2.val}}
+        TmConst {c with val = CFloat {val = mulf f1 f2.val}}
       else error "Not multiplying a numeric constant"
     else error "Not multiplying a constant"
   | CDivf _ ->
     match arg with TmConst c then
       match c.val with CFloat f then
-        TmConst {val = CDivf2 f.val}
+        TmConst {c with val = CDivf2 f.val}
       else error "Not dividing a numeric constant"
     else error "Not dividing a constant"
   | CDivf2 f1 ->
     match arg with TmConst c then
       match c.val with CFloat f2 then
-        TmConst {val = CFloat {val = divf f1 f2.val}}
+        TmConst {c with val = CFloat {val = divf f1 f2.val}}
       else error "Not dividing a numeric constant"
     else error "Not dividing a constant"
   | CNegf _ ->
     match arg with TmConst c then
       match c.val with CFloat f then
-        TmConst {val = CFloat {val = negf f.val}}
+        TmConst {c with val = CFloat {val = negf f.val}}
       else error "Not negating a numeric constant"
     else error "Not negating a constant"
 end
@@ -383,20 +383,20 @@ end
 lang FloatIntConversionEval = FloatIntConversionAst
   sem delta (arg : Expr) =
   | CFloorfi _ ->
-    match arg with TmConst {val = CFloat {val = r}} then
-      int_ (floorfi r)
+    match arg with TmConst (t & {val = CFloat {val = r}}) then
+      TmConst {t with val = CInt {val = floorfi r}}
     else error "Not flooring a float"
   | CCeilfi _ ->
-    match arg with TmConst {val = CFloat {val = r}} then
-      int_ (ceilfi r)
+    match arg with TmConst (t & {val = CFloat {val = r}}) then
+      TmConst {t with val = CInt {val = ceilfi r}}
     else error "Not ceiling a float"
   | CRoundfi _ ->
-    match arg with TmConst {val = CFloat {val = r}} then
-      int_ (roundfi r)
+    match arg with TmConst (t & {val = CFloat {val = r}}) then
+      TmConst {t with val = CInt {val = roundfi r}}
     else error "Not rounding a float"
   | CInt2float _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      float_ (int2float n)
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CFloat {val = int2float n}}
     else error "Not converting a integer"
 end
 
@@ -411,52 +411,52 @@ lang CmpIntEval = CmpIntAst + ConstEval
 
   sem delta (arg : Expr) =
   | CEqi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CEqi2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CEqi2 n}
     else error "Not comparing an integer constant"
   | CEqi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      TmConst {val = CBool {val = eqi n1 n2}}
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CBool {val = eqi n1 n2}}
     else error "Not comparing an integer constant"
   | CNeqi _ ->
-    match arg with TmConst {val = CInt {val = n1}} then
-      TmConst {val = CNeqi2 n1}
+    match arg with TmConst (t & {val = CInt {val = n1}}) then
+      TmConst {t with val = CNeqi2 n1}
     else error "Not comparing an integer constant"
   | CNeqi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      TmConst {val = CBool {val = neqi n1 n2}}
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CBool {val = neqi n1 n2}}
     else error "Not comparing an integer constant"
   | CLti _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CLti2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CLti2 n}
     else error "Not comparing an integer constant"
   | CLti2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      TmConst {val = CBool {val = lti n1 n2}}
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CBool {val = lti n1 n2}}
     else error "Not comparing an integer constant"
   | CGti _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CGti2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CGti2 n}
     else error "Not comparing an integer constant"
   | CGti2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      TmConst {val = CBool {val = gti n1 n2}}
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CBool {val = gti n1 n2}}
     else error "Not comparing an integer constant"
   | CLeqi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CLeqi2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CLeqi2 n}
     else error "Not comparing an integer constant"
   | CLeqi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      TmConst {val = CBool {val = leqi n1 n2}}
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CBool {val = leqi n1 n2}}
     else error "Not comparing an integer constant"
   | CGeqi _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CGeqi2 n}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CGeqi2 n}
     else error "Not comparing an integer constant"
   | CGeqi2 n1 ->
-    match arg with TmConst {val = CInt {val = n2}} then
-      TmConst {val = CBool {val = geqi n1 n2}}
+    match arg with TmConst (t & {val = CInt {val = n2}}) then
+      TmConst {t with val = CBool {val = geqi n1 n2}}
     else error "Not comparing an integer constant"
 end
 
@@ -466,24 +466,24 @@ lang CmpCharEval = CmpCharAst + ConstEval
 
   sem delta (arg : Expr) =
   | CEqc _ ->
-    match arg with TmConst {val = CChar {val = c}} then
-      TmConst {val = CEqc2 c}
+    match arg with TmConst (t & {val = CChar {val = c}}) then
+      TmConst {t with val = CEqc2 c}
     else error "Not comparing a character constant"
   | CEqc2 c1 ->
-    match arg with TmConst {val = CChar {val = c2}} then
-      TmConst {val = CBool {val = eqc c1 c2}}
+    match arg with TmConst (t & {val = CChar {val = c2}}) then
+      TmConst {t with val = CBool {val = eqc c1 c2}}
     else error "Not comparing a character constant"
 end
 
 lang IntCharConversionEval = IntCharConversionAst + ConstEval
   sem delta (arg : Expr) =
   | CInt2Char _ ->
-    match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CChar {val = int2char n}}
+    match arg with TmConst (t & {val = CInt {val = n}}) then
+      TmConst {t with val = CChar {val = int2char n}}
     else error "Not int2char of an integer constant"
   | CChar2Int _ ->
-    match arg with TmConst {val = CChar {val = c}} then
-      TmConst {val = CInt {val = char2int c}}
+    match arg with TmConst (t & {val = CChar {val = c}}) then
+      TmConst {t with val = CInt {val = char2int c}}
     else error "Not char2int of a character constant"
 end
 
@@ -500,58 +500,58 @@ lang CmpFloatEval = CmpFloatAst + ConstEval
   | CEqf _ ->
     match arg with TmConst c then
       match c.val with CFloat f then
-        TmConst {val = CEqf2 f.val}
+        TmConst {c with val = CEqf2 f.val}
       else error "Not comparing a numeric constant"
     else error "Not comparing a constant"
   | CEqf2 f1 ->
     match arg with TmConst c then
       match c.val with CFloat f2 then
-        TmConst {val = CBool {val = eqf f1 f2.val}}
+        TmConst {c with val = CBool {val = eqf f1 f2.val}}
       else error "Not comparing a numeric constant"
     else error "Not comparing a constant"
   | CLtf _ ->
     match arg with TmConst c then
       match c.val with CFloat f then
-        TmConst {val = CLtf2 f.val}
+        TmConst {c with val = CLtf2 f.val}
       else error "Not comparing a numeric constant"
     else error "Not comparing a constant"
   | CLtf2 f1 ->
     match arg with TmConst c then
       match c.val with CFloat f2 then
-        TmConst {val = CBool {val = ltf f1 f2.val}}
+        TmConst {c with val = CBool {val = ltf f1 f2.val}}
       else error "Not comparing a numeric constant"
     else error "Not comparing a constant"
   | CLeqf _ ->
-    match arg with TmConst {val = CFloat {val = f1}} then
-      TmConst {val = CLeqf2 f1}
+    match arg with TmConst (t & {val = CFloat {val = f1}}) then
+      TmConst {t with val = CLeqf2 f1}
     else error "Not comparing a floating-point constant"
   | CLeqf2 f1 ->
-    match arg with TmConst {val = CFloat {val = f2}} then
-      TmConst {val = CBool {val = leqf f1 f2}}
+    match arg with TmConst (t & {val = CFloat {val = f2}}) then
+      TmConst {t with val = CBool {val = leqf f1 f2}}
     else error "Not comparing a floating-point constant"
   | CGtf _ ->
-    match arg with TmConst {val = CFloat {val = f1}} then
-      TmConst {val = CGtf2 f1}
+    match arg with TmConst (t & {val = CFloat {val = f1}}) then
+      TmConst {t with val = CGtf2 f1}
     else error "Not comparing a floating-point constant"
   | CGtf2 f1 ->
-    match arg with TmConst {val = CFloat {val = f2}} then
-      TmConst {val = CBool {val = gtf f1 f2}}
+    match arg with TmConst (t & {val = CFloat {val = f2}}) then
+      TmConst {t with val = CBool {val = gtf f1 f2}}
     else error "Not comparing a floating-point constant"
   | CGeqf _ ->
-    match arg with TmConst {val = CFloat {val = f1}} then
-      TmConst {val = CGeqf2 f1}
+    match arg with TmConst (t & {val = CFloat {val = f1}}) then
+      TmConst {t with val = CGeqf2 f1}
     else error "Not comparing a floating-point constant"
   | CGeqf2 f1 ->
-    match arg with TmConst {val = CFloat {val = f2}} then
-      TmConst {val = CBool {val = geqf f1 f2}}
+    match arg with TmConst (t & {val = CFloat {val = f2}}) then
+      TmConst {t with val = CBool {val = geqf f1 f2}}
     else error "Not comparing a floating-point constant"
   | CNeqf _ ->
-    match arg with TmConst {val = CFloat {val = f1}} then
-      TmConst {val = CNeqf2 f1}
+    match arg with TmConst (t & {val = CFloat {val = f1}}) then
+      TmConst {t with val = CNeqf2 f1}
     else error "Not comparing a floating-point constant"
   | CNeqf2 f1 ->
-    match arg with TmConst {val = CFloat {val = f2}} then
-      TmConst {val = CBool {val = neqf f1 f2}}
+    match arg with TmConst (t & {val = CFloat {val = f2}}) then
+      TmConst {t with val = CBool {val = neqf f1 f2}}
     else error "Not comparing a floating-point constant"
 end
 
@@ -559,11 +559,11 @@ lang SymbEval = SymbAst + IntAst + RecordAst + ConstEval
   sem delta (arg : Expr) =
   | CGensym _ ->
     match arg with TmRecord {bindings = []} then
-      TmConst {val = CSymb {val = gensym ()}}
+      TmConst {val = CSymb {val = gensym ()}, ty = TyUnknown {}}
     else error "Argument in gensym is not unit"
   | CSym2hash _ ->
-    match arg with TmConst {val = CSymb s} then
-      TmConst {val = CInt {val = sym2hash s.val}}
+    match arg with TmConst (t & {val = CSymb s}) then
+      TmConst {t with val = CInt {val = sym2hash s.val}}
     else error "Argument in sym2hash is not a symbol"
 end
 
@@ -573,12 +573,12 @@ lang CmpSymbEval = CmpSymbAst + ConstEval
 
   sem delta (arg : Expr) =
   | CEqsym _ ->
-    match arg with TmConst {val = CSymb s} then
-      TmConst {val = CEqsym2 s.val}
+    match arg with TmConst (t & {val = CSymb s}) then
+      TmConst {t with val = CEqsym2 s.val}
     else error "First argument in eqsym is not a symbol"
   | CEqsym2 s1 ->
-    match arg with TmConst {val = CSymb s2} then
-      TmConst {val = CBool {val = eqsym s1 s2.val}}
+    match arg with TmConst (t & {val = CSymb s2}) then
+      TmConst {t with val = CBool {val = eqsym s1 s2.val}}
     else error "Second argument in eqsym is not a symbol"
 end
 
@@ -596,7 +596,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
   sem delta (arg : Expr) =
   | CGet _ ->
     match arg with TmSeq s then
-      TmConst {val = CGet2 s.tms}
+      TmConst {val = CGet2 s.tms, ty = TyUnknown {}}
     else error "Not a get of a constant sequence"
   | CGet2 tms ->
     match arg with TmConst {val = CInt {val = n}} then
@@ -604,7 +604,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     else error "n in get is not a number"
   | CSet _ ->
     match arg with TmSeq s then
-      TmConst {val = CSet2 s.tms}
+      TmConst {val = CSet2 s.tms, ty = TyUnknown {}}
     else error "Not a set of a constant sequence"
   | CSet2 tms ->
     match arg with TmConst {val = CInt {val = n}} then
@@ -613,20 +613,20 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
   | CSet3 (tms,n) ->
     TmSeq {tms = set tms n arg, ty = TyUnknown {}}
   | CCons _ ->
-    TmConst {val = CCons2 arg}
+    TmConst {val = CCons2 arg, ty = TyUnknown {}}
   | CCons2 tm ->
     match arg with TmSeq s then
       TmSeq {s with tms = cons tm s.tms}
     else error "Not a cons of a constant sequence"
   | CSnoc _ ->
     match arg with TmSeq s then
-      TmConst {val = CSnoc2 s.tms}
+      TmConst {val = CSnoc2 s.tms, ty = TyUnknown {}}
     else error "Not a snoc of a constant sequence"
   | CSnoc2 tms ->
     TmSeq {tms = snoc tms arg, ty = TyUnknown {}}
   | CConcat _ ->
     match arg with TmSeq s then
-      TmConst {val = CConcat2 s.tms}
+      TmConst {val = CConcat2 s.tms, ty = TyUnknown {}}
     else error "Not a concat of a constant sequence"
   | CConcat2 tms ->
     match arg with TmSeq s then
@@ -634,7 +634,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     else error "Not a concat of a constant sequence"
   | CLength _ ->
     match arg with TmSeq s then
-      TmConst {val = CInt {val = (length s.tms)}}
+      TmConst {val = CInt {val = length s.tms}, ty = TyUnknown {}}
     else error "Not length of a constant sequence"
   | CReverse _ ->
     match arg with TmSeq s then
@@ -642,7 +642,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     else error "Not reverse of a constant sequence"
   | CSplitAt _ ->
     match arg with TmSeq s then
-      TmConst {val = CSplitAt2 s.tms}
+      TmConst {val = CSplitAt2 s.tms, ty = TyUnknown {}}
     else error "Not splitAt of a constant sequence"
   | CSplitAt2 tms ->
     match arg with TmConst {val = CInt {val = n}} then
@@ -651,7 +651,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     else error "n in splitAt is not a number"
   | CMakeSeq _ ->
     match arg with TmConst {val = CInt {val = n}} then
-      TmConst {val = CMakeSeq2 n}
+      TmConst {val = CMakeSeq2 n, ty = TyUnknown {}}
     else error "n in makeSeq is not a number"
   | CMakeSeq2 n ->
     TmSeq {tms = makeSeq n arg, ty = TyUnknown {}}
@@ -666,7 +666,7 @@ lang FloatStringConversionEval = FloatStringConversionAst
     else error "Not converting a sequence"
 end
 
-lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst
+lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst + UnknownTypeAst
   syn Const =
   | CFileWrite2 string
 
@@ -679,7 +679,7 @@ lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst
   | CFileWrite _ ->
     match arg with TmSeq s then
       let f = _seqOfCharToString s.tms in
-      TmConst {val = CFileWrite2 f}
+      TmConst {val = CFileWrite2 f, ty = TyUnknown {}}
     else error "f in writeFile not a sequence"
   | CFileWrite2 f ->
     match arg with TmSeq s then
@@ -690,7 +690,7 @@ lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst
   | CFileExists _ ->
     match arg with TmSeq s then
       let f = _seqOfCharToString s.tms in
-      TmConst {val = CBool {val = fileExists f}}
+      TmConst {val = CBool {val = fileExists f}, ty = TyUnknown {}}
     else error "f in fileExists not a sequence"
   | CFileDelete _ ->
     match arg with TmSeq s then
@@ -721,19 +721,19 @@ lang RandomNumberGeneratorEval = RandomNumberGeneratorAst + IntAst
   | CRandIntU _ ->
     match arg with TmConst c then
       match c.val with CInt lo then
-        TmConst {val = CRandIntU2 lo.val}
+        TmConst {c with val = CRandIntU2 lo.val}
       else error "lo in randIntU not a constant integer"
     else error "lo in randIntU not a constant"
   | CRandIntU2 lo ->
     match arg with TmConst c then
       match c.val with CInt hi then
-        TmConst {val = CInt {val = randIntU lo hi.val}}
+        TmConst {c with val = CInt {val = randIntU lo hi.val}}
       else error "hi in randIntU not a constant integer"
     else error "hi in randIntU not a constant"
   | CRandSetSeed _ ->
     match arg with TmConst c then
       match c.val with CInt {val = s} then
-        TmConst {val = CInt {val = randSetSeed s}}
+        TmConst {c with val = CInt {val = randSetSeed s}}
       else error "s in randSetSeed not a constant integer"
     else error "s in randSetSeed not a constant"
 end

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -149,12 +149,13 @@ lang RecLetsEval =
       foldli
         (lam i. lam bodyacc. lam binding.
           TmLet {ident = binding.ident,
-                 ty = TyUnknown {},
+                 tyBody = TyUnknown {},
                  body = TmLam {ident = eta_name,
                                ty = TyUnknown {},
                                body = TmApp {lhs = dtupleproj_ i var,
                                              rhs = eta_var}},
-                 inexpr = bodyacc}
+                 inexpr = bodyacc,
+                 ty = TyUnknown {}}
         )
         body
         t.bindings in

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -378,11 +378,11 @@ end
 
 
 -- Parse variable
-lang VarParser = ExprParser + IdentParser + VarAst
+lang VarParser = ExprParser + IdentParser + VarAst + UnknownTypeAst
   sem nextIdent (p: Pos) (xs: string) =
   | x ->
       let p2 = advanceCol p (length x) in
-      {val = TmVar {ident = nameNoSym x, fi = makeInfo p p2},
+      {val = TmVar {ident = nameNoSym x, ty = TyUnknown {}, fi = makeInfo p p2},
        pos = p2, str = xs}
 end
 

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -453,12 +453,12 @@ lang ExprInfixParserClosed = ExprInfixParser
 end
 
 -- This parser should be used for application using juxaposition
-lang ExprInfixParserJuxtaposition = ExprInfixParser + AppAst
+lang ExprInfixParserJuxtaposition = ExprInfixParser + AppAst + UnknownTypeAst
   sem parseInfixImp (p: Pos) =
   | str ->
     Some {
       val = lam x. lam y.
-        TmApp {lhs = x, rhs = y, fi = mergeInfo (info x) (info y)},
+        TmApp {lhs = x, rhs = y, ty = TyUnknown {}, fi = mergeInfo (info x) (info y)},
       pos = p, str = str, assoc = LeftAssoc (), prec = 50}
 end
 

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -291,7 +291,9 @@ end
 
 
 -- Parsing if expressions
-lang IfParser = ExprParser + IdentParser + KeywordUtils +  MatchAst + BoolPat
+lang IfParser =
+  ExprParser + IdentParser + KeywordUtils +  MatchAst + BoolPat + UnknownTypeAst
+
   sem nextIdent (p: Pos) (xs: String) =
   | "if" ->
      let e1 = parseExprMain (advanceCol p 2) 0 xs in
@@ -300,7 +302,8 @@ lang IfParser = ExprParser + IdentParser + KeywordUtils +  MatchAst + BoolPat
      let r2 = matchKeyword "else" e2.pos e2.str  in
      let e3 = parseExprMain r2.pos 0 r2.str in
      {val = TmMatch {target = e1.val, pat = PBool {val = true, fi = NoInfo ()},
-                     thn = e2.val, els = e3.val, fi = makeInfo p e3.pos},
+                     thn = e2.val, els = e3.val, ty = TyUnknown {},
+                     fi = makeInfo p e3.pos},
       pos = e3.pos,
       str = e3.str}
  end

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -156,15 +156,19 @@ end
 
 
 -- Parsing of boolean literals
-lang BoolParser = ExprParser + IdentParser + ConstAst + BoolAst
+lang BoolParser = ExprParser + IdentParser + ConstAst + BoolAst + UnknownTypeAst
   sem nextIdent (p: Pos) (xs: String) =
   | "true" ->
       let p2 = advanceCol p 4 in
-      {val = TmConst {val = CBool {val = true}, fi = makeInfo p p2},
+      {val = TmConst {val = CBool {val = true},
+                      ty = TyUnknown {},
+                      fi = makeInfo p p2},
        pos = p2, str = xs}
   | "false" ->
       let p2 = advanceCol p 5 in
-      {val = TmConst {val = CBool {val = false}, fi = makeInfo p p2},
+      {val = TmConst {val = CBool {val = false},
+                      ty = TyUnknown {},
+                      fi = makeInfo p p2},
        pos = p2, str = xs}
 end
 
@@ -223,16 +227,18 @@ lang UNumParser = ExprParser
 end
 
 -- Parsing of an unsigned integer
-lang UIntParser = UNumParser + ConstAst + IntAst
+lang UIntParser = UNumParser + ConstAst + IntAst + UnknownTypeAst
   sem nextNum (p: Pos) (xs: String) =
   | (n, _) ->
     let p2 = advanceCol p (length n) in
-    {val = TmConst {val = CInt {val = string2int n}, fi = makeInfo p p2},
+    {val = TmConst {val = CInt {val = string2int n},
+                    ty = TyUnknown {},
+                    fi = makeInfo p p2},
      pos = p2, str = xs}
 end
 
 -- Parsing of an unsigned float
-lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst
+lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst + UnknownTypeAst
   sem nextNum (p: Pos) (xs: String) =
   | (n, (Some ('.' | 'e' | 'E'))) & (n, Some c) ->
     let exponentHelper = lam pos. lam pre. lam expChar. lam s. lam isFloat.
@@ -243,11 +249,14 @@ lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst
             CFloat {val = string2float pre}
           else
             CInt {val = string2int pre}
-        in {val = TmConst {val = constVal, fi = makeInfo p pos},
+        in {val = TmConst {val = constVal,
+                           ty = TyUnknown {},
+                           fi = makeInfo p pos},
             pos = pos, str = cons expChar s}
       else
         let floatStr = join [pre, "e", exp.val] in
         {val = TmConst {val = CFloat {val = string2float floatStr},
+                        ty = TyUnknown {},
                         fi = makeInfo p exp.pos},
          pos = exp.pos, str = exp.str}
     in
@@ -263,12 +272,14 @@ lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst
           exponentHelper n2.pos preExponentStr (head n2.str) s3 true
         else
           {val = TmConst {val = CFloat {val = string2float preExponentStr},
+                          ty = TyUnknown {},
                           fi = makeInfo p n2.pos},
            pos = n2.pos, str = n2.str}
       else match s with ['e' | 'E'] ++ s2 then
         exponentHelper p3 n (head s) s2 true
       else
         {val = TmConst {val = CFloat {val = string2float n},
+                        ty = TyUnknown {},
                         fi = makeInfo p p3},
          pos = p3, str = s}
     else match c with 'e' | 'E' then
@@ -358,23 +369,26 @@ lang StringParser = ExprParser + SeqAst + CharAst + UnknownTypeAst
   | "\"" ++ xs ->
     recursive let work = lam acc. lam p2. lam str.
       match str with "\"" ++ xs then
-        {val = TmSeq {tms = acc, ty = TyUnknown {}, fi = makeInfo p (advanceCol p2 1)},
+        {val = TmSeq {tms = acc, ty = TyUnknown {},
+                      fi = makeInfo p (advanceCol p2 1)},
 	 pos = advanceCol p2 1, str = xs}
       else
         let r =  matchChar p2 str in
-        let v = TmConst {val = CChar {val = r.val}, fi = makeInfo p2 r.pos} in
+        let v = TmConst {val = CChar {val = r.val}, ty = TyUnknown {},
+                         fi = makeInfo p2 r.pos} in
 	work (snoc acc v) r.pos r.str
     in
       work [] (advanceCol p 1) xs
 end
 
 -- Parses character literals
-lang CharParser = ExprParser + KeywordUtils + CharAst
+lang CharParser = ExprParser + KeywordUtils + CharAst + UnknownTypeAst
   sem parseExprImp (p: Pos) =
   | "\'" ++ xs ->
       let r =  matchChar (advanceCol p 1) xs in
       let r2 = matchKeyword "\'" r.pos r.str in
-      {val = TmConst {val = CChar {val = r.val}, fi = makeInfo p r2.pos},
+      {val = TmConst {val = CChar {val = r.val}, ty = TyUnknown {},
+                      fi = makeInfo p r2.pos},
        pos = r2.pos, str = r2.str}
 end
 
@@ -486,62 +500,81 @@ use MExprParser in
 
 -- Unsigned integer
 utest parseExprMain (initPos "file") 0 "  123foo" with
-      {val = TmConst {val = CInt {val = 123}, fi = infoVal "file" 1 2 1 5},
+      {val = TmConst {val = CInt {val = 123}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 2 1 5},
        pos = posVal "file" 1 5, str = "foo"} in
 -- Unsigned floats
 utest parseExprMain (initPos "file") 0 "  1.0 " with
-      {val = TmConst {val = CFloat {val = 1.0}, fi = infoVal "file" 1 2 1 5},
+      {val = TmConst {val = CFloat {val = 1.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 2 1 5},
        pos = posVal "file" 1 5, str = " "} in
 utest parseExprMain (initPos "file") 0 " 1234.  " with
-      {val = TmConst {val = CFloat {val = 1234.}, fi = infoVal "file" 1 1 1 6},
+      {val = TmConst {val = CFloat {val = 1234.}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = "  "} in
 utest parseExprMain (initPos "file") 0 " 13.37 " with
-      {val = TmConst {val = CFloat {val = 13.37}, fi = infoVal "file" 1 1 1 6},
+      {val = TmConst {val = CFloat {val = 13.37}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 "  1.0e-2" with
-      {val = TmConst {val = CFloat {val = 0.01}, fi = infoVal "file" 1 2 1 8},
+      {val = TmConst {val = CFloat {val = 0.01}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 2 1 8},
        pos = posVal "file" 1 8, str = ""} in
 utest parseExprMain (initPos "file") 0 " 2.5e+2  " with
-      {val = TmConst {val = CFloat {val = 250.0}, fi = infoVal "file" 1 1 1 7},
+      {val = TmConst {val = CFloat {val = 250.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 7},
        pos = posVal "file" 1 7, str = "  "} in
 utest parseExprMain (initPos "file") 0 "   2e3" with
-      {val = TmConst {val = CFloat {val = 2000.0}, fi = infoVal "file" 1 3 1 6},
+      {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 3 1 6},
        pos = posVal "file" 1 6, str = ""} in
 utest parseExprMain (initPos "file") 0 "   2E3 " with
-       {val = TmConst {val = CFloat {val = 2000.0}, fi = infoVal "file" 1 3 1 6},
+       {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
+                       fi = infoVal "file" 1 3 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 "   2.0e3" with
-      {val = TmConst {val = CFloat {val = 2000.0}, fi = infoVal "file" 1 3 1 8},
+      {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 3 1 8},
        pos = posVal "file" 1 8, str = ""} in
 utest parseExprMain (initPos "file") 0 " 1.e2 " with
-      {val = TmConst {val = CFloat {val = 100.0}, fi = infoVal "file" 1 1 1 5},
+      {val = TmConst {val = CFloat {val = 100.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 5},
        pos = posVal "file" 1 5, str = " "} in
 utest parseExprMain (initPos "file") 0 " 2.e+1 " with
-      {val = TmConst {val = CFloat {val = 20.0}, fi = infoVal "file" 1 1 1 6},
+      {val = TmConst {val = CFloat {val = 20.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 3.e-4 " with
-      {val = TmConst {val = CFloat {val = 0.0003}, fi = infoVal "file" 1 1 1 6},
+      {val = TmConst {val = CFloat {val = 0.0003}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 "  2.E3 " with
-      {val = TmConst {val = CFloat {val = 2000.0}, fi = infoVal "file" 1 2 1 6},
+      {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 2 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 4.E+1 " with
-      {val = TmConst {val = CFloat {val = 40.0}, fi = infoVal "file" 1 1 1 6},
+      {val = TmConst {val = CFloat {val = 40.0}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 1.E-3 " with
-      {val = TmConst {val = CFloat {val = 0.001}, fi = infoVal "file" 1 1 1 6},
+      {val = TmConst {val = CFloat {val = 0.001}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 1E " with
-      {val = TmConst {val = CInt {val = 1}, fi = infoVal "file" 1 1 1 2},
+      {val = TmConst {val = CInt {val = 1}, ty = TyUnknown {},
+                      fi = infoVal "file" 1 1 1 2},
        pos = posVal "file" 1 2, str = "E "} in
 utest parseExprMain (initPos "file") 0 " 1e " with
-       {val = TmConst {val = CInt {val = 1}, fi = infoVal "file" 1 1 1 2},
+       {val = TmConst {val = CInt {val = 1}, ty = TyUnknown {},
+                       fi = infoVal "file" 1 1 1 2},
        pos = posVal "file" 1 2, str = "e "} in
 utest parseExprMain (initPos "file") 0 " 1.e++2 " with
-       {val = TmConst {val = CFloat {val = 1.0}, fi = infoVal "file" 1 1 1 3},
+       {val = TmConst {val = CFloat {val = 1.0}, ty = TyUnknown {},
+                       fi = infoVal "file" 1 1 1 3},
        pos = posVal "file" 1 3, str = "e++2 "} in
 utest parseExprMain (initPos "file") 0 " 3.1992e--2 " with
-       {val = TmConst {val = CFloat {val = 3.1992}, fi = infoVal "file" 1 1 1 7},
+       {val = TmConst {val = CFloat {val = 3.1992}, ty = TyUnknown {},
+                       fi = infoVal "file" 1 1 1 7},
        pos = posVal "file" 1 7, str = "e--2 "} in
 
 --If expression
@@ -549,29 +582,36 @@ utest (parseExprMain (initPos "") 0 "  if 1 then 22 else 3").pos
   with posVal "" 1 21 in
 -- Boolean literal 'true'
 utest parseExpr (initPos "f") " true " with
-      TmConst {val = CBool {val = true}, fi = infoVal "f" 1 1 1 5} in
+      TmConst {val = CBool {val = true}, ty = TyUnknown {},
+               fi = infoVal "f" 1 1 1 5} in
 -- Boolean literal 'false'
 utest parseExpr (initPos "f") " true " with
-      TmConst {val = CBool {val = true}, fi = infoVal "f" 1 1 1 5} in
+      TmConst {val = CBool {val = true}, ty = TyUnknown {},
+               fi = infoVal "f" 1 1 1 5} in
 -- Parentheses
 utest parseExpr (initPos "") " ( 123) " with
-      TmConst {val = CInt {val = 123}, fi = infoVal "" 1 3 1 6} in
+      TmConst {val = CInt {val = 123}, ty = TyUnknown {},
+               fi = infoVal "" 1 3 1 6} in
 -- Sequences
 utest parseExpr (initPos "") "[]" with
       TmSeq {tms = [], ty = TyUnknown {}, fi = infoVal "" 1 0 1 2} in
 utest parseExpr (initPos "") " [ ] " with
       TmSeq {tms = [], ty = TyUnknown {}, fi = infoVal "" 1 1 1 4} in
 utest parseExprMain (initPos "") 0 " [ 17 ] " with
-      let v = TmConst {val = CInt {val = 17}, fi = infoVal "" 1 3 1 5} in
+      let v = TmConst {val = CInt {val = 17}, ty = TyUnknown {},
+                       fi = infoVal "" 1 3 1 5} in
       {val = TmSeq {tms = [v], ty = TyUnknown {}, fi = infoVal "" 1 1 1 7},
        pos = posVal "" 1 7, str = " "} in
 utest parseExpr (initPos "") " [ 232 , ( 19 ) ] " with
-      let v1 = TmConst {val = CInt {val = 232}, fi = infoVal "" 1 3 1 6} in
-      let v2 = TmConst {val = CInt {val = 19}, fi = infoVal "" 1 11 1 13} in
+      let v1 = TmConst {val = CInt {val = 232}, ty = TyUnknown {},
+                        fi = infoVal "" 1 3 1 6} in
+      let v2 = TmConst {val = CInt {val = 19}, ty = TyUnknown {},
+                        fi = infoVal "" 1 11 1 13} in
       TmSeq {tms = [v1,v2], ty = TyUnknown {}, fi = infoVal "" 1 1 1 17} in
 -- Strings
 let makeChar = lam k. lam c. lam n.
-    TmConst {val = CChar {val = c}, fi = infoVal "" 1 n 1 (addi n k)} in
+    TmConst {val = CChar {val = c}, ty = TyUnknown {},
+             fi = infoVal "" 1 n 1 (addi n k)} in
 let mkc = makeChar 1 in
 let mkc2 = makeChar 2 in
 utest parseExpr (initPos "") " \"Foo\" " with
@@ -582,10 +622,12 @@ utest parseExpr (initPos "") " \" a\\\\ \\n\" " with
   TmSeq {tms = str, ty = TyUnknown {}, fi = infoVal "" 1 1 1 10} in
 -- Chars
 utest parseExprMain (initPos "") 0 " \'A\' " with
-  {val = TmConst {val = CChar {val = 'A'}, fi = infoVal "" 1 1 1 4},
+  {val = TmConst {val = CChar {val = 'A'}, ty = TyUnknown {},
+                  fi = infoVal "" 1 1 1 4},
    pos = posVal "" 1 4, str = " "} in
 utest parseExpr (initPos "") " \'\\n\' " with
-  TmConst {val = CChar {val = '\n'}, fi = infoVal "" 1 1 1 5} in
+  TmConst {val = CChar {val = '\n'}, ty = TyUnknown {},
+           fi = infoVal "" 1 1 1 5} in
 -- Var
 utest (parseExprMain (initPos "") 0 " _xs ").pos with posVal "" 1 4 in
 utest (parseExprMain (initPos "") 0 " fOO_12a ").pos with posVal "" 1 8 in

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -432,8 +432,9 @@ lang LetParser =
     let e1 = parseExprMain r3.pos 0 r3.str in
     let r4 = matchKeyword "in" e1.pos e1.str in
     let e2 = parseExprMain r4.pos 0 r4.str in
-    {val = TmLet {ident = nameNoSym r2.val, ty = TyUnknown {}, body = e1.val,
-                  inexpr = e2.val, fi = makeInfo p e2.pos},
+    {val = TmLet {ident = nameNoSym r2.val, tyBody = TyUnknown {},
+                  body = e1.val, inexpr = e2.val, ty = TyUnknown {},
+                  fi = makeInfo p e2.pos},
      pos = e2.pos, str = e2.str}
 end
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -502,7 +502,7 @@ lang NeverPrettyPrint = PrettyPrint + NeverAst
   | TmNever _ -> true
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmNever {} -> (env,"never")
+  | TmNever _ -> (env,"never")
 end
 
 ---------------

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -323,7 +323,7 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
     match pprintVarName env t.ident with (env,str) then
       match pprintCode (pprintIncr indent) env t.body with (env,body) then
         match pprintCode indent env t.inexpr with (env,inexpr) then
-          match getTypeStringCode indent env t.ty with (env, ty) then
+          match getTypeStringCode indent env t.tyBody with (env, ty) then
             let ty = if eqString ty "Unknown" then "" else concat ": " ty in
             (env,
              join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -43,9 +43,9 @@ end
 
 lang VarSym = Sym + VarAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmVar t & var ->
+  | TmVar t ->
     match env with {varEnv = varEnv} then
-      if nameHasSym t.ident then var
+      if nameHasSym t.ident then TmVar t
       else
         let str = nameGetStr t.ident in
         match assocLookup {eq=eqString} str varEnv with Some ident then
@@ -82,12 +82,12 @@ end
 
 lang RecordSym = Sym + RecordAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmRecord {bindings = bindings} ->
-    TmRecord {bindings = assocMap {eq=eqString} (symbolizeExpr env) bindings}
+  | TmRecord t ->
+    TmRecord {t with bindings = assocMap {eq=eqString} (symbolizeExpr env) t.bindings}
 
-  | TmRecordUpdate {rec = rec, key = key, value = value} ->
-    TmRecordUpdate {rec = symbolizeExpr env rec, key = key,
-                    value = symbolizeExpr env value}
+  | TmRecordUpdate t ->
+    TmRecordUpdate {{t with rec = symbolizeExpr env t.rec}
+                       with value = symbolizeExpr env t.value}
 end
 
 lang LetSym = Sym + LetAst

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -43,13 +43,13 @@ end
 
 lang VarSym = Sym + VarAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmVar {ident = ident} & var ->
+  | TmVar t & var ->
     match env with {varEnv = varEnv} then
-      if nameHasSym ident then var
+      if nameHasSym t.ident then var
       else
-        let str = nameGetStr ident in
+        let str = nameGetStr t.ident in
         match assocLookup {eq=eqString} str varEnv with Some ident then
-          TmVar {ident = ident}
+          TmVar {t with ident = ident}
         else error (concat "Unknown variable in symbolizeExpr: " str)
     else never
 end

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -230,7 +230,7 @@ end
 
 lang SeqSym = Sym + SeqAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmSeq {tms = tms} -> TmSeq {tms = map (symbolizeExpr env) tms}
+  | TmSeq t -> TmSeq {t with tms = map (symbolizeExpr env) t.tms}
 end
 
 lang NeverSym = Sym + NeverAst

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -95,20 +95,23 @@ lang LetSym = Sym + LetAst
   -- Intentinally left blank
 
   sem symbolizeExpr (env : SymEnv) =
-  | TmLet {ident = ident, ty = ty, body = body, inexpr = inexpr} ->
+  | TmLet t ->
     match env with {varEnv = varEnv} then
-      let ty = symbolizeType env ty in
-      let body = symbolizeExpr env body in
-      if nameHasSym ident then
-        TmLet {ident = ident, ty = ty, body = body,
-               inexpr = symbolizeExpr env inexpr}
+      let tyBody = symbolizeType env t.tyBody in
+      let body = symbolizeExpr env t.body in
+      if nameHasSym t.ident then
+        TmLet {{{t with tyBody = tyBody}
+                   with body = body}
+                   with inexpr = symbolizeExpr env t.inexpr}
       else
-        let ident = nameSetNewSym ident in
+        let ident = nameSetNewSym t.ident in
         let str = nameGetStr ident in
         let varEnv = assocInsert {eq=eqString} str ident varEnv in
         let env = {env with varEnv = varEnv} in
-        TmLet {ident = ident, ty = ty, body = body,
-               inexpr = symbolizeExpr env inexpr}
+        TmLet {{{{t with ident = ident}
+                    with tyBody = tyBody}
+                    with body = body}
+                    with inexpr = symbolizeExpr env t.inexpr}
     else never
 end
 

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -56,8 +56,9 @@ end
 
 lang AppSym = Sym + AppAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmApp {lhs = lhs, rhs = rhs} ->
-    TmApp {lhs = symbolizeExpr env lhs, rhs = symbolizeExpr env rhs}
+  | TmApp t ->
+    TmApp {{t with lhs = symbolizeExpr env lhs}
+              with rhs = symbolizeExpr env rhs}
 end
 
 lang FunSym = Sym + FunAst + VarSym + AppSym

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -133,7 +133,7 @@ end
 
 lang RecLetsSym = Sym + RecLetsAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmRecLets {bindings = bindings, inexpr = inexpr} ->
+  | TmRecLets t ->
     match env with {varEnv = varEnv} then
 
     -- Generate fresh symbols for all identifiers
@@ -141,7 +141,7 @@ lang RecLetsSym = Sym + RecLetsAst
       map (lam bind.
              if nameHasSym bind.ident then bind
              else {bind with ident = nameSetNewSym bind.ident})
-        bindings in
+        t.bindings in
 
     -- Add all identifiers to environment
     let varEnv =
@@ -156,7 +156,8 @@ lang RecLetsSym = Sym + RecLetsAst
       map (lam bind. {bind with body = symbolizeExpr env bind.body})
         bindings in
 
-    TmRecLets {bindings = bindings, inexpr = symbolizeExpr env inexpr}
+    TmRecLets {{t with bindings = bindings}
+                  with inexpr = symbolizeExpr env t.inexpr}
 
     else never
 end
@@ -222,10 +223,10 @@ end
 
 lang UtestSym = Sym + UtestAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmUtest {test = test, expected = expected, next = next} ->
-    TmUtest {test = symbolizeExpr env test,
-             expected = symbolizeExpr env expected,
-             next = symbolizeExpr env next}
+  | TmUtest t ->
+    TmUtest {{{t with test = symbolizeExpr env t.test}
+                 with expected = symbolizeExpr env t.expected}
+                 with next = symbolizeExpr env t.next}
 end
 
 lang SeqSym = Sym + SeqAst
@@ -235,7 +236,7 @@ end
 
 lang NeverSym = Sym + NeverAst
   sem symbolizeExpr (env : SymEnv) =
-  | TmNever {} -> TmNever {}
+  | TmNever t -> TmNever t
 end
 
 -----------

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -184,14 +184,15 @@ lang DataSym = Sym + DataAst
         TmConDef {ident = ident, ty = ty, inexpr = symbolizeExpr env inexpr}
     else never
 
-  | TmConApp {ident = ident, body = body} ->
+  | TmConApp {ident = ident, body = body, ty = ty} ->
     match env with {conEnv = conEnv} then
+      let ty = symbolizeType env ty in
       if nameHasSym ident then
-        TmConApp {ident = ident, body = symbolizeExpr env body}
+        TmConApp {ident = ident, body = symbolizeExpr env body, ty = ty}
       else
         let str = nameGetStr ident in
         match assocLookup {eq=eqString} str conEnv with Some ident then
-          TmConApp {ident = ident, body = symbolizeExpr env body}
+          TmConApp {ident = ident, body = symbolizeExpr env body, ty = ty}
         else error (concat "Unknown constructor in symbolizeExpr: " str)
     else never
 end

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -57,8 +57,8 @@ end
 lang AppSym = Sym + AppAst
   sem symbolizeExpr (env : SymEnv) =
   | TmApp t ->
-    TmApp {{t with lhs = symbolizeExpr env lhs}
-              with rhs = symbolizeExpr env rhs}
+    TmApp {{t with lhs = symbolizeExpr env t.lhs}
+              with rhs = symbolizeExpr env t.rhs}
 end
 
 lang FunSym = Sym + FunAst + VarSym + AppSym

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -207,14 +207,15 @@ lang MatchSym = Sym + MatchAst
   -- Intentionally left blank
 
   sem symbolizeExpr (env : SymEnv) =
-  | TmMatch {target = target, pat = pat, thn = thn, els = els} ->
-    match symbolizePat env assocEmpty pat
+  | TmMatch t ->
+    match symbolizePat env assocEmpty t.pat
     with (thnVarEnv, pat) then
       let m = assocMergePreferRight {eq=eqString} in
       let thnPatEnv = {env with varEnv = m env.varEnv thnVarEnv} in
-      TmMatch {target = symbolizeExpr env target,
-               pat = pat, thn = symbolizeExpr thnPatEnv thn,
-               els = symbolizeExpr env els}
+      TmMatch {{{{t with target = symbolizeExpr env t.target}
+                    with pat = pat}
+                    with thn = symbolizeExpr thnPatEnv t.thn}
+                    with els = symbolizeExpr env t.els}
     else never
 end
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -1,0 +1,151 @@
+include "mexpr/ast.mc"
+include "mexpr/pprint.mc"
+include "mexpr/symbolize.mc"
+
+type TypeEnv = AssocMap Name Type
+
+let _tyEnvInsert = assocInsert {eq = nameEqSym}
+let _tyEnvLookup = assocLookup {eq = nameEqSym}
+
+lang TypeAnnot = UnknownTypeAst
+  sem typeExpr (env : TypeEnv) =
+  | t -> TyUnknown {}
+
+  sem typeAnnotExpr (env : TypeEnv) =
+
+  sem typeAnnot =
+  | expr -> typeAnnotExpr assocEmpty expr
+end
+
+lang VarTypeAnnot = TypeAnnot + VarAst
+  sem typeExpr (env : TypeEnv) =
+  | TmVar t ->
+    match _tyEnvLookup t.ident env with Some ty then
+      ty
+    else
+      TyUnknown {}
+end
+
+lang FunTypeAnnot = TypeAnnot + FunAst
+  sem typeAnnotExpr (env : TypeEnv) =
+  | TmLam t ->
+    let env = _tyEnvInsert t.ident t.ty env in
+    TmLam {t with body = typeAnnotExpr env t.body}
+end
+
+lang RecordTypeAnnot = TypeAnnot + RecordAst + RecordTypeAst
+  sem typeExpr (env : TypeEnv) =
+  | TmRecord t ->
+    let f = lam acc. lam k. lam v.
+      assocInsert {eq=eqString} k (typeExpr env v) acc
+    in
+    let sortBindingsByKey = lam bindings.
+      let cmpKey = lam l. lam r.
+        match ltString l.0 r.0 with true then (negi 1) else
+        match gtString l.0 r.0 with true then 1 else 0
+      in
+      let traits = {eq=eqString} in
+      seq2assoc traits (sort cmpKey (assoc2seq traits bindings))
+    in
+    let bindings = sortBindingsByKey t.bindings in
+    TyRecord {fields = assocFold {eq=eqString} f assocEmpty bindings}
+end
+
+lang LetTypeAnnot = TypeAnnot + LetAst
+  sem typeAnnotExpr (env : TypeEnv) =
+  | TmLet t ->
+    let ty =
+      match t.ty with TyUnknown {} then
+        typeExpr env t.body
+      else t.ty
+    in
+    let env2 = _tyEnvInsert t.ident ty env in
+    TmLet {{{t with ty = ty}
+               with body = typeAnnotExpr env t.body}
+               with inexpr = typeAnnotExpr env2 t.inexpr}
+end
+
+lang MExprTypeAnnot = VarTypeAnnot + FunTypeAnnot + RecordTypeAnnot + LetTypeAnnot
+  sem typeAnnotExpr (env : TypeEnv) =
+  | t -> smap_Expr_Expr (typeAnnotExpr env) t
+end
+
+lang TestLang = MExprTypeAnnot + MExprPrettyPrint
+
+mexpr
+
+use TestLang in
+
+let x = nameSym "x" in
+let y = nameSym "y" in
+let z = nameSym "z" in
+let n = nameSym "n" in
+
+let base = nulam_ x (nulam_ y (app_ (nvar_ x) (var_ y))) in
+utest typeAnnot base with base in
+
+let letexp = lam ty.
+  bind_
+    (nlet_ x ty (record_ [
+      ("a", int_ 5),
+      ("b", float_ 2.718)
+    ]))
+    (nvar_ x) in
+utest typeAnnot (letexp tyunknown_)
+with  letexp (tyrecord_ [("a", tyunknown_), ("b", tyunknown_)]) in
+
+let nestedRec = lam ty1. lam ty2.
+  bindall_ [
+    nlet_ x ty1 (record_ [
+      ("a", int_ 5),
+      ("b", record_ [("c", float_ 2.718), ("d", float_ 3.14)]),
+      ("e", float_ 1.2)
+    ]),
+    nlet_ y ty2 (record_ [
+      ("a", record_ [("b", int_ 0), ("c", int_ 1), ("d", record_ [])]),
+      ("e", nvar_ x)
+    ]),
+    nlet_ z ty2 (nvar_ y),
+    nvar_ z
+  ]
+in
+let xType = tyrecord_ [
+  ("a", tyunknown_),
+  ("b", tyrecord_ [
+    ("c", tyunknown_), ("d", tyunknown_)
+  ]),
+  ("e", tyunknown_)
+] in
+let yType = tyrecord_ [
+  ("a", tyrecord_ [
+    ("b", tyunknown_), ("c", tyunknown_), ("d", tyrecord_ [])
+  ]),
+  ("e", xType)
+] in
+utest typeAnnot (nestedRec tyunknown_ tyunknown_)
+with  nestedRec xType yType in
+
+let nestedTuple = lam ty.
+  bind_
+    (nlet_ x ty (tuple_ [int_ 0, float_ 2.5, tuple_ [int_ 0, int_ 1]]))
+    (nvar_ x)
+in
+let tupleType = tytuple_ [
+  tyunknown_, tyunknown_, tytuple_ [tyunknown_, tyunknown_]
+] in
+utest typeAnnot (nestedTuple tyunknown_)
+with  nestedTuple tupleType in
+
+let recordInLambda = lam ty.
+  bindall_ [
+    nulet_ x (
+      nulam_ n (
+        bind_ (nlet_ y ty (record_ [("value", nvar_ n)])) (nvar_ y)
+    )),
+    app_ (nvar_ x) (int_ 5)
+  ]
+in
+utest typeAnnot (recordInLambda tyunknown_)
+with  recordInLambda (tyrecord_ [("value", tyunknown_)]) in
+
+()

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -49,6 +49,7 @@ lang RecordTypeAnnot = TypeAnnot + RecordAst + RecordTypeAst
     in
     let bindings = sortBindingsByKey t.bindings in
     TyRecord {fields = assocFold {eq=eqString} f assocEmpty bindings}
+  | TmRecordUpdate t -> typeExpr env t.rec
 end
 
 lang LetTypeAnnot = TypeAnnot + LetAst
@@ -102,10 +103,11 @@ let nestedRec = lam ty1. lam ty2.
       ("e", float_ 1.2)
     ]),
     nlet_ y ty2 (record_ [
-      ("a", record_ [("b", int_ 0), ("c", int_ 1), ("d", record_ [])]),
-      ("e", nvar_ x)
+      ("a", record_ [("b", int_ 0), ("c", record_ [])]),
+      ("d", nvar_ x),
+      ("e", int_ 5)
     ]),
-    nlet_ z ty2 (nvar_ y),
+    nlet_ z ty2 (recordupdate_ (nvar_ y) "e" (int_ 4)),
     nvar_ z
   ]
 in
@@ -118,9 +120,10 @@ let xType = tyrecord_ [
 ] in
 let yType = tyrecord_ [
   ("a", tyrecord_ [
-    ("b", tyunknown_), ("c", tyunknown_), ("d", tyrecord_ [])
+    ("b", tyunknown_), ("c", tyrecord_ [])
   ]),
-  ("e", xType)
+  ("d", xType),
+  ("e", tyunknown_)
 ] in
 utest typeAnnot (nestedRec tyunknown_ tyunknown_)
 with  nestedRec xType yType in

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -194,12 +194,18 @@ lang DataTypeAnnot = TypeAnnot + DataAst + MExprEq
     TmConApp {t with ty = typeExpr env (TmConApp t)}
 end
 
-lang MatchTypeAnnot = TypeAnnot + MatchAst
+lang MatchTypeAnnot = TypeAnnot + MatchAst + MExprEq
   sem typeExpr (env : TypeEnv) =
   | TmMatch t ->
-    match t.ty with TyUnknown {} then
-      typeExpr env t.thn
-    else t.ty
+    match env with {tyEnv = tyEnv} then
+      match t.ty with TyUnknown {} then
+        let thnty = typeExpr env t.thn in
+        let elsty = typeExpr env t.els in
+        if eqType tyEnv thnty elsty then
+          thnty
+        else error "Types of match branches have different types"
+      else t.ty
+    else never
 
   sem typeAnnotExpr (env : TypeEnv) =
   | TmMatch t ->

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -106,6 +106,10 @@ lang ConstTypeAnnot = TypeAnnot + ConstAst
 
   sem typeExpr (env : TypeEnv) =
   | TmConst {val = v} -> typeConst v
+
+  sem typeAnnotExpr (env : TypeEnv) =
+  | const & TmConst t ->
+    TmConst {t with ty = typeExpr env const}
 end
 
 lang MatchTypeAnnot = TypeAnnot + MatchAst
@@ -286,7 +290,7 @@ utest typeAnnot (ascription recordBody)
 with  withType recordType recordBody
 using eqExpr in
 
-let constBody = const_ (int_ 0) in
+let constBody = int_ 0 in
 utest typeAnnot (ascription constBody)
 with  withType tyint_ constBody
 using eqExpr in

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -81,6 +81,13 @@ lang LetTypeAnnot = TypeAnnot + LetAst
                with inexpr = typeAnnotExpr env2 t.inexpr}
 end
 
+lang ConstTypeAnnot = TypeAnnot + ConstAst
+  sem typeConst =
+
+  sem typeExpr (env : TypeEnv) =
+  | TmConst {val = v} -> typeConst v
+end
+
 lang DataTypeAnnot = TypeAnnot + DataAst
   sem typeExpr (env : TypeEnv) =
   | TmConApp t ->
@@ -127,7 +134,108 @@ lang SeqTypeAnnot = TypeAnnot + SeqAst
               with tms = map (typeAnnotExpr env) t.tms}
 end
 
-lang MExprTypeAnnot = VarTypeAnnot + AppTypeAnnot + FunTypeAnnot + RecordTypeAnnot + LetTypeAnnot
+lang IntTypeAnnot = ConstTypeAnnot + IntAst
+  sem typeConst =
+  | CInt _ -> tyint_
+end
+
+lang ArithIntTypeAnnot = ConstTypeAnnot + ArithIntAst
+  sem typeConst =
+  | CAddi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+  | CSubi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+  | CMuli _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+  | CDivi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+  | CNegi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+  | CModi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+end
+
+lang ShiftIntTypeAnnot = ConstTypeAnnot + ShiftIntAst
+  sem typeConst =
+  | CSlli _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+  | CSrli _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+  | CSrai _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
+end
+
+lang FloatTypeAnnot = ConstTypeAnnot + FloatAst
+  sem typeConst =
+  | CFloat _ -> tyfloat_
+end
+
+lang ArithFloatTypeAnnot = ConstTypeAnnot + ArithFloatAst
+  sem typeConst =
+  | CAddf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
+  | CSubf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
+  | CMulf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
+  | CDivf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
+  | CNegf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
+end
+
+lang FloatIntConversionTypeAnnot = ConstTypeAnnot + FloatIntConversionAst
+  sem typeConst =
+  | CFloorfi _ -> tyarrow_ tyfloat_ tyint_
+  | CCeilfi _ -> tyarrow_ tyfloat_ tyint_
+  | CRoundfi _ -> tyarrow_ tyfloat_ tyint_
+  | CInt2float _ -> tyarrow_ tyint_ tyfloat_
+end
+
+lang BoolTypeAnnot = ConstTypeAnnot + BoolAst
+  sem typeConst =
+  | CBool _ -> tybool_
+end
+
+lang CmpIntTypeAnnot = ConstTypeAnnot + CmpIntAst
+  sem typeConst =
+  | CEqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
+  | CNeqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
+  | CLti _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
+  | CGti _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
+  | CLeqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
+  | CGeqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
+end
+
+lang CmpFloatTypeAnnot = ConstTypeAnnot + CmpFloatAst
+  sem typeConst =
+  | CEqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
+  | CNeqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
+  | CLtf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
+  | CGtf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
+  | CLeqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
+  | CGeqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
+end
+
+lang CharTypeAnnot = ConstTypeAnnot + CharAst
+  sem typeConst =
+  | CChar _ -> tychar_
+end
+
+lang CmpCharTypeAnnot = ConstTypeAnnot + CmpCharAst
+  sem typeConst =
+  | CEqc _ -> tyarrow_ tychar_ (tyarrow_ tychar_ tybool_)
+end
+
+lang IntCharConversionTypeAnnot = ConstTypeAnnot + IntCharConversionAst
+  sem typeConst =
+  | CInt2Char _ -> tyarrow_ tyint_ tychar_
+  | CChar2Int _ -> tyarrow_ tychar_ tyint_
+end
+
+lang FloatStringConversionTypeAnnot = ConstTypeAnnot + FloatStringConversionAst
+  sem typeConst =
+  | CString2float _ -> tyarrow_ tystr_ tyfloat_
+end
+
+lang MExprTypeAnnot =
+
+  -- Terms
+  VarTypeAnnot + AppTypeAnnot + FunTypeAnnot + RecordTypeAnnot + LetTypeAnnot +
+  ConstTypeAnnot + DataTypeAnnot + MatchTypeAnnot + SeqTypeAnnot +
+
+  -- Constants
+  IntTypeAnnot + ArithIntTypeAnnot + ShiftIntTypeAnnot + FloatTypeAnnot +
+  ArithFloatTypeAnnot + FloatIntConversionTypeAnnot + BoolTypeAnnot +
+  CmpIntTypeAnnot + CmpFloatTypeAnnot + CharTypeAnnot + CmpCharTypeAnnot +
+  IntCharConversionTypeAnnot + FloatStringConversionTypeAnnot
+
   sem typeExpr (env : TypeEnv) =
   | t -> TyUnknown {}
 
@@ -157,7 +265,7 @@ let letexp = lam ty.
     ]))
     unit_ in
 utest typeAnnot (letexp tyunknown_)
-with  letexp (tyrecord_ [("a", tyunknown_), ("b", tyunknown_)])
+with  letexp (tyrecord_ [("a", tyint_), ("b", tyfloat_)])
 using eqExpr in
 
 let nestedRec = lam ty1. lam ty2.
@@ -177,18 +285,18 @@ let nestedRec = lam ty1. lam ty2.
   ]
 in
 let xType = tyrecord_ [
-  ("a", tyunknown_),
+  ("a", tyint_),
   ("b", tyrecord_ [
-    ("c", tyunknown_), ("d", tyunknown_)
+    ("c", tyfloat_), ("d", tyfloat_)
   ]),
-  ("e", tyunknown_)
+  ("e", tyfloat_)
 ] in
 let yType = tyrecord_ [
   ("a", tyrecord_ [
-    ("b", tyunknown_), ("c", tyrecord_ [])
+    ("b", tyint_), ("c", tyrecord_ [])
   ]),
   ("d", xType),
-  ("e", tyunknown_)
+  ("e", tyint_)
 ] in
 utest typeAnnot (nestedRec tyunknown_ tyunknown_)
 with  nestedRec xType yType
@@ -200,7 +308,7 @@ let nestedTuple = lam ty.
     unit_
 in
 let tupleType = tytuple_ [
-  tyunknown_, tyunknown_, tytuple_ [tyunknown_, tyunknown_]
+  tyint_, tyfloat_, tytuple_ [tyint_, tyint_]
 ] in
 utest typeAnnot (nestedTuple tyunknown_)
 with  nestedTuple tupleType


### PR DESCRIPTION
Included in this PR:
* A `ty` field has been added to several additional AST nodes.
  * The following nodes have been updated: `TmVar`, `TmApp`, `TmRecord`, `TmRecordUpdate`, `TmConst`, `TmConApp`, `TmMatch`, `TmSeq`
  * A lot of constructor applications had to be rewritten to use record updates instead of creating new records, to keep the type information.
  * I added the field `ty = TyUnknown {}` in places where constructing a new record was necessary.
* A semantic function `withType` has been added to the `MExprAst`.
  * It only works for nodes that have a `ty` field, i.e. not on `TmUtest` or `TmRecLets`.
  * It can be used to update the type of an arbitrary AST node, without having to match on it.
* A semantic function `eqType` has been added to the `MExprEq` language fragment.
  * This function is intentionally not used in `eqExpr` because we don't want to compare the types of terms.
  * Two `TyVar` types are considered equivalent if they are free in the type environment, but they use the same symbol. Just pointing it out because I'm not sure that's the behaviour we want.
* Added a language fragment `MExprTypeAnnot`, which provides the semantic function `typeAnnot` for annotating the types of AST nodes. Currently it throws an error when something unexpected happens, but in the future I think it might be better to return an option instead.
  * Before the function runs, a pass is made through the given term to collect all data types.
  * Let-ascriptions `let x : Int = f y in x` is simplified into `f y` and this term is given type `Int`.
  * Annotations are added to:
    * Constant literals of type `Int`, `Float`, `Bool`, `Char`.
    * Most arithmetic intrinsic functions. I intentionally avoided functions where the type needs polymorphism (sequence functions) or where I'm not sure what the type should be (e.g. gensym).
    * Sequence terms. When annotating sequences, an error is thrown when elements have different types.
    * Match terms. The type of a match is set to be the type of its then-branch and else-branch. If they have different types, an error is thrown. The patterns are not checked.
    * Application terms. When the left-hand side of an application does not have type `TyArrow` an error is reported. Similarly if the right-hand side does not match the `from` type of the left-hand side arrow type.
    * Let-expressions and variables.
    * Data types. I assumed that all constructor definitions were annotated with an arrow type when annotating constructor applications. I'm not sure whether these kinds of annotations are what we want in the end, but I added something for completeness.
    * I do not annotate `reclet`, `utest` and `never` (as `smap` is used any terms within `reclet`s may still be annotated).