### PR TITLE
Add type annotation field to bindings in `TmRecLets`

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -201,7 +201,11 @@ let type_ = use MExprAst in
 
 let nreclets_ = use MExprAst in
   lam bs.
-  TmRecLets {bindings = map (lam t. {ident = t.0, ty = t.1, body = t.2, info = NoInfo ()}) bs,
+  TmRecLets {bindings = map (lam t. { ident = t.0
+                                    , tyBody = t.1
+                                    , body = t.2
+                                    , ty = TyUnknown {}
+                                    , info = NoInfo ()}) bs,
              inexpr = unit_, ty = TyUnknown {}, info = NoInfo ()}
 
 let reclets_ = use MExprAst in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -118,8 +118,9 @@ end
 lang RecLetsAst = VarAst
   syn Expr =
   | TmRecLets {bindings : [{ident : Name,
-                            ty : Type,
+                            tyBody : Type,
                             body : Expr,
+                            ty : Type,
                             info : Info}],
                inexpr : Expr,
                ty : Type,

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -72,8 +72,9 @@ lang BootParser = MExprAst
   | 104 /-TmRecLets-/ ->
       TmRecLets {bindings =
                    makeSeq (lam n. {ident = gname t n,
-                                    ty = gtype t n,
+                                    tyBody = gtype t n,
                                     body = gterm t n,
+                                    ty = TyUnknown(),
                                     info = ginfo t (addi n 1)})
                                       (glistlen t 0),
                  inexpr = gterm t (glistlen t 0),

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -129,14 +129,21 @@ end
 lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmRecLets t ->
-    let foldBinding = lam acc. lam binding.
+    -- Add mapping from binding identifier to annotated type before doing type
+    -- annotations of the bindings. This is to make annotations work for
+    -- mutually recursive functions, given correct type annotations.
+    let foldBindingInit = lam acc. lam binding.
+      mapInsert binding.ident binding.tyBody acc
+    in
+    -- Add mapping from binding identifier to the inferred type.
+    let foldBindingAfter = lam acc. lam binding.
       mapInsert binding.ident binding.ty acc
     in
     let annotBinding = lam env. lam binding.
       let body = typeAnnotExpr env binding.body in
       match env with {tyEnv = tyEnv} then
         let tyBody =
-          match _compatibleType tyEnv binding.ty (ty body) with Some tyBody then
+          match _compatibleType tyEnv binding.tyBody (ty body) with Some tyBody then
             tyBody
           else error "Inconsistent type annotation of recursive let-term"
         in
@@ -145,8 +152,9 @@ lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
       else never
     in
     match env with {varEnv = varEnv} then
-      let env = {env with varEnv = foldl foldBinding varEnv t.bindings} in
+      let env = {env with varEnv = foldl foldBindingInit varEnv t.bindings} in
       let bindings = map (annotBinding env) t.bindings in
+      let env = {env with varEnv = foldl foldBindingAfter varEnv bindings} in
       let inexpr = typeAnnotExpr env t.inexpr in
       TmRecLets {{{t with bindings = bindings}
                      with inexpr = inexpr}


### PR DESCRIPTION
The bindings in a `TmRecLets` only contained one `ty` field which was used both for annotations and for the type of its body. This PR adds a `tyBody` field for the type annotation, so now the `ty` field is used for the type inferred by the `typeAnnot` function.