### PR TITLE
Updates to pretty printers

### DIFF
--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -532,9 +532,13 @@ and print_tm' fmt t =
         (print_ty_if_known ty) print_tm (Lam, t1)
   | TmLet (_, x, s, ty, t1, t2) ->
       let x = string_of_ustring (ustring_of_var x s) in
-      let ty = ty |> ustring_of_ty |> string_of_ustring in
-      fprintf fmt "@[<hov 0>@[<hov %d>let %s%s =@ %a in@]@ %a@]" !ref_indent x
-        (print_ty_if_known ty) print_tm (Match, t1) print_tm (Match, t2)
+      if x = "" then
+        fprintf fmt "@[<hov 0>@[<hov %d>%a;@]@ %a@]" !ref_indent print_tm
+          (Match, t1) print_tm (Match, t2)
+      else
+        let ty = ty |> ustring_of_ty |> string_of_ustring in
+        fprintf fmt "@[<hov 0>@[<hov %d>let %s%s =@ %a in@]@ %a@]" !ref_indent
+          x (print_ty_if_known ty) print_tm (Match, t1) print_tm (Match, t2)
   | TmType (_, x, s, ty, t1) ->
       let x = string_of_ustring (ustring_of_var x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -517,6 +517,9 @@ and print_tm fmt (prec, t) =
 
 (** Auxiliary print function *)
 and print_tm' fmt t =
+  let print_ty_if_known tystr =
+    if tystr = "Unknown" then "" else ":" ^ tystr
+  in
   match t with
   | TmVar (_, x, s) ->
       let print = string_of_ustring (ustring_of_var x s) in
@@ -525,13 +528,13 @@ and print_tm' fmt t =
   | TmLam (_, x, s, ty, t1) ->
       let x = string_of_ustring (ustring_of_var x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in
-      fprintf fmt "@[<hov %d>lam %s:%s.@ %a@]" !ref_indent x ty print_tm
-        (Lam, t1)
+      fprintf fmt "@[<hov %d>lam %s%s.@ %a@]" !ref_indent x
+        (print_ty_if_known ty) print_tm (Lam, t1)
   | TmLet (_, x, s, ty, t1, t2) ->
       let x = string_of_ustring (ustring_of_var x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in
-      fprintf fmt "@[<hov 0>@[<hov %d>let %s:%s =@ %a in@]@ %a@]" !ref_indent x
-        ty print_tm (Match, t1) print_tm (Match, t2)
+      fprintf fmt "@[<hov 0>@[<hov %d>let %s%s =@ %a in@]@ %a@]" !ref_indent x
+        (print_ty_if_known ty) print_tm (Match, t1) print_tm (Match, t2)
   | TmType (_, x, s, ty, t1) ->
       let x = string_of_ustring (ustring_of_var x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in
@@ -542,8 +545,8 @@ and print_tm' fmt t =
         let x = string_of_ustring (ustring_of_var x s) in
         let ty = ty |> ustring_of_ty |> string_of_ustring in
         fun fmt ->
-          fprintf fmt "@[<hov %d>let %s:%s =@ %a@]" !ref_indent x ty print_tm
-            (Match, t)
+          fprintf fmt "@[<hov %d>let %s%s =@ %a@]" !ref_indent x
+            (print_ty_if_known ty) print_tm (Match, t)
       in
       let inner = List.map print lst in
       fprintf fmt "@[<hov 0>@[<hov %d>recursive@ @[<hov 0>%a@] in@]@ %a@]"
@@ -582,7 +585,8 @@ and print_tm' fmt t =
   | TmConDef (_, x, s, ty, t) ->
       let str = string_of_ustring (ustring_of_var x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in
-      fprintf fmt "@[<hov 0>con %s:%s in@ %a@]" str ty print_tm (Match, t)
+      fprintf fmt "@[<hov 0>con %s%s in@ %a@]" str (print_ty_if_known ty)
+        print_tm (Match, t)
   | TmConApp (_, x, sym, t) ->
       let str = string_of_ustring (ustring_of_var x sym) in
       fprintf fmt "%s %a" str print_tm (Atom, t)

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -566,11 +566,11 @@ and print_tm' fmt t =
       fprintf fmt "@[<hov %d>lam %s%s.@ %a@]" !ref_indent x
         (print_ty_if_known ty) print_tm (Lam, t1)
   | TmLet (_, x, s, ty, t1, t2) ->
-      let x = string_of_ustring (ustring_of_var x s) in
-      if x = "" then
+      if Ustring.length x = 0 then
         fprintf fmt "@[<hov 0>@[<hov %d>%a;@]@ %a@]" !ref_indent print_tm
           (Match, t1) print_tm (Match, t2)
       else
+        let x = string_of_ustring (ustring_of_var x s) in
         let ty = ty |> ustring_of_ty |> string_of_ustring in
         fprintf fmt "@[<hov 0>@[<hov %d>let %s%s =@ %a in@]@ %a@]" !ref_indent
           x (print_ty_if_known ty) print_tm (Match, t1) print_tm (Match, t2)

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -37,18 +37,18 @@ let parser_str s prefix cond =
 (** Variable string parser translation *)
 let pprint_var_str s =
   parser_str s (us "#var") (fun s ->
-      is_lower_alpha (Ustring.get s 0) || Ustring.starts_with (us "_") s )
+      is_ascii_lower_alpha (Ustring.get s 0) || Ustring.starts_with (us "_") s )
 
 (** Constructor string parser translation *)
 let pprint_con_str s =
   parser_str s (us "#con") (fun s ->
       let c = Ustring.get s 0 in
-      is_upper_alpha c )
+      is_ascii_upper_alpha c )
 
 (** Label string parser translation *)
 let pprint_label_str s =
   parser_str s (us "#label") (fun s ->
-      is_lower_alpha (Ustring.get s 0) || Ustring.starts_with (us "_") s )
+      is_ascii_lower_alpha (Ustring.get s 0) || Ustring.starts_with (us "_") s )
 
 (** Create string representation of an identifier *)
 let ustring_of_ident symbol pprint_ident x s =
@@ -66,6 +66,10 @@ let ustring_of_var ?(symbol = !ref_symbol) x s =
 (** Create string representation of a constructor *)
 let ustring_of_con ?(symbol = !ref_symbol) x s =
   ustring_of_ident symbol pprint_con_str x s
+
+(** Create string representation of a type or type variable *)
+let ustring_of_type ?(symbol = !ref_symbol) x s =
+  ustring_of_ident symbol (fun x -> x) x s
 
 (** Create a string from a uchar, as it would appear in a string literal. *)
 let lit_of_uchar c =
@@ -184,7 +188,7 @@ let rec ustring_of_ty = function
   | TyVariant _ ->
       failwith "Printing of non-empty variant types not yet supported"
   | TyVar (_, x, s) ->
-      ustring_of_con x s
+      ustring_of_type x s
   | TyApp (_, ty1, ty2) ->
       us "(" ^. ustring_of_ty ty1 ^. us " " ^. ustring_of_ty ty2 ^. us ")"
 
@@ -575,7 +579,7 @@ and print_tm' fmt t =
         fprintf fmt "@[<hov 0>@[<hov %d>let %s%s =@ %a in@]@ %a@]" !ref_indent
           x (print_ty_if_known ty) print_tm (Match, t1) print_tm (Match, t2)
   | TmType (_, x, s, ty, t1) ->
-      let x = string_of_ustring (ustring_of_con x s) in
+      let x = string_of_ustring (ustring_of_type x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in
       fprintf fmt "@[<hov 0>@[<hov %d>type %s =@ %s in@]@ %a@]" !ref_indent x
         ty print_tm (Match, t1)

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -37,10 +37,16 @@ let ustring_of_var ?(symbol = !ref_symbol) x s =
 let lit_of_uchar c =
   let str =
     match string_of_ustring (Ustring.from_uchars [|c|]) with
-    (* TODO(dlunde,?): This is a temporary fix for newlines only. How do we do this
-       properly? *)
     | "\n" ->
         "\\n"
+    | "\t" ->
+        "\\t"
+    | "\\" ->
+        "\\\\"
+    | "\'" ->
+        "\\'"
+    | "\"" ->
+        "\\\""
     | str ->
         str
   in

--- a/src/boot/lib/ustring.ml
+++ b/src/boot/lib/ustring.ml
@@ -279,9 +279,9 @@ module Op = struct
 
   let uc c = int_of_char (if c = '\x0D' then '\x0A' else c)
 
-  let is_lower_alpha c = uc 'a' <= c && c <= uc 'z'
+  let is_ascii_lower_alpha c = uc 'a' <= c && c <= uc 'z'
 
-  let is_upper_alpha c = uc 'A' <= c && c <= uc 'Z'
+  let is_ascii_upper_alpha c = uc 'A' <= c && c <= uc 'Z'
 
   module OrderedUString = struct
     type t = ustring

--- a/src/boot/lib/ustring.ml
+++ b/src/boot/lib/ustring.ml
@@ -279,6 +279,10 @@ module Op = struct
 
   let uc c = int_of_char (if c = '\x0D' then '\x0A' else c)
 
+  let is_lower_alpha c = uc 'a' <= c && c <= uc 'z'
+
+  let is_upper_alpha c = uc 'A' <= c && c <= uc 'Z'
+
   module OrderedUString = struct
     type t = ustring
 

--- a/src/boot/lib/ustring.mli
+++ b/src/boot/lib/ustring.mli
@@ -160,13 +160,13 @@ module Op : sig
   val uc : char -> uchar
   (** Creates a uchar from a Latin-1 encoded char. *)
 
-  val is_lower_alpha : uchar -> bool
-  (** Returns ["true"] if the [uchar] represents a lower-case alphabetical
+  val is_ascii_lower_alpha : uchar -> bool
+  (** Returns ["true"] if the [uchar] represents a lower-case ascii alphabetical
       character, otherwise ["false"]. *)
 
-  val is_upper_alpha : uchar -> bool
-  (** Returns ["true"] if the [uchar] represents an upper-case alphabetical
-      character, otherwise ["false"]. *)
+  val is_ascii_upper_alpha : uchar -> bool
+  (** Returns ["true"] if the [uchar] represents an upper-case ascii
+      alphabetical character, otherwise ["false"]. *)
 
   val sid_of_ustring : ustring -> sid
   (** Returns a unique string identifier for the ustring. This identifier can

--- a/src/boot/lib/ustring.mli
+++ b/src/boot/lib/ustring.mli
@@ -160,6 +160,14 @@ module Op : sig
   val uc : char -> uchar
   (** Creates a uchar from a Latin-1 encoded char. *)
 
+  val is_lower_alpha : uchar -> bool
+  (** Returns ["true"] if the [uchar] represents a lower-case alphabetical
+      character, otherwise ["false"]. *)
+
+  val is_upper_alpha : uchar -> bool
+  (** Returns ["true"] if the [uchar] represents an upper-case alphabetical
+      character, otherwise ["false"]. *)
+
   val sid_of_ustring : ustring -> sid
   (** Returns a unique string identifier for the ustring. This identifier can
       only be checked for equality using the standard = operator and for

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -608,6 +608,11 @@ end
 
 lang CharPrettyPrint = CharAst + ConstPrettyPrint
   sem getConstStringCode (indent : Int) =
+  | CChar {val = '\n'} -> "\\n"
+  | CChar {val = '\t'} -> "\\t"
+  | CChar {val = '\\'} -> "\\\\"
+  | CChar {val = '\''} -> "\\'"
+  | CChar {val = '\"'} -> "\\\""
   | CChar c -> ['\'', c.val, '\'']
 end
 


### PR DESCRIPTION
* Boot and interpreter: escapes the characters `\t`, `\\`, `\'`, and `\"` (along with `\n` from before).
* Boot: escapes variables, constructors and labels with `#var`, `#con`, and `#label` when needed (as done in the interpreter).
* Boot: only print type annotations for `TmLet`, `TmLam`, `TmVar`, `TmRecLets`, and `TmConDef` when the type is not `Unknown` (as done in the interpreter).
* Boot: pretty print a let-expression with an empty variable name using sequence operator `;` (as done in the interpreter).

The motivation is that I'm using the boot pretty printer to compile from OCaml to MCore, so I need the output to be parsable. (The last point is not needed for parsability but it annoyed me.)