### PR TITLE
Evaluate result of variable lookups iff they are a fixpoint application

### DIFF
--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1809,7 +1809,11 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
   match t with
   (* Variables using symbol bindings. Need to evaluate because fix point. *)
   | TmVar (_, _, s) -> (
-    match List.assoc s env with TmFix _ as t -> eval env t | t -> t )
+    match List.assoc s env with
+    | TmApp (_, TmFix _, _) as t ->
+        eval env t
+    | t ->
+        t )
   (* Application *)
   | TmApp (fiapp, t1, t2) -> (
     match eval env t1 with


### PR DESCRIPTION
This fixes a bug introduced in #251 in `eval` in boot where we previously evaluated fixpoint terms instead of *applications* of fixpoint terms, and makes the same optimization in the interpreter in `eval.mc`. Thanks to @elegios for finding the error.

I noticed no difference in the runtime of `make all` before and after the changes.