### PR TITLE
Complete tree-based dualnum implementation.

### DIFF
--- a/stdlib/ad/dualnum-tree.mc
+++ b/stdlib/ad/dualnum-tree.mc
@@ -74,7 +74,9 @@ lam e. lam n.
 
 -- generate unique epsilon e1 that fulfills the invariant e1 > e for all
 -- previously generated epsilons e.
-let dualnumGenEpsilon : Unit -> Eps = lam. error "Not implemented"
+let e = ref 0
+let dualnumGenEpsilon : Unit -> Eps =
+lam. modref e (addi (deref e) 1); deref e
 
 mexpr
 

--- a/stdlib/ad/dualnum.mc
+++ b/stdlib/ad/dualnum.mc
@@ -9,7 +9,7 @@
 
 
 
-include "dualnum-symb.mc"
+include "dualnum-tree.mc"
 include "dualnum-helpers.mc"
 include "string.mc"
 


### PR DESCRIPTION
Use references, now that we have them, to complete the tree-based dual number API. In addition use this interface since it is more performant than the symbol based implementation. A note, the performance of the latter might be improved by using the map intrinsic. 