### PR TITLE
Breakable operators parser

### DIFF
--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -14,10 +14,10 @@ ambiguities involved.
 
 A central concept herein is whether a "thing" (an operator or an
 expression) is open or closed on either side. For example, the infix
-operator "+" is both left-open and right-open, while the atomic
-expression "7" is both left-closed and right-closed. These properties
-transfer to partially constructed ASTs as well, "(_ + 4)" is left-open
-but right-closed, while "(1 + 2)" is both left-closed and
+operator `+` is both left-open and right-open, while the atomic
+expression `7` is both left-closed and right-closed. These properties
+transfer to partially constructed ASTs as well, `(_ + 4)` is left-open
+but right-closed, while `(1 + 2)` is both left-closed and
 right-closed.
 
 # Precedence
@@ -54,9 +54,9 @@ normal interactions. The canonical example is `if then else` (where
   then`
 
 This means that each `else` must have a corresponding `if condition
-then`, but we can handle any ambiguities arising using the same
-approach as for operators, i.e., we can resolve them with grouping
-parentheses.
+then`, but we can handle any ambiguities that arise
+(e.g. dangling-`else`) using the same approach as for operators, i.e.,
+we can resolve them with grouping parentheses.
 
 As a consequence, the only ambiguities that can arise when using this
 approach are those where it is unclear how things in the input
@@ -64,7 +64,7 @@ connect, as opposed to what their fundamental meaning is, which I
 (vipa) hypothesize is quite helpful for the understandability of
 ambiguities.
 
-# Mid-level usage
+# Mid-level usage instructions
 
 1. Create a value of the `BreakableGrammar` type. See the tests at the
 end of the file for examples.

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -31,7 +31,7 @@ would it be permissible to group it
 - only to the left, written as `a` <- `b`,
 - only to the right, written as `a` -> `b`,
 - either, written as `a` <-> `b`, or
-, neither, written as `a` - `b`?
+- neither, written as `a` - `b`?
 
 For example, we would likely give the following definitions for
 addition and multiplication:

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -3,37 +3,39 @@
 --
 
 include "map.mc"
+include "either.mc"
+include "string.mc"  -- NOTE(vipa, 2021-02-15): This is only required for the tests, but we can't put an include only there
 
 type AllowSet id
 con AllowSet : Map id () -> AllowSet id
 con DisallowSet : Map id () -> AllowSet id
 
-type BreakableProduction prodLabel self res
+type BreakableProduction prodLabel res self
 con BreakableAtom :
   { label : prodLabel
   , construct : self -> res
-  } -> BreakableProduction prodLabel self res
+  } -> BreakableProduction prodLabel res self
 con BreakableInfix :
   { label : prodLabel
   , construct : self -> res -> res -> res
   , leftAllow : AllowSet prodLabel
   , rightAllow : AllowSet prodLabel
-  } -> BreakableProduction prodLabel self res
+  } -> BreakableProduction prodLabel res self
 con BreakablePrefix :
   { label : prodLabel
   , construct : self -> res -> res
   , rightAllow : AllowSet prodLabel
-  } -> BreakableProduction prodLabel self res
+  } -> BreakableProduction prodLabel res self
 con BreakablePostfix :
   { label : prodLabel
   , construct : self -> res -> res
   , leftAllow : AllowSet prodLabel
-  } -> BreakableProduction prodLabel self res
+  } -> BreakableProduction prodLabel res self
 
 type OpGrouping = {mayGroupLeft : Bool, mayGroupRight : Bool}
 
-type BreakableGrammar prodLabel self res =
-  { productions : [BreakableProduction prodLabel self res]
+type BreakableGrammar prodLabel res self =
+  { productions : [BreakableProduction prodLabel res self]
   , precedences : [((prodLabel, prodLabel), OpGrouping)]
   }
 
@@ -159,16 +161,17 @@ con TentativeRoot :
 
 -- The data we carry along while parsing
 type State res self rstyle =
-  { nextId : Ref Int
-  , timestep : Ref Int
+  { timestep : Ref Int
   , frontier : [TentativeNode res self rstyle]
   }
 
 let _firstTimeStep : TimeStep = 0
 let _isBefore : TimeStep -> TimeStep -> Bool = lti
 let _eqOpId : OpId -> OpId -> Bool = eqi
+let _cmpOpId : OpId -> OpId -> Int = subi
 let _rootID : OpId = negi 1
 let _firstOpId : OpId = 0
+let _nextOpId : OpId -> OpId = addi 1
 let _uniqueID : () -> PermanentId = gensym
 let _getParents
   : TentativeNode res self rstyle
@@ -176,15 +179,6 @@ let _getParents
   = lam n.
     match n with TentativeLeaf{parents = ps} | TentativeMid{parents = ps} then Some ps else
     match n with TentativeRoot _ then None () else
-    never
-let _opIdP
-  : PermanentNode res self
-  -> OpId
-  = lam node.
-    match node with AtomP {id = id} then id else
-    match node with InfixP {id = id} then id else
-    match node with PrefixP {id = id} then id else
-    match node with PostfixP {id = id} then id else
     never
 let _opIdI
   : BreakableInput res self lstyle rstyle
@@ -197,6 +191,15 @@ let _opIdI
       | PostfixI {id = id}
       then id
     else never
+let _opIdP
+  : PermanentNode res self
+  -> OpId
+  = lam node.
+    match node with AtomP {input = input} then _opIdI input else
+    match node with InfixP {input = input} then _opIdI input else
+    match node with PrefixP {input = input} then _opIdI input else
+    match node with PostfixP {input = input} then _opIdI input else
+    never
 let _opIdTD
   : TentativeData res self
   -> OpId
@@ -208,7 +211,7 @@ let _opIdT
   -> OpId
   = lam node.
     match node with TentativeLeaf{node = node} then _opIdP node else
-    match node with TentativeMid{tentativeData = data} then _opIdTD else
+    match node with TentativeMid{tentativeData = data} then _opIdTD data else
     match node with TentativeRoot _ then _rootID else
     never
 let _addedNodesLeftChildren
@@ -231,28 +234,9 @@ recursive let _iter = lam f. lam xs.
     let _ = f x in _iter f xs
   else match xs with [] then
     ()
-  else never
+  else let _ = dprintLn xs in never
 end
 let _for = lam xs. lam f. _iter f xs
-
-
-let breakableGenGrammar
-  : (prodLabel -> prodLabel -> Int)
-  -> BreakableGrammar prodLabel self res
-  -> BreakableGenGrammar prodLabel self res
-  = lam cmp. lam grammar. never
-
-let breakableInitState : () -> State res self ROpen
-  = lam cmp. lam grammar.
-    let nextId = ref _firstOpId in
-    let timestep = ref _firstTimeStep in
-    let addedLeft = ref (_firstTimeStep, ref []) in
-    let addedRight = ref (_firstTimeStep, []) in
-    { nextId = nextId
-    , timestep = timestep
-    , frontier =
-      [ TentativeRoot { addedNodesLeftChildren = addedLeft, addedNodesRightChildren = addedRight } ]
-    }
 
 let inAllowSet
   : id
@@ -263,6 +247,111 @@ let inAllowSet
     match set with DisallowSet s then not (mapMem id s) else
     never
 
+let mapAllowSet
+  : (a -> b)
+  -> (b -> b -> Int)
+  -> AllowSet a
+  -> AllowSet b
+  = lam f. lam newCmp. lam s.
+    let convert = lam s. mapFromList newCmp (map (lam x. (f x.0, ())) (mapBindings s)) in
+    match s with AllowSet s then AllowSet (convert s) else
+    match s with DisallowSet s then DisallowSet (convert s) else
+    never
+
+let breakableGenGrammar
+  : (prodLabel -> prodLabel -> Int)
+  -> BreakableGrammar prodLabel res self
+  -> BreakableGenGrammar prodLabel res self
+  = lam cmp. lam grammar.
+    let nOpId : Ref OpId = ref _firstOpId in
+    let newOpId : () -> OpId = lam _.
+      let res = deref nOpId in
+      let _ = modref nOpId (_nextOpId res) in
+      res in
+
+    let label
+      : BreakableProduction prodLabel res self
+      -> prodLabel
+      = lam prod.
+        match prod with BreakableAtom {label = label} then label else
+        match prod with BreakablePrefix {label = label} then label else
+        match prod with BreakableInfix {label = label} then label else
+        match prod with BreakablePostfix {label = label} then label else
+        never
+    in
+
+    let prodLabelToOpId : Map prodLabel OpId =
+      mapFromList cmp (map (lam prod. (label prod, newOpId ())) grammar.productions) in
+    let toOpId : prodLabel -> OpId = lam label. mapFind label prodLabelToOpId in
+
+    -- TODO(vipa, 2021-02-15): This map can contain more entries than
+    -- required; the inner map should only ever have entries where the
+    -- key represents a right-open operator, but we here retain all
+    -- operators from the outside, which could have more (redundant)
+    -- entries
+    let groupingByRightOp : Map OpId (Map OpId OpGrouping) =
+      foldl
+        (lam acc. lam grouping.
+          match grouping with ((lplab, rplab), grouping) then
+           let lid = toOpId lplab in
+           let rid = toOpId rplab in
+           let prev = match mapLookup rid acc
+             with Some prev then prev
+             else mapEmpty _cmpOpId in
+           mapInsert rid (mapInsert lid grouping prev) acc
+          else never)
+        (mapEmpty _cmpOpId)
+        grammar.precedences
+    in
+    let getGroupingByRight : OpId -> Map OpId OpGrouping = lam opid.
+      match mapLookup opid groupingByRightOp with Some res then res
+      else mapEmpty _cmpOpId
+    in
+
+    let atoms : Ref [(prodLabel, BreakableInput res self LClosed RClosed)] = ref [] in
+    let prefixes : Ref [(prodLabel, BreakableInput res self LClosed ROpen)] = ref [] in
+    let infixes : Ref [(prodLabel, BreakableInput res self LOpen ROpen)] = ref [] in
+    let postfixes : Ref [(prodLabel, BreakableInput res self LOpen RClosed)] = ref [] in
+    let updateRef : Ref a -> (a -> a) -> ()
+      = lam ref. lam f. modref ref (f (deref ref)) in
+
+    let _ = _for grammar.productions
+      (lam prod.
+        let label = label prod in
+        let id = toOpId label in
+        match prod with BreakableAtom {construct = construct} then
+          updateRef atoms (cons (label, AtomI {id = id, construct = construct}))
+        else match prod with BreakablePrefix {construct = c, rightAllow = r} then
+          let r = mapAllowSet toOpId _cmpOpId r in
+          updateRef prefixes (cons (label, PrefixI {id = id, construct = c, rightAllow = r}))
+        else match prod with BreakableInfix {construct = c, leftAllow = l, rightAllow = r} then
+          let l = mapAllowSet toOpId _cmpOpId l in
+          let r = mapAllowSet toOpId _cmpOpId r in
+          let p = getGroupingByRight id in
+          updateRef infixes (cons (label, InfixI {id = id, construct = c, leftAllow = l, rightAllow = r, precWhenThisIsRight = p}))
+        else match prod with BreakablePostfix {construct = c, leftAllow = l} then
+          let l = mapAllowSet toOpId _cmpOpId l in
+          let p = getGroupingByRight id in
+          updateRef postfixes (cons (label, PostfixI {id = id, construct = c, leftAllow = l, precWhenThisIsRight = p}))
+        else never)
+    in
+
+    { atoms = mapFromList cmp (deref atoms)
+    , prefixes = mapFromList cmp (deref prefixes)
+    , infixes = mapFromList cmp (deref infixes)
+    , postfixes = mapFromList cmp (deref postfixes)
+    }
+
+let breakableInitState : () -> State res self ROpen
+  = lam grammar.
+    let timestep = ref _firstTimeStep in
+    let addedLeft = ref (_firstTimeStep, ref []) in
+    let addedRight = ref (_firstTimeStep, []) in
+    { timestep = timestep
+    , frontier =
+      [ TentativeRoot { addedNodesLeftChildren = addedLeft, addedNodesRightChildren = addedRight } ]
+    }
+
 recursive let _maxDistanceFromRoot
   : TentativeNode res self rstyle
   -> Int
@@ -270,7 +359,7 @@ recursive let _maxDistanceFromRoot
     match n with TentativeMid {maxDistanceFromRoot = r} then r else
     match n with TentativeRoot _ then 0 else
     match n with TentativeLeaf {parents = parents} then maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot parents) else
-    never
+    let _ = dprintLn n in never
 end
 
 let _shallowAllowedLeft
@@ -291,9 +380,9 @@ let _shallowAllowedRight
   = lam parent. lam child.
     match child with TentativeLeaf {node = node} then
       match parent with TentativeRoot _ then Some node else
-      match parent with TentativeMid {tentativeData = (InfixT {rightAllowed = s} | PrefixT {rightAllowed = s})} then
+      match parent with TentativeMid {tentativeData = (InfixT {input = InfixI {rightAllow = s}} | PrefixT {input = PrefixI {rightAllow = s}})} then
         if inAllowSet (_opIdP node) s then Some node else None ()
-      else never
+      else let _ = dprintLn parent in never
     else never
 
 let _addRightChildren
@@ -303,7 +392,7 @@ let _addRightChildren
   -> TentativeNode s res self RClosed
   = lam st. lam parent. lam children.
     match parent with TentativeMid {parents = parents, tentativeData = data} then
-      let id = _uniqueID st in
+      let id = _uniqueID () in
       let node =
         match data with InfixT {input = input, self = self, leftChildAlts = l} then
           InfixP {id = id, input = input, self = self, leftChildAlts = l, rightChildAlts = children}
@@ -335,7 +424,7 @@ let _addLeftChildren
         , tentativeData = InfixT {input = input, self = self, leftChildAlts = leftChildren}
         }
     else match input with PostfixI _ then
-      let id = _uniqueID st in
+      let id = _uniqueID () in
       TentativeLeaf
         { parents = parents
         , node = PostfixP {id = id, input = input, self = self, leftChildAlts = leftChildren}
@@ -361,7 +450,7 @@ let _addRightChildToParent
 let _addLeftChildToParent
   : TimeStep
   -> PermanentNode res self
-  -> [TentativeNode s res self ROpen] -- NonEmpty
+  -> [TentativeNode res self ROpen] -- NonEmpty
   -> Option (NonEmpty (TentativeNode res self ROpen))
   = lam time. lam child. lam parents.
     match parents with [p] ++ _ then
@@ -372,10 +461,10 @@ let _addLeftChildToParent
           let _ = _iter (lam p. modref (_addedNodesLeftChildren p) (time, leftChildrenHere)) parents in
           Some parents
         else
-          let _ = modref target (time, cons child prev) in
+          let _ = modref prev (cons child (deref prev)) in
           None ()
       else never
-    else never -- TODO(vipa, 2021-02-12): this isn't technically never by for the typesystem, since we're matching against a possibly empty list. However, the list will never be empty, by the comment about NonEmpty above
+    else never -- TODO(vipa, 2021-02-12): this isn't technically never for the typesystem, since we're matching against a possibly empty list. However, the list will never be empty, by the comment about NonEmpty above
 
 let _getOpGroup
   : BreakableInput res self LOpen rstyle
@@ -403,6 +492,39 @@ let _mayGroupLeft
   = lam l. lam r.
     (_getOpGroup r (_opIdT l)).mayGroupLeft
 
+-- NOTE(vipa, 2021-02-15): This should be a private type, and/or replaced with some standard library type at a later point in time
+type BreakableQueue res self = [Ref [TentativeNode res self ROpen]]
+let _newQueueFromFrontier
+  : [TentativeNode res self rstyle]
+  -> BreakableQueue res self
+  = lam frontier.
+    -- TODO(vipa, 2021-02-12): This could use a `make : (Int -> a) -> Int -> [a]` that we discussed a while back
+    map
+      (lam _. ref [])
+      (makeSeq
+        (addi 1 (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot frontier)))
+        ())
+let _addToQueue
+  : TentativeNode res self ROpen
+  -> BreakableQueue res self
+  -> ()
+  = lam node. lam queue.
+    let dist = _maxDistanceFromRoot node in
+    let target = get queue dist in
+    modref target (snoc (deref target) node)
+recursive let _popFromQueue
+  : BreakableQueue
+  -> Option (TentativeNode res self ROpen)
+  = lam queue.
+    match queue with queue ++ [target] then
+      let nodes = deref target in
+      match nodes with [node] ++ nodes then
+        let _ = modref target nodes in
+        Some node
+      else _popFromQueue queue
+    else None ()
+end
+
 -- NOTE(vipa, 2021-02-12): The type signatures in this function assume
 -- that type variables are scoped, e.g., `rstyle` on `makeNewParents`
 -- is the same `rstyle` as the one in the top-level type-signature
@@ -414,29 +536,6 @@ let _addLOpen
   = lam input. lam self. lam st.
     let time = addi 1 (deref st.timestep) in
     let _ = modref st.timestep time in
-
-    type BreakableQueue = [Ref [TentativeNode res self ROpen]] in
-    let addToQueue
-      : TentativeNode res self ROpen
-      -> BreakableQueue
-      -> ()
-      = lam node. lam queue.
-        let dist = _maxDistanceFromRoot node in
-        let target = get dist queue in
-        modref target (snoc (deref target) node)
-    in
-    recursive let popFromQueue
-      : BreakableQueue
-      -> Option (TentativeNode res self ROpen)
-      = lam queue.
-        match queue with queue ++ [target] then
-          let nodes = deref target in
-          match nodes with [node] ++ nodes then
-            let _ = modref target nodes in
-            Some node
-          else popFromQueue queue
-        else None ()
-    in
 
     let makeNewParents
       : [TentativeNode res self ROpen] -- NonEmpty
@@ -451,33 +550,34 @@ let _addLOpen
     in
 
     let handleLeaf
-      : TentativeNode res self RClosed
-      -> BreakableQueue
-      -> (MaxPQueue Int (TentativeNode res self ROpen), Option [TentativeNode res self ROpen]) -- NonEmpty
-      = lam child. lam queue.
-        let parents = _getParents child in
-        let _ = _for parents
-          (lam parent.
-            if not (_mayGroupLeft parent input) then () else
-            match _shallowAllowedRight parent child with Some child then
-              match _addRightChildToParent time child parent with Some parent then
-                addToQueue parent queue
-              else ()
-            else ()) in
-        match (_shallowAllowedLeft input child, filter (lam l. _mayGroupRight l input) parents)
-        with (Some child, parents & [_] ++ _) then
-          _addLeftChildToParent time child parents
-        else None ()
+      : BreakableQueue res self
+      -> TentativeNode res self RClosed
+      -> Option [TentativeNode res self ROpen] -- NonEmpty
+      = lam queue. lam child.
+        match _getParents child with Some parents then
+          let _ = _for parents
+            (lam parent.
+              if not (_mayGroupLeft parent input) then () else
+              match _shallowAllowedRight parent child with Some child then
+                match _addRightChildToParent time child parent with Some parent then
+                  _addToQueue parent queue
+                else ()
+              else ()) in
+          match (_shallowAllowedLeft input child, filter (lam l. _mayGroupRight l input) parents)
+          with (Some child, parents & [_] ++ _) then
+            _addLeftChildToParent time child parents
+          else None ()
+        else never
     in
 
     recursive let work
-      : BreakableQueue
+      : BreakableQueue res self
       -> [[TentativeNode res self ROpen]] -- The inner sequence is NonEmpty
       -> [[TentativeNode res self ROpen]] -- The inner sequence is NonEmpty
       = lam queue. lam acc.
-        match popFromQueue queue with Some (parent & TentativeMid{addedNodesRightChildren = addedRight}) then
+        match _popFromQueue queue with Some (parent & TentativeMid{addedNodesRightChildren = addedRight}) then
           match deref addedRight with (_, children & [_] ++ _) then
-            let acc = match handleLeaf (_addRightChildren st parent children) queue
+            let acc = match handleLeaf queue (_addRightChildren st parent children)
               with Some n then cons n acc
               else acc in
             work queue acc
@@ -485,9 +585,8 @@ let _addLOpen
         else acc
     in
 
-    -- TODO(vipa, 2021-02-12): This could use a `make : (Int -> a) -> Int -> [a]` that we discussed a while back
     let frontier = st.frontier in
-    let queue = map (lam _. ref []) (makeSeq (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot frontier)) ()) in
+    let queue = _newQueueFromFrontier frontier in
     let newParents = mapOption (handleLeaf queue) frontier in
     let newParents = work queue newParents in
     match map makeNewParents newParents with frontier & ([_] ++ _) then
@@ -536,5 +635,521 @@ let breakableAddAtom
   -> State res self ROpen
   -> State res self RClosed
   = lam input. lam self. lam st.
-    let id = _uniqueID st in
-    { st with frontier = [TentativeLeaf {id = id, input = input, self = self}] }
+    let id = _uniqueID () in
+    { st with frontier = [TentativeLeaf {parents = st.frontier, node = AtomP {id = id, input = input, self = self}}] }
+
+let breakableFinalizeParse
+  : State res self RClosed
+  -> [PermanentNode res self]
+  = lam st.
+    let time = addi 1 (deref st.timestep) in
+    let _ = modref st.timestep time in
+
+    let handleLeaf
+      : BreakableQueue res self
+      -> TentativeNode res self RClosed
+      -> ()
+      = lam queue. lam child.
+        match _getParents child with Some parents then
+          _for parents
+            (lam parent.
+              match _shallowAllowedRight parent child with Some child then
+                match _addRightChildToParent time child parent with Some parent then
+                  _addToQueue parent queue
+                else ()
+              else ())
+        else never
+    in
+
+    recursive let work
+      : BreakableQueue res self
+      -> [PermanentNode res self]
+      = lam queue.
+        match _popFromQueue queue with Some p then
+          let children = (deref (_addedNodesRightChildren p)).1 in
+          match p with TentativeRoot _ then children
+          else match (p, children) with (TentativeMid _, [_] ++ _) then
+            let _ = handleLeaf queue (_addRightChildren st p children) in
+            work queue
+          else match p with TentativeMid _ then
+            error "Somehow reached a TentativeMid without right children, that was still added to the queue"
+          else never
+        else []
+    in
+
+    let frontier = st.frontier in
+    let queue = _newQueueFromFrontier frontier in
+    let _ = _iter (handleLeaf queue) frontier in
+    work queue
+
+type BreakableError self
+con Ambiguities : [{first: self, last: self, irrelevant: [{first: self, last: self}]}] -> BreakableError self
+-- TODO(vipa, 2021-02-15): There should be more information in case of
+-- a parse failure, but it's not obvious precisely how the information
+-- should be presented, it's not obvious to me that there will always
+-- be a single cause of the failure that is easy to find
+-- algorithmically
+con InvalidParse : () -> BreakableError self
+
+let breakableConstructResult
+  : [PermanentNode res self]
+  -> Either (BreakableError self) res
+  = lam nodes.
+    match nodes with [] then InvalidParse () else
+
+    -- NOTE(vipa, 2021-02-15): All alternatives for children at the
+    -- same point in the tree have the exact same range in the input,
+    -- i.e., they will have exactly the same input as first and last
+    -- input, that's why we only look at one of the children, we don't
+    -- need to look at the others
+    recursive let makeError
+      : PermanentNode res self
+      -> {first: self, last: self}
+      = lam node.
+        match node with AtomP {self = self} then {first = self, last = self}
+        else match node with InfixP {leftChildAlts = [l] ++ _, rightChildAlts = [r] ++ _} then
+          { first = (makeError l).first
+          , last = (makeError r).last
+          }
+        else match node with PrefixP {self = self, rightChildAlts = [r] ++ _} then
+          { first = self
+          , last = (makeError r).last
+          }
+        else match node with PostfixP {self = self, leftChildAlts = [l] ++ _} then
+          { first = (makeError l).first
+          , last = self
+          }
+        else never
+    in
+
+    let ambiguities : Ref [{first: self, last: self, irrelevant: [self]}] = ref [] in
+
+    recursive
+      let workMany
+        : [PermanentNode res self] -- NonEmpty
+        -> Option res
+        = lam nodes.
+          match nodes with [n] then
+            workOne n
+          else match nodes with [n, _] ++ _ then
+            let err = makeError n in
+            -- TODO(vipa, 2021-02-15): Compute valid elisons, and use those to
+            -- populate the 'irrelevant' field
+            let err = {first = err.first, last = err.last, irrelevant = []} in
+            let _ = modref ambiguities (cons err (deref ambiguities)) in
+            None ()
+          else let _ = dprintLn nodes in never
+      let workOne
+        : PermanentNode res self
+        -> Option res
+        = lam node.
+          match node with AtomP {self = self, input = AtomI {construct = c}} then
+            Some (c self)
+          else match node with PrefixP {self = self, rightChildAlts = rs, input = PrefixI {construct = c}} then
+            optionMap (c self) (workMany rs)
+          else match node with InfixP {self = self, leftChildAlts = ls, rightChildAlts = rs, input = InfixI {construct = c}} then
+            optionZipWith (c self) (workMany ls) (workMany rs)
+          else match node with PostfixP {self = self, leftChildAlts = ls, input = PostfixI {construct = c}} then
+            optionMap (c self) (workMany ls)
+          else never
+    in
+
+    match workMany nodes
+    with Some res then Right res
+    else Left (Ambiguities (deref ambiguities))
+
+mexpr
+
+type Ast in
+con IntA : {pos: Int, val: Int} -> Ast in
+con PlusA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con TimesA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con DivideA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con NegateA : {pos: Int, r: Ast} -> Ast in
+con IfA : {pos: Int, r: Ast} -> Ast in
+con ElseA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con NonZeroA : {pos: Int, l: Ast} -> Ast in
+
+let allowAllBut = lam xs. DisallowSet (mapFromList cmpString (map (lam x. (x, ())) xs)) in
+let allowAll = allowAllBut [] in
+let allowOnly = lam xs. AllowSet (mapFromList cmpString (map (lam x. (x, ())) xs)) in
+
+let highLowPrec
+  : [prodLabel]
+  -> [prodLabel]
+  -> [((prodLabel, prodLabel), OpGrouping)]
+  =
+    let mkGrouping = lam high. lam low.
+      [ ((high, low), {mayGroupLeft = true, mayGroupRight = false})
+      , ((low, high), {mayGroupLeft = false, mayGroupRight = true})
+      ] in
+    lam high. lam low. join (seqLiftA2 mkGrouping high low)
+in
+
+recursive let precTableNoEq
+  : [[prodLabel]]
+  -> [((prodLabel, prodLabel), OpGrouping)]
+  = lam table.
+    match table with [high] ++ lows then
+      concat (highLowPrec high (join lows)) (precTableNoEq lows)
+    else []
+in
+
+let grammar =
+  { productions =
+    [ BreakableAtom {label = "int", construct = lam x. IntA x}
+    , BreakableInfix
+      { label = "plus"
+      , construct = lam x. lam l. lam r. PlusA {pos = x.pos, l = l, r = r}
+      , leftAllow = allowAll
+      , rightAllow = allowAll
+      }
+    , BreakableInfix
+      { label = "times"
+      , construct = lam x. lam l. lam r. TimesA {pos = x.pos, l = l, r = r}
+      , leftAllow = allowAll
+      , rightAllow = allowAll
+      }
+    , BreakableInfix
+      { label = "divide"
+      , construct = lam x. lam l. lam r. DivideA {pos = x.pos, l = l, r = r}
+      , leftAllow = allowAll
+      , rightAllow = allowAll
+      }
+    , BreakablePrefix
+      { label = "negate"
+      , construct = lam x. lam r. NegateA {pos = x.pos, r = r}
+      , rightAllow = allowAll
+      }
+    , BreakablePrefix
+      { label = "if"
+      , construct = lam x. lam r. IfA {pos = x.pos, r = r}
+      , rightAllow = allowAll
+      }
+    , BreakableInfix
+      { label = "else"
+      , construct = lam x. lam l. lam r. ElseA {pos = x.pos, l = l, r = r}
+      , leftAllow = allowOnly ["if"]
+      , rightAllow = allowAll
+      }
+    , BreakablePostfix
+      { label = "nonZero"
+      , construct = lam x. lam l. NonZeroA {pos = x.pos, l = l}
+      , leftAllow = allowAll
+      }
+    ]
+  , precedences = join
+    [ precTableNoEq
+      [ ["negate"]
+      , ["times", "divide"]
+      , ["plus"]
+      , ["if"]
+      ]
+    ]
+  }
+in
+let genned = breakableGenGrammar cmpString grammar in
+let atom = lam label. mapFind label genned.atoms in
+let prefix = lam label. mapFind label genned.prefixes in
+let infix = lam label. mapFind label genned.infixes in
+let postfix = lam label. mapFind label genned.postfixes in
+
+type Self = {val : Int, pos : Int} in
+
+type TestToken in
+con TestAtom : { x : Self, input : BreakableInput Ast Self RClosed RClosed } -> TestToken in
+con TestPrefix : { x : Self, input : BreakableInput Ast Self RClosed ROpen } -> TestToken in
+con TestInfix : { x : Self, input : BreakableInput Ast Self ROpen ROpen } -> TestToken in
+con TestPostfix : { x : Self, input : BreakableInput Ast Self ROpen RClosed } -> TestToken in
+
+let _int =
+  let input = atom "int" in
+  lam val. lam pos. TestAtom {x = {val = val, pos = pos}, input = input} in
+let _plus =
+  let input = infix "plus" in
+  lam pos. TestInfix {x = {val = 0, pos = pos}, input = input} in
+let _times =
+  let input = infix "times" in
+  lam pos. TestInfix {x = {val = 0, pos = pos}, input = input} in
+let _divide =
+  let input = infix "divide" in
+  lam pos. TestInfix {x = {val = 0, pos = pos}, input = input} in
+let _negate =
+  let input = prefix "negate" in
+  lam pos. TestPrefix {x = {val = 0, pos = pos}, input = input} in
+let _if =
+  let input = prefix "if" in
+  lam pos. TestPrefix {x = {val = 0, pos = pos}, input = input} in
+let _else =
+  let input = infix "else" in
+  lam pos. TestInfix {x = {val = 0, pos = pos}, input = input} in
+let _nonZero =
+  let input = postfix "nonZero" in
+  lam pos. TestPostfix {x = {val = 0, pos = pos}, input = input} in
+
+let testParse
+  : [Int -> TestToken]
+  -> Either (BreakableError Self) Ast
+  = recursive
+      let workROpen = lam pos. lam st. lam tokens.
+        match tokens with [t] ++ tokens then
+          let t = t pos in
+          let pos = addi 1 pos in
+          match t with TestAtom {x = self, input = input} then
+            workRClosed pos (breakableAddAtom input self st) tokens
+          else match t with TestPrefix {x = self, input = input} then
+            workROpen pos (breakableAddPrefix input self st) tokens
+          else Left (InvalidParse ())
+        else Left (InvalidParse ())
+      let workRClosed = lam pos. lam st. lam tokens.
+        match tokens with [t] ++ tokens then
+          let t = t pos in
+          let pos = addi 1 pos in
+          match t with TestInfix {x = self, input = input} then
+            match breakableAddInfix input self st with Some st
+            then workROpen pos st tokens
+            else Left (InvalidParse ())
+          else match t with TestPostfix {x = self, input = input} then
+            match breakableAddPostfix input self st with Some st
+            then workRClosed pos st tokens
+            else Left (InvalidParse ())
+          else Left (InvalidParse ())
+        else breakableConstructResult (breakableFinalizeParse st)
+    in workROpen 0 (breakableInitState ())
+in
+
+utest testParse []
+with Left (InvalidParse ())
+in
+
+utest testParse [_int 4]
+with Right (IntA {val = 4,pos = 0})
+in
+
+utest testParse [_int 4, _plus]
+with Left (InvalidParse ())
+in
+
+utest testParse [_int 4, _plus, _int 7]
+with Right
+  (PlusA
+    { pos = 1
+    , l = (IntA {val = 4,pos = 0})
+    , r = (IntA {val = 7,pos = 2})
+    })
+in
+
+utest testParse [_negate, _int 8]
+with Right
+  (NegateA
+    { pos = 0
+    , r = (IntA {val = 8,pos = 1})
+    })
+in
+
+utest testParse [_negate, _negate, _int 8]
+with Right
+  (NegateA
+    { pos = 0
+    , r = (NegateA
+      { pos = 1
+      , r = (IntA {val = 8,pos = 2})
+      })
+    })
+in
+
+utest testParse [_int 9, _nonZero, _nonZero]
+with Right
+  (NonZeroA
+    { pos = 2
+    , l = (NonZeroA
+      { pos = 1
+      , l = (IntA {val = 9,pos = 0})})
+    })
+in
+
+utest testParse [_negate, _nonZero]
+with Left (InvalidParse ())
+in
+
+utest testParse [_int 1, _plus, _int 2, _times, _int 3]
+with Right
+  (PlusA
+    { pos = 1
+    , l = (IntA {val = 1,pos = 0})
+    , r = (TimesA
+      { pos = 3
+      , l = (IntA {val = 2,pos = 2})
+      , r = (IntA {val = 3,pos = 4})
+      })
+    })
+in
+
+utest testParse [_int 1, _times, _int 2, _plus, _int 3]
+with Right
+  (PlusA
+    { pos = 3
+    , l = (TimesA
+      { pos = 1
+      , l = (IntA {val = 1,pos = 0})
+      , r = (IntA {val = 2,pos = 2})
+      })
+    , r = (IntA {val = 3,pos = 4})
+    })
+in
+
+utest testParse [_int 1, _times, _int 2, _divide, _int 3]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 1,pos = 0}
+    , last = {val = 3,pos = 4}
+    }
+  ]))
+in
+
+utest testParse [_int 1, _times, _int 2, _divide, _int 3, _plus, _int 4]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 1,pos = 0}
+    , last = {val = 3,pos = 4}
+    }
+  ]))
+in
+
+utest testParse [_int 0, _plus, _int 1, _times, _int 2, _divide, _int 3]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 1,pos = 2}
+    , last = {val = 3,pos = 6}
+    }
+  ]))
+in
+
+-- TODO(vipa, 2021-02-15): When we compute elisons we can report two ambiguities here, the nested one is independent
+utest testParse [_int 0, _plus, _int 1, _times, _int 2, _divide, _int 3, _plus, _int 4]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 0,pos = 0}
+    , last = {val = 4,pos = 8}
+    }
+  ]))
+in
+
+-- TODO(vipa, 2021-02-15): Do we want to specify the order of the returned ambiguities in some way?
+utest testParse [_int 1, _times, _int 2, _divide, _int 3, _plus, _int 4, _divide, _int 5, _times, _int 6]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 4, pos = 6}
+    , last = {val = 6, pos = 10}
+    }
+  , { irrelevant = ([])
+    , first = {val = 1,pos = 0}
+    , last = {val = 3,pos = 4}
+    }
+  ]))
+in
+
+utest testParse [_if, _int 1]
+with Right
+  (IfA
+    { pos = 0
+    , r = (IntA {val = 1,pos = 1})
+    })
+in
+
+utest testParse [_if, _int 1, _else, _int 2]
+with Right
+  (ElseA
+    { pos = 2
+    , l = (IfA
+      { pos = 0
+      , r = (IntA {val = 1,pos = 1})
+      })
+    , r = (IntA {val = 2,pos = 3})
+    })
+
+in
+
+utest testParse [_if, _int 1, _else, _int 2, _else, _int 3]
+with Left (InvalidParse ())
+in
+
+utest testParse [_if, _if, _int 1, _else, _int 2]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 0,pos = 0}
+    , last = {val = 2,pos = 4}
+    }
+  ]))
+in
+
+utest testParse [_negate, _if, _int 1, _else, _int 2]
+with Right
+  (NegateA
+    { pos = 0
+    , r = (ElseA
+      { pos = 3
+      , l = (IfA
+        { pos = 1
+        , r = (IntA {val = 1,pos = 2})
+        })
+      , r = (IntA {val = 2,pos = 4})
+      })
+    })
+in
+
+utest testParse [_if, _negate, _if, _int 1, _else, _int 2]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 0,pos = 0}
+    , last = {val = 2,pos = 5}
+    }
+  ]))
+in
+
+utest testParse [_int 1, _plus, _if, _negate, _if, _int 1, _else, _int 2]
+with Left (Ambiguities (
+  [ { irrelevant = ([])
+    , first = {val = 0,pos = 2}
+    , last = {val = 2,pos = 7}
+    }
+  ]))
+in
+
+utest testParse [_int 1, _times, _if, _int 7, _else, _int 12]
+with Right
+  (TimesA
+    { pos = 1
+    , l = (IntA {val = 1,pos = 0})
+    , r = (ElseA
+      { pos = 4
+      , l = (IfA
+        { pos = 2
+        , r = (IntA {val = 7,pos = 3})
+        })
+      , r = (IntA {val = 12,pos = 5})
+      })
+    })
+in
+
+utest testParse [_int 1, _plus, _plus, _int 2]
+with Left (InvalidParse ())
+in
+
+utest testParse [_int 1, _plus, _nonZero]
+with Left (InvalidParse ())
+in
+
+utest testParse [_int 1, _nonZero, _plus, _int 2]
+with Right
+  (PlusA
+    { pos = 2
+    , l = (NonZeroA
+      { pos = 1
+      , l = (IntA {val = 1,pos = 0})
+      })
+    , r = (IntA {val = 2,pos = 3})
+    })
+in
+
+()

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -1,0 +1,540 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+
+include "map.mc"
+
+type AllowSet id
+con AllowSet : Map id () -> AllowSet id
+con DisallowSet : Map id () -> AllowSet id
+
+type BreakableProduction prodLabel self res
+con BreakableAtom :
+  { label : prodLabel
+  , construct : self -> res
+  } -> BreakableProduction prodLabel self res
+con BreakableInfix :
+  { label : prodLabel
+  , construct : self -> res -> res -> res
+  , leftAllow : AllowSet prodLabel
+  , rightAllow : AllowSet prodLabel
+  } -> BreakableProduction prodLabel self res
+con BreakablePrefix :
+  { label : prodLabel
+  , construct : self -> res -> res
+  , rightAllow : AllowSet prodLabel
+  } -> BreakableProduction prodLabel self res
+con BreakablePostfix :
+  { label : prodLabel
+  , construct : self -> res -> res
+  , leftAllow : AllowSet prodLabel
+  } -> BreakableProduction prodLabel self res
+
+type OpGrouping = {mayGroupLeft : Bool, mayGroupRight : Bool}
+
+type BreakableGrammar prodLabel self res =
+  { productions : [BreakableProduction prodLabel self res]
+  , precedences : [((prodLabel, prodLabel), OpGrouping)]
+  }
+
+-- Each operator is uniquely identifiable by its ID, which is used to
+-- look up precedence and the like
+type OpId = Int
+
+-- Each node in the parsed SPPF has a unique ID (it will likely not be
+-- unique when comparing between two different SPPFs though).
+type PermanentId = Symbol
+
+-- This is the type that is used to describe an item to be added to the parse
+type LOpen
+type LClosed
+type ROpen
+type RClosed
+type BreakableInput res self lstyle rstyle
+con AtomI :
+  { id : OpId
+  , construct : self -> res
+  } -> BreakableInput res self LClosed RClosed
+con InfixI :
+  { id : OpId
+  , leftAllow : AllowSet OpId
+  , rightAllow : AllowSet OpId
+  , precWhenThisIsRight : Map OpId OpGrouping
+  , construct : self -> res -> res -> res
+  } -> BreakableInput res self LOpen ROpen
+con PrefixI :
+  { id : OpId
+  , rightAllow : AllowSet OpId
+  , construct : self -> res -> res
+  } -> BreakableInput res self LClosed ROpen
+con PostfixI :
+  { id : OpId
+  , leftAllow : AllowSet OpId
+  , precWhenThisIsRight : Map OpId OpGrouping
+  , construct : self -> res -> res
+  } -> BreakableInput res self LOpen RClosed
+
+-- This describes a generated breakable grammar that is ready for parsing with
+type BreakableGenGrammar prodLabel self res =
+  { atoms : Map prodLabel (BreakableInput res self LClosed RClosed)
+  , prefixes : Map prodLabel (BreakableInput res self LClosed ROpen)
+  , infixes : Map prodLabel (BreakableInput res self LOpen ROpen)
+  , postfixes : Map prodLabel (BreakableInput res self LOpen RClosed)
+  }
+
+-- NOTE(vipa, 2021-02-12): Many sequences in this file have an extra comment after them: NonEmpty. In the original implementation this was the type of a non-empty list, but we don't have one of those here, so for now I'm just recording that knowledge in comments, then we'll see what we do about it later.
+
+-- This is the type of a node in an SPPF.
+type PermanentNode res self
+con AtomP :
+  { id : PermanentId
+  , input : BreakableInput res self LClosed RClosed
+  , self : self
+  } -> PermanentNode res self
+con InfixP :
+  { id : PermanentId
+  , input : BreakableInput res self LOpen ROpen
+  , self : self
+  , leftChildAlts : [PermanentNode res self] -- NonEmpty
+  , rightChildAlts : [PermanentNode res self] -- NonEmpty
+  } -> PermanentNode res self
+con PrefixP :
+  { id : PermanentId
+  , input : BreakableInput res self LClosed ROpen
+  , self : self
+  , rightChildAlts : [PermanentNode res self] -- NonEmpty
+  } -> PermanentNode res self
+con PostfixP :
+  { id : PermanentId
+  , input : BreakableInput res self LOpen RClosed
+  , self : self
+  , leftChildAlts : [PermanentNode res self] -- NonEmpty
+  } -> PermanentNode res self
+
+-- This is the data carried by tentative nodes, nodes that don't yet
+-- have all their children known
+type TentativeData res self
+con InfixT :
+  { input : BreakableInput res self LOpen ROpen
+  , self : self
+  , leftChildAlts : [PermanentNode res self] -- NonEmpty
+  } -> TentativeData res self
+con PrefixT :
+  { input : BreakableInput res self LClose ROpen
+  , self : self
+  } -> TentativeData res self
+
+-- As an optimization we keep track of a kind of "current" time, all
+-- data from older timesteps is considered to be empty. The time is
+-- essentially just which BreakableInput we're processing currently in
+-- the sequence of input.
+type TimeStep = Int
+
+-- NOTE(vipa, 2021-02-12): This is the type of a node that may or may
+-- not be in the final SPPF, we haven't seen enough of the input to
+-- determine which yet. Note that there are references in the types,
+-- i.e., they're not pure data. These references are used to optimize
+-- knowledge of how new nodes are supposed to be added. Each of these
+-- references also have an attached time step; if the timestep is
+-- older than the current time in the algorithm then the reference
+-- should be considered as unset (i.e., we don't have to clear all
+-- references each iteration of the algorithm). We parse left to
+-- right, thus all tentative nodes are left-closed
+type TentativeNode res self rstyle
+con TentativeLeaf :
+  { parents : [TentativeNode res self ROpen] -- NonEmpty
+  , node : PermanentNode res self
+  } -> TentativeNode res self RClosed
+con TentativeMid :
+  { addedNodesLeftChildren : Ref (TimeStep, Ref [PermanentNode])
+  , addedNodesRightChildren : Ref (TimeStep, [PermanentNode])
+  , parents : [TentativeNode res self ROpen] -- NonEmpty
+  , tentativeData : TentativeData res self
+  , maxDistanceFromRoot : Int
+  } -> TentativeNode res self ROpen
+con TentativeRoot :
+  { addedNodesLeftChildren : Ref (TimeStep, Ref [PermanentNode])
+  , addedNodesRightChildren : Ref (TimeStep, [PermanentNode])
+  } -> TentativeNode res self ROpen
+
+-- The data we carry along while parsing
+type State res self rstyle =
+  { nextId : Ref Int
+  , timestep : Ref Int
+  , frontier : [TentativeNode res self rstyle]
+  }
+
+let _firstTimeStep : TimeStep = 0
+let _isBefore : TimeStep -> TimeStep -> Bool = lti
+let _eqOpId : OpId -> OpId -> Bool = eqi
+let _rootID : OpId = negi 1
+let _firstOpId : OpId = 0
+let _uniqueID : () -> PermanentId = gensym
+let _getParents
+  : TentativeNode res self rstyle
+  -> Option [TentativeNode res self ROpen] -- NonEmpty
+  = lam n.
+    match n with TentativeLeaf{parents = ps} | TentativeMid{parents = ps} then Some ps else
+    match n with TentativeRoot _ then None () else
+    never
+let _opIdP
+  : PermanentNode res self
+  -> OpId
+  = lam node.
+    match node with AtomP {id = id} then id else
+    match node with InfixP {id = id} then id else
+    match node with PrefixP {id = id} then id else
+    match node with PostfixP {id = id} then id else
+    never
+let _opIdI
+  : BreakableInput res self lstyle rstyle
+  -> OpId
+  = lam input.
+    match input with
+      AtomI {id = id}
+      | InfixI {id = id}
+      | PrefixI {id = id}
+      | PostfixI {id = id}
+      then id
+    else never
+let _opIdTD
+  : TentativeData res self
+  -> OpId
+  = lam data.
+    match data with InfixT {input = input} | PrefixT {input = input} then _opIdI input else
+    never
+let _opIdT
+  : TentativeNode res self lstyle rstyle
+  -> OpId
+  = lam node.
+    match node with TentativeLeaf{node = node} then _opIdP node else
+    match node with TentativeMid{tentativeData = data} then _opIdTD else
+    match node with TentativeRoot _ then _rootID else
+    never
+let _addedNodesLeftChildren
+  : TentativeNode res self ROpen
+  -> [TentativeNode res self ROpen] -- NonEmpty
+  = lam node.
+    match node with TentativeRoot{addedNodesLeftChildren = x} | TentativeMid{addedNodesLeftChildren = x}
+    then x
+    else never
+let _addedNodesRightChildren
+  : TentativeNode res self ROpen
+  -> [TentativeNode res self ROpen] -- NonEmpty
+  = lam node.
+    match node with TentativeRoot{addedNodesRightChildren = x} | TentativeMid{addedNodesRightChildren = x}
+    then x
+    else never
+-- NOTE(vipa, 2021-02-08): This should possibly be in the stdlib, but it might depend on opinions on side effects down the line
+recursive let _iter = lam f. lam xs.
+  match xs with [x] ++ xs then
+    let _ = f x in _iter f xs
+  else match xs with [] then
+    ()
+  else never
+end
+let _for = lam xs. lam f. _iter f xs
+
+
+let breakableGenGrammar
+  : (prodLabel -> prodLabel -> Int)
+  -> BreakableGrammar prodLabel self res
+  -> BreakableGenGrammar prodLabel self res
+  = lam cmp. lam grammar. never
+
+let breakableInitState : () -> State res self ROpen
+  = lam cmp. lam grammar.
+    let nextId = ref _firstOpId in
+    let timestep = ref _firstTimeStep in
+    let addedLeft = ref (_firstTimeStep, ref []) in
+    let addedRight = ref (_firstTimeStep, []) in
+    { nextId = nextId
+    , timestep = timestep
+    , frontier =
+      [ TentativeRoot { addedNodesLeftChildren = addedLeft, addedNodesRightChildren = addedRight } ]
+    }
+
+let inAllowSet
+  : id
+  -> AllowSet id
+  -> Bool
+  = lam id. lam set.
+    match set with AllowSet s then mapMem id s else
+    match set with DisallowSet s then not (mapMem id s) else
+    never
+
+recursive let _maxDistanceFromRoot
+  : TentativeNode res self rstyle
+  -> Int
+  = lam n.
+    match n with TentativeMid {maxDistanceFromRoot = r} then r else
+    match n with TentativeRoot _ then 0 else
+    match n with TentativeLeaf {parents = parents} then maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot parents) else
+    never
+end
+
+let _shallowAllowedLeft
+  : BreakableInput res self LOpen rstyle
+  -> TentativeNode res self RClosed
+  -> Option (PermanentNode res self)
+  = lam parent. lam child.
+    match child with TentativeLeaf {node = node} then
+      match parent with InfixI {leftAllow = s} | PostfixI {leftAllow = s} then
+        if inAllowSet (_opIdP node) s then Some node else None ()
+      else never
+    else never
+
+let _shallowAllowedRight
+  : TentativeNode s res self ROpen
+  -> TentativeNode res self RClosed
+  -> Option (PermanentNode res self)
+  = lam parent. lam child.
+    match child with TentativeLeaf {node = node} then
+      match parent with TentativeRoot _ then Some node else
+      match parent with TentativeMid {tentativeData = (InfixT {rightAllowed = s} | PrefixT {rightAllowed = s})} then
+        if inAllowSet (_opIdP node) s then Some node else None ()
+      else never
+    else never
+
+let _addRightChildren
+  : State res self rstyle
+  -> TentativeNode res self ROpen
+  -> [PermanentNode res self] -- NonEmpty
+  -> TentativeNode s res self RClosed
+  = lam st. lam parent. lam children.
+    match parent with TentativeMid {parents = parents, tentativeData = data} then
+      let id = _uniqueID st in
+      let node =
+        match data with InfixT {input = input, self = self, leftChildAlts = l} then
+          InfixP {id = id, input = input, self = self, leftChildAlts = l, rightChildAlts = children}
+        else match data with PrefixT {input = input, self = self} then
+          PrefixP {id = id, input = input, self = self, rightChildAlts = children}
+        else never in
+      TentativeLeaf {parents = parents, node = node}
+    else match parent with TentativeRoot _ then
+      error "Unexpectedly tried to add right children to the root"
+    else never
+
+let _addLeftChildren
+  : State res self rstyle2
+  -> BreakableInput res self LOpen rstyle
+  -> self
+  -> [PermanentNode res self] -- NonEmpty
+  -> [TentativeNode res self ROpen] -- NonEmpty
+  -> TentativeNode res self rstyle
+  = lam st. lam input. lam self. lam leftChildren. lam parents.
+    match input with InfixI _ then
+      let time = deref st.timestep in
+      let addedLeft = ref (_firstTimeStep, ref []) in
+      let addedRight = ref (_firstTimeStep, []) in
+      TentativeMid
+        { parents = parents
+        , addedNodesLeftChildren = addedLeft
+        , addedNodesRightChildren = addedRight
+        , maxDistanceFromRoot = addi 1 (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot parents))
+        , tentativeData = InfixT {input = input, self = self, leftChildAlts = leftChildren}
+        }
+    else match input with PostfixI _ then
+      let id = _uniqueID st in
+      TentativeLeaf
+        { parents = parents
+        , node = PostfixP {id = id, input = input, self = self, leftChildAlts = leftChildren}
+        }
+    else never
+
+let _addRightChildToParent
+  : TimeStep
+  -> PermanentNode res self
+  -> TentativeNode res self ROpen
+  -> Option (TentativeNode res self ROpen)
+  = lam time. lam child. lam parent.
+    let target = _addedNodesRightChildren parent in
+    match deref target with (lastUpdate, prev) then
+      if _isBefore lastUpdate time then
+        let _ = modref target (time, [child]) in
+        Some parent
+      else
+        let _ = modref target (time, cons child prev) in
+        None ()
+    else never
+
+let _addLeftChildToParent
+  : TimeStep
+  -> PermanentNode res self
+  -> [TentativeNode s res self ROpen] -- NonEmpty
+  -> Option (NonEmpty (TentativeNode res self ROpen))
+  = lam time. lam child. lam parents.
+    match parents with [p] ++ _ then
+      let target = _addedNodesLeftChildren p in
+      match deref target with (lastUpdate, prev) then
+        if _isBefore lastUpdate time then
+          let leftChildrenHere = ref [child] in
+          let _ = _iter (lam p. modref (_addedNodesLeftChildren p) (time, leftChildrenHere)) parents in
+          Some parents
+        else
+          let _ = modref target (time, cons child prev) in
+          None ()
+      else never
+    else never -- TODO(vipa, 2021-02-12): this isn't technically never by for the typesystem, since we're matching against a possibly empty list. However, the list will never be empty, by the comment about NonEmpty above
+
+let _getOpGroup
+  : BreakableInput res self LOpen rstyle
+  -> OpId
+  -> OpGrouping
+  = lam input. lam id.
+    if _eqOpId id _rootID then {mayGroupLeft = false, mayGroupRight = true} else
+    match input with InfixI {precWhenThisIsRight = prec} | PostfixI {precWhenThisIsRight = prec} then
+      match mapLookup id prec with Some res
+      then res
+      else {mayGroupLeft = true, mayGroupRight = true}
+    else never
+
+let _mayGroupRight
+  : TentativeNode res self ROpen
+  -> BreakableInput res self LOpen rstyle
+  -> Bool
+  = lam l. lam r.
+    (_getOpGroup r (_opIdT l)).mayGroupRight
+
+let _mayGroupLeft
+  : TentativeNode res self ROpen
+  -> BreakableInput res self LOpen rstyle
+  -> Bool
+  = lam l. lam r.
+    (_getOpGroup r (_opIdT l)).mayGroupLeft
+
+-- NOTE(vipa, 2021-02-12): The type signatures in this function assume
+-- that type variables are scoped, e.g., `rstyle` on `makeNewParents`
+-- is the same `rstyle` as the one in the top-level type-signature
+let _addLOpen
+  : BreakableInput res self LOpen rstyle
+  -> self
+  -> State res self RClosed
+  -> Option (State res self rstyle)
+  = lam input. lam self. lam st.
+    let time = addi 1 (deref st.timestep) in
+    let _ = modref st.timestep time in
+
+    type BreakableQueue = [Ref [TentativeNode res self ROpen]] in
+    let addToQueue
+      : TentativeNode res self ROpen
+      -> BreakableQueue
+      -> ()
+      = lam node. lam queue.
+        let dist = _maxDistanceFromRoot node in
+        let target = get dist queue in
+        modref target (snoc (deref target) node)
+    in
+    recursive let popFromQueue
+      : BreakableQueue
+      -> Option (TentativeNode res self ROpen)
+      = lam queue.
+        match queue with queue ++ [target] then
+          let nodes = deref target in
+          match nodes with [node] ++ nodes then
+            let _ = modref target nodes in
+            Some node
+          else popFromQueue queue
+        else None ()
+    in
+
+    let makeNewParents
+      : [TentativeNode res self ROpen] -- NonEmpty
+      -> TentativeNode res self rstyle
+      = lam parents.
+        match parents with [p] ++ _ then
+          let cs = deref (deref (_addedNodesLeftChildren p)).1 in
+          match cs with [_] ++ _ then
+            _addLeftChildren st input self cs parents
+          else error "Somehow thought that a node would be a new parent, but it had no added children"
+        else never -- TODO(vipa, 2021-02-12): this isn't technically never by for the typesystem, since we're matching against a possibly empty list. However, the list will never be empty, by the comment about NonEmpty above
+    in
+
+    let handleLeaf
+      : TentativeNode res self RClosed
+      -> BreakableQueue
+      -> (MaxPQueue Int (TentativeNode res self ROpen), Option [TentativeNode res self ROpen]) -- NonEmpty
+      = lam child. lam queue.
+        let parents = _getParents child in
+        let _ = _for parents
+          (lam parent.
+            if not (_mayGroupLeft parent input) then () else
+            match _shallowAllowedRight parent child with Some child then
+              match _addRightChildToParent time child parent with Some parent then
+                addToQueue parent queue
+              else ()
+            else ()) in
+        match (_shallowAllowedLeft input child, filter (lam l. _mayGroupRight l input) parents)
+        with (Some child, parents & [_] ++ _) then
+          _addLeftChildToParent time child parents
+        else None ()
+    in
+
+    recursive let work
+      : BreakableQueue
+      -> [[TentativeNode res self ROpen]] -- The inner sequence is NonEmpty
+      -> [[TentativeNode res self ROpen]] -- The inner sequence is NonEmpty
+      = lam queue. lam acc.
+        match popFromQueue queue with Some (parent & TentativeMid{addedNodesRightChildren = addedRight}) then
+          match deref addedRight with (_, children & [_] ++ _) then
+            let acc = match handleLeaf (_addRightChildren st parent children) queue
+              with Some n then cons n acc
+              else acc in
+            work queue acc
+          else error "Somehow reached a parent without right children that was still added to the queue"
+        else acc
+    in
+
+    -- TODO(vipa, 2021-02-12): This could use a `make : (Int -> a) -> Int -> [a]` that we discussed a while back
+    let frontier = st.frontier in
+    let queue = map (lam _. ref []) (makeSeq (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot frontier)) ()) in
+    let newParents = mapOption (handleLeaf queue) frontier in
+    let newParents = work queue newParents in
+    match map makeNewParents newParents with frontier & ([_] ++ _) then
+      Some {st with frontier = frontier}
+    else
+      None ()
+
+let breakableAddPrefix
+  : BreakableInput res self LClosed ROpen
+  -> self
+  -> State res self ROpen
+  -> State res self ROpen
+  = lam input. lam self. lam st.
+    let frontier = st.frontier in
+    let time = deref st.timestep in
+    let addedLeft = ref (_firstTimeStep, ref []) in
+    let addedRight = ref (_firstTimeStep, []) in
+    { st with frontier =
+      [ TentativeMid
+        { parents = frontier
+        , addedNodesLeftChildren = addedLeft
+        , addedNodesRightChildren = addedRight
+        , maxDistanceFromRoot = addi 1 (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot frontier))
+        , tentativeData = PrefixT {input = input, self = self}
+        }
+      ]
+    }
+
+let breakableAddInfix
+  : BreakableInput res self LOpen ROpen
+  -> self
+  -> State res self RClosed
+  -> Option (State res self ROpen)
+  = _addLOpen
+
+let breakableAddPostfix
+  : BreakableInput res self LOpen RClosed
+  -> self
+  -> State res self RClosed
+  -> Option (State res self RClosed)
+  = _addLOpen
+
+let breakableAddAtom
+  : BreakableInput res self LClosed RClosed
+  -> self
+  -> State res self ROpen
+  -> State res self RClosed
+  = lam input. lam self. lam st.
+    let id = _uniqueID st in
+    { st with frontier = [TentativeLeaf {id = id, input = input, self = self}] }

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -238,7 +238,7 @@ recursive let _iter = lam f. lam xs.
 end
 let _for = lam xs. lam f. _iter f xs
 
-let inAllowSet
+let breakableInAllowSet
   : id
   -> AllowSet id
   -> Bool
@@ -247,7 +247,7 @@ let inAllowSet
     match set with DisallowSet s then not (mapMem id s) else
     never
 
-let mapAllowSet
+let breakableMapAllowSet
   : (a -> b)
   -> (b -> b -> Int)
   -> AllowSet a
@@ -322,15 +322,15 @@ let breakableGenGrammar
         match prod with BreakableAtom {construct = construct} then
           updateRef atoms (cons (label, AtomI {id = id, construct = construct}))
         else match prod with BreakablePrefix {construct = c, rightAllow = r} then
-          let r = mapAllowSet toOpId _cmpOpId r in
+          let r = breakableMapAllowSet toOpId _cmpOpId r in
           updateRef prefixes (cons (label, PrefixI {id = id, construct = c, rightAllow = r}))
         else match prod with BreakableInfix {construct = c, leftAllow = l, rightAllow = r} then
-          let l = mapAllowSet toOpId _cmpOpId l in
-          let r = mapAllowSet toOpId _cmpOpId r in
+          let l = breakableMapAllowSet toOpId _cmpOpId l in
+          let r = breakableMapAllowSet toOpId _cmpOpId r in
           let p = getGroupingByRight id in
           updateRef infixes (cons (label, InfixI {id = id, construct = c, leftAllow = l, rightAllow = r, precWhenThisIsRight = p}))
         else match prod with BreakablePostfix {construct = c, leftAllow = l} then
-          let l = mapAllowSet toOpId _cmpOpId l in
+          let l = breakableMapAllowSet toOpId _cmpOpId l in
           let p = getGroupingByRight id in
           updateRef postfixes (cons (label, PostfixI {id = id, construct = c, leftAllow = l, precWhenThisIsRight = p}))
         else never)
@@ -369,7 +369,7 @@ let _shallowAllowedLeft
   = lam parent. lam child.
     match child with TentativeLeaf {node = node} then
       match parent with InfixI {leftAllow = s} | PostfixI {leftAllow = s} then
-        if inAllowSet (_opIdP node) s then Some node else None ()
+        if breakableInAllowSet (_opIdP node) s then Some node else None ()
       else never
     else never
 
@@ -381,7 +381,7 @@ let _shallowAllowedRight
     match child with TentativeLeaf {node = node} then
       match parent with TentativeRoot _ then Some node else
       match parent with TentativeMid {tentativeData = (InfixT {input = InfixI {rightAllow = s}} | PrefixT {input = PrefixI {rightAllow = s}})} then
-        if inAllowSet (_opIdP node) s then Some node else None ()
+        if breakableInAllowSet (_opIdP node) s then Some node else None ()
       else let _ = dprintLn parent in never
     else never
 

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -53,6 +53,28 @@ utest mapi (lam i. lam x. i) [] with []
 utest map (lam x. addi x 1) [3,4,8,9,20] with [4,5,9,10,21]
 utest map (lam x. addi x 1) [] with []
 
+let mapOption
+  : (a -> Option b)
+  -> [a]
+  -> [b]
+  = lam f.
+    recursive let work = lam as.
+      match as with [a] ++ as then
+        match f a with Some b
+        then cons b (work as)
+        else work as
+      else []
+    in work
+
+utest mapOption (lam a. if gti a 3 then Some (addi a 30) else None ()) [1, 2, 3, 4, 5, 6]
+with [34, 35, 36]
+
+utest mapOption (lam a. if gti a 3 then Some (addi a 30) else None ()) [1, 2]
+with []
+
+utest mapOption (lam a. if gti a 3 then Some (addi a 30) else None ()) []
+with []
+
 -- Folds
 recursive
   let foldl = lam f. lam acc. lam seq.

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -75,6 +75,33 @@ with []
 utest mapOption (lam a. if gti a 3 then Some (addi a 30) else None ()) []
 with []
 
+recursive let iter
+  : (a -> ())
+  -> [a]
+  -> ()
+  = lam f. lam xs.
+    match xs with [x] ++ xs then
+      let _ = f x in iter f xs
+    else match xs with [] then
+      ()
+    else never
+end
+
+utest iter (lam x. addi x 1) [1, 2, 3]
+with ()
+
+utest
+  let r = ref 0 in
+  let _ = iter (lam x. modref r (addi x (deref r))) [1, 2, 3, 4] in
+  deref r
+with 10
+
+let for_
+  : [a]
+  -> (a -> ())
+  -> ()
+  = lam xs. lam f. iter f xs
+
 -- Folds
 recursive
   let foldl = lam f. lam acc. lam seq.

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -182,6 +182,16 @@ utest join [[1,2],[3,4],[5,6]] with [1,2,3,4,5,6]
 utest join [[1,2],[],[5,6]] with [1,2,5,6]
 utest join [[],[],[]] with []
 
+-- Monadic and Applicative operations
+
+let seqLiftA2
+  : (a -> b -> c) -> [a] -> [b] -> [c]
+  = lam f. lam as. lam bs.
+    join (map (lam a. map (f a) bs) as)
+
+utest seqLiftA2 addi [10, 20, 30] [1, 2, 3]
+with [11, 12, 13, 21, 22, 23, 31, 32, 33]
+
 -- Searching
 recursive
   let filter = lam p. lam seq.
@@ -327,7 +337,3 @@ utest isSuffix eqi [2,3] [1,2,3] with true
 utest isSuffix eqi [1,2,3] [1,2,3] with true
 utest isSuffix eqi [1,2,3] [1,1,2,3] with true
 utest isSuffix eqi [1,1,2,3] [1,2,3] with false
-
-
-
-


### PR DESCRIPTION
This PR implements the low-level machinery intended for phase two of our parser. It contains the beginnings of my thoughts on how to include ambiguity in a programming language while...
- ...having better-than-[syncon](https://github.com/miking-lang/syncon) time complexities when constructing error messages for an ambiguous program
- ...keeping the ambiguities understandable. This approach limits the kind of ambiguity we can encounter to those of how parts of the program connect, as opposed to those where the meaning of one or more parts are changed. There is a little bit more text on this below, but I expect to need to figure out a better way to explain it.

The algorithm was originally written in Haskell, making very heavy use of GADTs, and I've done my best to transcribe all the code and types correctly, but it does put some demands on our type-system/typechecker once that becomes a thing.

The information produced in the case of an error is a bit limited at present compared to what we want it to be down the line. In particular:

- In case of ambiguity we only isolate where in the file the ambiguities are, we do not identify the sub-parts of the program that are irrelevant, nor how to resolve the ambiguity. Both are intended to happen, but I'm prioritizing the happy path at the moment (keeping in mind that showing the ambiguous region of the program is often good enough, which we do produce right now).
- In case of parse failure no information is given, except at which point in the parse we know that an error has occurred. There are a couple of possible reasons for the failure:
  - We got the wrong kind of operator, e.g., after parsing an infix operator we found another infix operator, which is trivially syntactically incorrect. This would never appear in our parser as phase one can never make this mistake (As an aside, such an error would also be a type error thanks to the GADT-stuff I use, not that that is checked at the moment).
  - There is some precedence rule `a` - `b` or a shallow forbid that prohibits all possible parse trees. These errors can occur fairly early in a parse, before we *know* that they must lead to an error, because there might come another operator that could be inserted in-between the conflicting operators. This means that the point at which it is no longer possible to produce a valid parse might not be the point where the error occurred. These two causes, which could probably interact, are the ones that really need good error messages, but I don't yet know how to explain them in general, only in particular cases.

I also put a high-level description of the approach and its usage in the file, which I also include below for convenience.

Finally, I added some functions to `seq.mc`. I also implemented `iter`, but put it as a private function in `breakable.mc` for now, since it is useless without side-effects, which I'm not quite sure how readily accessible we want to be. I also have it as a private function in `ll1.mc`, but I forgot to mention it in that PR.

-------

This file contains support for parsing operator expressions with precedence and shallow forbids/allows. We support ambiguities
properly; the parsing procedure produces a shared packed parse forest (SPPF), which can then be analyzed to determine the exact scope of any ambiguities involved.

# Left-open, right-open, left-closed, and right-closed

A central concept herein is whether a "thing" (an operator or an expression) is open or closed on either side. For example, the infix operator `+` is both left-open and right-open, while the atomic expression `7` is both left-closed and right-closed. These properties transfer to partially constructed ASTs as well, `(_ + 4)` is left-open but right-closed, while `(1 + 2)` is both left-closed and right-closed.

# Precedence

The precedence definition used herein is less strict than the conventional definition; it need not be total, nor transitive. Instead, it is defined as follows: given a right-open operator `a` and a left-open operator `b`, if we had a fully closed thing between them,
would it be permissible to group it

- only to the left, written as `a` <- `b`,
- only to the right, written as `a` -> `b`,
- either, written as `a` <-> `b`, or
- neither, written as `a` - `b`?

For example, we would likely give the following definitions for addition and multiplication:

- `+` -> `*` (normal precedence)
- `*` <- `+` (normal precedence)
- `+` <- `+` (left-associative)
- `*` <- `*` (left-associative)

# Shallow forbids/allows

Operators may also pose restrictions on which other operators are allowed to be their direct children. This is used to allow breaking other kinds of productions into operators that are then limited to the normal interactions. The canonical example is `if then else` (where `else` is optional), which can be specified as follows:

- Prefix `if condition then`
- Infix `else`, where the left child must be exactly `if condition
  then`

This means that each `else` must have a corresponding `if condition then`, but we can handle any ambiguities that arise (e.g. dangling-`else`) using the same approach as for operators, i.e., we can resolve them with grouping parentheses.

As a consequence, the only ambiguities that can arise when using this approach are those where it is unclear how things in the input connect, as opposed to what their fundamental meaning is, which I (vipa) hypothesize is quite helpful for the understandability of ambiguities.

# Mid-level usage instructions

1. Create a value of the `BreakableGrammar` type. See the tests at the end of the file for examples.
2. Call `breakableGenGrammar`. You can now query the result for the value the parser expects you to supply when each operator is parsed in step 4.
3. Call `breakableInitState` to start parsing an expression. Values of type `State` are mutable and should never be reused, consider them consumed when they are passed to a function.
4. Call `breakableAddAtom`, `breakableAddPrefix`, `breakableAddInfix`, and `breakableAddPostfix` repeatedly to add one "thing" at a time to the parse. Note that these functions are quite strongly typed, e.g., you cannot call `breakableAddAtom` when the currently parsed expression is already right-closed. See the tests for an example of how to handle this when the calling code does not have the same strictness in its types.
5. Call `breakableFinalizeParse` to create an SPPF of the parse.
6. Call `breakableConstructResult` to extract the single unambiguous parse, or an ambiguity error.
