### PR TITLE
Optimize interpreter

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -93,6 +93,7 @@ and const =
   | Csnoc of tm Mseq.t option
   | CsplitAt of tm Mseq.t option
   | Creverse
+  | Csub of tm Mseq.t option * int option
   (* MCore intrinsics: Random numbers *)
   | CrandIntU of int option
   | CrandSetSeed

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -93,7 +93,7 @@ and const =
   | Csnoc of tm Mseq.t option
   | CsplitAt of tm Mseq.t option
   | Creverse
-  | Csub of tm Mseq.t option * int option
+  | Csubsequence of tm Mseq.t option * int option
   (* MCore intrinsics: Random numbers *)
   | CrandIntU of int option
   | CrandSetSeed

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -23,7 +23,7 @@ module Mseq = struct
 
   let split_at = Rope.split_at_array
 
-  let sub = Rope.sub_array
+  let subsequence = Rope.sub_array
 
   module Helpers = struct
     let of_list = Rope.Convert.of_list_array

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -23,6 +23,8 @@ module Mseq = struct
 
   let split_at = Rope.split_at_array
 
+  let sub = Rope.sub_array
+
   module Helpers = struct
     let of_list = Rope.Convert.of_list_array
 

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -23,6 +23,8 @@ module Mseq : sig
 
   val split_at : 'a t -> int -> 'a t * 'a t
 
+  val sub : 'a t -> int -> int -> 'a t
+
   module Helpers : sig
     val of_list : 'a list -> 'a t
 

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -23,7 +23,7 @@ module Mseq : sig
 
   val split_at : 'a t -> int -> 'a t * 'a t
 
-  val sub : 'a t -> int -> int -> 'a t
+  val subsequence : 'a t -> int -> int -> 'a t
 
   module Helpers : sig
     val of_list : 'a list -> 'a t

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -81,7 +81,8 @@ let builtin =
   ; ("cons", f (Ccons None))
   ; ("snoc", f (Csnoc None))
   ; ("splitAt", f (CsplitAt None))
-  ; ("reverse", f Creverse) (* MCore intrinsics: Random numbers *)
+  ; ("reverse", f Creverse)
+  ; ("sub", f (Csub (None, None))) (* MCore intrinsics: Random numbers *)
   ; ("randIntU", f (CrandIntU None))
   ; ("randSetSeed", f CrandSetSeed) (* MCore intrinsics: Time *)
   ; ("wallTimeMs", f CwallTimeMs)
@@ -310,6 +311,12 @@ let arity = function
   | CsplitAt (Some _) ->
       1
   | Creverse ->
+      1
+  | Csub (None, None) ->
+      3
+  | Csub (Some _, None) ->
+      2
+  | Csub (_, Some _) ->
       1
   (* MCore intrinsics: Random numbers *)
   | CrandIntU None ->
@@ -754,6 +761,14 @@ let delta eval env fi c v =
   | Creverse, TmSeq (fi, s) ->
       TmSeq (fi, Mseq.reverse s)
   | Creverse, _ ->
+      fail_constapp fi
+  | Csub (None, None), TmSeq (fi, s) ->
+      TmConst (fi, Csub (Some s, None))
+  | Csub (Some s, None), TmConst (_, CInt off) ->
+      TmConst (fi, Csub (Some s, Some off))
+  | Csub (Some s, Some off), TmConst (_, CInt n) ->
+      TmSeq (fi, Mseq.sub s off n)
+  | Csub _, _ ->
       fail_constapp fi
   (* MCore intrinsics: Random numbers *)
   | CrandIntU None, TmConst (fi, CInt v) ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1521,8 +1521,8 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
   debug_eval env t ;
   match t with
   (* Variables using symbol bindings. Need to evaluate because fix point. *)
-  | TmVar (_, _, s) ->
-      eval env (List.assoc s env)
+  | TmVar (_, _, s) -> (
+    match List.assoc s env with TmFix _ as t -> eval env t | t -> t )
   (* Application *)
   | TmApp (fiapp, t1, t2) -> (
     match eval env t1 with

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -82,7 +82,8 @@ let builtin =
   ; ("snoc", f (Csnoc None))
   ; ("splitAt", f (CsplitAt None))
   ; ("reverse", f Creverse)
-  ; ("sub", f (Csub (None, None))) (* MCore intrinsics: Random numbers *)
+  ; ("subsequence", f (Csubsequence (None, None)))
+    (* MCore intrinsics: Random numbers *)
   ; ("randIntU", f (CrandIntU None))
   ; ("randSetSeed", f CrandSetSeed) (* MCore intrinsics: Time *)
   ; ("wallTimeMs", f CwallTimeMs)
@@ -312,11 +313,11 @@ let arity = function
       1
   | Creverse ->
       1
-  | Csub (None, None) ->
+  | Csubsequence (None, None) ->
       3
-  | Csub (Some _, None) ->
+  | Csubsequence (Some _, None) ->
       2
-  | Csub (_, Some _) ->
+  | Csubsequence (_, Some _) ->
       1
   (* MCore intrinsics: Random numbers *)
   | CrandIntU None ->
@@ -762,13 +763,13 @@ let delta eval env fi c v =
       TmSeq (fi, Mseq.reverse s)
   | Creverse, _ ->
       fail_constapp fi
-  | Csub (None, None), TmSeq (fi, s) ->
-      TmConst (fi, Csub (Some s, None))
-  | Csub (Some s, None), TmConst (_, CInt off) ->
-      TmConst (fi, Csub (Some s, Some off))
-  | Csub (Some s, Some off), TmConst (_, CInt n) ->
-      TmSeq (fi, Mseq.sub s off n)
-  | Csub _, _ ->
+  | Csubsequence (None, None), TmSeq (fi, s) ->
+      TmConst (fi, Csubsequence (Some s, None))
+  | Csubsequence (Some s, None), TmConst (_, CInt off) ->
+      TmConst (fi, Csubsequence (Some s, Some off))
+  | Csubsequence (Some s, Some off), TmConst (_, CInt n) ->
+      TmSeq (fi, Mseq.subsequence s off n)
+  | Csubsequence _, _ ->
       fail_constapp fi
   (* MCore intrinsics: Random numbers *)
   | CrandIntU None, TmConst (fi, CInt v) ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -323,6 +323,8 @@ let rec print_const fmt = function
       fprintf fmt "splitAt"
   | Creverse ->
       fprintf fmt "reverse"
+  | Csub _ ->
+      fprintf fmt "sub"
   (* MCore intrinsics: Random numbers *)
   | CrandIntU _ ->
       fprintf fmt "randIntU"

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -323,8 +323,8 @@ let rec print_const fmt = function
       fprintf fmt "splitAt"
   | Creverse ->
       fprintf fmt "reverse"
-  | Csub _ ->
-      fprintf fmt "sub"
+  | Csubsequence _ ->
+      fprintf fmt "subsequence"
   (* MCore intrinsics: Random numbers *)
   | CrandIntU _ ->
       fprintf fmt "randIntU"

--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -264,8 +264,8 @@ let sub_array (s : 'a array t) (off : int) (cnt : int) : 'a array t =
           let n = Array.length a in
           let src_offset = max (off - i) 0 in
           let dst_offset = max (i - off) 0 in
-          let copy_cnt = min (n - src_offset) (cnt - dst_offset) in
-          Array.blit a src_offset dst dst_offset copy_cnt ;
+          let copy_len = min (n - src_offset) (cnt - dst_offset) in
+          Array.blit a src_offset dst dst_offset copy_len ;
           i + n
       | Concat {lhs; rhs; _} ->
           let n = _length_array lhs in
@@ -287,9 +287,9 @@ let sub_bigarray (s : ('a, 'b) ba t) (off : int) (cnt : int) : ('a, 'b) ba t =
         let n = Array1.dim a in
         let src_offset = max (off - i) 0 in
         let dst_offset = max (i - off) 0 in
-        let copy_cnt = min (n - src_offset) (cnt - dst_offset) in
-        let src_sub = Array1.sub a src_offset copy_cnt in
-        let dst_sub = Array1.sub dst dst_offset copy_cnt in
+        let copy_len = min (n - src_offset) (cnt - dst_offset) in
+        let src_sub = Array1.sub a src_offset copy_len in
+        let dst_sub = Array1.sub dst dst_offset copy_len in
         Array1.blit src_sub dst_sub ;
         i + n
     | Concat {lhs; rhs; _} ->

--- a/src/boot/lib/rope.mli
+++ b/src/boot/lib/rope.mli
@@ -65,8 +65,9 @@ val split_at_array : 'a array t -> int -> 'a array t * 'a array t
 val split_at_bigarray : ('a, 'b) ba t -> int -> ('a, 'b) ba t * ('a, 'b) ba t
 
 val sub_array : 'a array t -> int -> int -> 'a array t
-(** [Rope.sub_* s i len] returns a sub-rope representing the interval i..i+len
-    of [s]. *)
+(** [Rope.sub_* s off cnt] returns a sub-rope representing the interval
+    off..off+x of [s], where x is the minimum of the length of [s] minus [off]
+    and [cnt]. *)
 
 val sub_bigarray : ('a, 'b) ba t -> int -> int -> ('a, 'b) ba t
 

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -131,7 +131,7 @@
 --           let _ = dprint e in
 --           let _ = print "\n" in
 --           error "st_addGenargsToEnv: Generated argument above was expected to be TmLamliftTypedVar"
---       ) st (slice st_w_genargs.genargs 0 genarg_diff_count)
+--       ) st (sub st_w_genargs.genargs 0 genarg_diff_count)
 --     else
 --       st
 --

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -295,7 +295,7 @@ lang KeywordUtils = WSACParser
      let r = eatWSAC p s in
      if isPrefix eqc keyword r.str then
        let l = length keyword in
-       {pos = advanceCol r.pos l, str = sub r.str l (subi (length r.str) l)}
+       {pos = advanceCol r.pos l, str = subsequence r.str l (subi (length r.str) l)}
      else
        posErrorExit r.pos (join ["Unknown character. Expected '", keyword, "'."])
 end

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -295,7 +295,7 @@ lang KeywordUtils = WSACParser
      let r = eatWSAC p s in
      if isPrefix eqc keyword r.str then
        let l = length keyword in
-       {pos = advanceCol r.pos l, str = slice r.str l (subi (length r.str) l)}
+       {pos = advanceCol r.pos l, str = sub r.str l (subi (length r.str) l)}
      else
        posErrorExit r.pos (join ["Unknown character. Expected '", keyword, "'."])
 end

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -9,9 +9,9 @@ utest make 0 100 with []
 
 let null = lam seq. eqi 0 (length seq)
 let head = lam seq. get seq 0
-let tail = lam seq. sub seq 1 (subi (length seq) 1)
+let tail = lam seq. subsequence seq 1 (subi (length seq) 1)
 let last = lam seq. get seq (subi (length seq) 1)
-let init = lam seq. sub seq 0 (subi (length seq) 1)
+let init = lam seq. subsequence seq 0 (subi (length seq) 1)
 
 utest head [2,3,5] with 2
 utest tail [2,4,8] with [4,8]

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -8,9 +8,9 @@ utest make 4 'a' with ['a', 'a', 'a', 'a']
 utest make 0 100 with []
 
 let null = lam seq. eqi 0 (length seq)
-let head = lam seq. get (splitAt seq 1).0 0
+let head = lam seq. get seq 0
 let tail = lam seq. (splitAt seq 1).1
-let last = lam seq. get (splitAt seq (subi (length seq) 1)).1 0
+let last = lam seq. get seq (subi (length seq) 1)
 let init = lam seq. (splitAt seq (subi (length seq) 1)).0
 
 utest head [2,3,5] with 2

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -34,13 +34,6 @@ utest eqSeq eqi [1] [1] with true
 utest eqSeq eqi [1] [2] with false
 utest eqSeq eqi [2] [1] with false
 
-let slice = lam seq. lam off. lam cnt. sub seq off cnt
-
-utest slice [1,3,5] 0 2 with [1,3]
-utest slice [3,7,10,20] 1 3 with [7,10,20]
-utest slice ['a','b'] 1 10 with ['b']
-utest slice [1,3] 2 10 with []
-
 -- Maps
 let mapi = lam f. lam seq.
   recursive let work = lam i. lam f. lam seq.

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -9,9 +9,9 @@ utest make 0 100 with []
 
 let null = lam seq. eqi 0 (length seq)
 let head = lam seq. get seq 0
-let tail = lam seq. (splitAt seq 1).1
+let tail = lam seq. sub seq 1 (subi (length seq) 1)
 let last = lam seq. get seq (subi (length seq) 1)
-let init = lam seq. (splitAt seq (subi (length seq) 1)).0
+let init = lam seq. sub seq 0 (subi (length seq) 1)
 
 utest head [2,3,5] with 2
 utest tail [2,4,8] with [4,8]
@@ -34,10 +34,7 @@ utest eqSeq eqi [1] [1] with true
 utest eqSeq eqi [1] [2] with false
 utest eqSeq eqi [2] [1] with false
 
-let slice = lam seq. lam off. lam cnt.
-  let seq = (splitAt seq off).1 in
-  let cnt = if gti cnt (length seq) then length seq else cnt in
-  (splitAt seq cnt).0
+let slice = lam seq. lam off. lam cnt. sub seq off cnt
 
 utest slice [1,3,5] 0 2 with [1,3]
 utest slice [3,7,10,20] 1 3 with [7,10,20]

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -101,7 +101,7 @@ let string2int = lam s.
     then 0
     else
       let lsd = subi (char2int (get s last)) (char2int '0') in
-      let rest = muli 10 (string2int_rechelper (slice s 0 last)) in
+      let rest = muli 10 (string2int_rechelper (sub s 0 last)) in
       addi rest lsd
   in
   match s with [] then 0 else
@@ -245,8 +245,8 @@ recursive
   let strSplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
     then cons s []
-    else if eqString delim (slice s 0 (length delim))
-         then cons [] (strSplit delim (slice s (length delim) (length s)))
+    else if eqString delim (sub s 0 (length delim))
+         then cons [] (strSplit delim (sub s (length delim) (length s)))
          else let remaining = strSplit delim (tail s) in
               cons (cons (head s) (head remaining)) (tail remaining)
 end

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -101,7 +101,7 @@ let string2int = lam s.
     then 0
     else
       let lsd = subi (char2int (get s last)) (char2int '0') in
-      let rest = muli 10 (string2int_rechelper (sub s 0 last)) in
+      let rest = muli 10 (string2int_rechelper (subsequence s 0 last)) in
       addi rest lsd
   in
   match s with [] then 0 else
@@ -245,8 +245,8 @@ recursive
   let strSplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
     then cons s []
-    else if eqString delim (sub s 0 (length delim))
-         then cons [] (strSplit delim (sub s (length delim) (length s)))
+    else if eqString delim (subsequence s 0 (length delim))
+         then cons [] (strSplit delim (subsequence s (length delim) (length s)))
          else let remaining = strSplit delim (tail s) in
               cons (cons (head s) (head remaining)) (tail remaining)
 end

--- a/test/mexpr/effects.mc
+++ b/test/mexpr/effects.mc
@@ -44,7 +44,7 @@ utest if false then error "message" else 0 with 0 in
 
 
 -- 'argv' contains the program arguments
-utest slice argv 1 2 with [] in
+utest sub argv 1 2 with [] in
 
 -- 'exit c' exits the program with error code 'c'
 utest if true then () else exit 1 with () in

--- a/test/mexpr/effects.mc
+++ b/test/mexpr/effects.mc
@@ -44,7 +44,7 @@ utest if false then error "message" else 0 with 0 in
 
 
 -- 'argv' contains the program arguments
-utest sub argv 1 2 with [] in
+utest subsequence argv 1 2 with [] in
 
 -- 'exit c' exits the program with error code 'c'
 utest if true then () else exit 1 with () in

--- a/test/mexpr/fix.mc
+++ b/test/mexpr/fix.mc
@@ -43,7 +43,7 @@ utest odd 42 with false in
 
 -- Generalized fixpoint for mutual recursion-----------------------------------
 let head = lam seq. get seq 0 in
-let tail = lam seq. sub seq 1 (length seq) in
+let tail = lam seq. subsequence seq 1 (length seq) in
 
 let map = fix (lam map. lam f. lam seq.
   if eqi (length seq) 0 then []

--- a/test/mexpr/fix.mc
+++ b/test/mexpr/fix.mc
@@ -43,7 +43,7 @@ utest odd 42 with false in
 
 -- Generalized fixpoint for mutual recursion-----------------------------------
 let head = lam seq. get seq 0 in
-let tail = lam seq. slice seq 1 (length seq) in
+let tail = lam seq. sub seq 1 (length seq) in
 
 let map = fix (lam map. lam f. lam seq.
   if eqi (length seq) 0 then []

--- a/test/mexpr/string.mc
+++ b/test/mexpr/string.mc
@@ -30,8 +30,8 @@ utest int2char 13 with '\r' in
 -- See seq.mc as well. Strings are sequences.
 utest concat "This " "is" with "This is" in
 utest get "Hello" 1 with 'e' in
-utest slice "This is all" 3 6 with "s is a" in
-utest slice "This is all" 3 6 with ['s',' ','i','s',' ','a'] in
+utest sub "This is all" 3 6 with "s is a" in
+utest sub "This is all" 3 6 with ['s',' ','i','s',' ','a'] in
 
 -- Nop
 utest () with () in

--- a/test/mexpr/string.mc
+++ b/test/mexpr/string.mc
@@ -30,8 +30,8 @@ utest int2char 13 with '\r' in
 -- See seq.mc as well. Strings are sequences.
 utest concat "This " "is" with "This is" in
 utest get "Hello" 1 with 'e' in
-utest sub "This is all" 3 6 with "s is a" in
-utest sub "This is all" 3 6 with ['s',' ','i','s',' ','a'] in
+utest subsequence "This is all" 3 6 with "s is a" in
+utest subsequence "This is all" 3 6 with ['s',' ','i','s',' ','a'] in
 
 -- Nop
 utest () with () in

--- a/test/mexpr/stringops.mc
+++ b/test/mexpr/stringops.mc
@@ -8,7 +8,7 @@ include "char.mc"
 mexpr
 
 let head = lam seq. get seq 0 in
-let tail = lam seq. slice seq 1 (length seq) in
+let tail = lam seq. sub seq 1 (length seq) in
 
 recursive
   let map = lam f. lam seq.
@@ -49,8 +49,8 @@ recursive
   let strsplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
     then cons s []
-    else if eqString delim (slice s 0 (length delim))
-         then cons [] (strsplit delim (slice s (length delim) (length s)))
+    else if eqString delim (sub s 0 (length delim))
+         then cons [] (strsplit delim (sub s (length delim) (length s)))
          else let remaining = strsplit delim (tail s) in
               cons (cons (head s) (head remaining)) (tail remaining)
 in

--- a/test/mexpr/stringops.mc
+++ b/test/mexpr/stringops.mc
@@ -8,7 +8,7 @@ include "char.mc"
 mexpr
 
 let head = lam seq. get seq 0 in
-let tail = lam seq. sub seq 1 (length seq) in
+let tail = lam seq. subsequence seq 1 (length seq) in
 
 recursive
   let map = lam f. lam seq.
@@ -49,8 +49,8 @@ recursive
   let strsplit = lam delim. lam s.
     if or (eqi (length delim) 0) (lti (length s) (length delim))
     then cons s []
-    else if eqString delim (sub s 0 (length delim))
-         then cons [] (strsplit delim (sub s (length delim) (length s)))
+    else if eqString delim (subsequence s 0 (length delim))
+         then cons [] (strsplit delim (subsequence s (length delim) (length s)))
          else let remaining = strsplit delim (tail s) in
               cons (cons (head s) (head remaining)) (tail remaining)
 in

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -96,8 +96,8 @@ lang StrFormatBase
         -- sequence of non-alpha chars.
         let found_idx = index isAlpha s in
         match found_idx with Some i then
-          let fmtstr = sub s 0 (addi i 1) in
-          let remaining = sub s (addi i 1) (length s) in
+          let fmtstr = subsequence s 0 (addi i 1) in
+          let remaining = subsequence s (addi i 1) (length s) in
           concat (toFormat fmtstr (head args)) (strFormat (tail args) remaining)
         else
           error (concat "StrFormatBase: strFormat: Unrecognized format: " s)

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -96,8 +96,8 @@ lang StrFormatBase
         -- sequence of non-alpha chars.
         let found_idx = index isAlpha s in
         match found_idx with Some i then
-          let fmtstr = slice s 0 (addi i 1) in
-          let remaining = slice s (addi i 1) (length s) in
+          let fmtstr = sub s 0 (addi i 1) in
+          let remaining = sub s (addi i 1) (length s) in
           concat (toFormat fmtstr (head args)) (strFormat (tail args) remaining)
         else
           error (concat "StrFormatBase: strFormat: Unrecognized format: " s)

--- a/test/mlang/top.mc
+++ b/test/mlang/top.mc
@@ -1,5 +1,5 @@
 let head = lam s. get s 0
-let tail = lam s. sub s 1 (length s)
+let tail = lam s. subsequence s 1 (length s)
 
 lang WrappedList
   syn List =

--- a/test/mlang/top.mc
+++ b/test/mlang/top.mc
@@ -1,5 +1,5 @@
 let head = lam s. get s 0
-let tail = lam s. slice s 1 (length s)
+let tail = lam s. sub s 1 (length s)
 
 lang WrappedList
   syn List =


### PR DESCRIPTION
This PR adds a few optimizations to the interpreter:
* Terms in the environment are now only evaluated if they are a `TmFix` (as discovered by @elegios).
* Functions `head` and `last` now use `get` instead of `splitAt` (better complexity).
* Adds a `sub` intrinsic, replacing the `slice` function of the standard library. Functions `tail` and `init` now use `sub` instead of `splitAt` (it seemed unnecessary to me to throw away half the result of `splitAt`, but in practice the difference is negligible).

The first two points had a significant impact on the performance of the test suite (mainly the first one). The time it takes to run the tests using `make test` (on my machine) decreased from 11s to 6s.