### PR TITLE
Implement tensors in the interpreter

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -135,7 +135,6 @@ and const =
   | CmapMapWithKey of (tm -> tm -> tm) option
   | CmapBindings
   (* MCore intrinsics: Tensors *)
-  | CTensor of tm T.t
   | CtensorCreate of int array option
   | CtensorGetExn of tm T.t option
   | CtensorSetExn of tm T.t option * int array option
@@ -248,6 +247,8 @@ and tm =
   | TmFix of info
   (* Reference *)
   | TmRef of info * tm ref
+  (* Tensor *)
+  | TmTensor of info * tm T.t
 
 (* Kind of pattern name *)
 and patName =
@@ -368,6 +369,8 @@ let rec map_tm f = function
       f t
   | TmRef _ as t ->
       f t
+  | TmTensor _ as t ->
+      f t
 
 (* Returns the info field from a term *)
 let tm_info = function
@@ -389,7 +392,8 @@ let tm_info = function
   | TmUse (fi, _, _)
   | TmClos (fi, _, _, _, _)
   | TmFix fi
-  | TmRef (fi, _) ->
+  | TmRef (fi, _)
+  | TmTensor (fi, _) ->
       fi
 
 let pat_info = function

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -478,7 +478,7 @@ let rec desugar_tm nss env =
   | TmNever fi ->
       TmNever fi
   (* Non-recursive *)
-  | (TmConst _ | TmFix _ | TmRef (_, _)) as tm ->
+  | (TmConst _ | TmFix _ | TmRef _ | TmTensor _) as tm ->
       tm
 
 (* add namespace to nss (overwriting) if relevant, prepend a tm -> tm function to stack, return updated tuple. Should use desugar_tm, as well as desugar both sem and syn *)

--- a/src/boot/lib/tensor.mli
+++ b/src/boot/lib/tensor.mli
@@ -36,6 +36,8 @@ module Num : sig
   val iteri : (int -> ('a, 'b) t -> unit) -> ('a, 'b) t -> unit
 
   val of_array : ('a, 'b) kind -> 'a array -> ('a, 'b) t
+
+  val data_to_array : ('a, 'b) t -> 'a array
 end
 
 module NoNum : sig
@@ -60,4 +62,10 @@ module NoNum : sig
   val sub_exn : 'a t -> int -> int -> 'a t
 
   val iteri : (int -> 'a t -> unit) -> 'a t -> unit
+
+  val equal : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+
+  val of_array : 'a array -> 'a t
+
+  val data_to_array : 'a t -> 'a array
 end

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -692,3 +692,44 @@ let wallTimeMs_ = use MExprAst in
 
 let sleepMs_ = use MExprAst in
   lam n. appf1_ (const_ (CSleepMs ())) n
+
+-- Tensors
+let tensorCreate_ = use MExprAst in
+  lam s. lam f.
+  appf2_ (const_ (CTensorCreate ())) s f
+
+let tensorGetExn_ = use MExprAst in
+  lam t. lam is.
+  appf2_ (const_ (CTensorGetExn ())) t is
+
+let tensorSetExn_ = use MExprAst in
+  lam t. lam is. lam v.
+  appf3_ (const_ (CTensorSetExn ())) t is v
+
+let tensorRank_ = use MExprAst in
+  lam t.
+  appf1_ (const_ (CTensorRank ())) t
+
+let tensorShape_ = use MExprAst in
+  lam t.
+  appf1_ (const_ (CTensorShape ())) t
+
+let tensorReshapeExn_ = use MExprAst in
+  lam t. lam s.
+  appf2_ (const_ (CTensorReshapeExn ())) t s
+
+let tensorCopyExn_ = use MExprAst in
+  lam t1. lam t2.
+  appf2_ (const_ (CTensorCopyExn ())) t1 t2
+
+let tensorSliceExn_ = use MExprAst in
+  lam t. lam s.
+  appf2_ (const_ (CTensorSliceExn ())) t s
+
+let tensorSubExn_ = use MExprAst in
+  lam t. lam ofs. lam len.
+  appf3_ (const_ (CTensorSubExn ())) t ofs len
+
+let tensorIteri_ = use MExprAst in
+  lam f. lam t.
+  appf2_ (const_ (CTensorIteri ())) f t

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -386,6 +386,7 @@ lang RefAst
   | TmRef t -> acc
 end
 
+
 ---------------
 -- CONSTANTS --
 ---------------
@@ -513,6 +514,20 @@ lang FileOpAst = ConstAst
   | CFileWrite {}
   | CFileExists {}
   | CFileDelete {}
+end
+
+lang TensorOpAst
+  syn Const =
+  | CTensorCreate {}
+  | CTensorGetExn {}
+  | CTensorSetExn {}
+  | CTensorRank {}
+  | CTensorShape {}
+  | CTensorReshapeExn {}
+  | CTensorCopyExn {}
+  | CTensorSliceExn {}
+  | CTensorSubExn {}
+  | CTensorIteri {}
 end
 
 lang IOAst = ConstAst
@@ -805,7 +820,7 @@ lang MExprAst =
   CmpIntAst + IntCharConversionAst + CmpFloatAst + CharAst + CmpCharAst +
   SymbAst + CmpSymbAst + SeqOpAst + FileOpAst + IOAst +
   RandomNumberGeneratorAst + SysAst + FloatIntConversionAst +
-  FloatStringConversionAst + TimeAst + RefOpAst +
+  FloatStringConversionAst + TimeAst + RefOpAst + TensorOpAst +
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -4,9 +4,11 @@
 
 include "name.mc"
 include "bool.mc"
+include "tensor.mc"
 
 include "mexpr/ast.mc"
 include "mexpr/symbolize.mc"
+
 
 -----------------
 -- ENVIRONMENT --
@@ -344,6 +346,20 @@ lang SeqOpEq = SeqOpAst
   | CSplitAt {} -> match lhs with CSplitAt _ then true else false
 end
 
+lang TensorOpEq = TensorOpAst
+  sem eqConst (lhs : Const) =
+  | CTensorCreate {} -> match lhs with CTensorCreate _ then true else false
+  | CTensorGetExn {} -> match lhs with CTensorGetExn _ then true else false
+  | CTensorSetExn {} -> match lhs with CTensorSetExn _ then true else false
+  | CTensorRank {} -> match lhs with CTensorRank _ then true else false
+  | CTensorShape {} -> match lhs with CTensorShape _ then true else false
+  | CTensorReshapeExn {} -> match lhs with CTensorReshapeExn _ then true else false
+  | CTensorCopyExn {} -> match lhs with CTensorCopyExn _ then true else false
+  | CTensorSliceExn {} -> match lhs with CTensorSliceExn _ then true else false
+  | CTensorSubExn {} -> match lhs with CTensorSubExn _ then true else false
+  | CTensorIteri {} -> match lhs with CTensorIteri _ then true else false
+end
+
 --------------
 -- PATTERNS --
 --------------
@@ -608,7 +624,7 @@ lang MExprEq =
 
   -- Constants
   + IntEq + ArithEq + FloatEq + ArithFloatEq + BoolEq + CmpIntEq + CmpFloatEq +
-  CharEq + SymbEq + CmpSymbEq + SeqOpEq
+  CharEq + SymbEq + CmpSymbEq + SeqOpEq + TensorOpEq
 
   -- Patterns
   + NamedPatEq + SeqTotPatEq + SeqEdgePatEq + RecordPatEq + DataPatEq + IntPatEq +
@@ -1041,6 +1057,7 @@ let s2 = seq_ [lam2, lam1, v4] in
 let s3e = seq_ [lam1, v5e, v3] in
 utest s1 with s2 using eqExpr in
 utest eqExpr s1 s3e with false in
+utest eqExpr (seq_ [c1]) (seq_ [c2]) with false in
 
 -- Never
 utest never_ with never_ using eqExpr in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1722,24 +1722,24 @@ utest
 with tuple_ [int_ 4, float_ 3.14, int_ 4] in
 
 -- Tensors
-let testTensors = lam vs.
-  let t0 = eval (tensorCreate_ (seq_ []) (ulam_ "x" vs.0)) in
-  let t1 = eval (tensorCreate_ (seq_ [int_ 4]) (ulam_ "x" vs.0)) in
-  let t2 = eval (tensorCreate_ (seq_ [int_ 4]) (ulam_ "x" vs.1)) in
+let testTensors = lam v.
+  let t0 = eval (tensorCreate_ (seq_ []) (ulam_ "x" v.0)) in
+  let t1 = eval (tensorCreate_ (seq_ [int_ 4]) (ulam_ "x" v.0)) in
+  let t2 = eval (tensorCreate_ (seq_ [int_ 4]) (ulam_ "x" v.1)) in
 
   let evaln = evalNoSymbolize in
 
-  utest evaln (tensorGetExn_ t0 (seq_ [])) with vs.0 in
-  utest evaln (tensorGetExn_ t1 (seq_ [int_ 0])) with vs.0 in
-  utest evaln (tensorGetExn_ t1 (seq_ [int_ 1])) with vs.0 in
+  utest evaln (tensorGetExn_ t0 (seq_ [])) with v.0 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 0])) with v.0 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 1])) with v.0 in
 
-  utest evaln (tensorSetExn_ t0 (seq_ []) vs.1) with unit_ in
-  utest evaln (tensorSetExn_ t1 (seq_ [int_ 0]) vs.1) with unit_ in
-  utest evaln (tensorSetExn_ t1 (seq_ [int_ 1]) vs.2) with unit_ in
+  utest evaln (tensorSetExn_ t0 (seq_ []) v.1) with unit_ in
+  utest evaln (tensorSetExn_ t1 (seq_ [int_ 0]) v.1) with unit_ in
+  utest evaln (tensorSetExn_ t1 (seq_ [int_ 1]) v.2) with unit_ in
 
-  utest evaln (tensorGetExn_ t0 (seq_ [])) with vs.1 in
-  utest evaln (tensorGetExn_ t1 (seq_ [int_ 0])) with vs.1 in
-  utest evaln (tensorGetExn_ t1 (seq_ [int_ 1])) with vs.2 in
+  utest evaln (tensorGetExn_ t0 (seq_ [])) with v.1 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 0])) with v.1 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 1])) with v.2 in
 
   utest evaln (tensorRank_ t0) with int_ 0 in
   utest evaln (tensorRank_ t1) with int_ 1 in
@@ -1767,10 +1767,10 @@ let testTensors = lam vs.
   utest evaln (tensorShape_ (tensorSubExn_ t1 (int_ 0) (int_ 2)))
   with seq_ [int_ 2] in
 
-  let t3 = eval (tensorCreate_ (seq_ [int_ 3]) (ulam_ "x" vs.0)) in
+  let t3 = eval (tensorCreate_ (seq_ [int_ 3]) (ulam_ "x" v.0)) in
   let f = eval (ulam_ "i"
                   (ulam_ "x"
-                     unit_))
+                     (tensorCopyExn_ (var_ "x") (var_ "x"))))
   in
   utest evaln (tensorIteri_ f t3) with unit_ in
   ()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -844,14 +844,14 @@ lang TensorOpEval = TensorOpAst + SeqAst + IntAst + FloatAst + TensorEval + Cons
   | CTensorReshapeExn2 t ->
     let is = _ofTmSeq arg in
     match t with TInt t then
-      let tnew = tensorReshapeExn t is in
-      TmTensor { val = TInt tnew }
+      let view = tensorReshapeExn t is in
+      TmTensor { val = TInt view }
     else match t with TFloat t then
-      let tnew = tensorReshapeExn t is in
-      TmTensor { val = TFloat tnew }
+      let view = tensorReshapeExn t is in
+      TmTensor { val = TFloat view }
     else match t with TExpr t then
-      let tnew = tensorReshapeExn t is in
-      TmTensor { val = TExpr tnew }
+      let view = tensorReshapeExn t is in
+      TmTensor { val = TExpr view }
     else never
   | CTensorCopyExn _ ->
     match arg with TmTensor { val = t } then
@@ -879,14 +879,14 @@ lang TensorOpEval = TensorOpAst + SeqAst + IntAst + FloatAst + TensorEval + Cons
   | CTensorSliceExn2 t ->
     let is = _ofTmSeq arg in
     match t with TInt t then
-      let tnew = tensorSliceExn t is in
-      TmTensor { val = TInt tnew }
+      let view = tensorSliceExn t is in
+      TmTensor { val = TInt view }
     else match t with TFloat t then
-      let tnew = tensorSliceExn t is in
-      TmTensor { val = TFloat tnew }
+      let view = tensorSliceExn t is in
+      TmTensor { val = TFloat view }
     else match t with TExpr t then
-      let tnew = tensorSliceExn t is in
-      TmTensor { val = TExpr tnew }
+      let view = tensorSliceExn t is in
+      TmTensor { val = TExpr view }
     else never
   | CTensorSubExn _ ->
     match arg with TmTensor { val = t } then
@@ -901,14 +901,14 @@ lang TensorOpEval = TensorOpAst + SeqAst + IntAst + FloatAst + TensorEval + Cons
   | CTensorSubExn3 (t, ofs) ->
     match arg with TmConst { val = CInt { val = len }} then
       match t with TInt t then
-        let tnew = tensorSubExn t ofs len in
-        TmTensor { val = TInt tnew }
+        let view = tensorSubExn t ofs len in
+        TmTensor { val = TInt view }
       else match t with TFloat t then
-        let tnew = tensorSubExn t ofs len in
-        TmTensor { val = TFloat tnew }
+        let view = tensorSubExn t ofs len in
+        TmTensor { val = TFloat view }
       else match t with TExpr t then
-        let tnew = tensorSubExn t ofs len in
-        TmTensor { val = TExpr tnew }
+        let view = tensorSubExn t ofs len in
+        TmTensor { val = TExpr view }
       else never
     else error "Second argument to CTensorSubExn not an integer"
   | CTensorIteri _ ->

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -138,7 +138,7 @@ end
 
 lang RecLetsEval =
   RecLetsAst + VarEval + FixAst + FixEval + RecordEval + LetEval +
-  UnknownTypeAst 
+  UnknownTypeAst
 
   sem eval (ctx : {env : Env}) =
   | TmRecLets t ->
@@ -245,6 +245,19 @@ end
 lang RefEval = RefAst
   sem eval (ctx : {env : Env}) =
   | TmRef r -> TmRef r
+end
+
+type T
+con TInt : Tensor Int -> T
+con TFloat : Tensor Float -> T
+con TExpr : Tensor Expr -> T
+
+lang TensorEval
+  syn Expr =
+  | TmTensor { val : T }
+
+  sem eval (ctx : {env : Env}) =
+  | TmTensor t -> TmTensor t
 end
 
 ---------------
@@ -683,6 +696,226 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     TmSeq {tms = create n f, ty = TyUnknown {}, info = NoInfo()}
 end
 
+lang TensorOpEval = TensorOpAst + SeqAst + IntAst + FloatAst + TensorEval + ConstEval
+  syn Const =
+  | CTensorCreate2 [Int]
+  | CTensorGetExn2 T
+  | CTensorSetExn2 T
+  | CTensorSetExn3 (T, [Int])
+  | CTensorReshapeExn2 T
+  | CTensorCopyExn2 T
+  | CTensorSliceExn2 T
+  | CTensorSubExn2 T
+  | CTensorSubExn3 (T, Int)
+  | CTensorIteri2 Expr
+
+  sem _ofTmSeq =
+  | TmSeq { tms = tms } ->
+    map (lam tm. match tm with TmConst { val = CInt { val = n }} then n
+                 else error "Not an integer sequence")
+        tms
+  | tm -> dprint tm; error "Not an integer sequence"
+
+  sem _toTmSeq =
+  | is ->
+    let tms = map (lam i. int_ i) is in
+    seq_ tms
+
+  sem apply (ctx : {env : Env}) (arg : Expr) =
+  | TmConst { val = CTensorCreate2 shape } ->
+    let is0 = create (length shape) (lam. 0) in -- First index
+
+    -- Value when applying f to the first index. This determines the type of
+    -- the tensor.
+    let res0 = apply ctx (_toTmSeq is0) arg in
+
+    -- The structure of f is reusable for all types of tensors.
+    let mkf = lam resf. lam x0. lam is.
+      if eqSeq eqi is is0 then x0
+      else
+        let res = apply ctx (_toTmSeq is0) arg in
+        resf res
+    in
+
+    match res0 with TmConst { val = CInt { val = n0 } } then
+      let resf = lam res.
+          match res with TmConst { val = CInt { val = n } } then n
+          else error "Expected integer from f in CTensorCreate"
+      in
+      let f = mkf resf n0 in
+      TmTensor { val = TInt (tensorCreate shape f) }
+    else match res0 with TmConst { val = CFloat { val = r0 } } then
+      let resf = lam res.
+          match res with TmConst { val = CFloat { val = r } } then r
+          else error "Expected float from f in CTensorCreate"
+      in
+      let f = mkf resf r0 in
+      TmTensor { val = TFloat (tensorCreate shape f) }
+    else
+      let f = mkf (lam x. x) res0 in
+      TmTensor { val = TExpr (tensorCreate shape f) }
+  | TmConst { val = CTensorIteri2 f } ->
+    match arg with TmTensor { val = t } then
+
+      let mkg = lam mkt. lam i. lam r.
+        let res =
+          apply ctx (TmTensor { val = mkt r })  (apply ctx (int_ i) f)
+        in
+        ()
+      in
+
+      match t with TInt t then
+        let g = mkg (lam t. TInt t) in
+        tensorIteri g t;
+        unit_
+      else match t with TFloat t then
+        let g = mkg (lam t. TFloat t) in
+        tensorIteri g t;
+        unit_
+      else match t with TExpr t then
+        let g = mkg (lam t. TExpr t) in
+        tensorIteri g t;
+        unit_
+      else never
+    else error "Second argument to CTensorIteri not a tensor"
+
+  sem delta (arg : Expr) =
+  | CTensorCreate _ ->
+    let val = CTensorCreate2 (_ofTmSeq arg) in
+    const_ val
+  | CTensorGetExn _ ->
+    match arg with TmTensor { val = t } then
+      let val = CTensorGetExn2 t in
+      const_ val
+    else error "First argument to CTensorGetExn not a tensor"
+  | CTensorGetExn2 t ->
+    let is = _ofTmSeq arg in
+    match t with TInt t then
+      let val = tensorGetExn t is in
+      int_ val
+    else match t with TFloat t then
+      let val = tensorGetExn t is in
+      float_ val
+    else match t with TExpr t then
+      let val = tensorGetExn t is in
+      val
+    else never
+  | CTensorSetExn _ ->
+    match arg with TmTensor { val = t } then
+      let val = CTensorSetExn2 t in
+      const_ val
+    else error "First argument to CTensorSetExn not a tensor"
+  | CTensorSetExn2 t ->
+    let is = _ofTmSeq arg in
+    let val = CTensorSetExn3 (t, is) in
+    const_ val
+  | CTensorSetExn3 (t, is) ->
+    match (t, arg) with (TInt t, TmConst { val = CInt { val = v } }) then
+      tensorSetExn t is v;
+      unit_
+    else
+    match (t, arg) with (TFloat t, TmConst { val = CFloat { val = v } }) then
+      tensorSetExn t is v;
+      unit_
+    else
+    match (t, arg) with (TExpr t, v) then
+      tensorSetExn t is v;
+      unit_
+    else error "Tensor and value type does not match in CTensorSetExn"
+  | CTensorRank _ ->
+    match arg with TmTensor { val = t } then
+      match t with TInt t | TFloat t | TExpr t then
+        let val = tensorRank t in
+        int_ val
+      else never
+    else error "First argument to CTensorRank not a tensor"
+  | CTensorShape _ ->
+    match arg with TmTensor { val = t } then
+      match t with TInt t | TFloat t | TExpr t then
+        let shape = tensorShape t in
+        _toTmSeq shape
+      else never
+    else error "First argument to CTensorRank not a tensor"
+  | CTensorReshapeExn _ ->
+    match arg with TmTensor { val = t } then
+      let val = CTensorReshapeExn2 t in
+      const_ val
+    else error "First argument to CTensorReshapeExn not a tensor"
+  | CTensorReshapeExn2 t ->
+    let is = _ofTmSeq arg in
+    match t with TInt t then
+      let tnew = tensorReshapeExn t is in
+      TmTensor { val = TInt tnew }
+    else match t with TFloat t then
+      let tnew = tensorReshapeExn t is in
+      TmTensor { val = TFloat tnew }
+    else match t with TExpr t then
+      let tnew = tensorReshapeExn t is in
+      TmTensor { val = TExpr tnew }
+    else never
+  | CTensorCopyExn _ ->
+    match arg with TmTensor { val = t } then
+      let val = CTensorCopyExn2 t in
+      const_ val
+    else error "First argument to CTensorCopyExn not a tensor"
+  | CTensorCopyExn2 t1 ->
+    match arg with TmTensor { val = t2 } then
+      match (t1, t2) with (TInt t1, TInt t2) then
+        tensorCopyExn t1 t2;
+        unit_
+      else match (t1, t2) with (TFloat t1, TFloat t2) then
+        tensorCopyExn t1 t2;
+        unit_
+      else match (t1, t2) with (TExpr t1, TExpr t2) then
+        tensorCopyExn t1 t2;
+        unit_
+      else error "Tensor type mismatch in CTensorCopyExn"
+    else error "First argument to CTensorCopyExn not a tensor"
+  | CTensorSliceExn _ ->
+    match arg with TmTensor { val = t } then
+      let val = CTensorSliceExn2 t in
+      const_ val
+    else error "First argument to CTensorSliceExn not a tensor"
+  | CTensorSliceExn2 t ->
+    let is = _ofTmSeq arg in
+    match t with TInt t then
+      let tnew = tensorSliceExn t is in
+      TmTensor { val = TInt tnew }
+    else match t with TFloat t then
+      let tnew = tensorSliceExn t is in
+      TmTensor { val = TFloat tnew }
+    else match t with TExpr t then
+      let tnew = tensorSliceExn t is in
+      TmTensor { val = TExpr tnew }
+    else never
+  | CTensorSubExn _ ->
+    match arg with TmTensor { val = t } then
+      let val = CTensorSubExn2 t in
+      const_ val
+    else error "First argument to CTensorSubExn not a tensor"
+  | CTensorSubExn2 t ->
+    match arg with TmConst { val = CInt { val = ofs }} then
+      let val = CTensorSubExn3 (t, ofs) in
+      const_ val
+    else error "Second argument to CTensorSubExn not an integer"
+  | CTensorSubExn3 (t, ofs) ->
+    match arg with TmConst { val = CInt { val = len }} then
+      match t with TInt t then
+        let tnew = tensorSubExn t ofs len in
+        TmTensor { val = TInt tnew }
+      else match t with TFloat t then
+        let tnew = tensorSubExn t ofs len in
+        TmTensor { val = TFloat tnew }
+      else match t with TExpr t then
+        let tnew = tensorSubExn t ofs len in
+        TmTensor { val = TExpr tnew }
+      else never
+    else error "Second argument to CTensorSubExn not an integer"
+  | CTensorIteri _ ->
+    let val = CTensorIteri2 arg in
+    const_ val
+end
+
 lang FloatStringConversionEval = FloatStringConversionAst
   sem delta (arg : Expr) =
   | CString2float _ ->
@@ -807,7 +1040,6 @@ lang RefOpEval = RefOpAst + IntAst
       deref r
     else error "not a deref of a reference"
 end
-
 
 --------------
 -- PATTERNS --
@@ -943,7 +1175,8 @@ lang MExprEval =
   + ArithIntEval + ShiftIntEval + ArithFloatEval + CmpIntEval + CmpFloatEval +
   SymbEval + CmpSymbEval + SeqOpEval + FileOpEval + IOEval + SysEval +
   RandomNumberGeneratorEval + FloatIntConversionEval + CmpCharEval +
-  IntCharConversionEval + FloatStringConversionEval + TimeEval + RefOpEval
+  IntCharConversionEval + FloatStringConversionEval + TimeEval + RefOpEval +
+  TensorOpEval
 
   -- Patterns
   + NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +
@@ -963,8 +1196,11 @@ mexpr
 use MExprEval in
 
 -- Evaluation shorthand used in tests below
+let evalNoSymbolize =
+  lam t. eval {env = assocEmpty} t in
+
 let eval =
-  lam t. eval {env = assocEmpty} (symbolize t) in
+  lam t. evalNoSymbolize (symbolize t) in
 
 let id = ulam_ "x" (var_ "x") in
 let bump = ulam_ "x" (addi_ (var_ "x") (int_ 1)) in
@@ -1484,5 +1720,77 @@ utest
      ulet_ "_" (modref_ (var_ "r3") (int_ 4)),
      tuple_ [deref_ (var_ "r1"), deref_ (var_ "r2"), deref_ (var_ "r3")]]))
 with tuple_ [int_ 4, float_ 3.14, int_ 4] in
+
+-- Tensors
+let testTensors = lam vs.
+  let t0 = eval (tensorCreate_ (seq_ []) (ulam_ "x" vs.0)) in
+  let t1 = eval (tensorCreate_ (seq_ [int_ 4]) (ulam_ "x" vs.0)) in
+  let t2 = eval (tensorCreate_ (seq_ [int_ 4]) (ulam_ "x" vs.1)) in
+
+  let evaln = evalNoSymbolize in
+
+  utest evaln (tensorGetExn_ t0 (seq_ [])) with vs.0 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 0])) with vs.0 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 1])) with vs.0 in
+
+  utest evaln (tensorSetExn_ t0 (seq_ []) vs.1) with unit_ in
+  utest evaln (tensorSetExn_ t1 (seq_ [int_ 0]) vs.1) with unit_ in
+  utest evaln (tensorSetExn_ t1 (seq_ [int_ 1]) vs.2) with unit_ in
+
+  utest evaln (tensorGetExn_ t0 (seq_ [])) with vs.1 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 0])) with vs.1 in
+  utest evaln (tensorGetExn_ t1 (seq_ [int_ 1])) with vs.2 in
+
+  utest evaln (tensorRank_ t0) with int_ 0 in
+  utest evaln (tensorRank_ t1) with int_ 1 in
+
+  utest evaln (tensorShape_ t0) with seq_ [] in
+  utest evaln (tensorShape_ t1) with seq_ [int_ 4] in
+
+  utest evaln (tensorShape_ (tensorReshapeExn_ t0 (seq_ [int_ 1])))
+  with seq_ [int_ 1] in
+
+  utest evaln (tensorShape_ (tensorReshapeExn_ t1 (seq_ [int_ 2, int_ 2])))
+  with seq_ [int_ 2, int_ 2] in
+
+  utest evaln (tensorCopyExn_ t1 t2) with unit_ in
+
+  utest evaln (tensorRank_ (tensorSliceExn_ t1 (seq_ [int_ 0])))
+  with int_ 0 in
+
+  utest evaln (tensorShape_ (tensorSliceExn_ t1 (seq_ [int_ 0])))
+  with seq_ [] in
+
+  utest evaln (tensorRank_ (tensorSubExn_ t1 (int_ 0) (int_ 2)))
+  with int_ 1 in
+
+  utest evaln (tensorShape_ (tensorSubExn_ t1 (int_ 0) (int_ 2)))
+  with seq_ [int_ 2] in
+
+  let t3 = eval (tensorCreate_ (seq_ [int_ 3]) (ulam_ "x" vs.0)) in
+  let f = eval (ulam_ "i"
+                  (ulam_ "x"
+                     unit_))
+  in
+  utest evaln (tensorIteri_ f t3) with unit_ in
+  ()
+in
+
+let t3 = eval (tensorCreate_ (seq_ [int_ 3]) (ulam_ "x" (int_ 0))) in
+let f = eval (ulam_ "i"
+                (ulam_ "x"
+                   (tensorSetExn_ (var_ "x") (seq_ []) (var_ "i"))))
+in
+
+let evaln = evalNoSymbolize in
+
+utest evaln (tensorIteri_ f t3) with unit_ in
+utest evaln (tensorGetExn_ t3 (seq_ [int_ 0])) with int_ 0 in
+utest evaln (tensorGetExn_ t3 (seq_ [int_ 1])) with int_ 1 in
+utest evaln (tensorGetExn_ t3 (seq_ [int_ 2])) with int_ 2 in
+
+testTensors (int_ 0, int_ 1, int_ 2);
+testTensors (float_ 0., float_ 1., float_ 2.);
+testTensors (seq_ [int_ 0], seq_ [int_ 1], seq_ [int_ 2]);
 
 ()

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -615,6 +615,20 @@ lang RefOpPrettyPrint = RefOpAst + ConstPrettyPrint
   | CDeRef _ -> "deref"
 end
 
+lang TensorOpPrettyPrint = TensorOpAst + ConstPrettyPrint
+  sem getConstStringCode (indent : Int) =
+  | CTensorCreate _ -> "tensorCreate"
+  | CTensorGetExn _ -> "tensorGetExn"
+  | CTensorSetExn _ -> "tensorSetExn"
+  | CTensorRank _ -> "tensorRank"
+  | CTensorShape _ -> "tensorShape"
+  | CTensorReshapeExn _ -> "tensorReshapeExn"
+  | CTensorCopyExn _ -> "tensorCopyExn"
+  | CTensorSliceExn _ -> "tensorSliceExn"
+  | CTensorSubExn _ -> "tensorSubExn"
+  | CTensorIteri _ -> "tensorIteri"
+end
+
 --------------
 -- PATTERNS --
 --------------
@@ -884,7 +898,7 @@ lang MExprPrettyPrint =
   IntPrettyPrint + ArithIntPrettyPrint + FloatPrettyPrint +
   ArithFloatPrettyPrint + BoolPrettyPrint + CmpIntPrettyPrint +
   CmpFloatPrettyPrint + CharPrettyPrint + SymbPrettyPrint + CmpSymbPrettyPrint
-  + SeqOpPrettyPrint + RefOpPrettyPrint +
+  + SeqOpPrettyPrint + RefOpPrettyPrint + TensorOpPrettyPrint +
 
   -- Patterns
   NamedPatPrettyPrint + SeqTotPatPrettyPrint + SeqEdgePatPrettyPrint +

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -3,11 +3,100 @@
 --
 -- Defines auxiliary functions for the tensor intrinsics.
 
+include "option.mc"
 include "seq.mc"
 
 type Tensor a
 
--- Construct a rank 1 tensor from a non-empty sequence.
+let _prod = foldl muli 1
+
+let _rowMajorOfsToIndex = lam shape. lam k.
+  let f = lam kis. lam d.
+    let k = kis.0 in
+    let is = kis.1 in
+    (divi k d, cons (modi k d) is)
+  in
+  (foldl f (k, []) shape).1
+
+-- Folds `f` over the range `start` `stop` using accumulator `acc`
+let indexFoldu : (a -> Int -> a) -> a -> Int -> Int -> a =
+lam f. lam acc. lam start. lam stop.
+  recursive let work = lam acc. lam i.
+    if lti i stop then work (f acc i) (addi i 1) else acc
+  in
+  work acc start
+
+utest indexFoldu (lam seq. lam i. snoc seq i) [] 0 4 with [0, 1, 2, 3]
+utest indexFoldu (lam seq. lam i. snoc seq i) [] 0 0 with []
+utest indexFoldu (lam seq. lam i. snoc seq i) [] 1 4 with [1, 2, 3]
+utest indexFoldu (lam seq. lam i. snoc seq i) [] 2 1 with []
+
+
+-- Folds `f` over the indexes up to `shape` in row-major order and accumulator
+-- `acc`
+let indexFoldRM : (a -> [Int] -> a) -> a -> [Int] -> a =
+lam f. lam acc. lam shape.
+  let size = _prod shape in
+  recursive let work = lam acc. lam k.
+    if lti k size then
+      let is = _rowMajorOfsToIndex shape k in
+      work (f acc is) (addi k 1)
+    else acc
+  in
+  work acc 0
+
+utest indexFoldRM (lam seq. lam is. snoc seq is) [] []
+with [[]]
+
+utest indexFoldRM (lam seq. lam is. snoc seq is) [] [2, 2]
+with [[0, 0], [0, 1], [1, 0], [1, 1]]
+
+
+-- Folds `f` over the indexes of `shape` in row-major order with accumulator
+-- `acc`. If `f acc is` is `None ()` then the result is `None ()`.
+let optionIndexFoldRMM : (a -> [Int] -> Option a) -> a -> [Int] -> Option a =
+lam f. lam acc. lam shape.
+  let size = _prod shape in
+  recursive let work = lam acc. lam k.
+    if lti k size then
+      let is = _rowMajorOfsToIndex shape k in
+      let res =  f acc is in
+      match res with Some acc then
+        work acc (addi k 1)
+      else match res with None _ then
+        None ()
+      else never
+    else Some acc
+  in
+  work acc 0
+
+utest optionFoldlM (lam acc. lam x. if lti x 4 then Some x else None ())
+        0 [1,2,2,4]
+with None ()
+
+utest optionIndexFoldRMM
+  (lam seq. lam is.
+     if lti (length seq) 5 then Some (snoc seq is) else None ())
+  []
+  []
+with Some [[]]
+
+utest optionIndexFoldRMM
+  (lam seq. lam is.
+     if lti (length seq) 5 then Some (snoc seq is) else None ())
+  []
+  [2, 2]
+with Some [[0, 0], [0, 1], [1, 0], [1, 1]]
+
+utest optionIndexFoldRMM
+  (lam seq. lam is.
+     if lti (length seq) 3 then Some (snoc seq is) else None ())
+  []
+  [2, 2]
+with None ()
+
+
+-- Construct a rank 1 tensor from a non-empty sequence `seq`.
 let tensorOfSeqOrElse : (Unit -> Tensor a) -> [a] -> Tensor a =
 lam f. lam seq.
   let n = length seq in
@@ -15,7 +104,11 @@ lam f. lam seq.
   else
     tensorCreate [n] (lam is. get seq (get is 0))
 
--- Construct a sequence from a rank 1 tensor.
+let tensorOfSeqExn : [a] -> Tensor a =
+  tensorOfSeqOrElse (lam. error "Empty seq in tensorOfSeqExn")
+
+
+-- Construct a sequence from a rank 1 tensor `t`.
 let tensorToSeqOrElse : (Unit -> [a]) -> Tensor a -> [a] =
 lam f. lam t.
   if neqi (tensorRank t) 1 then f ()
@@ -25,25 +118,33 @@ lam f. lam t.
                then Some (tensorGetExn t [i], addi i 1) else None ())
             0
 
-let tensorOfSeqExn : [a] -> Tensor a =
-  tensorOfSeqOrElse (lam. error "Empty seq in tensorOfSeqExn")
-
 let tensorToSeqExn : Tensor a -> [a] =
   tensorToSeqOrElse (lam. error "Not rank 1 tensor in tensorToSeqExn")
 
 utest tensorToSeqExn (tensorOfSeqExn [1, 2, 3, 4]) with [1, 2, 3, 4]
 
 
--- The number of elements in a tensor.
+-- Create a tensor filled with values `v`.
+let tensorRepeat : [Int] -> a -> Tensor a =
+lam shape. lam v.
+  tensorCreate shape (lam. v)
+
+utest
+  let t = tensorRepeat [4] 0 in
+  tensorToSeqExn t
+with [0, 0, 0, 0]
+
+
+-- The number of elements in a tensor `t`.
 let tensorSize : Tensor a -> Int =
-lam t.
-  foldl muli 1 (tensorShape t)
+lam t. _prod (tensorShape t)
 
 utest tensorSize (tensorCreate [1, 2, 3] (lam. 0)) with 6
 utest tensorSize (tensorCreate [] (lam. 0)) with 1
 
--- Map the elements of t1 to the elements of t2 using the function f, where t1
--- and t2 has to have the same shape.
+
+-- Map the elements of `t1` to the elements of `t2` using the function `f`,
+-- where `t1` and `t2` has to have the same shape.
 let tensorMapOrElse : (Unit -> Unit) -> (a -> b) -> Tensor a -> Tensor b -> Unit =
 lam f. lam g. lam t1. lam t2.
   if eqSeq eqi (tensorShape t1) (tensorShape t2) then
@@ -70,8 +171,14 @@ utest
   tensorToSeqExn t
 with [2, 3, 4, 5]
 
+utest
+  let t = tensorRepeat [] 0 in
+  tensorMapExn (addi 1) t t;
+  tensorGetExn t []
+with 1
 
--- Fill a tensor with values.
+
+-- Fill a tensor `t` with values `v`.
 let tensorFill : Tensor a -> a -> Unit =
 lam t. lam v. tensorMapExn (lam. v) t t
 
@@ -82,15 +189,55 @@ utest
 with [0, 0, 0, 0]
 
 
--- Create a tensor filled with values.
-let tensorRepeat : [Int] -> a -> Tensor a =
-lam shape. lam v.
-  tensorCreate shape (lam. v)
+-- Element-wise equality of tensor `t1` and `t2` using `eq`
+let eqTensor : (a -> b -> Bool) -> Tensor a -> Tensor b -> Bool =
+lam eq. lam t1. lam t2.
+  if eqSeq eqi (tensorShape t1) (tensorShape t2) then
+    let n = tensorSize t1 in
+    let v1 = tensorReshapeExn t1 [n] in
+    let v2 = tensorReshapeExn t2 [n] in
+
+    recursive let work = lam i.
+      if lti i n then
+        if eq (tensorGetExn v1 [i]) (tensorGetExn v2 [i]) then
+          work (addi i 1)
+        else false
+      else true
+    in
+
+    work 0
+
+  else false
 
 utest
-  let t = tensorRepeat [4] 0 in
-  tensorToSeqExn t
-with [0, 0, 0, 0]
+  let t1 = tensorRepeat [] 0 in
+  let t2 = tensorRepeat [1] 0 in
+  eqTensor eqi t1 t2
+with false
+
+utest
+  let t1 = tensorRepeat [2, 3] 0 in
+  let t2 = tensorRepeat [3, 2] 0 in
+  eqTensor eqi t1 t2
+with false
+
+utest
+  let t1 = tensorRepeat [2, 3] 0 in
+  let t2 = tensorRepeat [2, 3] 0 in
+  eqTensor eqi t1 t2
+with true
+
+utest
+  let t1 = tensorRepeat [2, 3] [0] in
+  let t2 = tensorRepeat [2, 3] 0 in
+  eqTensor (lam x. lam y. eqi (head x) y) t1 t2
+with true
+
+utest
+  let t1 = tensorOfSeqExn [1, 2] in
+  let t2 = tensorOfSeqExn [1, 3] in
+  eqTensor eqi t1 t2
+with false
 
 mexpr
 

--- a/test/mexpr/tensor.mc
+++ b/test/mexpr/tensor.mc
@@ -74,6 +74,10 @@ let testTensors = lam fromInt. lam v.
   utest tensorGetExn t1 [10] with v.11 in
   utest tensorGetExn t1 [11] with v.12 in
 
+  let t = tensorRepeat [] v.0 in
+  let t1 = tensorReshapeExn t [1] in
+  utest tensorShape t1 with [1] in
+
   -- Slice
   let t = tensorRepeat [] v.0 in
   let t1 = tensorSliceExn t [] in
@@ -367,11 +371,11 @@ let testTensors = lam fromInt. lam v.
 
   ()
 
-let v = ([0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12])
-let _void = testTensors (lam x. [x]) v
-
 let v = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
 let _void = testTensors (lam x. x) v
 
 let v = (0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.)
 let _void = testTensors int2float v
+
+let v = ([0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12])
+let _void = testTensors (lam x. [x]) v


### PR DESCRIPTION
This PR contains
- Tensors changed from constants to evaluation terms.
- Slightly better pretty printing of tensors in boot
- Tensors implemented in the interpreter
- Some additional functions added in tensors.mc
- Some minor formatting edits in boot
- Equality of tensors in boot (i.e. they can be used in utests)