### PR TITLE
Poor man's stack trace

### DIFF
--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1798,8 +1798,11 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
   | TmApp (fiapp, t1, t2) -> (
     match eval env t1 with
     (* Closure application *)
-    | TmClos (_, _, s, t3, env2) ->
-        eval ((s, eval env t2) :: Lazy.force env2) t3
+    | TmClos (_, _, s, t3, env2) -> (
+      try eval ((s, eval env t2) :: Lazy.force env2) t3
+      with Error _ as e ->
+        uprint_endline (us "TRACE: " ^. info2str fiapp) ;
+        raise e )
     (* Constant application using the delta function *)
     | TmConst (_, c) ->
         delta eval env fiapp c (eval env t2)


### PR DESCRIPTION
This implements a very simple form of stack trace printing; whenever an error is thrown by `eval` of the body of a closure we catch it, print the source code location of the closure, then rethrow it. It's hardly pretty or ideal, but it was really fast to implement, and gives useful information for debugging.

Fixes #174 

Example:
```
/home/vipa/Projects/miking/stdlib/parser/semantic.mc: ........TRACE: FILE "/home/vipa/Projects/miking/stdlib/map.mc" 24:67-24:79
TRACE: FILE "/home/vipa/Projects/miking/stdlib/parser/breakable.mc" 388:21-388:33
TRACE: FILE "/home/vipa/Projects/miking/stdlib/seq.mc" 115:18-115:33
TRACE: FILE "/home/vipa/Projects/miking/stdlib/seq.mc" 115:9-115:33
TRACE: FILE "/home/vipa/Projects/miking/stdlib/parser/breakable.mc" 385:6-396:27
TRACE: FILE "/home/vipa/Projects/miking/stdlib/parser/semantic.mc" 456:35-461:11
TRACE: FILE "/home/vipa/Projects/miking/stdlib/seq.mc" 55:37-55:40
TRACE: FILE "/home/vipa/Projects/miking/stdlib/seq.mc" 51:17-51:30
TRACE: FILE "/home/vipa/Projects/miking/stdlib/seq.mc" 53:2-53:14
TRACE: FILE "/home/vipa/Projects/miking/stdlib/parser/semantic.mc" 276:29-276:37
TRACE: FILE "/home/vipa/Projects/miking/stdlib/parser/semantic.mc" 326:14-328:27
TRACE: FILE "/home/vipa/Projects/miking/stdlib/parser/semantic.mc" 630:6-638:3

FILE "/home/vipa/Projects/miking/stdlib/parser/semantic.mc" 248:34-248:44 ERROR: Incorrect application. function: sym2hash value: {spec = {action = clos x. (label,x),ptype = (Infix {right = (DefaultIn ()),self = (DefaultIn ()),left = (DefaultIn ())}),name = ("add"),rhs = ([(ParserBase_Lit {lit = ("+")})]),nt = {name = ("expression"),sym = symb(4700)}},sym = symb(4702)}
```