### PR TITLE
Ast generation and pprint syntax sugar updates

### DIFF
--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -26,7 +26,7 @@
 
 
 
-  
+
 %}
 
 /* Misc tokens */
@@ -319,7 +319,7 @@ sequence:
      { $1 }
   | left SEMI mexpr
      { let fi = tm_info $1 in
-       TmLet(fi, us"", Symb.Helpers.nosym, TyUnknown(NoInfo), $1, $3) } 
+       TmLet(fi, us"", Symb.Helpers.nosym, TyUnknown(NoInfo), $1, $3) }
 
 left:
   | atom
@@ -358,7 +358,7 @@ atom:
       { TmRecord(mkinfo $1.i $3.i, $2 |> List.fold_left
         (fun acc (k,v) -> Record.add k v acc) Record.empty) }
   | LBRACKET RBRACKET    { TmRecord(mkinfo $1.i $2.i, Record.empty)}
-  | LBRACKET mexpr WITH var_ident EQ mexpr RBRACKET
+  | LBRACKET mexpr WITH label_ident EQ mexpr RBRACKET
       { TmRecordUpdate(mkinfo $1.i $7.i, $2, $4.v, $6) }
 
 proj_label:

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -131,7 +131,7 @@ let pprintConString = lam str.
 -- Get an optional list of tuple expressions for a record. If the record does
 -- not represent a tuple, None () is returned.
 let _record2tuple
-  : Map String a
+  : Map SID a
   -> Option [a]
   = lam bindings.
     let keys = map sidToString (mapKeys bindings) in
@@ -480,19 +480,20 @@ lang RecordProjectionSyntaxSugarPrettyPrint = MatchPrettyPrint + RecordPat + Nev
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmMatch (t &
     { pat = PatRecord
-      { bindings =
-        [ (fieldLabel, PatNamed {ident = PName patName})
-        ]
+      { bindings = bindings
       }
     , thn = TmVar {ident = exprName}
     , els = TmNever _
     , target = expr
     })
-  -> if nameEq patName exprName
+  -> match mapBindings bindings with [(fieldLabel, PatNamed {ident = PName patName})]
     then
-      match printParen indent env expr with (env, expr) then
-        (env, join [expr, ".", pprintLabelString fieldLabel])
-      else never
+      if nameEq patName exprName
+      then
+        match printParen indent env expr with (env, expr) then
+          (env, join [expr, ".", pprintLabelString fieldLabel])
+        else never
+      else pprintTmMatchNormally indent env t
     else pprintTmMatchNormally indent env t
 end
 

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -1,6 +1,7 @@
 include "mexpr/eq.mc"
 
 type SynType = String
+let stringToSynType = identity
 let _eqSynType = eqString
 let _cmpSynType = cmpString
 let _synTypeToString = identity
@@ -37,6 +38,13 @@ type GenInput =
   , constructors : [Constructor]
   , requestedSFunctions : [(SynType, Type)]
   }
+
+lang CarriedTypeBase
+  syn CarriedType =
+
+  sem carriedRepr /- : CarriedType -> Type -/ =
+  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) /- : CarriedType -> Option (Name -> Name -> Expr) -/ =
+end
 
 let _equalTypes = use MExprEq in eqType assocEmpty
 let _typeToString = use MExprPrettyPrint in lam ty. (getTypeStringCode 0 pprintEnvEmpty ty).1
@@ -83,46 +91,39 @@ let _pprintSemanticFunction
       else never
     else never
 
-let _pprintLanguageFragment
-  : LanguageFragment
-  -> String
-  = lam frag.
-    match frag with {name = name, extends = extends, synTypes = synTypes, semanticFunctions = semanticFunctions} then
-      let extends = match extends
-        with [] then ""
-        else concat " = " (strJoin " + " extends) in
-      let pprintConstructor = lam constructor.
-        match constructor with {name = name, carried = {repr = ty}} then
-          join ["\n  | ", nameGetStr name, " ", _typeToString ty]
-        else never in
-      let synDefns = map
-        (lam binding.
-          match binding with (synType, constructors) then
-            join
-              [ "  syn ", _synTypeToString synType, " ="
-              , join (map pprintConstructor constructors)
-              , "\n"
-              ]
-          else never)
-        (mapBindings synTypes) in
-      join
-        [ "lang ", name, extends , "\n"
-        , join synDefns
-        , "\n"
-        , strJoin "\n" (map _pprintSemanticFunction semanticFunctions)
-        , "\nend"
-        ]
-    else never
+lang CarriedTypeHelpers = CarriedTypeBase
+  sem _pprintLanguageFragment =
+  | {name = name, extends = extends, synTypes = synTypes, semanticFunctions = semanticFunctions} ->
+    let extends = match extends
+      with [] then ""
+      else concat " = " (strJoin " + " extends) in
+    let pprintConstructor = lam constructor.
+      match constructor with {name = name, carried = carried} then
+        join ["\n  | ", nameGetStr name, " ", _typeToString (carriedRepr carried)]
+      else never in
+    let synDefns = map
+      (lam binding.
+        match binding with (synType, constructors) then
+          join
+            [ "  syn ", _synTypeToString synType, " ="
+            , join (map pprintConstructor constructors)
+            , "\n"
+            ]
+        else never)
+      (mapBindings synTypes) in
+    join
+      [ "lang ", name, extends , "\n"
+      , join synDefns
+      , "\n"
+      , strJoin "\n" (map _pprintSemanticFunction semanticFunctions)
+      , "\nend"
+      ]
 
-let _mkSmapAccumL
-  : SynType -- "Container" type
-  -> Type -- Target type
-  -> Constructor
-  -> Option SemanticFunction
-  = lam synType. lam targetTy. lam constructor.
+  sem _mkSmapAccumL (synType : SynType) (targetTy : Type) =
+  | constructor ->
     if _eqSynType synType constructor.synType then
       let fName = nameSym "f" in
-      match constructor.carried.smapAccumL (appf2_ (nvar_ fName)) targetTy with Some mkNew then
+      match carriedSMapAccumL (appf2_ (nvar_ fName)) targetTy constructor.carried with Some mkNew then
         let accName = nameSym "acc" in
         let valName = nameSym "x" in
         Some
@@ -143,6 +144,7 @@ let _mkSmapAccumL
           }
       else None ()
     else None ()
+end
 
 let _mkSFuncStubs
   : SynType
@@ -197,93 +199,124 @@ let _mkSFuncStubs
       } in
     [smapAccumL, smap, sfold]
 
-let bareType
+lang CarriedTarget = CarriedTypeBase
+  syn CarriedType =
+  | TargetType {targetable : Bool, ty : Type}
+
+  sem carriedRepr =
+  | TargetType {ty = ty} -> ty
+
+  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) =
+  | TargetType {targetable = false} -> None ()
+  | TargetType {targetable = true, ty = ty} ->
+    if _equalTypes ty targetTy
+    then Some (lam accName. lam valName. f (nvar_ accName) (nvar_ valName))
+    else None ()
+end
+
+lang CarriedSeq = CarriedTypeBase
+  syn CarriedType =
+  | SeqType CarriedType
+
+  sem carriedRepr =
+  | SeqType ty -> tyseq_ (carriedRepr ty)
+
+  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) =
+  | SeqType ty ->
+    match carriedSMapAccumL f targetTy ty with Some mkNew then Some
+      (lam accName. lam valName.
+        let innerAcc = nameSym "acc" in
+        let innerVal = nameSym "x" in
+        appf3_
+          (var_ "mapAccumL")
+          (nulam_ innerAcc
+            (nulam_ innerVal
+              (mkNew innerAcc innerVal)))
+          (nvar_ accName)
+          (nvar_ valName)
+      )
+    else None ()
+end
+
+lang CarriedRecord = CarriedTypeBase
+  syn CarriedType =
+  | RecordType [(String, CarriedType)]
+
+  sem carriedRepr =
+  | RecordType tys -> tyrecord_
+    (map
+      (lam x. {x with #label"1" = carriedRepr x.1})
+      tys)
+
+  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) =
+  | RecordType fields ->
+    let mappingFields = mapOption
+      (lam x. optionMap (lam y. (x.0, y)) (carriedSMapAccumL f targetTy x.1))
+      fields in
+    match mappingFields with [] then None ()
+    else Some
+      (lam accName. lam valName.
+        -- NOTE(vipa, 2021-03-03): This constructs an AST with
+        -- shadowing of symbolized names, which may or may not be what
+        -- we want
+        let mappedFields = mapAccumR
+          (lam constr. lam x. match x with (field, mkNew) then
+             let fieldName = nameSym field in
+             let constr = lam innerMost.
+               match_
+                 (_nulet_
+                   fieldName
+                   (recordproj_ field (nvar_ valName))
+                   (mkNew accName fieldName))
+                 (ptuple_ [npvar_ accName, npvar_ fieldName])
+                 (constr innerMost)
+                 never_
+             in (constr, (field, fieldName))
+           else never)
+          identity
+          mappingFields
+        in match mappedFields with (constr, mappedFields) then
+          constr
+            (tuple_
+              [ nvar_ accName
+              , (foldl
+                  (lam acc. lam update.
+                    recordupdate_ acc update.0 (nvar_ update.1))
+                  (nvar_ valName)
+                  mappedFields)
+              ])
+        else never
+      )
+end
+
+let targetableType
   : Type
   -> CarriedType
-  = lam ty.
-    { repr = ty
-    , smapAccumL = lam func_. lam targetTy.
-      if _equalTypes ty targetTy
-      then Some (lam accName. lam valName. func_ (nvar_ accName) (nvar_ valName))
-      else None ()
-    }
+  = lam ty. use CarriedTarget in TargetType {targetable = true, ty = ty}
+
+let untargetableType
+  : Type
+  -> CarriedType
+  = lam ty. use CarriedTarget in TargetType {targetable = false, ty = ty}
 
 let seqType
   : CarriedType
   -> CarriedType
-  = lam inner.
-    { repr = tyseq_ inner.repr
-    , smapAccumL = lam func_. lam targetTy.
-      match inner.smapAccumL func_ targetTy with Some mkNew then Some
-        (lam accName. lam valName.
-          let innerAcc = nameSym "acc" in
-          let innerVal = nameSym "x" in
-          appf3_
-            (var_ "mapAccumL")
-            (nulam_ innerAcc
-              (nulam_ innerVal
-                (mkNew innerAcc innerVal)))
-            (nvar_ accName)
-            (nvar_ valName)
-        )
-      else None ()
-    }
+  = lam ty. use CarriedSeq in SeqType ty
 
 let recordType
   : [(String, CarriedType)]
   -> CarriedType
-  = lam fields.
-    { repr = tyrecord_
-      (map (lam x. (x.0, (x.1).repr)) fields)
-    , smapAccumL = lam func_. lam targetTy.
-      let mappingFields = mapOption
-        (lam x. optionMap (lam y. (x.0, y)) ((x.1).smapAccumL func_ targetTy))
-        fields in
-      match mappingFields with [] then None ()
-      else Some
-        (lam accName. lam valName.
-          -- NOTE(vipa, 2021-03-03): This constructs an AST with
-          -- shadowing of symbolized names, which may or may not be what
-          -- we want
-          let mappedFields = mapAccumR
-            (lam constr. lam x. match x with (field, mkNew) then
-               let fieldName = nameSym field in
-               let constr = lam innerMost.
-                 match_
-                   (_nulet_
-                     fieldName
-                     (recordproj_ field (nvar_ valName))
-                     (mkNew accName fieldName))
-                   (ptuple_ [npvar_ accName, npvar_ fieldName])
-                   (constr innerMost)
-                   never_
-               in (constr, (field, fieldName))
-             else never)
-            identity
-            mappingFields
-          in match mappedFields with (constr, mappedFields) then
-            constr
-              (tuple_
-                [ nvar_ accName
-                , (foldl
-                    (lam acc. lam update.
-                      recordupdate_ acc update.0 (nvar_ update.1))
-                    (nvar_ valName)
-                    mappedFields)
-                ])
-          else never
-        )
-    }
+  = lam fields. use CarriedRecord in RecordType fields
 
 let tupleType
   : [CarriedType]
   -> CarriedType
   = lam fields. recordType (mapi (lam i. lam field. (int2string i, field)) fields)
 
-let mkLanguages
-  : GenInput
-  -> String
-  = lam input.
+lang CarriedTypeGenerate = CarriedTypeHelpers
+  sem mkLanguages = /- GenInput -> String -/
+  | input ->
     match input with {namePrefix = namePrefix, constructors = constructors, requestedSFunctions = requestedSFunctions} then
       let synTypes = foldl
         (lam acc. lam c. mapInsert c.synType [] acc)
@@ -310,14 +343,19 @@ let mkLanguages
       let constructorLangs = map mkConstructorLang constructors in
       strJoin "\n\n" (map _pprintLanguageFragment (cons baseLang constructorLangs))
     else never
+end
+
+lang CarriedBasic = CarriedTypeGenerate + CarriedTarget + CarriedSeq + CarriedRecord
 
 mexpr
 
-let tyInfo = bareType (tyvar_ "Info") in
-let tyName = bareType (tyvar_ "Name") in
-let tyString = bareType tystr_ in
-let tyExpr = bareType (tyvar_ "Expr") in
-let tyType = bareType (tyvar_ "Type") in
+use CarriedBasic in
+
+let tyInfo = targetableType (tyvar_ "Info") in
+let tyName = targetableType (tyvar_ "Name") in
+let tyString = targetableType tystr_ in
+let tyExpr = targetableType (tyvar_ "Expr") in
+let tyType = targetableType (tyvar_ "Type") in
 let tyField = tupleType [tyString, tyExpr] in
 let tyFields = seqType tyField in
 let tyRecord = recordType
@@ -328,13 +366,13 @@ let tyRecord = recordType
 
 let recordConstructor =
   { name = nameSym "TmRecord"
-  , synType = "Expr"
+  , synType = stringToSynType "Expr"
   , carried = tyRecord
   } in
 
 let varConstructor =
   { name = nameSym "TmVar"
-  , synType = "Expr"
+  , synType = stringToSynType "Expr"
   , carried = recordType
     [ ("info", tyInfo)
     , ("ty", tyType)
@@ -344,7 +382,7 @@ let varConstructor =
 
 let seqConstructor =
   { name = nameSym "TmSeq"
-  , synType = "Expr"
+  , synType = stringToSynType "Expr"
   , carried = recordType
     [ ("info", tyInfo)
     , ("ty", tyType)
@@ -356,9 +394,9 @@ let input =
   { namePrefix = "MExpr"
   , constructors = [recordConstructor, varConstructor, seqConstructor]
   , requestedSFunctions =
-    [ ("Expr", tyvar_ "Info")
-    , ("Expr", tyvar_ "Expr")
-    , ("Expr", tyvar_ "Type")
+    [ (stringToSynType "Expr", tyvar_ "Info")
+    , (stringToSynType "Expr", tyvar_ "Expr")
+    , (stringToSynType "Expr", tyvar_ "Type")
     ]
   } in
 

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -1,0 +1,268 @@
+include "mexpr/eq.mc"
+
+type SynType = String
+let _eqSynType = eqString
+let _synTypeToString = identity
+
+type CarriedType =
+  { repr : Type
+  , smapAccumL
+    : (Expr -> Expr -> Expr) -- Staged function to apply
+    -> Type -- Target type
+    -> Option (Name -> Name -> Expr) -- acc name -> val name -> result expression
+  }
+
+type Constructor =
+  { name : Name
+  , synType : SynType
+  , carried : CarriedType
+  }
+
+type SemanticFunction =
+  { name : String
+  , preCaseArgs : [(Name, Type)]
+  , cases : [(Pat, Expr)]
+  }
+
+let _equalTypes = use MExprEq in eqType assocEmpty
+let _typeToString = use MExprPrettyPrint in lam ty. (getTypeStringCode 0 pprintEnvEmpty ty).1
+let _patToString = use MExprPrettyPrint in lam pat. (getPatStringCode 0 pprintEnvEmpty pat).1
+let _exprToString = use MExprPrettyPrint in expr2str
+let _nulet_ = lam n. lam body. lam inexpr. use LetAst in TmLet
+  { ident = n
+  , body = body
+  , tyBody = tyunknown_
+  , inexpr = inexpr
+  , info = NoInfo ()
+  , ty = tyunknown_
+  }
+
+let _pprintSemanticFunction
+  : SemanticFunction
+  -> String
+  = lam func.
+    match func with {name = name, preCaseArgs = preCaseArgs, cases = cases} then
+      let pprintArg = lam arg.
+        match arg with (name, ty) then
+          join [" (", nameGetStr name, " : ", _typeToString ty, ")"]
+        else never in
+      let pprintCase = lam case.
+        match case with (pat, expr) then
+          join ["| ", _patToString pat, " -> ", _exprToString expr, "\n"]
+        else never in
+      join
+        [ "sem ", name
+        , join (map pprintArg preCaseArgs)
+        , " =\n"
+        , join (map pprintCase cases)
+        ]
+    else never
+
+let _mkSmapAccumL
+  : SynType -- "Container" type
+  -> Type -- Target type
+  -> Constructor
+  -> Option SemanticFunction
+  = lam synType. lam targetTy. lam constructor.
+    if _eqSynType synType constructor.synType then
+      let fName = nameSym "f" in
+      match constructor.carried.smapAccumL (appf2_ (nvar_ fName)) targetTy with Some mkNew then
+        let accName = nameSym "acc" in
+        let valName = nameSym "x" in
+        Some
+          { name = join ["smapAccumL_", _synTypeToString synType, "_", _typeToString targetTy]
+          , preCaseArgs =
+            [ (fName, tyarrows_ [tyvar_ "a", targetTy, tytuple_ [tyvar_ "a", targetTy]])
+            , (accName, tyvar_ "a")
+            ]
+          , cases =
+            [ (npcon_ constructor.name (npvar_ valName), mkNew accName valName)
+            ]
+          }
+      else None ()
+    else None ()
+
+let _mkSfuncStubs
+  : SynType
+  -> Type
+  -> [SemanticFunction]
+  = lam synType. lam targetTy.
+    let suffix = join ["_", _synTypeToString synType, "_", _typeToString targetTy] in
+    let fName = nameSym "f" in
+    let accName = nameSym "acc" in
+    let valName = nameSym "x" in
+    let smapAccumL_ = appf3_ (var_ (concat "smapAccumL" suffix)) in
+    let smapAccumL =
+      { name = concat "smapAccumL" suffix
+      , preCaseArgs =
+        [ (fName, tyarrows_ [tyvar_ "a", targetTy, tytuple_ [tyvar_ "a", targetTy]])
+        , (accName, tyvar_ "a")
+        ]
+      , cases =
+        [ (npvar_ valName, tuple_ [nvar_ accName, nvar_ valName])
+        ]
+      } in
+    let smap =
+      { name = concat "smap" suffix
+      , preCaseArgs =
+        [ (fName, tyarrow_ targetTy targetTy)
+        ]
+      , cases =
+        [ ( npvar_ valName
+          , tupleproj_ 1
+            (smapAccumL_
+              (ulam_ "" (nulam_ valName (tuple_ [unit_, appf1_ (nvar_ fName) (nvar_ valName)])))
+              unit_
+              (nvar_ valName))
+          )
+        ]
+      } in
+    let sfold =
+      { name = concat "sfold" suffix
+      , preCaseArgs =
+        [ (fName, tyarrows_ [tyvar_ "a", targetTy, tyvar_ "a"])
+        , (accName, tyvar_ "a")
+        ]
+      , cases =
+        [ ( npvar_ valName
+          , tupleproj_ 0
+            (smapAccumL_
+              (nulam_ accName (nulam_ valName (tuple_ [appf2_ (nvar_ fName) (nvar_ accName) (nvar_ valName), nvar_ valName])))
+              (nvar_ accName)
+              (nvar_ valName))
+          )
+        ]
+      } in
+    [smapAccumL, smap, sfold]
+
+let bareType
+  : Type
+  -> CarriedType
+  = lam ty.
+    { repr = ty
+    , smapAccumL = lam func_. lam targetTy.
+      if _equalTypes ty targetTy
+      then Some (lam accName. lam valName. func_ (nvar_ accName) (nvar_ valName))
+      else None ()
+    }
+
+let seqType
+  : CarriedType
+  -> CarriedType
+  = lam inner.
+    { repr = tyseq_ inner.repr
+    , smapAccumL = lam func_. lam targetTy.
+      match inner.smapAccumL func_ targetTy with Some mkNew then Some
+        (lam accName. lam valName.
+          let innerAcc = nameSym "acc" in
+          let innerVal = nameSym "x" in
+          appf3_
+            (var_ "mapAccumL")
+            (nulam_ innerAcc
+              (nulam_ innerVal
+                (mkNew innerAcc innerVal)))
+            (nvar_ accName)
+            (nvar_ valName)
+        )
+      else None ()
+    }
+
+let recordType
+  : [(String, CarriedType)]
+  -> CarriedType
+  = lam fields.
+    { repr = tyrecord_
+      (map (lam x. (x.0, (x.1).repr)) fields)
+    , smapAccumL = lam func_. lam targetTy.
+      let mappingFields = mapOption
+        (lam x. optionMap (lam y. (x.0, y)) ((x.1).smapAccumL func_ targetTy))
+        fields in
+      match mappingFields with [] then None ()
+      else Some
+        (lam accName. lam valName.
+          -- NOTE(vipa, 2021-03-03): This constructs an AST with
+          -- shadowing of symbolized names, which may or may not be what
+          -- we want
+          let mappedFields = mapAccumR
+            (lam constr. lam x. match x with (field, mkNew) then
+               let fieldName = nameSym field in
+               let constr = lam innerMost.
+                 match_
+                   (_nulet_
+                     fieldName
+                     (recordproj_ field (nvar_ valName))
+                     (mkNew accName fieldName))
+                   (ptuple_ [npvar_ accName, npvar_ fieldName])
+                   (constr innerMost)
+                   never_
+               in (constr, (field, fieldName))
+             else never)
+            identity
+            mappingFields
+          in match mappedFields with (constr, mappedFields) then
+            constr
+              (foldl
+                (lam acc. lam update.
+                  recordupdate_ acc update.0 (nvar_ update.1))
+                (nvar_ valName)
+                mappedFields)
+          else never
+        )
+    }
+
+let tupleType
+  : [CarriedType]
+  -> CarriedType
+  = lam fields. recordType (mapi (lam i. lam field. (int2string i, field)) fields)
+
+mexpr
+
+let tyInfo = bareType (tyvar_ "Info") in
+let tyString = bareType tystr_ in
+let tyExpr = bareType (tyvar_ "Expr") in
+let tyField = tupleType [tyString, tyExpr] in
+let tyFields = seqType tyField in
+let tyRecord = recordType
+  [ ("info", tyInfo)
+  , ("fields", tyFields)
+  ] in
+let recordConstructor =
+  { name = nameSym "TmRecord"
+  , synType = "Expr"
+  , carried = tyRecord
+  } in
+
+for_ (_mkSfuncStubs "Expr" (tyvar_ "Info"))
+  (lam semFunc. printLn (_pprintSemanticFunction semFunc));
+
+(match _mkSmapAccumL "Expr" (tyvar_ "Info") recordConstructor with Some semFunc then
+  printLn (_pprintSemanticFunction semFunc)
+else never);
+
+()
+
+-- match
+--   let fields = x.fields in
+--   mapAccumL
+--     (lam acc. lam x2.
+--          match
+--            let #var"1" = x2.1 in
+--            f acc1 #var"1"
+--          with
+--            {#label"1" = #var"1", #label"0" = acc1}
+--          then
+--            { x2
+--              with
+--              #label"1" =
+--                #var"1" }
+--          else
+--            never)
+--     acc
+--     fields
+-- with {#label"1" = fields, #label"0" = acc} then
+--   { x
+--     with
+--     fields =
+--       fields }
+-- else
+--   never

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -364,30 +364,8 @@ let input =
 
 -- printLn (mkLanguages input);
 
-()
+-- TODO(vipa, 2021-03-05): The tests here need to parse and evaluate
+-- MLang, so I'm holding off on doing it in an automated fashion until
+-- `boot-parser.mc` handles that
 
--- match
---   let fields = x.fields in
---   mapAccumL
---     (lam acc. lam x2.
---          match
---            let #var"1" = x2.1 in
---            f acc1 #var"1"
---          with
---            {#label"1" = #var"1", #label"0" = acc1}
---          then
---            { x2
---              with
---              #label"1" =
---                #var"1" }
---          else
---            never)
---     acc
---     fields
--- with {#label"1" = fields, #label"0" = acc} then
---   { x
---     with
---     fields =
---       fields }
--- else
---   never
+()


### PR DESCRIPTION
This PR introduces a library to automatically generate AST language fragments with shallow mapping functions. It also makes one fix in the `boot` parser, and makes `pprint.mc` use syntactic sugar for tuple patterns and record projection.

Here's the file documentation, copied from the beginning of the file:

-----------------------

This library assists in automatically generating MLang fragments for arbitrary AST nodes, while also generating shallow mapping functions (see the [recursion cookbook](https://github.com/miking-lang/miking/wiki/Recursion-Cookbook)).

Input is a list of constructors and a list of shallow mappings to generate. Each constructor gets a name, a syn type, and a carried
type. The carried type, represented by `CarriedType`, is the type of the value the constructor is applied to. A `CarriedType` knows what type it is representing (in the form of a `Type` value) and how to build `smapAccumL` given a targeted type. It's built using a few helper functions: `targetableType`, `untargetableType`, `seqType`, `recordType`, and `tupleType`. `targetableType` and `untargetableType` are intended to be atomic from the generator's point of view, the former can be targeted by a shallow mapping while the latter cannot. The others represent composite types that know how to traverse themselves.

`untargetableType` is intended to be used for things that the AST node doesn't "contain", but are rather information about it, e.g., info fields and type annotations, as opposed to sub-expressions or the type of the lambda parameter.

-- NOTE(vipa, 2021-03-05): It is my hypothesis that we don't want a `smap_Expr_Type` to map over the `ty` field, hence this library supports untargetable types, but it remains to be seen if this is the case. Default to `targetableType`, use `untargetableType` if you have a good reason to suspect that most traversals won't want to include the given field.

For example, we can declare something like `TmRecord` like this:

```
let recordConstructor =
  { name = nameSym "TmRecord"
  , synType = stringToSynType "Expr"
  , carried = recordType
    [ ("info", targetableType (tyvar_ "Info"))
    , ("ty", untargetableType (tyvar_ "Type"))
    , ( "bindings"
      , seqType
        (tupleType
          [ targetableType tystr_
          , targetableType (tyvar_ "Expr")])
      )
    ]
  }
```

We can then generate some language fragments:

```
use CarriedBasic in mkLanguages
  { namePrefix = "MExpr"
  , constructors = [recordConstructor]
  , requestedSFunctions =
    [ (stringToSynType "Expr", tyvar_ "Expr")
    ]
  }

-- This is what's generated:

lang MExprBase
  syn Expr =

  sem smapAccumL_Expr_Expr (f : (a) -> ((Expr) -> ((a, Expr)))) (acc : a) =
  | x ->
    (acc, x)

  sem smap_Expr_Expr (f : (Expr) -> (Expr)) =
  | x ->
    (smapAccumL_Expr_Expr
       (lam #var"".
          lam x.
            ({}, f
              x))
       {}
       x).#label"1"

  sem sfold_Expr_Expr (f : (a) -> ((Expr) -> (a))) (acc : a) =
  | x ->
    (smapAccumL_Expr_Expr
       (lam acc.
          lam x.
            (f
              acc
              x, x))
       acc
       x).#label"0"

end

lang MExprTmRecord = MExprBase
  syn Expr =
  | TmRecord {bindings: [([Char], Expr)], ty: Type, info: Info}

  sem smapAccumL_Expr_Expr (f : (a) -> ((Expr) -> ((a, Expr)))) (acc : a) =
  | TmRecord x ->
    match
      match
        let bindings =
          x.bindings
        in
        mapAccumL
          (lam acc1.
             lam x1.
               match
                 let #var"1" =
                   x1.#label"1"
                 in
                 f
                   acc1
                   #var"1"
               with
                 (acc1, #var"1")
               then
                 (acc1, { x1
                   with
                   #label"1" =
                     #var"1" })
               else
                 never)
          acc
          bindings
      with
        (acc, bindings)
      then
        (acc, { x
          with
          bindings =
            bindings })
      else
        never
    with
      (acc, x)
    then
      (acc, TmRecord
        x)
    else
      never

end

```
