### PR TITLE
Preparation for type lifting

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -132,6 +132,7 @@ and const =
   | CmapRemove of tm option
   | CmapFindWithErr of tm option
   | CmapFindOrElse of tm option * tm option
+  | CmapFindApplyOrElse of tm option * tm option * tm option
   | CmapMem of tm option
   | CmapAny of (tm -> tm -> bool) option
   | CmapMap of (tm -> tm) option

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -25,6 +25,8 @@ let enable_debug_symbol_print = ref false
 
 let enable_debug_con_shape = ref false
 
+let enable_debug_stack_trace = ref false
+
 let enable_debug_profiling = ref false
 
 let utest = ref false (* Set to true if unit testing is enabled *)

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -140,6 +140,7 @@ and const =
   | CmapFoldWithKey of (tm -> tm -> tm -> tm) option * tm option
   | CmapBindings
   | CmapEq of (tm -> tm -> bool) option * (tm * Obj.t) option
+  | CmapCmp of (tm -> tm -> int) option * (tm * Obj.t) option
   (* MCore intrinsics: Tensors *)
   | CtensorCreate of int array option
   | CtensorGetExn of tm T.t option

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -124,16 +124,21 @@ and const =
   | CdeRef
   (* MCore intrinsics: Maps *)
   (* NOTE(Linnea, 2021-01-27): Obj.t denotes the type of the internal map (I was so far unable to express it properly) *)
-  | CMap of (tm -> tm -> int) * Obj.t
+  | CMap of tm * Obj.t
   | CmapEmpty
+  | CmapIsEmpty
+  | CmapGetCmpFun
   | CmapInsert of tm option * tm option
   | CmapRemove of tm option
-  | CmapFind of tm option
+  | CmapFindWithErr of tm option
+  | CmapFindOrElse of tm option * tm option
   | CmapMem of tm option
   | CmapAny of (tm -> tm -> bool) option
   | CmapMap of (tm -> tm) option
   | CmapMapWithKey of (tm -> tm -> tm) option
+  | CmapFoldWithKey of (tm -> tm -> tm -> tm) option * tm option
   | CmapBindings
+  | CmapEq of (tm -> tm -> bool) option * (tm * Obj.t) option
   (* MCore intrinsics: Tensors *)
   | CtensorCreate of int array option
   | CtensorGetExn of tm T.t option

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -128,11 +128,11 @@ and const =
   (* NOTE(Linnea, 2021-01-27): Obj.t denotes the type of the internal map (I was so far unable to express it properly) *)
   | CMap of tm * Obj.t
   | CmapEmpty
-  | CmapIsEmpty
+  | CmapSize
   | CmapGetCmpFun
   | CmapInsert of tm option * tm option
   | CmapRemove of tm option
-  | CmapFindWithErr of tm option
+  | CmapFindWithExn of tm option
   | CmapFindOrElse of tm option * tm option
   | CmapFindApplyOrElse of tm option * tm option * tm option
   | CmapMem of tm option

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -2007,7 +2007,8 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
           let res =
             try eval ((s, eval env t2) :: Lazy.force env2) t3
             with e ->
-              uprint_endline (us "TRACE: " ^. info2str fiapp) ;
+              if !enable_debug_stack_trace then
+                uprint_endline (us "TRACE: " ^. info2str fiapp) ;
               raise e
           in
           let t2 = get_wall_time_ms () in
@@ -2016,7 +2017,8 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
         else
           try eval ((s, eval env t2) :: Lazy.force env2) t3
           with e ->
-            uprint_endline (us "TRACE: " ^. info2str fiapp) ;
+            if !enable_debug_stack_trace then
+              uprint_endline (us "TRACE: " ^. info2str fiapp) ;
             raise e )
     (* Constant application using the delta function *)
     | TmConst (_, c) ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -389,6 +389,8 @@ let rec print_const fmt = function
       fprintf fmt "mapFindWithErr"
   | CmapFindOrElse _ ->
       fprintf fmt "mapFindOrElse"
+  | CmapFindApplyOrElse _ ->
+      fprintf fmt "mapFindOrElse"
   | CmapAny _ ->
       fprintf fmt "mapAny"
   | CmapMem _ ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -377,12 +377,18 @@ let rec print_const fmt = function
       fprintf fmt "map"
   | CmapEmpty ->
       fprintf fmt "mapEmpty"
+  | CmapIsEmpty ->
+      fprintf fmt "mapIsEmpty"
+  | CmapGetCmpFun ->
+      fprintf fmt "mapGetCmpFun"
   | CmapInsert _ ->
       fprintf fmt "mapInsert"
   | CmapRemove _ ->
       fprintf fmt "mapRemove"
-  | CmapFind _ ->
-      fprintf fmt "mapLookup"
+  | CmapFindWithErr _ ->
+      fprintf fmt "mapFindWithErr"
+  | CmapFindOrElse _ ->
+      fprintf fmt "mapFindOrElse"
   | CmapAny _ ->
       fprintf fmt "mapAny"
   | CmapMem _ ->
@@ -391,8 +397,12 @@ let rec print_const fmt = function
       fprintf fmt "mapMap"
   | CmapMapWithKey _ ->
       fprintf fmt "mapMapWithKey"
+  | CmapFoldWithKey _ ->
+      fprintf fmt "mapFoldWithKey"
   | CmapBindings ->
       fprintf fmt "mapBindings"
+  | CmapEq _ ->
+      fprintf fmt "mapEq"
   (* MCore intrinsics: Tensors *)
   | CtensorCreate _ ->
       fprintf fmt "tensorCreate"

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -377,16 +377,16 @@ let rec print_const fmt = function
       fprintf fmt "map"
   | CmapEmpty ->
       fprintf fmt "mapEmpty"
-  | CmapIsEmpty ->
-      fprintf fmt "mapIsEmpty"
+  | CmapSize ->
+      fprintf fmt "mapSize"
   | CmapGetCmpFun ->
       fprintf fmt "mapGetCmpFun"
   | CmapInsert _ ->
       fprintf fmt "mapInsert"
   | CmapRemove _ ->
       fprintf fmt "mapRemove"
-  | CmapFindWithErr _ ->
-      fprintf fmt "mapFindWithErr"
+  | CmapFindWithExn _ ->
+      fprintf fmt "mapFindWithExn"
   | CmapFindOrElse _ ->
       fprintf fmt "mapFindOrElse"
   | CmapFindApplyOrElse _ ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -405,6 +405,8 @@ let rec print_const fmt = function
       fprintf fmt "mapBindings"
   | CmapEq _ ->
       fprintf fmt "mapEq"
+  | CmapCmp _ ->
+      fprintf fmt "mapCmp"
   (* MCore intrinsics: Tensors *)
   | CtensorCreate _ ->
       fprintf fmt "tensorCreate"

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -83,6 +83,9 @@ let main =
       , Arg.Set enable_debug_con_shape
       , " Enables printing of the shape of values given to constructors, to \
          stderr." )
+    ; ( "--debug-stack-trace"
+      , Arg.Set enable_debug_stack_trace
+      , " Enables printing of a stack trace when errors occur." )
     ; ( "--debug-profile"
       , Arg.Set enable_debug_profiling
       , " Enables printing of number of calls to and cumulative runtime of \

--- a/stdlib/assoc-seq.mc
+++ b/stdlib/assoc-seq.mc
@@ -1,7 +1,8 @@
--- A simple library for associative sequences. The difference compared to
--- assoc.mc is that the data type contained here is ordered. With more recently
--- inserted bidings shadowing previous bindings, insertion is O(1). This makes
--- this data type suitable for e.g., evaluation environments and similar.
+-- A simple library of functions operating on associative sequences. The
+-- difference compared to assoc.mc is that the data type contained here is
+-- ordered. With more recently inserted bidings shadowing previous bindings,
+-- insertion is O(1). This makes this data type suitable for e.g., evaluation
+-- environments and similar.
 
 type AssocSeq k v = [(k, v)]
 type AssocTraits k = {eq: k -> k -> Bool}

--- a/stdlib/assoc-seq.mc
+++ b/stdlib/assoc-seq.mc
@@ -1,0 +1,13 @@
+-- A simple library for associative sequences. The difference compared to
+-- assoc.mc is that the data type contained here is ordered. With more recently
+-- inserted bidings shadowing previous bindings, insertion is O(1). This makes
+-- this data type suitable for e.g., evaluation environments and similar.
+
+type AssocSeq k v = [(k, v)]
+type AssocTraits k = {eq: k -> k -> Bool}
+
+let assocSeqInsert: k -> v -> AssocSeq k v -> AssocSeq k v =
+  lam k. lam v. lam s.
+    cons (k,v) s
+
+-- lookup

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -7,7 +7,7 @@ include "option.mc"
 include "seq.mc"
 
 let mapLength : Map k v -> Int =
-  lam m. mapFoldWithKey (lam acc. lam. lam. addi 1 acc) 0 m
+  mapFoldWithKey (lam acc. lam. lam. addi 1 acc) 0
 
 -- Aliases
 let mapLookupOrElse : (Unit -> v) -> k -> Map k v -> v =

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -6,10 +6,18 @@
 include "option.mc"
 include "seq.mc"
 
+let mapLength : Map k v -> Int =
+  lam m. mapFoldWithKey (lam acc. lam. lam. addi 1 acc) 0 m
+
+let mapLookupOrElse : (Unit -> v) -> k -> Map k v -> v =
+  mapFindOrElse
+
 let mapLookup : k -> Map k v -> Option v =
   lam k. lam m.
-    match mapMem k m with false then None ()
-    else Some (mapFind k m)
+    let res = mapLookupOrElse (lam. None ()) k m in
+    match res with None () then None ()
+    else match res with x then Some x
+    else never
 
 let mapInsertWith : (v -> v -> v) -> k -> v -> Map k v -> Map k v =
   lam f. lam k. lam v. lam m.
@@ -23,15 +31,38 @@ let mapUnion : Map k v -> Map k v -> Map k v = lam l. lam r.
 let mapFromList : (k -> k -> Int) -> [(k, v)] -> Map k v = lam cmp. lam bindings.
   foldl (lam acc. lam binding. mapInsert binding.0 binding.1 acc) (mapEmpty cmp) bindings
 
+let mapKeys : Map k v -> [k] = lam m.
+  mapFoldWithKey (lam ks. lam k. lam. snoc ks k) [] m
+
+let mapValues : Map k v -> [v] = lam m.
+  mapFoldWithKey (lam vs. lam. lam v. snoc vs v) [] m
+
+let mapMapAccum : (acc -> k -> v1 -> (acc, v2)) -> acc -> Map k v1 -> (acc, Map k v2) =
+  lam f. lam acc. lam m.
+    mapFoldWithKey
+      (lam tacc. lam k. lam v1.
+         match f tacc.0 k v1 with (acc, v2) then (acc, mapInsert k v2 tacc.1) else never)
+      (acc, mapEmpty (mapGetCmpFun m)) m
+
+let mapFoldlM : (acc -> k -> v -> Option acc)
+                  -> acc -> Map k v -> Option acc =
+  lam f. lam acc. lam m.
+    optionFoldlM (lam acc. lam t. f acc t.0 t.1) acc (mapBindings m)
+
 mexpr
 
 let m = mapEmpty subi in
+
+utest mapLookupOrElse (lam. 2) 1 m with 2 in
+utest mapLength m with 0 in
 
 utest mapLookup 1 m with None () in
 
 let m = mapInsert 1 "1" m in
 let m = mapInsert 2 "2" m in
 let m = mapInsert 3 "3" m in
+
+utest mapLength m with 3 in
 
 utest mapLookup 1 m with Some "1" in
 utest mapLookup 2 m with Some "2" in
@@ -50,6 +81,11 @@ utest mapLookup 4 merged with Some "44" in
 utest mapLookup (negi 1) merged with Some "-1" in
 utest mapLookup 5 merged with None () in
 
+utest mapFoldlM (lam acc. lam k. lam v. Some v) 0 m with Some "3" in
+utest mapFoldlM
+  (lam acc. lam k. lam v. if eqi k acc then None () else Some acc) 3 m
+with None () in
+
 let m = mapFromList subi
   [ (1, "1")
   , (2, "2")
@@ -62,5 +98,15 @@ let m2 = mapInsertWith concat 1 "blub" m in
 utest mapLookup 1 m2 with Some "1blub" in
 utest mapLookup 2 m2 with mapLookup 2 m in
 utest mapLookup 3 m2 with mapLookup 3 m in
+
+utest mapKeys m2 with [1,2] in
+utest mapValues m2 with ["1blub","2"] in
+
+utest
+match mapMapAccum (lam acc. lam k. lam v. ((addi k acc), concat "x" v)) 0 merged
+with (acc, m)
+then (acc, mapBindings m)
+else never
+with (9,[(negi 1,("x-1")),(1,("x1")),(2,("x22")),(3,("x3")),(4,("x44"))]) in
 
 ()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -6,14 +6,15 @@
 include "option.mc"
 include "seq.mc"
 
-let mapLength : Map k v -> Int =
-  mapFoldWithKey (lam acc. lam. lam. addi 1 acc) 0
 
 -- Aliases
+let mapLength : Map k v -> Int = mapSize
 let mapLookupOrElse : (Unit -> v) -> k -> Map k v -> v =
   mapFindOrElse
 let mapLookupApplyOrElse : (v1 -> v2) -> (Unit -> v2) -> k -> Map k v1 -> v2 =
   mapFindApplyOrElse
+
+let mapIsEmpty : Map k v -> Bool = lam m. eqi (mapSize m) 0
 
 let mapLookup : k -> Map k v -> Option v =
   lam k. lam m.
@@ -56,6 +57,7 @@ let m = mapEmpty subi in
 utest mapLookupOrElse (lam. 2) 1 m with 2 in
 utest mapLookupApplyOrElse (lam. 2) (lam. 3) 1 m with 3 in
 utest mapLength m with 0 in
+utest mapIsEmpty m with true in
 
 utest mapLookup 1 m with None () in
 
@@ -64,6 +66,7 @@ let m = mapInsert 2 "2" m in
 let m = mapInsert 3 "3" m in
 
 utest mapLength m with 3 in
+utest mapIsEmpty m with false in
 
 utest mapLookup 1 m with Some "1" in
 utest mapLookup 2 m with Some "2" in

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -2,6 +2,7 @@
 -- al. (1993).
 
 include "name.mc"
+include "stringid.mc"
 
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
@@ -93,10 +94,10 @@ lang RecordANF = ANF + RecordAst
       (lam acc. lam k. lam e.
          (lam bs.
             normalizeName
-              (lam v. acc (assocInsert {eq=eqString} k v bs))
+              (lam v. acc (mapInsert k v bs))
               e))
     in
-    (assocFold {eq=eqString} f acc t.bindings) assocEmpty
+    (mapFoldWithKey f acc t.bindings) (mapEmpty (mapGetCmpFun t.bindings))
 
   | TmRecordUpdate t ->
     normalizeName
@@ -314,30 +315,29 @@ let record =
 in
 utest _anf record with
   bindall_ [
-    ulet_ "t" (app_ (int_ 2) (int_ 3)),
-    ulet_ "t1" (app_ (int_ 1) (var_ "t")),
-    ulet_ "t2" (app_ (int_ 5) (int_ 6)),
+    ulet_ "t" (app_ (int_ 5) (int_ 6)),
+    ulet_ "t1" (app_ (int_ 2) (int_ 3)),
+    ulet_ "t2" (app_ (int_ 1) (var_ "t1")),
     ulet_ "t3" (record_ [
-      ("a", var_ "t1"),
+      ("a", var_ "t2"),
       ("b", int_ 4),
-      ("c", var_ "t2")
+      ("c", var_ "t")
     ]),
     var_ "t3"
   ]
 using eqExpr in
 
 
-let rupdate =
-  recordupdate_ record "b" (int_ 7) in
+let rupdate = recordupdate_ record "b" (int_ 7) in
 utest _anf rupdate with
   bindall_ [
-    ulet_ "t" (app_ (int_ 2) (int_ 3)),
-    ulet_ "t1" (app_ (int_ 1) (var_ "t")),
-    ulet_ "t2" (app_ (int_ 5) (int_ 6)),
+    ulet_ "t" (app_ (int_ 5) (int_ 6)),
+    ulet_ "t1" (app_ (int_ 2) (int_ 3)),
+    ulet_ "t2" (app_ (int_ 1) (var_ "t1")),
     ulet_ "t3" (record_ [
-      ("a", var_ "t1"),
+      ("a", var_ "t2"),
       ("b", int_ 4),
-      ("c", var_ "t2")
+      ("c", var_ "t")
     ]),
     ulet_ "t4" (recordupdate_ (var_ "t3") "b" (int_ 7)),
     var_ "t4"

--- a/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -1,4 +1,5 @@
 include "ast.mc"
+include "eq.mc"
 include "ast-builder.mc"
 include "info.mc"
 
@@ -10,8 +11,10 @@ include "info.mc"
 -- "ast-builder.mc" includes "ast.mc" though, so we can't use it inside "ast.mc",
 -- thus we create this file instead.
 
+lang TestLang = MExprAst + MExprEq
+
 mexpr
-use MExprAst in
+use TestLang in
 
 let tmVarX = (var_ "x") in
 let tmVarY = (var_ "y") in
@@ -190,7 +193,7 @@ in
 let countNodes = bottomUp (sfold_Expr_Expr addi 1) in
 
 utest bottomUp identity tmVarX with tmVarX in
-utest bottomUp cInt2cChar tmRecordI with tmRecordC in
+utest bottomUp cInt2cChar tmRecordI with tmRecordC using eqExpr in
 utest countNodes tmVarX with 1 in
 utest countNodes tmApp11C with 3 in
 utest countNodes tmRecordC with 5 in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -197,11 +197,11 @@ end
 -- TmRecord and TmRecordUpdate --
 lang RecordAst
   syn Expr =
-  | TmRecord {bindings : AssocMap String Expr,
+  | TmRecord {bindings : Map SID Expr,
               ty : Type,
               info : Info}
   | TmRecordUpdate {rec : Expr,
-                    key : String,
+                    key : SID,
                     value : Expr,
                     ty : Type,
                     info : Info}
@@ -219,12 +219,12 @@ lang RecordAst
   | TmRecordUpdate t -> TmRecordUpdate {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
-  | TmRecord t -> TmRecord {t with bindings = assocMap {eq=eqString} f t.bindings}
+  | TmRecord t -> TmRecord {t with bindings = mapMap f t.bindings}
   | TmRecordUpdate t -> TmRecordUpdate {{t with rec = f t.rec}
                                            with value = f t.value}
 
   sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
-  | TmRecord t -> assocFold {eq=eqString} (lam acc. lam _k. lam v. f acc v) acc t.bindings
+  | TmRecord t -> mapFoldWithKey (lam acc. lam _k. lam v. f acc v) acc t.bindings
   | TmRecordUpdate t -> f (f acc t.rec) t.value
 end
 
@@ -621,7 +621,7 @@ end
 
 lang RecordPat
   syn Pat =
-  | PatRecord {bindings : AssocMap String Pat,
+  | PatRecord {bindings : Map SID Pat,
                info: Info}
 
   sem info =
@@ -629,11 +629,11 @@ lang RecordPat
 
   sem smap_Pat_Pat (f : Pat -> a) =
   | PatRecord b ->
-      PatRecord {b with bindings = assocMap {eq=eqString} (lam b. (b.0, f b.1)) b.bindings}
+      PatRecord {b with bindings = mapMap f b.bindings}
 
   sem sfold_Pat_Pat (f : a -> b -> a) (acc : a) =
-  | PatRecord {bindings = bindings} -> assocFold {eq=eqString}
-                    (lam acc. lam _k. lam v. f acc v) acc bindings
+  | PatRecord {bindings = bindings} ->
+      mapFoldWithKey (lam acc. lam _k. lam v. f acc v) acc bindings
 end
 
 lang DataPat = DataAst
@@ -786,7 +786,7 @@ end
 
 lang RecordTypeAst
   syn Type =
-  | TyRecord {fields : AssocMap String Type}
+  | TyRecord {fields : Map SID Type}
 end
 
 lang VariantTypeAst

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -564,6 +564,7 @@ end
 lang PPrintLang = MExprPrettyPrint + HolePrettyPrint
 
 lang TestLang = MExpr + ContextAwareHoles + PPrintLang + MExprANF + HoleANF
+  + MExprSym
 
 mexpr
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -128,10 +128,10 @@ lang RecordEq = Eq + RecordAst
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmRecord r ->
     match lhs with TmRecord l then
-      if eqi (assocLength l.bindings) (assocLength r.bindings) then
-        assocFoldlM {eq=eqString}
+      if eqi (mapLength l.bindings) (mapLength r.bindings) then
+        mapFoldlM
           (lam free. lam k1. lam v1.
-            match assocLookup {eq=eqString} k1 r.bindings with Some v2 then
+            match mapLookup k1 r.bindings with Some v2 then
               eqExprH env free v1 v2
             else None ())
           free l.bindings
@@ -140,7 +140,7 @@ lang RecordEq = Eq + RecordAst
 
   | TmRecordUpdate r ->
     match lhs with TmRecordUpdate l then
-      if eqString l.key r.key then
+      if eqSID l.key r.key then
         match eqExprH env free l.rec r.rec with Some free then
           eqExprH env free l.value r.value
         else None ()
@@ -431,11 +431,11 @@ lang RecordPatEq = RecordPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : NameEnv) (lhs : Pat) =
   | PatRecord {bindings = bs2} ->
     match lhs with PatRecord {bindings = bs1} then
-      if eqi (assocLength bs1) (assocLength bs2) then
-        assocFoldlM {eq=eqString}
+      if eqi (mapLength bs1) (mapLength bs2) then
+        mapFoldlM
           (lam tEnv. lam k1. lam p1.
              match tEnv with (free,patEnv) then
-               match assocLookup {eq=eqString} k1 bs2 with Some p2 then
+               match mapLookup k1 bs2 with Some p2 then
                  eqPat env free patEnv p1 p2
                else None ()
              else never)
@@ -561,15 +561,8 @@ end
 lang RecordTypeEq = Eq + RecordTypeAst
   sem eqType (typeEnv : TypeEnv) (lhs : Type) =
   | TyRecord r ->
-    let f = lam k. lam ty1.
-      match assocLookup {eq=eqString} k r.fields with Some ty2 then
-        eqType typeEnv ty1 ty2
-      else false
-    in
     match _unwrapType typeEnv lhs with Some (TyRecord l) then
-      if eqi (assocLength l.fields) (assocLength r.fields) then
-        assocAll f l.fields
-      else false
+      mapEq (eqType typeEnv) l.fields r.fields
     else false
 end
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -5,6 +5,7 @@
 include "name.mc"
 include "bool.mc"
 include "tensor.mc"
+include "map.mc"
 
 include "mexpr/ast.mc"
 include "mexpr/symbolize.mc"
@@ -129,7 +130,7 @@ lang RecordEq = Eq + RecordAst
   | TmRecord r ->
     match lhs with TmRecord l then
       if eqi (mapLength l.bindings) (mapLength r.bindings) then
-        mapFoldlM
+        mapFoldlOption
           (lam free. lam k1. lam v1.
             match mapLookup k1 r.bindings with Some v2 then
               eqExprH env free v1 v2
@@ -432,7 +433,7 @@ lang RecordPatEq = RecordPat
   | PatRecord {bindings = bs2} ->
     match lhs with PatRecord {bindings = bs1} then
       if eqi (mapLength bs1) (mapLength bs2) then
-        mapFoldlM
+        mapFoldlOption
           (lam tEnv. lam k1. lam p1.
              match tEnv with (free,patEnv) then
                match mapLookup k1 bs2 with Some p2 then

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1086,7 +1086,7 @@ lang RecordPatEval = RecordAst + RecordPat
   sem tryMatch (env : Env) (t : Expr) =
   | PatRecord r ->
     match t with TmRecord {bindings = bs} then
-      mapFoldlM
+      mapFoldlOption
         (lam env. lam k. lam p.
           match mapLookup k bs with Some v then
             tryMatch env v p

--- a/stdlib/mexpr/infix.mc
+++ b/stdlib/mexpr/infix.mc
@@ -68,7 +68,7 @@ end
 lang MExprParserExt = MExprParserBase + ExprInfixArithParser + ExprInfixParserClosed +
                       ExprInfixTestParser
 
-lang MExprExt = MExprAst + MExprParserExt + MExprEval + MExprPrettyPrint
+lang MExprExt = MExprAst + MExprParserExt + MExprEval + MExprPrettyPrint + MExprSym
 
 
 -- Evaluate an expression into a value expression

--- a/stdlib/mexpr/lift-types.mc
+++ b/stdlib/mexpr/lift-types.mc
@@ -1,1 +1,0 @@
--- Lifts types to the top of an MExpr program.

--- a/stdlib/mexpr/mexpr.mc
+++ b/stdlib/mexpr/mexpr.mc
@@ -10,7 +10,7 @@ include "mexpr/info.mc"
 include "mexpr/pprint.mc"
 include "seq.mc"
 
-lang MExpr = MExprAst + MExprParser + MExprEval + MExprPrettyPrint 
+lang MExpr = MExprAst + MExprParser + MExprEval + MExprPrettyPrint + MExprSym
 
 
 -- Evaluate an expression into a value expression

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -92,7 +92,7 @@ end
 lang RecordSym = Sym + RecordAst
   sem symbolizeExpr (env : SymEnv) =
   | TmRecord t ->
-    TmRecord {t with bindings = assocMap {eq=eqString} (symbolizeExpr env) t.bindings}
+    TmRecord {t with bindings = mapMap (symbolizeExpr env) t.bindings}
 
   | TmRecordUpdate t ->
     TmRecordUpdate {{t with rec = symbolizeExpr env t.rec}
@@ -312,7 +312,7 @@ end
 lang RecordTypeSym = RecordTypeAst
   sem symbolizeType (env : SymEnv) =
   | TyRecord {fields = fields} ->
-    TyRecord {fields = assocMap {eq=eqString} (symbolizeType env) fields}
+    TyRecord {fields = mapMap (symbolizeType env) fields}
 end
 
 lang VariantTypeSym = VariantTypeAst
@@ -388,7 +388,7 @@ end
 lang RecordPatSym = RecordPat
   sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
   | PatRecord {bindings = bindings, info = info} ->
-    match assocMapAccum {eq=eqString}
+    match mapMapAccum
             (lam patEnv. lam. lam p. symbolizePat env patEnv p) patEnv bindings
     with (env,bindings) then
       (env, PatRecord {bindings = bindings, info = info})

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -172,8 +172,8 @@ end
 lang RecordTypeAnnot = TypeAnnot + RecordAst + RecordTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmRecord t ->
-    let bindings = assocMap {eq=eqString} (typeAnnotExpr env) t.bindings in
-    let bindingTypes = assocMap {eq=eqString} ty bindings in
+    let bindings = mapMap (typeAnnotExpr env) t.bindings in
+    let bindingTypes = mapMap ty bindings in
     let ty = TyRecord {fields = bindingTypes} in
     TmRecord {{t with bindings = bindings}
                  with ty = ty}

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -1,0 +1,23 @@
+-- Lift out types of an MExpr program. In particular, record types are lifted
+-- and replaced with type variables, and all constructors for variant types are
+-- lifted and collected into a single type.  Note that the latter probably has
+-- consequences for type checking: information is lost when lifting constructor
+-- definitions.
+--
+-- Requires symbolize and type-annot to be run first.
+
+-----------------
+-- ENVIRONMENT --
+-----------------
+-- * Associative sequence of tuples of type aliases. I cannot use AssocMap since there may be internal dependencies.
+-- * [Records] Map from currently defined records to their type names.
+-- * [Variants] Map from variant type names to their current constructors.
+
+-----------
+-- TERMS --
+-----------
+
+
+-----------
+-- TYPES --
+-----------

--- a/stdlib/multicore/eval.mc
+++ b/stdlib/multicore/eval.mc
@@ -79,10 +79,13 @@ lang ThreadEval = ThreadAst + IntAst + UnknownTypeAst + RecordAst + AppEval
       threadJoin thread
     else error "not a threadJoin of a thread"
   | CThreadSelf _ ->
-    match arg with TmRecord {bindings = []} then
-      TmConst {val = CThreadID {id = threadSelf ()},
-               info = NoInfo (), ty = TyUnknown ()}
-    else error "Argument in threadSelf is not unit"
+    let err = "Argument in threadSelf is not unit" in
+    match arg with TmRecord {bindings = bindings} then
+      if mapIsEmpty bindings then
+        TmConst {val = CThreadID {id = threadSelf ()},
+                 info = NoInfo (), ty = TyUnknown ()}
+      else error err
+    else error err
   | CThreadGetID _ ->
     match arg with TmConst ({val = CThread {thread = thread}} & t) then
       TmConst {t with val = CThreadID {id = threadGetID thread}}
@@ -92,10 +95,13 @@ lang ThreadEval = ThreadAst + IntAst + UnknownTypeAst + RecordAst + AppEval
       TmConst {t with val = CInt {val = threadID2int id}}
     else error "Argument to threadID2int not a thread ID"
   | CThreadWait _ ->
-    match arg with TmRecord {bindings = []} then
-      threadWait ();
-      unit_
-    else error "Argument to threadWait is not unit"
+    let err = "Argument to threadWait is not unit" in
+    match arg with TmRecord {bindings = bindings} then
+      if mapIsEmpty bindings then
+        threadWait ();
+        unit_
+      else error err
+    else error err
   | CThreadNotify _ ->
     match arg with TmConst ({val = CThreadID {id = id}} & t) then
       threadNotify id;
@@ -106,13 +112,17 @@ lang ThreadEval = ThreadAst + IntAst + UnknownTypeAst + RecordAst + AppEval
       TmApp {lhs = arg, rhs = unit_, info = NoInfo (), ty = TyUnknown ()}
     in threadCriticalSection (lam. eval {env = []} app)
   | CThreadCPURelax _ ->
-    match arg with TmRecord {bindings = []} then
-      threadCPURelax ();
-      unit_
-    else error "Argument to threadCPURelax is not unit"
+    let err = "Argument to threadCPURelax is not unit" in
+    match arg with TmRecord {bindings = bindings} then
+      if mapIsEmpty bindings then
+        threadCPURelax ();
+        unit_
+      else error err
+    else error err
 end
 
 lang MExprParEval = MExprEval + AtomicEval + ThreadEval + MExprPrettyPrint
+  + MExprSym
 
 mexpr
 

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -374,7 +374,7 @@ let breakableGenGrammar
 
     let prodLabelToOpId : Map prodLabel OpId =
       mapFromList cmp (map (lam prod. (label prod, newOpId ())) grammar.productions) in
-    let toOpId : prodLabel -> OpId = lam label. mapFindWithErr label prodLabelToOpId in
+    let toOpId : prodLabel -> OpId = lam label. mapFindWithExn label prodLabelToOpId in
 
     -- TODO(vipa, 2021-02-15): This map can contain more entries than
     -- required; the inner map should only ever have entries where the
@@ -938,10 +938,10 @@ let grammar =
   }
 in
 let genned = breakableGenGrammar cmpString grammar in
-let atom = lam label. mapFindWithErr label genned.atoms in
-let prefix = lam label. mapFindWithErr label genned.prefixes in
-let infix = lam label. mapFindWithErr label genned.infixes in
-let postfix = lam label. mapFindWithErr label genned.postfixes in
+let atom = lam label. mapFindWithExn label genned.atoms in
+let prefix = lam label. mapFindWithExn label genned.prefixes in
+let infix = lam label. mapFindWithExn label genned.infixes in
+let postfix = lam label. mapFindWithExn label genned.postfixes in
 
 type Self = {val : Int, pos : Int} in
 

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -374,7 +374,7 @@ let breakableGenGrammar
 
     let prodLabelToOpId : Map prodLabel OpId =
       mapFromList cmp (map (lam prod. (label prod, newOpId ())) grammar.productions) in
-    let toOpId : prodLabel -> OpId = lam label. mapFind label prodLabelToOpId in
+    let toOpId : prodLabel -> OpId = lam label. mapFindWithErr label prodLabelToOpId in
 
     -- TODO(vipa, 2021-02-15): This map can contain more entries than
     -- required; the inner map should only ever have entries where the
@@ -938,10 +938,10 @@ let grammar =
   }
 in
 let genned = breakableGenGrammar cmpString grammar in
-let atom = lam label. mapFind label genned.atoms in
-let prefix = lam label. mapFind label genned.prefixes in
-let infix = lam label. mapFind label genned.infixes in
-let postfix = lam label. mapFind label genned.postfixes in
+let atom = lam label. mapFindWithErr label genned.atoms in
+let prefix = lam label. mapFindWithErr label genned.prefixes in
+let infix = lam label. mapFindWithErr label genned.infixes in
+let postfix = lam label. mapFindWithErr label genned.postfixes in
 
 type Self = {val : Int, pos : Int} in
 

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -183,7 +183,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
         productions in
 
     let addNtToFirstSet = lam prev. lam nt. lam symset.
-      let prods = mapFind nt groupedProds in
+      let prods = mapFindWithErr nt groupedProds in
       foldl (lam symset. lam prod. addProdToFirst prev prod symset) symset prods in
 
     -- let dprintFirstSet = lam firstSet.
@@ -231,7 +231,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
             let otherSymset = firstOfRhs rhs in
             let ntFollow = mapUnion ntFollow otherSymset.syms in
             let ntFollow = if otherSymset.eps
-              then mapUnion ntFollow (mapFind prodNt follow)
+              then mapUnion ntFollow (mapFindWithErr prodNt follow)
               else ntFollow in
             work (mapInsert nt ntFollow follow) rhs
           else match rhs with [_] ++ rhs then
@@ -266,11 +266,11 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
     let ll1Errors = mapMap (lam. ref (mapEmpty _compareSymbol)) groupedProds in
 
     let addProdToTable = lam prod. match prod with {nt = prodNt, label = label, rhs = rhs, action = action} then
-      let tableRef = mapFind prodNt table in
+      let tableRef = mapFindWithErr prodNt table in
       let prev = deref tableRef in
       let firstSymset = firstOfRhs rhs in
       let symset = if firstSymset.eps
-        then mapUnion firstSymset.syms (mapFind prodNt followSet)
+        then mapUnion firstSymset.syms (mapFindWithErr prodNt followSet)
         else firstSymset.syms in
       let newProd = {action = action, label = label, syms = map specSymToGenSym rhs} in
       let tableAdditions = mapMap (lam. newProd) symset in
@@ -280,7 +280,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
             let sym = binding.0 in
             match mapLookup sym prev with Some prevProd then
               modref hasLl1Error true;
-              let errRef = mapFind prodNt ll1Errors in
+              let errRef = mapFindWithErr prodNt ll1Errors in
               let errTab = deref errRef in
               let errList = match mapLookup sym errTab
                 with Some prods then snoc prods label
@@ -310,7 +310,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
 
     if deref hasLl1Error
       then Left (mapFromList cmpString (filter (lam binding. not (null (mapBindings binding.1))) (mapBindings (mapMap deref ll1Errors))))
-      else Right {start = {nt = startNt, table = mapFind startNt table}, lits = lits}
+      else Right {start = {nt = startNt, table = mapFindWithErr startNt table}, lits = lits}
   else never
 
 let ll1NonTerminal : String -> NonTerminal = identity

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -183,7 +183,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
         productions in
 
     let addNtToFirstSet = lam prev. lam nt. lam symset.
-      let prods = mapFindWithErr nt groupedProds in
+      let prods = mapFindWithExn nt groupedProds in
       foldl (lam symset. lam prod. addProdToFirst prev prod symset) symset prods in
 
     -- let dprintFirstSet = lam firstSet.
@@ -231,7 +231,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
             let otherSymset = firstOfRhs rhs in
             let ntFollow = mapUnion ntFollow otherSymset.syms in
             let ntFollow = if otherSymset.eps
-              then mapUnion ntFollow (mapFindWithErr prodNt follow)
+              then mapUnion ntFollow (mapFindWithExn prodNt follow)
               else ntFollow in
             work (mapInsert nt ntFollow follow) rhs
           else match rhs with [_] ++ rhs then
@@ -266,11 +266,11 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
     let ll1Errors = mapMap (lam. ref (mapEmpty _compareSymbol)) groupedProds in
 
     let addProdToTable = lam prod. match prod with {nt = prodNt, label = label, rhs = rhs, action = action} then
-      let tableRef = mapFindWithErr prodNt table in
+      let tableRef = mapFindWithExn prodNt table in
       let prev = deref tableRef in
       let firstSymset = firstOfRhs rhs in
       let symset = if firstSymset.eps
-        then mapUnion firstSymset.syms (mapFindWithErr prodNt followSet)
+        then mapUnion firstSymset.syms (mapFindWithExn prodNt followSet)
         else firstSymset.syms in
       let newProd = {action = action, label = label, syms = map specSymToGenSym rhs} in
       let tableAdditions = mapMap (lam. newProd) symset in
@@ -280,7 +280,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
             let sym = binding.0 in
             match mapLookup sym prev with Some prevProd then
               modref hasLl1Error true;
-              let errRef = mapFindWithErr prodNt ll1Errors in
+              let errRef = mapFindWithExn prodNt ll1Errors in
               let errTab = deref errRef in
               let errList = match mapLookup sym errTab
                 with Some prods then snoc prods label
@@ -310,7 +310,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
 
     if deref hasLl1Error
       then Left (mapFromList cmpString (filter (lam binding. not (null (mapBindings binding.1))) (mapBindings (mapMap deref ll1Errors))))
-      else Right {start = {nt = startNt, table = mapFindWithErr startNt table}, lits = lits}
+      else Right {start = {nt = startNt, table = mapFindWithExn startNt table}, lits = lits}
   else never
 
 let ll1NonTerminal : String -> NonTerminal = identity

--- a/stdlib/parser/semantic.mc
+++ b/stdlib/parser/semantic.mc
@@ -520,10 +520,10 @@ let semanticGrammar
             (lam pair. (pair.0, (head pair.1).1))
             (mapBindings groupedPrecs)
           } in
-        let atom = lam sym. mapFind sym breakablePrecomputed.atoms in
-        let prefix = lam sym. mapFind sym breakablePrecomputed.prefixes in
-        let postfix = lam sym. mapFind sym breakablePrecomputed.postfixes in
-        let infix = lam sym. mapFind sym breakablePrecomputed.infixes in
+        let atom = lam sym. mapFindWithExn sym breakablePrecomputed.atoms in
+        let prefix = lam sym. mapFindWithExn sym breakablePrecomputed.prefixes in
+        let postfix = lam sym. mapFindWithExn sym breakablePrecomputed.postfixes in
+        let infix = lam sym. mapFindWithExn sym breakablePrecomputed.infixes in
 
         -- TODO(vipa, 2021-02-24): There will be a bug if multiple
         -- non-terminals have the same name, they will be merged, even

--- a/stdlib/stringid.mc
+++ b/stdlib/stringid.mc
@@ -13,32 +13,31 @@ include "string.mc"
 -- so that the map intrinsics can be used.
 type SID = Int
 
+let cmpSID = subi
+let eqSID = eqi
+
 -- These definitions are only defined once
-let _sidCounter = ref 0 
-let _mapStringToSid = ref (mapEmpty cmpString) 
-let _mapSidToString = ref (mapEmpty subi) 
+let _sidCounter = ref 0
+let _mapStringToSid = ref (mapEmpty cmpString)
+let _mapSidToString = ref (mapEmpty subi)
 
 
 -- Returns the string representation of a string ID
-let sidToString : SID -> String = lam sid. 
-  if mapMem sid (deref _mapSidToString) then
-     mapFind sid (deref _mapSidToString)
-  else
-     error "SID is not defined"
-     -- Note that if SID is a unique type, this cannot happen
+let sidToString : SID -> String = lam sid.
+  mapFindOrElse (lam. error "SID is not defined") sid (deref _mapSidToString)
+  -- Note that if SID is a unique type, the error case cannot happen
 
 
 -- Returns the string ID for a specific string
-let stringToSid : String -> SID = lam str. 
-  if mapMem str (deref _mapStringToSid)  then
-    mapFind str (deref _mapStringToSid)
-  else    
-    modref _sidCounter (addi (deref _sidCounter) 1);
-    let sid = deref _sidCounter in
-    modref _mapStringToSid (mapInsert str sid (deref _mapStringToSid));
-    modref _mapSidToString (mapInsert sid str (deref _mapSidToString));
-    sid
-
+let stringToSid : String -> SID = lam str.
+  mapFindOrElse
+    (lam.
+       modref _sidCounter (addi (deref _sidCounter) 1);
+       let sid = deref _sidCounter in
+       modref _mapStringToSid (mapInsert str sid (deref _mapStringToSid));
+       modref _mapSidToString (mapInsert sid str (deref _mapSidToString));
+       sid)
+    str (deref _mapStringToSid)
 
 mexpr
 
@@ -46,12 +45,18 @@ let sid1 = stringToSid "Foo" in
 utest sid1 with sid1 in
 utest sidToString sid1 with "Foo" in
 
+utest cmpSID sid1 sid1 with 0 in
+utest eqSID sid1 sid1 with true in
+
 let sid2 = stringToSid "Bar text" in
 utest sid2 with sid2 in
 utest sid2 with sid1 using neqi in
 utest sidToString sid2 with "Bar text" in
 utest sidToString sid1 with "Foo" in
 utest sidToString sid1 with sidToString sid2 using lam x. lam y. not (eqString x y) in
+
+utest eqi (cmpSID sid1 sid2) 0 with false in
+utest eqSID sid1 sid2 with false in
 
 let sid3 = stringToSid "Foo" in
 utest sid1 with sid3 in

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -10,16 +10,28 @@ mexpr
 -- Int map
 let m = mapEmpty subi in
 
+utest (mapGetCmpFun m) 2 1 with 1 in
+
+utest mapIsEmpty m with true in
+
 let m = mapInsert 1 '1' m in
 let m = mapInsert 2 '2' m in
 let m = mapInsert 3 '3' m in
 let m = mapInsert 4 '4' m in
 let m = mapInsert 4 '5' m in
 
-utest mapFind 1 m with '1' in
-utest mapFind 2 m with '2' in
-utest mapFind 3 m with '3' in
-utest mapFind 4 m with '5' in
+utest mapIsEmpty m with false in
+
+utest mapFindWithErr 1 m with '1' in
+utest mapFindWithErr 2 m with '2' in
+utest mapFindWithErr 3 m with '3' in
+utest mapFindWithErr 4 m with '5' in
+
+utest mapFindOrElse (lam. '0') 1 m with '1' in
+utest mapFindOrElse (lam. '0') 2 m with '2' in
+utest mapFindOrElse (lam. '0') 3 m with '3' in
+utest mapFindOrElse (lam. '0') 4 m with '5' in
+utest mapFindOrElse (lam. '0') 5 m with '0' in
 
 utest mapMem 1 m with true in
 utest mapMem 42 m with false in
@@ -38,6 +50,9 @@ utest bindsSort (mapBindings m) with [(1,'2'), (2,'3'), (3,'4'), (4,'6')] in
 let m = mapMapWithKey (lam k. lam v. int2char (addi k (char2int v))) m in
 utest bindsSort (mapBindings m) with [(1,'3'), (2,'5'), (3,'7'), (4,':')] in
 
+utest mapFoldWithKey (lam acc. lam k. lam v. addi (addi k acc) (char2int v)) 0 m
+with 227 in
+
 -- Int tuple map
 let cmpTuple = lam t1. lam t2.
   let d = subi t1.0 t2.0 in
@@ -48,15 +63,25 @@ in
 
 let m = mapEmpty cmpTuple in
 
+utest (mapGetCmpFun m) (1, 1) (1, 2) with negi 1 in
+
 let m = mapInsert (1, 1) 1 m in
 let m = mapInsert (1, 1) 2 m in
 let m = mapInsert (1, 2) 2 m in
 let m = mapInsert (2, 42) 3 m in
 let m = mapInsert (3, 42) 4 m in
 
-utest mapFind (1, 1) m with 2 in
-utest mapFind (1, 2) m with 2 in
-utest mapFind (2, 42) m with 3 in
-utest mapFind (3, 42) m with 4 in
+utest mapFindWithErr (1, 1) m with 2 in
+utest mapFindWithErr (1, 2) m with 2 in
+utest mapFindWithErr (2, 42) m with 3 in
+utest mapFindWithErr (3, 42) m with 4 in
+
+-- NOTE(dlunde,2021-03-04): mapEq is a bit hazardous, since the compare
+-- function for keys bundled with the first map is always used when doing the
+-- comparison. I assume we only use this as a temporary solution (I'm not sure
+-- how this would be type checked otherwise)
+utest mapEq eqi m m with true in
+utest mapEq neqi m m with false in
+utest mapEq eqi (mapInsert (2,2) 42 m) m with false in
 
 ()

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -12,7 +12,7 @@ let m = mapEmpty subi in
 
 utest (mapGetCmpFun m) 2 1 with 1 in
 
-utest mapIsEmpty m with true in
+utest mapSize m with 0 in
 
 let m = mapInsert 1 '1' m in
 let m = mapInsert 2 '2' m in
@@ -20,12 +20,12 @@ let m = mapInsert 3 '3' m in
 let m = mapInsert 4 '4' m in
 let m = mapInsert 4 '5' m in
 
-utest mapIsEmpty m with false in
+utest mapSize m with 4 in
 
-utest mapFindWithErr 1 m with '1' in
-utest mapFindWithErr 2 m with '2' in
-utest mapFindWithErr 3 m with '3' in
-utest mapFindWithErr 4 m with '5' in
+utest mapFindWithExn 1 m with '1' in
+utest mapFindWithExn 2 m with '2' in
+utest mapFindWithExn 3 m with '3' in
+utest mapFindWithExn 4 m with '5' in
 
 utest mapFindOrElse (lam. '0') 1 m with '1' in
 utest mapFindOrElse (lam. '0') 2 m with '2' in
@@ -75,10 +75,10 @@ let m = mapInsert (1, 2) 2 m in
 let m = mapInsert (2, 42) 3 m in
 let m = mapInsert (3, 42) 4 m in
 
-utest mapFindWithErr (1, 1) m with 2 in
-utest mapFindWithErr (1, 2) m with 2 in
-utest mapFindWithErr (2, 42) m with 3 in
-utest mapFindWithErr (3, 42) m with 4 in
+utest mapFindWithExn (1, 1) m with 2 in
+utest mapFindWithExn (1, 2) m with 2 in
+utest mapFindWithExn (2, 42) m with 3 in
+utest mapFindWithExn (3, 42) m with 4 in
 
 -- NOTE(dlunde,2021-03-04): mapEq and mapCmp are a bit hazardous, since the compare
 -- function for keys bundled with the first map is always used when doing the

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -33,6 +33,10 @@ utest mapFindOrElse (lam. '0') 3 m with '3' in
 utest mapFindOrElse (lam. '0') 4 m with '5' in
 utest mapFindOrElse (lam. '0') 5 m with '0' in
 
+utest mapFindApplyOrElse char2int (lam. 0) 1 m with 49 in
+utest mapFindApplyOrElse char2int (lam. 0) 2 m with 50 in
+utest mapFindApplyOrElse char2int (lam. 0) 5 m with 0 in
+
 utest mapMem 1 m with true in
 utest mapMem 42 m with false in
 

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -80,12 +80,15 @@ utest mapFindWithErr (1, 2) m with 2 in
 utest mapFindWithErr (2, 42) m with 3 in
 utest mapFindWithErr (3, 42) m with 4 in
 
--- NOTE(dlunde,2021-03-04): mapEq is a bit hazardous, since the compare
+-- NOTE(dlunde,2021-03-04): mapEq and mapCmp are a bit hazardous, since the compare
 -- function for keys bundled with the first map is always used when doing the
 -- comparison. I assume we only use this as a temporary solution (I'm not sure
 -- how this would be type checked otherwise)
 utest mapEq eqi m m with true in
 utest mapEq neqi m m with false in
 utest mapEq eqi (mapInsert (2,2) 42 m) m with false in
+utest mapCmp subi m m with 0 in
+utest mapCmp subi (mapInsert (2,2) 42 m) m with negi 40 in
+utest mapCmp subi m (mapInsert (2,2) 42 m) with 40 in
 
 ()


### PR DESCRIPTION
- OCaml map now contains the compare function as an MExpr term, and not as an OCaml function (makes it possible to extract in MExpr code)
- Added map intrinsics
  * `mapIsEmpty`
  * `mapGetCmpFun`
  * `mapFindOrElse`
  * `mapFoldWithKey`
  * `mapEq`
- Implemented map functions
  * `mapLength`
  * `mapKeys`
  * `mapValues`
  * `mapMapAccum`
  * `mapFoldlM`
- Renamed map intrinsic `mapFind` -> `mapFindWithErr`
- Added skeleton for `assoc-seq.mc` (Library for ordered association lists)
- Refactored `TmRecord`, `PatRecord`, and `TyRecord` to use (intrinsic) maps with `SID` as type (rather than `String`).
- Updated `TmRecordUpdate` to use `SID` as key instead of `String`.
