### PR TITLE
Fix types not being recorded as toplevel definitions in REPL

### DIFF
--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1503,5 +1503,19 @@ let rec eval_toplevel (env : (Symb.t * tm) list) = function
       eval_toplevel (Lazy.force env') t2
   | TmCondef (_, _, _, _, t) ->
       eval_toplevel env t
-  | t ->
+  | ( TmVar _
+    | TmLam _
+    | TmClos _
+    | TmApp _
+    | TmConst _
+    | TmFix _
+    | TmSeq _
+    | TmRecord _
+    | TmRecordUpdate _
+    | TmConapp _
+    | TmMatch _
+    | TmUse _
+    | TmUtest _
+    | TmNever _
+    | TmRef _ ) as t ->
       (env, eval env t)

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1484,6 +1484,8 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
 let rec eval_toplevel (env : (Symb.t * tm) list) = function
   | TmLet (_, _, s, _ty, t1, t2) ->
       eval_toplevel ((s, eval env t1) :: env) t2
+  | TmType (_, _, _, _, t1) ->
+      eval_toplevel env t1
   | TmRecLets (_, lst, t2) ->
       let rec env' =
         lazy


### PR DESCRIPTION
This fixes the Not_found bug in the REPL (issue #240), introduced in commit 227f2c9.

I haven't followed the recent developments regarding types, so I don't know if there are any deeper problems regarding this, but this seems to make things work as far as I can see.