### PR TITLE
Refactored names of pattern AST nodes

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -8,35 +8,35 @@ include "info.mc"
 
 let npvar_ = use MExprAst in
   lam n.
-  PNamed {ident = PName n}
+  PatNamed {ident = PName n}
 
 let pvar_ = use MExprAst in
   lam s.
   npvar_ (nameNoSym s)
 
 let pvarw_ = use MExprAst in
-  PNamed {ident = PWildcard (), info = NoInfo()}
+  PatNamed {ident = PWildcard (), info = NoInfo()}
 
 let punit_ = use MExprAst in
-  PRecord { bindings = assocEmpty, info = NoInfo() }
+  PatRecord { bindings = assocEmpty, info = NoInfo() }
 
 let pint_ = use MExprAst in
   lam i.
-  PInt {val = i, info = NoInfo()}
+  PatInt {val = i, info = NoInfo()}
 
 let pchar_ = use MExprAst in
   lam c.
-  PChar {val = c, info = NoInfo()}
+  PatChar {val = c, info = NoInfo()}
 
 let ptrue_ = use MExprAst in
-  PBool {val = true, info = NoInfo()}
+  PatBool {val = true, info = NoInfo()}
 
 let pfalse_ = use MExprAst in
-  PBool {val = false, info = NoInfo()}
+  PatBool {val = false, info = NoInfo()}
 
 let npcon_ = use MExprAst in
   lam n. lam cp.
-  PCon {ident = n, subpat = cp, info = NoInfo()}
+  PatCon {ident = n, subpat = cp, info = NoInfo()}
 
 let pcon_ = use MExprAst in
   lam cs. lam cp.
@@ -44,7 +44,7 @@ let pcon_ = use MExprAst in
 
 let prec_ = use MExprAst in
   lam bindings.
-  PRecord {
+  PatRecord {
     bindings =
       foldl
         (lam acc. lam b. assocInsert {eq=eqString} b.0 b.1 acc)
@@ -58,15 +58,15 @@ let ptuple_ = use MExprAst in
 
 let pseqtot_ = use MExprAst in
   lam ps.
-  PSeqTot {pats = ps, info = NoInfo()}
+  PatSeqTot {pats = ps, info = NoInfo()}
 
 let pseqedgew_ = use MExprAst in
   lam pre. lam post.
-  PSeqEdge {prefix = pre, middle = PWildcard (), postfix = post, info = NoInfo()}
+  PatSeqEdge {prefix = pre, middle = PWildcard (), postfix = post, info = NoInfo()}
 
 let pseqedgen_ = use MExprAst in
   lam pre. lam middle. lam post.
-  PSeqEdge {prefix = pre, middle = PName middle, postfix = post, info = NoInfo()}
+  PatSeqEdge {prefix = pre, middle = PName middle, postfix = post, info = NoInfo()}
 
 let pseqedge_ = use MExprAst in
   lam pre. lam middle. lam post.
@@ -74,15 +74,15 @@ let pseqedge_ = use MExprAst in
 
 let pand_ = use MExprAst in
   lam l. lam r.
-  PAnd {lpat = l, rpat = r, info = NoInfo()}
+  PatAnd {lpat = l, rpat = r, info = NoInfo()}
 
 let por_ = use MExprAst in
   lam l. lam r.
-  POr {lpat = l, rpat = r, info = NoInfo()}
+  PatOr {lpat = l, rpat = r, info = NoInfo()}
 
 let pnot_ = use MExprAst in
   lam p.
-  PNot {subpat = p, info = NoInfo()}
+  PatNot {subpat = p, info = NoInfo()}
 
 -- Types --
 let tyarrow_ = use MExprAst in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -555,175 +555,175 @@ con PWildcard : () -> PatName
 
 lang NamedPat
   syn Pat =
-  | PNamed {ident : PatName,
-            info : Info}
+  | PatNamed {ident : PatName,
+              info : Info}
 
   sem info =
-  | PNamed r -> r.info
+  | PatNamed r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PNamed p -> PNamed p
+  | PatNamed p -> PatNamed p
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PNamed _ -> acc
+  | PatNamed _ -> acc
 end
 
 lang SeqTotPat
   syn Pat =
-  | PSeqTot {pats : [Pat],
-             info : Info}
+  | PatSeqTot {pats : [Pat],
+               info : Info}
 
   sem info =
-  | PSeqTot r -> r.info
+  | PatSeqTot r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PSeqTot p -> PSeqTot {p with pats = map f p.pats}
+  | PatSeqTot p -> PatSeqTot {p with pats = map f p.pats}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PSeqTot {pats = pats} -> foldl f acc pats
+  | PatSeqTot {pats = pats} -> foldl f acc pats
 end
 
 lang SeqEdgePat
   syn Pat =
-  | PSeqEdge {prefix : [Pat],
-              middle: PatName,
-              postfix : [Pat],
-              info: Info}
+  | PatSeqEdge {prefix : [Pat],
+                middle: PatName,
+                postfix : [Pat],
+                info: Info}
 
   sem info =
-  | PSeqEdge r -> r.info
+  | PatSeqEdge r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PSeqEdge p ->
-      PSeqEdge {{p with prefix = map f p.prefix} with postfix = map f p.postfix}
+  | PatSeqEdge p ->
+      PatSeqEdge {{p with prefix = map f p.prefix} with postfix = map f p.postfix}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PSeqEdge {prefix = pre, postfix = post} -> foldl f (foldl f acc pre) post
+  | PatSeqEdge {prefix = pre, postfix = post} -> foldl f (foldl f acc pre) post
 end
 
 lang RecordPat
   syn Pat =
-  | PRecord {bindings : AssocMap String Pat,
-             info: Info}
+  | PatRecord {bindings : AssocMap String Pat,
+               info: Info}
 
   sem info =
-  | PRecord r -> r.info
+  | PatRecord r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PRecord b ->
-      PRecord {b with bindings = assocMap {eq=eqString} (lam b. (b.0, f b.1)) b.bindings}
+  | PatRecord b ->
+      PatRecord {b with bindings = assocMap {eq=eqString} (lam b. (b.0, f b.1)) b.bindings}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PRecord {bindings = bindings} -> assocFold {eq=eqString}
+  | PatRecord {bindings = bindings} -> assocFold {eq=eqString}
                     (lam acc. lam _k. lam v. f acc v) acc bindings
 end
 
 lang DataPat = DataAst
   syn Pat =
-  | PCon {ident : Name,
-          subpat : Pat,
-          info : Info}
+  | PatCon {ident : Name,
+            subpat : Pat,
+            info : Info}
 
   sem info =
-  | PCon r -> r.info
+  | PatCon r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PCon c -> PCon {c with subpat = f c.subpat}
+  | PatCon c -> PatCon {c with subpat = f c.subpat}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PCon {subpat = subpat} -> f acc subpat
+  | PatCon {subpat = subpat} -> f acc subpat
 end
 
 lang IntPat = IntAst
   syn Pat =
-  | PInt {val : Int,
+  | PatInt {val : Int,
           info : Info}
 
   sem info =
-  | PInt r -> r.info
+  | PatInt r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PInt v -> PInt v
+  | PatInt v -> PatInt v
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PInt _ -> acc
+  | PatInt _ -> acc
 end
 
 lang CharPat
   syn Pat =
-  | PChar {val : Char,
-           info : Info}
+  | PatChar {val : Char,
+             info : Info}
 
   sem info =
-  | PChar r -> r.info
+  | PatChar r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PChar v -> PChar v
+  | PatChar v -> PatChar v
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PChar _ -> acc
+  | PatChar _ -> acc
 end
 
 lang BoolPat = BoolAst
   syn Pat =
-  | PBool {val : Bool,
-           info : Info}
+  | PatBool {val : Bool,
+             info : Info}
 
   sem info =
-  | PBool r -> r.info
+  | PatBool r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PBool v -> PBool v
+  | PatBool v -> PatBool v
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PBool _ -> acc
+  | PatBool _ -> acc
 end
 
 lang AndPat
   syn Pat =
-  | PAnd {lpat : Pat,
-          rpat : Pat,
-          info : Info}
+  | PatAnd {lpat : Pat,
+            rpat : Pat,
+            info : Info}
 
   sem info =
-  | PAnd r -> r.info
+  | PatAnd r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PAnd p -> PAnd {{p with lpat = f p.lpat} with rpat = f p.rpat}
+  | PatAnd p -> PatAnd {{p with lpat = f p.lpat} with rpat = f p.rpat}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PAnd {lpat = l, rpat = r} -> f (f acc l) r
+  | PatAnd {lpat = l, rpat = r} -> f (f acc l) r
 end
 
 lang OrPat
   syn Pat =
-  | POr {lpat : Pat,
-         rpat : Pat,
-         info : Info}
+  | PatOr {lpat : Pat,
+           rpat : Pat,
+           info : Info}
 
   sem info =
-  | POr r -> r.info
+  | PatOr r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | POr p -> POr {{p with lpat = f p.lpat} with rpat = f p.rpat}
+  | PatOr p -> PatOr {{p with lpat = f p.lpat} with rpat = f p.rpat}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | POr {lpat = l, rpat = r} -> f (f acc l) r
+  | PatOr {lpat = l, rpat = r} -> f (f acc l) r
 end
 
 lang NotPat
   syn Pat =
-  | PNot {subpat : Pat,
-          info : Info}
+  | PatNot {subpat : Pat,
+            info : Info}
 
   sem info =
-  | PNot r -> r.info
+  | PatNot r -> r.info
 
   sem smap_Pat_Pat (f : Pat -> a) =
-  | PNot p -> PNot {p with subpat = f p.subpat}
+  | PatNot p -> PatNot {p with subpat = f p.subpat}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PNot {subpat = p} -> f acc p
+  | PatNot {subpat = p} -> f acc p
 end
 
 -----------

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -141,44 +141,44 @@ lang BootParser = MExprAst
   -- Match pattern from ID
   sem matchPat (t:Unknown) =
   | 400 /-PatNamed-/ ->
-    PNamed {ident = strToPatName (gstr t 0),
+    PatNamed {ident = strToPatName (gstr t 0),
             info = ginfo t 0}
   | 401 /-PatSeqTot-/ ->
-    PSeqTot {pats = makeSeq (lam n. gpat t n) (glistlen t 0),
+    PatSeqTot {pats = makeSeq (lam n. gpat t n) (glistlen t 0),
              info = ginfo t 0}
   | 402 /-PatSeqEdge-/ ->
     let len = glistlen t 0 in
-    PSeqEdge {prefix = makeSeq (lam n. gpat t n) len,
+    PatSeqEdge {prefix = makeSeq (lam n. gpat t n) len,
               middle = strToPatName (gstr t 0),
               postfix = makeSeq (lam n. gpat t (addi n len)) (glistlen t 1),
               info = ginfo t 0}
   | 403 /-PatRecord-/ ->
      let lst = makeSeq (lam n. (gstr t n, gpat t n)) (glistlen t 0) in
-     PRecord {bindings = seq2assoc {eq = eqString} lst,
+     PatRecord {bindings = seq2assoc {eq = eqString} lst,
               info = ginfo t 0}
   | 404 /-PatCon-/ ->
-     PCon {ident = gname t 0, 
+     PatCon {ident = gname t 0, 
            subpat = gpat t 0,
            info = ginfo t 0}
   | 405 /-PatInt-/ ->     
-     PInt {val = gint t 0,
+     PatInt {val = gint t 0,
            info = ginfo t 0}
   | 406 /-PatChar-/ ->     
-     PChar {val = int2char (gint t 0),
+     PatChar {val = int2char (gint t 0),
             info = ginfo t 0}
   | 407 /-PatBool-/ ->     
-     PBool {val = eqi (gint t 0) 1,
+     PatBool {val = eqi (gint t 0) 1,
             info = ginfo t 0}
   | 408 /-PatAnd-/ ->     
-     PAnd {lpat = gpat t 0,
+     PatAnd {lpat = gpat t 0,
            rpat = gpat t 1,
            info = ginfo t 0}
   | 409 /-PatOr-/ ->     
-     POr {lpat = gpat t 0,
+     PatOr {lpat = gpat t 0,
            rpat = gpat t 1,
            info = ginfo t 0}
   | 410 /-PatNot-/ ->     
-     PNot {subpat = gpat t 0,
+     PatNot {subpat = gpat t 0,
            info = ginfo t 0}
 
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -363,16 +363,16 @@ let _eqpatname : NameEnv -> NameEnv -> PatName -> PatName -> Option NameEnv =
 
 lang NamedPatEq = NamedPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PNamed {ident = p2} ->
-    match lhs with PNamed {ident = p1} then
+  | PatNamed {ident = p2} ->
+    match lhs with PatNamed {ident = p1} then
       _eqpatname patEnv free p1 p2
     else None ()
 end
 
 lang SeqTotPatEq = SeqTotPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PSeqTot {pats = ps2} ->
-    match lhs with PSeqTot {pats = ps1} then
+  | PatSeqTot {pats = ps2} ->
+    match lhs with PatSeqTot {pats = ps1} then
       if eqi (length ps2) (length ps1) then
         let z = zipWith (lam p1. lam p2. (p1,p2)) ps1 ps2 in
         optionFoldlM (lam fpEnv. lam ps.
@@ -386,8 +386,8 @@ end
 
 lang SeqEdgePatEq = SeqEdgePat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PSeqEdge {prefix = pre2, middle = mid2, postfix = post2} ->
-    match lhs with PSeqEdge {prefix = pre1, middle = mid1, postfix = post1} then
+  | PatSeqEdge {prefix = pre2, middle = mid2, postfix = post2} ->
+    match lhs with PatSeqEdge {prefix = pre1, middle = mid1, postfix = post1} then
       match _eqpatname patEnv free mid1 mid2 with Some (f,p) then
         if eqi (length pre1) (length pre2) then
           let z1 = zipWith (lam p1. lam p2. (p1,p2)) pre1 pre2 in
@@ -413,8 +413,8 @@ end
 
 lang RecordPatEq = RecordPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PRecord {bindings = bs2} ->
-    match lhs with PRecord {bindings = bs1} then
+  | PatRecord {bindings = bs2} ->
+    match lhs with PatRecord {bindings = bs1} then
       if eqi (assocLength bs1) (assocLength bs2) then
         assocFoldlM {eq=eqString}
           (lam tEnv. lam k1. lam p1.
@@ -430,8 +430,8 @@ end
 
 lang DataPatEq = DataPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PCon {ident = i2, subpat = s2} ->
-    match lhs with PCon {ident = i1, subpat = s1} then
+  | PatCon {ident = i2, subpat = s2} ->
+    match lhs with PatCon {ident = i1, subpat = s1} then
       match (env,free) with ({conEnv = conEnv},{conEnv = freeConEnv}) then
         match _eqCheck i1 i2 conEnv freeConEnv with Some freeConEnv then
           eqPat env {free with conEnv = freeConEnv} patEnv s1 s2
@@ -442,32 +442,32 @@ end
 
 lang IntPatEq = IntPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PInt {val = i2} ->
-    match lhs with PInt {val = i1} then
+  | PatInt {val = i2} ->
+    match lhs with PatInt {val = i1} then
       if eqi i1 i2 then Some (free,patEnv) else None ()
     else None ()
 end
 
 lang CharPatEq = CharPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PChar {val = c2} ->
-    match lhs with PChar {val = c1} then
+  | PatChar {val = c2} ->
+    match lhs with PatChar {val = c1} then
       if eqChar c1 c2 then Some (free,patEnv) else None ()
     else None ()
 end
 
 lang BoolPatEq = BoolPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PBool {val = b2} ->
-    match lhs with PBool {val = b1} then
+  | PatBool {val = b2} ->
+    match lhs with PatBool {val = b1} then
       if eqBool b1 b2 then Some (free,patEnv) else None ()
     else None ()
 end
 
 lang AndPatEq = AndPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PAnd {lpat = l2, rpat = r2} ->
-    match lhs with PAnd {lpat = l1, rpat = r1} then
+  | PatAnd {lpat = l2, rpat = r2} ->
+    match lhs with PatAnd {lpat = l1, rpat = r1} then
       match eqPat env free patEnv l1 l2 with Some (free,patEnv) then
         eqPat env free patEnv r1 r2
       else None ()
@@ -476,8 +476,8 @@ end
 
 lang OrPatEq = OrPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | POr {lpat = l2, rpat = r2} ->
-    match lhs with POr {lpat = l1, rpat = r1} then
+  | PatOr {lpat = l2, rpat = r2} ->
+    match lhs with PatOr {lpat = l1, rpat = r1} then
       match eqPat env free patEnv l1 l2 with Some (free,patEnv) then
         eqPat env free patEnv r1 r2
       else None ()
@@ -486,8 +486,8 @@ end
 
 lang NotPatEq = NotPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
-  | PNot {subpat = p2} ->
-    match lhs with PNot {subpat = p1} then
+  | PatNot {subpat = p2} ->
+    match lhs with PatNot {subpat = p1} then
       eqPat env free patEnv p1 p2
     else None ()
 end

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -673,8 +673,8 @@
 --                                    (st_addLambdaref newname (TmVar {ident = newname}) state)) in
 --       (updatedstate, PVar {t with ident = newname})
 --     | PUnit t -> (state, PUnit t)
---     | PInt t -> (state, PInt t)
---     | PBool t -> (state, PBool t)
+--     | PatInt t -> (state, PatInt t)
+--     | PatBool t -> (state, PatBool t)
 --     | PTuple t ->
 --       -- acc.0: state
 --       -- acc.1: list of patterns
@@ -684,16 +684,16 @@
 --       in
 --       let foldret = foldl liftpats (state, []) t.pats in
 --       (foldret.0, PTuple {t with pats = foldret.1})
---     | PCon t ->
+--     | PatCon t ->
 --       let newident = find (lam e. eqString (e.key) t.ident) state.env.econ in
 --       let subret = lamliftPat state t.subpat in
 --       match newident with Some t1 then
 --         match t1.value with TmConFun t2 then
---           (subret.0, PCon {{t with ident = t2.ident} with subpat = subret.1})
+--           (subret.0, PatCon {{t with ident = t2.ident} with subpat = subret.1})
 --         else
---           (subret.0, PCon {t with subpat = subret.1})
+--           (subret.0, PatCon {t with subpat = subret.1})
 --       else
---         (subret.0, PCon {t with subpat = subret.1})
+--         (subret.0, PatCon {t with subpat = subret.1})
 -- end
 --
 -- lang UtestLamlift = UtestAst

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -312,7 +312,7 @@ lang IfParser =
      let e2 = parseExprMain r1.pos 0 r1.str in
      let r2 = matchKeyword "else" e2.pos e2.str  in
      let e3 = parseExprMain r2.pos 0 r2.str in
-     {val = TmMatch {target = e1.val, pat = PBool {val = true, info = NoInfo ()},
+     {val = TmMatch {target = e1.val, pat = PatBool {val = true, info = NoInfo ()},
                      thn = e2.val, els = e3.val, ty = TyUnknown {},
                      info = makeInfo p e3.pos},
       pos = e3.pos,

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -625,10 +625,10 @@ end
 
 lang NamedPatPrettyPrint = NamedPat + PatNamePrettyPrint
   sem patIsAtomic =
-  | PNamed _ -> true
+  | PatNamed _ -> true
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
-  | PNamed {ident = patname} -> _pprint_patname env patname
+  | PatNamed {ident = patname} -> _pprint_patname env patname
 end
 
 let _pprint_patseq: (Int -> PprintEnv -> Pat -> (PprintEnv, String)) -> Int ->
@@ -636,7 +636,7 @@ let _pprint_patseq: (Int -> PprintEnv -> Pat -> (PprintEnv, String)) -> Int ->
 lam recur. lam indent. lam env. lam pats.
   use CharPat in
   let extract_char = lam e.
-    match e with PChar c then Some c.val
+    match e with PatChar c then Some c.val
     else None () in
   match optionMapM extract_char pats with Some str then
     (env, join ["\"", str, "\""])
@@ -649,18 +649,18 @@ lam recur. lam indent. lam env. lam pats.
 
 lang SeqTotPatPrettyPrint = SeqTotPat + CharPat
   sem patIsAtomic =
-  | PSeqTot _ -> true
+  | PatSeqTot _ -> true
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
-  | PSeqTot {pats = pats} -> _pprint_patseq getPatStringCode indent env pats
+  | PatSeqTot {pats = pats} -> _pprint_patseq getPatStringCode indent env pats
 end
 
 lang SeqEdgePatPrettyPrint = SeqEdgePat + PatNamePrettyPrint
   sem patIsAtomic =
-  | PSeqEdge _ -> false
+  | PatSeqEdge _ -> false
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
-  | PSeqEdge {prefix = pre, middle = patname, postfix = post} ->
+  | PatSeqEdge {prefix = pre, middle = patname, postfix = post} ->
     match _pprint_patseq getPatStringCode indent env pre with (env, pre) then
     match _pprint_patname env patname with (env, pname) then
     match _pprint_patseq getPatStringCode indent env post with (env, post) then
@@ -670,10 +670,10 @@ end
 
 lang RecordPatPrettyPrint = RecordPat + IdentifierPrettyPrint
   sem patIsAtomic =
-  | PRecord _ -> true
+  | PatRecord _ -> true
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
-  | PRecord {bindings = bindings} ->
+  | PatRecord {bindings = bindings} ->
     match
       assocMapAccum {eq=eqString}
         (lam env. lam k. lam v.
@@ -688,10 +688,10 @@ end
 
 lang DataPatPrettyPrint = DataPat + IdentifierPrettyPrint
   sem patIsAtomic =
-  | PCon _ -> false
+  | PatCon _ -> false
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
-  | PCon t ->
+  | PatCon t ->
     match pprintConName env t.ident with (env,str) then
       match getPatStringCode indent env t.subpat with (env,subpat) then
         let subpat = if patIsAtomic t.subpat then subpat
@@ -703,34 +703,34 @@ end
 
 lang IntPatPrettyPrint = IntPat
   sem patIsAtomic =
-  | PInt _ -> true
+  | PatInt _ -> true
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
-  | PInt t -> (env, int2string t.val)
+  | PatInt t -> (env, int2string t.val)
 end
 
 lang CharPatPrettyPrint = CharPat
   sem patIsAtomic =
-  | PChar _ -> true
+  | PatChar _ -> true
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
-  | PChar t -> (env, join ["\'", escapeChar t.val, "\'"])
+  | PatChar t -> (env, join ["\'", escapeChar t.val, "\'"])
 end
 
 lang BoolPatPrettyPrint = BoolPat
   sem patIsAtomic =
-  | PBool _ -> true
+  | PatBool _ -> true
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
-  | PBool b -> (env, if b.val then "true" else "false")
+  | PatBool b -> (env, if b.val then "true" else "false")
 end
 
 lang AndPatPrettyPrint = PrettyPrint + AndPat
   sem patIsAtomic =
-  | PAnd _ -> false
+  | PatAnd _ -> false
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
-  | PAnd {lpat = l, rpat = r} ->
+  | PatAnd {lpat = l, rpat = r} ->
     match printPatParen indent env l with (env, l2) then
     match printPatParen indent env r with (env, r2) then
     (env, join [l2, " & ", r2])
@@ -739,10 +739,10 @@ end
 
 lang OrPatPrettyPrint = PrettyPrint + OrPat
   sem patIsAtomic =
-  | POr _ -> false
+  | PatOr _ -> false
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
-  | POr {lpat = l, rpat = r} ->
+  | PatOr {lpat = l, rpat = r} ->
     match printPatParen indent env l with (env, l2) then
     match printPatParen indent env r with (env, r2) then
     (env, join [l2, " | ", r2])
@@ -751,10 +751,10 @@ end
 
 lang NotPatPrettyPrint = PrettyPrint + NotPat
   sem patIsAtomic =
-  | PNot _ -> false  -- OPT(vipa, 2020-09-23): this could possibly be true, just because it binds stronger than everything else
+  | PatNot _ -> false  -- OPT(vipa, 2020-09-23): this could possibly be true, just because it binds stronger than everything else
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
-  | PNot {subpat = p} ->
+  | PatNot {subpat = p} ->
     match printPatParen indent env p with (env, p2) then
     (env, join ["!", p2])
     else never

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -353,42 +353,42 @@ let _symbolize_patname: SymEnv -> PatName -> (SymEnv, PatName) =
 
 lang NamedPatSym = NamedPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PNamed p ->
+  | PatNamed p ->
     match _symbolize_patname patEnv p.ident with (patEnv, patname) then
-      (patEnv, PNamed {p with ident = patname})
+      (patEnv, PatNamed {p with ident = patname})
     else never
 end
 
 lang SeqTotPatSym = SeqTotPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PSeqTot p ->
+  | PatSeqTot p ->
     let res = mapAccumL (symbolizePat env) patEnv p.pats in
-    (res.0, PSeqTot {p with pats = res.1})
+    (res.0, PatSeqTot {p with pats = res.1})
 end
 
 lang SeqEdgePatSym = SeqEdgePat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PSeqEdge p ->
+  | PatSeqEdge p ->
     let preRes = mapAccumL (symbolizePat env) patEnv p.prefix in
     let midRes = _symbolize_patname preRes.0 p.middle in
     let postRes = mapAccumL (symbolizePat env) midRes.0 p.postfix in
-    (postRes.0, PSeqEdge
+    (postRes.0, PatSeqEdge
       {{{p with prefix = preRes.1} with middle = midRes.1} with postfix = postRes.1})
 end
 
 lang RecordPatSym = RecordPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PRecord {bindings = bindings, info = info} ->
+  | PatRecord {bindings = bindings, info = info} ->
     match assocMapAccum {eq=eqString}
             (lam patEnv. lam _. lam p. symbolizePat env patEnv p) patEnv bindings
     with (env,bindings) then
-      (env, PRecord {bindings = bindings, info = info})
+      (env, PatRecord {bindings = bindings, info = info})
     else never
 end
 
 lang DataPatSym = DataPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PCon {ident = ident, subpat = subpat, info = info} ->
+  | PatCon {ident = ident, subpat = subpat, info = info} ->
     match env with {conEnv = conEnv} then
       let ident =
         if nameHasSym ident then ident
@@ -398,52 +398,52 @@ lang DataPatSym = DataPat
           else error (concat "Unknown constructor in symbolizeExpr: " str)
       in
       match symbolizePat env patEnv subpat with (patEnv, subpat) then
-        (patEnv, PCon {ident = ident, subpat = subpat, info = info})
+        (patEnv, PatCon {ident = ident, subpat = subpat, info = info})
       else never
     else never
 end
 
 lang IntPatSym = IntPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PInt i -> (patEnv, PInt i)
+  | PatInt i -> (patEnv, PatInt i)
 end
 
 lang CharPatSym = CharPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PChar c -> (patEnv, PChar c)
+  | PatChar c -> (patEnv, PatChar c)
 end
 
 lang BoolPatSym = BoolPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PBool b -> (patEnv, PBool b)
+  | PatBool b -> (patEnv, PatBool b)
 end
 
 lang AndPatSym = AndPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PAnd p ->
+  | PatAnd p ->
     let lRes = symbolizePat env patEnv p.lpat in
     let rRes = symbolizePat env lRes.0 p.rpat in
-    (rRes.0, PAnd {{p with lpat = lRes.1} with rpat = rRes.1})
+    (rRes.0, PatAnd {{p with lpat = lRes.1} with rpat = rRes.1})
 end
 
 lang OrPatSym = OrPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | POr p ->
+  | PatOr p ->
     let lRes = symbolizePat env patEnv p.lpat in
     let rRes = symbolizePat env lRes.0 p.rpat in
-    (rRes.0, POr {{p with lpat = lRes.1} with rpat = rRes.1})
+    (rRes.0, PatOr {{p with lpat = lRes.1} with rpat = rRes.1})
 end
 
 lang NotPatSym = NotPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
-  | PNot p ->
+  | PatNot p ->
     -- NOTE(vipa, 2020-09-23): new names in a not-pattern do not
     -- matter since they will never bind (it should probably be an
     -- error to bind a name inside a not-pattern, but we're not doing
     -- that kind of static checks yet.  Note that we still need to run
     -- symbolizeExpr though, constructors must refer to the right symbol.
     let res = symbolizePat env patEnv p.subpat in
-    (patEnv, PNot {p with subpat = res.1})
+    (patEnv, PatNot {p with subpat = res.1})
 end
 
 ------------------------------

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -24,7 +24,7 @@ lang OCamlData
   | OTmConApp { ident : Name, args : [Expr] }
 
   syn Pat =
-  | OPCon { ident : Name, args : [Pat] }
+  | OPatCon { ident : Name, args : [Pat] }
 end
 
 lang OCamlAst = LamAst + LetAst + RecLetsAst + ArithIntAst + ShiftIntAst

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -207,8 +207,8 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
 
   sem patIsAtomic =
   | OPTuple _ -> true
-  | OPCon {args = []} -> true
-  | OPCon _ -> false
+  | OPatCon {args = []} -> true
+  | OPatCon _ -> false
 
   sem getConstStringCode (indent : Int) =
   | CInt {val = i} -> int2string i
@@ -301,8 +301,8 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | OTmMatch {
     target = target,
     arms
-      = [ (PBool {val = true}, thn), (PBool {val = false}, els) ]
-      | [ (PBool {val = false}, els), (PBool {val = true}, thn) ]
+      = [ (PatBool {val = true}, thn), (PatBool {val = false}, els) ]
+      | [ (PatBool {val = false}, els), (PatBool {val = true}, thn) ]
     } ->
     let i = indent in
     let ii = pprintIncr i in
@@ -356,14 +356,14 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
     match mapAccumL (getPatStringCode indent) env pats with (env, pats) then
       (env, join ["(", strJoin ", " pats, ")"])
     else never
-  | OPCon {ident = ident, args = []} -> pprintConName env ident
-  | OPCon {ident = ident, args = [arg]} ->
+  | OPatCon {ident = ident, args = []} -> pprintConName env ident
+  | OPatCon {ident = ident, args = [arg]} ->
     match pprintConName env ident with (env, ident) then
       match printPatParen indent env arg with (env, arg) then
         (env, join [ident, " ", arg])
       else never
     else never
-  | OPCon {ident = ident, args = args} ->
+  | OPatCon {ident = ident, args = args} ->
     match pprintConName env ident with (env, ident) then
       match mapAccumL (getPatStringCode indent) env args with (env, args) then
         (env, join [ident, " (", strJoin ", " args, ")"])

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -23,5 +23,5 @@ lang OCamlSym =
     match mapAccumL (symbolizePat env) patEnv pats with (patEnv, pats) then
       (patEnv, OPTuple { pats = pats })
     else never
-  | OPCon _ -> error "We're not quite done with adt's in ocaml yet, so symbolize won't work with programs that use them (in this case OPCon)"
+  | OPatCon _ -> error "We're not quite done with adt's in ocaml yet, so symbolize won't work with programs that use them (in this case OPatCon)"
 end


### PR DESCRIPTION
This PR makes sure that Boot and the compiler use the same names for pattern nodes.