### PR TITLE
Ocaml pprint optimization

### DIFF
--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -30,7 +30,11 @@ end
 -- This fragment contains variants of other ocaml constructs where the
 -- names should appear exactly as specified, intended to be used to
 -- refer to externally defined names, e.g., in the ocaml standard
--- library
+-- library. Note that these names will not affect other names in any
+-- way, meaning that these names should be chosen so that they
+-- *cannot* overlap with other names. An easy way to do that is to
+-- always use fully qualified names, since normal names cannot contain
+-- dots.
 lang OCamlExternal
   syn Expr =
   | OTmVarExt { ident : Name }

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -37,7 +37,7 @@ end
 -- dots.
 lang OCamlExternal
   syn Expr =
-  | OTmVarExt { ident : Name }
+  | OTmVarExt { ident : String }
   | OTmConAppExt { ident : String, args : [Expr] }
 
   syn Pat =

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -27,11 +27,25 @@ lang OCamlData
   | OPatCon { ident : Name, args : [Pat] }
 end
 
+-- This fragment contains variants of other ocaml constructs where the
+-- names should appear exactly as specified, intended to be used to
+-- refer to externally defined names, e.g., in the ocaml standard
+-- library
+lang OCamlExternal
+  syn Expr =
+  | OTmVarExt { ident : Name }
+  | OTmConAppExt { ident : String, args : [Expr] }
+
+  syn Pat =
+  | OPatConExt { ident : String, args : [Pat] }
+end
+
 lang OCamlAst = LamAst + LetAst + RecLetsAst + ArithIntAst + ShiftIntAst
                 + ArithFloatAst + BoolAst + CmpIntAst + CmpFloatAst
                 + CharAst + OCamlMatch + NamedPat + IntPat + CharPat
                 + BoolPat + OCamlTuple + OCamlData
                 + CharAst + FloatIntConversionAst
+                + OCamlExternal
 end
 
 mexpr

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -9,51 +9,11 @@ include "mexpr/eq.mc"
 include "ocaml/compile.mc"
 include "hashmap.mc"
 
-let _opHashMap = lam prefix. lam ops.
-  let mkOp = lam op. nameSym (join [prefix, op]) in
-  foldl (lam a. lam op. hashmapInsert hashmapStrTraits op (mkOp op) a)
-        hashmapEmpty
-        ops
+let _seqOp = use OCamlAst in lam op. OTmVarExt {ident = concat "Boot.Intrinsics.Mseq." op}
 
-let _op = lam opHashMap. lam op.
-  nvar_
-  (hashmapLookupOrElse hashmapStrTraits
-    (lam.
-      error (strJoin " " ["Operation", op, "not found"]))
-      op
-      opHashMap)
+let _symbOp = use OCamlAst in lam op. OTmVarExt {ident = concat "Boot.Intrinsics.Symb." op}
 
-let _seqOps = [
-  "create",
-  "empty",
-  "length",
-  "concat",
-  "get",
-  "set",
-  "cons",
-  "snoc",
-  "reverse",
-  "split_at"
-]
-
-let _seqOp = _op (_opHashMap "Boot.Intrinsics.Mseq." _seqOps)
-
-let _symbOps = [
-  "gensym",
-  "eqsym",
-  "hash"
-]
-
-let _symbOp = _op (_opHashMap "Boot.Intrinsics.Symb." _symbOps)
-
-let _floatOps = [
-  "floorfi",
-  "ceilfi",
-  "roundfi",
-  "string2float"
-]
-
-let _floatOp = _op (_opHashMap "Boot.Intrinsics.FloatConversion." _floatOps)
+let _floatOp = use OCamlAst in lam op. OTmVarExt {ident = concat "Boot.Intrinsics.FloatConversion." op}
 
 -- Input is a map from name to be introduced to name containing the value to be bound to that location
 -- Output is essentially `M.toList input & unzip & \(pats, exprs) -> (OPTuple pats, TmTuple exprs)`
@@ -67,16 +27,16 @@ let _mkFinalPatExpr : Map Name Name -> (Pat, Expr) = use OCamlAst in lam nameMap
   else never
 
 -- Construct a match expression that matches against an option
-let _someName = nameSym "Option.Some"
-let _noneName = nameSym "Option.None"
+let _someName = "Option.Some"
+let _noneName = "Option.None"
 let _optMatch = use OCamlAst in lam target. lam somePat. lam someExpr. lam noneExpr.
   OTmMatch
   { target = target
   , arms =
-    [ (OPatCon {ident = _someName, args = [somePat]}, someExpr)
-    , (OPatCon {ident = _noneName, args = []}, noneExpr)]}
-let _some = use OCamlAst in lam val. OTmConApp {ident = _someName, args = [val]}
-let _none = use OCamlAst in OTmConApp {ident = _noneName, args = []}
+    [ (OPatConExt {ident = _someName, args = [somePat]}, someExpr)
+    , (OPatConExt {ident = _noneName, args = []}, noneExpr)]}
+let _some = use OCamlAst in lam val. OTmConAppExt {ident = _someName, args = [val]}
+let _none = use OCamlAst in OTmConAppExt {ident = _noneName, args = []}
 let _if = use OCamlAst in lam cond. lam thn. lam els. OTmMatch {target = cond, arms = [(ptrue_, thn), (pfalse_, els)]}
 let _tuplet = use OCamlAst in lam pats. lam val. lam body. OTmMatch {target = val, arms = [(OPTuple {pats = pats}, body)]}
 

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -52,107 +52,27 @@ utest isIdentifierString "AA" with false
 utest isIdentifierString "__*" with false
 utest isIdentifierString "" with false
 
-let isModuleString = lam s.
-  if not (null s) then
-    if isUpperAlpha (head s) then
-      let s = cons (char2lower (head s)) (tail s) in
-      isIdentifierString s
-    else false
-  else
-    false
-
-utest isModuleString "A" with true
-utest isModuleString "ABCD" with true
-utest isModuleString "AbCd" with true
-utest isModuleString "Aa123" with true
-utest isModuleString "A_" with true
-utest isModuleString "__" with false
-utest isModuleString "a" with false
-utest isModuleString "_" with false
-utest isModuleString "aa" with false
-utest isModuleString "A*" with false
-utest isModuleString "1a" with false
-utest isModuleString "1" with false
-utest isModuleString "aA" with false
-utest isModuleString "" with false
-
-let isModuleCallString = lam s.
-  let parts = strSplit "." s in
-  let modules = init parts in
-  if null modules then false
-  else
-    and (all isModuleString modules) (isIdentifierString (last parts))
-
-let isModuleConString = lam s.
-  let parts = strSplit "." s in
-  let modules = init parts in
-  if null modules then false
-  else
-    and (all isModuleString modules) (isConString (last parts))
-
-utest isModuleCallString "Foo.bar" with true
-utest isModuleCallString "A.B.C.D.E.F.G.hello" with true
-utest isModuleCallString "Foo.Bar.foo" with true
-utest isModuleCallString "Foo.Bar.__" with true
-utest isModuleCallString "Foo.Bar._a" with true
-utest isModuleCallString "Foo.Bar._A" with true
-utest isModuleCallString "Foo.Bar._" with false
-utest isModuleCallString "Foo.Bar.A" with false
-utest isModuleCallString "Foo.Bar.*" with false
-utest isModuleCallString "a" with false
-utest isModuleCallString "A" with false
-utest isModuleCallString "_a" with false
-utest isModuleCallString "Foo.@" with false
-utest isModuleCallString "foo.bar" with false
-utest isModuleCallString "Foo.bar.foo" with false
-utest isModuleCallString "Foo.B@r.foo" with false
-utest isModuleCallString "foo.Bar.foo" with false
-
-utest isModuleConString "Foo.Bar" with true
-utest isModuleConString "A.B.C.D.E.F.G.Hello" with true
-utest isModuleConString "Foo.Bar.Foo" with true
-utest isModuleConString "Foo.Bar.__" with false
-utest isModuleConString "Foo.Bar._a" with false
-utest isModuleConString "Foo.Bar._A" with false
-utest isModuleConString "Foo.Bar._" with false
-utest isModuleConString "Foo.Bar.a" with false
-utest isModuleConString "Foo.Bar.*" with false
-utest isModuleConString "a" with false
-utest isModuleConString "A" with false
-utest isModuleConString "_a" with false
-utest isModuleConString "Foo.@" with false
-utest isModuleConString "foo.Bar" with false
-utest isModuleConString "Foo.bar.Foo" with false
-utest isModuleConString "Foo.B@r.Foo" with false
-utest isModuleConString "foo.Bar.Foo" with false
-
 let escapeString = lam s.
   let n = length s in
   if gti n 0 then
-    if isModuleCallString s then
-      s
+    let hd = head s in
+    let tl = tail s in
+    if or (neqi n 1) (isLowerAlpha hd) then
+      cons (escapeFirstChar hd) (map escapeChar tl)
     else
-      let hd = head s in
-      let tl = tail s in
-      if or (neqi n 1) (isLowerAlpha hd) then
-        cons (escapeFirstChar hd) (map escapeChar tl)
-      else
-        defaultIdentName
+      defaultIdentName
   else
     defaultIdentName
 
 let escapeConString = lam s.
   let n = length s in
   if gti n 0 then
-    if isModuleConString s then
-      s
+    let hd = head s in
+    let tl = tail s in
+    if or (neqi n 1) (isUpperAlpha hd) then
+      cons (escapeFirstConChar hd) (map escapeChar tl)
     else
-      let hd = head s in
-      let tl = tail s in
-      if or (neqi n 1) (isUpperAlpha hd) then
-        cons (escapeFirstConChar hd) (map escapeChar tl)
-      else
-        defaultConName
+      defaultConName
   else
     defaultConName
 
@@ -204,11 +124,14 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | OTmTuple _ -> true
   | OTmConApp {args = []} -> true
   | OTmConApp _ -> false
+  | OTmVarExt _ -> true
+  | OTmConAppExt _ -> false
 
   sem patIsAtomic =
   | OPTuple _ -> true
   | OPatCon {args = []} -> true
   | OPatCon _ -> false
+  | OPatConExt _ -> false
 
   sem getConstStringCode (indent : Int) =
   | CInt {val = i} -> int2string i
@@ -250,6 +173,7 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
   | CChar {val = c} -> show_char c
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
+  | OTmVarExt {ident = ident} -> (env, ident)
   | OTmConApp {ident = ident, args = []} -> pprintConName env ident
   | OTmConApp {ident = ident, args = [arg]} ->
     match pprintConName env ident with (env, ident) then
@@ -262,6 +186,15 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
       match mapAccumL (pprintCode indent) env args with (env, args) then
         (env, join [ident, " (", strJoin ", " args, ")"])
       else never
+    else never
+  | OTmConAppExt {ident = ident, args = []} -> (env, ident)
+  | OTmConAppExt {ident = ident, args = [arg]} ->
+    match printParen ident env arg with (env, arg) then
+      (env, join [ident, " ", arg])
+    else never
+  | OTmConAppExt {ident = ident, args = args} ->
+    match mapAccumL (pprintCode indent) env args with (env, args) then
+      (env, join [ident, " (", strJoin ", " args, ")"])
     else never
   | TmLam {ident = id, body = b} ->
     match pprintVarName env id with (env,str) then
@@ -368,6 +301,15 @@ lang OCamlPrettyPrint = VarPrettyPrint + AppPrettyPrint
       match mapAccumL (getPatStringCode indent) env args with (env, args) then
         (env, join [ident, " (", strJoin ", " args, ")"])
       else never
+    else never
+  | OPatConExt {ident = ident, args = []} -> (env, ident)
+  | OPatConExt {ident = ident, args = [arg]} ->
+    match printPatParen indent env arg with (env, arg) then
+      (env, join [ident, " ", arg])
+    else never
+  | OPatConExt {ident = ident, args = args} ->
+    match mapAccumL (getPatStringCode indent) env args with (env, args) then
+      (env, join [ident, " (", strJoin ", " args, ")"])
     else never
 end
 


### PR DESCRIPTION
This PR changes how we handle identifiers that are supposed to refer to externally defined values in the compilation to OCaml. The idea is to have two versions of every AST node that refers to names (as opposed to introduces them):

- One that uses `Name`s and refers to a name defined in the current program.
- One that uses `String`s and refers to values defined externally, typically in the OCaml standard library.

In particular, we get these variants:
- `TmVar` (from mexpr originally) and `OTmVarExt`
- `OTmConApp` and `OTmConAppExt`
- `OPatCon` and `OPatConExt`

The `Ext` versions use strings that are included in the final program without processing. They also do not interact at all with `pprint` finding unique names, so they must be made unique in some other way, typically by just making them fully qualified names, e.g. `OTmVarExt {ident = "Boot.Intrinsics.Mseq.length"}`, since normal names cannot contain dots.

This means that `pprintVarName`, which was relatively expensive, is called less (since the `Ext` variants don't use it) and does less work (since it doesn't have to check if the name is a valid fully qualified name).

Basic benchmarking (no averaging over multiple runs, etc., so not super precise) suggests the following improvements:
- `pprintVarName` from 893 calls, 2613.768 ms, to 548 calls, 724.159 ms. This means that time taken went from 2.923 ms/call to 1.321 ms/call.
- `sameSemantics` from 39165 ms to 35535 ms, i.e., 3630 ms improvement

Note that we save more time in total (for `sameSemantics`) than we gained from the runtime improvement of `pprintVarName`. I believe this is because many names don't need to interact with the unique name printing mechanism at all, of which `pprintVarName` is only one part.
