### PR TITLE
Added info fields to the boot parser, and refactored things related to naming and info fields.

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -141,6 +141,7 @@ and const =
   | CbootParserGetListLength of tm option
   | CbootParserGetConst of tm option
   | CbootParserGetPat of tm option
+  | CbootParserGetInfo of tm option
   (* External functions *)
   | CExt of Extast.ext
   | CSd of Sdast.ext
@@ -152,6 +153,7 @@ and ptree =
   | PTreeTy of ty
   | PTreePat of pat
   | PTreeConst of const
+  | PTreeInfo of info
 
 (* Terms in MLang *)
 and cdecl = CDecl of info * ustring * ty

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -193,16 +193,14 @@ and program = Program of include_ list * top list * tm
 and tm =
   (* Variable *)
   | TmVar of info * ustring * Symb.t
+  (* Application *)
+  | TmApp of info * tm * tm
   (* Lambda abstraction *)
   | TmLam of info * ustring * Symb.t * ty * tm
   (* Let *)
   | TmLet of info * ustring * Symb.t * ty * tm * tm
-  (* Type let *)
-  | TmType of info * ustring * Symb.t * ty * tm
   (* Recursive lets *)
   | TmRecLets of info * (info * ustring * Symb.t * ty * tm) list * tm
-  (* Application *)
-  | TmApp of info * tm * tm
   (* Constant *)
   | TmConst of info * const
   (* Sequence *)
@@ -211,6 +209,8 @@ and tm =
   | TmRecord of info * tm Record.t
   (* Record update *)
   | TmRecordUpdate of info * tm * ustring * tm
+  (* Type let *)
+  | TmType of info * ustring * Symb.t * ty * tm
   (* Constructor definition *)
   | TmCondef of info * ustring * Symb.t * ty * tm
   (* Constructor application *)
@@ -310,25 +310,19 @@ module Option = BatOption
 let rec map_tm f = function
   | TmVar (_, _, _) as t ->
       f t
+  | TmApp (fi, t1, t2) ->
+      f (TmApp (fi, map_tm f t1, map_tm f t2))
   | TmLam (fi, x, s, ty, t1) ->
       f (TmLam (fi, x, s, ty, map_tm f t1))
-  | TmClos (fi, x, s, t1, env) ->
-      f (TmClos (fi, x, s, map_tm f t1, env))
   | TmLet (fi, x, s, ty, t1, t2) ->
       f (TmLet (fi, x, s, ty, map_tm f t1, map_tm f t2))
-  | TmType (fi, x, s, ty, t1) ->
-      f (TmType (fi, x, s, ty, map_tm f t1))
   | TmRecLets (fi, lst, tm) ->
       f
         (TmRecLets
            ( fi
            , List.map (fun (fi, x, s, ty, t) -> (fi, x, s, ty, map_tm f t)) lst
            , map_tm f tm ))
-  | TmApp (fi, t1, t2) ->
-      f (TmApp (fi, map_tm f t1, map_tm f t2))
   | TmConst (_, _) as t ->
-      f t
-  | TmFix _ as t ->
       f t
   | TmSeq (fi, tms) ->
       f (TmSeq (fi, Mseq.Helpers.map (map_tm f) tms))
@@ -336,18 +330,24 @@ let rec map_tm f = function
       f (TmRecord (fi, Record.map (map_tm f) r))
   | TmRecordUpdate (fi, r, l, t) ->
       f (TmRecordUpdate (fi, map_tm f r, l, map_tm f t))
+  | TmType (fi, x, s, ty, t1) ->
+      f (TmType (fi, x, s, ty, map_tm f t1))
   | TmCondef (fi, x, s, ty, t1) ->
       f (TmCondef (fi, x, s, ty, map_tm f t1))
   | TmConapp (fi, k, s, t) ->
       f (TmConapp (fi, k, s, t))
   | TmMatch (fi, t1, p, t2, t3) ->
       f (TmMatch (fi, map_tm f t1, p, map_tm f t2, map_tm f t3))
-  | TmUse (fi, l, t1) ->
-      f (TmUse (fi, l, map_tm f t1))
   | TmUtest (fi, t1, t2, tusing, tnext) ->
       let tusing_mapped = Option.map (map_tm f) tusing in
       f (TmUtest (fi, map_tm f t1, map_tm f t2, tusing_mapped, map_tm f tnext))
   | TmNever _ as t ->
+      f t
+  | TmUse (fi, l, t1) ->
+      f (TmUse (fi, l, map_tm f t1))
+  | TmClos (fi, x, s, t1, env) ->
+      f (TmClos (fi, x, s, map_tm f t1, env))
+  | TmFix _ as t ->
       f t
   | TmRef _ as t ->
       f t
@@ -355,23 +355,23 @@ let rec map_tm f = function
 (* Returns the info field from a term *)
 let tm_info = function
   | TmVar (fi, _, _)
-  | TmLam (fi, _, _, _, _)
-  | TmClos (fi, _, _, _, _)
-  | TmLet (fi, _, _, _, _, _)
-  | TmType (fi, _, _, _, _)
-  | TmRecLets (fi, _, _)
   | TmApp (fi, _, _)
+  | TmLam (fi, _, _, _, _)
+  | TmLet (fi, _, _, _, _, _)
+  | TmRecLets (fi, _, _)
   | TmConst (fi, _)
-  | TmFix fi
   | TmSeq (fi, _)
   | TmRecord (fi, _)
   | TmRecordUpdate (fi, _, _, _)
+  | TmType (fi, _, _, _, _)
   | TmCondef (fi, _, _, _, _)
   | TmConapp (fi, _, _, _)
   | TmMatch (fi, _, _, _, _)
-  | TmUse (fi, _, _)
   | TmUtest (fi, _, _, _, _)
   | TmNever fi
+  | TmUse (fi, _, _)
+  | TmClos (fi, _, _, _, _)
+  | TmFix fi
   | TmRef (fi, _) ->
       fi
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -212,9 +212,9 @@ and tm =
   (* Type let *)
   | TmType of info * ustring * Symb.t * ty * tm
   (* Constructor definition *)
-  | TmCondef of info * ustring * Symb.t * ty * tm
+  | TmConDef of info * ustring * Symb.t * ty * tm
   (* Constructor application *)
-  | TmConapp of info * ustring * Symb.t * tm
+  | TmConApp of info * ustring * Symb.t * tm
   (* Match data *)
   | TmMatch of info * tm * pat * tm * tm
   (* Unit testing *)
@@ -332,10 +332,10 @@ let rec map_tm f = function
       f (TmRecordUpdate (fi, map_tm f r, l, map_tm f t))
   | TmType (fi, x, s, ty, t1) ->
       f (TmType (fi, x, s, ty, map_tm f t1))
-  | TmCondef (fi, x, s, ty, t1) ->
-      f (TmCondef (fi, x, s, ty, map_tm f t1))
-  | TmConapp (fi, k, s, t) ->
-      f (TmConapp (fi, k, s, t))
+  | TmConDef (fi, x, s, ty, t1) ->
+      f (TmConDef (fi, x, s, ty, map_tm f t1))
+  | TmConApp (fi, k, s, t) ->
+      f (TmConApp (fi, k, s, t))
   | TmMatch (fi, t1, p, t2, t3) ->
       f (TmMatch (fi, map_tm f t1, p, map_tm f t2, map_tm f t3))
   | TmUtest (fi, t1, t2, tusing, tnext) ->
@@ -364,8 +364,8 @@ let tm_info = function
   | TmRecord (fi, _)
   | TmRecordUpdate (fi, _, _, _)
   | TmType (fi, _, _, _, _)
-  | TmCondef (fi, _, _, _, _)
-  | TmConapp (fi, _, _, _)
+  | TmConDef (fi, _, _, _, _)
+  | TmConApp (fi, _, _, _)
   | TmMatch (fi, _, _, _, _)
   | TmUtest (fi, _, _, _, _)
   | TmNever fi

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -10,23 +10,23 @@ open Intrinsics
 (* Terms *)
 let idTmVar = 100
 
-let idTmLam = 101
+let idTmApp = 101
 
-let idTmLet = 102
+let idTmLam = 102
 
-let idTmType = 103
+let idTmLet = 103
 
 let idTmRecLets = 104
 
-let idTmApp = 105
+let idTmConst = 105
 
-let idTmConst = 106
+let idTmSeq = 106
 
-let idTmSeq = 107
+let idTmRecord = 107
 
-let idTmRecord = 108
+let idTmRecordUpdate = 108
 
-let idTmRecordUpdate = 109
+let idTmType = 109
 
 let idTmCondef = 110
 
@@ -122,12 +122,12 @@ let getData = function
   (* Terms *)
   | PTreeTm (TmVar (fi, x, _)) ->
       (idTmVar, [fi], [], [], [], [x], [], [], [], [])
+  | PTreeTm (TmApp (fi, t1, t2)) ->
+      (idTmApp, [fi], [], [], [t1; t2], [], [], [], [], [])
   | PTreeTm (TmLam (fi, x, _, ty, t)) ->
       (idTmLam, [fi], [], [ty], [t], [x], [], [], [], [])
   | PTreeTm (TmLet (fi, x, _, ty, t1, t2)) ->
       (idTmLet, [fi], [], [ty], [t1; t2], [x], [], [], [], [])
-  | PTreeTm (TmType (fi, x, _, ty, t)) ->
-      (idTmType, [fi], [], [ty], [t], [x], [], [], [], [])
   | PTreeTm (TmRecLets (fi, lst, t)) ->
       let fis = fi :: List.map (fun (fi, _, _, _, _) -> fi) lst in
       let len = List.length lst in
@@ -135,8 +135,6 @@ let getData = function
       let tms = List.map (fun (_, _, _, _, t) -> t) lst @ [t] in
       let strs = List.map (fun (_, s, _, _, _) -> s) lst in
       (idTmRecLets, fis, [len], tys, tms, strs, [], [], [], [])
-  | PTreeTm (TmApp (fi, t1, t2)) ->
-      (idTmApp, [fi], [], [], [t1; t2], [], [], [], [], [])
   | PTreeTm (TmConst (fi, c)) ->
       (idTmConst, [fi], [], [], [], [], [], [], [c], [])
   | PTreeTm (TmSeq (fi, ts)) ->
@@ -148,6 +146,8 @@ let getData = function
       (idTmRecord, [fi], [List.length slst], [], tlst, slst, [], [], [], [])
   | PTreeTm (TmRecordUpdate (fi, t1, x, t2)) ->
       (idTmRecordUpdate, [fi], [], [], [t1; t2], [x], [], [], [], [])
+  | PTreeTm (TmType (fi, x, _, ty, t)) ->
+      (idTmType, [fi], [], [ty], [t], [x], [], [], [], [])
   | PTreeTm (TmCondef (fi, x, _, ty, t)) ->
       (idTmCondef, [fi], [], [ty], [t], [x], [], [], [], [])
   | PTreeTm (TmConapp (fi, x, _, t)) ->

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -28,9 +28,9 @@ let idTmRecordUpdate = 108
 
 let idTmType = 109
 
-let idTmCondef = 110
+let idTmConDef = 110
 
-let idTmConapp = 111
+let idTmConApp = 111
 
 let idTmMatch = 112
 
@@ -148,10 +148,10 @@ let getData = function
       (idTmRecordUpdate, [fi], [], [], [t1; t2], [x], [], [], [], [])
   | PTreeTm (TmType (fi, x, _, ty, t)) ->
       (idTmType, [fi], [], [ty], [t], [x], [], [], [], [])
-  | PTreeTm (TmCondef (fi, x, _, ty, t)) ->
-      (idTmCondef, [fi], [], [ty], [t], [x], [], [], [], [])
-  | PTreeTm (TmConapp (fi, x, _, t)) ->
-      (idTmConapp, [fi], [], [], [t], [x], [], [], [], [])
+  | PTreeTm (TmConDef (fi, x, _, ty, t)) ->
+      (idTmConDef, [fi], [], [ty], [t], [x], [], [], [], [])
+  | PTreeTm (TmConApp (fi, x, _, t)) ->
+      (idTmConApp, [fi], [], [], [t], [x], [], [], [], [])
   | PTreeTm (TmMatch (fi, t1, p, t2, t3)) ->
       (idTmMatch, [fi], [], [], [t1; t2; t3], [], [], [], [], [p])
   | PTreeTm (TmUtest (fi, t1, t2, t4_op, t3)) -> (

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -93,6 +93,12 @@ let idPatOr = 409
 
 let idPatNot = 410
 
+(* Info *)
+
+let idInfo = 500
+
+let idNoInfo = 501
+
 let sym = Symb.gensym ()
 
 let patNameToStr = function NameStr (x, _) -> x | NameWildcard -> us ""
@@ -199,6 +205,11 @@ let getData = function
       (idPatOr, [fi], [], [], [], [], [], [], [], [p1; p2])
   | PTreePat (PatNot (fi, p)) ->
       (idPatNot, [fi], [], [], [], [], [], [], [], [p])
+  (* Info *)
+  | PTreeInfo (Info (fn, r1, c1, r2, c2)) ->
+      (idInfo, [], [], [], [], [fn], [r1; c1; r2; c2], [], [], [])
+  | PTreeInfo NoInfo ->
+      (idNoInfo, [], [], [], [], [], [], [], [], [])
   | _ ->
       failwith "The AST node is unknown"
 
@@ -233,3 +244,7 @@ let getConst t n =
 let getPat t n =
   let _, _, _, _, _, _, _, _, _, lst = getData t in
   PTreePat (List.nth lst n)
+
+let getInfo t n =
+  let _, lst, _, _, _, _, _, _, _, _ = getData t in
+  PTreeInfo (List.nth lst n)

--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -208,7 +208,7 @@ rule main = parse
 	 let s = Ustring.from_utf8 (Buffer.contents string_buf) in
          let esc_s = Ustring.convert_escaped_chars s in
 	 let rval = Parser.STRING{i=mkinfo_ustring (s ^. us"  "); v=esc_s} in
-	 add_colno 2; rval}
+	 rval}
   | eof
       { Parser.EOF }
   | utf8 as c

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -128,7 +128,8 @@ let builtin =
   ; ("bootParserGetFloat", f (CbootParserGetFloat None))
   ; ("bootParserGetListLength", f (CbootParserGetListLength None))
   ; ("bootParserGetConst", f (CbootParserGetConst None))
-  ; ("bootParserGetPat", f (CbootParserGetPat None)) ]
+  ; ("bootParserGetPat", f (CbootParserGetPat None))
+  ; ("bootParserGetInfo", f (CbootParserGetInfo None)) ]
   (* Append external functions *)
   @ Ext.externals
   (* Append sundials intrinsics *)
@@ -432,6 +433,10 @@ let arity = function
   | CbootParserGetPat None ->
       2
   | CbootParserGetPat (Some _) ->
+      1
+  | CbootParserGetInfo None ->
+      2
+  | CbootParserGetInfo (Some _) ->
       1
   (* Python intrinsics *)
   | CPy v ->
@@ -1047,6 +1052,13 @@ let delta eval env fi c v =
     , TmConst (_, CInt n) ) ->
       TmConst (fi, CbootParserTree (Bootparser.getPat ptree n))
   | CbootParserGetPat (Some _), _ ->
+      fail_constapp fi
+  | CbootParserGetInfo None, t ->
+      TmConst (fi, CbootParserGetInfo (Some t))
+  | ( CbootParserGetInfo (Some (TmConst (fi, CbootParserTree ptree)))
+    , TmConst (_, CInt n) ) ->
+      TmConst (fi, CbootParserTree (Bootparser.getInfo ptree n))
+  | CbootParserGetInfo (Some _), _ ->
       fail_constapp fi
   (* Python intrinsics *)
   | CPy v, t ->

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -1,7 +1,7 @@
 (*
    Miking is licensed under the MIT license.
    Copyright (C) David Broman. See file LICENSE.txt
- *)
+*)
 
 open Ast
 open Msg
@@ -381,15 +381,15 @@ let rec desugar_tm nss env =
               (fi, empty_mangle name, s, ty, desugar_tm nss env' e))
             bindings
         , desugar_tm nss env' body )
-  | TmCondef (fi, name, s, ty, body) ->
-      TmCondef
+  | TmConDef (fi, name, s, ty, body) ->
+      TmConDef
         ( fi
         , empty_mangle name
         , s
         , ty
         , desugar_tm nss (delete_con env name) body )
-  | TmConapp (fi, x, s, t) ->
-      TmConapp (fi, resolve_con env x, s, desugar_tm nss env t)
+  | TmConApp (fi, x, s, t) ->
+      TmConApp (fi, resolve_con env x, s, desugar_tm nss env t)
   | TmClos _ as tm ->
       tm
   (* Both introducing and referencing *)
@@ -503,7 +503,7 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
       let ns = List.fold_left add_decl previous_ns decls in
       (* wrap in "con"s *)
       let wrap_con ty_name (CDecl (fi, cname, ty)) tm =
-        TmCondef
+        TmConDef
           ( fi
           , mangle cname
           , Symb.Helpers.nosym
@@ -583,7 +583,7 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
       (nss, wrap :: stack)
   | TopCon (Con (fi, id, ty)) ->
       let wrap tm' =
-        TmCondef (fi, empty_mangle id, Symb.Helpers.nosym, ty, tm')
+        TmConDef (fi, empty_mangle id, Symb.Helpers.nosym, ty, tm')
       in
       (nss, wrap :: stack)
   | TopUtest (Utest (fi, lhs, rhs, using)) ->

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -266,7 +266,7 @@ mexpr:
       { $1 }
   | TYPE type_ident type_params IN mexpr
       // Type parameters are currently ignored
-      { let fi = mkinfo $1.i (tm_info $5) in
+      { let fi = mkinfo $1.i $4.i in
         TmType(fi, $2.v, Symb.Helpers.nosym, TyVariant (fi, []), $5) }
   | TYPE type_ident type_params EQ ty IN mexpr
       // Type parameters are currently ignored
@@ -295,7 +295,7 @@ mexpr:
       { let fi = mkinfo $1.i $3.i in
         TmUse(fi,$2.v,$4) }
   | UTEST mexpr WITH mexpr IN mexpr
-      { let fi = mkinfo $1.i (tm_info $4) in
+      { let fi = mkinfo $1.i $5.i in
         TmUtest(fi,$2,$4,None,$6) }
   | UTEST mexpr WITH mexpr USING mexpr IN mexpr
       { let fi = mkinfo $1.i (tm_info $6) in

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -287,7 +287,7 @@ mexpr:
         TmMatch(fi,$2,PatBool(NoInfo,true),$4,$6) }
   | CON con_ident ty_op IN mexpr
       { let fi = mkinfo $1.i $4.i in
-        TmCondef(fi,$2.v,Symb.Helpers.nosym,$3,$5)}
+        TmConDef(fi,$2.v,Symb.Helpers.nosym,$3,$5)}
   | MATCH mexpr WITH pat THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $8) in
          TmMatch(fi,$2,$4,$6,$8) }
@@ -318,7 +318,7 @@ left:
         TmApp(fi,$1,$2) }
   | con_ident atom
       { let fi = mkinfo $1.i (tm_info $2) in
-        TmConapp(fi,$1.v,Symb.Helpers.nosym,$2) }
+        TmConApp(fi,$1.v,Symb.Helpers.nosym,$2) }
 
 
 atom:

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -410,6 +410,8 @@ let rec print_const fmt = function
       fprintf fmt "bootParserParseGetConst"
   | CbootParserGetPat _ ->
       fprintf fmt "bootParserParseGetPat"
+  | CbootParserGetInfo _ ->
+      fprintf fmt "bootParserParseGetInfo"
   (* Python intrinsics *)
   | CPy v ->
       fprintf fmt "%s" (string_of_ustring (Pypprint.pprint v))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -443,7 +443,7 @@ and print_tm fmt (prec, t) =
         Match
     | TmLam _ ->
         Lam
-    | TmConapp _ | TmSeq _ ->
+    | TmConApp _ | TmSeq _ ->
         Semicolon
     | TmApp _ ->
         App
@@ -452,7 +452,7 @@ and print_tm fmt (prec, t) =
     | TmConst _
     | TmRecord _
     | TmRecordUpdate _
-    | TmCondef _
+    | TmConDef _
     | TmUse _
     | TmUtest _
     | TmClos _
@@ -528,11 +528,11 @@ and print_tm' fmt t =
       let l = string_of_ustring l in
       (* TODO(?,?): The below Atom precedences can probably be made less conservative *)
       fprintf fmt "{%a with %s = %a}" print_tm (Atom, t1) l print_tm (Atom, t2)
-  | TmCondef (_, x, s, ty, t) ->
+  | TmConDef (_, x, s, ty, t) ->
       let str = string_of_ustring (ustring_of_var x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in
       fprintf fmt "@[<hov 0>con %s:%s in@ %a@]" str ty print_tm (Match, t)
-  | TmConapp (_, x, sym, t) ->
+  | TmConApp (_, x, sym, t) ->
       let str = string_of_ustring (ustring_of_var x sym) in
       fprintf fmt "%s %a" str print_tm (Atom, t)
   (* If expressions *)

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -64,7 +64,7 @@ lang AppANF = ANF + AppAst
 
 end
 
-lang FunANF = ANF + LamAst
+lang LamANF = ANF + LamAst
   sem isValue =
   | TmLam _ -> true
 
@@ -218,7 +218,7 @@ lang NeverANF = ANF + NeverAst
 end
 
 lang MExprANF =
-  VarANF + AppANF + FunANF + RecordANF + LetANF + TypeANF + RecLetsANF +
+  VarANF + AppANF + LamANF + RecordANF + LetANF + TypeANF + RecLetsANF +
   ConstANF + DataANF + MatchANF + UtestANF + SeqANF + NeverANF
 
 -----------

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -64,7 +64,7 @@ lang AppANF = ANF + AppAst
 
 end
 
-lang FunANF = ANF + FunAst
+lang FunANF = ANF + LamAst
   sem isValue =
   | TmLam _ -> true
 

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -8,6 +8,7 @@ include "mexpr/ast-builder.mc"
 include "mexpr/pprint.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/eq.mc"
+include "mexpr/info.mc"
 
 lang ANF = LetAst + VarAst + UnknownTypeAst
   sem isValue =
@@ -25,10 +26,14 @@ lang ANF = LetAst + VarAst + UnknownTypeAst
     let var = TmVar {
       ident = ident,
       ty = TyUnknown {},
-      fi = NoInfo {}
+      info = NoInfo {}
     } in
-    TmLet {ident = ident, tyBody = TyUnknown {},
-           body = n, inexpr = k var, ty = TyUnknown {}}
+    TmLet {ident = ident,
+           tyBody = TyUnknown {},
+           body = n,
+           inexpr = k var,
+           ty = TyUnknown {},
+           info = NoInfo{}}
 
   sem normalizeName (k : Expr -> Expr) =
   | m -> normalize (lam n. if (isValue n) then k n else bind k n) m
@@ -69,8 +74,8 @@ lang LamANF = ANF + LamAst
   | TmLam _ -> true
 
   sem normalize (k : Expr -> Expr) =
-  | TmLam {ident = ident, ty = ty, body = body} ->
-    k (TmLam {ident = ident, ty = ty, body = normalizeTerm body})
+  | TmLam {ident = ident, ty = ty, body = body, info = info} ->
+    k (TmLam {ident = ident, body = normalizeTerm body, ty = ty, info = info})
 
 end
 
@@ -122,8 +127,8 @@ lang TypeANF = ANF + TypeAst
   | TmType _ -> false
 
   sem normalize (k : Expr -> Expr) =
-  | TmType {ident = ident, ty = ty, inexpr = m1} ->
-    TmType {ident = ident, ty = ty, inexpr = normalizeName k m1}
+  | TmType {ident = ident, inexpr = m1, ty = ty, info = info} ->
+    TmType {ident = ident, ty = ty, inexpr = normalizeName k m1, info = info}
 
 end
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -15,28 +15,28 @@ let pvar_ = use MExprAst in
   npvar_ (nameNoSym s)
 
 let pvarw_ = use MExprAst in
-  PNamed {ident = PWildcard ()}
+  PNamed {ident = PWildcard (), info = NoInfo()}
 
 let punit_ = use MExprAst in
-  PRecord { bindings = assocEmpty }
+  PRecord { bindings = assocEmpty, info = NoInfo() }
 
 let pint_ = use MExprAst in
   lam i.
-  PInt {val = i}
+  PInt {val = i, info = NoInfo()}
 
 let pchar_ = use MExprAst in
   lam c.
-  PChar {val = c}
+  PChar {val = c, info = NoInfo()}
 
 let ptrue_ = use MExprAst in
-  PBool {val = true}
+  PBool {val = true, info = NoInfo()}
 
 let pfalse_ = use MExprAst in
-  PBool {val = false}
+  PBool {val = false, info = NoInfo()}
 
 let npcon_ = use MExprAst in
   lam n. lam cp.
-  PCon {ident = n, subpat = cp}
+  PCon {ident = n, subpat = cp, info = NoInfo()}
 
 let pcon_ = use MExprAst in
   lam cs. lam cp.
@@ -48,7 +48,8 @@ let prec_ = use MExprAst in
     bindings =
       foldl
         (lam acc. lam b. assocInsert {eq=eqString} b.0 b.1 acc)
-        assocEmpty bindings
+        assocEmpty bindings,
+    info = NoInfo()
     }
 
 let ptuple_ = use MExprAst in
@@ -57,15 +58,15 @@ let ptuple_ = use MExprAst in
 
 let pseqtot_ = use MExprAst in
   lam ps.
-  PSeqTot {pats = ps}
+  PSeqTot {pats = ps, info = NoInfo()}
 
 let pseqedgew_ = use MExprAst in
   lam pre. lam post.
-  PSeqEdge {prefix = pre, middle = PWildcard (), postfix = post}
+  PSeqEdge {prefix = pre, middle = PWildcard (), postfix = post, info = NoInfo()}
 
 let pseqedgen_ = use MExprAst in
   lam pre. lam middle. lam post.
-  PSeqEdge {prefix = pre, middle = PName middle, postfix = post}
+  PSeqEdge {prefix = pre, middle = PName middle, postfix = post, info = NoInfo()}
 
 let pseqedge_ = use MExprAst in
   lam pre. lam middle. lam post.
@@ -73,15 +74,15 @@ let pseqedge_ = use MExprAst in
 
 let pand_ = use MExprAst in
   lam l. lam r.
-  PAnd {lpat = l, rpat = r}
+  PAnd {lpat = l, rpat = r, info = NoInfo()}
 
 let por_ = use MExprAst in
   lam l. lam r.
-  POr {lpat = l, rpat = r}
+  POr {lpat = l, rpat = r, info = NoInfo()}
 
 let pnot_ = use MExprAst in
   lam p.
-  PNot {subpat = p}
+  PNot {subpat = p, info = NoInfo()}
 
 -- Types --
 let tyarrow_ = use MExprAst in

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -2,6 +2,7 @@
 
 include "mexpr/ast.mc"
 include "assoc.mc"
+include "info.mc"
 
 -- Patterns --
 
@@ -160,11 +161,12 @@ let bindall_ = use MExprAst in
   foldr1 bind_ exprs
 
 let unit_ = use MExprAst in
-  TmRecord {bindings = assocEmpty, ty = TyUnknown {}}
+  TmRecord {bindings = assocEmpty, ty = TyUnknown {}, info = NoInfo ()}
 
 let nlet_ = use MExprAst in
   lam n. lam ty. lam body.
-  TmLet {ident = n, tyBody = ty, body = body, inexpr = unit_, ty = TyUnknown {}}
+  TmLet {ident = n, tyBody = ty, body = body,
+  inexpr = unit_, ty = TyUnknown {}, info = NoInfo ()}
 
 let let_ = use MExprAst in
   lam s. lam ty. lam body.
@@ -180,7 +182,7 @@ let ulet_ = use MExprAst in
 
 let ntype_ = use MExprAst in
   lam n. lam ty.
-  TmType {ident = n, ty = ty, inexpr = unit_}
+  TmType {ident = n, ty = ty, inexpr = unit_, info = NoInfo ()}
 
 let type_ = use MExprAst in
   lam s. lam ty.
@@ -188,8 +190,8 @@ let type_ = use MExprAst in
 
 let nreclets_ = use MExprAst in
   lam bs.
-  TmRecLets {bindings = map (lam t. {ident = t.0, ty = t.1, body = t.2}) bs,
-             inexpr = unit_, ty = TyUnknown {}}
+  TmRecLets {bindings = map (lam t. {ident = t.0, ty = t.1, body = t.2, info = NoInfo ()}) bs,
+             inexpr = unit_, ty = TyUnknown {}, info = NoInfo ()}
 
 let reclets_ = use MExprAst in
   lam bs.
@@ -217,7 +219,7 @@ let reclets_empty = use MExprAst in
 let nreclets_add = use MExprAst in
   lam n. lam ty. lam body. lam reclets.
   match reclets with TmRecLets t then
-    let newbind = {ident = n, ty = ty, body = body} in
+    let newbind = {ident = n, ty = ty, body = body, info = NoInfo ()} in
     TmRecLets {t with bindings = cons newbind t.bindings}
   else
     error "reclets is not a TmRecLets construct"
@@ -236,7 +238,7 @@ let ureclets_add = use MExprAst in
 
 let ncondef_ = use MExprAst in
   lam n. lam ty.
-  TmConDef {ident = n, ty = ty, inexpr = unit_}
+  TmConDef {ident = n, ty = ty, inexpr = unit_, info = NoInfo ()}
 
 let condef_ = use MExprAst in
   lam s. lam ty.
@@ -252,7 +254,7 @@ let ucondef_ = use MExprAst in
 
 let nvar_ = use MExprAst in
   lam n.
-  TmVar {ident = n, ty = TyUnknown {}}
+  TmVar {ident = n, ty = TyUnknown {}, info = NoInfo ()}
 
 let var_ = use MExprAst in
   lam s.
@@ -260,7 +262,7 @@ let var_ = use MExprAst in
 
 let nconapp_ = use MExprAst in
   lam n. lam b.
-  TmConApp {ident = n, body = b, ty = TyUnknown {}}
+  TmConApp {ident = n, body = b, ty = TyUnknown {}, info = NoInfo ()}
 
 let conapp_ = use MExprAst in
   lam s. lam b.
@@ -268,11 +270,11 @@ let conapp_ = use MExprAst in
 
 let const_ = use MExprAst in
   lam c.
-  TmConst {val = c, ty = TyUnknown {}}
+  TmConst {val = c, ty = TyUnknown {}, info = NoInfo ()}
 
 let nlam_ = use MExprAst in
   lam n. lam ty. lam body.
-  TmLam {ident = n, ty = ty, body = body}
+  TmLam {ident = n, ty = ty, body = body, info = NoInfo ()}
 
 let lam_ = use MExprAst in
   lam s. lam ty. lam body.
@@ -296,15 +298,17 @@ let ulams_ = use MExprAst in
 
 let if_ = use MExprAst in
   lam cond. lam thn. lam els.
-  TmMatch {target = cond, pat = ptrue_, thn = thn, els = els, ty = TyUnknown {}}
+  TmMatch {target = cond, pat = ptrue_, thn = thn,
+           els = els, ty = TyUnknown {}, info = NoInfo ()}
 
 let match_ = use MExprAst in
   lam target. lam pat. lam thn. lam els.
-  TmMatch {target = target, pat = pat, thn = thn, els = els, ty = TyUnknown {}}
+  TmMatch {target = target, pat = pat, thn = thn, els = els,
+           ty = TyUnknown {}, info = NoInfo ()}
 
 let seq_ = use MExprAst in
   lam tms.
-  TmSeq {tms = tms, ty = TyUnknown {}}
+  TmSeq {tms = tms, ty = TyUnknown {}, info = NoInfo ()}
 
 let record_ = use MExprAst in
   lam bindings.
@@ -313,7 +317,8 @@ let record_ = use MExprAst in
       foldl
         (lam acc. lam b. assocInsert {eq=eqString} b.0 b.1 acc)
         assocEmpty bindings,
-    ty = TyUnknown {}
+    ty = TyUnknown {},
+    info = NoInfo ()
   }
 
 let tuple_ = use MExprAst in
@@ -333,7 +338,7 @@ let record_add_bindings = lam bindings. lam record.
   foldl (lam recacc. lam b. record_add b.0 b.1 recacc) record bindings
 
 let never_ = use MExprAst in
-  TmNever {ty = TyUnknown {}}
+  TmNever {ty = TyUnknown {}, info = NoInfo ()}
 
 let nrecordproj_ = use MExprAst in
   lam name. lam key. lam r.
@@ -356,11 +361,11 @@ let tupleproj_ = use MExprAst in
 
 let recordupdate_ = use MExprAst in
   lam rec. lam key. lam value.
-  TmRecordUpdate {rec = rec, key = key, value = value, ty = TyUnknown {}}
+  TmRecordUpdate {rec = rec, key = key, value = value, ty = TyUnknown {}, info = NoInfo ()}
 
 let app_ = use MExprAst in
   lam l. lam r.
-  TmApp {lhs = l, rhs = r, ty = TyUnknown {}}
+  TmApp {lhs = l, rhs = r, ty = TyUnknown {}, info = NoInfo ()}
 
 let appSeq_ = use MExprAst in
   lam f. lam seq.
@@ -400,7 +405,7 @@ let appf8_ = use MExprAst in
 
 let utest_ = use MExprAst in
   lam t. lam e. lam n.
-  TmUtest {test = t, expected = e, next = n, ty = TyUnknown {}}
+  TmUtest {test = t, expected = e, next = n, ty = TyUnknown {}, info = NoInfo ()}
 
 
 -- Ascription
@@ -430,7 +435,7 @@ let char_ = use MExprAst in
 
 let str_ = use MExprAst in
   lam s.
-  TmSeq {tms = map char_ s, ty = TyUnknown {}}
+  TmSeq {tms = map char_ s, ty = TyUnknown {}, info = NoInfo ()}
 
 let symb_ = use MExprAst in
   lam c.

--- a/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -1,5 +1,6 @@
 include "ast.mc"
 include "ast-builder.mc"
+include "info.mc"
 
 -- This file contains tests for the sfold and smap semantic functions
 -- defined in "ast.mc". These will eventually be automatically generated,
@@ -173,7 +174,7 @@ let cInt2cChar =
 lam e. match e with TmConst t then
          match t.val with CInt i
            then TmConst {val = CChar {val = int2char i.val},
-                         ty = TyUnknown {}}
+                         ty = TyUnknown {}, info = NoInfo()}
          else e
        else e
 in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -11,10 +11,12 @@ include "mexpr/info.mc"
 
 lang VarAst
   syn Expr =
-  | TmVar {ident : Name, ty: Type, fi: Info}
+  | TmVar {ident : Name,
+           ty: Type,
+           info: Info}
 
   sem info =
-  | TmVar r -> r.fi
+  | TmVar r -> r.info
 
   sem ty =
   | TmVar t -> t.ty
@@ -31,10 +33,13 @@ end
 
 lang AppAst
   syn Expr =
-  | TmApp {lhs : Expr, rhs : Expr, ty: Type, fi: Info}
+  | TmApp {lhs : Expr,
+           rhs : Expr,
+           ty: Type,
+           info: Info}
 
   sem info =
-  | TmApp r -> r.fi
+  | TmApp r -> r.info
 
   sem ty =
   | TmApp t -> t.ty
@@ -54,12 +59,12 @@ end
 lang FunAst = VarAst + AppAst
   syn Expr =
   | TmLam {ident : Name,
-           ty    : Type,
-           body  : Expr,
-           fi    : Info}
+           body : Expr,
+           ty : Type,
+           info : Info}
 
   sem info =
-  | TmLam r -> r.fi
+  | TmLam r -> r.info
 
   sem ty =
   | TmLam t -> t.ty

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -550,12 +550,16 @@ end
 --------------
 
 type PatName
-con PName     : Name -> PatName
-con PWildcard : ()   -> PatName
+con PName : Name -> PatName
+con PWildcard : () -> PatName
 
 lang NamedPat
   syn Pat =
-  | PNamed {ident : PatName}
+  | PNamed {ident : PatName,
+            info : Info}
+
+  sem info =
+  | PNamed r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PNamed p -> PNamed p
@@ -566,7 +570,11 @@ end
 
 lang SeqTotPat
   syn Pat =
-  | PSeqTot { pats : [Pat] }
+  | PSeqTot {pats : [Pat],
+             info : Info}
+
+  sem info =
+  | PSeqTot r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PSeqTot p -> PSeqTot {p with pats = map f p.pats}
@@ -577,10 +585,17 @@ end
 
 lang SeqEdgePat
   syn Pat =
-  | PSeqEdge {prefix : [Pat], middle: PatName, postfix : [Pat]}
+  | PSeqEdge {prefix : [Pat],
+              middle: PatName,
+              postfix : [Pat],
+              info: Info}
+
+  sem info =
+  | PSeqEdge r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PSeqEdge p -> PSeqEdge {{p with prefix = map f p.prefix} with postfix = map f p.postfix}
+  | PSeqEdge p ->
+      PSeqEdge {{p with prefix = map f p.prefix} with postfix = map f p.postfix}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
   | PSeqEdge {prefix = pre, postfix = post} -> foldl f (foldl f acc pre) post
@@ -588,19 +603,29 @@ end
 
 lang RecordPat
   syn Pat =
-  | PRecord {bindings : AssocMap String Pat}
+  | PRecord {bindings : AssocMap String Pat,
+             info: Info}
+
+  sem info =
+  | PRecord r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PRecord b -> PRecord {b with bindings = assocMap {eq=eqString} (lam b. (b.0, f b.1)) b.bindings}
+  | PRecord b ->
+      PRecord {b with bindings = assocMap {eq=eqString} (lam b. (b.0, f b.1)) b.bindings}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PRecord {bindings = bindings} -> assocFold {eq=eqString} (lam acc. lam _k. lam v. f acc v) acc bindings
+  | PRecord {bindings = bindings} -> assocFold {eq=eqString}
+                    (lam acc. lam _k. lam v. f acc v) acc bindings
 end
 
 lang DataPat = DataAst
   syn Pat =
-  | PCon {ident  : Name,
-          subpat : Pat}
+  | PCon {ident : Name,
+          subpat : Pat,
+          info : Info}
+
+  sem info =
+  | PCon r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PCon c -> PCon {c with subpat = f c.subpat}
@@ -611,7 +636,11 @@ end
 
 lang IntPat = IntAst
   syn Pat =
-  | PInt {val : Int}
+  | PInt {val : Int,
+          info : Info}
+
+  sem info =
+  | PInt r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PInt v -> PInt v
@@ -622,7 +651,11 @@ end
 
 lang CharPat
   syn Pat =
-  | PChar {val : Char}
+  | PChar {val : Char,
+           info : Info}
+
+  sem info =
+  | PChar r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PChar v -> PChar v
@@ -633,10 +666,11 @@ end
 
 lang BoolPat = BoolAst
   syn Pat =
-  | PBool {val : Bool, fi : Info}
+  | PBool {val : Bool,
+           info : Info}
 
   sem info =
-  | PBool r -> r.fi
+  | PBool r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PBool v -> PBool v
@@ -647,7 +681,12 @@ end
 
 lang AndPat
   syn Pat =
-  | PAnd {lpat : Pat, rpat : Pat}
+  | PAnd {lpat : Pat,
+          rpat : Pat,
+          info : Info}
+
+  sem info =
+  | PAnd r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PAnd p -> PAnd {{p with lpat = f p.lpat} with rpat = f p.rpat}
@@ -658,7 +697,12 @@ end
 
 lang OrPat
   syn Pat =
-  | POr {lpat : Pat, rpat : Pat}
+  | POr {lpat : Pat,
+         rpat : Pat,
+         info : Info}
+
+  sem info =
+  | POr r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | POr p -> POr {{p with lpat = f p.lpat} with rpat = f p.rpat}
@@ -669,7 +713,11 @@ end
 
 lang NotPat
   syn Pat =
-  | PNot {subpat : Pat}
+  | PNot {subpat : Pat,
+          info : Info}
+
+  sem info =
+  | PNot r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PNot p -> PNot {p with subpat = f p.subpat}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -88,15 +88,15 @@ end
 -- TmLet --
 lang LetAst = VarAst
   syn Expr =
-  | TmLet {ident  : Name,
+  | TmLet {ident : Name,
            tyBody : Type,
-           body   : Expr,
+           body : Expr,
            inexpr : Expr,
-           ty     : Type,
-           fi     : Info}
+           ty : Type,
+           info : Info}
 
   sem info =
-  | TmLet r -> r.fi
+  | TmLet r -> r.info
 
   sem ty =
   | TmLet t -> t.ty
@@ -116,10 +116,15 @@ end
 lang RecLetsAst = VarAst
   syn Expr =
   | TmRecLets {bindings : [{ident : Name,
-                            ty    : Type,
-                            body  : Expr}],
-               inexpr   : Expr,
-               ty       : Type}
+                            ty : Type,
+                            body : Expr,
+                            info : Info}],
+               inexpr : Expr,
+               ty : Type,
+               info : Info}
+
+  sem info =
+  | TmRecLets r -> r.info
 
   sem ty =
   | TmRecLets t -> t.ty

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -56,7 +56,7 @@ lang AppAst
 
 end
 
-lang FunAst = VarAst + AppAst
+lang LamAst = VarAst + AppAst
   syn Expr =
   | TmLam {ident : Name,
            body : Expr,
@@ -698,7 +698,7 @@ end
 lang MExprAst =
 
   -- Terms
-  VarAst + AppAst + FunAst + RecordAst + LetAst + TypeAst + RecLetsAst +
+  VarAst + AppAst + LamAst + RecordAst + LetAst + TypeAst + RecLetsAst +
   ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst + RefAst +
 
   -- Constants

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -148,10 +148,12 @@ lang ConstAst
   syn Const =
 
   syn Expr =
-  | TmConst {val : Const, ty: Type, fi: Info}
+  | TmConst {val : Const,
+             ty: Type,
+             info: Info}
 
   sem info =
-  | TmConst r -> r.fi
+  | TmConst r -> r.info
 
   sem ty =
   | TmConst t -> t.ty

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -193,7 +193,7 @@ lang SeqAst
 end
 
 
--- TmRecord and TmRecorsUpdate -- 
+-- TmRecord and TmRecordUpdate -- 
 lang RecordAst
   syn Expr =
   | TmRecord {bindings : AssocMap String Expr,

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -3,6 +3,7 @@
 include "string.mc"
 include "name.mc"
 include "assoc.mc"
+include "info.mc"
 include "mexpr/info.mc"
 
 -----------
@@ -171,10 +172,12 @@ end
 -- TmSeq --
 lang SeqAst
   syn Expr =
-  | TmSeq {tms : [Expr], ty: Type, fi: Info}
+  | TmSeq {tms : [Expr],
+           ty: Type,
+           info: Info}
 
   sem info =
-  | TmSeq r -> r.fi
+  | TmSeq r -> r.info
 
   sem ty =
   | TmSeq t -> t.ty
@@ -195,16 +198,16 @@ lang RecordAst
   syn Expr =
   | TmRecord {bindings : AssocMap String Expr,
               ty : Type, 
-              fi : Info}
-  | TmRecordUpdate {rec   : Expr,
-                    key   : String,
+              info : Info}
+  | TmRecordUpdate {rec : Expr,
+                    key : String,
                     value : Expr,
-                    ty    : Type,
-                    fi : Info}
+                    ty : Type,
+                    info : Info}
 
   sem info =
-  | TmRecord r -> r.fi
-  | TmRecordUpdate r -> r.fi
+  | TmRecord r -> r.info
+  | TmRecordUpdate r -> r.info
 
   sem ty =
   | TmRecord t -> t.ty
@@ -227,13 +230,13 @@ end
 -- TmType -- 
 lang TypeAst
   syn Expr =
-  | TmType {ident  : Name,
-            ty     : Type,
+  | TmType {ident : Name,
+            ty : Type,
             inexpr : Expr,
-            fi     : Info}
+            info : Info}
 
   sem info =
-  | TmType r -> r.fi
+  | TmType r -> r.info
 
   sem ty =
   | TmType t -> t.ty
@@ -251,12 +254,18 @@ end
 -- TmCondef and TmConApp --
 lang DataAst
   syn Expr =
-  | TmConDef {ident  : Name,
-              ty     : Type,
-              inexpr : Expr}
+  | TmConDef {ident : Name,
+              ty : Type,
+              inexpr : Expr,
+              info : Info}
   | TmConApp {ident : Name,
-              body  : Expr,
-              ty    : Type}
+              body : Expr,
+              ty : Type,
+              info: Info}
+
+  sem info =
+  | TmConDef r -> r.info
+  | TmConApp r -> r.info
 
   sem ty =
   | TmConDef t -> t.ty
@@ -283,12 +292,12 @@ lang MatchAst
              thn    : Expr,
              els    : Expr,
              ty     : Type,
-             fi     : Info}
+             info     : Info}
 
   syn Pat =
 
   sem info =
-  | TmMatch r -> r.fi
+  | TmMatch r -> r.info
 
   sem ty =
   | TmMatch t -> t.ty
@@ -309,10 +318,14 @@ end
 -- TmUtest --
 lang UtestAst
   syn Expr =
-  | TmUtest {test     : Expr,
+  | TmUtest {test : Expr,
              expected : Expr,
-             next     : Expr,   
-             ty       : Type} 
+             next : Expr,   
+             ty : Type,
+             info : Info} 
+
+  sem info =
+  | TmUtest r -> r.info
 
   sem ty =
   | TmUtest t -> t.ty
@@ -333,10 +346,11 @@ end
 -- TmNever --
 lang NeverAst
   syn Expr =
-  | TmNever {ty: Type, fi: Info}
+  | TmNever {ty: Type,
+            info: Info}
 
   sem info =
-  | TmNever r -> r.fi
+  | TmNever r -> r.info
 
   sem ty =
   | TmNever t -> t.ty
@@ -353,9 +367,14 @@ end
 
 
 -- TmRef --
+-- TODO (dbro, 2020-02-16): this term should be moved into an evaluation term
+-- in the same way as for closures. Eventually, this should be a rank 0 tensor.
 lang RefAst
   syn Expr =
   | TmRef {ref : Ref}
+
+  sem info =
+  | TmRef r -> NoInfo ()
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | TmRef t -> TmRef t

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -224,6 +224,8 @@ utest l_info "  _aas_12 " with r_info 1 2 1 9 in
 let s = "let y = lam x.x in y" in
 utest lside s with rside s in
 utest l_info "  \n lam x.x" with r_info 2 1 2 8 in
+utest info (match parseMExprString s with TmLet r then r.body else ())
+with r_info 1 8 1 15 in
 
 -- TmType
 let s = "type Foo in x" in

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -39,23 +39,23 @@ lang BootParser = MExprAst
       TmVar {ident = gname t 0,
              ty = TyUnknown(),
              info = ginfo t}
-  | 101 /-TmLam-/ ->
+  | 101 /-TmApp-/ ->
+      TmApp {lhs = gterm t 0,
+             rhs = gterm t 1,
+             ty = TyUnknown(),
+             fi = ginfo t}     
+  | 102 /-TmLam-/ ->
       TmLam {ident = gname t 0,
              ty = gtype t 0,
              info = ginfo t,
              body = gterm t 0}
-  | 102 /-TmLet-/ ->
+  | 103 /-TmLet-/ ->
       TmLet {ident = gname t 0,
              tyBody = gtype t 0,
              body = gterm t 0,
              inexpr = gterm t 1,
              ty = TyUnknown(),
              fi = ginfo t}
-  | 103 /-TmType-/ ->
-      TmType {ident = gname t 0,
-              ty = gtype t 0,
-              inexpr = gterm t 0,
-              fi = ginfo t}
   | 104 /-TmRecLets-/ ->
       TmRecLets {bindings =
                    makeSeq (lam n. {ident = gname t n,
@@ -63,12 +63,7 @@ lang BootParser = MExprAst
                                  body = gterm t n}) (glistlen t 0),
                  inexpr = gterm t (glistlen t 0),
                  ty = TyUnknown()}                            
-  | 105 /-TmApp-/ ->
-      TmApp {lhs = gterm t 0,
-             rhs = gterm t 1,
-             ty = TyUnknown(),
-             fi = ginfo t}     
-  | 106 /-TmConst-/ ->
+  | 105 /-TmConst-/ ->
       let c = gconst t 0 in
       TmConst {val = gconst t 0,
                ty = match c with CBool _ then TyBool {} else
@@ -76,21 +71,26 @@ lang BootParser = MExprAst
                     match c with CFloat _ then TyFloat {} else
                     TyChar {},
                fi = ginfo t}
-  | 107 /-TmSeq-/ ->
+  | 106 /-TmSeq-/ ->
       TmSeq {tms = makeSeq (lam n. gterm t n) (glistlen t 0),
              ty =  TyUnknown(),
              fi = ginfo t}
-  | 108 /-TmRecord-/ ->
+  | 107 /-TmRecord-/ ->
      let lst = makeSeq (lam n. (gstr t n, gterm t n)) (glistlen t 0) in
       TmRecord {bindings = seq2assoc {eq = eqString} lst,
                ty = TyUnknown(),
                fi = ginfo t}
-  | 109 /-TmRecordUpdate-/ ->
+  | 108 /-TmRecordUpdate-/ ->
      TmRecordUpdate {rec = gterm t 0,
                     key = gstr t 0,
                     value = gterm t 1,
                     ty = TyUnknown(),
                     fi = ginfo t}
+  | 109 /-TmType-/ ->
+      TmType {ident = gname t 0,
+              ty = gtype t 0,
+              inexpr = gterm t 0,
+              fi = ginfo t}
   | 110 /-TmConDef-/ ->
      TmConDef {ident = gname t 0,
                ty = gtype t 0,

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -59,9 +59,10 @@ lang BootParser = MExprAst
   | 104 /-TmRecLets-/ ->
       TmRecLets {bindings =
                    makeSeq (lam n. {ident = gname t n,
-                                 ty = gtype t n,
-                                 body = gterm t n}) (glistlen t 0),
-                                 info = ginfo t (addi n 1),
+                                    ty = gtype t n,
+                                    body = gterm t n,
+                                    info = ginfo t (addi n 1)})
+                                      (glistlen t 0),                                 
                  inexpr = gterm t (glistlen t 0),
                  ty = TyUnknown(),
                  info = ginfo t 0}                            
@@ -244,7 +245,10 @@ let s = "recursive let x = lam x.x in x" in
 utest lside s with rside s in
 let s = "recursive let x = lam x.x let y = lam x. x in y" in
 utest lside s with rside s in
-utest l_info "   recursive let x = 5 \n let foo = 7 in x "  with r_info 1 3 2 15 in
+let s = "   recursive let x = 5 \n let foo = 7 in x " in
+utest l_info s with r_info 1 3 2 15 in
+utest match parseMExprString s with TmRecLets r then (head (r.bindings)).info else ()
+with r_info 1 13 1 22 in
 
 -- TmConst
 let s = "true" in

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -8,7 +8,7 @@ include "mexpr/ast-builder.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/eq.mc"
 
-lang FunCPS = FunSym + FunEq + UnknownTypeSym + UnknownTypeEq
+lang FunCPS = LamSym + LamEq + UnknownTypeSym + UnknownTypeEq
 
   sem cpsK (cont: Expr -> Expr) =
   | TmLam t -> cont (cpsM (TmLam t))

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -84,13 +84,13 @@ let hole_ = use HoleAst in
 
 type CallGraph = DiGraph Name Symbol
 
-let _handleLetVertex = use FunAst in
+let _handleLetVertex = use LamAst in
   lam letexpr. lam f.
     match letexpr.body with TmLam lm
     then cons letexpr.ident (f lm.body)
     else f letexpr.body
 
-let _handleLetEdge = use FunAst in
+let _handleLetEdge = use LamAst in
   lam letexpr. lam f. lam g. lam prev.
     match letexpr.body with TmLam lm
     then f g letexpr.ident lm.body
@@ -117,7 +117,7 @@ let _handleApps = use AppAst in use VarAst in
 -- time potentially perform a graph union operation, which we assume has
 -- complexity O(|F|). V is the set of nodes in the AST and F is the set of nodes
 -- in the call graph (i.e. set of functions in the AST).
-lang Ast2CallGraph = LetAst + FunAst + RecLetsAst
+lang Ast2CallGraph = LetAst + LamAst + RecLetsAst
   sem toCallGraph =
   | arg ->
     let gempty = digraphAddVertex _top (digraphEmpty _eqn eqsym) in

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -111,7 +111,7 @@ lang AppEq = Eq + AppAst
     else None ()
 end
 
-lang FunEq = Eq + FunAst + VarEq + AppEq
+lang FunEq = Eq + LamAst + VarEq + AppEq
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmLam r ->
     match env with {varEnv = varEnv} then

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -111,7 +111,7 @@ lang AppEq = Eq + AppAst
     else None ()
 end
 
-lang FunEq = Eq + LamAst + VarEq + AppEq
+lang LamEq = Eq + LamAst + VarEq + AppEq
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmLam r ->
     match env with {varEnv = varEnv} then
@@ -603,7 +603,7 @@ lang MExprEq =
   MExprSym
 
   -- Terms
-  + VarEq + AppEq + FunEq + RecordEq + LetEq + RecLetsEq + ConstEq + DataEq +
+  + VarEq + AppEq + LamEq + RecordEq + LetEq + RecLetsEq + ConstEq + DataEq +
   MatchEq + UtestEq + SeqEq + NeverEq
 
   -- Constants

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -77,7 +77,7 @@ lang AppEval = AppAst
   | TmApp t -> apply ctx (eval ctx t.rhs) (eval ctx t.lhs)
 end
 
-lang FunEval = FunAst + VarEval + AppEval
+lang FunEval = LamAst + VarEval + AppEval
   syn Expr =
   | TmClos {ident : Name, body : Expr, env : Env}
 
@@ -97,7 +97,7 @@ lang LetEval = LetAst + VarEval
 end
 
 -- Fixpoint operator is only needed for eval. Hence, it is not in ast.mc
-lang FixAst = FunAst
+lang FixAst = LamAst
   syn Expr =
   | TmFix ()
 end

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1,7 +1,5 @@
 -- Interpreters for the various fragments of MExpr.
 
--- TODO(?,?): Add types
-
 include "string.mc"
 include "char.mc"
 include "assoc.mc"
@@ -77,7 +75,7 @@ lang AppEval = AppAst
   | TmApp t -> apply ctx (eval ctx t.rhs) (eval ctx t.lhs)
 end
 
-lang FunEval = LamAst + VarEval + AppEval
+lang LamEval = LamAst + VarEval + AppEval
   syn Expr =
   | TmClos {ident : Name, body : Expr, env : Env}
 
@@ -102,7 +100,7 @@ lang FixAst = LamAst
   | TmFix ()
 end
 
-lang FixEval = FixAst + FunEval
+lang FixEval = FixAst + LamEval
   sem apply (ctx : {env : Env}) (arg : Expr) =
   | TmFix _ ->
     match arg with TmClos clos then
@@ -918,7 +916,7 @@ lang MExprEval =
   MExprSym + MExprEq
 
   -- Terms
-  + VarEval + AppEval + FunEval + FixEval + RecordEval + RecLetsEval +
+  + VarEval + AppEval + LamEval + FixEval + RecordEval + RecLetsEval +
   ConstEval + DataEval + MatchEval + UtestEval + SeqEval + NeverEval + RefEval
 
   -- Constants

--- a/stdlib/mexpr/infix.mc
+++ b/stdlib/mexpr/infix.mc
@@ -25,7 +25,7 @@ lang MExprMakeConstBinOp = ArithIntAst + AppAst
       val = lam x. lam y.
         let op = TmConst {val = op, fi = makeInfo p p2} in
         let app = lam x. lam y. 
-                TmApp {lhs = x, rhs = y, fi = mergeInfo (info x) (info y)} in
+                TmApp {lhs = x, rhs = y, info = mergeInfo (info x) (info y)} in
         let res = (app (app op x) y) in
         res, 
       pos = p2, str = xs, assoc = assoc, prec = prec}

--- a/stdlib/mexpr/infix.mc
+++ b/stdlib/mexpr/infix.mc
@@ -16,14 +16,14 @@ include "mexpr/pprint.mc"
 include "ast-builder.mc"
 
 -- Fragment for constructing constant binary operators. Used by InfixArithParser
-lang MExprMakeConstBinOp = ArithIntAst + AppAst
+lang MExprMakeConstBinOp = ArithIntAst + AppAst + UnknownTypeAst
   sem makeConstBinOp (n: Int) (p: Pos) (xs: String)
                      (assoc: Associativity) (prec: Int) =
   | op ->
     let p2 = advanceCol p 1 in
     Some {
       val = lam x. lam y.
-        let op = TmConst {val = op, fi = makeInfo p p2} in
+        let op = TmConst {val = op, ty = TyUnknown (), info = makeInfo p p2} in
         let app = lam x. lam y. 
                 TmApp {lhs = x, rhs = y, info = mergeInfo (info x) (info y)} in
         let res = (app (app op x) y) in

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -284,7 +284,7 @@
 --                            with rhs = lamliftReplaceIdentifiers newnames t.rhs}
 -- end
 --
--- lang FunLamlift = VarLamlift + FunAst + ConstAst + UnitAst
+-- lang FunLamlift = VarLamlift + LamAst + ConstAst + UnitAst
 --     syn Expr =
 --     | TmLamChain {body : Expr}
 --

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -399,14 +399,14 @@ lang VarParser = ExprParser + IdentParser + VarAst + UnknownTypeAst
   sem nextIdent (p: Pos) (xs: string) =
   | x ->
       let p2 = advanceCol p (length x) in
-      {val = TmVar {ident = nameNoSym x, ty = TyUnknown {}, fi = makeInfo p p2},
+      {val = TmVar {ident = nameNoSym x, ty = TyUnknown {}, info = makeInfo p p2},
        pos = p2, str = xs}
 end
 
 
 -- Parsing of a lambda
 lang FunParser =
-  ExprParser + IdentParser + KeywordUtils + FunAst + UnknownTypeAst
+  ExprParser + IdentParser + KeywordUtils + LamAst + UnknownTypeAst
 
   sem nextIdent (p: Pos) (xs: String) =
   | "lam" ->
@@ -415,9 +415,8 @@ lang FunParser =
     let r3 = matchKeyword "." r2.pos r2.str  in
     let e = parseExprMain r3.pos 0 r3.str in
     {val = TmLam {ident = nameNoSym r2.val, ty = TyUnknown {},
-                  body = e.val, fi = makeInfo p e.pos},
+                  body = e.val, info = makeInfo p e.pos},
      pos = e.pos, str = e.str}
-    -- TODO (David, 2020-09-27): Add parsing of type
 end
 
 
@@ -476,7 +475,7 @@ lang ExprInfixParserJuxtaposition = ExprInfixParser + AppAst + UnknownTypeAst
   | str ->
     Some {
       val = lam x. lam y.
-        TmApp {lhs = x, rhs = y, ty = TyUnknown {}, fi = mergeInfo (info x) (info y)},
+        TmApp {lhs = x, rhs = y, ty = TyUnknown {}, info = mergeInfo (info x) (info y)},
       pos = p, str = str, assoc = LeftAssoc (), prec = 50}
 end
 

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -162,13 +162,13 @@ lang BoolParser = ExprParser + IdentParser + ConstAst + BoolAst + UnknownTypeAst
       let p2 = advanceCol p 4 in
       {val = TmConst {val = CBool {val = true},
                       ty = TyUnknown {},
-                      fi = makeInfo p p2},
+                      info = makeInfo p p2},
        pos = p2, str = xs}
   | "false" ->
       let p2 = advanceCol p 5 in
       {val = TmConst {val = CBool {val = false},
                       ty = TyUnknown {},
-                      fi = makeInfo p p2},
+                      info = makeInfo p p2},
        pos = p2, str = xs}
 end
 
@@ -233,7 +233,7 @@ lang UIntParser = UNumParser + ConstAst + IntAst + UnknownTypeAst
     let p2 = advanceCol p (length n) in
     {val = TmConst {val = CInt {val = string2int n},
                     ty = TyUnknown {},
-                    fi = makeInfo p p2},
+                    info = makeInfo p p2},
      pos = p2, str = xs}
 end
 
@@ -251,13 +251,13 @@ lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst + UnknownTypeAst
             CInt {val = string2int pre}
         in {val = TmConst {val = constVal,
                            ty = TyUnknown {},
-                           fi = makeInfo p pos},
+                           info = makeInfo p pos},
             pos = pos, str = cons expChar s}
       else
         let floatStr = join [pre, "e", exp.val] in
         {val = TmConst {val = CFloat {val = string2float floatStr},
                         ty = TyUnknown {},
-                        fi = makeInfo p exp.pos},
+                        info = makeInfo p exp.pos},
          pos = exp.pos, str = exp.str}
     in
     let p2 = advanceCol p (length n) in
@@ -273,14 +273,14 @@ lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst + UnknownTypeAst
         else
           {val = TmConst {val = CFloat {val = string2float preExponentStr},
                           ty = TyUnknown {},
-                          fi = makeInfo p n2.pos},
+                          info = makeInfo p n2.pos},
            pos = n2.pos, str = n2.str}
       else match s with ['e' | 'E'] ++ s2 then
         exponentHelper p3 n (head s) s2 true
       else
         {val = TmConst {val = CFloat {val = string2float n},
                         ty = TyUnknown {},
-                        fi = makeInfo p p3},
+                        info = makeInfo p p3},
          pos = p3, str = s}
     else match c with 'e' | 'E' then
       exponentHelper (advanceCol p (length n)) n c (tail xs) false
@@ -312,9 +312,9 @@ lang IfParser =
      let e2 = parseExprMain r1.pos 0 r1.str in
      let r2 = matchKeyword "else" e2.pos e2.str  in
      let e3 = parseExprMain r2.pos 0 r2.str in
-     {val = TmMatch {target = e1.val, pat = PBool {val = true, fi = NoInfo ()},
+     {val = TmMatch {target = e1.val, pat = PBool {val = true, info = NoInfo ()},
                      thn = e2.val, els = e3.val, ty = TyUnknown {},
-                     fi = makeInfo p e3.pos},
+                     info = makeInfo p e3.pos},
       pos = e3.pos,
       str = e3.str}
  end
@@ -337,7 +337,7 @@ lang SeqParser = ExprParser + KeywordUtils + SeqAst + UnknownTypeAst
       recursive let work = lam acc. lam first. lam p2. lam str.
         let r = eatWSAC p2 str in
   	match r.str with "]" ++ xs then
-	  {val = TmSeq{tms = acc, ty = TyUnknown {}, fi = makeInfo p (advanceCol r.pos 1)},
+	  {val = TmSeq{tms = acc, ty = TyUnknown {}, info = makeInfo p (advanceCol r.pos 1)},
 	   pos = advanceCol r.pos 1, str = xs}
 	else
 	  let r2 = if first then r else matchKeyword "," r.pos r.str in
@@ -370,12 +370,12 @@ lang StringParser = ExprParser + SeqAst + CharAst + UnknownTypeAst
     recursive let work = lam acc. lam p2. lam str.
       match str with "\"" ++ xs then
         {val = TmSeq {tms = acc, ty = TyUnknown {},
-                      fi = makeInfo p (advanceCol p2 1)},
+                      info = makeInfo p (advanceCol p2 1)},
 	 pos = advanceCol p2 1, str = xs}
       else
         let r =  matchChar p2 str in
         let v = TmConst {val = CChar {val = r.val}, ty = TyUnknown {},
-                         fi = makeInfo p2 r.pos} in
+                         info = makeInfo p2 r.pos} in
 	work (snoc acc v) r.pos r.str
     in
       work [] (advanceCol p 1) xs
@@ -388,7 +388,7 @@ lang CharParser = ExprParser + KeywordUtils + CharAst + UnknownTypeAst
       let r =  matchChar (advanceCol p 1) xs in
       let r2 = matchKeyword "\'" r.pos r.str in
       {val = TmConst {val = CChar {val = r.val}, ty = TyUnknown {},
-                      fi = makeInfo p r2.pos},
+                      info = makeInfo p r2.pos},
        pos = r2.pos, str = r2.str}
 end
 
@@ -501,80 +501,80 @@ use MExprParser in
 -- Unsigned integer
 utest parseExprMain (initPos "file") 0 "  123foo" with
       {val = TmConst {val = CInt {val = 123}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 2 1 5},
+                      info = infoVal "file" 1 2 1 5},
        pos = posVal "file" 1 5, str = "foo"} in
 -- Unsigned floats
 utest parseExprMain (initPos "file") 0 "  1.0 " with
       {val = TmConst {val = CFloat {val = 1.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 2 1 5},
+                      info = infoVal "file" 1 2 1 5},
        pos = posVal "file" 1 5, str = " "} in
 utest parseExprMain (initPos "file") 0 " 1234.  " with
       {val = TmConst {val = CFloat {val = 1234.}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 6},
+                      info = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = "  "} in
 utest parseExprMain (initPos "file") 0 " 13.37 " with
       {val = TmConst {val = CFloat {val = 13.37}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 6},
+                      info = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 "  1.0e-2" with
       {val = TmConst {val = CFloat {val = 0.01}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 2 1 8},
+                      info = infoVal "file" 1 2 1 8},
        pos = posVal "file" 1 8, str = ""} in
 utest parseExprMain (initPos "file") 0 " 2.5e+2  " with
       {val = TmConst {val = CFloat {val = 250.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 7},
+                      info = infoVal "file" 1 1 1 7},
        pos = posVal "file" 1 7, str = "  "} in
 utest parseExprMain (initPos "file") 0 "   2e3" with
       {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 3 1 6},
+                      info = infoVal "file" 1 3 1 6},
        pos = posVal "file" 1 6, str = ""} in
 utest parseExprMain (initPos "file") 0 "   2E3 " with
        {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
-                       fi = infoVal "file" 1 3 1 6},
+                       info = infoVal "file" 1 3 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 "   2.0e3" with
       {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 3 1 8},
+                      info = infoVal "file" 1 3 1 8},
        pos = posVal "file" 1 8, str = ""} in
 utest parseExprMain (initPos "file") 0 " 1.e2 " with
       {val = TmConst {val = CFloat {val = 100.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 5},
+                      info = infoVal "file" 1 1 1 5},
        pos = posVal "file" 1 5, str = " "} in
 utest parseExprMain (initPos "file") 0 " 2.e+1 " with
       {val = TmConst {val = CFloat {val = 20.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 6},
+                      info = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 3.e-4 " with
       {val = TmConst {val = CFloat {val = 0.0003}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 6},
+                      info = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 "  2.E3 " with
       {val = TmConst {val = CFloat {val = 2000.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 2 1 6},
+                      info = infoVal "file" 1 2 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 4.E+1 " with
       {val = TmConst {val = CFloat {val = 40.0}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 6},
+                      info = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 1.E-3 " with
       {val = TmConst {val = CFloat {val = 0.001}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 6},
+                      info = infoVal "file" 1 1 1 6},
        pos = posVal "file" 1 6, str = " "} in
 utest parseExprMain (initPos "file") 0 " 1E " with
       {val = TmConst {val = CInt {val = 1}, ty = TyUnknown {},
-                      fi = infoVal "file" 1 1 1 2},
+                      info = infoVal "file" 1 1 1 2},
        pos = posVal "file" 1 2, str = "E "} in
 utest parseExprMain (initPos "file") 0 " 1e " with
        {val = TmConst {val = CInt {val = 1}, ty = TyUnknown {},
-                       fi = infoVal "file" 1 1 1 2},
+                       info = infoVal "file" 1 1 1 2},
        pos = posVal "file" 1 2, str = "e "} in
 utest parseExprMain (initPos "file") 0 " 1.e++2 " with
        {val = TmConst {val = CFloat {val = 1.0}, ty = TyUnknown {},
-                       fi = infoVal "file" 1 1 1 3},
+                       info = infoVal "file" 1 1 1 3},
        pos = posVal "file" 1 3, str = "e++2 "} in
 utest parseExprMain (initPos "file") 0 " 3.1992e--2 " with
        {val = TmConst {val = CFloat {val = 3.1992}, ty = TyUnknown {},
-                       fi = infoVal "file" 1 1 1 7},
+                       info = infoVal "file" 1 1 1 7},
        pos = posVal "file" 1 7, str = "e--2 "} in
 
 --If expression
@@ -583,51 +583,51 @@ utest (parseExprMain (initPos "") 0 "  if 1 then 22 else 3").pos
 -- Boolean literal 'true'
 utest parseExpr (initPos "f") " true " with
       TmConst {val = CBool {val = true}, ty = TyUnknown {},
-               fi = infoVal "f" 1 1 1 5} in
+               info = infoVal "f" 1 1 1 5} in
 -- Boolean literal 'false'
 utest parseExpr (initPos "f") " true " with
       TmConst {val = CBool {val = true}, ty = TyUnknown {},
-               fi = infoVal "f" 1 1 1 5} in
+               info = infoVal "f" 1 1 1 5} in
 -- Parentheses
 utest parseExpr (initPos "") " ( 123) " with
       TmConst {val = CInt {val = 123}, ty = TyUnknown {},
-               fi = infoVal "" 1 3 1 6} in
+               info = infoVal "" 1 3 1 6} in
 -- Sequences
 utest parseExpr (initPos "") "[]" with
-      TmSeq {tms = [], ty = TyUnknown {}, fi = infoVal "" 1 0 1 2} in
+      TmSeq {tms = [], ty = TyUnknown {}, info = infoVal "" 1 0 1 2} in
 utest parseExpr (initPos "") " [ ] " with
-      TmSeq {tms = [], ty = TyUnknown {}, fi = infoVal "" 1 1 1 4} in
+      TmSeq {tms = [], ty = TyUnknown {}, info = infoVal "" 1 1 1 4} in
 utest parseExprMain (initPos "") 0 " [ 17 ] " with
       let v = TmConst {val = CInt {val = 17}, ty = TyUnknown {},
-                       fi = infoVal "" 1 3 1 5} in
-      {val = TmSeq {tms = [v], ty = TyUnknown {}, fi = infoVal "" 1 1 1 7},
+                       info = infoVal "" 1 3 1 5} in
+      {val = TmSeq {tms = [v], ty = TyUnknown {}, info = infoVal "" 1 1 1 7},
        pos = posVal "" 1 7, str = " "} in
 utest parseExpr (initPos "") " [ 232 , ( 19 ) ] " with
       let v1 = TmConst {val = CInt {val = 232}, ty = TyUnknown {},
-                        fi = infoVal "" 1 3 1 6} in
+                        info = infoVal "" 1 3 1 6} in
       let v2 = TmConst {val = CInt {val = 19}, ty = TyUnknown {},
-                        fi = infoVal "" 1 11 1 13} in
-      TmSeq {tms = [v1,v2], ty = TyUnknown {}, fi = infoVal "" 1 1 1 17} in
+                        info = infoVal "" 1 11 1 13} in
+      TmSeq {tms = [v1,v2], ty = TyUnknown {}, info = infoVal "" 1 1 1 17} in
 -- Strings
 let makeChar = lam k. lam c. lam n.
     TmConst {val = CChar {val = c}, ty = TyUnknown {},
-             fi = infoVal "" 1 n 1 (addi n k)} in
+             info = infoVal "" 1 n 1 (addi n k)} in
 let mkc = makeChar 1 in
 let mkc2 = makeChar 2 in
 utest parseExpr (initPos "") " \"Foo\" " with
   let str = [mkc 'F' 2, mkc 'o' 3, mkc 'o' 4] in
-  TmSeq {tms = str, ty = TyUnknown {}, fi = infoVal "" 1 1 1 6} in
+  TmSeq {tms = str, ty = TyUnknown {}, info = infoVal "" 1 1 1 6} in
 utest parseExpr (initPos "") " \" a\\\\ \\n\" " with
   let str = [mkc ' ' 2, mkc 'a' 3, mkc2 '\\' 4, mkc ' ' 6, mkc2 '\n' 7] in
-  TmSeq {tms = str, ty = TyUnknown {}, fi = infoVal "" 1 1 1 10} in
+  TmSeq {tms = str, ty = TyUnknown {}, info = infoVal "" 1 1 1 10} in
 -- Chars
 utest parseExprMain (initPos "") 0 " \'A\' " with
   {val = TmConst {val = CChar {val = 'A'}, ty = TyUnknown {},
-                  fi = infoVal "" 1 1 1 4},
+                  info = infoVal "" 1 1 1 4},
    pos = posVal "" 1 4, str = " "} in
 utest parseExpr (initPos "") " \'\\n\' " with
   TmConst {val = CChar {val = '\n'}, ty = TyUnknown {},
-           fi = infoVal "" 1 1 1 5} in
+           info = infoVal "" 1 1 1 5} in
 -- Var
 utest (parseExprMain (initPos "") 0 " _xs ").pos with posVal "" 1 4 in
 utest (parseExprMain (initPos "") 0 " fOO_12a ").pos with posVal "" 1 8 in

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -433,7 +433,7 @@ lang LetParser =
     let e2 = parseExprMain r4.pos 0 r4.str in
     {val = TmLet {ident = nameNoSym r2.val, tyBody = TyUnknown {},
                   body = e1.val, inexpr = e2.val, ty = TyUnknown {},
-                  fi = makeInfo p e2.pos},
+                  info = makeInfo p e2.pos},
      pos = e2.pos, str = e2.str}
 end
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -251,7 +251,7 @@ lang AppPrettyPrint = PrettyPrint + AppAst
     else error "Impossible"
 end
 
-lang FunPrettyPrint = PrettyPrint + FunAst + UnknownTypeAst
+lang FunPrettyPrint = PrettyPrint + LamAst + UnknownTypeAst
   sem isAtomic =
   | TmLam _ -> false
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -251,7 +251,7 @@ lang AppPrettyPrint = PrettyPrint + AppAst
     else error "Impossible"
 end
 
-lang FunPrettyPrint = PrettyPrint + LamAst + UnknownTypeAst
+lang LamPrettyPrint = PrettyPrint + LamAst + UnknownTypeAst
   sem isAtomic =
   | TmLam _ -> false
 
@@ -871,7 +871,7 @@ end
 lang MExprPrettyPrint =
 
   -- Terms
-  VarPrettyPrint + AppPrettyPrint + FunPrettyPrint + RecordPrettyPrint +
+  VarPrettyPrint + AppPrettyPrint + LamPrettyPrint + RecordPrettyPrint +
   LetPrettyPrint + TypePrettyPrint + RecLetsPrettyPrint + ConstPrettyPrint +
   DataPrettyPrint + MatchPrettyPrint + UtestPrettyPrint + SeqPrettyPrint +
   NeverPrettyPrint + RefPrettyPrint +

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -61,7 +61,7 @@ lang AppSym = Sym + AppAst
               with rhs = symbolizeExpr env t.rhs}
 end
 
-lang FunSym = Sym + LamAst + VarSym + AppSym
+lang LamSym = Sym + LamAst + VarSym + AppSym
   sem symbolizeType (env : SymEnv) =
   -- Intentinally left blank
 
@@ -435,7 +435,7 @@ end
 lang MExprSym =
 
   -- Terms
-  VarSym + AppSym + FunSym + RecordSym + LetSym + TypeSym + RecLetsSym +
+  VarSym + AppSym + LamSym + RecordSym + LetSym + TypeSym + RecLetsSym +
   ConstSym + DataSym + MatchSym + UtestSym + SeqSym + NeverSym +
 
   -- Types

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -61,7 +61,7 @@ lang AppSym = Sym + AppAst
               with rhs = symbolizeExpr env t.rhs}
 end
 
-lang FunSym = Sym + FunAst + VarSym + AppSym
+lang FunSym = Sym + LamAst + VarSym + AppSym
   sem symbolizeType (env : SymEnv) =
   -- Intentinally left blank
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -100,7 +100,7 @@ lang AppTypeAnnot = TypeAnnot + AppAst + FunTypeAst + MExprEq
     TmApp {t with ty = typeExpr env (TmApp t)}
 end
 
-lang FunTypeAnnot = TypeAnnot + LamAst + FunTypeAst
+lang LamTypeAnnot = TypeAnnot + LamAst + FunTypeAst
   sem typeExpr (env : TypeEnv) =
   | TmLam t ->
     match t.ty with TyUnknown {} then
@@ -410,7 +410,7 @@ end
 lang MExprTypeAnnot =
 
   -- Terms
-  VarTypeAnnot + AppTypeAnnot + FunTypeAnnot + RecordTypeAnnot + LetTypeAnnot +
+  VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +
   TypeTypeAnnot + RecLetsTypeAnnot + ConstTypeAnnot + DataTypeAnnot +
   MatchTypeAnnot + UtestTypeAnnot + SeqTypeAnnot + NeverTypeAnnot +
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -100,7 +100,7 @@ lang AppTypeAnnot = TypeAnnot + AppAst + FunTypeAst + MExprEq
     TmApp {t with ty = typeExpr env (TmApp t)}
 end
 
-lang FunTypeAnnot = TypeAnnot + FunAst + FunTypeAst
+lang FunTypeAnnot = TypeAnnot + LamAst + FunTypeAst
   sem typeExpr (env : TypeEnv) =
   | TmLam t ->
     match t.ty with TyUnknown {} then
@@ -184,7 +184,7 @@ lang TypeTypeAnnot = TypeAnnot + TypeAst
                with inexpr = typeAnnotExpr env t.inexpr}
 end
 
-lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + FunAst
+lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
   sem typeExpr (env : TypeEnv) =
   | TmRecLets t ->
     let f = lam b.

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -27,7 +27,7 @@ lang OCamlData
   | OPCon { ident : Name, args : [Pat] }
 end
 
-lang OCamlAst = FunAst + LetAst + RecLetsAst + ArithIntAst + ShiftIntAst
+lang OCamlAst = LamAst + LetAst + RecLetsAst + ArithIntAst + ShiftIntAst
                 + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
                 + CharAst + OCamlMatch + NamedPat + IntPat + CharPat
                 + BoolPat + OCamlTuple + OCamlData

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -2,7 +2,7 @@ include "ocaml/ast.mc"
 include "mexpr/symbolize.mc"
 
 lang OCamlSym =
-  VarSym + AppSym + FunSym + LetSym + RecLetsSym + ConstSym
+  VarSym + AppSym + LamSym + LetSym + RecLetsSym + ConstSym
   + NamedPatSym + IntPatSym + CharPatSym + BoolPatSym
   + OCamlMatch + OCamlTuple + OCamlData + UnknownTypeSym
 


### PR DESCRIPTION
This PR includes the following:

- Added info handling for the BootParser
- Renamed from “fi” to “info”
- Changed the order of terms. Made Boot and the compiler consistent. 
- Renamed  AstFun to AstLam, and all other “Fun” names in the code.
- Updated AstBuilder with info types
- Updated inconsistencies in the eval function