### PR TITLE
Ll1 fixes

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -125,6 +125,7 @@ and const =
   | CMap of (tm -> tm -> int) * Obj.t
   | CmapEmpty
   | CmapInsert of tm option * tm option
+  | CmapRemove of tm option
   | CmapFind of tm option
   | CmapMem of tm option
   | CmapAny of (tm -> tm -> bool) option

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -379,6 +379,8 @@ let rec print_const fmt = function
       fprintf fmt "mapEmpty"
   | CmapInsert _ ->
       fprintf fmt "mapInsert"
+  | CmapRemove _ ->
+      fprintf fmt "mapRemove"
   | CmapFind _ ->
       fprintf fmt "mapLookup"
   | CmapAny _ ->

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -11,6 +11,12 @@ let mapLookup : k -> Map k v -> Option v =
     match mapMem k m with false then None ()
     else Some (mapFind k m)
 
+let mapInsertWith : (v -> v -> v) -> k -> v -> Map k v -> Map k v =
+  lam f. lam k. lam v. lam m.
+    match mapLookup k m with Some prev then
+      mapInsert k (f prev v) m
+    else mapInsert k v m
+
 let mapUnion : Map k v -> Map k v -> Map k v = lam l. lam r.
   foldl (lam acc. lam binding. mapInsert binding.0 binding.1 acc) l (mapBindings r)
 
@@ -51,5 +57,10 @@ let m = mapFromList subi
 utest mapLookup 1 m with Some "1" in
 utest mapLookup 2 m with Some "2" in
 utest mapLookup 3 m with None () in
+
+let m2 = mapInsertWith concat 1 "blub" m in
+utest mapLookup 1 m2 with Some "1blub" in
+utest mapLookup 2 m2 with mapLookup 2 m in
+utest mapLookup 3 m2 with mapLookup 3 m in
 
 ()

--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -39,9 +39,9 @@ let mergeInfo : Info -> Info -> Info = lam fi1. lam fi2.
     match fi2 with Info r2 then
       Info {filename = r1.filename, row1 = r1.row1, col1 = r1.col1,
             row2 = r2.row2, col2 = r2.col2}
-    else NoInfo ()
-  else NoInfo ()
-  
+    else fi1
+  else fi2
+
 -- Create an info structure
 let infoVal : String -> Int -> Int -> Int -> Int =
   lam filename. lam r1. lam c1. lam r2. lam c2.

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -127,8 +127,7 @@ type BreakableGrammar prodLabel res self =
 -- look up precedence and the like
 type OpId = Int
 
--- Each node in the parsed SPPF has a unique ID (it will likely not be
--- unique when comparing between two different SPPFs though).
+-- Each node in the parsed SPPF has a unique ID via `gensym`.
 type PermanentId = Symbol
 
 -- This is the type that is used to describe an item to be added to the parse
@@ -320,6 +319,24 @@ let breakableInAllowSet
   = lam id. lam set.
     match set with AllowSet s then mapMem id s else
     match set with DisallowSet s then not (mapMem id s) else
+    never
+
+let breakableInsertAllowSet
+  : id
+  -> AllowSet id
+  -> AllowSet id
+  = lam id. lam set.
+    match set with AllowSet s then AllowSet (mapInsert id s) else
+    match set with DisallowSet s then DisallowSet (mapRemove id s) else
+    never
+
+let breakableRemoveAllowSet
+  : id
+  -> AllowSet id
+  -> AllowSet id
+  = lam id. lam set.
+    match set with AllowSet s then AllowSet (mapRemove id s) else
+    match set with DisallowSet s then DisallowSet (mapInsert id s) else
     never
 
 let breakableMapAllowSet
@@ -713,9 +730,14 @@ let breakableAddAtom
     let id = _uniqueID () in
     { st with frontier = [TentativeLeaf {parents = st.frontier, node = AtomP {id = id, input = input, self = self}}] }
 
+-- TODO(vipa, 2021-02-15): There should be more information in case of
+-- a parse failure, but it's not obvious precisely how the information
+-- should be presented, it's not obvious to me that there will always
+-- be a single cause of the failure that is easy to find
+-- algorithmically
 let breakableFinalizeParse
   : State res self RClosed
-  -> [PermanentNode res self]
+  -> Option [PermanentNode res self] -- NonEmpty
   = lam st.
     let time = addi 1 (deref st.timestep) in
     modref st.timestep time;
@@ -755,23 +777,15 @@ let breakableFinalizeParse
     let frontier = st.frontier in
     let queue = _newQueueFromFrontier frontier in
     iter (handleLeaf queue) frontier;
-    work queue
+    match work queue with res & [_] ++ _ then Some res else None ()
 
 type BreakableError self
 con Ambiguities : [{first: self, last: self, irrelevant: [{first: self, last: self}]}] -> BreakableError self
--- TODO(vipa, 2021-02-15): There should be more information in case of
--- a parse failure, but it's not obvious precisely how the information
--- should be presented, it's not obvious to me that there will always
--- be a single cause of the failure that is easy to find
--- algorithmically
-con InvalidParse : () -> BreakableError self
 
 let breakableConstructResult
-  : [PermanentNode res self]
+  : [PermanentNode res self] -- NonEmpty
   -> Either (BreakableError self) res
   = lam nodes.
-    match nodes with [] then InvalidParse () else
-
     -- NOTE(vipa, 2021-02-15): All alternatives for children at the
     -- same point in the tree have the exact same range in the input,
     -- i.e., they will have exactly the same input as first and last
@@ -974,8 +988,8 @@ let testParse
             workRClosed pos (breakableAddAtom input self st) tokens
           else match t with TestPrefix {x = self, input = input} then
             workROpen pos (breakableAddPrefix input self st) tokens
-          else Left (InvalidParse ())
-        else Left (InvalidParse ())
+          else None ()
+        else None ()
       let workRClosed = lam pos. lam st. lam tokens.
         match tokens with [t] ++ tokens then
           let t = t pos in
@@ -983,72 +997,72 @@ let testParse
           match t with TestInfix {x = self, input = input} then
             match breakableAddInfix input self st with Some st
             then workROpen pos st tokens
-            else Left (InvalidParse ())
+            else None ()
           else match t with TestPostfix {x = self, input = input} then
             match breakableAddPostfix input self st with Some st
             then workRClosed pos st tokens
-            else Left (InvalidParse ())
-          else Left (InvalidParse ())
-        else breakableConstructResult (breakableFinalizeParse st)
+            else None ()
+          else None ()
+        else optionMap breakableConstructResult (breakableFinalizeParse st)
     in workROpen 0 (breakableInitState ())
 in
 
 utest testParse []
-with Left (InvalidParse ())
+with None ()
 in
 
 utest testParse [_int 4]
-with Right (IntA {val = 4,pos = 0})
+with Some (Right (IntA {val = 4,pos = 0}))
 in
 
 utest testParse [_int 4, _plus]
-with Left (InvalidParse ())
+with None ()
 in
 
 utest testParse [_int 4, _plus, _int 7]
-with Right
+with Some (Right
   (PlusA
     { pos = 1
     , l = (IntA {val = 4,pos = 0})
     , r = (IntA {val = 7,pos = 2})
-    })
+    }))
 in
 
 utest testParse [_negate, _int 8]
-with Right
+with Some (Right
   (NegateA
     { pos = 0
     , r = (IntA {val = 8,pos = 1})
-    })
+    }))
 in
 
 utest testParse [_negate, _negate, _int 8]
-with Right
+with Some (Right
   (NegateA
     { pos = 0
     , r = (NegateA
       { pos = 1
       , r = (IntA {val = 8,pos = 2})
       })
-    })
+    }))
 in
 
 utest testParse [_int 9, _nonZero, _nonZero]
-with Right
+with Some (Right
   (NonZeroA
     { pos = 2
     , l = (NonZeroA
       { pos = 1
       , l = (IntA {val = 9,pos = 0})})
-    })
+    }))
 in
 
 utest testParse [_negate, _nonZero]
-with Left (InvalidParse ())
+with None ()
 in
 
 utest testParse [_int 1, _plus, _int 2, _times, _int 3]
-with Right
+with Some (Right
   (PlusA
     { pos = 1
     , l = (IntA {val = 1,pos = 0})
@@ -1057,11 +1071,11 @@ with Right
       , l = (IntA {val = 2,pos = 2})
       , r = (IntA {val = 3,pos = 4})
       })
-    })
+    }))
 in
 
 utest testParse [_int 1, _times, _int 2, _plus, _int 3]
-with Right
+with Some (Right
   (PlusA
     { pos = 3
     , l = (TimesA
@@ -1070,49 +1084,49 @@ with Right
       , r = (IntA {val = 2,pos = 2})
       })
     , r = (IntA {val = 3,pos = 4})
-    })
+    }))
 in
 
 utest testParse [_int 1, _times, _int 2, _divide, _int 3]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 1,pos = 0}
     , last = {val = 3,pos = 4}
     }
-  ]))
+  ])))
 in
 
 utest testParse [_int 1, _times, _int 2, _divide, _int 3, _plus, _int 4]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 1,pos = 0}
     , last = {val = 3,pos = 4}
     }
-  ]))
+  ])))
 in
 
 utest testParse [_int 0, _plus, _int 1, _times, _int 2, _divide, _int 3]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 1,pos = 2}
     , last = {val = 3,pos = 6}
     }
-  ]))
+  ])))
 in
 
 -- TODO(vipa, 2021-02-15): When we compute elisons we can report two ambiguities here, the nested one is independent
 utest testParse [_int 0, _plus, _int 1, _times, _int 2, _divide, _int 3, _plus, _int 4]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 0,pos = 0}
     , last = {val = 4,pos = 8}
     }
-  ]))
+  ])))
 in
 
 -- TODO(vipa, 2021-02-15): Do we want to specify the order of the returned ambiguities in some way?
 utest testParse [_int 1, _times, _int 2, _divide, _int 3, _plus, _int 4, _divide, _int 5, _times, _int 6]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 4, pos = 6}
     , last = {val = 6, pos = 10}
@@ -1121,19 +1135,19 @@ with Left (Ambiguities (
     , first = {val = 1,pos = 0}
     , last = {val = 3,pos = 4}
     }
-  ]))
+  ])))
 in
 
 utest testParse [_if, _int 1]
-with Right
+with Some (Right
   (IfA
     { pos = 0
     , r = (IntA {val = 1,pos = 1})
-    })
+    }))
 in
 
 utest testParse [_if, _int 1, _else, _int 2]
-with Right
+with Some (Right
   (ElseA
     { pos = 2
     , l = (IfA
@@ -1141,25 +1155,25 @@ with Right
       , r = (IntA {val = 1,pos = 1})
       })
     , r = (IntA {val = 2,pos = 3})
-    })
+    }))
 
 in
 
 utest testParse [_if, _int 1, _else, _int 2, _else, _int 3]
-with Left (InvalidParse ())
+with None ()
 in
 
 utest testParse [_if, _if, _int 1, _else, _int 2]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 0,pos = 0}
     , last = {val = 2,pos = 4}
     }
-  ]))
+  ])))
 in
 
 utest testParse [_negate, _if, _int 1, _else, _int 2]
-with Right
+with Some (Right
   (NegateA
     { pos = 0
     , r = (ElseA
@@ -1170,29 +1184,29 @@ with Right
         })
       , r = (IntA {val = 2,pos = 4})
       })
-    })
+    }))
 in
 
 utest testParse [_if, _negate, _if, _int 1, _else, _int 2]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 0,pos = 0}
     , last = {val = 2,pos = 5}
     }
-  ]))
+  ])))
 in
 
 utest testParse [_int 1, _plus, _if, _negate, _if, _int 1, _else, _int 2]
-with Left (Ambiguities (
+with Some (Left (Ambiguities (
   [ { irrelevant = ([])
     , first = {val = 0,pos = 2}
     , last = {val = 2,pos = 7}
     }
-  ]))
+  ])))
 in
 
 utest testParse [_int 1, _times, _if, _int 7, _else, _int 12]
-with Right
+with Some (Right
   (TimesA
     { pos = 1
     , l = (IntA {val = 1,pos = 0})
@@ -1204,19 +1218,19 @@ with Right
         })
       , r = (IntA {val = 12,pos = 5})
       })
-    })
+    }))
 in
 
 utest testParse [_int 1, _plus, _plus, _int 2]
-with Left (InvalidParse ())
+with None ()
 in
 
 utest testParse [_int 1, _plus, _nonZero]
-with Left (InvalidParse ())
+with None ()
 in
 
 utest testParse [_int 1, _nonZero, _plus, _int 2]
-with Right
+with Some (Right
   (PlusA
     { pos = 2
     , l = (NonZeroA
@@ -1224,7 +1238,7 @@ with Right
       , l = (IntA {val = 1,pos = 0})
       })
     , r = (IntA {val = 2,pos = 3})
-    })
+    }))
 in
 
 ()

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -24,6 +24,7 @@ lang TokenParser = WSACParser
 
   sem parseToken (pos : Pos) /- : String -> {token : Token, lit : String, info : Info, stream : {pos : Pos, str : String}} -/ =
   sem tokKindEq (tok : Token) /- : Token -> Bool -/ =
+  sem tokInfo /- : Token -> Info -/ =
 end
 
 -- Eats whitespace
@@ -79,6 +80,9 @@ lang EOFTokenParser = TokenParser
 
   sem tokKindEq (tok : Tok) =
   | EOFTok _ -> match tok with EOFTok _ then true else false
+
+  sem tokInfo =
+  | EOFTok {fi = fi} -> fi
 end
 
 -- Parses the continuation of an identifier, i.e., upper and lower
@@ -146,9 +150,11 @@ lang UIdentTokenParser = TokenParser
       }
     else never
 
-
   sem tokKindEq (tok : Tok) =
   | UIdentTok _ -> match tok with UIdentTok _ then true else false
+
+  sem tokInfo =
+  | UIdentTok {fi = fi} -> fi
 end
 
 let parseUInt : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -195,6 +201,9 @@ lang UIntTokenParser = TokenParser
 
   sem tokKindEq (tok : Tok) =
   | IntTok _ -> match tok with IntTok _ then true else false
+
+  sem tokInfo =
+  | IntTok {fi = fi} -> fi
 end
 
 let parseFloatExponent : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -262,6 +271,9 @@ lang UFloatTokenParser = UIntTokenParser
 
   sem tokKindEq (tok : Tok) =
   | FloatTok _ -> match tok with FloatTok _ then true else false
+
+  sem tokInfo =
+  | FloatTok {fi = fi} -> fi
 end
 
 let parseOperatorCont : Pos -> String -> {val : String, stream : {pos : Pos, str : String}} = lam p. lam str.
@@ -303,6 +315,9 @@ lang OperatorTokenParser = TokenParser
 
   sem tokKindEq (tok : Tok) =
   | OperatorTok _ -> match tok with OperatorTok _ then true else false
+
+  sem tokInfo =
+  | OperatorTok {fi = fi} -> fi
 end
 
 lang BracketTokenParser = TokenParser
@@ -347,6 +362,14 @@ lang BracketTokenParser = TokenParser
   | RBracketTok _ -> match tok with RBracketTok _ then true else false
   | LBraceTok _ -> match tok with LBraceTok _ then true else false
   | RBraceTok _ -> match tok with RBraceTok _ then true else false
+
+  sem tokInfo =
+  | LParenTok {fi = fi} -> fi
+  | RParenTok {fi = fi} -> fi
+  | LBracketTok {fi = fi} -> fi
+  | RBracketTok {fi = fi} -> fi
+  | LBraceTok {fi = fi} -> fi
+  | RBraceTok {fi = fi} -> fi
 end
 
 lang SemiTokenParser = TokenParser
@@ -361,6 +384,9 @@ lang SemiTokenParser = TokenParser
 
   sem tokKindEq (tok : Tok) =
   | SemiTok _ -> match tok with SemiTok _ then true else false
+
+  sem tokInfo =
+  | SemiTok {fi = fi} -> fi
 end
 
 lang CommaTokenParser = TokenParser
@@ -375,6 +401,9 @@ lang CommaTokenParser = TokenParser
 
   sem tokKindEq (tok : Tok) =
   | CommaTok _ -> match tok with CommaTok _ then true else false
+
+  sem tokInfo =
+  | CommaTok {fi = fi} -> fi
 end
 
 -- Matches a character (including escape character).
@@ -418,6 +447,9 @@ lang StringTokenParser = TokenParser
 
   sem tokKindEq (tok : Tok) =
   | StringTok _ -> match tok with StringTok _ then true else false
+
+  sem tokInfo =
+  | StringTok {fi = fi} -> fi
 end
 
 lang CharTokenParser = TokenParser
@@ -440,6 +472,9 @@ lang CharTokenParser = TokenParser
 
   sem tokKindEq (tok : Tok) =
   | CharTok _ -> match tok with CharTok _ then true else false
+
+  sem tokInfo =
+  | CharTok {fi = fi} -> fi
 end
 
 lang HashStringTokenParser = TokenParser
@@ -471,6 +506,9 @@ lang HashStringTokenParser = TokenParser
   | HashStringTok {hash = hash} -> match tok with HashStringTok {hash = hash2}
     then eqString hash hash2
     else false
+
+  sem tokInfo =
+  | HashStringTok {fi = fi} -> fi
 end
 
 lang Lexer

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -71,18 +71,18 @@ lang MExprWSACParser = WhitespaceParser + LineCommentParser + MultilineCommentPa
 
 lang EOFTokenParser = TokenParser
   syn Token =
-  | EOFTok {fi : Info}
+  | EOFTok {info : Info}
 
   sem parseToken (pos : Pos) =
   | [] ->
     let info = makeInfo pos pos in
-    {token = EOFTok {fi = info}, lit = "", info = info, stream = {pos = pos, str = []}}
+    {token = EOFTok {info = info}, lit = "", info = info, stream = {pos = pos, str = []}}
 
   sem tokKindEq (tok : Tok) =
   | EOFTok _ -> match tok with EOFTok _ then true else false
 
   sem tokInfo =
-  | EOFTok {fi = fi} -> fi
+  | EOFTok {info = info} -> info
 end
 
 -- Parses the continuation of an identifier, i.e., upper and lower
@@ -110,7 +110,7 @@ with {val = "Asd12", str = " ", pos = posVal "" 1 5}
 
 lang LIdentTokenParser = TokenParser
   syn Token =
-  | LIdentTok {fi : Info, val : String}
+  | LIdentTok {info : Info, val : String}
 
   sem parseToken (pos : Pos) =
   | [('_' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' |
@@ -120,7 +120,7 @@ lang LIdentTokenParser = TokenParser
     then
       let val = cons c val in
       let info = makeInfo pos pos2 in
-      { token = LIdentTok {fi = info, val = val}
+      { token = LIdentTok {info = info, val = val}
       , lit = val
       , info = info
       , stream = {pos = pos2, str = str}
@@ -133,7 +133,7 @@ end
 
 lang UIdentTokenParser = TokenParser
   syn Token =
-  | UIdentTok {fi : Info, val : String}
+  | UIdentTok {info : Info, val : String}
 
   sem parseToken (pos : Pos) =
   | [('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
@@ -143,7 +143,7 @@ lang UIdentTokenParser = TokenParser
     then
       let val = cons c val in
       let info = makeInfo pos pos2 in
-      { token = UIdentTok {fi = info, val = val}
+      { token = UIdentTok {info = info, val = val}
       , lit = val
       , info = info
       , stream = {pos = pos2, str = str}
@@ -154,7 +154,7 @@ lang UIdentTokenParser = TokenParser
   | UIdentTok _ -> match tok with UIdentTok _ then true else false
 
   sem tokInfo =
-  | UIdentTok {fi = fi} -> fi
+  | UIdentTok {info = info} -> info
 end
 
 let parseUInt : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -182,7 +182,7 @@ utest parseUInt (initPos "") "Not a number"
 
 lang UIntTokenParser = TokenParser
   syn Token =
-  | IntTok {fi : Info, val : Int}
+  | IntTok {info : Info, val : Int}
 
   sem parseToken (pos : Pos) =
   | (['0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ _) & str ->
@@ -193,7 +193,7 @@ lang UIntTokenParser = TokenParser
   sem parseIntCont (acc : String) (pos1 : Pos) (pos2 : Pos) =
   | str ->
     let info = makeInfo pos1 pos2 in
-    { token = IntTok {fi = info, val = string2int acc}
+    { token = IntTok {info = info, val = string2int acc}
     , lit = ""
     , info = info
     , stream = {pos = pos2, str = str}
@@ -203,7 +203,7 @@ lang UIntTokenParser = TokenParser
   | IntTok _ -> match tok with IntTok _ then true else false
 
   sem tokInfo =
-  | IntTok {fi = fi} -> fi
+  | IntTok {info = info} -> info
 end
 
 let parseFloatExponent : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -228,7 +228,7 @@ utest parseFloatExponent (initPos "") "Not an exponent"
 
 lang UFloatTokenParser = UIntTokenParser
   syn Token =
-  | FloatTok {fi : Info, val : Float}
+  | FloatTok {info : Info, val : Float}
 
   sem parseIntCont (acc : String) (pos1 : Pos) (pos2 : Pos) =
   | ['.'] ++ str ->
@@ -255,7 +255,7 @@ lang UFloatTokenParser = UIntTokenParser
     match parseFloatExponent (advanceCol pos2 1) (tail str) with {val = val, pos = pos2, str = str}
     then
       let info = makeInfo pos1 pos2 in
-      { token = FloatTok {fi = info, val = string2float (join [acc, "e", val])}
+      { token = FloatTok {info = info, val = string2float (join [acc, "e", val])}
       , lit = ""
       , info = info
       , stream = {pos = pos2, str = str}
@@ -263,7 +263,7 @@ lang UFloatTokenParser = UIntTokenParser
     else never
   | str ->
     let info = makeInfo pos1 pos2 in
-    { token = FloatTok {fi = info, val = string2float acc}
+    { token = FloatTok {info = info, val = string2float acc}
     , lit = ""
     , info = info
     , stream = {pos = pos2, str = str}
@@ -273,7 +273,7 @@ lang UFloatTokenParser = UIntTokenParser
   | FloatTok _ -> match tok with FloatTok _ then true else false
 
   sem tokInfo =
-  | FloatTok {fi = fi} -> fi
+  | FloatTok {info = info} -> info
 end
 
 let parseOperatorCont : Pos -> String -> {val : String, stream : {pos : Pos, str : String}} = lam p. lam str.
@@ -298,7 +298,7 @@ with {val = "<&>", stream = {str = " ", pos = posVal "" 1 3}}
 
 lang OperatorTokenParser = TokenParser
   syn Token =
-  | OperatorTok {fi : Info, val : String}
+  | OperatorTok {info : Info, val : String}
 
   sem parseToken (pos : Pos) =
   | [('%' | '<' | '>' | '!' | '?' | '~' | ':' | '.' | '$' | '&' | '*' |
@@ -307,7 +307,7 @@ lang OperatorTokenParser = TokenParser
     then
       let val = cons c val in
       let info = makeInfo pos stream.pos in
-      { token = OperatorTok {fi = info, val = val}
+      { token = OperatorTok {info = info, val = val}
       , lit = val
       , info = info
       , stream = stream}
@@ -317,43 +317,43 @@ lang OperatorTokenParser = TokenParser
   | OperatorTok _ -> match tok with OperatorTok _ then true else false
 
   sem tokInfo =
-  | OperatorTok {fi = fi} -> fi
+  | OperatorTok {info = info} -> info
 end
 
 lang BracketTokenParser = TokenParser
   syn Token =
-  | LParenTok {fi : Info}
-  | RParenTok {fi : Info}
-  | LBracketTok {fi : Info}
-  | RBracketTok {fi : Info}
-  | LBraceTok {fi : Info}
-  | RBraceTok {fi : Info}
+  | LParenTok {info : Info}
+  | RParenTok {info : Info}
+  | LBracketTok {info : Info}
+  | RBracketTok {info : Info}
+  | LBraceTok {info : Info}
+  | RBraceTok {info : Info}
 
   sem parseToken (pos : Pos) =
   | "(" ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = LParenTok {fi = info}, lit = "(", info = info, stream = {pos = pos2, str = str}}
+    {token = LParenTok {info = info}, lit = "(", info = info, stream = {pos = pos2, str = str}}
   | ")" ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = RParenTok {fi = info}, lit = ")", info = info, stream = {pos = pos2, str = str}}
+    {token = RParenTok {info = info}, lit = ")", info = info, stream = {pos = pos2, str = str}}
   | "[" ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = LBracketTok {fi = info}, lit = "[", info = info, stream = {pos = pos2, str = str}}
+    {token = LBracketTok {info = info}, lit = "[", info = info, stream = {pos = pos2, str = str}}
   | "]" ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = RBracketTok {fi = info}, lit = "]", info = info, stream = {pos = pos2, str = str}}
+    {token = RBracketTok {info = info}, lit = "]", info = info, stream = {pos = pos2, str = str}}
   | "{" ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = LBraceTok {fi = info}, lit = "{", info = info, stream = {pos = pos2, str = str}}
+    {token = LBraceTok {info = info}, lit = "{", info = info, stream = {pos = pos2, str = str}}
   | "}" ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = RBraceTok {fi = info}, lit = "}", info = info, stream = {pos = pos2, str = str}}
+    {token = RBraceTok {info = info}, lit = "}", info = info, stream = {pos = pos2, str = str}}
 
   sem tokKindEq (tok : Tok) =
   | LParenTok _ -> match tok with LParenTok _ then true else false
@@ -364,46 +364,46 @@ lang BracketTokenParser = TokenParser
   | RBraceTok _ -> match tok with RBraceTok _ then true else false
 
   sem tokInfo =
-  | LParenTok {fi = fi} -> fi
-  | RParenTok {fi = fi} -> fi
-  | LBracketTok {fi = fi} -> fi
-  | RBracketTok {fi = fi} -> fi
-  | LBraceTok {fi = fi} -> fi
-  | RBraceTok {fi = fi} -> fi
+  | LParenTok {info = info} -> info
+  | RParenTok {info = info} -> info
+  | LBracketTok {info = info} -> info
+  | RBracketTok {info = info} -> info
+  | LBraceTok {info = info} -> info
+  | RBraceTok {info = info} -> info
 end
 
 lang SemiTokenParser = TokenParser
   syn Token =
-  | SemiTok {fi : Info}
+  | SemiTok {info : Info}
 
   sem parseToken (pos : Pos) =
   | ";" ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = SemiTok {fi = info}, lit = ";", info = info, stream = {pos = pos2, str = str}}
+    {token = SemiTok {info = info}, lit = ";", info = info, stream = {pos = pos2, str = str}}
 
   sem tokKindEq (tok : Tok) =
   | SemiTok _ -> match tok with SemiTok _ then true else false
 
   sem tokInfo =
-  | SemiTok {fi = fi} -> fi
+  | SemiTok {info = info} -> info
 end
 
 lang CommaTokenParser = TokenParser
   syn Token =
-  | CommaTok {fi : Info}
+  | CommaTok {info : Info}
 
   sem parseToken (pos : Pos) =
   | "," ++ str ->
     let pos2 = advanceCol pos 1 in
     let info = makeInfo pos pos2 in
-    {token = CommaTok {fi = info}, lit = ",", info = info, stream = {pos = pos2, str = str}}
+    {token = CommaTok {info = info}, lit = ",", info = info, stream = {pos = pos2, str = str}}
 
   sem tokKindEq (tok : Tok) =
   | CommaTok _ -> match tok with CommaTok _ then true else false
 
   sem tokInfo =
-  | CommaTok {fi = fi} -> fi
+  | CommaTok {info = info} -> info
 end
 
 -- Matches a character (including escape character).
@@ -426,7 +426,7 @@ let matchChar : Pos -> String -> {val: Char, pos: Pos, str: String} =
 
 lang StringTokenParser = TokenParser
   syn Token =
-  | StringTok {fi : Info, val : String}
+  | StringTok {info : Info, val : String}
 
   sem parseToken (pos : Pos) =
   | "\"" ++ str ->
@@ -438,7 +438,7 @@ lang StringTokenParser = TokenParser
       else never
     in match work "" (advanceCol pos 1) str with {val = val, pos = pos2, str = str} then
       let info = makeInfo pos pos2 in
-      { token = StringTok {fi = info, val = val}
+      { token = StringTok {info = info, val = val}
       , lit = ""
       , info = info
       , stream = {pos = pos2, str = str}
@@ -449,12 +449,12 @@ lang StringTokenParser = TokenParser
   | StringTok _ -> match tok with StringTok _ then true else false
 
   sem tokInfo =
-  | StringTok {fi = fi} -> fi
+  | StringTok {info = info} -> info
 end
 
 lang CharTokenParser = TokenParser
   syn Token =
-  | CharTok {fi : Info, val : Char}
+  | CharTok {info : Info, val : Char}
 
   sem parseToken (pos : Pos) =
   | "'" ++ str ->
@@ -462,7 +462,7 @@ lang CharTokenParser = TokenParser
       match str with "'" ++ str then
         let pos2 = advanceCol pos2 1 in
         let info = makeInfo pos pos2 in
-        { token = CharTok {fi = info, val = val}
+        { token = CharTok {info = info, val = val}
         , lit = ""
         , info = info
         , stream = {pos = pos2, str = str}
@@ -474,12 +474,12 @@ lang CharTokenParser = TokenParser
   | CharTok _ -> match tok with CharTok _ then true else false
 
   sem tokInfo =
-  | CharTok {fi = fi} -> fi
+  | CharTok {info = info} -> info
 end
 
 lang HashStringTokenParser = TokenParser
   syn Token =
-  | HashStringTok {fi : Info, hash : String, val : String}
+  | HashStringTok {info : Info, hash : String, val : String}
 
   sem parseToken (pos : Pos) =
   | "#" ++ str ->
@@ -493,7 +493,7 @@ lang HashStringTokenParser = TokenParser
           else never
         in match work "" (advanceCol pos2 1) str with {val = val, pos = pos2, str = str} then
           let info = makeInfo pos pos2 in
-          { token = HashStringTok {fi = info, hash = hash, val = val}
+          { token = HashStringTok {info = info, hash = hash, val = val}
           , lit = ""
           , info = info
           , stream = {pos = pos2, str = str}
@@ -508,7 +508,7 @@ lang HashStringTokenParser = TokenParser
     else false
 
   sem tokInfo =
-  | HashStringTok {fi = fi} -> fi
+  | HashStringTok {info = info} -> info
 end
 
 lang Lexer
@@ -583,301 +583,301 @@ let start = initPos "file" in
 let parse = lam str. nextToken {pos = start, str = str} in
 
 utest parse " --foo \n  bar " with
-  { token = LIdentTok {val = "bar", fi = infoVal "file" 2 2 2 5}
+  { token = LIdentTok {val = "bar", info = infoVal "file" 2 2 2 5}
   , lit = "bar"
   , info = infoVal "file" 2 2 2 5
   , stream = {pos = posVal "file" 2 5 , str = " "}
   } in
 
 utest parse " /- foo -/ bar" with
-  { token = LIdentTok {val = "bar", fi = infoVal "file" 1 11 1 14}
+  { token = LIdentTok {val = "bar", info = infoVal "file" 1 11 1 14}
   , lit = "bar"
   , info = infoVal "file" 1 11 1 14
   , stream = {pos = posVal "file" 1 14 , str = ""}
   } in
 
 utest parse " /- foo\n x \n -/ \nbar " with
-  { token = LIdentTok {val = "bar", fi = infoVal "file" 4 0 4 3}
+  { token = LIdentTok {val = "bar", info = infoVal "file" 4 0 4 3}
   , lit = "bar"
   , info = infoVal "file" 4 0 4 3
   , stream = {pos = posVal "file" 4 3 , str = " "}
   } in
 
 utest parse " /- x -- y /- foo \n -/ -/ !" with
-  { token = OperatorTok {val = "!", fi = infoVal "file" 2 7 2 8}
+  { token = OperatorTok {val = "!", info = infoVal "file" 2 7 2 8}
   , lit = "!"
   , info = infoVal "file" 2 7 2 8
   , stream = {pos = posVal "file" 2 8 , str = ""}
   } in
 
 utest parse "  123foo" with
-  { token = IntTok {val = 123, fi = infoVal "file" 1 2 1 5}
+  { token = IntTok {val = 123, info = infoVal "file" 1 2 1 5}
   , lit = ""
   , info = infoVal "file" 1 2 1 5
   , stream = {pos = posVal "file" 1 5 , str = "foo"}
   } in
 
 utest parse "  1.0" with
-  { token = FloatTok {val = 1.0, fi = infoVal "file" 1 2 1 5}
+  { token = FloatTok {val = 1.0, info = infoVal "file" 1 2 1 5}
   , lit = ""
   , info = infoVal "file" 1 2 1 5
   , stream = {pos = posVal "file" 1 5 , str = ""}
   } in
 
 utest parse " 1234.  " with
-  { token = FloatTok {val = 1234.0, fi = infoVal "file" 1 1 1 6}
+  { token = FloatTok {val = 1234.0, info = infoVal "file" 1 1 1 6}
   , lit = ""
   , info = infoVal "file" 1 1 1 6
   , stream = {pos = posVal "file" 1 6 , str = "  "}
   } in
 
 utest parse " 13.37 " with
-  { token = FloatTok {val = 13.37, fi = infoVal "file" 1 1 1 6}
+  { token = FloatTok {val = 13.37, info = infoVal "file" 1 1 1 6}
   , lit = ""
   , info = infoVal "file" 1 1 1 6
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse "  1.0e-2" with
-  { token = FloatTok {val = 0.01, fi = infoVal "file" 1 2 1 8}
+  { token = FloatTok {val = 0.01, info = infoVal "file" 1 2 1 8}
   , lit = ""
   , info = infoVal "file" 1 2 1 8
   , stream = {pos = posVal "file" 1 8, str = ""}
   } in
 
 utest parse " 2.5e+2  " with
-  { token = FloatTok {val = 250.0, fi = infoVal "file" 1 1 1 7}
+  { token = FloatTok {val = 250.0, info = infoVal "file" 1 1 1 7}
   , lit = ""
   , info = infoVal "file" 1 1 1 7
   , stream = {pos = posVal "file" 1 7, str = "  "}
   } in
 
 utest parse "   2e3" with
-  { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 6}
+  { token = FloatTok {val = 2000.0, info = infoVal "file" 1 3 1 6}
   , lit = ""
   , info = infoVal "file" 1 3 1 6
   , stream = {pos = posVal "file" 1 6, str = ""}
   } in
 
 utest parse "   2E3" with
-  { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 6}
+  { token = FloatTok {val = 2000.0, info = infoVal "file" 1 3 1 6}
   , lit = ""
   , info = infoVal "file" 1 3 1 6
   , stream = {pos = posVal "file" 1 6, str = ""}
   } in
 
 utest parse "   2.0E3" with
-  { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 8}
+  { token = FloatTok {val = 2000.0, info = infoVal "file" 1 3 1 8}
   , lit = ""
   , info = infoVal "file" 1 3 1 8
   , stream = {pos = posVal "file" 1 8, str = ""}
   } in
 
 utest parse "   2.E3" with
-  { token = FloatTok {val = 2000.0, fi = infoVal "file" 1 3 1 7}
+  { token = FloatTok {val = 2000.0, info = infoVal "file" 1 3 1 7}
   , lit = ""
   , info = infoVal "file" 1 3 1 7
   , stream = {pos = posVal "file" 1 7, str = ""}
   } in
 
 utest parse " 1.e2 " with
-  { token = FloatTok {val = 100.0, fi = infoVal "file" 1 1 1 5}
+  { token = FloatTok {val = 100.0, info = infoVal "file" 1 1 1 5}
   , lit = ""
   , info = infoVal "file" 1 1 1 5
   , stream = {pos = posVal "file" 1 5, str = " "}
   } in
 
 utest parse " 3.e-4 " with
-  { token = FloatTok {val = 0.0003, fi = infoVal "file" 1 1 1 6}
+  { token = FloatTok {val = 0.0003, info = infoVal "file" 1 1 1 6}
   , lit = ""
   , info = infoVal "file" 1 1 1 6
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " 4.E+1 " with
-  { token = FloatTok {val = 40.0, fi = infoVal "file" 1 1 1 6}
+  { token = FloatTok {val = 40.0, info = infoVal "file" 1 1 1 6}
   , lit = ""
   , info = infoVal "file" 1 1 1 6
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " 1.E-3 " with
-  { token = FloatTok {val = 0.001, fi = infoVal "file" 1 1 1 6}
+  { token = FloatTok {val = 0.001, info = infoVal "file" 1 1 1 6}
   , lit = ""
   , info = infoVal "file" 1 1 1 6
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " 1E " with
-  { token = IntTok {val = 1, fi = infoVal "file" 1 1 1 2}
+  { token = IntTok {val = 1, info = infoVal "file" 1 1 1 2}
   , lit = ""
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = "E "}
   } in
 
 utest parse " 1e " with
-  { token = IntTok {val = 1, fi = infoVal "file" 1 1 1 2}
+  { token = IntTok {val = 1, info = infoVal "file" 1 1 1 2}
   , lit = ""
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = "e "}
   } in
 
 utest parse " 1.e++2 " with
-  { token = FloatTok {val = 1.0, fi = infoVal "file" 1 1 1 3}
+  { token = FloatTok {val = 1.0, info = infoVal "file" 1 1 1 3}
   , lit = ""
   , info = infoVal "file" 1 1 1 3
   , stream = {pos = posVal "file" 1 3, str = "e++2 "}
   } in
 
 utest parse " 3.1992e--2 " with
-  { token = FloatTok {val = 3.1992, fi = infoVal "file" 1 1 1 7}
+  { token = FloatTok {val = 3.1992, info = infoVal "file" 1 1 1 7}
   , lit = ""
   , info = infoVal "file" 1 1 1 7
   , stream = {pos = posVal "file" 1 7, str = "e--2 "}
   } in
 
 utest parse "  if 1 then 22 else 3" with
-  { token = LIdentTok {val = "if", fi = infoVal "file" 1 2 1 4}
+  { token = LIdentTok {val = "if", info = infoVal "file" 1 2 1 4}
   , lit = "if"
   , info = infoVal "file" 1 2 1 4
   , stream = {pos = posVal "file" 1 4, str = " 1 then 22 else 3"}
   } in
 
 utest parse " true " with
-  { token = LIdentTok {val = "true", fi = infoVal "file" 1 1 1 5}
+  { token = LIdentTok {val = "true", info = infoVal "file" 1 1 1 5}
   , lit = "true"
   , info = infoVal "file" 1 1 1 5
   , stream = {pos = posVal "file" 1 5, str = " "}
   } in
 
 utest parse " ( 123) " with
-  { token = LParenTok {fi = infoVal "file" 1 1 1 2}
+  { token = LParenTok {info = infoVal "file" 1 1 1 2}
   , lit = "("
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = " 123) "}
   } in
 
 utest parse "[]" with
-  { token = LBracketTok {fi = infoVal "file" 1 0 1 1}
+  { token = LBracketTok {info = infoVal "file" 1 0 1 1}
   , lit = "["
   , info = infoVal "file" 1 0 1 1
   , stream = {pos = posVal "file" 1 1, str = "]"}
   } in
 
 utest parse " [ ] " with
-  { token = LBracketTok {fi = infoVal "file" 1 1 1 2}
+  { token = LBracketTok {info = infoVal "file" 1 1 1 2}
   , lit = "["
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = " ] "}
   } in
 
 utest parse " [ 17 ] " with
-  { token = LBracketTok {fi = infoVal "file" 1 1 1 2}
+  { token = LBracketTok {info = infoVal "file" 1 1 1 2}
   , lit = "["
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = " 17 ] "}
   } in
 
 utest parse " [ 232 , ( 19 ) ] " with
-  { token = LBracketTok {fi = infoVal "file" 1 1 1 2}
+  { token = LBracketTok {info = infoVal "file" 1 1 1 2}
   , lit = "["
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = " 232 , ( 19 ) ] "}
   } in
 
 utest parse " \"Foo\" " with
-  { token = StringTok {val = "Foo", fi = infoVal "file" 1 1 1 6}
+  { token = StringTok {val = "Foo", info = infoVal "file" 1 1 1 6}
   , lit = ""
   , info = infoVal "file" 1 1 1 6
   , stream = {pos = posVal "file" 1 6, str = " "}
   } in
 
 utest parse " \" a\\\\ \\n\" " with
-  { token = StringTok {val = " a\\ \n", fi = infoVal "file" 1 1 1 10}
+  { token = StringTok {val = " a\\ \n", info = infoVal "file" 1 1 1 10}
   , lit = ""
   , info = infoVal "file" 1 1 1 10
   , stream = {pos = posVal "file" 1 10, str = " "}
   } in
 
 utest parse " \'A\' " with
-  { token = CharTok {val = 'A', fi = infoVal "file" 1 1 1 4}
+  { token = CharTok {val = 'A', info = infoVal "file" 1 1 1 4}
   , lit = ""
   , info = infoVal "file" 1 1 1 4
   , stream = {pos = posVal "file" 1 4, str = " "}
   } in
 
 utest parse " \'\\n\' " with
-  { token = CharTok {val = '\n', fi = infoVal "file" 1 1 1 5}
+  { token = CharTok {val = '\n', info = infoVal "file" 1 1 1 5}
   , lit = ""
   , info = infoVal "file" 1 1 1 5
   , stream = {pos = posVal "file" 1 5, str = " "}
   } in
 
 utest parse " _xs " with
-  { token = LIdentTok {val = "_xs", fi = infoVal "file" 1 1 1 4}
+  { token = LIdentTok {val = "_xs", info = infoVal "file" 1 1 1 4}
   , lit = "_xs"
   , info = infoVal "file" 1 1 1 4
   , stream = {pos = posVal "file" 1 4, str = " "}
   } in
 
 utest parse " fOO_12a " with
-  { token = LIdentTok {val = "fOO_12a", fi = infoVal "file" 1 1 1 8}
+  { token = LIdentTok {val = "fOO_12a", info = infoVal "file" 1 1 1 8}
   , lit = "fOO_12a"
   , info = infoVal "file" 1 1 1 8
   , stream = {pos = posVal "file" 1 8, str = " "}
   } in
 
 utest parse " lam x . x " with
-  { token = LIdentTok {val = "lam", fi = infoVal "file" 1 1 1 4}
+  { token = LIdentTok {val = "lam", info = infoVal "file" 1 1 1 4}
   , lit = "lam"
   , info = infoVal "file" 1 1 1 4
   , stream = {pos = posVal "file" 1 4, str = " x . x "}
   } in
 
 utest parse " Lam x . x " with
-  { token = UIdentTok {val = "Lam", fi = infoVal "file" 1 1 1 4}
+  { token = UIdentTok {val = "Lam", info = infoVal "file" 1 1 1 4}
   , lit = "Lam"
   , info = infoVal "file" 1 1 1 4
   , stream = {pos = posVal "file" 1 4, str = " x . x "}
   } in
 
 utest parse "  let x = 5 in 8 " with
-  { token = LIdentTok {val = "let", fi = infoVal "file" 1 2 1 5}
+  { token = LIdentTok {val = "let", info = infoVal "file" 1 2 1 5}
   , lit = "let"
   , info = infoVal "file" 1 2 1 5
   , stream = {pos = posVal "file" 1 5, str = " x = 5 in 8 "}
   } in
 
 utest parse " += 47;" with
-  { token = OperatorTok {val = "+=", fi = infoVal "file" 1 1 1 3}
+  { token = OperatorTok {val = "+=", info = infoVal "file" 1 1 1 3}
   , lit = "+="
   , info = infoVal "file" 1 1 1 3
   , stream = {pos = posVal "file" 1 3, str = " 47;"}
   } in
 
 utest parse " ; println foo" with
-  { token = SemiTok {fi = infoVal "file" 1 1 1 2}
+  { token = SemiTok {info = infoVal "file" 1 1 1 2}
   , lit = ";"
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = " println foo"}
   } in
 
 utest parse " #foo\"Zomething\"more" with
-  { token = HashStringTok {hash = "foo", val = "Zomething", fi = infoVal "file" 1 1 1 16}
+  { token = HashStringTok {hash = "foo", val = "Zomething", info = infoVal "file" 1 1 1 16}
   , lit = ""
   , info = infoVal "file" 1 1 1 16
   , stream = {pos = posVal "file" 1 16, str = "more"}
   } in
 
 utest parse " #\"Zomething\"more" with
-  { token = HashStringTok {hash = "", val = "Zomething", fi = infoVal "file" 1 1 1 13}
+  { token = HashStringTok {hash = "", val = "Zomething", info = infoVal "file" 1 1 1 13}
   , lit = ""
   , info = infoVal "file" 1 1 1 13
   , stream = {pos = posVal "file" 1 13, str = "more"}
   } in
 
 utest parse " #123\"Zomething\"more" with
-  { token = HashStringTok {hash = "123", val = "Zomething", fi = infoVal "file" 1 1 1 16}
+  { token = HashStringTok {hash = "123", val = "Zomething", info = infoVal "file" 1 1 1 16}
   , lit = ""
   , info = infoVal "file" 1 1 1 16
   , stream = {pos = posVal "file" 1 16, str = "more"}

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -309,6 +309,20 @@ let ll1Lit : String -> Symbol = use ParserSpec in lam str.
 let ll1Lident : Symbol = use ParserSpec in Tok (LIdentTok {val = "", fi = NoInfo ()})
 let ll1Uident : Symbol = use ParserSpec in Tok (UIdentTok {val = "", fi = NoInfo ()})
 let ll1Int : Symbol = use ParserSpec in Tok (IntTok {val = 0, fi = NoInfo ()})
+let ll1Float : Symbol = use ParserSpec in Tok (FloatTok {val = 0.0, fi = NoInfo ()})
+let ll1Operator : Symbol = use ParserSpec in Tok (OperatorTok {val = "", fi = NoInfo ()})
+let ll1LParen : Symbol = use ParserSpec in Tok (LParenTok {fi = NoInfo ()})
+let ll1RParen = use ParserSpec in Tok (RParenTok {fi = NoInfo ()})
+let ll1LBracket = use ParserSpec in Tok (LBracketTok {fi = NoInfo ()})
+let ll1RBracket = use ParserSpec in Tok (RBracketTok {fi = NoInfo ()})
+let ll1LBrace = use ParserSpec in Tok (LBraceTok {fi = NoInfo ()})
+let ll1RBrace = use ParserSpec in Tok (RBraceTok {fi = NoInfo ()})
+let ll1Semi = use ParserSpec in Tok (SemiTok {fi = NoInfo ()})
+let ll1Comma = use ParserSpec in Tok (CommaTok {fi = NoInfo ()})
+let ll1String = use ParserSpec in Tok (StringTok {val = "", fi = NoInfo ()})
+let ll1Char = use ParserSpec in Tok (CharTok {val = ' ', fi = NoInfo ()})
+let ll1HashString = use ParserSpec in
+  lam hash. Tok (HashStringTok {val = "", hash = hash, fi = NoInfo ()})
 
 mexpr
 

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -17,7 +17,7 @@ type NonTerminal = String
 lang ParserBase = Lexer
   syn Symbol =
   | Tok Token
-  | Lit {lit: String, fi: Info}
+  | Lit {lit: String, info: Info}
 
   -- NOTE(vipa, 2021-02-08): This should be ParserConcrete.Symbol -> Dyn
   -- type Action = [Symbol] -> Dyn
@@ -87,7 +87,7 @@ let ll1ParseWithTable : Table parseLabel -> String -> String -> Either (ParseErr
         -- OPT(vipa, 2021-02-08): Could use the hash of the lit to maybe optimize this, either by using a hashmap, or by first checking against the hash in a bloom filter or something like that
         if if (eqString "" lit) then true else not (mapMem lit lits)
           then {token = Tok token, stream = stream}
-          else {token = Lit {lit = lit, fi = info }, stream = stream}
+          else {token = Lit {lit = lit, info = info }, stream = stream}
       else never in
     recursive
       let openNt = lam nt. lam token. lam stack. lam stream.
@@ -243,7 +243,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
     let followSet : Map NonTerminal (Map Symbol ()) =
       _iterateUntilFixpoint eqFollowSet
         (lam prev. foldl (lam prev. lam prod. addProdToFollow prod prev) prev productions)
-        (mapInsert startNt (mapInsert (Tok (EOFTok {fi = NoInfo ()})) () (mapEmpty _compareSymbol))
+        (mapInsert startNt (mapInsert (Tok (EOFTok {info = NoInfo ()})) () (mapEmpty _compareSymbol))
           (mapMap (lam. mapEmpty _compareSymbol) groupedProds)) in
 
     -- let _ = print "\n\nFollows:" in
@@ -321,23 +321,23 @@ let ll1Lit : String -> Symbol = use ParserSpec in lam str.
     match (unlexed, lit) with ([], ![]) then Lit {lit = str}
     else error (join ["A literal token does not lex as a single token: \"", str, "\""])
   else never
-let ll1Lident : Symbol = use ParserSpec in Tok (LIdentTok {val = "", fi = NoInfo ()})
-let ll1Uident : Symbol = use ParserSpec in Tok (UIdentTok {val = "", fi = NoInfo ()})
-let ll1Int : Symbol = use ParserSpec in Tok (IntTok {val = 0, fi = NoInfo ()})
-let ll1Float : Symbol = use ParserSpec in Tok (FloatTok {val = 0.0, fi = NoInfo ()})
-let ll1Operator : Symbol = use ParserSpec in Tok (OperatorTok {val = "", fi = NoInfo ()})
-let ll1LParen : Symbol = use ParserSpec in Tok (LParenTok {fi = NoInfo ()})
-let ll1RParen = use ParserSpec in Tok (RParenTok {fi = NoInfo ()})
-let ll1LBracket = use ParserSpec in Tok (LBracketTok {fi = NoInfo ()})
-let ll1RBracket = use ParserSpec in Tok (RBracketTok {fi = NoInfo ()})
-let ll1LBrace = use ParserSpec in Tok (LBraceTok {fi = NoInfo ()})
-let ll1RBrace = use ParserSpec in Tok (RBraceTok {fi = NoInfo ()})
-let ll1Semi = use ParserSpec in Tok (SemiTok {fi = NoInfo ()})
-let ll1Comma = use ParserSpec in Tok (CommaTok {fi = NoInfo ()})
-let ll1String = use ParserSpec in Tok (StringTok {val = "", fi = NoInfo ()})
-let ll1Char = use ParserSpec in Tok (CharTok {val = ' ', fi = NoInfo ()})
+let ll1Lident : Symbol = use ParserSpec in Tok (LIdentTok {val = "", info = NoInfo ()})
+let ll1Uident : Symbol = use ParserSpec in Tok (UIdentTok {val = "", info = NoInfo ()})
+let ll1Int : Symbol = use ParserSpec in Tok (IntTok {val = 0, info = NoInfo ()})
+let ll1Float : Symbol = use ParserSpec in Tok (FloatTok {val = 0.0, info = NoInfo ()})
+let ll1Operator : Symbol = use ParserSpec in Tok (OperatorTok {val = "", info = NoInfo ()})
+let ll1LParen : Symbol = use ParserSpec in Tok (LParenTok {info = NoInfo ()})
+let ll1RParen = use ParserSpec in Tok (RParenTok {info = NoInfo ()})
+let ll1LBracket = use ParserSpec in Tok (LBracketTok {info = NoInfo ()})
+let ll1RBracket = use ParserSpec in Tok (RBracketTok {info = NoInfo ()})
+let ll1LBrace = use ParserSpec in Tok (LBraceTok {info = NoInfo ()})
+let ll1RBrace = use ParserSpec in Tok (RBraceTok {info = NoInfo ()})
+let ll1Semi = use ParserSpec in Tok (SemiTok {info = NoInfo ()})
+let ll1Comma = use ParserSpec in Tok (CommaTok {info = NoInfo ()})
+let ll1String = use ParserSpec in Tok (StringTok {val = "", info = NoInfo ()})
+let ll1Char = use ParserSpec in Tok (CharTok {val = ' ', info = NoInfo ()})
 let ll1HashString = use ParserSpec in
-  lam hash. Tok (HashStringTok {val = "", hash = hash, fi = NoInfo ()})
+  lam hash. Tok (HashStringTok {val = "", hash = hash, info = NoInfo ()})
 
 mexpr
 
@@ -482,17 +482,17 @@ with Right
           , val =
             [ ParserBase_Lit
               { lit = "let"
-              , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 3 , col1 = 0 }
+              , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 3 , col1 = 0 }
               }
             , ParserBase_Tok
               ( LIdentTokenParser_LIdentTok
                 { val = "a"
-                , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 5 , col1 = 4 }
+                , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 5 , col1 = 4 }
                 }
               )
             , ParserBase_Lit
               { lit = "="
-              , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 7 , col1 = 6 }
+              , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 7 , col1 = 6 }
               }
             , ParserConcrete_UserSym
               { label = "exprint"
@@ -500,7 +500,7 @@ with Right
                 [ ParserBase_Tok
                   ( UIntTokenParser_IntTok
                     { val = 1
-                    , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 9 , col1 = 8 }
+                    , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 9 , col1 = 8 }
                     }
                   )
                 ]
@@ -527,17 +527,17 @@ with Right
           , val =
             [ ParserBase_Lit
               { lit = "let"
-              , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 3 , col1 = 0 }
+              , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 3 , col1 = 0 }
               }
             , ParserBase_Tok
               ( LIdentTokenParser_LIdentTok
                 { val = "a"
-                , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 5 , col1 = 4 }
+                , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 5 , col1 = 4 }
                 }
               )
             , ParserBase_Lit
               { lit = "="
-              , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 7 , col1 = 6 }
+              , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 7 , col1 = 6 }
               }
             , ParserConcrete_UserSym
               { label = "exprint"
@@ -545,7 +545,7 @@ with Right
                 [ ParserBase_Tok
                   ( UIntTokenParser_IntTok
                     { val = 1
-                    , fi = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 9 , col1 = 8 }
+                    , info = Info { filename = "file" , row2 = 1 , row1 = 1 , col2 = 9 , col1 = 8 }
                     }
                   )
                 ]
@@ -566,17 +566,17 @@ with Right
               , val =
                 [ ParserBase_Lit
                   { lit = "let"
-                  , fi = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 3 , col1 = 0 }
+                  , info = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 3 , col1 = 0 }
                   }
                 , ParserBase_Tok
                   ( LIdentTokenParser_LIdentTok
                     { val = "b"
-                    , fi = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 5 , col1 = 4 }
+                    , info = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 5 , col1 = 4 }
                     }
                   )
                 , ParserBase_Lit
                   { lit = "="
-                  , fi = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 7 , col1 = 6 }
+                  , info = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 7 , col1 = 6 }
                   }
                 , ParserConcrete_UserSym
                   { label = "exprint"
@@ -584,7 +584,7 @@ with Right
                     [ ParserBase_Tok
                       ( UIntTokenParser_IntTok
                         { val = 4
-                        , fi = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 9 , col1 = 8 }
+                        , info = Info { filename = "file" , row2 = 2 , row1 = 2 , col2 = 9 , col1 = 8 }
                         }
                       )
                     ]
@@ -602,49 +602,49 @@ in
 
 utest parse "let"
 with Left (UnexpectedToken
-  { expected = (ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),fi = (NoInfo ())}))
+  { expected = (ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),info = (NoInfo ())}))
   , stack = (
     [ {label = ("toptop"),seen = ([]),rest = ([(ParserSpec_NtSpec ("FileFollow"))])}
     , {label = ("topdecl"),seen = ([]),rest = ([])}
     , { label = ("decllet")
-      , seen = ([(ParserBase_Lit {lit = ("let"),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 0})})])
-      , rest = ([(ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),fi = (NoInfo ())})),(ParserBase_Lit {lit = ("=")}),(ParserSpec_NtSpec ("Expression"))])
+      , seen = ([(ParserBase_Lit {lit = ("let"),info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 0})})])
+      , rest = ([(ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),info = (NoInfo ())})),(ParserBase_Lit {lit = ("=")}),(ParserSpec_NtSpec ("Expression"))])
       }
     ])
-  , found = (ParserBase_Tok (EOFTokenParser_EOFTok {fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 3})}))
+  , found = (ParserBase_Tok (EOFTokenParser_EOFTok {info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 3})}))
   })
 in
 
 utest parse "let x ="
 with Left (UnexpectedFirst
   { expected =
-    [ Tok (IntTok {fi = NoInfo (), val = 0})
+    [ Tok (IntTok {info = NoInfo (), val = 0})
     ]
   , stack = (
     [ {label = ("toptop"),seen = ([]),rest = ([(ParserSpec_NtSpec ("FileFollow"))])}
     , {label = ("topdecl"),seen = ([]),rest = ([])}
     , { label = ("decllet")
-      , seen = ([(ParserBase_Lit {lit = ("let"),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 0})}),(ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ("x"),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 5,col1 = 4})})),(ParserBase_Lit {lit = ("="),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 7,col1 = 6})})])
+      , seen = ([(ParserBase_Lit {lit = ("let"),info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 0})}),(ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ("x"),info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 5,col1 = 4})})),(ParserBase_Lit {lit = ("="),info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 7,col1 = 6})})])
       , rest = ([])
       }
     ])
-  , found = (ParserBase_Tok (EOFTokenParser_EOFTok {fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 7,col1 = 7})}))
+  , found = (ParserBase_Tok (EOFTokenParser_EOFTok {info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 7,col1 = 7})}))
   , nt = ("Expression")
   })
 in
 
 utest parse "let let = 4"
 with Left (UnexpectedToken
-  { expected = (ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),fi = (NoInfo ())}))
+  { expected = (ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),info = (NoInfo ())}))
   , stack = (
     [ {label = ("toptop"),seen = ([]),rest = ([(ParserSpec_NtSpec ("FileFollow"))])}
     , {label = ("topdecl"),seen = ([]),rest = ([])}
     , { label = ("decllet")
-      , seen = ([(ParserBase_Lit {lit = ("let"),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 0})})])
-      , rest = ([(ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),fi = (NoInfo ())})),(ParserBase_Lit {lit = ("=")}),(ParserSpec_NtSpec ("Expression"))])
+      , seen = ([(ParserBase_Lit {lit = ("let"),info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 3,col1 = 0})})])
+      , rest = ([(ParserBase_Tok (LIdentTokenParser_LIdentTok {val = ([]),info = (NoInfo ())})),(ParserBase_Lit {lit = ("=")}),(ParserSpec_NtSpec ("Expression"))])
       }
     ])
-  , found = (ParserBase_Lit {lit = ("let"),fi = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 7,col1 = 4})})
+  , found = (ParserBase_Lit {lit = ("let"),info = (Info {filename = ("file"),row2 = 1,row1 = 1,col2 = 7,col1 = 4})})
   })
 in
 


### PR DESCRIPTION
This PR makes various fixes, changes, and additions that I need in the next PR for the parser. The commit messages should be fairly self-explanatory with two exceptions:
- "Add missing symbol helpers": this is for `ll1.mc`, it has helpers for writing the right-hand side of productions, but the list of helpers was incomplete.
- "Map intrinsics update": this adds a `mapRemove` intrinsic and an `mapInsertWith` stdlib function for the ocaml ordered map.