### PR TITLE
String identfiers

### DIFF
--- a/stdlib/stringid.mc
+++ b/stdlib/stringid.mc
@@ -5,39 +5,58 @@
 -- are often compared for equality. For instance, instead
 -- of inserting a string into an AST, the string identifier (SID)
 -- of the string is inserted instead. Since the string ID is internally
--- represented as a symbol, it is much faster to compare for equality, etc.
+-- represented as an integer, it is much faster to compare for equality.
 
 include "string.mc"
 
--- We use an integer as the identifer, so that the map intrinsics can be used.
+-- Right now, we use an integer as the identifier,
+-- so that the map intrinsics can be used.
 type SID = Int
 
 -- These definitions are only defined once
-let _string_id_counter = ref 0
-let _map_string_to_sid = ref (mapEmpty cmpString) in
-let _map_sid_to_string = ref (mapEmpty subi) in
+let _sidCounter = ref 0 
+let _mapStringToSid = ref (mapEmpty cmpString) 
+let _mapSidToString = ref (mapEmpty subi) 
 
 
 -- Returns the string representation of a string ID
 let sidToString : SID -> String = lam sid. 
-  if mapMem sid _map_sid_to_string then
-     mapFind sid
+  if mapMem sid (deref _mapSidToString) then
+     mapFind sid (deref _mapSidToString)
   else
      error "SID is not defined"
-     -- Note that if SID is a unique type, this should happen
+     -- Note that if SID is a unique type, this cannot happen
 
 
--- Returns the SID for a specific string
+-- Returns the string ID for a specific string
 let stringToSid : String -> SID = lam str. 
-  if mapMem str (deref _sid_counter) then
-    mapFind str (deref _s_id_counter)
+  if mapMem str (deref _mapStringToSid)  then
+    mapFind str (deref _mapStringToSid)
   else    
-    let _ = modref _sid_counter (addi (deref _sid_counter) 1) in
-    let sid = deref _sid_counter in
-    let _ = modref _map_string_to_sid (mapInsert str sid (dref _map_string_to_sid)) in
-    let _ = modref _map_sid_to_string (mapInsert sid str (dref _map_sid_to_string)) in
+    modref _sidCounter (addi (deref _sidCounter) 1);
+    let sid = deref _sidCounter in
+    modref _mapStringToSid (mapInsert str sid (deref _mapStringToSid));
+    modref _mapSidToString (mapInsert sid str (deref _mapSidToString));
     sid
 
 
 mexpr
 
+let sid1 = stringToSid "Foo" in
+utest sid1 with sid1 in
+utest sidToString sid1 with "Foo" in
+
+let sid2 = stringToSid "Bar text" in
+utest sid2 with sid2 in
+utest sid2 with sid1 using neqi in
+utest sidToString sid2 with "Bar text" in
+utest sidToString sid1 with "Foo" in
+utest sidToString sid1 with sidToString sid2 using lam x. lam y. not (eqString x y) in
+
+let sid3 = stringToSid "Foo" in
+utest sid1 with sid3 in
+utest sidToString sid1 with "Foo" in
+utest sidToString sid2 with "Bar text" in
+utest sidToString sid3 with "Foo" in
+
+()

--- a/stdlib/stringid.mc
+++ b/stdlib/stringid.mc
@@ -1,0 +1,43 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- The String ID library should be used when strings
+-- are often compared for equality. For instance, instead
+-- of inserting a string into an AST, the string identifier (SID)
+-- of the string is inserted instead. Since the string ID is internally
+-- represented as a symbol, it is much faster to compare for equality, etc.
+
+include "string.mc"
+
+-- We use an integer as the identifer, so that the map intrinsics can be used.
+type SID = Int
+
+-- These definitions are only defined once
+let _string_id_counter = ref 0
+let _map_string_to_sid = ref (mapEmpty cmpString) in
+let _map_sid_to_string = ref (mapEmpty subi) in
+
+
+-- Returns the string representation of a string ID
+let sidToString : SID -> String = lam sid. 
+  if mapMem sid _map_sid_to_string then
+     mapFind sid
+  else
+     error "SID is not defined"
+     -- Note that if SID is a unique type, this should happen
+
+
+-- Returns the SID for a specific string
+let stringToSid : String -> SID = lam str. 
+  if mapMem str (deref _sid_counter) then
+    mapFind str (deref _s_id_counter)
+  else    
+    let _ = modref _sid_counter (addi (deref _sid_counter) 1) in
+    let sid = deref _sid_counter in
+    let _ = modref _map_string_to_sid (mapInsert str sid (dref _map_string_to_sid)) in
+    let _ = modref _map_sid_to_string (mapInsert sid str (dref _map_sid_to_string)) in
+    sid
+
+
+mexpr
+


### PR DESCRIPTION
This PR adds a small library `stringid.mc` for faster equality comparison of strings. The basic idea is to keep a global and unique mapping between integer identifiers and strings. Instead of comparing if strings are equal or not, the integer identifiers are instead compared. Then later, if the actual string is needed, the string can be retrieved via the mapping. See file `stringid.mc` for details.