### PR TITLE
Fix failing test

### DIFF
--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -60,10 +60,10 @@ in
 
 let utestRunner =
   lam info   : {filename : String, row : String}.
-  lam printf : a -> String.
-  lam eqfunc : a -> a -> Bool.
-  lam lhs    : a.
-  lam rhs    : a.
+  lam printf : Unknown -> String.
+  lam eqfunc : Unknown -> Unknown -> Bool.
+  lam lhs    : Unknown.
+  lam rhs    : Unknown.
   -- Check whether we are using a new file
   (if deref utestFirstTest then
      print (join [info.filename, \": \"]);


### PR DESCRIPTION
The tests of `stdlib/mexpr/utesttrans.mc` fails in `develop` right now because the `utestRunner` definition uses type variables of an undefined type `a`. This PR solves this by replacing `a` with `Unknown`.