### PR TITLE
Poor mans typechecker

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -23,6 +23,8 @@ let enable_debug_after_mlang = ref false
 
 let enable_debug_symbol_print = ref false
 
+let enable_debug_con_shape = ref false
+
 let utest = ref false (* Set to true if unit testing is enabled *)
 
 let utest_ok = ref 0 (* Counts the number of successful unit tests *)

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -908,6 +908,27 @@ let debug_eval env t =
     uprint_endline (env_str ^. tm_str) )
   else ()
 
+let shape_str = function
+  | TmRecord(_, record) ->
+     Record.bindings record
+     |> List.map fst
+     |> Ustring.concat (us",")
+     |> fun x -> us"record: {" ^. x ^. us"}"
+  | TmSeq _ -> us"Sequence"
+  | TmConapp(_, x, s, _) ->
+     ustring_of_var ~symbol:!enable_debug_symbol_print x s
+  | TmConst(_, CInt _) -> us"Int"
+  | TmConst(_, CBool _) -> us"Bool"
+  | TmConst(_, CFloat _) -> us"Float"
+  | TmConst(_, CChar _) -> us"Char"
+  | TmConst(_, CSymb _) -> us"Symbol"
+  | TmConst(_, CMap _) -> us"Intrinsic Map"
+  | TmConst(_, CPy _) -> us"Python Const"
+  | TmConst(_, _) -> us"Other Const"
+  | TmClos _ -> us"(closure)"
+  | TmRef _ -> us"(ref)"
+  | _ -> us"Other tm"
+
 (* Print out error message when a unit test fails *)
 let unittest_failed fi t1 t2 tusing =
   uprint_endline
@@ -1383,7 +1404,14 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
   | TmCondef (_, _, _, _, t) ->
       eval env t
   | TmConapp (fi, x, s, t) ->
-      TmConapp (fi, x, s, eval env t)
+      let rhs = eval env t in
+      if !enable_debug_con_shape then begin
+          let shape = shape_str rhs in
+          let sym = ustring_of_var ~symbol:!enable_debug_symbol_print x s in
+          let info = info2str fi in
+          Printf.eprintf "%-40s: %-40s (%s)\n" (Ustring.to_utf8 sym) (Ustring.to_utf8 shape) (Ustring.to_utf8 info)
+      end;
+      TmConapp (fi, x, s, rhs)
   | TmMatch (_, t1, p, t2, t3) -> (
     match try_match env (eval env t1) p with
     | Some env ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -909,25 +909,36 @@ let debug_eval env t =
   else ()
 
 let shape_str = function
-  | TmRecord(_, record) ->
-     Record.bindings record
-     |> List.map fst
-     |> Ustring.concat (us",")
-     |> fun x -> us"record: {" ^. x ^. us"}"
-  | TmSeq _ -> us"Sequence"
-  | TmConapp(_, x, s, _) ->
-     ustring_of_var ~symbol:!enable_debug_symbol_print x s
-  | TmConst(_, CInt _) -> us"Int"
-  | TmConst(_, CBool _) -> us"Bool"
-  | TmConst(_, CFloat _) -> us"Float"
-  | TmConst(_, CChar _) -> us"Char"
-  | TmConst(_, CSymb _) -> us"Symbol"
-  | TmConst(_, CMap _) -> us"Intrinsic Map"
-  | TmConst(_, CPy _) -> us"Python Const"
-  | TmConst(_, _) -> us"Other Const"
-  | TmClos _ -> us"(closure)"
-  | TmRef _ -> us"(ref)"
-  | _ -> us"Other tm"
+  | TmRecord (_, record) ->
+      Record.bindings record |> List.map fst
+      |> Ustring.concat (us ",")
+      |> fun x -> us "record: {" ^. x ^. us "}"
+  | TmSeq _ ->
+      us "Sequence"
+  | TmConapp (_, x, s, _) ->
+      ustring_of_var ~symbol:!enable_debug_symbol_print x s
+  | TmConst (_, CInt _) ->
+      us "Int"
+  | TmConst (_, CBool _) ->
+      us "Bool"
+  | TmConst (_, CFloat _) ->
+      us "Float"
+  | TmConst (_, CChar _) ->
+      us "Char"
+  | TmConst (_, CSymb _) ->
+      us "Symbol"
+  | TmConst (_, CMap _) ->
+      us "Intrinsic Map"
+  | TmConst (_, CPy _) ->
+      us "Python Const"
+  | TmConst (_, _) ->
+      us "Other Const"
+  | TmClos _ ->
+      us "(closure)"
+  | TmRef _ ->
+      us "(ref)"
+  | _ ->
+      us "Other tm"
 
 (* Print out error message when a unit test fails *)
 let unittest_failed fi t1 t2 tusing =
@@ -1405,12 +1416,12 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
       eval env t
   | TmConapp (fi, x, s, t) ->
       let rhs = eval env t in
-      if !enable_debug_con_shape then begin
-          let shape = shape_str rhs in
-          let sym = ustring_of_var ~symbol:!enable_debug_symbol_print x s in
-          let info = info2str fi in
-          Printf.eprintf "%s:\t%s\t(%s)\n" (Ustring.to_utf8 sym) (Ustring.to_utf8 shape) (Ustring.to_utf8 info)
-      end;
+      ( if !enable_debug_con_shape then
+        let shape = shape_str rhs in
+        let sym = ustring_of_var ~symbol:!enable_debug_symbol_print x s in
+        let info = info2str fi in
+        Printf.eprintf "%s:\t%s\t(%s)\n" (Ustring.to_utf8 sym)
+          (Ustring.to_utf8 shape) (Ustring.to_utf8 info) ) ;
       TmConapp (fi, x, s, rhs)
   | TmMatch (_, t1, p, t2, t3) -> (
     match try_match env (eval env t1) p with

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1409,7 +1409,7 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
           let shape = shape_str rhs in
           let sym = ustring_of_var ~symbol:!enable_debug_symbol_print x s in
           let info = info2str fi in
-          Printf.eprintf "%-40s: %-40s (%s)\n" (Ustring.to_utf8 sym) (Ustring.to_utf8 shape) (Ustring.to_utf8 info)
+          Printf.eprintf "%s:\t%s\t(%s)\n" (Ustring.to_utf8 sym) (Ustring.to_utf8 shape) (Ustring.to_utf8 info)
       end;
       TmConapp (fi, x, s, rhs)
   | TmMatch (_, t1, p, t2, t3) -> (

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -25,8 +25,8 @@ let ref_indent = ref 2
 let string_of_ustring = Ustring.to_utf8
 
 (** Create string representation of variable *)
-let ustring_of_var x s =
-  if !ref_symbol then
+let ustring_of_var ?(symbol = !ref_symbol) x s =
+  if symbol then
     x
     ^.
     if Symb.eqsym Symb.Helpers.nosym s then us "#"

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -87,7 +87,8 @@ let main =
       , " Enables output of the environment in each eval step." )
     ; ( "--debug-con-shapes"
       , Arg.Set enable_debug_con_shape
-      , " Enables printing of the shape of values given to constructors, to stderr." )
+      , " Enables printing of the shape of values given to constructors, to \
+         stderr." )
     ; ( "--symbol"
       , Arg.Set enable_debug_symbol_print
       , " Enables output of symbols for variables. Affects all other debug \

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -85,6 +85,9 @@ let main =
     ; ( "--debug-eval-env"
       , Arg.Set enable_debug_eval_env
       , " Enables output of the environment in each eval step." )
+    ; ( "--debug-con-shapes"
+      , Arg.Set enable_debug_con_shape
+      , " Enables printing of the shape of values given to constructors, to stderr." )
     ; ( "--symbol"
       , Arg.Set enable_debug_symbol_print
       , " Enables output of symbols for variables. Affects all other debug \


### PR DESCRIPTION
This PR adds debug printing of the shapes of values put into constructors at runtime, as a command line flag. This gives as a form of poor man's after-the-fact typechecking. This is designed to facilitate the level of type correctness we need for the OCaml compilation, i.e., we don't record the full type, only a shallow version of it. Intended usage is as follows:

```bash
$ mi --debug-con-shapes test something-to-test 2> tmp
$ sort < tmp | uniq > tmp2
$ less tmp2
```

Example output from running all our tests (~1.1GB in `tmp`, ~92KB in `tmp2`, showing the first 100 lines of `tmp2`)

```
A_ACon:	record: {afield,aextfield}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 143:20-143:51)
A_ACon:	record: {afield,aextfield}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 144:26-144:57)
AndPat_PAnd:	record: {lpat,rpat}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 73:2-73:27)
AndPat_PAnd:	record: {lpat,rpat}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast.mc" 504:14-504:66)
AndPat_PAnd:	record: {lpat,rpat}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/symbolize.mc" 401:13-401:61)
AppAst_TmApp:	record: {fi,lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/infix.mc" 28:16-28:74)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/anf.mc" 50:33-50:40)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/anf.mc" 55:39-55:63)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 360:2-360:26)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast.mc" 34:15-34:51)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/decision-points.mc" 109:34-109:41)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/decision-points.mc" 186:32-186:39)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/decision-points.mc" 515:66-515:73)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 110:27-110:68)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 155:38-156:59)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 168:34-168:77)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/pprint.mc" 244:23-244:30)
AppAst_TmApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/symbolize.mc" 60:4-60:68)
AppTypeAst_TyApp:	record: {lhs,rhs}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 129:2-129:30)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 100:23-100:50)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 105:14-105:32)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 110:14-113:52)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 113:23-113:50)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 124:14-124:32)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 129:14-132:52)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 130:31-130:49)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 132:23-132:50)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 51:10-51:28)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 92:14-92:32)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 97:14-100:52)
Arith_Add:	record: {0,1}	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 98:31-98:49)
ArithBool2_IsZero:	Arith_Add	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 130:23-130:49)
ArithBool2_IsZero:	Arith_Add	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 98:23-98:49)
ArithBool2_IsZero:	Arith_Num	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 125:18-125:31)
ArithBool2_IsZero:	Arith_Num	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 93:18-93:31)
ArithFloatAst_CAddf:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 462:18-462:25)
ArithFloatAst_CDivf:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 474:18-474:25)
ArithFloatAst_CMulf:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 470:18-470:25)
ArithFloatAst_CNegf:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 478:18-478:25)
ArithFloatAst_CSubf:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 466:18-466:25)
ArithFloatEval_CAddf2:	Float	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 335:23-335:35)
ArithFloatEval_CDivf2:	Float	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 371:23-371:35)
ArithFloatEval_CMulf2:	Float	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 359:23-359:35)
ArithFloatEval_CSubf2:	Float	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 347:23-347:35)
ArithIntAst_CAddi:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 438:18-438:25)
ArithIntAst_CAddi:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/infix.mc" 38:60-38:68)
ArithIntAst_CDivi:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 450:18-450:25)
ArithIntAst_CModi:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 454:18-454:25)
ArithIntAst_CMuli:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 446:18-446:25)
ArithIntAst_CMuli:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/infix.mc" 40:60-40:68)
ArithIntAst_CNegi:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 458:18-458:25)
ArithIntAst_CSubi:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/ast-builder.mc" 442:18-442:25)
ArithIntAst_CSubi:	record: {}	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/infix.mc" 39:60-39:68)
ArithIntEval_CAddi2:	Int	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 247:21-247:29)
ArithIntEval_CDivi2:	Int	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 271:21-271:29)
ArithIntEval_CModi2:	Int	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 279:21-279:29)
ArithIntEval_CMuli2:	Int	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 263:21-263:29)
ArithIntEval_CSubi2:	Int	(FILE "/home/vipa/Projects/miking/stdlib/mexpr/eval.mc" 255:21-255:29)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 100:28-100:33)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 100:36-100:47)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 105:19-105:24)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 105:26-105:31)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 107:18-107:23)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 108:18-108:23)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 110:19-110:25)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 112:23-112:29)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 113:28-113:33)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 113:36-113:47)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 124:19-124:24)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 124:26-124:31)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 125:26-125:31)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 126:18-126:23)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 127:18-127:23)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 129:19-129:25)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 130:36-130:41)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 130:43-130:48)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 131:23-131:29)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 132:28-132:33)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 132:36-132:47)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 136:39-136:44)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 136:46-136:51)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 137:40-137:45)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 137:47-137:52)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 51:15-51:20)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 51:22-51:27)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 92:19-92:24)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 92:26-92:31)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 93:26-93:31)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 94:18-94:23)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 95:18-95:23)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 97:19-97:25)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 98:36-98:41)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 98:43-98:48)
Arith_Num:	Int	(FILE "/home/vipa/Projects/miking/test/mlang/mlang.mc" 99:23-99:29)
A_TmFoo:	record: {}	(FILE "/home/vipa/Projects/miking/test/mlang/sharedcons.mc" 24:21-24:28)
A_TmFoo:	record: {}	(FILE "/home/vipa/Projects/miking/test/mlang/sharedcons.mc" 25:22-25:29)
A_TmFoo:	record: {}	(FILE "/home/vipa/Projects/miking/test/mlang/sharedcons.mc" 26:23-26:30)
A_TmFoo:	record: {}	(FILE "/home/vipa/Projects/miking/test/mlang/sharedcons.mc" 33:13-33:20)
A_TmFoo:	record: {}	(FILE "/home/vipa/Projects/miking/test/mlang/sharedcons.mc" 34:13-34:20)
A_TmFoo:	record: {}	(FILE "/home/vipa/Projects/miking/test/mlang/sharedcons.mc" 40:13-40:20)
```

In this case, we're mostly good about constructing things with the same shape, with the exception of `AppAst_TmApp` which is mostly constructor with `{lhs, rhs}` but sometimes as `{fi,lhs,rhs}`.

`----debug-con-shapes` respects `--symbols`, but it's essentially only useful when examining the data from a single invocation of `mi` since symbols are not stable between invocations. This means that we can get output that has different symbols for the same constructor, even when the application is in the exact same source location.

Each line has a `\t` between the three data points, for easier post-processing. For example, using [tab](https://tkatchev.bitbucket.io/tab/index.html) to find the constructors that have different shapes:

```bash
$ tab '?[ (count.@[1])>1, @[0], join([@[0] : @[1]],",") : {l=cut(@,"\t"), l~0 -> map(l~1, 1)}]' < tmp2
Some:	Sequence,Some,SeqAst_TmSeq,record: {conEnv,varEnv},RefAst_TmRef,record: {0,1},AppAst_TmApp,CAst_CIExpr,None,CAst_CEInt,RecordAst_TmRecord,NamedPat_PNamed,CAst_CIList,Int,Char,Bool,ConstAst_TmConst,DataAst_TmConApp,record: {pos,str,val,prec,assoc},record: {count,nameMap,strings},FunEval_TmClos,Symbol,FunAst_TmLam
SeqAst_TmSeq:	record: {tms},record: {fi,tms}
PName:	Sequence,record: {0,1}
Nat_S:	Nat_Z,Nat_S
MatchAst_TmMatch:	record: {fi,els,pat,thn,target},record: {els,pat,thn,target}
LetAst_TmLet:	record: {ty,body,ident,inexpr},record: {fi,ty,body,ident,inexpr}
K2:	record: {},record: {0,1},Int
FunAst_TmLam:	record: {ty,body,ident},record: {fi,ty,body,ident}
ArithBool2_IsZero:	Arith_Num,Arith_Add
BoolPat_PBool:	record: {val},record: {fi,val}
VarAst_TmVar:	record: {ident},record: {fi,ident}
DualNum:	Sequence,record: {e,x,xp}
K3:	record: {0,1},Int
AppAst_TmApp:	record: {lhs,rhs},record: {fi,lhs,rhs}
Num:	Int,Float
ConstAst_TmConst:	record: {val},record: {fi,val}
```