### PR TITLE
LL(1) table driven parser with semantic actions

### DIFF
--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -10,6 +10,9 @@ let mapLookup : k -> Map k v -> Option v =
     match mapMem k m with false then None ()
     else Some (mapFind k m)
 
+let mapUnion : Map k v -> Map k v -> Map k v = lam l. lam r.
+  foldl (lam acc. lam binding. mapInsert binding.0 binding.1 acc) l (mapBindings r)
+
 mexpr
 
 let m = mapEmpty subi in
@@ -24,5 +27,17 @@ utest mapLookup 1 m with Some "1" in
 utest mapLookup 2 m with Some "2" in
 utest mapLookup 3 m with Some "3" in
 utest mapLookup 4 m with None () in
+
+let m2 = mapInsert 2 "22" m in
+let m2 = mapInsert 4 "44" m2 in
+let m2 = mapInsert (negi 1) "-1" m2 in
+
+let merged = mapUnion m m2 in
+utest mapLookup 1 merged with Some "1" in
+utest mapLookup 2 merged with Some "22" in
+utest mapLookup 3 merged with Some "3" in
+utest mapLookup 4 merged with Some "44" in
+utest mapLookup (negi 1) merged with Some "-1" in
+utest mapLookup 5 merged with None () in
 
 ()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -4,6 +4,7 @@
 -- Defines auxiliary functions for the map intrinsics.
 
 include "option.mc"
+include "seq.mc"
 
 let mapLookup : k -> Map k v -> Option v =
   lam k. lam m.
@@ -12,6 +13,9 @@ let mapLookup : k -> Map k v -> Option v =
 
 let mapUnion : Map k v -> Map k v -> Map k v = lam l. lam r.
   foldl (lam acc. lam binding. mapInsert binding.0 binding.1 acc) l (mapBindings r)
+
+let mapFromList : (k -> k -> Int) -> [(k, v)] -> Map k v = lam cmp. lam bindings.
+  foldl (lam acc. lam binding. mapInsert binding.0 binding.1 acc) (mapEmpty cmp) bindings
 
 mexpr
 
@@ -39,5 +43,13 @@ utest mapLookup 3 merged with Some "3" in
 utest mapLookup 4 merged with Some "44" in
 utest mapLookup (negi 1) merged with Some "-1" in
 utest mapLookup 5 merged with None () in
+
+let m = mapFromList subi
+  [ (1, "1")
+  , (2, "2")
+  ] in
+utest mapLookup 1 m with Some "1" in
+utest mapLookup 2 m with Some "2" in
+utest mapLookup 3 m with None () in
 
 ()

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -4,7 +4,6 @@
 
 include "string.mc"
 include "seq.mc"
-include "mexpr/ast.mc"
 include "mexpr/info.mc"
 
 
@@ -23,7 +22,8 @@ lang TokenParser = WSACParser
       parseToken pos str
     else never
 
-  sem parseToken (pos : Pos) /- : {String -> {token : Token, stream : {pos : Pos, str : String}}} -/ =
+  sem parseToken (pos : Pos) /- : String -> {token : Token, lit : String, stream : {pos : Pos, str : String}} -/ =
+  sem tokKindEq (tok : Token) /- : Token -> Bool -/ =
 end
 
 -- Eats whitespace
@@ -73,8 +73,6 @@ lang MultilineCommentParser = WSACParser
     in remove (advanceCol p 2) xs 1
 end
 
-
--- TODO(vipa, 2021-02-03): move tests to new fragment
 -- Commbined WSAC parser for MExpr
 lang MExprWSACParser = WhitespaceParser + LineCommentParser + MultilineCommentParser
 
@@ -94,7 +92,10 @@ lang EOFTokenParser = TokenParser
   | EOFTok {pos : Pos}
 
   sem parseToken (pos : Pos) =
-  | [] -> {token = EOFTok {pos = pos}, stream = {pos = pos, str = []}}
+  | [] -> {token = EOFTok {pos = pos}, lit = "", stream = {pos = pos, str = []}}
+
+  sem tokKindEq (tok : Tok) =
+  | EOFTok _ -> match tok with EOFTok _ then true else false
 end
 
 -- Parses the continuation of an identifier, i.e., upper and lower
@@ -129,10 +130,16 @@ lang LIdentTokenParser = TokenParser
       'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' |
       'x' | 'y' | 'z' ) & c] ++ str ->
     match parseIdentCont (advanceCol pos 1) str with {val = val, pos = pos2, str = str}
-    then { token = LIdentTok {fi = makeInfo pos pos2, val = cons c val}
-         , stream = {pos = pos2, str = str}
-         }
+    then
+      let val = cons c val in
+      { token = LIdentTok {fi = makeInfo pos pos2, val = val}
+      , lit = val
+      , stream = {pos = pos2, str = str}
+      }
     else never
+
+  sem tokKindEq (tok : Tok) =
+  | LIdentTok _ -> match tok with LIdentTok _ then true else false
 end
 
 lang UIdentTokenParser = TokenParser
@@ -143,11 +150,18 @@ lang UIdentTokenParser = TokenParser
   | [('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
       'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' |
       'X' | 'Y' | 'Z' ) & c] ++ str ->
-    match parseIdentCont pos str with {val = val, pos = pos2, str = str}
-    then { token = UIdentTok {fi = makeInfo pos pos2, val = val}
-         , stream = {pos = pos2, str = str}
-         }
+    match parseIdentCont (advanceCol pos 1) str with {val = val, pos = pos2, str = str}
+    then
+      let val = cons c val in
+      { token = UIdentTok {fi = makeInfo pos pos2, val = val}
+      , lit = val
+      , stream = {pos = pos2, str = str}
+      }
     else never
+
+
+  sem tokKindEq (tok : Tok) =
+  | UIdentTok _ -> match tok with UIdentTok _ then true else false
 end
 
 let parseUInt : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -186,8 +200,12 @@ lang UIntTokenParser = TokenParser
   sem parseIntCont (acc : String) (pos1 : Pos) (pos2 : Pos) =
   | str ->
     { token = IntTok {fi = makeInfo pos1 pos2, val = string2int acc}
+    , lit = ""
     , stream = {pos = pos2, str = str}
     }
+
+  sem tokKindEq (tok : Tok) =
+  | IntTok _ -> match tok with IntTok _ then true else false
 end
 
 let parseFloatExponent : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -220,7 +238,9 @@ lang UFloatTokenParser = UIntTokenParser
   | (['.', '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ _) & str ->
     match parseFloatExponent (advanceCol pos2 1) (tail str)
     with {val = val, pos = pos3, str = str}
-    then parseFloatCont (join [acc, ".", val]) pos1 pos3 str
+    then
+      let acc = join [acc, ".", val] in
+      parseFloatCont acc pos1 pos3 str
     else never
   | ( [ 'e' | 'E'] ++ _
     & ( [_, '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ _
@@ -229,20 +249,26 @@ lang UFloatTokenParser = UIntTokenParser
     ) & str -> parseFloatCont acc pos1 pos2 str
 
   sem parseFloatCont (acc : String) (pos1 : Pos) (pos2 : Pos) =
-  | ( [ 'e' | 'E'] ++ _
+  | ( [ ('e' | 'E') & e] ++ _
     & ( [_, '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ _
       | [_, '+' | '-', '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ _
       )
     ) & str ->
     match parseFloatExponent (advanceCol pos2 1) (tail str) with {val = val, pos = pos2, str = str}
-    then { token = FloatTok {fi = makeInfo pos1 pos2, val = string2float (join [acc, "e", val])}
-         , stream = {pos = pos2, str = str}
-         }
+    then
+      { token = FloatTok {fi = makeInfo pos1 pos2, val = string2float (join [acc, "e", val])}
+      , lit = ""
+      , stream = {pos = pos2, str = str}
+      }
     else never
   | str ->
     { token = FloatTok {fi = makeInfo pos1 pos2, val = string2float acc}
+    , lit = ""
     , stream = {pos = pos2, str = str}
     }
+
+  sem tokKindEq (tok : Tok) =
+  | FloatTok _ -> match tok with FloatTok _ then true else false
 end
 
 let parseOperatorCont : Pos -> String -> {val : String, stream : {pos : Pos, str : String}} = lam p. lam str.
@@ -273,8 +299,15 @@ lang OperatorTokenParser = TokenParser
   | [('%' | '<' | '>' | '!' | '?' | '~' | ':' | '.' | '$' | '&' | '*' |
       '+' | '-' | '/' | '=' | '@' | '^' | '|') & c] ++ str ->
     match parseOperatorCont (advanceCol pos 1) str with {val = val, stream = stream}
-    then {token = OperatorTok {fi = makeInfo pos stream.pos, val = cons c val}, stream = stream}
+    then
+      let val = cons c val in
+      { token = OperatorTok {fi = makeInfo pos stream.pos, val = val}
+      , lit = val
+      , stream = stream}
     else never
+
+  sem tokKindEq (tok : Tok) =
+  | OperatorTok _ -> match tok with OperatorTok _ then true else false
 end
 
 lang BracketTokenParser = TokenParser
@@ -289,22 +322,30 @@ lang BracketTokenParser = TokenParser
   sem parseToken (pos : Pos) =
   | "(" ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = LParenTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = LParenTok {fi = makeInfo pos pos2}, lit = "(", stream = {pos = pos2, str = str}}
   | ")" ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = RParenTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = RParenTok {fi = makeInfo pos pos2}, lit = ")", stream = {pos = pos2, str = str}}
   | "[" ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = LBracketTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = LBracketTok {fi = makeInfo pos pos2}, lit = "[", stream = {pos = pos2, str = str}}
   | "]" ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = RBracketTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = RBracketTok {fi = makeInfo pos pos2}, lit = "]", stream = {pos = pos2, str = str}}
   | "{" ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = LBraceTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = LBraceTok {fi = makeInfo pos pos2}, lit = "{", stream = {pos = pos2, str = str}}
   | "}" ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = RBraceTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = RBraceTok {fi = makeInfo pos pos2}, lit = "}", stream = {pos = pos2, str = str}}
+
+  sem tokKindEq (tok : Tok) =
+  | LParenTok _ -> match tok with LParenTok _ then true else false
+  | RParenTok _ -> match tok with RParenTok _ then true else false
+  | LBracketTok _ -> match tok with LBracketTok _ then true else false
+  | RBracketTok _ -> match tok with RBracketTok _ then true else false
+  | LBraceTok _ -> match tok with LBraceTok _ then true else false
+  | RBraceTok _ -> match tok with RBraceTok _ then true else false
 end
 
 lang SemiTokenParser = TokenParser
@@ -314,7 +355,10 @@ lang SemiTokenParser = TokenParser
   sem parseToken (pos : Pos) =
   | ";" ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = SemiTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = SemiTok {fi = makeInfo pos pos2}, lit = ";", stream = {pos = pos2, str = str}}
+
+  sem tokKindEq (tok : Tok) =
+  | SemiTok _ -> match tok with SemiTok _ then true else false
 end
 
 lang CommaTokenParser = TokenParser
@@ -324,7 +368,10 @@ lang CommaTokenParser = TokenParser
   sem parseToken (pos : Pos) =
   | "," ++ str ->
     let pos2 = advanceCol pos 1 in
-    {token = CommaTok {fi = makeInfo pos pos2}, stream = {pos = pos2, str = str}}
+    {token = CommaTok {fi = makeInfo pos pos2}, lit = ",", stream = {pos = pos2, str = str}}
+
+  sem tokKindEq (tok : Tok) =
+  | CommaTok _ -> match tok with CommaTok _ then true else false
 end
 
 -- Matches a character (including escape character).
@@ -359,9 +406,13 @@ lang StringTokenParser = TokenParser
       else never
     in match work "" (advanceCol pos 1) str with {val = val, pos = pos2, str = str} then
       { token = StringTok {fi = makeInfo pos pos2, val = val}
+      , lit = ""
       , stream = {pos = pos2, str = str}
       }
     else never
+
+  sem tokKindEq (tok : Tok) =
+  | StringTok _ -> match tok with StringTok _ then true else false
 end
 
 lang CharTokenParser = TokenParser
@@ -374,10 +425,14 @@ lang CharTokenParser = TokenParser
       match str with "'" ++ str then
         let pos2 = advanceCol pos2 1 in
         { token = CharTok {fi = makeInfo pos pos2, val = val}
+        , lit = ""
         , stream = {pos = pos2, str = str}
         }
       else posErrorExit pos "Expected ' to close character literal."
     else never
+
+  sem tokKindEq (tok : Tok) =
+  | CharTok _ -> match tok with CharTok _ then true else false
 end
 
 lang HashStringTokenParser = TokenParser
@@ -396,11 +451,17 @@ lang HashStringTokenParser = TokenParser
           else never
         in match work "" (advanceCol pos2 1) str with {val = val, pos = pos2, str = str} then
           { token = HashStringTok {fi = makeInfo pos pos2, hash = hash, val = val}
+          , lit = ""
           , stream = {pos = pos2, str = str}
           }
         else never
       else posErrorExit pos2 "Expected \" to begin hash string"
     else never
+
+  sem tokKindEq (tok : Tok) =
+  | HashStringTok {hash = hash} -> match tok with HashStringTok {hash = hash2}
+    then eqString hash hash2
+    else false
 end
 
 lang Lexer
@@ -411,6 +472,37 @@ lang Lexer
   + StringTokenParser + CharTokenParser
   + HashStringTokenParser
 
+-- NOTE(vipa, 2021-02-05): This is not a semantic function in a
+-- language fragment since the output for each case must be distinct
+-- from the output for any other fragment, meaning that there would be
+-- an invisible dependency between them
+let _tokKindInt = use Lexer in lam tok.
+  match tok with EOFTok _ then 1 else
+  match tok with LIdentTok _ then 2 else
+  match tok with UIdentTok _ then 3 else
+  match tok with IntTok _ then 4 else
+  match tok with FloatTok _ then 5 else
+  match tok with OperatorTok _ then 6 else
+  match tok with LParenTok _ then 7 else
+  match tok with RParenTok _ then 8 else
+  match tok with LBracketTok _ then 9 else
+  match tok with RBracketTok _ then 10 else
+  match tok with LBraceTok _ then 11 else
+  match tok with RBraceTok _ then 12 else
+  match tok with SemiTok _ then 13 else
+  match tok with CommaTok _ then 14 else
+  match tok with StringTok _ then 15 else
+  match tok with CharTok _ then 16 else
+  match tok with HashStringTok _ then 17 else
+  never
+
+let compareTokKind = use Lexer in lam ltok. lam rtok.
+  let pair = (ltok, rtok) in
+  match pair with (HashStringTok {hash = h1}, HashStringTok {hash = h2}) then cmpString h1 h2 else
+  match pair with (HashStringTok _, _) then negi 1 else
+  match pair with (_, HashStringTok _) then 1 else
+  subi (_tokKindInt ltok) (_tokKindInt rtok)
+
 mexpr
 
 use Lexer in
@@ -420,211 +512,259 @@ let parse = lam str. nextToken {pos = start, str = str} in
 
 utest parse " --foo \n  bar " with
   { token = LIdentTok {val = "bar", fi = infoVal "file" 2 2 2 5}
+  , lit = "bar"
   , stream = {pos = posVal "file" 2 5 , str = " "}
   } in
 
 utest parse " /- foo -/ bar" with
   { token = LIdentTok {val = "bar", fi = infoVal "file" 1 11 1 14}
+  , lit = "bar"
   , stream = {pos = posVal "file" 1 14 , str = ""}
   } in
 
 utest parse " /- foo\n x \n -/ \nbar " with
   { token = LIdentTok {val = "bar", fi = infoVal "file" 4 0 4 3}
+  , lit = "bar"
   , stream = {pos = posVal "file" 4 3 , str = " "}
   } in
 
 utest parse " /- x -- y /- foo \n -/ -/ !" with
   { token = OperatorTok {val = "!", fi = infoVal "file" 2 7 2 8}
+  , lit = "!"
   , stream = {pos = posVal "file" 2 8 , str = ""}
   } in
 
 utest parse "  123foo" with
   { token = IntTok {val = 123, fi = infoVal "file" 1 2 1 5}
+  , lit = ""
   , stream = {pos = posVal "file" 1 5 , str = "foo"}
   } in
 
 utest parse "  1.0" with
   { token = FloatTok {val = 1.0, fi = infoVal "file" 1 2 1 5}
+  , lit = ""
   , stream = {pos = posVal "file" 1 5 , str = ""}
   } in
 
 utest parse " 1234.  " with
   { token = FloatTok {val = 1234.0, fi = infoVal "file" 1 1 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6 , str = "  "}
   } in
 
 utest parse " 13.37 " with
   { token = FloatTok {val = 13.37, fi = infoVal "file" 1 1 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse "  1.0e-2" with
   { token = FloatTok {val = 0.01, fi = infoVal "file" 1 2 1 8}
+  , lit = ""
   , stream = {pos = posVal "file" 1 8, str = ""}
   } in
 
 utest parse " 2.5e+2  " with
   { token = FloatTok {val = 250.0, fi = infoVal "file" 1 1 1 7}
+  , lit = ""
   , stream = {pos = posVal "file" 1 7, str = "  "}
   } in
 
 utest parse "   2e3" with
   { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6, str = ""}
   } in
 
 utest parse "   2E3" with
   { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6, str = ""}
   } in
 
 utest parse "   2.0E3" with
   { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 8}
+  , lit = ""
   , stream = {pos = posVal "file" 1 8, str = ""}
   } in
 
 utest parse "   2.E3" with
   { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 7}
+  , lit = ""
   , stream = {pos = posVal "file" 1 7, str = ""}
   } in
 
 utest parse " 1.e2 " with
   { token = FloatTok {val = 100.0, fi = infoVal "file" 1 1 1 5}
+  , lit = ""
   , stream = {pos = posVal "file" 1 5, str = " "}
   } in
 
 utest parse " 3.e-4 " with
   { token = FloatTok {val = 0.0003, fi = infoVal "file" 1 1 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " 4.E+1 " with
   { token = FloatTok {val = 40.0, fi = infoVal "file" 1 1 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " 1.E-3 " with
   { token = FloatTok {val = 0.001, fi = infoVal "file" 1 1 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " 1E " with
   { token = IntTok {val = 1, fi = infoVal "file" 1 1 1 2}
+  , lit = ""
   , stream = {pos = posVal "file" 1 2, str = "E "}
   } in
 
 utest parse " 1e " with
   { token = IntTok {val = 1, fi = infoVal "file" 1 1 1 2}
+  , lit = ""
   , stream = {pos = posVal "file" 1 2, str = "e "}
   } in
 
 utest parse " 1.e++2 " with
   { token = FloatTok {val = 1.0, fi = infoVal "file" 1 1 1 3}
+  , lit = ""
   , stream = {pos = posVal "file" 1 3, str = "e++2 "}
   } in
 
 utest parse " 3.1992e--2 " with
   { token = FloatTok {val = 3.1992, fi = infoVal "file" 1 1 1 7}
+  , lit = ""
   , stream = {pos = posVal "file" 1 7, str = "e--2 "}
   } in
 
 utest parse "  if 1 then 22 else 3" with
   { token = LIdentTok {val = "if", fi = infoVal "file" 1 2 1 4}
+  , lit = "if"
   , stream = {pos = posVal "file" 1 4, str = " 1 then 22 else 3"}
   } in
 
 utest parse " true " with
   { token = LIdentTok {val = "true", fi = infoVal "file" 1 1 1 5}
+  , lit = "true"
   , stream = {pos = posVal "file" 1 5, str = " "}
   } in
 
 utest parse " ( 123) " with
   { token = LParenTok {fi = infoVal "file" 1 1 1 2}
+  , lit = "("
   , stream = {pos = posVal "file" 1 2, str = " 123) "}
   } in
 
 utest parse "[]" with
   { token = LBracketTok {fi = infoVal "file" 1 0 1 1}
+  , lit = "["
   , stream = {pos = posVal "file" 1 1, str = "]"}
   } in
 
 utest parse " [ ] " with
   { token = LBracketTok {fi = infoVal "file" 1 1 1 2}
+  , lit = "["
   , stream = {pos = posVal "file" 1 2, str = " ] "}
   } in
 
 utest parse " [ 17 ] " with
   { token = LBracketTok {fi = infoVal "file" 1 1 1 2}
+  , lit = "["
   , stream = {pos = posVal "file" 1 2, str = " 17 ] "}
   } in
 
 utest parse " [ 232 , ( 19 ) ] " with
   { token = LBracketTok {fi = infoVal "file" 1 1 1 2}
+  , lit = "["
   , stream = {pos = posVal "file" 1 2, str = " 232 , ( 19 ) ] "}
   } in
 
 utest parse " \"Foo\" " with
   { token = StringTok {val = "Foo", fi = infoVal "file" 1 1 1 6}
+  , lit = ""
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " \" a\\\\ \\n\" " with
   { token = StringTok {val = " a\\ \n", fi = infoVal "file" 1 1 1 10}
+  , lit = ""
   , stream = {pos = posVal "file" 1 10, str = " "}
   } in
 
 utest parse " \'A\' " with
   { token = CharTok {val = 'A', fi = infoVal "file" 1 1 1 4}
+  , lit = ""
   , stream = {pos = posVal "file" 1 4, str = " "}
   } in
 
 utest parse " \'\\n\' " with
   { token = CharTok {val = '\n', fi = infoVal "file" 1 1 1 5}
+  , lit = ""
   , stream = {pos = posVal "file" 1 5, str = " "}
   } in
 
 utest parse " _xs " with
   { token = LIdentTok {val = "_xs", fi = infoVal "file" 1 1 1 4}
+  , lit = "_xs"
   , stream = {pos = posVal "file" 1 4, str = " "}
   } in
 
 utest parse " fOO_12a " with
   { token = LIdentTok {val = "fOO_12a", fi = infoVal "file" 1 1 1 8}
+  , lit = "fOO_12a"
   , stream = {pos = posVal "file" 1 8, str = " "}
   } in
 
 utest parse " lam x . x " with
   { token = LIdentTok {val = "lam", fi = infoVal "file" 1 1 1 4}
+  , lit = "lam"
+  , stream = {pos = posVal "file" 1 4, str = " x . x "}
+  } in
+
+utest parse " Lam x . x " with
+  { token = UIdentTok {val = "Lam", fi = infoVal "file" 1 1 1 4}
+  , lit = "Lam"
   , stream = {pos = posVal "file" 1 4, str = " x . x "}
   } in
 
 utest parse "  let x = 5 in 8 " with
   { token = LIdentTok {val = "let", fi = infoVal "file" 1 2 1 5}
+  , lit = "let"
   , stream = {pos = posVal "file" 1 5, str = " x = 5 in 8 "}
   } in
 
 utest parse " += 47;" with
   { token = OperatorTok {val = "+=", fi = infoVal "file" 1 1 1 3}
+  , lit = "+="
   , stream = {pos = posVal "file" 1 3, str = " 47;"}
   } in
 
 utest parse " ; println foo" with
   { token = SemiTok {fi = infoVal "file" 1 1 1 2}
+  , lit = ";"
   , stream = {pos = posVal "file" 1 2, str = " println foo"}
   } in
 
 utest parse " #foo\"Zomething\"more" with
   { token = HashStringTok {hash = "foo", val = "Zomething", fi = infoVal "file" 1 1 1 16}
+  , lit = ""
   , stream = {pos = posVal "file" 1 16, str = "more"}
   } in
 
 utest parse " #\"Zomething\"more" with
   { token = HashStringTok {hash = "", val = "Zomething", fi = infoVal "file" 1 1 1 13}
+  , lit = ""
   , stream = {pos = posVal "file" 1 13, str = "more"}
   } in
 
 utest parse " #123\"Zomething\"more" with
   { token = HashStringTok {hash = "123", val = "Zomething", fi = infoVal "file" 1 1 1 16}
+  , lit = ""
   , stream = {pos = posVal "file" 1 16, str = "more"}
   } in
 

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -1,0 +1,301 @@
+include "lexer.mc"
+include "map.mc"
+include "string.mc"
+include "hashmap.mc"
+
+type NonTerminal = String
+
+-- NOTE(vipa, 2021-02-05): I want to create types that refer to
+-- `Token`, which lives in a language fragment. There is no top-level
+-- `use` (for fairly good reasons), and there is no type-level `use`
+-- (just because it hasn't been done yet), so for the moment I create
+-- a new language fragment to declare the types
+lang ParserBase = Lexer
+  syn Symbol =
+  | Tok Token
+  | Lit {hash: Int, lit: String}
+
+  -- NOTE(vipa, 2021-02-08): This should be ParserConcrete.Symbol -> Dyn
+  -- type Action = [Symbol] -> Dyn
+end
+
+lang ParserSpec = ParserBase
+  -- type Production = {nt: NonTerminal, rhs: [Symbol], action: Action}
+  -- type Grammar =
+  --   { start: NonTerminal
+  --   , productions: [Production]
+  --   }
+
+  syn Symbol =
+  | NtSpec NonTerminal
+end
+
+lang ParserGenerated = ParserBase
+  syn Symbol =
+  -- NOTE(vipa, 2021-02-08): The `Ref` here is slightly undesirable, but I see no other way to construct a cyclic data structure
+  -- NOTE(vipa, 2021-02-08): The first `Symbol` here should be `ParserBase.Symbol`
+  | NtSym (Ref (Map Symbol {syms: [Symbol], action: Action}))
+end
+
+lang ParserConcrete = ParserBase
+  syn Symbol =
+  | UserSym Dyn
+end
+
+let _compareSymbol = use ParserBase in lam lsym. lam rsym.
+  let pair = (lsym, rsym) in
+  match pair with (Tok _, Lit _) then negi 1 else
+  match pair with (Lit _, Tok _) then 1 else
+  match pair with (Tok a, Tok b) then compareTokKind a b else
+  match pair with (Lit {lit = a}, Lit {lit = b}) then cmpString a b else
+  let _ = dprint pair in
+  never
+
+let _eqSymbol = lam a. lam b. eqi (_compareSymbol a b) 0
+
+let _hashStr : String -> Int = hashmapStrTraits.hashfn
+
+let _iterateUntilFixpoint : (a -> a -> Bool) -> (a -> a) -> a -> a =
+  lam eq. lam f.
+    recursive let work = lam a.
+      let next = f a in
+      if eq a next then a else work next
+    in work
+
+-- NOTE(vipa, 2021-02-08): This should be opaque, and the first `Symbol` should be `ParserBase.Symbol`, the second should be `ParserGenerated.Symbol`
+type Table = {start: Map Symbol {syms: [Symbol], action: Action}, lits: Map String ()}
+
+let dprintLn = lam x. let _ = dprint x in printLn ""
+
+let parseWithTable : Table -> String -> String -> Dyn = use ParserGenerated in use ParserConcrete in
+  lam table. lam filename. lam contents. match table with {start = start, lits = lits} then
+    let openNt = lam table. lam token.
+      match mapLookup token table with Some {syms = rest, action = action} then
+        {seen = [], rest = rest, action = action}
+      else let _ = dprintLn token in error "Unexpected token" in
+    -- TODO(vipa, 2021-02-08): handle `Lit`s properly
+    let getNextToken = lam stream.
+      match nextToken stream with {token = token, lit = lit, stream = stream} then
+        -- OPT(vipa, 2021-02-08): Could use the hash of the lit to maybe optimize this, either by using a hashmap, or by first checking against the hash in a bloom filter or something like that
+        if if (eqString "" lit) then true else not (mapMem lit lits)
+          then {token = Tok token, stream = stream}
+          else {token = Lit {hash = _hashStr lit, lit = lit}, stream = stream}
+      else never in
+    recursive let work = lam stack : [{seen: Symbol, rest: Symbol, action: Action}]. lam token. lam stream.
+      match stack with stack ++ [curr & {rest = [NtSym tabRef] ++ rest}] then
+        work (snoc (snoc stack {curr with rest = rest}) (openNt (deref tabRef) token)) token stream
+      else match stack with stack ++ [above & {seen = seenAbove}, {seen = seen, rest = [], action = action}] then
+        work (snoc stack {above with seen = snoc seenAbove (UserSym (action seen))}) token stream
+      else match stack with stack ++ [curr & {rest = [t] ++ rest, seen = seen}] then
+        if _eqSymbol t token then
+          let next = getNextToken stream in
+          work (snoc stack {{curr with rest = rest} with seen = snoc seen token}) next.token next.stream
+        else let _ = dprintLn (t, token) in error "Wrong token"
+      else match (stack, token) with ([{seen = seen, rest = [], action = action}], Tok (EOFTok _)) then
+        action seen
+      else let _ = print "ERROR: " in let _ = dprintLn (stack, token, stream) in error "Failed to parse stuff"
+    in
+      let stream = {pos = initPos filename, str = contents} in
+      match getNextToken stream with {token = token, stream = stream} then
+        work [openNt start token] token stream
+      else never
+  else never
+
+let genParser : Grammar -> Table = use ParserSpec in lam grammar.
+  match grammar with {productions = productions, start = startNt} then
+    type SymSet = {eps: Bool, syms: Map Symbol ()} in
+
+    let eqSymSet = lam s1. lam s2.
+      match (s1, s2) with ({eps = e1, syms = s1}, {eps = e2, syms = s2}) then
+        and (eqBool e1 e2) (eqSeq (lam a. lam b. _eqSymbol a.0 b.0) (mapBindings s1) (mapBindings s2))
+      else let _ = dprintLn (s1, s2) in never in
+
+    let eqFirstSet = lam s1. lam s2.
+      eqSeq
+        (lam a. lam b. if eqString a.0 b.0 then eqSymSet a.1 b.1 else false)
+        (mapBindings s1)
+        (mapBindings s2) in
+
+    let eqFollowSymSet = lam s1. lam s2.
+      eqSeq (lam a. lam b. _eqSymbol a.0 b.0) (mapBindings s1) (mapBindings s2) in
+
+    let eqFollowSet = lam s1. lam s2.
+      eqSeq
+        (lam a. lam b. if eqString a.0 b.0 then eqFollowSymSet a.1 b.1 else false)
+        (mapBindings s1)
+        (mapBindings s2) in
+
+    let addProdToFirst : Map NonTerminal SymSet -> Production -> SymSet -> SymSet =
+      lam prev. lam prod. lam symset.
+        recursive let work = lam symset. lam rhs.
+          match rhs with [] then {symset with eps = true}
+          else match rhs with [(Tok _ | Lit _) & t] ++ _ then
+            {symset with syms = mapInsert t () symset.syms}
+          else match rhs with [NtSpec nt] ++ rhs then
+            let otherSymset = mapFind nt prev in
+            let symset = {symset with syms = mapUnion symset.syms otherSymset.syms} in
+            if otherSymset.eps then work symset rhs else symset
+          else never
+        in work symset prod.rhs in
+
+    let groupedProds : Map NonTerminal [Production] =
+      foldl
+        (lam acc. lam prod. mapInsert prod.nt (snoc (optionGetOr [] (mapLookup prod.nt acc)) prod) acc)
+        (mapEmpty cmpString)
+        productions in
+
+    let addNtToFirstSet = lam prev. lam nt. lam symset.
+      let prods = mapFind nt groupedProds in
+      foldl (lam symset. lam prod. addProdToFirst prev prod symset) symset prods in
+
+    let dprintFirstSet = lam firstSet.
+      let _ = printLn "" in
+      let _ = dprint (mapBindings (mapMap (lam symset. {symset with syms = mapBindings symset.syms}) firstSet)) in
+      let _ = printLn "" in
+      firstSet in
+
+    let dprintFollowSet = lam followSet.
+      let _ = printLn "" in
+      let _ = dprint (mapBindings (mapMap mapBindings followSet)) in
+      let _ = printLn "" in
+      followSet in
+
+    let firstSet : Map NonTerminal SymSet =
+      _iterateUntilFixpoint eqFirstSet
+        (lam prev. mapMapWithKey (addNtToFirstSet prev) prev)
+        (mapMap (lam _. {eps = false, syms = mapEmpty _compareSymbol}) groupedProds) in
+
+    let _ = print "\n\nFirsts:" in
+    let _ = dprintFirstSet firstSet in
+
+    let firstOfRhs : [Symbol] -> SymSet =
+      recursive let work = lam symset. lam rhs.
+        match rhs with [] then {symset with eps = true}
+        else match rhs with [(Tok _ | Lit _) & t] ++ _ then
+          {symset with syms = mapInsert t () symset.syms}
+        else match rhs with [NtSpec nt] ++ rhs then
+          let otherSymset = mapFind nt firstSet in
+          let symset = {symset with syms = mapUnion symset.syms otherSymset.syms} in
+          if otherSymset.eps then work symset rhs else symset
+        else never
+      in work {eps = false, syms = mapEmpty _compareSymbol} in
+
+    let addProdToFollow : Production -> Map NonTerminal (Map Symbol ()) -> Map NonTerminal (Map Symbol ()) = lam prod. lam follow.
+      match prod with {nt = prodNt, rhs = rhs} then
+        recursive let work = lam follow. lam rhs.
+          match rhs with [] then follow
+          else match rhs with [NtSpec nt] ++ rhs then
+            let ntFollow = mapFind nt follow in
+            let otherSymset = firstOfRhs rhs in
+            let ntFollow = mapUnion ntFollow otherSymset.syms in
+            let ntFollow = if otherSymset.eps
+              then mapUnion ntFollow (mapFind prodNt follow)
+              else ntFollow in
+            work (mapInsert nt ntFollow follow) rhs
+          else match rhs with [_] ++ rhs then
+            work follow rhs
+          else never
+        in work follow rhs
+      else never in
+
+    let followSet : Map NonTerminal (Map Symbol ()) =
+      _iterateUntilFixpoint eqFollowSet
+        (lam prev. foldl (lam prev. lam prod. addProdToFollow prod prev) prev productions)
+        (mapInsert startNt (mapInsert (Tok (EOFTok {fi = NoInfo ()})) () (mapEmpty _compareSymbol))
+          (mapMap (lam _. mapEmpty _compareSymbol) groupedProds)) in
+
+    let _ = print "\n\nFollows:" in
+    let _ = dprintFollowSet followSet in
+
+    -- The first `Symbol` should be `ParserBase.Symbol`, the second should be `ParserGenerated.Symbol`
+    let table : Map NonTerminal (Ref (Map Symbol {syms : [Symbol], action: Action})) =
+      mapMap (lam _. ref (mapEmpty _compareSymbol)) groupedProds in
+
+    -- NOTE(vipa, 2021-02-08): This should possibly be in the stdlib, but it might depend on opinions on side effects down the line
+    recursive let iter = lam f. lam xs.
+      match xs with [x] ++ xs then
+        let _ = f x in iter f xs
+      else match xs with [] then
+        ()
+      else never in
+
+    use ParserGenerated in
+
+    let specSymToGenSym = lam sym.
+      match sym with NtSpec nt then NtSym (mapFind nt table) else sym in
+
+    let addProdToTable = lam prod. match prod with {nt = prodNt, rhs = rhs, action = action} then
+      let tableRef = mapFind prodNt table in
+      let prev = deref tableRef in
+      let firstSymset = firstOfRhs rhs in
+      let symset = if firstSymset.eps
+        then mapUnion firstSymset.syms (mapFind prodNt followSet)
+        else firstSymset.syms in
+      let newProd = {action = action, syms = map specSymToGenSym rhs} in
+      let tableAdditions = mapMap (lam _. newProd) symset in
+      -- TODO(vipa, 2021-02-08): This will silently discard duplicate actions, i.e., if the grammar isn't LL(1) this will just silently ignore that
+      modref tableRef (mapUnion prev tableAdditions)
+    else never in
+
+    let _ = iter addProdToTable productions in
+
+    let addLitToLits = lam lits. lam sym.
+      match sym with Lit {lit = lit}
+        then mapInsert lit () lits
+        else lits in
+    let lits = foldl
+      (lam acc. lam prod. foldl addLitToLits acc prod.rhs)
+      (mapEmpty cmpString)
+      productions in
+
+    let dprintTablePair = lam nt. lam actions.
+      dprintLn (nt, mapBindings (deref actions))
+    in
+    let _ = printLn "\n\nParse table:" in
+    let _ = mapMapWithKey dprintTablePair table in
+
+    {start = deref (mapFind startNt table), lits = lits}
+  else never
+
+let nonTerminal : String -> NonTerminal = identity
+
+let nt : NonTerminal -> Symbol = use ParserSpec in lam nt. NtSpec nt
+let lit : String -> Symbol = use ParserSpec in lam str.
+  match nextToken {str = str, pos = posVal "" 1 1} with {lit = lit, stream = {str = unlexed}} then
+    match (unlexed, lit) with ([], ![]) then Lit {hash = _hashStr str, lit = str}
+    else error (join ["A literal token does not lex as a single token: \"", str, "\""])
+  else never
+let lident : Symbol = use ParserSpec in Tok (LIdentTok {val = "", fi = NoInfo ()})
+let uident : Symbol = use ParserSpec in Tok (UIdentTok {val = "", fi = NoInfo ()})
+let int : Symbol = use ParserSpec in Tok (IntTok {val = 0, fi = NoInfo ()})
+
+mexpr
+
+use ParserSpec in
+
+let top = nonTerminal "File" in
+let topAtom = nonTerminal "FileAtom" in
+let topInfix = nonTerminal "FileInfix" in
+let topFollow = nonTerminal "FileFollow" in
+let decl = nonTerminal "Declaration" in
+let expr = nonTerminal "Expression" in
+
+let g =
+  { start = top
+  , productions =
+    [ {nt = top, rhs = [nt topAtom, nt topFollow], action = identity}
+    , {nt = topAtom, rhs = [nt decl], action = identity}
+    , {nt = topFollow, rhs = [nt topInfix, nt topAtom, nt topFollow], action = identity}
+    , {nt = topFollow, rhs = [], action = identity}
+    , {nt = topInfix, rhs = [], action = identity}
+    , {nt = decl, rhs = [lit "let", lident, lit "=", nt expr], action = identity}
+    , {nt = expr, rhs = [int], action = identity}
+    ]
+  } in
+
+let table = genParser g in
+let res = parseWithTable table "file" "let a = 1" in
+let _ = printLn "\n\nParse result:" in
+let _ = dprintLn res in
+
+()

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -76,7 +76,7 @@ let _sanitizeStack = use ParserGenerated in use ParserSpec in lam stack.
     {seen = item.seen, rest = map genSymToSym item.rest, label = item.label} in
   map work stack
 
-let parseWithTable : Table parseLabel -> String -> String -> Either (ParseError parseLabel) Dyn = use ParserGenerated in use ParserConcrete in
+let ll1ParseWithTable : Table parseLabel -> String -> String -> Either (ParseError parseLabel) Dyn = use ParserGenerated in use ParserConcrete in
   lam table. lam filename. lam contents. match table with {start = start, lits = lits} then
     let getNextToken = lam stream.
       match nextToken stream with {token = token, lit = lit, info = info, stream = stream} then
@@ -130,7 +130,7 @@ let parseWithTable : Table parseLabel -> String -> String -> Either (ParseError 
 
 type GenError prodLabel = Map NonTerminal (Map Symbol [prodLabel])
 
-let genParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodLabel) = use ParserSpec in lam grammar.
+let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodLabel) = use ParserSpec in lam grammar.
   match grammar with {productions = productions, start = startNt} then
     type SymSet = {eps: Bool, syms: Map Symbol ()} in
 
@@ -306,21 +306,31 @@ let genParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodLabe
       else Right {start = {nt = startNt, table = mapFind startNt table}, lits = lits}
   else never
 
-let nonTerminal : String -> NonTerminal = identity
+let ll1NonTerminal : String -> NonTerminal = identity
 
-let nt : NonTerminal -> Symbol = use ParserSpec in lam nt. NtSpec nt
-let lit : String -> Symbol = use ParserSpec in lam str.
+let ll1Nt : NonTerminal -> Symbol = use ParserSpec in lam nt. NtSpec nt
+let ll1Lit : String -> Symbol = use ParserSpec in lam str.
   match nextToken {str = str, pos = posVal "" 1 1} with {lit = lit, stream = {str = unlexed}} then
     match (unlexed, lit) with ([], ![]) then Lit {lit = str}
     else error (join ["A literal token does not lex as a single token: \"", str, "\""])
   else never
-let lident : Symbol = use ParserSpec in Tok (LIdentTok {val = "", fi = NoInfo ()})
-let uident : Symbol = use ParserSpec in Tok (UIdentTok {val = "", fi = NoInfo ()})
-let int : Symbol = use ParserSpec in Tok (IntTok {val = 0, fi = NoInfo ()})
+let ll1Lident : Symbol = use ParserSpec in Tok (LIdentTok {val = "", fi = NoInfo ()})
+let ll1Uident : Symbol = use ParserSpec in Tok (UIdentTok {val = "", fi = NoInfo ()})
+let ll1Int : Symbol = use ParserSpec in Tok (IntTok {val = 0, fi = NoInfo ()})
 
 mexpr
 
 use ParserSpec in
+
+let genParser = ll1GenParser in
+let parseWithTable = ll1ParseWithTable in
+
+let nonTerminal = ll1NonTerminal in
+let nt = ll1Nt in
+let lit = ll1Lit in
+let lident = ll1Lident in
+let uident = ll1Uident in
+let int = ll1Int in
 
 let errorMapToBindingsExc = lam m.
   match m with Left m then

--- a/stdlib/prelude.mc
+++ b/stdlib/prelude.mc
@@ -24,6 +24,8 @@ let fixMutual =
 -- Printing stuff
 let printLn = lam s. print (concat s "\n")
 
+let dprintLn = lam x. let _ = dprint x in printLn ""
+
 mexpr
 
 utest apply identity 42 with identity 42 in

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -12,6 +12,22 @@ utest tail [2,4,8] with [4,8]
 utest init [2,3,5] with [2,3]
 utest last [2,4,8] with 8
 
+let eqSeq = lam eq : (a -> a -> Bool).
+  recursive let work = lam as. lam bs.
+    let pair = (as, bs) in
+    match pair with ([], []) then true else
+    match pair with ([a] ++ as, [b] ++ bs) then
+      if eq a b then work as bs else false
+    else false
+  in work
+
+utest eqSeq eqi [] [] with true
+utest eqSeq eqi [1] [] with false
+utest eqSeq eqi [] [1] with false
+utest eqSeq eqi [1] [1] with true
+utest eqSeq eqi [1] [2] with false
+utest eqSeq eqi [2] [1] with false
+
 let slice = lam seq. lam off. lam cnt.
   let seq = (splitAt seq off).1 in
   let cnt = if gti cnt (length seq) then length seq else cnt in


### PR DESCRIPTION
This PR adds an LL(1) parser, intended to be used for the first phase of our parser. It is written to be entirely independent of what we'll build on top of it later, thus it has a proper API including error reporting in case of parse errors as well as grammar errors. However, most users should essentially never interface with it.

A grammar is given as a record, containing a starting non-terminal and a list of productions. Each production has a left-hand side (non-terminal), right-hand side (list of symbols), a label (which the parser ignores but carries with it, for error reporting mostly), and an action (a function that constructs the result of parsing). The type argument to `Grammar` (and some other types) is the type of the production label. Here is an example (from the tests) in the structure of something we might generate later from a more high-level API:

```
let top = nonTerminal "File" in
let topAtom = nonTerminal "FileAtom" in
let topInfix = nonTerminal "FileInfix" in
let topFollow = nonTerminal "FileFollow" in
let decl = nonTerminal "Declaration" in
let expr = nonTerminal "Expression" in
let exprAtom = nonTerminal "ExpressionAtom" in
let exprFollow = nonTerminal "ExpressionFollow" in
let exprInfix = nonTerminal "ExpressionInfix" in
let exprPrefix = nonTerminal "ExpressionPrefix" in
let exprPrefixes = nonTerminal "ExpressionPrefixes" in

-- Simple way to build something like a parse tree.
let wrap = lam label. lam x. {label = label, val = x} in

let gFailLet : Grammar String =
  { start = top
  , productions =
    [ {nt = top, label = "toptop", rhs = [nt topAtom, nt topFollow], action = wrap "toptop"}
    , {nt = topAtom, label = "topdecl", rhs = [nt decl], action = wrap "topdecl"}
    , {nt = topFollow, label = "topfollowsome", rhs = [nt topInfix, nt topAtom, nt topFollow], action = wrap "topfollowsome"}
    , {nt = topFollow, label = "topfollownone", rhs = [], action = wrap "topfollownone"}
    , {nt = topInfix, label = "topinfixjuxt", rhs = [], action = wrap "topinfixjuxt"}
    , {nt = decl, label = "decllet", rhs = [lit "let", lident, lit "=", nt expr], action = wrap "decllet"}
    , {nt = expr, label = "exprtop", rhs = [nt exprPrefixes, nt exprAtom, nt exprFollow], action = wrap "exprtop"}
    , {nt = exprPrefixes, label = "exprpresome", rhs = [nt exprPrefix, nt exprPrefixes], action = wrap "exprpresome"}
    , {nt = exprPrefixes, label = "exprprenone", rhs = [], action = wrap "exprprenone"}
    , {nt = exprFollow, label = "exprfollowsome", rhs = [nt exprInfix, nt exprPrefixes, nt exprAtom, nt exprFollow], action = wrap "exprfollowsome"}
    , {nt = exprFollow, label = "exprfollownone", rhs = [], action = wrap "exprfollownone"}
    , {nt = exprPrefix, label = "exprlet", rhs = [lit "let", lident, lit "=", nt expr, lit "in"], action = wrap "exprlet"}
    , {nt = exprInfix, label = "exprinfixjuxt", rhs = [], action = wrap "exprinfixjuxt"}
    , {nt = exprAtom, label = "exprint", rhs = [int], action = wrap "exprint"}
    ]
  }
```

The details of this grammar are not particularly important for this PR, except that it is not LL(1); if we see a `let` after an expression we don't know if it's an expression `let` (this could appear if we write something like `f let x = 1 in x`, i.e., "call `f` with the expression `let x = 1 in x` as the argument") or a top-level `let`. Here's the error we produce:

```
-- The returned result uses the intrinsic maps from ocaml, which can't be `dprint`ed, so we call `mapBindings` first
dprint (eitherMapLeft (lam m. mapBindings (mapMap mapBindings m)) (genParser gFailLet))
-- Prints the following (after some prettifying)
Left
  [ ( "ExpressionFollow"
    , [ ( ParserBase_Lit { lit = "let" }
        , [ "exprfollowsome" , "exprfollownone" ]
        )
      ]
    )
  ]
```

In case of parse error we get to know the token we found, what token(s) we were expecting, and the full context of the parse; we get a stack of productions that we are currently parsing. For example, parsing using essentially the same grammar as above, but without the LL(1) conflict:

```
utest parse "let let = 4"
with Left (UnexpectedToken
  { expected = (ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),fi = (NoInfo ())}))
  , stack = (
    [ { label = ("toptop"),seen = ([]),rest = ([(ParserSpec_NtSpec ("FileFollow"))]) }
    , { label = ("topdecl"),seen = ([]),rest = ([]) }
    , { label = ("decllet")
      , seen = ([(ParserBase_Lit {lit = ("let"),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 0})})])
      , rest = ([(ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),fi = (NoInfo ())})),(ParserBase_Lit {lit = ("=")}),(ParserSpec_NtSpec ("Expression"))])
      }
    ])
  , found = (ParserBase_Lit {lit = ("let"),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 7,col1 = 4})})
  })
in
```

If parsing succeeds (or rather, as soon as each production parses successfully) the parser will call each production's `action`. This should be a function `[Symbol] -> Dyn` (where `Symbol` isn't the `gensym` thing, but rather either a token or a `UserSym` (which contains the result of a previous call to the `action` of the child production in that position). This notably uses `Dyn` for user-generated content in the tree, rather than something more strongly typed. I believe that we could make a strongly typed version, where a production is an applicative functor, and both productions and non-terminals carry their produced type as a phantom type argument, but I suspect it might be a bit more overhead, and we don't have a type system anyway at this point, so I opted for something a bit closer to what you'd do in a language with a weaker type system.