### PR TITLE
Adding using term for TmUtest in the standard library.

### DIFF
--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -6,7 +6,7 @@
 
 
 -- Logical NOT
-let not: Bool -> Bool -> Bool =
+let not: Bool -> Bool =
   lam a. if a then false else true
 
 utest not true with false

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -4,6 +4,7 @@ let inf = divf 1.0 0.0
 let maxf = lam r. lam l. if gtf r l then r else l
 let minf = lam r. lam l. if ltf r l then r else l
 let absf = lam f. maxf f (negf f)
+let eqfApprox = lam epsilon. lam r. lam l. if leqf (absf (subf r l)) epsilon then true else false
 
 utest maxf 0. 0. with 0.
 utest maxf 1. 0. with 1.
@@ -16,6 +17,13 @@ utest minf 0. 1. with 0.
 utest absf 0. with 0.
 utest absf 1. with 1.
 utest absf (negf 1.) with 1.
+
+utest 1. with 1.01 using eqfApprox 0.011
+utest negf 1.0 with negf 1.009 using eqfApprox 0.01
+utest 0.0 with 0.0  using (eqfApprox 0.)
+utest eqfApprox 0.01 1.0 1.011 with false
+utest 1. with 1.000009 using eqfApprox 0.00001
+utest eqfApprox 0.00001 1.0 1.000011 with false
 
 -- Int stuff
 

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -191,10 +191,11 @@ lang UtestANF = ANF + UtestAst
   | TmUtest _ -> false
 
   sem normalize (k : Expr -> Expr) =
-  | TmUtest t ->
-    TmUtest {{{t with test = normalizeTerm t.test}
+  | TmUtest t -> let tusing = optionMap normalizeTerm t.tusing in
+    TmUtest {{{{t with test = normalizeTerm t.test}
                  with expected = normalizeTerm t.expected}
                  with next = normalize k t.next}
+                 with tusing = tusing}
 
 end
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -424,7 +424,7 @@ let appf8_ = use MExprAst in
 
 let utestu_ = use MExprAst in
   lam t. lam e. lam n. lam u.
-  TmUtest {test = t, expected = e, next = n, tusing = u, ty = TyUnknown {}, info = NoInfo ()}
+  TmUtest {test = t, expected = e, next = n, tusing = Some u, ty = TyUnknown {}, info = NoInfo ()}
 
 let utest_ = use MExprAst in
   lam t. lam e. lam n.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -422,10 +422,13 @@ let appf8_ = use MExprAst in
   lam f. lam a1. lam a2. lam a3. lam a4. lam a5. lam a6. lam a7. lam a8.
   app_ (appf7_ f a1 a2 a3 a4 a5 a6 a7) a8
 
+let utestu_ = use MExprAst in
+  lam t. lam e. lam n. lam u.
+  TmUtest {test = t, expected = e, next = n, tusing = u, ty = TyUnknown {}, info = NoInfo ()}
+
 let utest_ = use MExprAst in
   lam t. lam e. lam n.
-  TmUtest {test = t, expected = e, next = n, ty = TyUnknown {}, info = NoInfo ()}
-
+  TmUtest {test = t, expected = e, next = n, tusing = None (), ty = TyUnknown {}, info = NoInfo ()}
 
 -- Ascription
 let asc_ = use MExprAst in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -324,7 +324,7 @@ lang UtestAst
   | TmUtest {test : Expr,
              expected : Expr,
              next : Expr,
-             tusing : Expr,
+             tusing : Option Expr,
              ty : Type,
              info : Info}
 

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -324,6 +324,7 @@ lang UtestAst
   | TmUtest {test : Expr,
              expected : Expr,
              next : Expr,
+             tusing : Expr,
              ty : Type,
              info : Info}
 
@@ -337,12 +338,14 @@ lang UtestAst
   | TmUtest t -> TmUtest {t with ty = ty}
 
   sem smap_Expr_Expr (f : Expr -> a) =
-  | TmUtest t -> TmUtest {{{t with test = f t.test}
+  | TmUtest t -> let tusing = optionMap f t.tusing in
+                 TmUtest {{{{t with test = f t.test}
                               with expected = f t.expected}
                               with next = f t.next}
+                              with tusing = tusing}
 
   sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
-  | TmUtest t -> f (f (f acc t.test) t.expected) t.next
+  | TmUtest t -> f (f (f (f acc t.test) t.expected) t.next) t.tusing
 end
 
 

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -129,9 +129,13 @@ lang BootParser = MExprAst
               ty = TyUnknown(),
               info = ginfo t 0}
   | 113 /-TmUtest-/ ->
+     let tusing = match (glistlen t 0) with 4 then
+                    Some (gterm t 3)
+                  else None () in
      TmUtest {test = gterm t 0,
               expected = gterm t 1,
               next = gterm t 2,
+              tusing = tusing,
               ty = TyUnknown(),
               info = ginfo t 0}
   | 114 /-TmNever-/ ->

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -242,11 +242,18 @@ end
 
 lang UtestEq = Eq + UtestAst
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmUtest {test = t2, expected = e2, next = n2} ->
-    match lhs with TmUtest {test = t1, expected = e1, next = n1} then
+  | TmUtest {test = t2, expected = e2, next = n2, tusing = u2} ->
+    match lhs with TmUtest {test = t1, expected = e1, next = n1, tusing = u1} then
       match eqExprH env free t1 t2 with Some free then
         match eqExprH env free e1 e2 with Some free then
-          eqExprH env free n1 n2
+          match (u1, u2) with (Some tu1, Some tu2) then
+            match eqExprH env free u1 u2 with Some free then
+              eqExprH env free n1 n2
+            else None ()
+          else
+            match (u1, u2) with (None (), None ()) then
+              eqExprH env free n1 n2
+            else None ()
         else None ()
       else None ()
     else None ()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -226,7 +226,12 @@ lang UtestEval = Eq + UtestAst
   | TmUtest t ->
     let v1 = eval ctx t.test in
     let v2 = eval ctx t.expected in
-    if eqExpr v1 v2 then print "Test passed\n" else print "Test failed\n";
+    let tusing = optionMap (eval ctx) t.tusing in
+    let result = match tusing with Some tusing then
+      tusing v1 v2
+    else
+      eqExpr v1 v2 in
+    if result then print "Test passed\n" else print "Test failed\n";
     eval ctx t.next
 end
 

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -535,7 +535,7 @@ let litpat =
 
 let ut = utest_ base base base in
 
-let utu = utestu_ base base base eqi_ in
+let utu = utestu_ base base base (const_ (CEqi{})) in
 
 let seq = seq_ [base, data, const, utu] in
 

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -257,9 +257,11 @@ end
 lang UtestSym = Sym + UtestAst
   sem symbolizeExpr (env : SymEnv) =
   | TmUtest t ->
-    TmUtest {{{t with test = symbolizeExpr env t.test}
+    let tusing = optionMap (symbolizeExpr env) t.tusing in
+    TmUtest {{{{t with test = symbolizeExpr env t.test}
                  with expected = symbolizeExpr env t.expected}
                  with next = symbolizeExpr env t.next}
+                 with tusing = tusing}
 end
 
 lang SeqSym = Sym + SeqAst
@@ -533,7 +535,9 @@ let litpat =
 
 let ut = utest_ base base base in
 
-let seq = seq_ [base, data, const] in
+let utu = utestu_ base base base eqi_ in
+
+let seq = seq_ [base, data, const, utu] in
 
 let nev = never_ in
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -253,9 +253,11 @@ lang UtestTypeAnnot = TypeAnnot + UtestAst + MExprEq
     let test = typeAnnotExpr env t.test in
     let expected = typeAnnotExpr env t.expected in
     let next = typeAnnotExpr env t.next in
-    TmUtest {{{{t with test = test}
+    let tusing = optionMap (typeAnnotExpr env) t.tusing in
+    TmUtest {{{{{t with test = test}
                   with expected = expected}
                   with next = next}
+                  with tusing = tusing}
                   with ty = ty next}
 end
 

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -350,10 +350,19 @@ lang UtestTypeLift = TypeLift + UtestAst
       match typeLiftExpr env t.expected with (env, expected) then
         match typeLiftExpr env t.next with (env, next) then
           match typeLiftType env t.ty with (env, ty) then
-            (env, TmUtest {{{{t with test = test}
-                                with expected = expected}
-                                with next = next}
-                                with ty = ty})
+            match t.tusing with Some tusing then
+              match typeLiftType env t.tusing with (env, tusing) then
+                (env, TmUtest {{{{{t with test = test}
+                                    with expected = expected}
+                                    with next = next}
+                                    with tusing = t.tusing}
+                                    with ty = ty})
+              else never
+            else (env, TmUtest {{{{{t with test = test}
+                                    with expected = expected}
+                                    with next = next}
+                                    with tusing = t.tusing}
+                                    with ty = ty})
           else never
         else never
       else never

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -231,13 +231,13 @@ let utestu_info_ =
   TmUtest { test = t
           , expected = e
           , next = n
-          , tusing = u
+          , tusing = Some u
           , ty = TyUnknown {}
           , info = default_info}
 in
 
 let t = typeAnnot (utest_info_ (int_ 1) (int_ 0) unit_) in
-let t1 = typeAnnot (utestu_info_ (int_ 1) (int_ 0) unit_ eqi_) in
+let t1 = typeAnnot (utestu_info_ (int_ 1) (int_ 0) unit_ (const_ (CEqi{}))) in
 -- eval {env = _builtinEnv} (symbolizeExpr (symVarNameEnv _names) (utestGen t));
 
 utest utestStrip t with unit_ using eqExpr in

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -221,13 +221,25 @@ let utest_info_ =
   TmUtest { test = t
           , expected = e
           , next = n
+          , tusing = None ()
+          , ty = TyUnknown {}
+          , info = default_info}
+in
+
+let utestu_info_ =
+  lam t. lam e. lam n. lam u.
+  TmUtest { test = t
+          , expected = e
+          , next = n
+          , tusing = u
           , ty = TyUnknown {}
           , info = default_info}
 in
 
 let t = typeAnnot (utest_info_ (int_ 1) (int_ 0) unit_) in
+let t1 = typeAnnot (utestu_info_ (int_ 1) (int_ 0) unit_ eqi_) in
 -- eval {env = _builtinEnv} (symbolizeExpr (symVarNameEnv _names) (utestGen t));
 
 utest utestStrip t with unit_ using eqExpr in
-
+utest utestStrip t1 with unit_ using eqExpr in
 ()


### PR DESCRIPTION
This PR

- Adds using term for TmUtest in the standard library.
- Changes type signature of `not` in `bool.mc`
- Adds epsilon tolerated float equivalence function in `math.mc`