### PR TITLE
Fix standard library self-reference problem

### DIFF
--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -108,6 +108,14 @@ let rec merge_includes root visited = function
             let file_stdloc =
               Filename.concat stdlib_loc (Ustring.to_utf8 path)
             in
+            let is_suffix_of suff s =
+              let n = String.length suff in
+              let ns = String.length s in
+              if ns > n then
+                let s' = String.sub s (ns - n) n in
+                String.equal suff s'
+              else false
+            in
             if List.mem filename visited then
               raise_error info ("Cycle detected in included files: " ^ filename)
             else if List.mem filename !parsed_files then None
@@ -115,6 +123,8 @@ let rec merge_includes root visited = function
               Sys.file_exists filename
               && Sys.file_exists file_stdloc
               && file_stdloc <> filename
+              (* This should not apply to files in the standard library *)
+              && not (is_suffix_of filename file_stdloc)
             then
               raise_error info
                 ( "File exists both locally and in standard library: "

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -107,14 +107,7 @@ let rec merge_includes root visited = function
             in
             let file_stdloc =
               Filename.concat stdlib_loc (Ustring.to_utf8 path)
-            in
-            let is_suffix_of suff s =
-              let n = String.length suff in
-              let ns = String.length s in
-              if ns > n then
-                let s' = String.sub s (ns - n) n in
-                String.equal suff s'
-              else false
+              |> Utils.normalize_path
             in
             if List.mem filename visited then
               raise_error info ("Cycle detected in included files: " ^ filename)
@@ -123,8 +116,6 @@ let rec merge_includes root visited = function
               Sys.file_exists filename
               && Sys.file_exists file_stdloc
               && file_stdloc <> filename
-              (* This should not apply to files in the standard library *)
-              && not (is_suffix_of filename file_stdloc)
             then
               raise_error info
                 ( "File exists both locally and in standard library: "

--- a/src/boot/lib/utils.ml
+++ b/src/boot/lib/utils.ml
@@ -149,6 +149,11 @@ let list_zip_right = function
       ZipRightEnd (x :: ls)
 
 let normalize_path p =
+  let p =
+    if Filename.is_relative p then
+      Filename.concat (Sys.getcwd ()) p
+    else p
+  in
   let delim = Str.regexp_string Filename.dir_sep in
   let rec recur = function
     | Zipper (ls, d, rs) when d = Filename.current_dir_name ->

--- a/src/boot/lib/utils.ml
+++ b/src/boot/lib/utils.ml
@@ -150,9 +150,7 @@ let list_zip_right = function
 
 let normalize_path p =
   let p =
-    if Filename.is_relative p then
-      Filename.concat (Sys.getcwd ()) p
-    else p
+    if Filename.is_relative p then Filename.concat (Sys.getcwd ()) p else p
   in
   let delim = Str.regexp_string Filename.dir_sep in
   let rec recur = function


### PR DESCRIPTION
Adds support for compiling standard library files referencing each other. The problem was that the `normalize_path` did not translate relative paths to absolute paths, and the comparison of a relative path and an absolute path always fails (as they were compared as strings).

The solution was to append the current working directory (which is the result of `Sys.getcwd ()`) to relative paths passed to `normalize_path`, as this results in an absolute path.