### PR TITLE
add type information

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -160,6 +160,7 @@ and const =
   | CbootParserParseMCoreFile
   | CbootParserGetId
   | CbootParserGetTerm of tm option
+  | CbootParserGetType of tm option
   | CbootParserGetString of tm option
   | CbootParserGetInt of tm option
   | CbootParserGetFloat of tm option

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -175,20 +175,20 @@ let getData = function
       (idTyChar, [fi], [], [], [], [], [], [], [], [])
   | PTreeTy (TyArrow (fi, ty1, ty2)) ->
       (idTyArrow, [fi], [], [ty1; ty2], [], [], [], [], [], [])
-  | PTreeTy (TySeq (fi,ty)) ->
+  | PTreeTy (TySeq (fi, ty)) ->
       (idTySeq, [fi], [], [ty], [], [], [], [], [], [])
   | PTreeTy (TyRecord (fi, tymap)) ->
       let slst, tylst = tymap |> Record.bindings |> List.split in
       let len = List.length slst in
       (idTyRecord, [fi], [len], tylst, [], slst, [], [], [], [])
   | PTreeTy (TyVariant (fi, lst)) ->
-      let strs = List.map (fun (x,_) -> x) lst in
+      let strs = List.map (fun (x, _) -> x) lst in
       let len = List.length lst in
       (idTyVariant, [fi], [len], [], [], strs, [], [], [], [])
   | PTreeTy (TyVar (fi, x, _)) ->
       (idTyVar, [fi], [], [], [], [x], [], [], [], [])
   | PTreeTy (TyApp (fi, ty1, ty2)) ->
-      (idTyApp, [fi], [], [ty1;ty2], [], [], [], [], [], [])
+      (idTyApp, [fi], [], [ty1; ty2], [], [], [], [], [], [])
   (* Const *)
   | PTreeConst (CBool v) ->
       let i = if v then 1 else 0 in

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -162,6 +162,33 @@ let getData = function
         (idTmUtest, [fi], [3], [], [t1; t2; t3], [], [], [], [], []) )
   | PTreeTm (TmNever fi) ->
       (idTmNever, [fi], [], [], [], [], [], [], [], [])
+  (* Types *)
+  | PTreeTy (TyUnknown fi) ->
+      (idTyUnknown, [fi], [], [], [], [], [], [], [], [])
+  | PTreeTy (TyBool fi) ->
+      (idTyBool, [fi], [], [], [], [], [], [], [], [])
+  | PTreeTy (TyInt fi) ->
+      (idTyInt, [fi], [], [], [], [], [], [], [], [])
+  | PTreeTy (TyFloat fi) ->
+      (idTyFloat, [fi], [], [], [], [], [], [], [], [])
+  | PTreeTy (TyChar fi) ->
+      (idTyChar, [fi], [], [], [], [], [], [], [], [])
+  | PTreeTy (TyArrow (fi, ty1, ty2)) ->
+      (idTyArrow, [fi], [], [ty1; ty2], [], [], [], [], [], [])
+  | PTreeTy (TySeq (fi,ty)) ->
+      (idTySeq, [fi], [], [ty], [], [], [], [], [], [])
+  | PTreeTy (TyRecord (fi, tymap)) ->
+      let slst, tylst = tymap |> Record.bindings |> List.split in
+      let len = List.length slst in
+      (idTyRecord, [fi], [len], tylst, [], slst, [], [], [], [])
+  | PTreeTy (TyVariant (fi, lst)) ->
+      let strs = List.map (fun (x,_) -> x) lst in
+      let len = List.length lst in
+      (idTyVariant, [fi], [len], [], [], strs, [], [], [], [])
+  | PTreeTy (TyVar (fi, x, _)) ->
+      (idTyVar, [fi], [], [], [], [x], [], [], [], [])
+  | PTreeTy (TyApp (fi, ty1, ty2)) ->
+      (idTyApp, [fi], [], [ty1;ty2], [], [], [], [], [], [])
   (* Const *)
   | PTreeConst (CBool v) ->
       let i = if v then 1 else 0 in
@@ -220,6 +247,10 @@ let getId t =
 let getTerm t n =
   let _, _, _, _, lst, _, _, _, _, _ = getData t in
   PTreeTm (List.nth lst n)
+
+let getType t n =
+  let _, _, _, lst, _, _, _, _, _, _ = getData t in
+  PTreeTy (List.nth lst n)
 
 let getString t n =
   let _, _, _, _, _, lst, _, _, _, _ = getData t in

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -144,6 +144,7 @@ let builtin =
   ; ("bootParserParseMCoreFile", f CbootParserParseMCoreFile)
   ; ("bootParserGetId", f CbootParserGetId)
   ; ("bootParserGetTerm", f (CbootParserGetTerm None))
+  ; ("bootParserGetType", f (CbootParserGetType None))
   ; ("bootParserGetString", f (CbootParserGetString None))
   ; ("bootParserGetInt", f (CbootParserGetInt None))
   ; ("bootParserGetFloat", f (CbootParserGetFloat None))
@@ -521,6 +522,10 @@ let arity = function
   | CbootParserGetTerm None ->
       2
   | CbootParserGetTerm (Some _) ->
+      1
+  | CbootParserGetType None ->
+      2
+  | CbootParserGetType (Some _) ->
       1
   | CbootParserGetString None ->
       2
@@ -1354,6 +1359,13 @@ let delta eval env fi c v =
       TmConst (fi, CbootParserTree (Bootparser.getTerm ptree n))
   | CbootParserGetTerm (Some _), _ ->
       fail_constapp fi
+  | CbootParserGetType None, t ->
+      TmConst (fi, CbootParserGetType (Some t))
+  | ( CbootParserGetType (Some (TmConst (fi, CbootParserTree ptree)))
+    , TmConst (_, CInt n) ) ->
+      TmConst (fi, CbootParserTree (Bootparser.getType ptree n))
+  | CbootParserGetType (Some _), _ ->
+    fail_constapp fi
   | CbootParserGetString None, t ->
       TmConst (fi, CbootParserGetString (Some t))
   | ( CbootParserGetString (Some (TmConst (fi, CbootParserTree ptree)))

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1365,7 +1365,7 @@ let delta eval env fi c v =
     , TmConst (_, CInt n) ) ->
       TmConst (fi, CbootParserTree (Bootparser.getType ptree n))
   | CbootParserGetType (Some _), _ ->
-    fail_constapp fi
+      fail_constapp fi
   | CbootParserGetString None, t ->
       TmConst (fi, CbootParserGetString (Some t))
   | ( CbootParserGetString (Some (TmConst (fi, CbootParserTree ptree)))

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -484,6 +484,8 @@ let rec print_const fmt = function
       fprintf fmt "bootParserParseGetId"
   | CbootParserGetTerm _ ->
       fprintf fmt "bootParserParseGetTerm"
+  | CbootParserGetType _ ->
+      fprintf fmt "bootParserParseGetType"
   | CbootParserGetString _ ->
       fprintf fmt "bootParserParseGetString"
   | CbootParserGetInt _ ->

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -799,58 +799,92 @@ end
 
 lang UnknownTypeAst
   syn Type =
-  | TyUnknown {}
+  | TyUnknown {info : Info}
+
+  sem info =
+  | TyUnknown r -> r.info
 end
 
 lang BoolTypeAst
   syn Type =
-  | TyBool {}
+  | TyBool {info  : Info}
+
+  sem info =
+  | TyBool r -> r.info
 end
 
 lang IntTypeAst
   syn Type =
-  | TyInt {}
+  | TyInt {info : Info}
+
+  sem info =
+  | TyInt r -> r.info
 end
 
 lang FloatTypeAst
   syn Type =
-  | TyFloat {}
+  | TyFloat {info : Info}
+
+  sem info =
+  | TyFloat r -> r.info
 end
 
 lang CharTypeAst
   syn Type =
-  | TyChar {}
+  | TyChar {info  : Info}
+
+  sem info =
+  | TyChar r -> r.info
 end
 
 lang FunTypeAst
   syn Type =
-  | TyArrow {from : Type,
+  | TyArrow {info : Info,
+             from : Type,
              to   : Type}
+  sem info =
+  | TyArrow r -> r.info
 end
 
 lang SeqTypeAst
   syn Type =
-  | TySeq {ty : Type}
+  | TySeq {info : Info,
+           ty   : Type}
+  sem info =
+  | TySeq r -> r.info
 end
 
 lang RecordTypeAst
   syn Type =
-  | TyRecord {fields : Map SID Type}
+  | TyRecord {info    : Info,
+              fields  : Map SID Type}
+  sem info =
+  | TyRecord r -> r.info
 end
 
 lang VariantTypeAst
   syn Type =
-  | TyVariant {constrs : Map Name Type}
+  | TyVariant {info     : Info,
+               constrs  : Map Name Type}
+  sem info =
+  | TyVariant r -> r.info
 end
 
 lang VarTypeAst
   syn Type =
-  | TyVar {ident : Name}
+  | TyVar {info   : Info,
+           ident  : Name}
+  sem info =
+  | TyVar r -> r.info
 end
 
 lang AppTypeAst
   syn Type =
-  | TyApp {lhs : Type, rhs : Type}
+  | TyApp {info : Info,
+           lhs  : Type,
+           rhs  : Type}
+  sem info =
+  | TyApp r -> r.info
 end
 
 

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -169,9 +169,6 @@ lang BootParser = MExprAst
     if eqi (glistlen t 0) 0 then
       TyVariant {info = ginfo t 0,
                  constrs = mapEmpty nameEqSym}
-      --let lst = makeSeq (lam n. (gname t n, gtype t n)) (glistlen t 0) in
-      --TyVariant {info = ginfo t 0,
-      --          constrs = mapFromList nameEqSym (map (lam b. (b.0, b.1)) lst)}
     else error "Parsing of non-empty variant types not yet supported"
   | 209 /-TyVar-/ ->
     TyVar {info = ginfo t 0,


### PR DESCRIPTION
Working progress in type information. Some existing test cases fail since `pprint` prints types for some terms, e.g. TmConDef, but it wasn't expected in the test case.
Also structure for variant types is not parsed properly but treated as variables. For example, in
`type Foo = <> in x`
`<>` is treated as two separate variables: `<` and `>`.
Beside these problem, the type information works on the test cases created. 