### PR TITLE
Use ocamlformat version 0.16.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.15.0
+version=0.16.0
 profile=ocamlformat
 margin=79

--- a/README.md
+++ b/README.md
@@ -1090,10 +1090,10 @@ automatically format ocaml source code.
 
 ###  Setup and use `ocamlformat`
 
-We are currently using this package at version `0.15.0`. To pin and/or install
+We are currently using this package at version `0.16.0`. To pin and/or install
 the package at this version using `opam` do
 ```
-opam pin ocamlformat 0.15.0
+opam pin ocamlformat 0.16.0
 ```
 Then you can then run `dune build @fmt` to see a
 diff between your code and the formatted code. To promote the changes run `dune

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -334,7 +334,7 @@ let rec map_tm f = function
         (TmRecLets
            ( fi
            , List.map (fun (fi, x, s, ty, t) -> (fi, x, s, ty, map_tm f t)) lst
-           , map_tm f tm ))
+           , map_tm f tm ) )
   | TmConst (_, _) as t ->
       f t
   | TmSeq (fi, tms) ->
@@ -424,7 +424,7 @@ let tmseq2ustring fi s =
       | TmConst (_, CChar i) ->
           i
       | _ ->
-          raise_error fi "The term is not a string")
+          raise_error fi "The term is not a string" )
     s
   |> Mseq.Helpers.to_ustring
 

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -101,7 +101,7 @@ let builtin =
                    ( NoInfo
                    , s |> us |> Mseq.Helpers.of_ustring
                      |> Mseq.Helpers.map (fun x -> TmConst (NoInfo, CChar x))
-                   )) ) )
+                   ) ) ) )
   ; ("readFile", f CreadFile)
   ; ("writeFile", f (CwriteFile None))
   ; ("fileExists", f CfileExists)
@@ -547,7 +547,7 @@ let delta eval env fi c v =
          | TmConst (_, CInt n) ->
              n
          | _ ->
-             fail_constapp fi)
+             fail_constapp fi )
     |> Mseq.Helpers.to_array
   in
   let int_array2tm_seq fi a =
@@ -1115,7 +1115,7 @@ let delta eval env fi c v =
                Tensor.Num.create Tensor.Num.Float shape f' |> T.float
            | tm ->
                let f' is = if is = is0 then tm else f is in
-               Tensor.NoNum.create shape f' |> T.no_num)
+               Tensor.NoNum.create shape f' |> T.no_num )
       |> fun t -> TmConst (fi, CTensor t)
   | CtensorCreate _, _ ->
       fail_constapp fi
@@ -1502,7 +1502,7 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
     Mseq.Helpers.fold_right
       (fun p (patEnv, ps) ->
         let patEnv, p = sPat patEnv p in
-        (patEnv, Mseq.cons p ps))
+        (patEnv, Mseq.cons p ps) )
       pats (patEnv, Mseq.empty)
   and sPat (patEnv : (ident * Symb.t) list) = function
     | PatNamed (fi, NameStr (x, _)) ->
@@ -1532,7 +1532,7 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
             (fun p ->
               let patEnv', p = sPat !patEnv p in
               patEnv := patEnv' ;
-              p)
+              p )
             pats
         in
         (!patEnv, PatRecord (fi, pats))
@@ -1600,7 +1600,7 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
         List.fold_left
           (fun env (_, x, _, _, _) ->
             let s = Symb.gensym () in
-            (IdVar (sid_of_ustring x), s) :: env)
+            (IdVar (sid_of_ustring x), s) :: env )
           env lst
       in
       TmRecLets
@@ -1611,7 +1611,7 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
               , x
               , findsym fi (IdVar (sid_of_ustring x)) env2
               , symbolize_type env ty
-              , symbolize env2 t ))
+              , symbolize env2 t ) )
             lst
         , symbolize env2 tm )
   | TmApp (fi, t1, t2) ->
@@ -1677,7 +1677,7 @@ let rec symbolize_toplevel (env : (ident * Symb.t) list) = function
         List.fold_left
           (fun env (_, x, _, _, _) ->
             let s = Symb.gensym () in
-            (IdVar (sid_of_ustring x), s) :: env)
+            (IdVar (sid_of_ustring x), s) :: env )
           env lst
       in
       let new_env, new_tm = symbolize_toplevel env2 tm in
@@ -1690,7 +1690,7 @@ let rec symbolize_toplevel (env : (ident * Symb.t) list) = function
                 , x
                 , findsym fi (IdVar (sid_of_ustring x)) env2
                 , symbolize_type env ty
-                , symbolize env2 t ))
+                , symbolize env2 t ) )
               lst
           , new_tm ) )
   | TmConDef (fi, x, _, ty, t) ->
@@ -1852,7 +1852,7 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
            in
            List.fold_left
              (fun env (_, _, s, _ty, rhs) -> (s, wraplambda rhs) :: env)
-             env lst)
+             env lst )
       in
       eval (Lazy.force env') t2
   (* Constant *)
@@ -1962,7 +1962,7 @@ let rec eval_toplevel (env : (Symb.t * tm) list) = function
            in
            List.fold_left
              (fun env (_, _, s, _ty, rhs) -> (s, wraplambda rhs) :: env)
-             env lst)
+             env lst )
       in
       eval_toplevel (Lazy.force env') t2
   | TmConDef (_, _, _, _, t) ->

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -74,7 +74,7 @@ type lang_data =
 let spprint_inter_data {info; cases; _} : ustring =
   List.map
     (fun (fi, {pat; _}) ->
-      us "  " ^. ustring_of_pat pat ^. us " at " ^. info2str fi)
+      us "  " ^. ustring_of_pat pat ^. us " at " ^. info2str fi )
     cases
   |> Ustring.concat (us "\n")
   |> fun msg -> us "My location is " ^. info2str info ^. us "\n" ^. msg
@@ -199,7 +199,7 @@ let merge_lang_data fi {inters= i1; syns= s1} {inters= i2; syns= s2} :
           let c2 =
             List.filter
               (fun (fi, _) ->
-                List.exists (fun (fi2, _) -> eq_info fi fi2) c1 |> not)
+                List.exists (fun (fi2, _) -> eq_info fi fi2) c1 |> not )
               c2
           in
           let subsets =
@@ -378,7 +378,7 @@ let rec desugar_tm nss env =
         ( fi
         , List.map
             (fun (fi, name, s, ty, e) ->
-              (fi, empty_mangle name, s, ty, desugar_tm nss env' e))
+              (fi, empty_mangle name, s, ty, desugar_tm nss env' e) )
             bindings
         , desugar_tm nss env' body )
   | TmConDef (fi, name, s, ty, body) ->
@@ -403,7 +403,7 @@ let rec desugar_tm nss env =
       let rec desugar_pat_seq env pats =
         Mseq.Helpers.fold_right
           (fun p (env, pats) ->
-            desugar_pat env p |> map_right (fun p -> Mseq.cons p pats))
+            desugar_pat env p |> map_right (fun p -> Mseq.cons p pats) )
           pats (env, Mseq.empty)
       and desugar_pat env = function
         | PatNamed (fi, name) ->
@@ -423,7 +423,7 @@ let rec desugar_tm nss env =
               |> Record.map (fun p ->
                      let env', p = desugar_pat !env p in
                      env := env' ;
-                     p)
+                     p )
             in
             (!env, PatRecord (fi, pats))
         | PatAnd (fi, l, r) ->
@@ -576,7 +576,7 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
                 , empty_mangle id
                 , Symb.Helpers.nosym
                 , ty
-                , desugar_tm nss emptyMlangEnv tm ))
+                , desugar_tm nss emptyMlangEnv tm ) )
               lets
           , tm' )
       in

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -116,7 +116,7 @@ let rec merge_includes root visited = function
       let included_tops =
         included
         |> List.map (function Program (_, tops, _) ->
-               List.filter not_test tops)
+               List.filter not_test tops )
         |> List.concat
       in
       Program (includes, included_tops @ tops, tm)

--- a/src/boot/lib/patterns.ml
+++ b/src/boot/lib/patterns.ml
@@ -244,7 +244,7 @@ let rec list_complement (constr : npat list -> npat) (l : npat list) : normpat
      normpat (since it's a set) up to the top-most list, which we can do using `traverse`
      in the list monad. *)
   |> concat_map ~f:(fun np_list ->
-         traverse NPatSet.elements np_list |> List.map constr)
+         traverse NPatSet.elements np_list |> List.map constr )
   |> NPatSet.of_list
 
 (* construct a normpat *)
@@ -263,7 +263,7 @@ and npat_complement : npat -> normpat = function
       let with_forbidden_labels =
         UstringSet.elements neg_labels
         |> List.map (fun label ->
-               NPatRecord (Record.add label wildpat pats, UstringSet.empty))
+               NPatRecord (Record.add label wildpat pats, UstringSet.empty) )
         |> NPatSet.of_list
       in
       let labels, pats = Record.bindings pats |> List.split in
@@ -271,13 +271,13 @@ and npat_complement : npat -> normpat = function
         list_complement
           (fun pats ->
             List.combine labels pats |> List.to_seq |> Record.of_seq
-            |> fun x -> NPatRecord (x, UstringSet.empty))
+            |> fun x -> NPatRecord (x, UstringSet.empty) )
           pats
       in
       let missing_labels =
         labels
         |> List.map (fun label ->
-               NPatRecord (Record.empty, UstringSet.singleton label))
+               NPatRecord (Record.empty, UstringSet.singleton label) )
         |> NPatSet.of_list
       in
       NPatSet.union complemented_product missing_labels
@@ -291,7 +291,7 @@ and npat_complement : npat -> normpat = function
         list_complement
           (fun pats ->
             let pre, post = split_at lenPre pats in
-            NPatSeqEdge (pre, post))
+            NPatSeqEdge (pre, post) )
           (pre @ post)
       in
       let allowed_lengths =
@@ -322,7 +322,7 @@ and npat_complement : npat -> normpat = function
              | ConCon c ->
                  NSPat (SPatCon (c, wildpat))
              | RecCon ->
-                 NPatRecord (Record.empty, UstringSet.empty))
+                 NPatRecord (Record.empty, UstringSet.empty) )
         |> NPatSet.of_list
       in
       NPatSet.union seqs cons
@@ -366,14 +366,14 @@ and npat_intersect (a : npat) (b : npat) : normpat =
           |> List.filter (fun n -> IntSet.mem (n + min_len) lens |> not)
           |> List.map (fun n_extras ->
                  NPatSeqTot
-                   (pre @ List.rev_append (repeat n_extras wildpat) post))
+                   (pre @ List.rev_append (repeat n_extras wildpat) post) )
           |> NPatSet.of_list
           |> NPatSet.add
                (NPatSeqEdge
                   ( pre
                   , List.rev_append
                       (repeat (max_forbidden_len - min_len + 1) wildpat)
-                      post )) )
+                      post ) ) )
   | NSPat p1, NSPat p2 -> (
     match (p1, p2) with
     | SPatInt i1, SPatInt i2 when i1 = i2 ->
@@ -408,7 +408,7 @@ and npat_intersect (a : npat) (b : npat) : normpat =
         Record.merge merge_f r1 r2 |> Record.bindings
         |> traverse (fun (k, vs) -> List.map (fun v -> (k, v)) vs)
         |> List.map (fun bindings ->
-               NPatRecord (List.to_seq bindings |> Record.of_seq, neg))
+               NPatRecord (List.to_seq bindings |> Record.of_seq, neg) )
         |> NPatSet.of_list
   | NPatRecord _, (NPatSeqTot _ | NPatSeqEdge _)
   | (NPatSeqTot _ | NPatSeqEdge _), NPatRecord _ ->
@@ -431,7 +431,7 @@ and npat_intersect (a : npat) (b : npat) : normpat =
         pre @ post |> traverse NPatSet.elements
         |> List.map (fun pats ->
                let pre, post = split_at (List.length pre) pats in
-               NPatSeqEdge (pre, post))
+               NPatSeqEdge (pre, post) )
         |> NPatSet.of_list
       in
       let overlapping =
@@ -444,7 +444,7 @@ and npat_intersect (a : npat) (b : npat) : normpat =
             List.init (List.length pre_extras) (fun n ->
                 List.rev_append (repeat n wildpat) post_extras
                 |> map2_with_extras npat_intersect wildpat wildpat pre_extras
-                |> fun mid -> pre @ mid @ post)
+                |> fun mid -> pre @ mid @ post )
             |> concat_map ~f:(traverse NPatSet.elements)
             |> List.map (fun pats -> NPatSeqTot pats)
             |> NPatSet.of_list
@@ -495,15 +495,15 @@ let rec pat_to_normpat = function
       |> traverse (fun p -> pat_to_normpat p |> NPatSet.elements)
       |> List.map (fun pats ->
              let pre, post = split_at (Mseq.length pre) pats in
-             NPatSeqEdge (pre, post))
+             NPatSeqEdge (pre, post) )
       |> NPatSet.of_list
   | PatRecord (_, r) ->
       Record.bindings r
       |> traverse (fun (k, p) ->
-             pat_to_normpat p |> NPatSet.elements |> List.map (fun p -> (k, p)))
+             pat_to_normpat p |> NPatSet.elements |> List.map (fun p -> (k, p)) )
       |> List.map (fun bindings ->
              NPatRecord
-               (List.to_seq bindings |> Record.of_seq, UstringSet.empty))
+               (List.to_seq bindings |> Record.of_seq, UstringSet.empty) )
       |> NPatSet.of_list
   | PatCon (_, c, _, p) ->
       pat_to_normpat p |> NPatSet.map (fun p -> NSPat (SPatCon (c, p)))
@@ -537,7 +537,7 @@ let pat_example normpat =
         let pos = PatRecord (NoInfo, Record.map npat_to_pat r) in
         UstringSet.elements neg
         |> List.map (fun label ->
-               PatRecord (NoInfo, Record.singleton label wildpat))
+               PatRecord (NoInfo, Record.singleton label wildpat) )
         |> function
         | [] ->
             pos
@@ -564,7 +564,7 @@ let pat_example normpat =
               IntSet.elements lens
               |> List.map (fun len ->
                      PatSeqTot
-                       (NoInfo, repeat len wildpat |> Mseq.Helpers.of_list))
+                       (NoInfo, repeat len wildpat |> Mseq.Helpers.of_list) )
         in
         let cons =
           ConSet.elements cons
@@ -578,7 +578,7 @@ let pat_example normpat =
                | ConCon str ->
                    PatCon (NoInfo, str, Symb.Helpers.nosym, wildpat)
                | RecCon ->
-                   PatRecord (NoInfo, Record.empty))
+                   PatRecord (NoInfo, Record.empty) )
         in
         match seqs @ cons with
         | [] ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -400,7 +400,7 @@ let rec print_const fmt = function
            | T.Float t' ->
                Tensor.Num.shape t'
            | T.NoNum t' ->
-               Tensor.NoNum.shape t')
+               Tensor.NoNum.shape t' )
       |> Array.to_list |> List.map string_of_int |> String.concat ","
       |> fprintf fmt "tensor[%s]"
   | CtensorCreate _ ->

--- a/src/boot/lib/pyffi.py.ml
+++ b/src/boot/lib/pyffi.py.ml
@@ -143,8 +143,7 @@ let delta _ _ fi c v =
   | Pycall (None, None), _ ->
       fail_constapp fi
   | Pycall (Some m, None), TmSeq (fi, lst) ->
-      mk_py fi
-        (Pycall (Some m, Some (tmseq2ustring fi lst |> Ustring.to_utf8)))
+      mk_py fi (Pycall (Some m, Some (tmseq2ustring fi lst |> Ustring.to_utf8)))
   | Pycall (Some _, None), _ ->
       fail_constapp fi
   | Pycall (Some m, Some s), TmRecord (fi, args) ->
@@ -162,7 +161,8 @@ let delta _ _ fi c v =
       fail_constapp fi
   | PycallKw (Some m, None, None), TmSeq (fi, lst) ->
       mk_py fi
-        (PycallKw (Some m, Some (tmseq2ustring fi lst |> Ustring.to_utf8), None))
+        (PycallKw (Some m, Some (tmseq2ustring fi lst |> Ustring.to_utf8), None)
+        )
   | PycallKw (Some _, None, None), _ ->
       fail_constapp fi
   | PycallKw (Some m, Some s, None), TmRecord (fi, args) ->

--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -326,8 +326,8 @@ let map_bigarray_array (f : 'a -> 'b) (s : ('a, 'c) ba t) : 'b array t =
     done ;
     ref (Leaf dst)
 
-let map_bigarray_bigarray (k : ('b, 'd) kind) (f : 'a -> 'b)
-    (s : ('a, 'c) ba t) : ('b, 'd) ba t =
+let map_bigarray_bigarray (k : ('b, 'd) kind) (f : 'a -> 'b) (s : ('a, 'c) ba t)
+    : ('b, 'd) ba t =
   let a = _collapse_bigarray s in
   let n = Array1.dim a in
   let dst = _uninit_bigarray k n in

--- a/src/boot/lib/sd.sd.ml
+++ b/src/boot/lib/sd.sd.ml
@@ -154,7 +154,7 @@ let delta eval env fi c v =
              [ float_ NoInfo t
              ; sa_array_ NoInfo y
              ; sa_array_ NoInfo y'
-             ; sa_array_ NoInfo r ])
+             ; sa_array_ NoInfo r ] )
       in
       ()
     in
@@ -294,7 +294,7 @@ let delta eval env fi c v =
                    ; float_ NoInfo cj
                    ; sa_array_ NoInfo y
                    ; sa_array_ NoInfo y'
-                   ; sa_matrix_dense_ NoInfo mm ])
+                   ; sa_matrix_dense_ NoInfo mm ] )
             in
             ()
       in
@@ -303,25 +303,26 @@ let delta eval env fi c v =
   | SIdaInitDenseJac (Some tol, Some jacf, None, None, None, None), tm_resf ->
       sd_ (tm_info tm_resf)
         (SIdaInitDenseJac
-           (Some tol, Some jacf, Some (mk_idafun tm_resf), None, None, None))
+           (Some tol, Some jacf, Some (mk_idafun tm_resf), None, None, None) )
   | ( SIdaInitDenseJac (Some tol, Some jacf, Some resf, None, None, None)
     , TmRecord (_, r) ) ->
       let n, rootf = get_roots fi r in
       sd_ fi
         (SIdaInitDenseJac
-           (Some tol, Some jacf, Some resf, Some (n, rootf), None, None))
+           (Some tol, Some jacf, Some resf, Some (n, rootf), None, None) )
   | ( SIdaInitDenseJac
         (Some tol, Some jacf, Some resf, Some (n, rootf), None, None)
     , TmConst (_, CFloat t0) ) ->
       sd_ fi
         (SIdaInitDenseJac
-           (Some tol, Some jacf, Some resf, Some (n, rootf), Some t0, None))
+           (Some tol, Some jacf, Some resf, Some (n, rootf), Some t0, None) )
   | ( SIdaInitDenseJac
         (Some tol, Some jacf, Some resf, Some (n, rootf), Some t0, None)
     , TmConst (fi, CSd (SArray y0)) ) ->
       sd_ fi
         (SIdaInitDenseJac
-           (Some tol, Some jacf, Some resf, Some (n, rootf), Some t0, Some y0))
+           (Some tol, Some jacf, Some resf, Some (n, rootf), Some t0, Some y0)
+        )
   | ( SIdaInitDenseJac
         ( Some (rtol, atol)
         , Some jacf
@@ -376,8 +377,7 @@ let delta eval env fi c v =
     ->
       sd_ fi (SIdaCalcICYYYP (Some s, None, None, None))
   | SIdaCalcICYYYP (Some s, None, None, None), TmConst (_, CSd (SArray y)) ->
-      sd_ fi
-        (SIdaCalcICYYYP (Some s, Some (Nvector_serial.wrap y), None, None))
+      sd_ fi (SIdaCalcICYYYP (Some s, Some (Nvector_serial.wrap y), None, None))
   | SIdaCalcICYYYP (Some s, Some y, None, None), TmConst (_, CSd (SArray y'))
     ->
       sd_ fi

--- a/src/boot/lib/sdast.sd.ml
+++ b/src/boot/lib/sdast.sd.ml
@@ -23,7 +23,7 @@ type ext =
       (float * float) option
       * (   (RealArray.t Ida.triple, RealArray.t) Ida.jacobian_arg
          -> Matrix.Dense.t
-         -> unit)
+         -> unit )
         option
       * (float -> RealArray.t -> RealArray.t -> RealArray.t -> unit) option
       * (int * (float -> RealArray.t -> RealArray.t -> RealArray.t -> unit))

--- a/src/boot/lib/ustring.ml
+++ b/src/boot/lib/ustring.ml
@@ -188,9 +188,8 @@ let rec to_latin1 s =
 let from_uchars a =
   Array.iter
     (fun c ->
-      if not (valid_uchar c) then
-        raise (Invalid_argument "Ustring.from_uchars")
-      else ())
+      if not (valid_uchar c) then raise (Invalid_argument "Ustring.from_uchars")
+      else () )
     a ;
   ref (Uchars a)
 
@@ -203,7 +202,7 @@ let rec to_utf8 s =
         if ae <= 0b1111111 then n + 1
         else if ae <= 0b11111111111 then n + 2
         else if ae <= 0b1111111111111111 then n + 3
-        else n + 4)
+        else n + 4 )
       0 a
   in
   match !s with
@@ -320,8 +319,7 @@ module Op = struct
   let ustring_of_int i = us (string_of_int i)
 
   let int_of_ustring s =
-    try int_of_string (to_latin1 s)
-    with _ -> raise (Failure "int_of_ustring")
+    try int_of_string (to_latin1 s) with _ -> raise (Failure "int_of_ustring")
 
   let ustring_of_float f = us (string_of_float f)
 

--- a/src/boot/lib/utils.ml
+++ b/src/boot/lib/utils.ml
@@ -84,7 +84,7 @@ let string_of_intlist il =
   |> List.fold_left
        (fun i x ->
          Bytes.set s i (char_of_int x) ;
-         i + 1)
+         i + 1 )
        0
   |> ignore ;
   Bytes.to_string s

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -33,9 +33,9 @@ let files_of_folders lst =
         |> List.map (fun x -> add_slash v ^ x)
         |> List.filter (fun x -> not (Sys.is_directory x))
         |> List.filter (fun x ->
-               not (String.contains x '#' || String.contains x '~')) )
+               not (String.contains x '#' || String.contains x '~') ) )
         @ a
-      else v :: a)
+      else v :: a )
     [] lst
 
 (* Iterate over all potential test files and run tests *)


### PR DESCRIPTION
Bumps the version of `ocamlformat` from `0.15.0` to `0.16.0`. After this PR will follow another PR that adds the commit hash of this PR to the `.git-blame-ignore-revs` file.