### PR TITLE
Add main compilation file

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -40,7 +40,8 @@ let ocamlCompile = lam sourcePath. lam ocamlAst.
       subsequence sourcePath 0 idx
     else sourcePath
   in
-  phMoveFile p.binaryPath pathWithoutExtension
+  phMoveFile p.binaryPath pathWithoutExtension;
+  phChmodWriteAccessFile pathWithoutExtension
 
 let compile = lam files. lam options.
   use MCoreCompile in

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -1,0 +1,70 @@
+
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+
+include "mexpr/boot-parser.mc"
+include "mexpr/builtin.mc"
+include "mexpr/symbolize.mc"
+include "mexpr/type-annot.mc"
+include "ocaml/ast.mc"
+include "ocaml/generate.mc"
+include "ocaml/pprint.mc"
+
+lang MCoreCompile =
+  BootParser +
+  MExprSym + MExprTypeAnnot +
+  OCamlPrettyPrint + OCamlTypeDeclGenerate + OCamlGenerate + OCamlObjWrap
+end
+
+-- Hack for pretty-printing the preamble and inserting it into the beginning of
+-- the OCaml file, after all type definitions.
+let _preambleStr =
+  use OCamlPrettyPrint in
+  let str = expr2str (bind_ _preamble (int_ 0)) in
+  subsequence str 0 (subi (length str) 1)
+
+recursive let _withPreamble = lam expr.
+  use OCamlAst in
+  match expr with OTmVariantTypeDecl t then
+    OTmVariantTypeDecl {t with inexpr = _withPreamble t.inexpr}
+  else
+    OTmPreambleText {text = _preambleStr, inexpr = expr}
+end
+
+let ocamlCompile = lam sourcePath. lam ocamlAst.
+  use MCoreCompile in
+  let p = ocamlCompile (expr2str ocamlAst) in
+  -- Imperfect solution: assumes the path contains at most one dot
+  let pathWithoutExtension =
+    match strLastIndex '.' sourcePath with Some idx then
+      subsequence sourcePath 0 idx
+    else sourcePath
+  in
+  phMoveFile p.binaryPath pathWithoutExtension
+
+let compile = lam files. lam options.
+  use MCoreCompile in
+  let compileFile = lam file.
+    let ast = parseMCoreFile file in
+    let names = map (lam x. match x with (s,_) then nameSym s else never) builtin in
+
+    -- If option --debug-parse, then pretty print the AST
+    (if options.debugParse then print (expr2str ast) else ());
+
+    -- Symbolize the MExpr AST and annotate it with types
+    let ast = symbolizeExpr (symVarNameEnv names) ast in
+    let ast = typeAnnot ast in
+
+    -- Translate the MExpr AST into an OCaml AST
+    let ocamlAst =
+      match generateTypeDecl ast with (env, ast) then
+        let ast = generate env ast in
+        let ast = objWrap ast in
+        _withPreamble ast
+      else never
+    in
+
+    -- Compile OCaml AST
+    ocamlCompile file ocamlAst
+  in
+  map compileFile files

--- a/src/main/mi.mc
+++ b/src/main/mi.mc
@@ -3,6 +3,7 @@
 --
 -- File miking.mi is the main file of the Miking tool chain.
 
+include "compile.mc"
 include "seq.mc"
 include "string.mc"
 include "run.mc"
@@ -12,7 +13,7 @@ mexpr
 
 -- Menu
 let menu = strJoin "\n" [
-  "Usage: mi [run] <files>",
+  "Usage: mi [compile|run] <files>",
   "",
   "Options:",
   "  --debug-parse      Print the AST after parsing"]
@@ -31,19 +32,20 @@ let optionsMap = [
 -- Commands map, maps command strings to functions. The functions
 -- always take two arguments: a list of filename and an option structure.
 let commandsMap = [
-("run", run)
+("run", run),
+("compile", compile)
 ] in
 
 -- Lookup for a string map
 let mapStringLookup = assocLookup {eq = eqString} in
 
 -- Simple handling of options before we have an argument parsing library.
-let parseOptions = lam xs. 
+let parseOptions = lam xs.
   foldl
-    (lam accOps. lam s. 
+    (lam accOps. lam s.
       match mapStringLookup s optionsMap with Some f
       then f accOps
-      else printLn (concat "Unknown option " s); exit 1 
+      else printLn (concat "Unknown option " s); exit 1
     ) options xs
 in
 

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -29,7 +29,6 @@ let ocamlCompileWithConfig : {warnings: Bool} -> String -> {run: Program, cleanu
       exit 1
   else ();
 
-
   {
     run =
       lam stdin. lam args.
@@ -37,11 +36,12 @@ let ocamlCompileWithConfig : {warnings: Bool} -> String -> {run: Program, cleanu
           concat ["dune", "exec", "./program.exe", "--"] args
         in
         phRunCommand command stdin (tempfile ""),
-    cleanup = phTempDirDelete td
+    cleanup = phTempDirDelete td,
+    binaryPath = pyconvert (tempfile "_build/default/program.exe")
   }
 
 let ocamlCompile : String -> {run: Program, cleanup: Unit -> Unit} =
-  ocamlCompileWithConfig {warnings=true}
+  ocamlCompileWithConfig {warnings=false}
 
 mexpr
 

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -243,7 +243,7 @@ lang OCamlGenerate = MExprAst + OCamlAst
     let msg = "Reached a never term, which should be impossible in a well-typed program." in
     TmApp {
       lhs = OTmVarExt {ident = "failwith"},
-      rhs = OTmString {text = infoErrorString t.info msg},
+      rhs = OTmString {text = escapeString (infoErrorString t.info msg)},
       ty = t.ty,
       info = NoInfo ()
     }

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -270,13 +270,10 @@ lang OCamlPrettyPrint =
       match pprintCode (pprintIncr indent) env t.body with (env,body) then
         match pprintCode indent env t.inexpr with (env,inexpr) then
           (env,
-           if eqString (nameGetStr t.ident) "" then
-             join [body, pprintNewline indent, ";", inexpr]
-           else
-             join ["let ", str, " =", pprintNewline (pprintIncr indent),
-                   body, pprintNewline indent,
-                   "in", pprintNewline indent,
-                   inexpr])
+           join ["let ", str, " =", pprintNewline (pprintIncr indent),
+                 body, pprintNewline indent,
+                 "in", pprintNewline indent,
+                 inexpr])
         else never
       else never
     else never

--- a/stdlib/ocaml/process-helpers.mc
+++ b/stdlib/ocaml/process-helpers.mc
@@ -21,7 +21,7 @@ let phReadFile = lam filename.
   pyconvert content
 
 let phMoveFile = lam fromFile. lam toFile.
-  pycall _subprocess "run" (["mv", fromFile, toFile],)
+  pycall _subprocess "run" (["mv", "-f", fromFile, toFile],)
 
 let phJoinPath = lam p1. lam p2.
   let p = pycall _pathlib "Path" (p1,) in

--- a/stdlib/ocaml/process-helpers.mc
+++ b/stdlib/ocaml/process-helpers.mc
@@ -23,6 +23,9 @@ let phReadFile = lam filename.
 let phMoveFile = lam fromFile. lam toFile.
   pycall _subprocess "run" (["mv", "-f", fromFile, toFile],)
 
+let phChmodWriteAccessFile = lam file.
+  pycall _subprocess "run" (["chmod", "+w", file],)
+
 let phJoinPath = lam p1. lam p2.
   let p = pycall _pathlib "Path" (p1,) in
   pycall _blt "str" (pycall p "joinpath" (p2,),)

--- a/stdlib/ocaml/process-helpers.mc
+++ b/stdlib/ocaml/process-helpers.mc
@@ -20,6 +20,9 @@ let phReadFile = lam filename.
   pycall f "close" ();
   pyconvert content
 
+let phMoveFile = lam fromFile. lam toFile.
+  pycall _subprocess "run" (["mv", fromFile, toFile],)
+
 let phJoinPath = lam p1. lam p2.
   let p = pycall _pathlib "Path" (p1,) in
   pycall _blt "str" (pycall p "joinpath" (p2,),)


### PR DESCRIPTION
This PR adds a main compilation file. It also includes a two minor fixes to bugs that I discovered while trying out the compilation:
1. The OCaml error message generated from a `TmNever` is now properly escaped
2. A let-expression with an empty variable was pretty-printed as a sequencing expression in OCaml, but this did not work because OCaml requires the term to be of type `unit`, which it never will be due to the Obj wrapping.