### PR TITLE
Sequence operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ utest answer with "yes" in
 
 checks if `x` is less than 10 (using the `lti` function with signature `Int -> Int -> Bool`). If it is true, the string `"yes"` is returned, else string `"no"` is returned.
 
-Note that an `if` expression is not a construct in pure MExpr. It is a syntactic sugar for a `match` expression. That is, expression
+Note that an `if` expression is not a construct in pure MExpr. It is syntactic sugar for a `match` expression. That is, expression
 
 ```
 if x then e1 else e2

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ utest foo 2 3 with 5 in
 ```
 creates a function `foo` that takes two arguments.
 
+A lambda can also be defined without a variable, e.g., `lam. e`, where
+`e` is some expression representing the body of the function. Such
+notation is useful if the actual variable is not used inside `e`. Note
+that `lam. e` is syntactic sugar for a normal lambda `lam #var"". e`,
+where the identifier of the variable name is the empty identifier.
+
 ### Sequencing
 
 Sometimes an expression has a side effect and you are not interested
@@ -223,10 +229,17 @@ syntactic sugar for a `let` construct. For instance, the pure version
 
 ```
 let foo = lam x.
-  let _ = print x in
+  let #var"" = print x in
   x
 ```
 
+Note that a variable with an empty identifier is used in the `let` expression. Moreover, note that a `let` expression
+
+```
+let _ = foo x in ...
+```
+
+is syntactically not valid since `let` expressions always bind a value to a variable. Underscore `_` is a pattern and patterns are only allowed in `match` expressions.
 
 ### `if` Expressions
 
@@ -240,6 +253,18 @@ utest answer with "yes" in
 ```
 
 checks if `x` is less than 10 (using the `lti` function with signature `Int -> Int -> Bool`). If it is true, the string `"yes"` is returned, else string `"no"` is returned.
+
+Note that an `if` expression is not a construct in pure MExpr. It is a syntactic sugar for a `match` expression. That is, expression
+
+```
+if x then e1 else e2
+```
+
+is translated into
+
+```
+match x with true then e1 else e2
+```
 
 ### Recursion
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ x
 introduces a new name `x`. The built-in function `addi` performs an addition between two integers. Note that MCore uses a call-by-value evaluation order, which means that expressions are evaluated into a value before they are applied to a function or substituted using a `let` expression. Hence, the expression `addi 1 2` is evaluated before it is substituted for `x` in the rest of the expression.
 
 
-
 ### Functions
 
 Functions are always defined anonymously as lambda functions. If you would like to give a function a name, a `let` expression can be used. For instance, the following program defines a function `double` that doubles the value of its argument.
@@ -204,6 +203,30 @@ utest foo 2 3 with 5 in
 ()
 ```
 creates a function `foo` that takes two arguments.
+
+### Sequencing
+
+Sometimes an expression has a side effect and you are not interested
+in the returned value. If that is the case, you can use the sequence
+operator `;`. For instance, suppose you would like to print a value in
+a function before it returns:
+
+```
+let foo = lam x.
+  print x;
+  x
+```
+
+The sequence operator `;` is not a construct of pure MExpr, but
+syntactic sugar for a `let` construct. For instance, the pure version
+(without syntactic sugar) of the program above is as follows:
+
+```
+let foo = lam x.
+  let _ = print x in
+  x
+```
+
 
 ### `if` Expressions
 

--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -60,6 +60,7 @@ let reserved_strings = [
   ("|",             fun(i) -> Parser.BAR{i=i;v=()});
   ("&",             fun(i) -> Parser.AND{i=i;v=()});
   ("!",             fun(i) -> Parser.NOT{i=i;v=()});
+  ("_",             fun(i) -> Parser.UNDERSCORE{i=i;v=()});
   ("->",            fun(i) -> Parser.ARROW{i=i;v=()});
 
 ]

--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -55,6 +55,7 @@ let reserved_strings = [
   ("}",             fun(i) -> Parser.RBRACKET{i=i;v=()});
   (":",             fun(i) -> Parser.COLON{i=i;v=()});
   (",",             fun(i) -> Parser.COMMA{i=i;v=()});
+  (";",             fun(i) -> Parser.SEMI{i=i;v=()});
   (".",             fun(i) -> Parser.DOT{i=i;v=()});
   ("|",             fun(i) -> Parser.BAR{i=i;v=()});
   ("&",             fun(i) -> Parser.AND{i=i;v=()});
@@ -151,7 +152,7 @@ let uident = ucase_letter (digit | '_' | us_letter)*
 
 let symtok =  "="  | "+" |  "-" | "*"  | "/" | "%"  | "<"  | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "==" |
               "!=" | "!" | "&&" | "||" | "++"| "$" | "("  | ")"  | "["  | "]" | "{"  | "}"  |
-              "::" | ":" | ","  | "."  | "&" | "|" | "->" | "=>" | "++"
+              "::" | ":" | ","  | ";"  | "."  | "&" | "|" | "->" | "=>" | "++"
 
 
 let line_comment = "--" [^ '\013' '\010']*

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -83,6 +83,7 @@
 %token <unit Ast.tokendata> RBRACKET      /* "}"   */
 %token <unit Ast.tokendata> COLON         /* ":"   */
 %token <unit Ast.tokendata> COMMA         /* ","   */
+%token <unit Ast.tokendata> SEMI         /* ";"   */
 %token <unit Ast.tokendata> DOT           /* "."   */
 %token <unit Ast.tokendata> BAR           /* "|"   */
 %token <unit Ast.tokendata> AND           /* "&"   */
@@ -262,7 +263,7 @@ case:
 
 
 mexpr:
-  | left
+  | sequence
       { $1 }
   | TYPE type_ident type_params IN mexpr
       // Type parameters are currently ignored
@@ -309,6 +310,12 @@ lets:
       { let fi = mkinfo $1.i (tm_info $5) in
         (fi, $2.v, $3, $5)::$6 }
 
+sequence:
+  | left
+     { $1 }
+  | left SEMI mexpr
+     { let fi = tm_info $1 in
+       TmLet(fi, us"_", Symb.Helpers.nosym, TyUnknown(NoInfo), $1, $3) } 
 
 left:
   | atom
@@ -319,7 +326,6 @@ left:
   | con_ident atom
       { let fi = mkinfo $1.i (tm_info $2) in
         TmConApp(fi,$1.v,Symb.Helpers.nosym,$2) }
-
 
 atom:
   | atom DOT proj_label

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -83,11 +83,12 @@
 %token <unit Ast.tokendata> RBRACKET      /* "}"   */
 %token <unit Ast.tokendata> COLON         /* ":"   */
 %token <unit Ast.tokendata> COMMA         /* ","   */
-%token <unit Ast.tokendata> SEMI         /* ";"   */
+%token <unit Ast.tokendata> SEMI          /* ";"   */
 %token <unit Ast.tokendata> DOT           /* "."   */
 %token <unit Ast.tokendata> BAR           /* "|"   */
 %token <unit Ast.tokendata> AND           /* "&"   */
 %token <unit Ast.tokendata> NOT           /* "!"   */
+%token <unit Ast.tokendata> UNDERSCORE    /* "_"   */
 %token <unit Ast.tokendata> CONCAT        /* "++"  */
 
 %start main
@@ -283,6 +284,9 @@ mexpr:
   | LAM var_ident ty_op DOT mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
         TmLam(fi,$2.v,Symb.Helpers.nosym,$3,$5) }
+  | LAM DOT mexpr
+      { let fi = mkinfo $1.i (tm_info $3) in
+        TmLam(fi,us"",Symb.Helpers.nosym,TyUnknown(fi),$3) }
   | IF mexpr THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $6) in
         TmMatch(fi,$2,PatBool(NoInfo,true),$4,$6) }
@@ -315,7 +319,7 @@ sequence:
      { $1 }
   | left SEMI mexpr
      { let fi = tm_info $1 in
-       TmLet(fi, us"_", Symb.Helpers.nosym, TyUnknown(NoInfo), $1, $3) } 
+       TmLet(fi, us"", Symb.Helpers.nosym, TyUnknown(NoInfo), $1, $3) } 
 
 left:
   | atom
@@ -398,11 +402,12 @@ pat_labels:
     {($1.v, $3)::$5}
 
 
+
 name:
   | var_ident
-      { if $1.v =. us"_"
-        then ($1.i, NameWildcard)
-        else ($1.i, NameStr($1.v,Symb.Helpers.nosym)) }
+    { ($1.i, NameStr($1.v,Symb.Helpers.nosym)) }
+  | UNDERSCORE
+    { ($1.i, NameWildcard) }
 
 pat:
   | pat_conj BAR pat

--- a/stdlib/ad/ad.mc
+++ b/stdlib/ad/ad.mc
@@ -47,7 +47,7 @@ let jacj = lam f. lam x. lam j.
 
 -- transpose of Jacobian of f at x
 let jac : ([DualNum] -> [DualNum]) -> [DualNum] -> [[DualNum]] =
-lam f. lam x. mapi (lam j. lam _. jacj f x j) x
+lam f. lam x. mapi (lam j. lam. jacj f x j) x
 
 -- gradient of f at x
 let grad : ([DualNum] -> DualNum) -> [DualNum] -> [DualNum] =

--- a/stdlib/ad/dualnum-symb.mc
+++ b/stdlib/ad/dualnum-symb.mc
@@ -93,7 +93,7 @@ lam e. lam p.
        (removeIf (lam t. not (memq e t.0)) (terms p)))
 
 -- generate unique epsilon
-let dualnumGenEpsilon : Unit -> Eps = lam _. gensym ()
+let dualnumGenEpsilon : Unit -> Eps = lam. gensym ()
 
 mexpr
 

--- a/stdlib/ad/dualnum-tree.mc
+++ b/stdlib/ad/dualnum-tree.mc
@@ -74,7 +74,7 @@ lam e. lam n.
 
 -- generate unique epsilon e1 that fulfills the invariant e1 > e for all
 -- previously generated epsilons e.
-let dualnumGenEpsilon : Unit -> Eps = lam _. error "Not implemented"
+let dualnumGenEpsilon : Unit -> Eps = lam. error "Not implemented"
 
 mexpr
 

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -23,7 +23,7 @@ let assocLength : AssocMap k v -> Int =
 -- overwritten.
 let assocInsert : AssocTraits k -> k -> v -> AssocMap k v -> AssocMap k v =
   lam traits. lam k. lam v. lam m.
-    optionMapOrElse (lam _. cons (k,v) m)
+    optionMapOrElse (lam. cons (k,v) m)
                     (lam i. set m i (k,v))
                     (index (lam t. traits.eq k t.0) m)
 
@@ -95,22 +95,22 @@ let assocMem : AssocTraits k -> k -> AssocMap k v -> Bool =
 
 -- 'assocKeys traits m' returns a list of all keys stored in 'm'
 let assocKeys : AssocTraits k -> AssocMap k v -> [k] =
-  lam _. lam m.
+  lam. lam m.
     map (lam t. t.0) m
 
 -- 'assocValues traits m' returns a list of all values stored in 'm'
 let assocValues : AssocTraits k -> AssocMap k v -> [v] =
-  lam _. lam m.
+  lam. lam m.
     map (lam t. t.1) m
 
 -- 'assocMap traits f m' maps over the values of 'm' using function 'f'.
 let assocMap : AssocTraits k -> (v1 -> v2) -> AssocMap k v1 -> AssocMap k v2 =
-  lam _. lam f. lam m.
+  lam. lam f. lam m.
     map (lam t. (t.0, f t.1)) m
 
 -- 'assocMapWithKey f m' maps over the values of 'm' using function 'f', where 'f' additionally has access to the key of the value being operated upon.
 let assocMapWithKey : AssocTraits k -> (k -> v1 -> v2) -> AssocMap k v1 -> AssocMap k v2 =
-  lam _. lam f. lam m.
+  lam. lam f. lam m.
     map (lam t. (t.0, f t.0 t.1)) m
 
 -- 'assocFold traits f acc m' folds over 'm' using function 'f' and accumulator
@@ -118,7 +118,7 @@ let assocMapWithKey : AssocTraits k -> (k -> v1 -> v2) -> AssocMap k v1 -> Assoc
 -- IMPORTANT: The folding order is unspecified.
 let assocFold : AssocTraits k -> (acc -> k -> v -> acc)
                   -> acc -> AssocMap k v -> acc =
-  lam _. lam f. lam acc. lam m.
+  lam. lam f. lam acc. lam m.
     foldl (lam acc. lam t. f acc t.0 t.1) acc m
 
 -- 'assocFoldlM traits f acc m' folds over 'm' using function 'f' and accumulator
@@ -126,7 +126,7 @@ let assocFold : AssocTraits k -> (acc -> k -> v -> acc)
 -- IMPORTANT: The folding order is unspecified.
 let assocFoldlM : AssocTraits k -> (acc -> k -> v -> Option acc)
                         -> acc -> AssocMap k v -> Option acc =
-  lam _. lam f. lam acc. lam m.
+  lam. lam f. lam acc. lam m.
     optionFoldlM (lam acc. lam t. f acc t.0 t.1) acc m
 
 -- 'assocMapAccum traits f acc m' simultaneously performs a map (over values)
@@ -134,7 +134,7 @@ let assocFoldlM : AssocTraits k -> (acc -> k -> v -> Option acc)
 -- IMPORTANT: The folding order is unspecified.
 let assocMapAccum : AssocTraits k -> (acc -> k -> v1 -> (acc, v2))
                       -> acc -> AssocMap k v1 -> (acc, AssocMap k v2) =
-  lam _. lam f. lam acc. lam m.
+  lam. lam f. lam acc. lam m.
     mapAccumL
       (lam acc. lam t.
          match f acc t.0 t.1 with (acc, b) then (acc, (t.0, b)) else never)
@@ -186,9 +186,9 @@ utest lookup 1 m with Some '1' in
 utest lookup 2 m with Some '2' in
 utest lookup 3 m with Some '3' in
 utest lookup 4 m with None () in
-utest lookupOrElse (lam _. 42) 1 m with '1' in
-utest lookupOrElse (lam _. 42) 2 m with '2' in
-utest lookupOrElse (lam _. 42) 3 m with '3' in
+utest lookupOrElse (lam. 42) 1 m with '1' in
+utest lookupOrElse (lam. 42) 2 m with '2' in
+utest lookupOrElse (lam. 42) 3 m with '3' in
 utest lookupPred (eqi 2) m with Some '2' in
 utest any (lam k. lam v. eqChar v '2') m with true in
 utest any (lam k. lam v. eqChar v '4') m with false in

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -51,7 +51,7 @@ let digraphEdges = lam g.
 
 -- Get the outgoing edges from vertex v in graph g.
 let digraphEdgesFrom = lam v. lam g.
-  map (lam t. (v, t.0, t.1)) (assocLookupOrElse {eq=g.eqv} (lam _. error "Lookup failed") v g.adj)
+  map (lam t. (v, t.0, t.1)) (assocLookupOrElse {eq=g.eqv} (lam. error "Lookup failed") v g.adj)
 
 -- Get the incoming edges to vertex v in graph g.
 let digraphEdgesTo = lam v. lam g.
@@ -138,7 +138,7 @@ let digraphAddEdgeCheckLabel = lam v1. lam v2. lam l. lam g. lam check.
   else if any (g.eql l) (digraphLabels v1 v2 g) then
     if check then error "label already exists" else g
   else
-    let oldEdgeList = assocLookupOrElse {eq=g.eqv} (lam _. error "Edge not found") v1 g.adj in
+    let oldEdgeList = assocLookupOrElse {eq=g.eqv} (lam. error "Edge not found") v1 g.adj in
     {g with adj = assocInsert {eq=g.eqv} v1 (snoc oldEdgeList (v2, l)) g.adj}
 
 -- Add edge e=(v1,v2,l) to g. Throws an error if l already exists in g.
@@ -173,7 +173,7 @@ let digraphReverse = lam g.
 -- https://doi.org/10.1137/0201010
 let digraphTarjan = lam g.
   let mapMem = assocMem {eq=g.eqv} in
-  let mapLookup = assocLookupOrElse {eq=g.eqv} (lam _. error "Lookup failed") in
+  let mapLookup = assocLookupOrElse {eq=g.eqv} (lam. error "Lookup failed") in
   let mapInsert = assocInsert {eq=g.eqv} in
   let setMem = setMem g.eqv in
 
@@ -229,16 +229,16 @@ let digraphStrongConnects = lam g. digraphTarjan g
 
 -- Print as dot format
 let digraphPrintDot = lam g. lam v2str. lam l2str.
-  let _ = print "digraph {" in
-  let _ = map
-    (lam e. let _ = print (v2str e.0) in
-            let _ = print " -> " in
-            let _ = print (v2str e.1) in
-            let _ = print "[label=" in
-            let _ = print (l2str e.2) in
+  print "digraph {";
+  (map
+    (lam e. print (v2str e.0);
+            print " -> ";
+            print (v2str e.1);
+            print "[label=";
+            print (l2str e.2);
             print "];")
-    (digraphEdges g) in
-  let _ = print "}\n" in ()
+    (digraphEdges g));
+  print "}\n"; ()
 
 mexpr
 let l1 = gensym () in

--- a/stdlib/either.mc
+++ b/stdlib/either.mc
@@ -126,7 +126,7 @@ let eitherBindLeft: Either a b -> (a -> Either c b) -> Either c b =
   else never
 
 utest eitherBindLeft (Left "a") (lam s. Left (head s)) with Left 'a'
-utest eitherBindLeft (Left "a") (lam _. Right 42) with Right 42
+utest eitherBindLeft (Left "a") (lam. Right 42) with Right 42
 utest eitherBindLeft (Right 42) (lam s. Left (head s)) with Right 42
 
 --  *-
@@ -150,7 +150,7 @@ let eitherBindRight: Either a b -> (b -> Either a c) -> Either a c =
 
 utest eitherBindRight (Left "a") (lam i. Right [int2char i]) with Left "a"
 utest eitherBindRight (Right 10) (lam i. Right [int2char i]) with Right "\n"
-utest eitherBindRight (Right 11) (lam _. Left "c") with Left "c"
+utest eitherBindRight (Right 11) (lam. Left "c") with Left "c"
 
 --  *-
 --  * .brief Partitions a list of Eithers into the Left case values and the
@@ -242,7 +242,7 @@ utest eitherIsRight (Right (Left 1)) with true
 --  *
 --  * .return The Left case value or the default value.
 -- -*
-let eitherFromLeft: a -> Either a b -> a = lam v. eitherEither (lam x. x) (lam _. v)
+let eitherFromLeft: a -> Either a b -> a = lam v. eitherEither (lam x. x) (lam. v)
 
 utest eitherFromLeft "a" (Right 5) with "a"
 utest eitherFromLeft "a" (Left "foo") with "foo"
@@ -256,7 +256,7 @@ utest eitherFromLeft "a" (Left "foo") with "foo"
 --  *
 --  * .return The Right case value or the default value.
 -- -*
-let eitherFromRight: b -> Either a b -> b = lam v. eitherEither (lam _. v) (lam x. x)
+let eitherFromRight: b -> Either a b -> b = lam v. eitherEither (lam. v) (lam x. x)
 
 utest eitherFromRight 0 (Left "foo") with 0
 utest eitherFromRight 0 (Right 42) with 42

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -141,7 +141,7 @@ let hashmapLookupOrElse : HashMapTraits k -> (Unit -> v) -> k -> HashMap k v -> 
 -- 'default' if no element was found.
 let hashmapLookupOr : HashMapTraits k -> v -> k -> HashMap k v -> v =
   lam traits. lam default. lam key. lam hm.
-    hashmapLookupOrElse traits (lam _. default) key hm
+    hashmapLookupOrElse traits (lam. default) key hm
 
 -- 'hashmapLookupPred p hm' returns the value of a key that satisfies the
 -- predicate 'p'. If several keys satisfies 'p', the one that happens to be
@@ -211,12 +211,12 @@ let hashmapFilterValues : HashMapTraits k -> (v -> Bool) -> HashMap k v -> [v] =
 -- 'hashmapKeys hm' returns a list of all keys stored in 'hm'
 let hashmapKeys : HashMapTraits k -> HashMap k v -> [k] =
   lam traits. lam hm.
-    hashmapFilterKeys traits (lam _. true) hm
+    hashmapFilterKeys traits (lam. true) hm
 
 -- 'hashmapValues hm' returns a list of all values stored in 'hm'
 let hashmapValues : HashMapTraits k -> HashMap k v -> [v] =
   lam traits. lam hm.
-    hashmapFilterValues traits (lam _. true) hm
+    hashmapFilterValues traits (lam. true) hm
 
 
 mexpr
@@ -251,21 +251,21 @@ let m = insert "foo" "aaa" m in
 utest count m with 1 in
 utest mem "foo" m with true in
 utest lookup "foo" m with Some ("aaa") in
-utest lookupOrElse (lam _. 42) "foo" m with "aaa" in
+utest lookupOrElse (lam. 42) "foo" m with "aaa" in
 
 let m = insert "bar" "bbb" m in
 
 utest count m with 2 in
 utest mem "bar" m with true in
-utest any (lam _. lam b. eqString "BBB" (str2upper b)) m with true in
-utest any (lam a. lam _. eqString "FOO" (str2upper a)) m with true in
+utest any (lam. lam b. eqString "BBB" (str2upper b)) m with true in
+utest any (lam a. lam. eqString "FOO" (str2upper a)) m with true in
 utest any (lam a. lam b. eqString a b) m with false in
-utest any (lam a. lam _. eqString "bar" a) m with true in
-utest all (lam a. lam _. eqString "bar" a) m with false in
-utest all (lam a. lam _. eqi (length a) 3) m with true in
-utest all (lam _. lam b. eqi (length b) 3) m with true in
+utest any (lam a. lam. eqString "bar" a) m with true in
+utest all (lam a. lam. eqString "bar" a) m with false in
+utest all (lam a. lam. eqi (length a) 3) m with true in
+utest all (lam. lam b. eqi (length b) 3) m with true in
 utest lookup "bar" m with Some ("bbb") in
-utest lookupOrElse (lam _. "BABAR") "bar" m with "bbb" in
+utest lookupOrElse (lam. "BABAR") "bar" m with "bbb" in
 utest lookupOr "bananas" "bar42" m with "bananas" in
 utest lookupPred (eqString "bar") m with Some "bbb" in
 utest
@@ -281,8 +281,8 @@ utest
   then true else false
 with true in
 utest filter (eqString) m with empty in
-utest hashmap2seq (filter (lam a. lam _. eqString "foo" a) m) with [("foo", "aaa")] in
-utest hashmap2seq (filter (lam _. lam b. eqString "bbb" b) m) with [("bar", "bbb")] in
+utest hashmap2seq (filter (lam a. lam. eqString "foo" a) m) with [("foo", "aaa")] in
+utest hashmap2seq (filter (lam. lam b. eqString "bbb" b) m) with [("bar", "bbb")] in
 utest filterKeys (lam a. optionIsSome (strIndex 'o' a)) m with ["foo"] in
 utest filterValues (lam a. optionIsSome (strIndex 'b' a)) m with ["bbb"] in
 
@@ -298,8 +298,8 @@ let m = insert "foo" "ccc" m in
 utest count m with 2 in
 utest mem "foo" m with true in
 utest lookup "foo" m with Some ("ccc") in
-utest lookupOrElse (lam _. 42) "foo" m with "ccc" in
-utest lookupOrElse (lam _. 42) "abc" m with 42 in
+utest lookupOrElse (lam. 42) "foo" m with "ccc" in
+utest lookupOrElse (lam. 42) "abc" m with 42 in
 
 let m = remove "foo" m in
 
@@ -324,7 +324,7 @@ let m = insert "" "ddd" m in
 utest count m with 2 in
 utest mem "" m with true in
 utest lookup "" m with Some ("ddd") in
-utest lookupOrElse (lam _. 1) "" m with "ddd" in
+utest lookupOrElse (lam. 1) "" m with "ddd" in
 
 -- Test with collisions
 let n = addi _hashmapDefaultBucketCount 10 in
@@ -350,7 +350,7 @@ recursive let checkmem = lam i.
     utest lookup key m with Some (i) in
     checkmem (addi i 1)
 in
-let _ = checkmem 0 in
+checkmem 0;
 
 recursive let removeall = lam i. lam hm.
   if geqi i n then

--- a/stdlib/local-search.mc
+++ b/stdlib/local-search.mc
@@ -64,11 +64,11 @@ let minimize : (SearchState v c -> Bool) -> (SearchState v c -> Unit) -> SearchS
           ({sstate with stuck = true}, mstate)
         else
           let mstate = next.1 in
-          let cur = optionGetOrElse (lam _. error "Expected a solution") newCur in
+          let cur = optionGetOrElse (lam. error "Expected a solution") newCur in
           -- New best solution?
           let inc = if lti (sstate.cmp cur.1 sstate.inc.1) 0 then cur else sstate.inc in
           let sstate = {{sstate with cur = cur} with inc = inc} in
-          let _ = callAfterEachIter sstate in
+          callAfterEachIter sstate;
           search sstate mstate
       else
         (sstate, mstate)
@@ -104,7 +104,7 @@ let stepSA : NeighbourhoodFun v c -> SelectFun v c -> StepFun v c =
         let proposalOpt = select (neighbourhood state) state in
         -- Leave meta unchanged if stuck
         match proposalOpt with None () then (None (), meta) else
-        let proposal = optionGetOrElse (lam _. error "Expected a solution") proposalOpt in
+        let proposal = optionGetOrElse (lam. error "Expected a solution") proposalOpt in
         -- Metropolis condition
         if leqi (state.cmp proposal.1 state.cur.1) 0 then
           -- Always accept improving solution
@@ -244,7 +244,7 @@ let randElem = lam seq.
 let randomBest = lam ns. lam state.
   match ns with [] then None () else
   let costs = map cost ns in
-  let minCost = minOrElse (lam _. error "undefined") subi costs in
+  let minCost = minOrElse (lam. error "undefined") subi costs in
   let nsCosts = zipWith (lam n. lam c. (n,c)) ns costs in
   let minNs = filter (lam t. eqi t.1 minCost) nsCosts in
   randElem minNs
@@ -290,8 +290,8 @@ let metaTabu = (tabuState, stepTabu (neighbours g) randomBest) in
 -- Solve the problem --
 -----------------------
 
-let _ = print "Choose a random best solution:\n" in
-let _ = printIter initState in
+print "Choose a random best solution:\n";
+printIter initState;
 let r = minimizeTSP1 (lam st. geqi st.iter 50) metaRandBest in
 
 let sstate = r.0 in
@@ -299,16 +299,16 @@ utest sstate.iter with 50 in
 utest sstate.inc.1 with 251 in -- optimum
 utest sstate.stuck with false in
 
-let _ = print "Steepest descent:\n" in
-let _ = printIter initState in
+print "Steepest descent:\n";
+printIter initState;
 let r = minimizeTSP1 (lam st. geqi st.iter 100) metaSteepDesc in
 
 let sstate = r.0 in
 utest sstate.inc.1 with 251 in
 utest sstate.stuck with true in
 
-let _ = print "Simulated annealing:\n" in
-let _ = printIter initState in
+print "Simulated annealing:\n";
+printIter initState;
 let r = minimizeTSP metaSA in
 
 let sstate = r.0 in
@@ -317,8 +317,8 @@ utest sstate.iter with 3 in
 utest sstate.stuck with false in
 utest mstate.temp with mulf 0.95 (mulf 0.95 (mulf 0.95 100.0)) in
 
-let _ = print "Tabu search:\n" in
-let _ = printIter initState in
+print "Tabu search:\n";
+printIter initState;
 let r = minimizeTSP metaTabu in
 
 let sstate = r.0 in
@@ -331,10 +331,10 @@ utest mstate.isTabu sstate.cur.0 mstate.tabu with true in
 utest mstate.isTabu sstate.inc.0 mstate.tabu with true in
 
 -- Switch between meta-heuristics during search
-let _ = print "Start with tabu search:\n" in
-let _ = printIter initState in
+print "Start with tabu search:\n";
+printIter initState;
 let r = minimizeTSP2 (lam state. geqi state.iter 5) initState metaTabu in
-let _ = print "Switch to simulated annealing:\n" in
+print "Switch to simulated annealing:\n";
 let r = minimizeTSP2 (lam state. geqi state.iter 10) r.0 metaSA in
 
 ------------------------------------
@@ -350,8 +350,8 @@ let fooStep : StepFun = lam state. lam mstate.
 
 let metaHeurFoo = (FooMetaState {foo = 0}, fooStep) in
 
-let _ = print "Foo search:\n" in
-let _ = printIter initState in
+print "Foo search:\n";
+printIter initState;
 let r = minimizeTSP metaHeurFoo in
 
 let fooVal = match r.1 with FooMetaState s then s.foo else error "Not a FooMetaState" in

--- a/stdlib/matrix.mc
+++ b/stdlib/matrix.mc
@@ -35,7 +35,7 @@ let matrixMapij = lam f. lam mtx.
   mapi (lam i. lam c. mapi (lam j. lam v. f i j v) c) mtx
 
 -- Applies function f x over the elements of mtx, where x is the elements value.
-let matrixMap = lam f. matrixMapij (lam _. lam _. lam x. f x)
+let matrixMap = lam f. matrixMapij (lam. lam. lam x. f x)
 
 -- Size of matrix mtx.
 let matrixSize = lam mtx. (length mtx, length (get mtx 0))
@@ -127,7 +127,7 @@ let matB = matrixSet matB 1 1 4 in
 utest matB with matA in
 utest matrixAdd matA matB with [[2,6],[4,8]] in
 
-utest matrixMapij (lam i. lam j. lam _. (i, j)) (matrixConst (2,2) (0,0))
+utest matrixMapij (lam i. lam j. lam. (i, j)) (matrixConst (2,2) (0,0))
 with [[(0,0),(0,1)],[(1,0),(1,1)]] in
 
 utest matrixSMul 3 matA with [[3,9],[6,12]] in

--- a/stdlib/maxmatch.mc
+++ b/stdlib/maxmatch.mc
@@ -40,7 +40,7 @@ lam w.
       w = w,
       n = n,
       -- assign feasible labels, e.g.
-      lus = map (maxOrElse (lam _. error "undefined") subi) w,
+      lus = map (maxOrElse (lam. error "undefined") subi) w,
       -- lu[u] + lv[v] => w[u][v] for all v in V, u in U
       lvs = zerov,
       mus = negv,
@@ -53,23 +53,23 @@ lam w.
     }
 
 let debugShowState = lam state.
-  let _ = printLn "===" in
-  let _ = print "lus: " in
-  let _ = dprint state.lus in
-  let _ = print "lvs: " in
-  let _ = dprint state.lvs in
-  let _ = print "mus: " in
-  let _ = dprint state.mus in
-  let _ = print "mvs: " in
-  let _ = dprint state.mvs in
-  let _ = print "ss: " in
-  let _ = dprint state.ss in
-  let _ = print "ts: " in
-  let _ = dprint state.ts in
-  let _ = print "slacks: " in
-  let _ = dprint state.slacks in
-  let _ = print "preds: " in
-  let _ = dprint state.preds in
+  printLn "===";
+  print "lus: ";
+  dprint state.lus;
+  print "lvs: ";
+  dprint state.lvs;
+  print "mus: ";
+  dprint state.mus;
+  print "mvs: ";
+  dprint state.mvs;
+  print "ss: ";
+  dprint state.ss;
+  print "ts: ";
+  dprint state.ts;
+  print "slacks: ";
+  dprint state.slacks;
+  print "preds: ";
+  dprint state.preds;
   ()
 
 ------------------------------------------------------------
@@ -82,7 +82,7 @@ let isMatch = lam x. neqi x (negi 1)
 let isPerfectMatch = all isMatch
 
 let findNonCovered = lam x.
-  optionGetOrElse (lam _. error "All nodes are covered")
+  optionGetOrElse (lam. error "All nodes are covered")
                   (index (lam x. not (isMatch x)) x)
 
 -- lu[u] + lv[v] - w[u][v]
@@ -167,7 +167,7 @@ recursive
   let augment = lam state.
   let s =
     -- min slack over v's not in T
-    minOrElse (lam _. error "undefined")
+    minOrElse (lam. error "undefined")
               cmpSlack
               (filter (lam s. not (memT s.v state)) state.slacks)
   in

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -432,12 +432,12 @@ let debug = false in
 let debugPrint = lam t.
     let s = symbolize t in
     let n = normalizeTerm s in
-    let _ = printLn "--- BEFORE ANF ---" in
-    let _ = printLn (expr2str s) in
-    let _ = print "\n" in
-    let _ = printLn "--- AFTER ANF ---" in
-    let _ = printLn (expr2str n) in
-    let _ = print "\n" in
+    printLn "--- BEFORE ANF ---";
+    printLn (expr2str s);
+    print "\n";
+    printLn "--- AFTER ANF ---";
+    printLn (expr2str n);
+    print "\n";
     ()
 in
 

--- a/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -94,7 +94,7 @@ with record_ [("x", tmVarX), ("y", tmVarX)] in
 -- TODO(vipa, 2020-09-24): the best test here would be one that collects all the children to see that we see all of them. The issue is that we shouldn't depend on the enumeration order, so we would like to collect the (multi-)set of children, not a sequence.
 -- We would thus like something like `sfold_Expr_Expr (lam acc. lam c. setInsert c acc) emptySet tmRecordI with setFromList [tmConst3, tmApp11] using setEqual`
 -- There is also another test further down the file, search for the other todo with the same metadata
-utest sfold_Expr_Expr (lam acc. lam _. addi acc 1) 0 tmRecordI with 2 in
+utest sfold_Expr_Expr (lam acc. lam. addi acc 1) 0 tmRecordI with 2 in
 
 let tmRecordUpdate = recordupdate_ tmRecordI "x" tmVarY in
 

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -7,6 +7,7 @@ include "mexpr/info.mc"
 include "mexpr/pprint.mc"
 include "string.mc"
 include "seq.mc"
+include "name.mc"
 
 let gstr = lam t. lam n. bootParserGetString t n
 let gname = lam t. lam n. nameNoSym (bootParserGetString t n)
@@ -233,6 +234,8 @@ let r_info = lam r1. lam c1. lam r2. lam c2.
 -- TmVar 
 let s = "_asdXA123" in
 utest lside s with rside s in
+utest match parseMExprString "#var\"\"" with TmVar r
+      then nameGetStr r.ident else "ERROR" with "" in
 
 -- TmApp
 let s = "f x" in

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -253,6 +253,9 @@ utest l_info "  \n lam x.x" with r_info 2 1 2 8 in
 utest info (match parseMExprString s with TmLet r then r.body else ())
 with r_info 1 8 1 15 in
 utest l_info "  let x = 4 in y  " with r_info 1 2 1 14 in
+let s = "print x; 10" in
+utest lside s with rside s in
+
 
 -- TmRecLets, TmLam
 let s = "recursive let x = lam x.x in x" in

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -32,7 +32,7 @@ let _eqn = lam n1. lam n2.
 
 let _getSym = lam n.
   (optionGetOrElse
-    (lam _. error "Expected symbol")
+    (lam. error "Expected symbol")
     (nameGetSym n))
 
 lang HoleAst
@@ -246,7 +246,7 @@ lang ContextAwareHoles = Ast2CallGraph + HoleAst + IntAst + SymbAst
     let maxDepth =
       match lookupTable with [] then 0
       else
-        maxOrElse (lam _. error "Expected non-empty lookup table")
+        maxOrElse (lam. error "Expected non-empty lookup table")
                   subi
                   (map (lam r. length r.path) lookupTable)
     in
@@ -582,9 +582,9 @@ let evalE = lam expr. lam expected.
 
 -- Prettyprinting
 let pprint = lam ast.
-  let _ = print "\n\n" in
-  let _ = print (expr2str ast) in
-  let _ = print "\n\n" in () in
+  print "\n\n";
+  print (expr2str ast);
+  print "\n\n" in ();
 
 -- Perform transform tests
 let dprintTransform = lam ast.
@@ -592,14 +592,14 @@ let dprintTransform = lam ast.
   let ast = symbolize ast in
   let anfast = anf ast in
   -- Label applications
-  let _ = print "\n-------------- BEFORE ANF --------------" in
-  let _ = pprint ast in
-  let _ = print "-------------- AFTER ANF --------------" in
-  let _ = pprint anfast in
-  let _ = print "-------------- AFTER TRANSFORMATION --------------" in
+  print "\n-------------- BEFORE ANF --------------";
+  pprint ast;
+  print "-------------- AFTER ANF --------------";
+  pprint anfast;
+  print "-------------- AFTER TRANSFORMATION --------------";
   let ast = transform [] anfast in
-  let _ = pprint ast in
-  let _ = print "-------------- END OF TRANSFORMED AST --------------" in
+  pprint ast;
+  print "-------------- END OF TRANSFORMED AST --------------";
   ast
 in
 let testTransform = lam r.
@@ -868,7 +868,7 @@ let allTests = [
 let tTests = [hole1, hole2, hole3] in
 let cgTests = allTests in
 
-let _ = map testTransform tTests in
-let _ = map testCallgraph cgTests in
+map testTransform tTests;
+map testCallgraph cgTests;
 
 ()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -224,7 +224,7 @@ lang UtestEval = Eq + UtestAst
   | TmUtest t ->
     let v1 = eval ctx t.test in
     let v2 = eval ctx t.expected in
-    let _ = if eqExpr v1 v2 then print "Test passed\n" else print "Test failed\n" in
+    if eqExpr v1 v2 then print "Test passed\n" else print "Test failed\n";
     eval ctx t.next
 end
 
@@ -707,7 +707,7 @@ lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst + UnknownTypeAst
   | CFileWrite2 f ->
     match arg with TmSeq s then
       let d = _seqOfCharToString s.tms in
-      let _ = writeFile f d in
+      writeFile f d;
       unit_
     else error "d in writeFile not a sequence"
   | CFileExists _ ->
@@ -718,7 +718,7 @@ lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst + UnknownTypeAst
   | CFileDelete _ ->
     match arg with TmSeq s then
       let f = _seqOfCharToString s.tms in
-      let _ = deleteFile f in
+      deleteFile f;
       unit_
     else error "f in deleteFile not a sequence"
 end
@@ -728,7 +728,7 @@ lang IOEval = IOAst + SeqAst + UnknownTypeAst
   | CPrintString _ ->
     match arg with TmSeq s then
       let s = _seqOfCharToString s.tms in
-      let _ = print s in
+      print s;
       unit_
     else error "string to print is not a string"
   | CReadLine _ ->
@@ -779,7 +779,7 @@ lang TimeEval = TimeAst + IntAst
   sem delta (arg : Expr) =
   | CSleepMs _ ->
     match arg with TmConst {val = CInt {val = n}} then
-      let _ = sleepMs n in
+      sleepMs n;
       unit_
     else error "n in wallTimeMs not a constant integer"
   | CWallTimeMs _ ->
@@ -797,7 +797,7 @@ lang RefOpEval = RefOpAst + IntAst
       TmConst {val = CModRef2 r, info = NoInfo()}
     else error "first argument of modref not a reference"
   | CModRef2 r ->
-    let _ = modref r arg in
+    modref r arg;
     unit_
   | CDeRef _ ->
     match arg with TmRef {ref = r} then
@@ -912,7 +912,7 @@ end
 lang OrPatEval = OrPat
   sem tryMatch (env : Env) (t : Expr) =
   | PatOr {lpat = l, rpat = r} ->
-    optionOrElse (lam _. tryMatch env t r) (tryMatch env t l)
+    optionOrElse (lam. tryMatch env t r) (tryMatch env t l)
 end
 
 lang NotPatEval = NotPat
@@ -1189,7 +1189,7 @@ let splitAtAst = splitat_ (seq_ [int_ 1, int_ 4, int_ 2, int_ 3]) (int_ 2) in
 utest eval splitAtAst
 with tuple_ [seq_ [int_ 1, int_ 4], seq_ [int_ 2, int_ 3]] in
 
--- create 3 (lam _. 42) -> [42, 42, 42]
+-- create 3 (lam. 42) -> [42, 42, 42]
 let createAst = create_ (int_ 3) (ulam_ "_" (int_ 42)) in
 utest eval createAst with seq_ [int_ 42, int_ 42, int_ 42] in
 

--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -60,7 +60,7 @@ let infoErrorString : Info -> String -> String = lam fi. lam str.
 
 -- Print an error with info struct info and exit (error code 1)
 let infoErrorExit : Info -> String -> () = lam fi. lam str.
-  let _ = print (join ["\n", (infoErrorString fi str), "\n"]) in
+  print (join ["\n", (infoErrorString fi str), "\n"]);
   exit 1
 
 -- Print an error with position info and exit (error code 1)

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -25,15 +25,6 @@ lang WhitespaceParser = WSACParser
   | x -> {str = x, pos = p}
 end
 
-let _ = use WhitespaceParser in
-  utest eatWSAC (initPos "") "  foo"
-    with {str = "foo", pos = (posVal "" 1 2)} in
-  utest eatWSAC (initPos "") " \tfoo"
-    with {str = "foo", pos = (posVal "" 1 3)} in
-  utest eatWSAC (initPos "") " \n    bar "
-    with {str = "bar ", pos = (posVal "" 2 4)} in
-  ()
-
 -- Eat line comments of the form --
 lang LineCommentParser = WSACParser
   sem eatWSAC (p : Pos)  =
@@ -65,16 +56,6 @@ end
 -- Commbined WSAC parser for MExpr
 lang MExprWSACParser = WhitespaceParser + LineCommentParser + MultilineCommentParser
 
-let _ = use MExprWSACParser in
-  utest eatWSAC (initPos "") " --foo \n  bar "
-    with {str = "bar ", pos = posVal "" 2 2} in
-  utest eatWSAC (initPos "") " /- foo -/ bar"
-    with {str = "bar", pos = posVal "" 1 11} in
-  utest eatWSAC (initPos "") " /- foo\n x \n -/ \nbar "
-    with {str = "bar ", pos = posVal "" 4 0} in
-  utest eatWSAC (initPos "") " /- x -- y /- foo \n -/ -/ !"
-    with {str = "!", pos = posVal "" 2 7} in
-  ()
 
 
 
@@ -127,19 +108,20 @@ let parseIdent = lam upper. lam p. lam str.
   in work "" true p str
 
 utest parseIdent false (initPos "") "+"
-  with {val = "", str = "+", pos = posVal "" 1 0}
+  with {val = "", str = "+", pos = posVal "" 1 0} 
 utest parseIdent false (initPos "") "a "
-  with {val = "a", str = " ", pos = posVal "" 1 1}
+  with {val = "a", str = " ", pos = posVal "" 1 1} 
 utest parseIdent false (initPos "") "ba"
-  with {val = "ba", str = "", pos = posVal "" 1 2}
+  with {val = "ba", str = "", pos = posVal "" 1 2} 
 utest parseIdent false (initPos "") "_asd "
-  with {val = "_asd", str = " ", pos = posVal "" 1 4}
+  with {val = "_asd", str = " ", pos = posVal "" 1 4} 
 utest parseIdent true (initPos "") "_asd "
-  with {val = "", str = "_asd ", pos = posVal "" 1 0}
+  with {val = "", str = "_asd ", pos = posVal "" 1 0} 
 utest parseIdent false (initPos "") "Asd12 "
-  with {val = "", str = "Asd12 ", pos = posVal "" 1 0}
+  with {val = "", str = "Asd12 ", pos = posVal "" 1 0} 
 utest parseIdent true (initPos "") "Asd12 "
-  with {val = "Asd12", str = " ", pos = posVal "" 1 5}
+  with {val = "Asd12", str = " ", pos = posVal "" 1 5} 
+
 
 
 -- Parse identifier
@@ -493,6 +475,27 @@ lang MExprParser = MExprParserBase + ExprParserNoInfix
 
 
 mexpr
+
+use WhitespaceParser in
+  utest eatWSAC (initPos "") "  foo"
+    with {str = "foo", pos = (posVal "" 1 2)} in
+  utest eatWSAC (initPos "") " \tfoo"
+    with {str = "foo", pos = (posVal "" 1 3)} in
+  utest eatWSAC (initPos "") " \n    bar "
+    with {str = "bar ", pos = (posVal "" 2 4)} in
+  ();
+
+use MExprWSACParser in
+  utest eatWSAC (initPos "") " --foo \n  bar "
+    with {str = "bar ", pos = posVal "" 2 2} in
+  utest eatWSAC (initPos "") " /- foo -/ bar"
+    with {str = "bar", pos = posVal "" 1 11} in
+  utest eatWSAC (initPos "") " /- foo\n x \n -/ \nbar "
+    with {str = "bar ", pos = posVal "" 4 0} in
+  utest eatWSAC (initPos "") " /- x -- y /- foo \n -/ -/ !"
+    with {str = "!", pos = posVal "" 2 7} in
+  ();
+
 
 
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -142,7 +142,7 @@ let _record2tuple = lam tm.
       -- Note: Quadratic complexity. Sorting the association list directly
       -- w.r.t. key would improve complexity to n*log(n).
       Some (map (lam key. assocLookupOrElse {eq=eqString}
-                            (lam _. error "Key not found")
+                            (lam. error "Key not found")
                             (int2string key) t.bindings)
                  sortedKeys)
     else None ()
@@ -335,7 +335,7 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
           match getTypeStringCode indent env t.tyBody with (env, ty) then
             let ty = if eqString ty "Unknown" then "" else concat ": " ty in
             (env,
-             if eqString str "_" then
+             if eqString (nameGetStr t.ident) "" then
                join [body, pprintNewline indent, ";",
                      inexpr]
              else
@@ -836,7 +836,7 @@ lang RecordTypePrettyPrint = RecordTypeAst
         then (env, join ["(", strJoin ", " tuple, ")"])
         else never
       else
-        let f = lam env. lam _. lam v. getTypeStringCode indent env v in
+        let f = lam env. lam. lam v. getTypeStringCode indent env v in
         match assocMapAccum {eq=eqString} f env t.fields with (env, fields) then
           let fields = assoc2seq {eq=eqString} fields in
           let conventry = lam entry. join [entry.0, ": ", entry.1] in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -335,10 +335,14 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
           match getTypeStringCode indent env t.tyBody with (env, ty) then
             let ty = if eqString ty "Unknown" then "" else concat ": " ty in
             (env,
-             join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
-                   body, pprintNewline indent,
-                   "in", pprintNewline indent,
-                   inexpr])
+             if eqString str "_" then
+               join [body, pprintNewline indent, ";",
+                     inexpr]
+             else
+               join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
+                     body, pprintNewline indent,
+                     "in", pprintNewline indent,
+                     inexpr])
           else never
         else never
       else never

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -380,7 +380,7 @@ lang RecordPatSym = RecordPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PatRecord {bindings = bindings, info = info} ->
     match assocMapAccum {eq=eqString}
-            (lam patEnv. lam _. lam p. symbolizePat env patEnv p) patEnv bindings
+            (lam patEnv. lam. lam p. symbolizePat env patEnv p) patEnv bindings
     with (env,bindings) then
       (env, PatRecord {bindings = bindings, info = info})
     else never
@@ -538,18 +538,17 @@ let debug = false in
 let debugPrint = lam i. lam t.
   let r = symbolize t in
   if debug then
-    let _ = printLn (join ["--- ", int2string i, " BEFORE SYMBOLIZE ---"]) in
-    let _ = printLn (expr2str t) in
-    let _ = print "\n" in
-    let _ = printLn "--- AFTER SYMBOLIZE ---" in
-    let _ = printLn (expr2str r) in
-    let _ = print "\n" in
+    printLn (join ["--- ", int2string i, " BEFORE SYMBOLIZE ---"]);
+    printLn (expr2str t);
+    print "\n";
+    printLn "--- AFTER SYMBOLIZE ---";
+    printLn (expr2str r);
+    print "\n";
     ()
   else ()
 in
 
-let _ =
-  mapi debugPrint [
+mapi debugPrint [
     base,
     rec,
     letin,
@@ -568,7 +567,7 @@ let _ =
     matchor,
     matchnot,
     matchoredge
-  ]
-in
+  ];
+
 
 ()

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -196,7 +196,7 @@ lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
       else b.ty
     in
     match t.ty with TyUnknown {} then
-      let _ = map f t.bindings in
+      map f t.bindings;
       typeExpr env t.inexpr
     else t.ty
   sem typeAnnotExpr (env : TypeEnv) =

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -158,8 +158,8 @@ let nameCmp : Name -> Name -> Int =
     if nameEq n1 n2 then
       0
     else if and (nameHasSym n1) (nameHasSym n2) then
-      subi (sym2hash (optionGetOrElse (lam _. error "Expected symbol") (nameGetSym n1)))
-           (sym2hash (optionGetOrElse (lam _. error "Expected symbol") (nameGetSym n2)))
+      subi (sym2hash (optionGetOrElse (lam. error "Expected symbol") (nameGetSym n1)))
+           (sym2hash (optionGetOrElse (lam. error "Expected symbol") (nameGetSym n2)))
     else if (nameHasSym n1) then subi 0 1
     else if (nameHasSym n2) then 1
     else

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -11,14 +11,14 @@ type Program = String -> [String] -> ExecResult
 
 let _writeToFile = lam str. lam filename.
   let f = pycall _blt "open" (filename, "w+") in
-  let _ = pycall f "write" (str,) in
-  let _ = pycall f "close" () in
+  pycall f "write" (str,);
+  pycall f "close" ();
   ()
 
 let _readFile = lam filename.
   let f = pycall _blt "open" (filename, "r+") in
   let content = pycall f "read" () in
-  let _ = pycall f "close" () in
+  pycall f "close" ();
   pyconvert content
 
 
@@ -50,21 +50,20 @@ let ocamlCompileWithConfig : {warnings: Bool} -> String -> {run: Program, cleanu
     pycall _blt "str" (pycall p "joinpath" (f,),)
   in
 
-  let _ = _writeToFile p (tempfile "program.ml") in
-  let _ = _writeToFile dunefile (tempfile "dune") in
+  _writeToFile p (tempfile "program.ml");
+  _writeToFile dunefile (tempfile "dune");
 
   let command = ["dune", "build"] in
   let r = _runCommand command "" (tempfile "") in
-  let _ =
-    if neqi r.returncode 0 then
-      let _ = print (join ["'dune build' failed on program:\n\n",
-                           _readFile (tempfile "program.ml"),
-                           "\n\nexit code: ",
-                           int2string r.returncode,
-                           "\n\nstandard error:\n", r.stderr]) in
+  if neqi r.returncode 0 then
+      print (join ["'dune build' failed on program:\n\n",
+                   _readFile (tempfile "program.ml"),
+                   "\n\nexit code: ",
+                   int2string r.returncode,
+                   "\n\nstandard error:\n", r.stderr]);
       exit 1
-    else ()
-  in
+  else ();
+  
 
   {
     run =
@@ -74,8 +73,8 @@ let ocamlCompileWithConfig : {warnings: Bool} -> String -> {run: Program, cleanu
         in
         _runCommand command stdin (tempfile ""),
     cleanup =
-      lam _.
-        let _ = pycall td "cleanup" () in
+      lam.
+        pycall td "cleanup" ();
         ()
   }
 
@@ -116,11 +115,11 @@ utest (args.run "" ["world"]).stdout with "world" in
 utest (err.run "" []).stderr with "Hello World!" in
 utest (manyargs.run "" ["hello", "world"]).stderr with "hello world" in
 
-let _ = sym.cleanup () in
-let _ = hello.cleanup () in
-let _ = echo.cleanup () in
-let _ = args.cleanup () in
-let _ = err.cleanup () in
-let _ = manyargs.cleanup () in
+sym.cleanup ();
+hello.cleanup ();
+echo.cleanup ();
+args.cleanup ();
+err.cleanup ();
+manyargs.cleanup ();
 
 ()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -18,7 +18,7 @@ let _opHashMap = lam prefix. lam ops.
 let _op = lam opHashMap. lam op.
   nvar_
   (hashmapLookupOrElse hashmapStrTraits
-    (lam _.
+    (lam.
       error (strJoin " " ["Operation", op, "not found"]))
       op
       opHashMap)
@@ -191,7 +191,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
       match generatePat targetName rpat with (rnames, rwrap) then
         match _mkFinalPatExpr lnames with (lpat, lexpr) then
           match _mkFinalPatExpr rnames with (_, rexpr) then  -- NOTE(vipa, 2020-12-03): the pattern is identical between the two, assuming the two branches bind exactly the same names, which they should
-            let names = assocMapWithKey {eq=nameEqSym} (lam k. lam _. k) lnames in
+            let names = assocMapWithKey {eq=nameEqSym} (lam k. lam. k) lnames in
             let xname = nameSym "_x" in
             let wrap = lam cont.
               _optMatch
@@ -248,7 +248,7 @@ let ocamlEval = lam p. lam strConvert.
   let blt = pyimport "builtins" in
     let res = ocamlCompileWithConfig {warnings=false} (join ["print_string (", strConvert, "(", p, "))"]) in
     let out = (res.run "" []).stdout in
-    let _ = res.cleanup () in
+    res.cleanup ();
     parseAsMExpr out
 in
 

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -380,7 +380,7 @@ let debugPrint = false in
 
 let pprintProg = lam ast.
   if debugPrint then
-    let _ = print "\n\n" in
+    print "\n\n";
     print (expr2str (symbolize ast))
   else ()
 in
@@ -528,6 +528,6 @@ let asts = [
   testTuple
 ] in
 
-let _ = map pprintProg asts in
+map pprintProg asts;
 
 ()

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -48,7 +48,7 @@ let optionBind: Option a -> (a -> Option b) -> Option b = lam o. lam f.
 
 utest optionBind (None ()) (lam t. Some (addi 1 t)) with (None ())
 utest optionBind (Some 1) (lam t. Some (addi 1 t)) with (Some 2)
-utest optionBind (Some 1) (lam _. None ()) with (None ())
+utest optionBind (Some 1) (lam. None ()) with (None ())
 
 -- 'optionCompose f g' composes the option-producing functions 'f' and 'g' into
 -- a new function, which only succeeds if both 'f' and 'g' succeed.
@@ -83,14 +83,14 @@ let optionZipWithOrElse: (Unit -> c) -> (a -> b -> c) -> (Option a) -> (Option b
     else
       d ()
 
-utest optionZipWithOrElse (lam _. "ERROR") (lam a. lam b. [a,b]) (Some 'm') (Some 'i') with "mi"
-utest optionZipWithOrElse (lam _. "ERROR") (lam a. lam b. [a,b]) (Some 'm') (None ()) with "ERROR"
-utest optionZipWithOrElse (lam _. "ERROR") (lam a. lam b. [a,b]) (None ()) (None ()) with "ERROR"
+utest optionZipWithOrElse (lam. "ERROR") (lam a. lam b. [a,b]) (Some 'm') (Some 'i') with "mi"
+utest optionZipWithOrElse (lam. "ERROR") (lam a. lam b. [a,b]) (Some 'm') (None ()) with "ERROR"
+utest optionZipWithOrElse (lam. "ERROR") (lam a. lam b. [a,b]) (None ()) (None ()) with "ERROR"
 
 -- 'optionZipWithOr v f o1 o2' applies the function f on the values contained
 -- in o1 and o2. If either o1 or o2 is None, then v is returned.
 let optionZipWithOr: c -> (a -> b -> c) -> (Option a) -> (Option b) -> c =
-  lam v. optionZipWithOrElse (lam _. v)
+  lam v. optionZipWithOrElse (lam. v)
 
 utest optionZipWithOr false eqi (Some 10) (Some 11) with false
 utest optionZipWithOr false eqi (Some 10) (Some 10) with true
@@ -105,12 +105,12 @@ let optionGetOrElse: (Unit -> a) -> Option a -> a = lam d. lam o.
   else
     d ()
 
-utest optionGetOrElse (lam _. 3) (Some 1) with 1
-utest optionGetOrElse (lam _. 3) (None ()) with 3
+utest optionGetOrElse (lam. 3) (Some 1) with 1
+utest optionGetOrElse (lam. 3) (None ()) with 3
 
 -- Try to retrieve the contained value, or fallback to a default value
 let optionGetOr: a -> Option a -> a = lam d.
-  optionGetOrElse (lam _. d)
+  optionGetOrElse (lam. d)
 
 utest optionGetOr 3 (Some 1) with 1
 utest optionGetOr 3 (None ()) with 3
@@ -120,8 +120,8 @@ utest optionGetOr 3 (None ()) with 3
 let optionMapOrElse: (Unit -> b) -> (a -> b) -> Option a -> b = lam d. lam f. lam o.
   optionGetOrElse d (optionMap f o)
 
-utest optionMapOrElse (lam _. 3) (addi 1) (Some 1) with 2
-utest optionMapOrElse (lam _. 3) (addi 1) (None ()) with 3
+utest optionMapOrElse (lam. 3) (addi 1) (Some 1) with 2
+utest optionMapOrElse (lam. 3) (addi 1) (None ()) with 3
 
 -- Applies a function to the contained value (if any),
 -- or returns the provided default (if not).
@@ -188,7 +188,7 @@ utest optionContains (Some 2) (eqi 1) with false
 utest optionContains (None ()) (eqi 1) with false
 
 -- Returns `true` if the option is a `Some` value.
-let optionIsSome: Option a -> Bool = lam o. optionContains o (lam _. true)
+let optionIsSome: Option a -> Bool = lam o. optionContains o (lam. true)
 
 utest optionIsSome (Some 1) with true
 utest optionIsSome (None ()) with false
@@ -228,13 +228,13 @@ utest optionFilter (eqi 2) (None ()) with (None ())
 let optionOrElse: (Unit -> Option a) -> Option a -> Option a = lam f. lam o.
   optionGetOrElse f (optionMap (lam x. Some x) o)
 
-utest optionOrElse (lam _. Some 2) (Some 1) with (Some 1)
-utest optionOrElse (lam _. Some 2) (None ()) with (Some 2)
+utest optionOrElse (lam. Some 2) (Some 1) with (Some 1)
+utest optionOrElse (lam. Some 2) (None ()) with (Some 2)
 
 -- Returns the first option if it contains a value, otherwise returns
 -- the second option.
 let optionOr: Option a -> Option a -> Option a = lam o1. lam o2.
-  optionOrElse (lam _. o2) o1
+  optionOrElse (lam. o2) o1
 
 utest optionOr (Some 1) (Some 2) with (Some 1)
 utest optionOr (Some 1) (None ()) with (Some 1)

--- a/stdlib/parser-combinators.mc
+++ b/stdlib/parser-combinators.mc
@@ -268,7 +268,7 @@ let satisfy = lam cnd. lam expected. lam st.
   bind next (lam c.
   if cnd c
   then pure c
-  else lam _ . fail (showChar c) expected st) st
+  else lam. fail (showChar c) expected st) st
 
 -- try : Parser a -> Parser a
 --
@@ -442,8 +442,8 @@ recursive
       let cs = tail s in
       label (concat "'" (concat s "'")) (
         try ( -- This 'try' makes the parser consume the whole string or nothing
-          bind (lexChar c) (lam _ .
-          bind (lexString cs) (lam _ .
+          bind (lexChar c) (lam.
+          bind (lexString cs) (lam.
           pure s))
         ))
 end
@@ -656,10 +656,10 @@ recursive
 -- Innermost expression parser.
   let atom = lam st.
     let varAccess =
-      let _ = debug "== Parsing varAccess" in
+      debug "== Parsing varAccess";
       fmap (lam x. Var x) identifier in
     let num =
-      let _ = debug "== Parsing num ==" in
+      debug "== Parsing num ==";
       fmap (lam n. Num n) number
     in
       label "atomic expression"
@@ -677,30 +677,30 @@ recursive
       pure (foldl1 (curry (lam x. App x)) as))
     in
     let abs =
-      let _ = debug "== Parsing abstraction ==" in
-      bind (reserved "lam") (lam _.
+      debug "== Parsing abstraction ==";
+      bind (reserved "lam") (lam.
       bind identifier (lam x.
-      bind (symbol ".") (lam _.
+      bind (symbol ".") (lam.
       bind expr (lam e.
       pure (Abs (x, e))))))
     in
     let let_ =
-      let _ = debug "== Parsing let ==" in
-      bind (reserved "let") (lam _.
+      debug "== Parsing let ==";
+      bind (reserved "let") (lam.
       bind identifier (lam x.
-      bind (symbol "=") (lam _.
+      bind (symbol "=") (lam.
       bind expr (lam e.
-      bind (symbol "in") (lam _.
+      bind (symbol "in") (lam.
       bind expr (lam body.
       pure (Let (x, e, body))))))))
     in
     let if_ =
-      let _ = debug "== Parsing if ==" in
-      bind (reserved "if") (lam _.
+      debug "== Parsing if ==";
+      bind (reserved "if") (lam.
       bind expr (lam cnd.
-      bind (reserved "then") (lam _.
+      bind (reserved "then") (lam.
       bind expr (lam thn.
-      bind (reserved "else") (lam _.
+      bind (reserved "else") (lam.
       bind expr (lam els.
       pure (If(cnd, thn, els))))))))
     in

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -339,9 +339,9 @@ let breakableGenGrammar
   -> BreakableGenGrammar prodLabel res self
   = lam cmp. lam grammar.
     let nOpId : Ref OpId = ref _firstOpId in
-    let newOpId : () -> OpId = lam _.
+    let newOpId : () -> OpId = lam.
       let res = deref nOpId in
-      let _ = modref nOpId (_nextOpId res) in
+      modref nOpId (_nextOpId res);
       res in
 
     let label
@@ -390,7 +390,7 @@ let breakableGenGrammar
     let updateRef : Ref a -> (a -> a) -> ()
       = lam ref. lam f. modref ref (f (deref ref)) in
 
-    let _ = for_ grammar.productions
+    for_ grammar.productions
       (lam prod.
         let label = label prod in
         let id = toOpId label in
@@ -408,8 +408,7 @@ let breakableGenGrammar
           let l = breakableMapAllowSet toOpId _cmpOpId l in
           let p = getGroupingByRight id in
           updateRef postfixes (cons (label, PostfixI {id = id, construct = c, leftAllow = l, precWhenThisIsRight = p}))
-        else never)
-    in
+        else never);
 
     { atoms = mapFromList cmp (deref atoms)
     , prefixes = mapFromList cmp (deref prefixes)
@@ -433,8 +432,9 @@ recursive let _maxDistanceFromRoot
   = lam n.
     match n with TentativeMid {maxDistanceFromRoot = r} then r else
     match n with TentativeRoot _ then 0 else
-    match n with TentativeLeaf {parents = parents} then maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot parents) else
-    let _ = dprintLn n in never
+    match n with TentativeLeaf {parents = parents} then maxOrElse (lam. 0) subi (map _maxDistanceFromRoot parents) else
+    dprintLn n;
+    never
 end
 
 let _shallowAllowedLeft
@@ -457,7 +457,7 @@ let _shallowAllowedRight
       match parent with TentativeRoot _ then Some node else
       match parent with TentativeMid {tentativeData = (InfixT {input = InfixI {rightAllow = s}} | PrefixT {input = PrefixI {rightAllow = s}})} then
         if breakableInAllowSet (_opIdP node) s then Some node else None ()
-      else let _ = dprintLn parent in never
+      else dprintLn parent; never
     else never
 
 let _addRightChildren
@@ -495,7 +495,7 @@ let _addLeftChildren
         { parents = parents
         , addedNodesLeftChildren = addedLeft
         , addedNodesRightChildren = addedRight
-        , maxDistanceFromRoot = addi 1 (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot parents))
+        , maxDistanceFromRoot = addi 1 (maxOrElse (lam. 0) subi (map _maxDistanceFromRoot parents))
         , tentativeData = InfixT {input = input, self = self, leftChildAlts = leftChildren}
         }
     else match input with PostfixI _ then
@@ -515,10 +515,10 @@ let _addRightChildToParent
     let target = _addedNodesRightChildren parent in
     match deref target with (lastUpdate, prev) then
       if _isBefore lastUpdate time then
-        let _ = modref target (time, [child]) in
+        modref target (time, [child]);
         Some parent
       else
-        let _ = modref target (time, cons child prev) in
+        modref target (time, cons child prev);
         None ()
     else never
 
@@ -533,10 +533,10 @@ let _addLeftChildToParent
       match deref target with (lastUpdate, prev) then
         if _isBefore lastUpdate time then
           let leftChildrenHere = ref [child] in
-          let _ = for_ parents (lam p. modref (_addedNodesLeftChildren p) (time, leftChildrenHere)) in
+          for_ parents (lam p. modref (_addedNodesLeftChildren p) (time, leftChildrenHere));
           Some parents
         else
-          let _ = modref prev (cons child (deref prev)) in
+          modref prev (cons child (deref prev));
           None ()
       else never
     else never -- TODO(vipa, 2021-02-12): this isn't technically never for the typesystem, since we're matching against a possibly empty list. However, the list will never be empty, by the comment about NonEmpty above
@@ -575,10 +575,10 @@ let _newQueueFromFrontier
   = lam frontier.
     -- TODO(vipa, 2021-02-12): This could use a `make : (Int -> a) -> Int -> [a]` that we discussed a while back
     map
-      (lam _. ref [])
+      (lam. ref [])
       (create
-        (addi 1 (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot frontier)))
-        (lam _. ()))
+        (addi 1 (maxOrElse (lam. 0) subi (map _maxDistanceFromRoot frontier)))
+        (lam. ()))
 let _addToQueue
   : TentativeNode res self ROpen
   -> BreakableQueue res self
@@ -594,7 +594,7 @@ recursive let _popFromQueue
     match queue with queue ++ [target] then
       let nodes = deref target in
       match nodes with [node] ++ nodes then
-        let _ = modref target nodes in
+        modref target nodes;
         Some node
       else _popFromQueue queue
     else None ()
@@ -610,7 +610,7 @@ let _addLOpen
   -> Option (State res self rstyle)
   = lam input. lam self. lam st.
     let time = addi 1 (deref st.timestep) in
-    let _ = modref st.timestep time in
+    modref st.timestep time;
 
     let makeNewParents
       : [TentativeNode res self ROpen] -- NonEmpty
@@ -630,14 +630,14 @@ let _addLOpen
       -> Option [TentativeNode res self ROpen] -- NonEmpty
       = lam queue. lam child.
         match _getParents child with Some parents then
-          let _ = for_ parents
+          for_ parents
             (lam parent.
               if not (_mayGroupLeft parent input) then () else
               match _shallowAllowedRight parent child with Some child then
                 match _addRightChildToParent time child parent with Some parent then
                   _addToQueue parent queue
                 else ()
-              else ()) in
+              else ());
           match (_shallowAllowedLeft input child, filter (lam l. _mayGroupRight l input) parents)
           with (Some child, parents & [_] ++ _) then
             _addLeftChildToParent time child parents
@@ -684,7 +684,7 @@ let breakableAddPrefix
         { parents = frontier
         , addedNodesLeftChildren = addedLeft
         , addedNodesRightChildren = addedRight
-        , maxDistanceFromRoot = addi 1 (maxOrElse (lam _. 0) subi (map _maxDistanceFromRoot frontier))
+        , maxDistanceFromRoot = addi 1 (maxOrElse (lam. 0) subi (map _maxDistanceFromRoot frontier))
         , tentativeData = PrefixT {input = input, self = self}
         }
       ]
@@ -718,7 +718,7 @@ let breakableFinalizeParse
   -> [PermanentNode res self]
   = lam st.
     let time = addi 1 (deref st.timestep) in
-    let _ = modref st.timestep time in
+    modref st.timestep time;
 
     let handleLeaf
       : BreakableQueue res self
@@ -744,7 +744,7 @@ let breakableFinalizeParse
           let children = (deref (_addedNodesRightChildren p)).1 in
           match p with TentativeRoot _ then children
           else match (p, children) with (TentativeMid _, [_] ++ _) then
-            let _ = handleLeaf queue (_addRightChildren st p children) in
+            handleLeaf queue (_addRightChildren st p children);
             work queue
           else match p with TentativeMid _ then
             error "Somehow reached a TentativeMid without right children, that was still added to the queue"
@@ -754,7 +754,7 @@ let breakableFinalizeParse
 
     let frontier = st.frontier in
     let queue = _newQueueFromFrontier frontier in
-    let _ = iter (handleLeaf queue) frontier in
+    iter (handleLeaf queue) frontier;
     work queue
 
 type BreakableError self
@@ -811,9 +811,9 @@ let breakableConstructResult
             -- TODO(vipa, 2021-02-15): Compute valid elisons, and use those to
             -- populate the 'irrelevant' field
             let err = {first = err.first, last = err.last, irrelevant = []} in
-            let _ = modref ambiguities (cons err (deref ambiguities)) in
+            modref ambiguities (cons err (deref ambiguities));
             None ()
-          else let _ = dprintLn nodes in never
+          else dprintLn nodes; never
       let workOne
         : PermanentNode res self
         -> Option res

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -36,14 +36,6 @@ lang WhitespaceParser = WSACParser
   | x -> {str = x, pos = p}
 end
 
-let _ = use WhitespaceParser in
-  utest eatWSAC (initPos "") "  foo"
-    with {str = "foo", pos = (posVal "" 1 2)} in
-  utest eatWSAC (initPos "") " \tfoo"
-    with {str = "foo", pos = (posVal "" 1 3)} in
-  utest eatWSAC (initPos "") " \n    bar "
-    with {str = "bar ", pos = (posVal "" 2 4)} in
-  ()
 
 -- Eat line comments of the form --
 lang LineCommentParser = WSACParser
@@ -75,17 +67,6 @@ end
 
 -- Commbined WSAC parser for MExpr
 lang MExprWSACParser = WhitespaceParser + LineCommentParser + MultilineCommentParser
-
-let _ = use MExprWSACParser in
-  utest eatWSAC (initPos "") " --foo \n  bar "
-    with {str = "bar ", pos = posVal "" 2 2} in
-  utest eatWSAC (initPos "") " /- foo -/ bar"
-    with {str = "bar", pos = posVal "" 1 11} in
-  utest eatWSAC (initPos "") " /- foo\n x \n -/ \nbar "
-    with {str = "bar ", pos = posVal "" 4 0} in
-  utest eatWSAC (initPos "") " /- x -- y /- foo \n -/ -/ !"
-    with {str = "!", pos = posVal "" 2 7} in
-  ()
 
 lang EOFTokenParser = TokenParser
   syn Token =
@@ -532,6 +513,31 @@ let compareTokKind = use Lexer in lam ltok. lam rtok.
   subi (_tokKindInt ltok) (_tokKindInt rtok)
 
 mexpr
+
+
+use WhitespaceParser in
+  utest eatWSAC (initPos "") "  foo"
+    with {str = "foo", pos = (posVal "" 1 2)} in
+  utest eatWSAC (initPos "") " \tfoo"
+    with {str = "foo", pos = (posVal "" 1 3)} in
+  utest eatWSAC (initPos "") " \n    bar "
+    with {str = "bar ", pos = (posVal "" 2 4)} in
+  ();
+
+
+
+use MExprWSACParser in
+  utest eatWSAC (initPos "") " --foo \n  bar "
+    with {str = "bar ", pos = posVal "" 2 2} in
+  utest eatWSAC (initPos "") " /- foo -/ bar"
+    with {str = "bar", pos = posVal "" 1 11} in
+  utest eatWSAC (initPos "") " /- foo\n x \n -/ \nbar "
+    with {str = "bar ", pos = posVal "" 4 0} in
+  utest eatWSAC (initPos "") " /- x -- y /- foo \n -/ -/ !"
+    with {str = "!", pos = posVal "" 2 7} in
+  ();
+
+
 
 use Lexer in
 

--- a/stdlib/prelude.mc
+++ b/stdlib/prelude.mc
@@ -6,7 +6,7 @@ include "option.mc"
 
 -- Function stuff
 let identity = lam x. x
-let const = lam x. lam _. x
+let const = lam x. lam. x
 let apply = lam f. lam x. f x
 let compose = lam f. lam g. lam x. f (g x)
 let curry = lam f. lam x. lam y. f(x, y)
@@ -24,7 +24,7 @@ let fixMutual =
 -- Printing stuff
 let printLn = lam s. print (concat s "\n")
 
-let dprintLn = lam x. let _ = dprint x in printLn ""
+let dprintLn = lam x. dprint x; printLn ""
 
 mexpr
 

--- a/stdlib/ref.mc
+++ b/stdlib/ref.mc
@@ -1,5 +1,5 @@
 -- Construct a reference
-let ref = lam x. tensorCreate [] (lam _. x)
+let ref = lam x. tensorCreate [] (lam. x)
 
 -- De-reference
 let deref = lam t. tensorGetExn t []

--- a/stdlib/regex.mc
+++ b/stdlib/regex.mc
@@ -40,7 +40,7 @@ let regEx2str = lam sym2str. lam reg.
   pprint reg
 
 let regExPprint = lam sym2str. lam reg.
-  let _ = print (regEx2str sym2str reg) in
+  print (regEx2str sym2str reg);
   print "\n"
 
 -- Checks structural equivalence of two regexes.
@@ -237,7 +237,7 @@ let regexFromDFA = lam dfa.
                       let mergedSuccessors =
                         map (lam s1.
                               optionGetOrElse
-                                (lam _. error "Expected transition between states")
+                                (lam. error "Expected transition between states")
                                 (pairMergeTrans dfa s s1))
                             (nfaOutStates s dfa) in
                       concat acc mergedSuccessors)

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -1,7 +1,7 @@
 include "option.mc"
 include "bool.mc"
 
-let make = lam n. lam v. create n (lam _. v)
+let make = lam n. lam v. create n (lam. v)
 
 utest make 3 5 with [5,5,5]
 utest make 4 'a' with ['a', 'a', 'a', 'a']
@@ -42,7 +42,7 @@ let mapi = lam f. lam seq.
   in
   work 0 f seq
 
-let map = lam f. mapi (lam _. lam x. f x)
+let map = lam f. mapi (lam. lam x. f x)
 
 utest mapi (lam i. lam x. i) [3,4,8,9,20] with [0,1,2,3,4]
 utest mapi (lam i. lam x. i) [] with []
@@ -77,7 +77,8 @@ recursive let iter
   -> ()
   = lam f. lam xs.
     match xs with [x] ++ xs then
-      let _ = f x in iter f xs
+      f x;
+      iter f xs
     else match xs with [] then
       ()
     else never
@@ -88,7 +89,7 @@ with ()
 
 utest
   let r = ref 0 in
-  let _ = iter (lam x. modref r (addi x (deref r))) [1, 2, 3, 4] in
+  iter (lam x. modref r (addi x (deref r))) [1, 2, 3, 4];
   deref r
 with 10
 
@@ -224,7 +225,7 @@ recursive
 end
 
 utest filter (lam x. eqi x 1) [1,2,4] with [1]
-utest filter (lam _. false) [3,5,234,1,43] with []
+utest filter (lam. false) [3,5,234,1,43] with []
 utest filter (lam x. gti x 2) [3,5,234,1,43] with [3,5,234,43]
 
 recursive
@@ -300,13 +301,13 @@ utest max (lam l. lam r. subi l r) [] with None ()
 let minOrElse = lam d. lam cmp. lam seq.
   optionGetOrElse d (min cmp seq)
 
-utest minOrElse (lam _. 0) (lam l. lam r. subi l r) [3,4,8,9,20] with 3
-utest minOrElse (lam _. 0) (lam l. lam r. subi l r) [9,8,4,20,3] with 3
+utest minOrElse (lam. 0) (lam l. lam r. subi l r) [3,4,8,9,20] with 3
+utest minOrElse (lam. 0) (lam l. lam r. subi l r) [9,8,4,20,3] with 3
 
 let maxOrElse = lam d. lam cmp. minOrElse d (lam l. lam r. cmp r l)
 
-utest maxOrElse (lam _. 0) (lam l. lam r. subi l r) [3,4,8,9,20] with 20
-utest maxOrElse (lam _. 0) (lam l. lam r. subi l r) [9,8,4,20,3] with 20
+utest maxOrElse (lam. 0) (lam l. lam r. subi l r) [3,4,8,9,20] with 20
+utest maxOrElse (lam. 0) (lam l. lam r. subi l r) [9,8,4,20,3] with 20
 
 -- First index in seq that satifies pred
 let index = lam pred. lam seq.

--- a/stdlib/sundials/sundials.mc
+++ b/stdlib/sundials/sundials.mc
@@ -6,7 +6,7 @@ let idaRCStopTimeReached = 1
 let idaVarIdDifferential = 1.
 let idaVarIdAlgebraic = 0.
 
-let noroots = (0, lam _. error "Called noroots")
+let noroots = (0, lam. error "Called noroots")
 
 let sArr2Seq = lam a.
   recursive let work = lam seq. lam i.

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -26,10 +26,10 @@ lam f. lam t.
             0
 
 let tensorOfSeqExn : [a] -> Tensor a =
-  tensorOfSeqOrElse (lam _. error "Empty seq in tensorOfSeqExn")
+  tensorOfSeqOrElse (lam. error "Empty seq in tensorOfSeqExn")
 
 let tensorToSeqExn : Tensor a -> [a] =
-  tensorToSeqOrElse (lam _. error "Not rank 1 tensor in tensorToSeqExn")
+  tensorToSeqOrElse (lam. error "Not rank 1 tensor in tensorToSeqExn")
 
 utest tensorToSeqExn (tensorOfSeqExn [1, 2, 3, 4]) with [1, 2, 3, 4]
 
@@ -39,8 +39,8 @@ let tensorSize : Tensor a -> Int =
 lam t.
   foldl muli 1 (tensorShape t)
 
-utest tensorSize (tensorCreate [1, 2, 3] (lam _. 0)) with 6
-utest tensorSize (tensorCreate [] (lam _. 0)) with 1
+utest tensorSize (tensorCreate [1, 2, 3] (lam. 0)) with 6
+utest tensorSize (tensorCreate [] (lam. 0)) with 1
 
 -- Map the elements of t1 to the elements of t2 using the function f, where t1
 -- and t2 has to have the same shape.
@@ -55,29 +55,29 @@ lam f. lam g. lam t1. lam t2.
   else f ()
 
 let tensorMapExn =
-  tensorMapOrElse (lam _. error "Tensor shape mismatch in tensorMap")
+  tensorMapOrElse (lam. error "Tensor shape mismatch in tensorMap")
 
 utest
   let t1 = tensorOfSeqExn [1, 2, 3, 4] in
-  let t2 = tensorCreate [4] (lam _. []) in
-  let _ = tensorMapExn (lam x. [x]) t1 t2 in
+  let t2 = tensorCreate [4] (lam. []) in
+  tensorMapExn (lam x. [x]) t1 t2;
   tensorToSeqExn t2
 with [[1], [2], [3], [4]]
 
 utest
   let t = tensorOfSeqExn [1, 2, 3, 4] in
-  let _ = tensorMapExn (addi 1) t t in
+  tensorMapExn (addi 1) t t;
   tensorToSeqExn t
 with [2, 3, 4, 5]
 
 
 -- Fill a tensor with values.
 let tensorFill : Tensor a -> a -> Unit =
-lam t. lam v. tensorMapExn (lam _. v) t t
+lam t. lam v. tensorMapExn (lam. v) t t
 
 utest
   let t = tensorOfSeqExn [1, 2, 3, 4] in
-  let _ = tensorFill t 0 in
+  tensorFill t 0;
   tensorToSeqExn t
 with [0, 0, 0, 0]
 
@@ -85,7 +85,7 @@ with [0, 0, 0, 0]
 -- Create a tensor filled with values.
 let tensorRepeat : [Int] -> a -> Tensor a =
 lam shape. lam v.
-  tensorCreate shape (lam _. v)
+  tensorCreate shape (lam. v)
 
 utest
   let t = tensorRepeat [4] 0 in
@@ -102,7 +102,7 @@ mexpr
 -- index as an argument and returning the element at that index.
 
 -- We can construct a zero-order tensor with value 'a' as
-let t0 = tensorCreate [] (lam _. 'a') in
+let t0 = tensorCreate [] (lam. 'a') in
 utest tensorRank t0 with 0 in
 utest tensorShape t0 with [] in
 
@@ -119,7 +119,7 @@ utest tensorToSeqExn t1 with [1, 2, 3, 4, 5, 6, 7, 8, 9] in
 let t2 = tensorReshapeExn t1 [3, 3] in
 
 -- Reshape does no copying and the data is shared between `t1` and `t2`
-let _ = tensorSetExn t2 [0, 0] 2 in
+tensorSetExn t2 [0, 0] 2;
 utest tensorGetExn t1 [0] with 2 in
 
 -- We can slice the second row from `t2` as
@@ -135,7 +135,7 @@ utest tensorGetExn e [] with 5 in
 utest tensorRank e with 0 in
 
 -- A slice shares data with the original tensor and no copying of data is done.
-let _ = tensorFill r2 0 in
+tensorFill r2 0;
 utest tensorToSeqExn t1 with [2, 2, 3, 0, 0, 0, 7, 8, 9] in
 -- where we use `tensorFill` from `tensor.mc`
 

--- a/test/mexpr/effects.mc
+++ b/test/mexpr/effects.mc
@@ -20,7 +20,7 @@ utest if false then dprint ["message\n","hi"] else 0 with 0 in
 -- String -> String -> ()
 let str1 = "A unicode string.\n島" in
 let file = "_testfile" in
-let _ = writeFile file str1 in
+writeFile file str1;
 
 
 -- 'readFile fname' reads a text file with filename 'fname' and returns a string
@@ -34,7 +34,7 @@ utest fileExists file with true in
 
 
 -- 'deleteFile fname' deletes a file with name 'fname'
-let _ = deleteFile file in
+deleteFile file;
 utest fileExists file with false in
 
 

--- a/test/mexpr/letlamif.mc
+++ b/test/mexpr/letlamif.mc
@@ -31,6 +31,10 @@ let z = 8 in
 let m = lam x. lam y. muli x y in
 utest if eqi (m 2 3) 6 then addi z 2 else 0 with 10 in
 
+-- Sequence operator "t1 ; t2", which syntactic sugar for let _ = t2 in t2
+let foo = lam x.
+  dprint ["Value x", x];
+  addi x 2 in
 
 -- factorial function
 recursive

--- a/test/mexpr/letlamif.mc
+++ b/test/mexpr/letlamif.mc
@@ -34,6 +34,7 @@ utest if eqi (m 2 3) 6 then addi z 2 else 0 with 10 in
 -- Sequence operator "t1 ; t2", which syntactic sugar for let _ = t2 in t2
 let foo = lam x.
   dprint ["Value x", x];
+  dprint x;
   addi x 2 in
 
 -- factorial function

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -101,8 +101,8 @@ utest match s1 with [1,3,5,10] then true else false with true in
 utest match s1 with [1,3] ++ _ then true else false with true in
 utest match s1 with [2,3] ++ _ then true else false with false in
 utest match s1 with [1,a] ++ _ then a else 0 with 3 in
-utest let _ = [] in match s1 with [b] ++ _ then let a = 2 in (a, b, _) else (0, 0, []) with (2, 1, []) in
-utest let _ = [] in match s1 with _ ++ [b] then let a = 2 in (a, b, _) else (0, 0, []) with (2, 10, []) in
+utest match s1 with [b] ++ _ then let a = 2 in (a, b, []) else (0, 0, []) with (2, 1, []) in
+utest match s1 with _ ++ [b] then let a = 2 in (a, b, []) else (0, 0, []) with (2, 10, []) in
 utest match s1 with [_,a] ++ b then (a,b) else (0,[]) with (3,[5,10]) in
 utest match s1 with _ ++ [5,10] then true else false with true in
 utest match s1 with _ ++ [5,11] then true else false with false in

--- a/test/mexpr/random.mc
+++ b/test/mexpr/random.mc
@@ -17,15 +17,15 @@ mexpr
 
 -- Generate a sequence of random numbers
 let randSeq = lam lower. lam upper. lam length.
-  map (lam _. randIntU lower upper) (create length (lam _. 0)) in
+  map (lam. randIntU lower upper) (create length (lam. 0)) in
 
 -- With high probability all possible elements are present in the random sequence
 utest [2,3,4,5,6] with distinct eqi (randSeq 2 7 1000) using setEqual eqi in
 
 -- The same seed should give the same sequence of numbers
-let _ = randSetSeed 42 in
+randSetSeed 42;
 let randSeq1 = randSeq 123 89018 100 in
-let _ = randSetSeed 42 in
+randSetSeed 42;
 let randSeq2 = randSeq 123 89018 100 in
 utest randSeq1 with randSeq2 using setEqual eqi in
 

--- a/test/mexpr/references.mc
+++ b/test/mexpr/references.mc
@@ -15,7 +15,7 @@ utest deref r2 with 2. in
 utest deref r3 with 1 in
 utest (deref r4) "there" "!" with "Hello there!" in
 
-let _ = modref r3 4 in
+modref r3 4;
 utest deref r1 with 4 in
 utest deref r3 with 4 in
 

--- a/test/mexpr/seq.mc
+++ b/test/mexpr/seq.mc
@@ -13,8 +13,8 @@ utest [[2,3,10],7] with [[2,3,10],7] in
 -- 'create n f' creates a new sequence with 'n' elements of value given
 -- by calling function 'f' with the index of the element
 -- Int -> (Int -> a) -> [a]
-utest create 3 (lam _. 10) with [10,10,10] in
-utest create 8 (lam _. 'a') with ['a','a','a','a','a','a','a','a'] in
+utest create 3 (lam. 10) with [10,10,10] in
+utest create 8 (lam. 'a') with ['a','a','a','a','a','a','a','a'] in
 utest create 4 (lam i. muli 2 i) with [0,2,4,6] in
 utest create 0 (lam i. i) with [] in
 

--- a/test/mexpr/tensor.mc
+++ b/test/mexpr/tensor.mc
@@ -1,16 +1,16 @@
 -- Some helper functions
 let tensorRepeat = lam shape. lam v.
-  tensorCreate shape (lam _. v)
+  tensorCreate shape (lam. v)
 
 let tensorFill = lam t. lam v.
   let n = foldl muli 1 (tensorShape t) in
   let t1 = tensorReshapeExn t [n] in
-  tensorIteri (lam _. lam e. tensorSetExn e [] v) t1
+  tensorIteri (lam. lam e. tensorSetExn e [] v) t1
 
 -- Run all tests
 let testTensors = lam fromInt. lam v.
  -- Rank < 2 Tensors
-  let mkRank2TestTensor = lam _.
+  let mkRank2TestTensor = lam.
     tensorCreate [3, 4] (lam is.
                           let i = get is 0 in
                           let j = get is 1 in
@@ -18,7 +18,7 @@ let testTensors = lam fromInt. lam v.
 
   -- Set and Get
   let t = tensorRepeat [] v.0 in
-  let _ = tensorSetExn t [] v.1 in
+  tensorSetExn t [] v.1;
   utest tensorGetExn t [] with v.1 in
   utest tensorRank t with 0 in
   utest tensorShape t with [] in
@@ -42,7 +42,7 @@ let testTensors = lam fromInt. lam v.
   -- Copy
   let t1 = tensorRepeat [3, 4] v.0 in
   let t2 = mkRank2TestTensor () in
-  let _ = tensorCopyExn t2 t1 in
+  tensorCopyExn t2 t1;
   utest tensorGetExn t1 [0, 0] with v.1 in
   utest tensorGetExn t1 [0, 1] with v.2 in
   utest tensorGetExn t1 [0, 2] with v.3 in
@@ -123,7 +123,7 @@ let testTensors = lam fromInt. lam v.
   let t = mkRank2TestTensor () in
   let t1 = tensorSliceExn t [0] in
   let t2 = tensorSliceExn t [1] in
-  let _ = tensorFill t1 v.0 in
+  tensorFill t1 v.0;
   utest tensorGetExn t [0, 0] with v.0 in
   utest tensorGetExn t [0, 1] with v.0 in
   utest tensorGetExn t [0, 2] with v.0 in
@@ -136,7 +136,7 @@ let testTensors = lam fromInt. lam v.
   utest tensorGetExn t [2, 1] with v.10 in
   utest tensorGetExn t [2, 2] with v.11 in
   utest tensorGetExn t [2, 3] with v.12 in
-  let _ = tensorFill t2 v.1 in
+  tensorFill t2 v.1;
   utest tensorGetExn t [0, 0] with v.0 in
   utest tensorGetExn t [0, 1] with v.0 in
   utest tensorGetExn t [0, 2] with v.0 in
@@ -154,7 +154,7 @@ let testTensors = lam fromInt. lam v.
   let t = mkRank2TestTensor () in
   let t1 = tensorSliceExn t [0] in
   let t2 = tensorSliceExn t [1] in
-  let _ = tensorCopyExn t1 t2 in
+  tensorCopyExn t1 t2;
   utest tensorGetExn t [0, 0] with v.1 in
   utest tensorGetExn t [0, 1] with v.2 in
   utest tensorGetExn t [0, 2] with v.3 in
@@ -200,7 +200,7 @@ let testTensors = lam fromInt. lam v.
   let t1 = tensorSubExn t 0 1 in
   let t2 = tensorSubExn t 1 2 in
 
-  let _ = tensorFill t1 v.0 in
+  tensorFill t1 v.0;
   utest tensorGetExn t [0, 0] with v.0 in
   utest tensorGetExn t [0, 1] with v.0 in
   utest tensorGetExn t [0, 2] with v.0 in
@@ -213,7 +213,7 @@ let testTensors = lam fromInt. lam v.
   utest tensorGetExn t [2, 1] with v.10 in
   utest tensorGetExn t [2, 2] with v.11 in
   utest tensorGetExn t [2, 3] with v.12 in
-  let _ = tensorFill t2 v.1 in
+  tensorFill t2 v.1;
   utest tensorGetExn t [0, 0] with v.0 in
   utest tensorGetExn t [0, 1] with v.0 in
   utest tensorGetExn t [0, 2] with v.0 in
@@ -229,12 +229,11 @@ let testTensors = lam fromInt. lam v.
 
   -- Iteri
   let t = tensorRepeat [2, 2] v.0 in
-  let _ = tensorIteri (lam i. lam row.
+  tensorIteri (lam i. lam row.
                          tensorIteri (lam j. lam e.
                                         tensorSetExn e [] (fromInt (addi (muli i 2) j)))
                                       row)
-                      t
-  in
+                      t;
 
   utest tensorGetExn t [0, 0] with v.0 in
   utest tensorGetExn t [0, 1] with v.1 in
@@ -242,7 +241,7 @@ let testTensors = lam fromInt. lam v.
   utest tensorGetExn t [1, 1] with v.3 in
 
   -- Rank 3 Tensors
-  let mkRank3TestTensor = lam _.
+  let mkRank3TestTensor = lam.
     tensorCreate [2, 2, 3] (lam is.
                               let i = get is 0 in
                               let j = get is 1 in
@@ -305,8 +304,8 @@ let testTensors = lam fromInt. lam v.
   let t = mkRank3TestTensor () in
   let t1 = tensorSliceExn t [0, 1] in
   let t2 = tensorSliceExn t [1] in
-  let _ = tensorFill t1 v.0 in
-  let _ = tensorFill t2 v.1 in
+  tensorFill t1 v.0;
+  tensorFill t2 v.1;
   utest tensorGetExn t [0, 0, 0] with v.1 in
   utest tensorGetExn t [0, 0, 1] with v.2 in
   utest tensorGetExn t [0, 0, 2] with v.3 in
@@ -334,7 +333,7 @@ let testTensors = lam fromInt. lam v.
   -- Sub and Fill
   let t = mkRank3TestTensor () in
   let t1 = tensorSubExn t 1 1 in
-  let _ = tensorFill t1 v.0 in
+  tensorFill t1 v.0;
   utest tensorGetExn t [0, 0, 0] with v.1 in
   utest tensorGetExn t [0, 0, 1] with v.2 in
   utest tensorGetExn t [0, 0, 2] with v.3 in
@@ -352,7 +351,7 @@ let testTensors = lam fromInt. lam v.
   let t = mkRank3TestTensor () in
   let t1 = tensorSliceExn t [1] in
   let t2 = tensorSubExn t1 1 1 in
-  let _ = tensorFill t2 v.0 in
+  tensorFill t2 v.0;
   utest tensorGetExn t [0, 0, 0] with v.1 in
   utest tensorGetExn t [0, 0, 1] with v.2 in
   utest tensorGetExn t [0, 0, 2] with v.3 in
@@ -369,10 +368,10 @@ let testTensors = lam fromInt. lam v.
   ()
 
 let v = ([0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12])
-let _ = testTensors (lam x. [x]) v
+let _void = testTensors (lam x. [x]) v
 
 let v = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
-let _ = testTensors (lam x. x) v
+let _void = testTensors (lam x. x) v
 
 let v = (0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.)
-let _ = testTensors int2float v
+let _void = testTensors int2float v

--- a/test/mexpr/time.mc
+++ b/test/mexpr/time.mc
@@ -12,7 +12,7 @@ mexpr
 -- 'sleepMs ms : Int -> Unit' pauses the execution for 'ms' number of ms.
 
 let t1 = wallTimeMs () in
-let _ = sleepMs 1 in
+sleepMs 1;
 let t2 = wallTimeMs () in
 
 utest t2 with t1 using gtf in ()

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -87,7 +87,7 @@ lang FooCombined = FooA + FooTrans
 
 mexpr
 
-use ArithBool2 in
+(use ArithBool2 in
   utest eval (Add (Num 1, Num 2)) with 3 in
   utest eval (If (IsZero (Num 0)
                  ,Num 1
@@ -97,9 +97,9 @@ use ArithBool2 in
                   ,If (IsZero (Add (Num 0, Num 3))
                       ,Num 10
                       ,Add (Num 5, (Num (negi 2)))))) with 13
-  in ();
+  in ());
 
-use ArithBool in
+(use ArithBool in
   utest eval (Add (Num 1, Num 2)) with 3 in
   utest eval (If (True ()
                  ,Num 1
@@ -109,15 +109,15 @@ use ArithBool in
                   ,If (False ()
                       ,Num 10
                       ,Add (Num 5, (Num (negi 2)))))) with 13
-  in ();
+  in ());
 
 
-use User in
+(use User in
   utest inspect (Unit ()) with 3 in
   utest bump (inspect (Unit ())) (Unit ()) with 4 in
-  ();
+  ());
 
-use Overlap in
+(use Overlap in
   utest eval (Add (Num 1, Num 2)) with 3 in
   utest eval (If (IsZero (Num 0)
                  ,Num 1
@@ -127,7 +127,7 @@ use Overlap in
                   ,If (IsZero (Add (Num 0, Num 3))
                       ,Num 10
                       ,Add (Num 5, (Num (negi 2)))))) with 13 in
-  ();
+  ());
 
 let e1 = use ArithBool in If(True(), Num 1, Num 2) in
 let e2 = use ArithBool2 in If(True(), Num 1, Num 2) in
@@ -139,10 +139,10 @@ let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
 utest e1 with e2 in
 
 
-use FooCombined in
+(use FooCombined in
   utest foo (A {}) with "A" in
   utest foo (B {}) with "B" in
-  ();
+  ());
 
 
 ()

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -87,8 +87,7 @@ lang FooCombined = FooA + FooTrans
 
 mexpr
 
-let _ =
-  use ArithBool2 in
+use ArithBool2 in
   utest eval (Add (Num 1, Num 2)) with 3 in
   utest eval (If (IsZero (Num 0)
                  ,Num 1
@@ -98,10 +97,9 @@ let _ =
                   ,If (IsZero (Add (Num 0, Num 3))
                       ,Num 10
                       ,Add (Num 5, (Num (negi 2)))))) with 13
-  in ()
-in
-let _ =
-  use ArithBool in
+  in ();
+
+use ArithBool in
   utest eval (Add (Num 1, Num 2)) with 3 in
   utest eval (If (True ()
                  ,Num 1
@@ -111,16 +109,15 @@ let _ =
                   ,If (False ()
                       ,Num 10
                       ,Add (Num 5, (Num (negi 2)))))) with 13
-  in ()
-in
-let _ =
-  use User in
+  in ();
+
+
+use User in
   utest inspect (Unit ()) with 3 in
   utest bump (inspect (Unit ())) (Unit ()) with 4 in
-  ()
-in
-let _ =
-  use Overlap in
+  ();
+
+use Overlap in
   utest eval (Add (Num 1, Num 2)) with 3 in
   utest eval (If (IsZero (Num 0)
                  ,Num 1
@@ -130,27 +127,22 @@ let _ =
                   ,If (IsZero (Add (Num 0, Num 3))
                       ,Num 10
                       ,Add (Num 5, (Num (negi 2)))))) with 13 in
-  ()
-in
-let _ =
-  let e1 = use ArithBool in If(True(), Num 1, Num 2) in
-  let e2 = use ArithBool2 in If(True(), Num 1, Num 2) in
-  utest e1 with e2 in
-  ()
-in
+  ();
 
-let _ =
-  let e1 = use A in ACon{afield = 1, aextfield = 2} in -- TODO(vipa,?): this should break once we start typechecking product extensions of a constructor
-  let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
-  utest e1 with e2 in
-  ()
-in
+let e1 = use ArithBool in If(True(), Num 1, Num 2) in
+let e2 = use ArithBool2 in If(True(), Num 1, Num 2) in
+utest e1 with e2 in
 
-let _ =
-  use FooCombined in
+
+let e1 = use A in ACon{afield = 1, aextfield = 2} in -- TODO(vipa,?): this should break once we start typechecking product extensions of a constructor
+let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
+utest e1 with e2 in
+
+
+use FooCombined in
   utest foo (A {}) with "A" in
   utest foo (B {}) with "B" in
-  ()
-in
+  ();
+
 
 ()

--- a/test/mlang/nestedpatterns.mc
+++ b/test/mlang/nestedpatterns.mc
@@ -157,8 +157,7 @@ utest use RecordsWithNegation in foo {blue = true} with 4 in
 utest use RecordsWithNegation in foo {red = true} with 2 in
 utest use RecordsWithNegation in foo {blue = false} with 3 in
 
-let _ =
-  use Lexer in
+use Lexer in
   utest lex "" with Some [] in
   utest lex "0" with Some [IntTok "0"] in
   utest lex "0109" with Some [IntTok "0109"] in
@@ -167,6 +166,3 @@ let _ =
   utest lex "0b 10" with None () in
   utest lex "  32 " with Some [IntTok "32"] in
   ()
-in
-
-()

--- a/test/mlang/sharedcons.mc
+++ b/test/mlang/sharedcons.mc
@@ -28,24 +28,18 @@ let fooAC = use AC in (TmFoo ()) in
 utest fooA2 with fooA in
 utest fooAC with fooA in
 
-let _ = 
-  use A in
+use A in
   utest isA (TmFoo ()) with true in
   utest isB (TmFoo ()) with false in
-  ()
-in
+  ();
 
-let _ = 
-  use AC in
+use AC in
   utest isA (TmFoo ()) with true in
   utest isB (TmFoo ()) with false in
-  ()
-in
+  ();
 
-let _ = 
-  use B in
+
+use B in
   utest isA (TmFoo ()) with false in
   utest isB (TmFoo ()) with true in
   ()
-in
-()

--- a/test/mlang/simple.mc
+++ b/test/mlang/simple.mc
@@ -52,44 +52,37 @@ end
 
 mexpr
 
-let _ =
-  use Empty in
-  ()
-in
-let _ =
-  use Bool in
+use Empty in
+  ();
+
+use Bool in
   utest my_not (True ()) with False () in
-  ()
-in
-let _ =
-  use AlsoBool in
+  ();
+
+use AlsoBool in
   utest my_not (True ()) with (False ()) in
-  ()
-in
-let _ =
-  use AlsoAlsoBool in
+  ();
+
+use AlsoAlsoBool in
   utest to_bool(my_not (True ())) with false in
-  ()
-in
-let _ =
-  use Recursive in
+  ();
+
+use Recursive in
   utest my_not 5 (True ()) with False () in
-  ()
-in
-let _ =
-  use Mutual in
+  ();
+
+use Mutual in
   utest my_not 10 (True ()) with (False ()) in
   utest my_not2 5 (True ()) with (False ()) in
   utest my_not 42 (False ()) with (True ()) in
   utest my_not2 1 (False ()) with (True ()) in
-  ()
-in
-let _ =
-  use And in
+  ();
+
+use And in
   utest my_and (True ()) (True ()) with (True ()) in
   utest my_and (True ()) (False ()) with (False ()) in
   utest my_and (False ()) (True ()) with (False ()) in
   utest my_and (False ()) (False ()) with (False ()) in
   ()
-in
-()
+
+

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -122,6 +122,6 @@ utest sprintf "Hello, %s!" [FmtStr("John Doe")] with "Hello, John Doe!" in
 utest sprintf "My initials are %c.%c." [FmtChar('J'), FmtChar('D')] with "My initials are J.D." in
 utest sprintf "%* means %*" [FmtStr("Five"), FmtInt(5)] with "Five means 5" in
 
-utest sprintf "%s should be %_s or %^s" (create 3 (lam _. (FmtStr ("cAsE")))) with "cAsE should be case or CASE" in
+utest sprintf "%s should be %_s or %^s" (create 3 (lam. (FmtStr ("cAsE")))) with "cAsE should be case or CASE" in
 
 ()

--- a/test/sundials/sundials.mc
+++ b/test/sundials/sundials.mc
@@ -2,9 +2,9 @@ include "sundials/sundials.mc"
 
 mexpr
 let a = sArrMake 3 0. in
-let _ = sArrSet a 0 0. in
-let _ = sArrSet a 1 1. in
-let _ = sArrSet a 2 2. in
+sArrSet a 0 0.;
+sArrSet a 1 1.;
+sArrSet a 2 2.;
 
 utest sArrGet a 0 with 0. in
 utest sArrGet a 1 with 1. in
@@ -14,13 +14,13 @@ utest sArr2Seq a with [0., 1., 2.] in
 
 let y = sArrMake 2 0. in
 let yp = sArrMake 2 0. in
-let _ = sArrSet y 0 1. in
-let _ = sArrSet y 1 2. in
-let _ = sArrSet yp 0 3. in
-let _ = sArrSet yp 1 4. in
+sArrSet y 0 1.;
+sArrSet y 1 2.;
+sArrSet yp 0 3.;
+sArrSet yp 1 4.;
 let tol = (1e-6, 1e-6) in
 let resf = lam t. lam y. lam yp. lam r.
-  let _ = sArrSet r 0 (subf (sArrGet yp 0) (sArrGet y 1)) in
+  sArrSet r 0 (subf (sArrGet yp 0) (sArrGet y 1));
   sArrSet r 1 (addf (sArrGet yp 1) (sArrGet y 0))
 in
 let s = idaInitDense tol resf noroots 0. y yp in
@@ -28,12 +28,12 @@ utest idaCalcICYY s y 0.001 with () in
 utest idaSolveNormal s 10. y yp with (10., idaRCSuccess) in
 
 let jacf = lam t. lam c. lam y. lam yp. lam m.
-  let _ = sMatrixDenseSet m 0 0 c in
-  let _ = sMatrixDenseSet m 0 1 (negf 1.) in
-  let _ = sMatrixDenseSet m 1 0 1. in
+  sMatrixDenseSet m 0 0 c;
+  sMatrixDenseSet m 0 1 (negf 1.);
+  sMatrixDenseSet m 1 0 1.;
   sMatrixDenseSet m 1 1 c
 in
-let rootf = lam t. lam _. lam _. lam g.
+let rootf = lam t. lam. lam. lam g.
   sArrSet g 0 (subf t 5.)
 in
 let s = idaInitDenseJac tol jacf resf (1, rootf) 0. y yp in
@@ -46,10 +46,10 @@ utest idaGetDky s y (subf (idaGetCurrentTime s) (idaGetLastStep s)) 0 with () in
 utest idaGetDky s yp (subf (idaGetCurrentTime s) (idaGetLastStep s)) 1 with () in
 
 let m = sMatrixDenseCreate 2 2 in
-let _ = sMatrixDenseSet m 0 0 1. in
-let _ = sMatrixDenseSet m 0 1 1. in
-let _ = sMatrixDenseSet m 1 0 1. in
-let _ = sMatrixDenseSet m 1 1 1. in
+sMatrixDenseSet m 0 0 1.;
+sMatrixDenseSet m 0 1 1.;
+sMatrixDenseSet m 1 0 1.;
+sMatrixDenseSet m 1 1 1.;
 
 utest sMatrixDenseGet m 0 0 with 1. in
 utest sMatrixDenseGet m 0 1 with 1. in
@@ -58,10 +58,10 @@ utest sMatrixDenseGet m 1 1 with 1. in
 
 let y = sArrMake 2 0. in
 let yp = sArrMake 2 0. in
-let _ = sArrSet y 0 1. in
-let _ = sArrSet y 1 2. in
-let _ = sArrSet yp 0 3. in
-let _ = sArrSet yp 1 4. in
+sArrSet y 0 1.;
+sArrSet y 1 2.;
+sArrSet yp 0 3.;
+sArrSet yp 1 4.;
 let varid = sArrMake 2 idaVarIdDifferential in
 
 let s = idaInitDense tol resf noroots 0. y yp in


### PR DESCRIPTION
This PR adds a sequence operator `;` as syntactic sugar to MExpr. The PR includes updates to the boot parser, and pretty printing in the MLang compiler. Specifically, the PR includes the following:

- The expression `e1 ; e2` is syntactic sugar for `let #var"" = e1 in e2`. Note that we do not add a special wildcard for `let`, to avoid unnecessary complications when transferring `let` expressions.
- An expression `let #var"" = e1 in e2` is pretty printed as `e1 ; e2`.
- We add syntactic sugar for lambdas where the lambda variable is not used. That is,
`lam. e1` is syntactic sugar for `lam #var"". e1`.
- `_` is not possible to use in MExpr code. Instead, `_` is a keyword that is only used in patterns. Hence, `let _ = ...` is not a legal form and it is not possible to use `_` as a variable directly. 