### PR TITLE
Add all intrinsics to builtin.mc

### DIFF
--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -601,8 +601,10 @@ end
 lang BootParserAst = ConstAst
   syn Const =
   | CBootParserParseMExprString {}
+  | CBootParserParseMCoreFile {}
   | CBootParserGetId {}
   | CBootParserGetTerm {}
+  | CBootParserGetType ()
   | CBootParserGetString {}
   | CBootParserGetInt {}
   | CBootParserGetFloat {}

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -61,6 +61,7 @@ let builtin = use MExprAst in
   -- , ("dprint", CDprint ())   -- dprint is not yet implemented
   , ("readLine", CReadLine ())
   , ("readBytesAsString", CReadBytesAsString ())
+  , ("argv", CArgv ())
   , ("readFile", CFileRead ())
   , ("writeFile", CFileWrite ())
   , ("fileExists", CFileExists ())
@@ -91,7 +92,7 @@ let builtin = use MExprAst in
   , ("mapFoldWithKey", CMapFoldWithKey ())
   , ("mapBindings", CMapBindings ())
   , ("mapEq", CMapEq ())
-  , ("mapCMp", CMapCmp ())
+  , ("mapCmp", CMapCmp ())
   -- Tensors
   , ("tensorCreate", CTensorCreate ())
   , ("tensorGetExn", CTensorGetExn ())

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -1,5 +1,5 @@
-
 include "ast.mc"
+include "ast-builder.mc"
 
 let builtin = use MExprAst in
   [ ("addi", CAddi ())

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -1,44 +1,121 @@
 
 include "ast.mc"
 
-let builtin = use MExprAst in [
-  -- Integers
-  ("addi", CAddi ()),
-  ("subi", CSubi ()),
-  ("muli", CMuli ()),
-  ("divi", CDivi ()),
-  ("modi", CModi ()),
-  ("negi", CNegi ()),
-  ("negi", CNegi ()),
-  ("lti", CLti ()),
-  ("leqi", CEqi ()),
-  ("gti", CGti ()),
-  ("geqi", CGeqi ()),
-  ("eqi", CEqi ()),
-  ("neqi", CNeqi ()),
-  ("slli", CSlli ()),
-  ("srli", CSrli ()),
-  ("srai", CSrai ()),
-  -- ("arity", CArity ()),   -- Arity is not yet implemented
+let builtin = use MExprAst in
+  [ ("addi", CAddi ())
+  , ("subi", CSubi ())
+  , ("muli", CMuli ())
+  , ("divi", CDivi ())
+  , ("modi", CModi ())
+  , ("negi", CNegi ())
+  , ("lti", CLti ())
+  , ("leqi", CLeqi ())
+  , ("gti", CGti ())
+  , ("geqi", CGeqi ())
+  , ("eqi", CEqi ())
+  , ("neqi", CNeqi ())
+  , ("slli", CSlli ())
+  , ("srli", CSrli ())
+  , ("srai", CSrai ())
+  -- , ("arity", Carity ())   -- Arity is not yet implemented
+  -- Floating-point numbers
+  , ("addf", CAddf ())
+  , ("subf", CSubf ())
+  , ("mulf", CMulf ())
+  , ("divf", CDivf ())
+  , ("negf", CNegf ())
+  , ("ltf", CLtf ())
+  , ("leqf", CLeqf ())
+  , ("gtf", CGtf ())
+  , ("geqf", CGeqf ())
+  , ("eqf", CEqf ())
+  , ("neqf", CNeqf ())
+  , ("floorfi", CFloorfi ())
+  , ("ceilfi", CCeilfi ())
+  , ("roundfi", CRoundfi ())
+  , ("int2float", CInt2float ())
+  , ("string2float", CString2float ())
   -- Characters
-  ("int2char", CInt2Char ()),
-  ("char2int", CChar2Int ()),
-  ("eqc", CEqc ()),
+  , ("eqc", CEqc ())
+  , ("char2int", CChar2Int ())
+  , ("int2char", CInt2Char ())
   -- Sequences
-  ("length", CLength ()),
-  ("get", CGet ()),
-  ("concat", CConcat ()),
-  ("create", CCreate ()),
-  ("set", CSet ()),
-  ("cons", CCons ()),
-  ("snoc", CSnoc ()),
-  ("splitAt", CSplitAt ()),
-  ("reverse", CReverse ()),
-  ("subsequence", CSubsequence ()),
+  , ("create", CCreate ())
+  , ("length", CLength ())
+  , ("concat", CConcat ())
+  , ("get", CGet ())
+  , ("set", CSet ())
+  , ("cons", CCons ())
+  , ("snoc", CSnoc ())
+  , ("splitAt", CSplitAt ())
+  , ("reverse", CReverse ())
+  , ("subsequence", CSubsequence ())
+  -- Random numbers
+  , ("randIntU", CRandIntU ())
+  , ("randSetSeed", CRandSetSeed ())
+  -- MCore intrinsics: Time
+  , ("wallTimeMs", CWallTimeMs ())
+  , ("sleepMs", CSleepMs ())
+  -- MCore intrinsics: Debug and I/O
+  , ("print", CPrint ())
+  -- , ("dprint", CDprint ())   -- dprint is not yet implemented
+  , ("readLine", CReadLine ())
+  , ("readBytesAsString", CReadBytesAsString ())
+  , ("readFile", CFileRead ())
+  , ("writeFile", CFileWrite ())
+  , ("fileExists", CFileExists ())
+  , ("deleteFile", CFileDelete ())
+  , ("error", CError ())
+  , ("exit", CExit ())
+  -- Symbols
+  , ("eqsym", CEqsym ())
+  , ("gensym", CGensym ())
+  , ("sym2hash", CSym2hash ())
   -- References
-  ("ref", CRef ()),
-  ("deref", CDeRef ()),
-  ("modref", CModRef ()),
-  -- IO operations
-  ("print", CPrint ())
-]
+  , ("ref", CRef ())
+  , ("deref", CDeRef ())
+  , ("modref", CModRef ())
+  -- Maps
+  , ("mapEmpty", CMapEmpty ())
+  , ("mapSize", CMapSize ())
+  , ("mapGetCmpFun", CMapGetCmpFun ())
+  , ("mapInsert", CMapInsert ())
+  , ("mapRemove", CMapRemove ())
+  , ("mapFindWithExn", CMapFindWithExn ())
+  , ("mapFindOrElse", CMapFindOrElse ())
+  , ("mapFindApplyOrElse", CMapFindApplyOrElse ())
+  , ("mapAny", CMapAny ())
+  , ("mapMem", CMapMem ())
+  , ("mapMap", CMapMap ())
+  , ("mapMapWithKey", CMapMapWithKey ())
+  , ("mapFoldWithKey", CMapFoldWithKey ())
+  , ("mapBindings", CMapBindings ())
+  , ("mapEq", CMapEq ())
+  , ("mapCMp", CMapCmp ())
+  -- Tensors
+  , ("tensorCreate", CTensorCreate ())
+  , ("tensorGetExn", CTensorGetExn ())
+  , ("tensorSetExn", CTensorSetExn ())
+  , ("tensorRank", CTensorRank ())
+  , ("tensorShape", CTensorShape ())
+  , ("tensorReshapeExn", CTensorReshapeExn ())
+  , ("tensorCopyExn", CTensorCopyExn ())
+  , ("tensorSliceExn", CTensorSliceExn ())
+  , ("tensorSubExn", CTensorSubExn ())
+  , ("tensorIteri", CTensorIteri ())
+  -- Boot parser
+  , ("bootParserParseMExprString", CBootParserParseMExprString ())
+  , ("bootParserParseMCoreFile", CBootParserParseMCoreFile ())
+  , ("bootParserGetId", CBootParserGetId ())
+  , ("bootParserGetTerm", CBootParserGetTerm ())
+  , ("bootParserGetType", CBootParserGetType ())
+  , ("bootParserGetString", CBootParserGetString ())
+  , ("bootParserGetInt", CBootParserGetInt ())
+  , ("bootParserGetFloat", CBootParserGetFloat ())
+  , ("bootParserGetListLength", CBootParserGetListLength ())
+  , ("bootParserGetConst", CBootParserGetConst ())
+  , ("bootParserGetPat", CBootParserGetPat ())
+  , ("bootParserGetInfo", CBootParserGetInfo ())
+  ]
+
+let builtinEnv = map (lam x. match x with (s,c) then (nameSym s, const_ c) else never) builtin


### PR DESCRIPTION
Adds all the instrinsics to `builtin.mc`, comments out the ones that don't exist in `ast.mc` yet, and exports the symbolized builtin environment.