### PR TITLE
Move intrinsic information to `builtin.mc`

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -46,7 +46,6 @@ let ocamlCompile = lam sourcePath. lam ocamlAst.
 
 let compile = lam files. lam options.
   use MCoreCompile in
-  let builtinNames = map (lam x. x.0) builtinEnv in
   let compileFile = lam file.
     let ast = parseMCoreFile file in
 

--- a/src/main/run.mc
+++ b/src/main/run.mc
@@ -15,7 +15,6 @@ lang ExtMCore = BootParser + MExpr + MExprTypeAnnot + MExprUtestTrans
 
 let run = lam files. lam options.
   use ExtMCore in
-  let builtinNames = map (lam x. x.0) builtinEnv in
   let runFile = lam file.
     let ast = parseMCoreFile file in
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -1,6 +1,7 @@
 -- Helper functions for creating AST nodes.
 
 include "mexpr/ast.mc"
+include "mexpr/builtin.mc"
 include "assoc.mc"
 include "info.mc"
 include "stringid.mc"
@@ -465,182 +466,182 @@ let symb_ = use MExprAst in
 
 let addi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CAddi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "addi")) a b
 
 let subi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CSubi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "subi")) a b
 
 let muli_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CMuli ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "muli")) a b
 
 let divi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CDivi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "divi")) a b
 
 let modi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CModi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "modi")) a b
 
 let negi_ = use MExprAst in
   lam n.
-  appf1_ (const_ (CNegi ())) n
+  appf1_ (nvar_ (builtinIntrinsicName "negi")) n
 
 let addf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CAddf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "addf")) a b
 
 let subf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CSubf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "subf")) a b
 
 let mulf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CMulf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "mulf")) a b
 
 let divf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CDivf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "divf")) a b
 
 let negf_ = use MExprAst in
   lam a.
-  appf1_ (const_ (CNegf ())) a
+  appf1_ (nvar_ (builtinIntrinsicName "negf")) a
 
 let floorfi_ = use MExprAst in
   lam x.
-  appf1_ (const_ (CFloorfi ())) x
+  appf1_ (nvar_ (builtinIntrinsicName "floorfi")) x
 
 let ceilfi_ = use MExprAst in
   lam x.
-  appf1_ (const_ (CCeilfi ())) x
+  appf1_ (nvar_ (builtinIntrinsicName "ceilfi")) x
 
 let roundfi_ = use MExprAst in
   lam x.
-  appf1_ (const_ (CRoundfi ())) x
+  appf1_ (nvar_ (builtinIntrinsicName "roundfi")) x
 
 let int2float_ = use MExprAst in
   lam x.
-  appf1_ (const_ (CInt2float ())) x
+  appf1_ (nvar_ (builtinIntrinsicName "int2float")) x
 
 let eqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CEqi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "eqi")) a b
 
 let neqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CNeqi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "neqi")) a b
 
 let lti_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CLti ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "lti")) a b
 
 let gti_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CGti ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "gti")) a b
 
 let leqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CLeqi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "leqi")) a b
 
 let geqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CGeqi ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "geqi")) a b
 
 let eqc_ = use MExprAst in
   lam c1. lam c2.
-  appf2_ (const_ (CEqc ())) c1 c2
+  appf2_ (nvar_ (builtinIntrinsicName "eqc")) c1 c2
 
 let int2char_ = use MExprAst in
   lam i.
-  app_ (const_ (CInt2Char ())) i
+  app_ (nvar_ (builtinIntrinsicName "int2char")) i
 
 let char2int_ = use MExprAst in
   lam c.
-  app_ (const_ (CChar2Int ())) c
+  app_ (nvar_ (builtinIntrinsicName "char2int")) c
 
 let string2float_ = use MExprAst in
   lam s.
-  app_ (const_ (CString2float ())) s
+  app_ (nvar_ (builtinIntrinsicName "string2float")) s
 
 let eqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CEqf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "eqf")) a b
 
 let ltf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CLtf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "ltf")) a b
 
 let leqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CLeqf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "leqf")) a b
 
 let gtf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CGtf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "gtf")) a b
 
 let geqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CGeqf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "geqf")) a b
 
 let neqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CNeqf ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "neqf")) a b
 
 let slli_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CSlli ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "slli")) a b
 
 let srli_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CSrli ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "srli")) a b
 
 let srai_ = use MExprAst in
   lam a. lam b.
-  appf2_ (const_ (CSrai ())) a b
+  appf2_ (nvar_ (builtinIntrinsicName "srai")) a b
 
 let get_ = use MExprAst in
   lam s. lam i.
-  appf2_ (const_ (CGet ())) s i
+  appf2_ (nvar_ (builtinIntrinsicName "get")) s i
 
 let set_ = use MExprAst in
   lam s. lam i. lam v.
-  appf3_ (const_ (CSet ())) s i v
+  appf3_ (nvar_ (builtinIntrinsicName "set")) s i v
 
 let empty_ = use MExprAst in
   seq_ []
 
 let cons_ = use MExprAst in
   lam x. lam s.
-  appf2_ (const_ (CCons ())) x s
+  appf2_ (nvar_ (builtinIntrinsicName "cons")) x s
 
 let snoc_ = use MExprAst in
   lam s. lam x.
-  appf2_ (const_ (CSnoc ())) s x
+  appf2_ (nvar_ (builtinIntrinsicName "snoc")) s x
 
 let concat_ = use MExprAst in
   lam s1. lam s2.
-  appf2_ (const_ (CConcat ())) s1 s2
+  appf2_ (nvar_ (builtinIntrinsicName "concat")) s1 s2
 
 let length_ = use MExprAst in
   lam s.
-  appf1_ (const_ (CLength ())) s
+  appf1_ (nvar_ (builtinIntrinsicName "length")) s
 
 let reverse_ = use MExprAst in
   lam s.
-  appf1_ (const_ (CReverse ())) s
+  appf1_ (nvar_ (builtinIntrinsicName "reverse")) s
 
 let splitat_ = use MExprAst in
   lam s. lam n.
-  appf2_ (const_ (CSplitAt ())) s n
+  appf2_ (nvar_ (builtinIntrinsicName "splitAt")) s n
 
 let create_ = use MExprAst in
   lam n. lam f.
-  appf2_ (const_ (CCreate ())) n f
+  appf2_ (nvar_ (builtinIntrinsicName "create")) n f
 
 let subsequence_ = use MExprAst in
   lam s. lam off. lam n.
-  appf3_ (const_ (CSubsequence ())) s off n
+  appf3_ (nvar_ (builtinIntrinsicName "subsequence")) s off n
 
 -- Short circuit logical expressions
 let and_ = use MExprAst in
@@ -654,215 +655,215 @@ let not_ = use MExprAst in
 
 -- Symbol operations
 let gensym_ = use MExprAst in
-  lam u. appf1_ (const_ (CGensym ())) u
+  lam u. appf1_ (nvar_ (builtinIntrinsicName "gensym")) u
 
 let eqsym_ = use MExprAst in
   lam s1. lam s2.
-  appf2_ (const_ (CEqsym ())) s1 s2
+  appf2_ (nvar_ (builtinIntrinsicName "eqsym")) s1 s2
 
 let sym2hash_ = use MExprAst in
   lam s.
-  appf1_ (const_ (CSym2hash ())) s
+  appf1_ (nvar_ (builtinIntrinsicName "sym2hash")) s
 
 -- References
 let ref_ = use MExprAst in
-  lam v. appf1_ (const_ (CRef ())) v
+  lam v. appf1_ (nvar_ (builtinIntrinsicName "ref")) v
 
 let deref_ = use MExprAst in
-  lam r. appf1_ (const_ (CDeRef ())) r
+  lam r. appf1_ (nvar_ (builtinIntrinsicName "deref")) r
 
 let modref_ = use MExprAst in
-  lam r. lam v. appf2_ (const_ (CModRef ())) r v
+  lam r. lam v. appf2_ (nvar_ (builtinIntrinsicName "modref")) r v
 
 -- File operations
 let readFile_ = use MExprAst in
-  lam f. appf1_ (const_ (CFileRead ())) f
+  lam f. appf1_ (nvar_ (builtinIntrinsicName "readFile")) f
 
 let writeFile_ = use MExprAst in
-  lam f. lam d. appf2_ (const_ (CFileWrite ())) f d
+  lam f. lam d. appf2_ (nvar_ (builtinIntrinsicName "writeFile")) f d
 
 let fileExists_ = use MExprAst in
-  lam f. appf1_ (const_ (CFileExists ())) f
+  lam f. appf1_ (nvar_ (builtinIntrinsicName "fileExists")) f
 
 let deleteFile_ = use MExprAst in
-  lam f. appf1_ (const_ (CFileDelete ())) f
+  lam f. appf1_ (nvar_ (builtinIntrinsicName "deleteFile")) f
 
 -- I/O operations
 let print_ = use MExprAst in
-  lam s. app_ (const_ (CPrint ())) s
+  lam s. app_ (nvar_ (builtinIntrinsicName "print")) s
 
 let dprint_ = use MExprAst in
-  lam s. app_ (const_ (CDPrint ())) s
+  lam s. app_ (nvar_ (builtinIntrinsicName "dprint")) s
 
 let readLine_ = use MExprAst in
-  lam u. app_ (const_ (CReadLine ())) u
+  lam u. app_ (nvar_ (builtinIntrinsicName "readLine")) u
 
 -- Random number generation
 let randIntU_ = use MExprAst in
-  lam lo. lam hi. appf2_ (const_ (CRandIntU ())) lo hi
+  lam lo. lam hi. appf2_ (nvar_ (builtinIntrinsicName "randIntU")) lo hi
 
 let randSetSeed_ = use MExprAst in
-  lam s. appf1_ (const_ (CRandSetSeed ())) s
+  lam s. appf1_ (nvar_ (builtinIntrinsicName "randSetSeed")) s
 
 -- Error
 let error_ = use MExprAst in
-  lam s. appf1_ (const_ (CError ())) s
+  lam s. appf1_ (nvar_ (builtinIntrinsicName "error")) s
 
 -- Exit
 let exit_ = use MExprAst in
-  lam n. appf1_ (const_ (CExit ())) n
+  lam n. appf1_ (nvar_ (builtinIntrinsicName "exit")) n
 
 -- Argv
 let argv_ = use MExprAst in
-  const_ (CArgv ())
+  nvar_ (builtinIntrinsicName "argv")
 
 -- Time operations
 let wallTimeMs_ = use MExprAst in
-  lam u. appf1_ (const_ (CWallTimeMs ())) u
+  lam u. appf1_ (nvar_ (builtinIntrinsicName "wallTimeMs")) u
 
 let sleepMs_ = use MExprAst in
-  lam n. appf1_ (const_ (CSleepMs ())) n
+  lam n. appf1_ (nvar_ (builtinIntrinsicName "sleepMs")) n
 
 -- Tensors
 let tensorCreate_ = use MExprAst in
   lam s. lam f.
-  appf2_ (const_ (CTensorCreate ())) s f
+  appf2_ (nvar_ (builtinIntrinsicName "tensorCreate")) s f
 
 let tensorGetExn_ = use MExprAst in
   lam t. lam is.
-  appf2_ (const_ (CTensorGetExn ())) t is
+  appf2_ (nvar_ (builtinIntrinsicName "tensorGetExn")) t is
 
 let tensorSetExn_ = use MExprAst in
   lam t. lam is. lam v.
-  appf3_ (const_ (CTensorSetExn ())) t is v
+  appf3_ (nvar_ (builtinIntrinsicName "tensorSetExn")) t is v
 
 let tensorRank_ = use MExprAst in
   lam t.
-  appf1_ (const_ (CTensorRank ())) t
+  appf1_ (nvar_ (builtinIntrinsicName "tensorRank")) t
 
 let tensorShape_ = use MExprAst in
   lam t.
-  appf1_ (const_ (CTensorShape ())) t
+  appf1_ (nvar_ (builtinIntrinsicName "tensorShape")) t
 
 let tensorReshapeExn_ = use MExprAst in
   lam t. lam s.
-  appf2_ (const_ (CTensorReshapeExn ())) t s
+  appf2_ (nvar_ (builtinIntrinsicName "tensorReshapeExn")) t s
 
 let tensorCopyExn_ = use MExprAst in
   lam t1. lam t2.
-  appf2_ (const_ (CTensorCopyExn ())) t1 t2
+  appf2_ (nvar_ (builtinIntrinsicName "tensorCopyExn")) t1 t2
 
 let tensorSliceExn_ = use MExprAst in
   lam t. lam s.
-  appf2_ (const_ (CTensorSliceExn ())) t s
+  appf2_ (nvar_ (builtinIntrinsicName "tensorSliceExn")) t s
 
 let tensorSubExn_ = use MExprAst in
   lam t. lam ofs. lam len.
-  appf3_ (const_ (CTensorSubExn ())) t ofs len
+  appf3_ (nvar_ (builtinIntrinsicName "tensorSubExn")) t ofs len
 
 let tensorIteri_ = use MExprAst in
   lam f. lam t.
-  appf2_ (const_ (CTensorIteri ())) f t
+  appf2_ (nvar_ (builtinIntrinsicName "tensorIteri")) f t
 
 -- Bootparser
 let bootParserParseMExprString_ = use MExprAst in
-  lam str. appf1_ (const_ (CBootParserParseMExprString ())) str
+  lam str. appf1_ (nvar_ (builtinIntrinsicName "bootParserParseMExprString")) str
 
 let bootParserGetId_ = use MExprAst in
-  lam pt. appf1_ (const_ (CBootParserGetId ())) pt
+  lam pt. appf1_ (nvar_ (builtinIntrinsicName "bootParserGetId")) pt
 
 let bootParserGetTerm_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetTerm ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetTerm")) pt n
 
 let bootParserGetString_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetString ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetString")) pt n
 
 let bootParserGetInt_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetInt ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetInt")) pt n
 
 let bootParserGetFloat_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetFloat ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetFloat")) pt n
 
 let bootParserGetListLength_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetListLength ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetListLength")) pt n
 
 let bootParserGetConst_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetConst ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetConst")) pt n
 
 let bootParserGetPat_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetPat ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetPat")) pt n
 
 let bootParserGetInfo_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (const_ (CBootParserGetInfo ())) pt n
+  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetInfo")) pt n
 
 let mapEmpty_ = use MExprAst in
   lam cmp.
-  appf1_ (const_ (CMapEmpty ())) cmp
+  appf1_ (nvar_ (builtinIntrinsicName "mapEmpty")) cmp
 
 let mapInsert_ = use MExprAst in
   lam k. lam v. lam m.
-  appf3_ (const_ (CMapInsert ())) k v m
+  appf3_ (nvar_ (builtinIntrinsicName "mapInsert")) k v m
 
 let mapRemove_ = use MExprAst in
   lam k. lam m.
-  appf2_ (const_ (CMapRemove ())) k m
+  appf2_ (nvar_ (builtinIntrinsicName "mapRemove")) k m
 
 let mapFindWithExn_ = use MExprAst in
   lam k. lam m.
-  appf2_ (const_ (CMapFindWithExn ())) k m
+  appf2_ (nvar_ (builtinIntrinsicName "mapFindWithExn")) k m
 
 let mapFindOrElse_ = use MExprAst in
   lam f. lam k. lam m.
-  appf3_ (const_ (CMapFindOrElse ())) f k m
+  appf3_ (nvar_ (builtinIntrinsicName "mapFindOrElse")) f k m
 
 let mapFindApplyOrElse_ = use MExprAst in
   lam f. lam felse. lam k. lam m.
-  appf4_ (const_ (CMapFindApplyOrElse ())) f felse k m
+  appf4_ (nvar_ (builtinIntrinsicName "mapFindApplyOrElse")) f felse k m
 
 let mapBindings_ = use MExprAst in
   lam m.
-  appf1_ (const_ (CMapBindings ())) m
+  appf1_ (nvar_ (builtinIntrinsicName "mapBindings")) m
 
 let mapSize_ = use MExprAst in
   lam m.
-  appf1_ (const_ (CMapSize ())) m
+  appf1_ (nvar_ (builtinIntrinsicName "mapSize")) m
 
 let mapMem_ = use MExprAst in
   lam k. lam m.
-  appf2_ (const_ (CMapMem ())) k m
+  appf2_ (nvar_ (builtinIntrinsicName "mapMem")) k m
 
 let mapAny_ = use MExprAst in
   lam p. lam m.
-  appf2_ (const_ (CMapAny ())) p m
+  appf2_ (nvar_ (builtinIntrinsicName "mapAny")) p m
 
 let mapMap_ = use MExprAst in
   lam f. lam m.
-  appf2_ (const_ (CMapMap ())) f m
+  appf2_ (nvar_ (builtinIntrinsicName "mapMap")) f m
 
 let mapMapWithKey_ = use MExprAst in
   lam f. lam m.
-  appf2_ (const_ (CMapMapWithKey ())) f m
+  appf2_ (nvar_ (builtinIntrinsicName "mapMapWithKey")) f m
 
 let mapFoldWithKey_ = use MExprAst in
   lam f. lam z. lam m.
-  appf3_ (const_ (CMapFoldWithKey ())) f z m
+  appf3_ (nvar_ (builtinIntrinsicName "mapFoldWithKey")) f z m
 
 let mapEq_ = use MExprAst in
   lam veq. lam m1. lam m2.
-  appf3_ (const_ (CMapEq ())) veq m1 m2
+  appf3_ (nvar_ (builtinIntrinsicName "mapEq")) veq m1 m2
 
 let mapCmp_ = use MExprAst in
   lam vcmp. lam m1. lam m2.
-  appf3_ (const_ (CMapCmp ())) vcmp m1 m2
+  appf3_ (nvar_ (builtinIntrinsicName "mapCmp")) vcmp m1 m2
 
 let mapGetCmpFun_ = use MExprAst in
   lam m.
-  appf1_ (const_ (CMapGetCmpFun ())) m
+  appf1_ (nvar_ (builtinIntrinsicName "mapGetCmpFun")) m

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -1,4 +1,5 @@
 -- Helper functions for creating AST nodes.
+-- Functions for types are defined in ast.mc
 
 include "mexpr/ast.mc"
 include "mexpr/builtin.mc"
@@ -84,71 +85,6 @@ let por_ = use MExprAst in
 let pnot_ = use MExprAst in
   lam p.
   PatNot {subpat = p, info = NoInfo()}
-
--- Types --
-let tyarrow_ = use MExprAst in
-  lam from. lam to.
-  TyArrow {from = from, to = to, info = NoInfo ()}
-
-let tyarrows_ = use MExprAst in
-  lam tys.
-  foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
-
-let tyunknown_ = use MExprAst in
-  TyUnknown {info = NoInfo ()}
-
-let tyunit_ = use MExprAst in
-  TyRecord {fields = mapEmpty cmpSID, info = NoInfo ()}
-
-let tyint_ = use MExprAst in
-  TyInt {info = NoInfo ()}
-
-let tyfloat_ = use MExprAst in
-  TyFloat {info = NoInfo ()}
-
-let tybool_ = use MExprAst in
-  TyBool {info = NoInfo ()}
-
-let tychar_ = use MExprAst in
-  TyChar {info = NoInfo ()}
-
-let tyseq_ = use MExprAst in
-  lam ty.
-  TySeq {ty = ty, info = NoInfo ()}
-
-let tystr_ = use MExprAst in
-  tyseq_ tychar_
-
-let tyrecord_ = use MExprAst in
-  lam fields.
-  TyRecord {
-    fields = mapFromList cmpSID (map (lam b. (stringToSid b.0, b.1)) fields),
-    info = NoInfo ()
-  }
-
-
-let tytuple_ = use MExprAst in
-  lam tys.
-  tyrecord_ (mapi (lam i. lam t. (int2string i,t)) tys)
-
-let tyvariant_ = use MExprAst in
-  lam constrs.
-  TyVariant {
-    constrs = mapFromList nameCmp constrs,
-    info = NoInfo ()
-  }
-
-let tyapp_ = use MExprAst in
-  lam lhs. lam rhs.
-  TyApp {lhs = lhs, rhs = rhs, info = NoInfo ()}
-
-let ntyvar_ = use MExprAst in
-  lam n.
-  TyVar {ident = n, info = NoInfo ()}
-
-let tyvar_ = use MExprAst in
-  lam s.
-  ntyvar_ (nameNoSym s)
 
 -- Terms --
 -- Methods of binding an expression into a chain of lets/reclets/condefs --

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -2,7 +2,6 @@
 -- Functions for types are defined in ast.mc
 
 include "mexpr/ast.mc"
-include "mexpr/builtin.mc"
 include "assoc.mc"
 include "info.mc"
 include "stringid.mc"
@@ -85,6 +84,67 @@ let por_ = use MExprAst in
 let pnot_ = use MExprAst in
   lam p.
   PatNot {subpat = p, info = NoInfo()}
+
+-- Types --
+
+let tyint_ = use IntTypeAst in
+  TyInt {info = NoInfo ()}
+
+let tyfloat_ = use FloatTypeAst in
+  TyFloat {info = NoInfo ()}
+
+let tybool_ = use BoolTypeAst in
+  TyBool {info = NoInfo ()}
+
+let tychar_ = use CharTypeAst in
+  TyChar {info = NoInfo ()}
+
+let tyunknown_ = use UnknownTypeAst in
+  TyUnknown {info = NoInfo ()}
+
+let tyseq_ = use SeqTypeAst in
+  lam ty.
+  TySeq {ty = ty, info = NoInfo ()}
+
+let tystr_ = tyseq_ tychar_
+
+let tyarrow_ = use FunTypeAst in
+  lam from. lam to.
+  TyArrow {from = from, to = to, info = NoInfo ()}
+
+let tyarrows_ = use FunTypeAst in
+  lam tys.
+  foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
+
+let tyrecord_ = use RecordTypeAst in
+  lam fields.
+  TyRecord {
+    fields = mapFromList cmpSID (map (lam b. (stringToSid b.0, b.1)) fields),
+    info = NoInfo ()
+  }
+
+let tytuple_ = lam tys.
+  tyrecord_ (mapi (lam i. lam ty. (int2string i, ty)) tys)
+
+let tyunit_ = tyrecord_ []
+
+let tyvariant_ = use VariantTypeAst in
+  lam constrs.
+  TyVariant {
+    constrs = mapFromList nameCmp constrs,
+    info = NoInfo ()
+  }
+
+let tyapp_ = use AppTypeAst in
+  lam lhs. lam rhs.
+  TyApp {lhs = lhs, rhs = rhs, info = NoInfo ()}
+
+let ntyvar_ = use VarTypeAst in
+  lam n.
+  TyVar {ident = n, info = NoInfo ()}
+
+let tyvar_ = lam s.
+  ntyvar_ (nameNoSym s)
 
 -- Terms --
 -- Methods of binding an expression into a chain of lets/reclets/condefs --
@@ -402,182 +462,182 @@ let symb_ = use MExprAst in
 
 let addi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "addi")) a b
+  appf2_ (const_ (CAddi ())) a b
 
 let subi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "subi")) a b
+  appf2_ (const_ (CSubi ())) a b
 
 let muli_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "muli")) a b
+  appf2_ (const_ (CMuli ())) a b
 
 let divi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "divi")) a b
+  appf2_ (const_ (CDivi ())) a b
 
 let modi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "modi")) a b
+  appf2_ (const_ (CModi ())) a b
 
 let negi_ = use MExprAst in
   lam n.
-  appf1_ (nvar_ (builtinIntrinsicName "negi")) n
+  appf1_ (const_ (CNegi ())) n
 
 let addf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "addf")) a b
+  appf2_ (const_ (CAddf ())) a b
 
 let subf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "subf")) a b
+  appf2_ (const_ (CSubf ())) a b
 
 let mulf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "mulf")) a b
+  appf2_ (const_ (CMulf ())) a b
 
 let divf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "divf")) a b
+  appf2_ (const_ (CDivf ())) a b
 
 let negf_ = use MExprAst in
   lam a.
-  appf1_ (nvar_ (builtinIntrinsicName "negf")) a
+  appf1_ (const_ (CNegf ())) a
 
 let floorfi_ = use MExprAst in
   lam x.
-  appf1_ (nvar_ (builtinIntrinsicName "floorfi")) x
+  appf1_ (const_ (CFloorfi ())) x
 
 let ceilfi_ = use MExprAst in
   lam x.
-  appf1_ (nvar_ (builtinIntrinsicName "ceilfi")) x
+  appf1_ (const_ (CCeilfi ())) x
 
 let roundfi_ = use MExprAst in
   lam x.
-  appf1_ (nvar_ (builtinIntrinsicName "roundfi")) x
+  appf1_ (const_ (CRoundfi ())) x
 
 let int2float_ = use MExprAst in
   lam x.
-  appf1_ (nvar_ (builtinIntrinsicName "int2float")) x
+  appf1_ (const_ (CInt2float ())) x
 
 let eqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "eqi")) a b
+  appf2_ (const_ (CEqi ())) a b
 
 let neqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "neqi")) a b
+  appf2_ (const_ (CNeqi ())) a b
 
 let lti_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "lti")) a b
+  appf2_ (const_ (CLti ())) a b
 
 let gti_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "gti")) a b
+  appf2_ (const_ (CGti ())) a b
 
 let leqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "leqi")) a b
+  appf2_ (const_ (CLeqi ())) a b
 
 let geqi_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "geqi")) a b
+  appf2_ (const_ (CGeqi ())) a b
 
 let eqc_ = use MExprAst in
   lam c1. lam c2.
-  appf2_ (nvar_ (builtinIntrinsicName "eqc")) c1 c2
+  appf2_ (const_ (CEqc ())) c1 c2
 
 let int2char_ = use MExprAst in
   lam i.
-  app_ (nvar_ (builtinIntrinsicName "int2char")) i
+  app_ (const_ (CInt2Char ())) i
 
 let char2int_ = use MExprAst in
   lam c.
-  app_ (nvar_ (builtinIntrinsicName "char2int")) c
+  app_ (const_ (CChar2Int ())) c
 
 let string2float_ = use MExprAst in
   lam s.
-  app_ (nvar_ (builtinIntrinsicName "string2float")) s
+  app_ (const_ (CString2float ())) s
 
 let eqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "eqf")) a b
+  appf2_ (const_ (CEqf ())) a b
 
 let ltf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "ltf")) a b
+  appf2_ (const_ (CLtf ())) a b
 
 let leqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "leqf")) a b
+  appf2_ (const_ (CLeqf ())) a b
 
 let gtf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "gtf")) a b
+  appf2_ (const_ (CGtf ())) a b
 
 let geqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "geqf")) a b
+  appf2_ (const_ (CGeqf ())) a b
 
 let neqf_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "neqf")) a b
+  appf2_ (const_ (CNeqf ())) a b
 
 let slli_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "slli")) a b
+  appf2_ (const_ (CSlli ())) a b
 
 let srli_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "srli")) a b
+  appf2_ (const_ (CSrli ())) a b
 
 let srai_ = use MExprAst in
   lam a. lam b.
-  appf2_ (nvar_ (builtinIntrinsicName "srai")) a b
+  appf2_ (const_ (CSrai ())) a b
 
 let get_ = use MExprAst in
   lam s. lam i.
-  appf2_ (nvar_ (builtinIntrinsicName "get")) s i
+  appf2_ (const_ (CGet ())) s i
 
 let set_ = use MExprAst in
   lam s. lam i. lam v.
-  appf3_ (nvar_ (builtinIntrinsicName "set")) s i v
+  appf3_ (const_ (CSet ())) s i v
 
 let empty_ = use MExprAst in
   seq_ []
 
 let cons_ = use MExprAst in
   lam x. lam s.
-  appf2_ (nvar_ (builtinIntrinsicName "cons")) x s
+  appf2_ (const_ (CCons ())) x s
 
 let snoc_ = use MExprAst in
   lam s. lam x.
-  appf2_ (nvar_ (builtinIntrinsicName "snoc")) s x
+  appf2_ (const_ (CSnoc ())) s x
 
 let concat_ = use MExprAst in
   lam s1. lam s2.
-  appf2_ (nvar_ (builtinIntrinsicName "concat")) s1 s2
+  appf2_ (const_ (CConcat ())) s1 s2
 
 let length_ = use MExprAst in
   lam s.
-  appf1_ (nvar_ (builtinIntrinsicName "length")) s
+  appf1_ (const_ (CLength ())) s
 
 let reverse_ = use MExprAst in
   lam s.
-  appf1_ (nvar_ (builtinIntrinsicName "reverse")) s
+  appf1_ (const_ (CReverse ())) s
 
 let splitat_ = use MExprAst in
   lam s. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "splitAt")) s n
+  appf2_ (const_ (CSplitAt ())) s n
 
 let create_ = use MExprAst in
   lam n. lam f.
-  appf2_ (nvar_ (builtinIntrinsicName "create")) n f
+  appf2_ (const_ (CCreate ())) n f
 
 let subsequence_ = use MExprAst in
   lam s. lam off. lam n.
-  appf3_ (nvar_ (builtinIntrinsicName "subsequence")) s off n
+  appf3_ (const_ (CSubsequence ())) s off n
 
 -- Short circuit logical expressions
 let and_ = use MExprAst in
@@ -591,215 +651,215 @@ let not_ = use MExprAst in
 
 -- Symbol operations
 let gensym_ = use MExprAst in
-  lam u. appf1_ (nvar_ (builtinIntrinsicName "gensym")) u
+  lam u. appf1_ (const_ (CGensym ())) u
 
 let eqsym_ = use MExprAst in
   lam s1. lam s2.
-  appf2_ (nvar_ (builtinIntrinsicName "eqsym")) s1 s2
+  appf2_ (const_ (CEqsym ())) s1 s2
 
 let sym2hash_ = use MExprAst in
   lam s.
-  appf1_ (nvar_ (builtinIntrinsicName "sym2hash")) s
+  appf1_ (const_ (CSym2hash ())) s
 
 -- References
 let ref_ = use MExprAst in
-  lam v. appf1_ (nvar_ (builtinIntrinsicName "ref")) v
+  lam v. appf1_ (const_ (CRef ())) v
 
 let deref_ = use MExprAst in
-  lam r. appf1_ (nvar_ (builtinIntrinsicName "deref")) r
+  lam r. appf1_ (const_ (CDeRef ())) r
 
 let modref_ = use MExprAst in
-  lam r. lam v. appf2_ (nvar_ (builtinIntrinsicName "modref")) r v
+  lam r. lam v. appf2_ (const_ (CModRef ())) r v
 
 -- File operations
 let readFile_ = use MExprAst in
-  lam f. appf1_ (nvar_ (builtinIntrinsicName "readFile")) f
+  lam f. appf1_ (const_ (CFileRead ())) f
 
 let writeFile_ = use MExprAst in
-  lam f. lam d. appf2_ (nvar_ (builtinIntrinsicName "writeFile")) f d
+  lam f. lam d. appf2_ (const_ (CFileWrite ())) f d
 
 let fileExists_ = use MExprAst in
-  lam f. appf1_ (nvar_ (builtinIntrinsicName "fileExists")) f
+  lam f. appf1_ (const_ (CFileExists ())) f
 
 let deleteFile_ = use MExprAst in
-  lam f. appf1_ (nvar_ (builtinIntrinsicName "deleteFile")) f
+  lam f. appf1_ (const_ (CFileDelete ())) f
 
 -- I/O operations
 let print_ = use MExprAst in
-  lam s. app_ (nvar_ (builtinIntrinsicName "print")) s
+  lam s. app_ (const_ (CPrint ())) s
 
 let dprint_ = use MExprAst in
-  lam s. app_ (nvar_ (builtinIntrinsicName "dprint")) s
+  lam s. app_ (const_ (CDPrint ())) s
 
 let readLine_ = use MExprAst in
-  lam u. app_ (nvar_ (builtinIntrinsicName "readLine")) u
+  lam u. app_ (const_ (CReadLine ())) u
 
 -- Random number generation
 let randIntU_ = use MExprAst in
-  lam lo. lam hi. appf2_ (nvar_ (builtinIntrinsicName "randIntU")) lo hi
+  lam lo. lam hi. appf2_ (const_ (CRandIntU ())) lo hi
 
 let randSetSeed_ = use MExprAst in
-  lam s. appf1_ (nvar_ (builtinIntrinsicName "randSetSeed")) s
+  lam s. appf1_ (const_ (CRandSetSeed ())) s
 
 -- Error
 let error_ = use MExprAst in
-  lam s. appf1_ (nvar_ (builtinIntrinsicName "error")) s
+  lam s. appf1_ (const_ (CError ())) s
 
 -- Exit
 let exit_ = use MExprAst in
-  lam n. appf1_ (nvar_ (builtinIntrinsicName "exit")) n
+  lam n. appf1_ (const_ (CExit ())) n
 
 -- Argv
 let argv_ = use MExprAst in
-  nvar_ (builtinIntrinsicName "argv")
+  const_ (CArgv ())
 
 -- Time operations
 let wallTimeMs_ = use MExprAst in
-  lam u. appf1_ (nvar_ (builtinIntrinsicName "wallTimeMs")) u
+  lam u. appf1_ (const_ (CWallTimeMs ())) u
 
 let sleepMs_ = use MExprAst in
-  lam n. appf1_ (nvar_ (builtinIntrinsicName "sleepMs")) n
+  lam n. appf1_ (const_ (CSleepMs ())) n
 
 -- Tensors
 let tensorCreate_ = use MExprAst in
   lam s. lam f.
-  appf2_ (nvar_ (builtinIntrinsicName "tensorCreate")) s f
+  appf2_ (const_ (CTensorCreate ())) s f
 
 let tensorGetExn_ = use MExprAst in
   lam t. lam is.
-  appf2_ (nvar_ (builtinIntrinsicName "tensorGetExn")) t is
+  appf2_ (const_ (CTensorGetExn ())) t is
 
 let tensorSetExn_ = use MExprAst in
   lam t. lam is. lam v.
-  appf3_ (nvar_ (builtinIntrinsicName "tensorSetExn")) t is v
+  appf3_ (const_ (CTensorSetExn ())) t is v
 
 let tensorRank_ = use MExprAst in
   lam t.
-  appf1_ (nvar_ (builtinIntrinsicName "tensorRank")) t
+  appf1_ (const_ (CTensorRank ())) t
 
 let tensorShape_ = use MExprAst in
   lam t.
-  appf1_ (nvar_ (builtinIntrinsicName "tensorShape")) t
+  appf1_ (const_ (CTensorShape ())) t
 
 let tensorReshapeExn_ = use MExprAst in
   lam t. lam s.
-  appf2_ (nvar_ (builtinIntrinsicName "tensorReshapeExn")) t s
+  appf2_ (const_ (CTensorReshapeExn ())) t s
 
 let tensorCopyExn_ = use MExprAst in
   lam t1. lam t2.
-  appf2_ (nvar_ (builtinIntrinsicName "tensorCopyExn")) t1 t2
+  appf2_ (const_ (CTensorCopyExn ())) t1 t2
 
 let tensorSliceExn_ = use MExprAst in
   lam t. lam s.
-  appf2_ (nvar_ (builtinIntrinsicName "tensorSliceExn")) t s
+  appf2_ (const_ (CTensorSliceExn ())) t s
 
 let tensorSubExn_ = use MExprAst in
   lam t. lam ofs. lam len.
-  appf3_ (nvar_ (builtinIntrinsicName "tensorSubExn")) t ofs len
+  appf3_ (const_ (CTensorSubExn ())) t ofs len
 
 let tensorIteri_ = use MExprAst in
   lam f. lam t.
-  appf2_ (nvar_ (builtinIntrinsicName "tensorIteri")) f t
+  appf2_ (const_ (CTensorIteri ())) f t
 
 -- Bootparser
 let bootParserParseMExprString_ = use MExprAst in
-  lam str. appf1_ (nvar_ (builtinIntrinsicName "bootParserParseMExprString")) str
+  lam str. appf1_ (const_ (CBootParserParseMExprString ())) str
 
 let bootParserGetId_ = use MExprAst in
-  lam pt. appf1_ (nvar_ (builtinIntrinsicName "bootParserGetId")) pt
+  lam pt. appf1_ (const_ (CBootParserGetId ())) pt
 
 let bootParserGetTerm_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetTerm")) pt n
+  appf2_ (const_ (CBootParserGetTerm ())) pt n
 
 let bootParserGetString_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetString")) pt n
+  appf2_ (const_ (CBootParserGetString ())) pt n
 
 let bootParserGetInt_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetInt")) pt n
+  appf2_ (const_ (CBootParserGetInt ())) pt n
 
 let bootParserGetFloat_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetFloat")) pt n
+  appf2_ (const_ (CBootParserGetFloat ())) pt n
 
 let bootParserGetListLength_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetListLength")) pt n
+  appf2_ (const_ (CBootParserGetListLength ())) pt n
 
 let bootParserGetConst_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetConst")) pt n
+  appf2_ (const_ (CBootParserGetConst ())) pt n
 
 let bootParserGetPat_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetPat")) pt n
+  appf2_ (const_ (CBootParserGetPat ())) pt n
 
 let bootParserGetInfo_ = use MExprAst in
   lam pt. lam n.
-  appf2_ (nvar_ (builtinIntrinsicName "bootParserGetInfo")) pt n
+  appf2_ (const_ (CBootParserGetInfo ())) pt n
 
 let mapEmpty_ = use MExprAst in
   lam cmp.
-  appf1_ (nvar_ (builtinIntrinsicName "mapEmpty")) cmp
+  appf1_ (const_ (CMapEmpty ())) cmp
 
 let mapInsert_ = use MExprAst in
   lam k. lam v. lam m.
-  appf3_ (nvar_ (builtinIntrinsicName "mapInsert")) k v m
+  appf3_ (const_ (CMapInsert ())) k v m
 
 let mapRemove_ = use MExprAst in
   lam k. lam m.
-  appf2_ (nvar_ (builtinIntrinsicName "mapRemove")) k m
+  appf2_ (const_ (CMapRemove ())) k m
 
 let mapFindWithExn_ = use MExprAst in
   lam k. lam m.
-  appf2_ (nvar_ (builtinIntrinsicName "mapFindWithExn")) k m
+  appf2_ (const_ (CMapFindWithExn ())) k m
 
 let mapFindOrElse_ = use MExprAst in
   lam f. lam k. lam m.
-  appf3_ (nvar_ (builtinIntrinsicName "mapFindOrElse")) f k m
+  appf3_ (const_ (CMapFindOrElse ())) f k m
 
 let mapFindApplyOrElse_ = use MExprAst in
   lam f. lam felse. lam k. lam m.
-  appf4_ (nvar_ (builtinIntrinsicName "mapFindApplyOrElse")) f felse k m
+  appf4_ (const_ (CMapFindApplyOrElse ())) f felse k m
 
 let mapBindings_ = use MExprAst in
   lam m.
-  appf1_ (nvar_ (builtinIntrinsicName "mapBindings")) m
+  appf1_ (const_ (CMapBindings ())) m
 
 let mapSize_ = use MExprAst in
   lam m.
-  appf1_ (nvar_ (builtinIntrinsicName "mapSize")) m
+  appf1_ (const_ (CMapSize ())) m
 
 let mapMem_ = use MExprAst in
   lam k. lam m.
-  appf2_ (nvar_ (builtinIntrinsicName "mapMem")) k m
+  appf2_ (const_ (CMapMem ())) k m
 
 let mapAny_ = use MExprAst in
   lam p. lam m.
-  appf2_ (nvar_ (builtinIntrinsicName "mapAny")) p m
+  appf2_ (const_ (CMapAny ())) p m
 
 let mapMap_ = use MExprAst in
   lam f. lam m.
-  appf2_ (nvar_ (builtinIntrinsicName "mapMap")) f m
+  appf2_ (const_ (CMapMap ())) f m
 
 let mapMapWithKey_ = use MExprAst in
   lam f. lam m.
-  appf2_ (nvar_ (builtinIntrinsicName "mapMapWithKey")) f m
+  appf2_ (const_ (CMapMapWithKey ())) f m
 
 let mapFoldWithKey_ = use MExprAst in
   lam f. lam z. lam m.
-  appf3_ (nvar_ (builtinIntrinsicName "mapFoldWithKey")) f z m
+  appf3_ (const_ (CMapFoldWithKey ())) f z m
 
 let mapEq_ = use MExprAst in
   lam veq. lam m1. lam m2.
-  appf3_ (nvar_ (builtinIntrinsicName "mapEq")) veq m1 m2
+  appf3_ (const_ (CMapEq ())) veq m1 m2
 
 let mapCmp_ = use MExprAst in
   lam vcmp. lam m1. lam m2.
-  appf3_ (nvar_ (builtinIntrinsicName "mapCmp")) vcmp m1 m2
+  appf3_ (const_ (CMapCmp ())) vcmp m1 m2
 
 let mapGetCmpFun_ = use MExprAst in
   lam m.
-  appf1_ (nvar_ (builtinIntrinsicName "mapGetCmpFun")) m
+  appf1_ (const_ (CMapGetCmpFun ())) m

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -87,44 +87,42 @@ let pnot_ = use MExprAst in
 -- Types --
 let tyarrow_ = use MExprAst in
   lam from. lam to.
-  TyArrow {from = from, to = to}
+  TyArrow {from = from, to = to, info = NoInfo ()}
 
 let tyarrows_ = use MExprAst in
   lam tys.
-  foldr1 (lam e. lam acc. TyArrow {from = e, to = acc}) tys
+  foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
 
 let tyunknown_ = use MExprAst in
-  TyUnknown ()
+  TyUnknown {info = NoInfo ()}
 
 let tyunit_ = use MExprAst in
-  TyRecord {fields = mapEmpty cmpSID}
+  TyRecord {fields = mapEmpty cmpSID, info = NoInfo ()}
 
 let tyint_ = use MExprAst in
-  TyInt ()
+  TyInt {info = NoInfo ()}
 
 let tyfloat_ = use MExprAst in
-  TyFloat ()
+  TyFloat {info = NoInfo ()}
 
 let tybool_ = use MExprAst in
-  TyBool ()
+  TyBool {info = NoInfo ()}
 
 let tychar_ = use MExprAst in
-  TyChar ()
-
-let tystr_ = use MExprAst in
-  TySeq {ty = tychar_}
+  TyChar {info = NoInfo ()}
 
 let tyseq_ = use MExprAst in
   lam ty.
-  TySeq {ty = ty}
+  TySeq {ty = ty, info = NoInfo ()}
 
-let utyseq_ = use MExprAst in
-  TySeq {ty = TyUnknown ()}
+let tystr_ = use MExprAst in
+  tyseq_ tychar_
 
 let tyrecord_ = use MExprAst in
   lam fields.
   TyRecord {
-    fields = mapFromList cmpSID (map (lam b. (stringToSid b.0, b.1)) fields)
+    fields = mapFromList cmpSID (map (lam b. (stringToSid b.0, b.1)) fields),
+    info = NoInfo ()
   }
 
 
@@ -135,16 +133,17 @@ let tytuple_ = use MExprAst in
 let tyvariant_ = use MExprAst in
   lam constrs.
   TyVariant {
-    constrs = mapFromList nameCmp constrs
+    constrs = mapFromList nameCmp constrs,
+    info = NoInfo ()
   }
 
 let tyapp_ = use MExprAst in
   lam lhs. lam rhs.
-  TyApp {lhs = lhs, rhs = rhs}
+  TyApp {lhs = lhs, rhs = rhs, info = NoInfo ()}
 
 let ntyvar_ = use MExprAst in
   lam n.
-  TyVar {ident = n}
+  TyVar {ident = n, info = NoInfo ()}
 
 let tyvar_ = use MExprAst in
   lam s.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1,12 +1,10 @@
 -- Language fragments of MExpr
 
+include "mexpr/info.mc"
 include "assoc.mc"
 include "info.mc"
-include "map.mc"
 include "name.mc"
 include "string.mc"
-include "stringid.mc"
-include "mexpr/info.mc"
 
 -----------
 -- TERMS --
@@ -388,179 +386,13 @@ lang RefAst
   | TmRef t -> acc
 end
 
------------
--- TYPES --
------------
-
-lang UnknownTypeAst
-  syn Type =
-  | TyUnknown {info : Info}
-
-  sem info =
-  | TyUnknown r -> r.info
-end
-
-lang BoolTypeAst
-  syn Type =
-  | TyBool {info  : Info}
-
-  sem info =
-  | TyBool r -> r.info
-end
-
-lang IntTypeAst
-  syn Type =
-  | TyInt {info : Info}
-
-  sem info =
-  | TyInt r -> r.info
-end
-
-lang FloatTypeAst
-  syn Type =
-  | TyFloat {info : Info}
-
-  sem info =
-  | TyFloat r -> r.info
-end
-
-lang CharTypeAst
-  syn Type =
-  | TyChar {info  : Info}
-
-  sem info =
-  | TyChar r -> r.info
-end
-
-lang FunTypeAst
-  syn Type =
-  | TyArrow {info : Info,
-             from : Type,
-             to   : Type}
-  sem info =
-  | TyArrow r -> r.info
-end
-
-lang SeqTypeAst
-  syn Type =
-  | TySeq {info : Info,
-           ty   : Type}
-  sem info =
-  | TySeq r -> r.info
-end
-
-lang RecordTypeAst
-  syn Type =
-  | TyRecord {info    : Info,
-              fields  : Map SID Type}
-  sem info =
-  | TyRecord r -> r.info
-end
-
-lang VariantTypeAst
-  syn Type =
-  | TyVariant {info     : Info,
-               constrs  : Map Name Type}
-  sem info =
-  | TyVariant r -> r.info
-end
-
-lang VarTypeAst
-  syn Type =
-  | TyVar {info   : Info,
-           ident  : Name}
-  sem info =
-  | TyVar r -> r.info
-end
-
-lang AppTypeAst
-  syn Type =
-  | TyApp {info : Info,
-           lhs  : Type,
-           rhs  : Type}
-  sem info =
-  | TyApp r -> r.info
-end
-
 ---------------
 -- CONSTANTS --
 ---------------
 
-let tyint_ = use IntTypeAst in
-  TyInt {info = NoInfo ()}
-
-let tyfloat_ = use FloatTypeAst in
-  TyFloat {info = NoInfo ()}
-
-let tybool_ = use BoolTypeAst in
-  TyBool {info = NoInfo ()}
-
-let tychar_ = use CharTypeAst in
-  TyChar {info = NoInfo ()}
-
-let tyunknown_ = use UnknownTypeAst in
-  TyUnknown {info = NoInfo ()}
-
-let tyseq_ = use SeqTypeAst in
-  lam ty.
-  TySeq {ty = ty, info = NoInfo ()}
-
-let tystr_ = tyseq_ tychar_
-
-let tyarrow_ = use FunTypeAst in
-  lam from. lam to.
-  TyArrow {from = from, to = to, info = NoInfo ()}
-
-let tyarrows_ = use FunTypeAst in
-  lam tys.
-  foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
-
-let tyrecord_ = use RecordTypeAst in
-  lam fields.
-  TyRecord {
-    fields = mapFromList cmpSID (map (lam b. (stringToSid b.0, b.1)) fields),
-    info = NoInfo ()
-  }
-
-let tytuple_ = lam tys.
-  tyrecord_ (mapi (lam i. lam ty. (int2string i, ty)) tys)
-
-let tyunit_ = tyrecord_ []
-
-let tyvariant_ = use VariantTypeAst in
-  lam constrs.
-  TyVariant {
-    constrs = mapFromList nameCmp constrs,
-    info = NoInfo ()
-  }
-
-let tyapp_ = use AppTypeAst in
-  lam lhs. lam rhs.
-  TyApp {lhs = lhs, rhs = rhs, info = NoInfo ()}
-
-let ntyvar_ = use VarTypeAst in
-  lam n.
-  TyVar {ident = n, info = NoInfo ()}
-
-let tyvar_ = lam s.
-  ntyvar_ (nameNoSym s)
-
--- The types defined below are used for documentation purposes.
-let tysym_ = tyunknown_
-let tyref_ = tyunknown_
-let tymap_ = tyunknown_
-let tytensor_ = lam ty. tyunknown_
-let tybootparsetree_ = tyunknown_
-let tygeneric_ = lam id. tyunknown_
-let tygenericseq_ = lam id. tyseq_ (tygeneric_ id)
-let tygenerictensor_ = lam id. tytensor_ (tygeneric_ id)
-
 lang IntAst = ConstAst
   syn Const =
   | CInt {val : Int}
-
-  sem tyConst =
-  | CInt _ -> tyint_
 end
 
 lang ArithIntAst = ConstAst + IntAst
@@ -571,14 +403,6 @@ lang ArithIntAst = ConstAst + IntAst
   | CDivi {}
   | CNegi {}
   | CModi {}
-
-  sem tyConst =
-  | CAddi _ -> tyarrows_ [tyint_, tyint_, tyint_]
-  | CSubi _ -> tyarrows_ [tyint_, tyint_, tyint_]
-  | CMuli _ -> tyarrows_ [tyint_, tyint_, tyint_]
-  | CDivi _ -> tyarrows_ [tyint_, tyint_, tyint_]
-  | CNegi _ -> tyarrow_ tyint_ tyint_
-  | CModi _ -> tyarrows_ [tyint_, tyint_, tyint_]
 end
 
 lang ShiftIntAst = ConstAst + IntAst
@@ -586,19 +410,11 @@ lang ShiftIntAst = ConstAst + IntAst
   | CSlli {}
   | CSrli {}
   | CSrai {}
-
-  sem tyConst =
-  | CSlli _ -> tyarrows_ [tyint_, tyint_, tyint_]
-  | CSrli _ -> tyarrows_ [tyint_, tyint_, tyint_]
-  | CSrai _ -> tyarrows_ [tyint_, tyint_, tyint_]
 end
 
 lang FloatAst = ConstAst
   syn Const =
   | CFloat {val : Float}
-
-  sem tyConst =
-  | CFloat _ -> tyfloat_
 end
 
 lang ArithFloatAst = ConstAst + FloatAst
@@ -608,13 +424,6 @@ lang ArithFloatAst = ConstAst + FloatAst
   | CMulf {}
   | CDivf {}
   | CNegf {}
-
-  sem tyConst =
-  | CAddf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
-  | CSubf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
-  | CMulf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
-  | CDivf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
-  | CNegf _ -> tyarrow_ tyfloat_ tyfloat_
 end
 
 lang FloatIntConversionAst = IntAst + FloatAst
@@ -623,20 +432,11 @@ lang FloatIntConversionAst = IntAst + FloatAst
   | CCeilfi {}
   | CRoundfi {}
   | CInt2float {}
-
-  sem tyConst =
-  | CFloorfi _ -> tyarrow_ tyfloat_ tyint_
-  | CCeilfi _ -> tyarrow_ tyfloat_ tyint_
-  | CRoundfi _ -> tyarrow_ tyfloat_ tyint_
-  | CInt2float _ -> tyarrow_ tyint_ tyfloat_
 end
 
 lang BoolAst = ConstAst
   syn Const =
   | CBool {val : Bool}
-
-  sem tyConst =
-  | CBool _ -> tybool_
 end
 
 lang CmpIntAst = IntAst + BoolAst
@@ -647,14 +447,6 @@ lang CmpIntAst = IntAst + BoolAst
   | CGti {}
   | CLeqi {}
   | CGeqi {}
-
-  sem tyConst =
-  | CEqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
-  | CNeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
-  | CLti _ -> tyarrows_ [tyint_, tyint_, tybool_]
-  | CGti _ -> tyarrows_ [tyint_, tyint_, tybool_]
-  | CLeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
-  | CGeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
 end
 
 lang CmpFloatAst = FloatAst + BoolAst
@@ -665,48 +457,27 @@ lang CmpFloatAst = FloatAst + BoolAst
   | CGtf {}
   | CGeqf {}
   | CNeqf {}
-
-  sem tyConst =
-  | CEqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
-  | CLtf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
-  | CLeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
-  | CGtf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
-  | CGeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
-  | CNeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
 end
 
 lang CharAst = ConstAst
   syn Const =
   | CChar {val : Char}
-
-  sem tyConst =
-  | CChar _ -> tychar_
 end
 
 lang CmpCharAst = CharAst + BoolAst
   syn Const =
   | CEqc {}
-
-  sem tyConst =
-  | CEqc _ -> tyarrows_ [tychar_, tychar_, tybool_]
 end
 
 lang IntCharConversionAst = IntAst + CharAst
   syn Const =
   | CInt2Char {}
   | CChar2Int {}
-
-  sem tyConst =
-  | CInt2Char _ -> tyarrow_ tyint_ tychar_
-  | CChar2Int _ -> tyarrow_ tychar_ tyint_
 end
 
 lang FloatStringConversionAst = SeqAst + FloatAst
   syn Const =
   | CString2float {}
-
-  sem tyConst =
-  | CString2float _ -> tyarrow_ tystr_ tyfloat_
 end
 
 lang SymbAst = ConstAst
@@ -714,19 +485,11 @@ lang SymbAst = ConstAst
   | CSymb {val : Symb}
   | CGensym {}
   | CSym2hash {}
-
-  sem tyConst =
-  | CSymb _ -> tysym_
-  | CGensym _ -> tyarrow_ tyunit_ tysym_
-  | CSym2hash _ -> tyarrow_ tysym_ tyint_
 end
 
 lang CmpSymbAst = SymbAst + BoolAst
   syn Const =
   | CEqsym {}
-
-  sem tyConst =
-  | CEqsym _ -> tyarrows_ [tysym_, tysym_, tybool_]
 end
 
 lang SeqOpAst = SeqAst
@@ -741,23 +504,6 @@ lang SeqOpAst = SeqAst
   | CCreate {}
   | CSplitAt {}
   | CSubsequence {}
-
-  sem tyConst =
-  | CSet _ -> tyarrows_ [tygenericseq_ "a", tyint_,
-                         tygeneric_ "a", tygenericseq_ "a"]
-  | CGet _ -> tyarrows_ [tygenericseq_ "a", tyint_, tygeneric_ "a"]
-  | CCons _ -> tyarrows_ [tygeneric_ "a", tygenericseq_ "a", tygenericseq_ "a"]
-  | CSnoc _ -> tyarrows_ [tygenericseq_ "a", tygeneric_ "a", tygenericseq_ "a"]
-  | CConcat _ -> tyarrows_ [tygenericseq_ "a", tygenericseq_ "a",
-                            tygenericseq_ "a"]
-  | CLength _ -> tyarrow_ (tygenericseq_ "a") tyint_
-  | CReverse _ -> tyarrow_ (tygenericseq_ "a") (tygenericseq_ "a")
-  | CCreate _ -> tyarrows_ [tyint_, tyarrow_ tyint_ (tygeneric_ "a"),
-                            tygenericseq_ "a"]
-  | CSplitAt _ -> tyarrows_ [tygenericseq_ "a", tyint_,
-                             tytuple_ [tygenericseq_ "a", tygenericseq_ "a"]]
-  | CSubsequence _ -> tyarrows_ [tygenericseq_ "a", tyint_, tyint_,
-                                 tygenericseq_ "a"]
 end
 
 lang FileOpAst = ConstAst
@@ -766,12 +512,6 @@ lang FileOpAst = ConstAst
   | CFileWrite {}
   | CFileExists {}
   | CFileDelete {}
-
-  sem tyConst =
-  | CFileRead _ -> tyarrow_ tystr_ tystr_
-  | CFileWrite _ -> tyarrows_ [tystr_, tystr_, tyunit_]
-  | CFileExists _ -> tyarrow_ tystr_ tybool_
-  | CFileDelete _ -> tyarrow_ tystr_ tyunit_
 end
 
 lang IOAst = ConstAst
@@ -780,22 +520,12 @@ lang IOAst = ConstAst
   | CDPrint {}
   | CReadLine {}
   | CReadBytesAsString {}
-
-  sem tyConst =
-  | CPrint _ -> tyarrow_ tystr_ tyunit_
-  | CDPrint _ -> tyarrow_ tystr_ tyunit_
-  | CReadLine _ -> tyarrow_ tyunit_ tystr_
-  | CReadBytesAsString _ -> tyarrow_ tyint_ (tytuple_ [tystr_, tystr_])
 end
 
 lang RandomNumberGeneratorAst = ConstAst
   syn Const =
   | CRandIntU {}
   | CRandSetSeed {}
-
-  sem tyConst =
-  | CRandIntU _ -> tyarrows_ [tyint_, tyint_, tyint_]
-  | CRandSetSeed _ -> tyarrow_ tyint_ tyunit_
 end
 
 lang SysAst = ConstAst
@@ -803,21 +533,12 @@ lang SysAst = ConstAst
   | CExit {}
   | CError {}
   | CArgv {}
-
-  sem tyConst =
-  | CExit _ -> tyarrow_ tyint_ tyunknown_
-  | CError _ -> tyarrow_ tyint_ tyunknown_
-  | CArgv _ -> tyseq_ tystr_
 end
 
 lang TimeAst = ConstAst
   syn Const =
   | CWallTimeMs {}
   | CSleepMs {}
-
-  sem tyConst =
-  | CWallTimeMs _ -> tyarrow_ tyunit_ tyfloat_
-  | CSleepMs _ -> tyarrow_ tyint_ tyunit_
 end
 
 lang RefOpAst = ConstAst + RefAst
@@ -825,11 +546,6 @@ lang RefOpAst = ConstAst + RefAst
   | CRef {}
   | CModRef {}
   | CDeRef {}
-
-  sem tyConst =
-  | CRef _ -> tyarrow_ (tygeneric_ "a") tyref_
-  | CModRef _ -> tyarrow_ tyref_ (tygeneric_ "a")
-  | CDeRef _ -> tyarrows_ [tyref_, tygeneric_ "a", tyunit_]
 end
 
 lang MapAst = ConstAst
@@ -850,39 +566,6 @@ lang MapAst = ConstAst
   | CMapEq {}
   | CMapCmp {}
   | CMapGetCmpFun {}
-
-  sem tyConst =
-  | CMapEmpty _ -> tyarrow_ (tyarrows_ [tygeneric_ "a", tygeneric_ "a", tyint_])
-                            tymap_
-  | CMapInsert _ -> tyarrows_ [tygeneric_ "a", tygeneric_ "b", tymap_, tymap_]
-  | CMapRemove _ -> tyarrows_ [tygeneric_ "a", tymap_, tymap_]
-  | CMapFindWithExn _ -> tyarrows_ [tygeneric_ "a", tymap_, tygeneric_ "b"]
-  | CMapFindOrElse _ -> tyarrows_ [tyarrow_ tyunit_ (tygeneric_ "b"),
-                                   tygeneric_ "a", tymap_, tygeneric_ "b"]
-  | CMapFindApplyOrElse _ ->
-    tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
-               tyarrow_ tyunit_ (tygeneric_ "c"), tygeneric_ "a",
-               tymap_, tygeneric_ "c"]
-  | CMapBindings _ -> tyarrow_ tymap_
-                               (tyseq_ (tytuple_ [tygeneric_ "a", tygeneric_ "b"]))
-  | CMapSize _ -> tyarrow_ tymap_ tyint_
-  | CMapMem _ -> tyarrows_ [tygeneric_ "a", tymap_, tyint_]
-  | CMapAny _ -> tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tybool_],
-                            tymap_, tybool_]
-  | CMapMap _ -> tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
-                            tymap_, tymap_]
-  | CMapMapWithKey _ ->
-    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tygeneric_ "c"],
-               tymap_, tymap_]
-  | CMapFoldWithKey _ ->
-    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b",
-                          tygeneric_ "c", tygeneric_ "c"],
-               tygeneric_ "c", tymap_, tygeneric_ "c"]
-  | CMapEq _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tybool_],
-                           tymap_, tymap_, tybool_]
-  | CMapCmp _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tyint_],
-                            tymap_, tymap_, tyint_]
-  | CMapGetCmpFun _ -> tyarrows_ [tymap_, tygeneric_ "a", tygeneric_ "a", tyint_]
 end
 
 lang TensorOpAst = ConstAst
@@ -897,28 +580,6 @@ lang TensorOpAst = ConstAst
   | CTensorSliceExn {}
   | CTensorSubExn {}
   | CTensorIteri {}
-
-  sem tyConst =
-  | CTensorCreate _ -> tyarrows_ [tyseq_ tyint_,
-                                  tyarrow_ (tyseq_ tyint_) (tygeneric_ "a"),
-                                  tygenerictensor_ "a"]
-  | CTensorGetExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
-                                  tygeneric_ "a"]
-  | CTensorSetExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
-                                  tygeneric_ "a", tyunit_]
-  | CTensorRank _ -> tyarrow_ (tygenerictensor_ "a") tyint_
-  | CTensorShape _ -> tyarrow_ (tygenerictensor_ "a") (tyseq_ tyint_)
-  | CTensorReshapeExn _ -> tyarrows_ [tygenerictensor_ "a",
-                                      tyseq_ tyint_, tygenerictensor_ "a"]
-  | CTensorCopyExn _ -> tyarrows_ [tygenerictensor_ "a", tygenerictensor_ "a",
-                                   tyunit_]
-  | CTensorSliceExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
-                                    tygenerictensor_ "a"]
-  | CTensorSubExn _ -> tyarrows_ [tygenerictensor_ "a", tyint_, tyint_,
-                                  tygenerictensor_ "a"]
-  | CTensorIteri _ -> tyarrows_ [tyarrows_ [tyint_, tygenerictensor_ "a",
-                                            tyunit_],
-                                 tygenerictensor_ "a", tyunit_]
 end
 
 lang BootParserAst = ConstAst
@@ -935,20 +596,6 @@ lang BootParserAst = ConstAst
   | CBootParserGetConst {}
   | CBootParserGetPat {}
   | CBootParserGetInfo {}
-
-  sem tyConst =
-  | CBootParserParseMExprString _ -> tyarrow_ tystr_ tybootparsetree_
-  | CBootParserParseMCoreFile _ -> tyarrow_ tystr_ tybootparsetree_
-  | CBootParserGetId _ -> tyarrow_ tybootparsetree_ tyint_
-  | CBootParserGetTerm _ -> tyarrow_ tybootparsetree_ tybootparsetree_
-  | CBootParserGetType _ -> tyarrow_ tybootparsetree_ tybootparsetree_
-  | CBootParserGetString _ -> tyarrow_ tybootparsetree_ tystr_
-  | CBootParserGetInt _ -> tyarrow_ tybootparsetree_ tyint_
-  | CBootParserGetFloat _ -> tyarrow_ tybootparsetree_ tyfloat_
-  | CBootParserGetListLength _ -> tyarrow_ tybootparsetree_ tyint_
-  | CBootParserGetConst _ -> tyarrow_ tybootparsetree_ tybootparsetree_
-  | CBootParserGetPat _ -> tyarrow_ tybootparsetree_ tybootparsetree_
-  | CBootParserGetInfo _ -> tyarrow_ tybootparsetree_ tybootparsetree_
 end
 
 --------------
@@ -1132,6 +779,100 @@ lang NotPat
   | PatNot {subpat = p} -> f acc p
 end
 
+-----------
+-- TYPES --
+-----------
+
+lang UnknownTypeAst
+  syn Type =
+  | TyUnknown {info : Info}
+
+  sem info =
+  | TyUnknown r -> r.info
+end
+
+lang BoolTypeAst
+  syn Type =
+  | TyBool {info  : Info}
+
+  sem info =
+  | TyBool r -> r.info
+end
+
+lang IntTypeAst
+  syn Type =
+  | TyInt {info : Info}
+
+  sem info =
+  | TyInt r -> r.info
+end
+
+lang FloatTypeAst
+  syn Type =
+  | TyFloat {info : Info}
+
+  sem info =
+  | TyFloat r -> r.info
+end
+
+lang CharTypeAst
+  syn Type =
+  | TyChar {info  : Info}
+
+  sem info =
+  | TyChar r -> r.info
+end
+
+lang FunTypeAst
+  syn Type =
+  | TyArrow {info : Info,
+             from : Type,
+             to   : Type}
+  sem info =
+  | TyArrow r -> r.info
+end
+
+lang SeqTypeAst
+  syn Type =
+  | TySeq {info : Info,
+           ty   : Type}
+  sem info =
+  | TySeq r -> r.info
+end
+
+lang RecordTypeAst
+  syn Type =
+  | TyRecord {info    : Info,
+              fields  : Map SID Type}
+  sem info =
+  | TyRecord r -> r.info
+end
+
+lang VariantTypeAst
+  syn Type =
+  | TyVariant {info     : Info,
+               constrs  : Map Name Type}
+  sem info =
+  | TyVariant r -> r.info
+end
+
+lang VarTypeAst
+  syn Type =
+  | TyVar {info   : Info,
+           ident  : Name}
+  sem info =
+  | TyVar r -> r.info
+end
+
+lang AppTypeAst
+  syn Type =
+  | TyApp {info : Info,
+           lhs  : Type,
+           rhs  : Type}
+  sem info =
+  | TyApp r -> r.info
+end
+
 ------------------------
 -- MEXPR AST FRAGMENT --
 ------------------------
@@ -1141,11 +882,6 @@ lang MExprAst =
   -- Terms
   VarAst + AppAst + LamAst + RecordAst + LetAst + TypeAst + RecLetsAst +
   ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst + RefAst +
-
-  -- Types
-  UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
-  FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + VarTypeAst +
-  AppTypeAst +
 
   -- Constants
   IntAst + ArithIntAst + ShiftIntAst + FloatAst + ArithFloatAst + BoolAst +
@@ -1157,4 +893,9 @@ lang MExprAst =
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +
-  BoolPat + AndPat + OrPat + NotPat
+  BoolPat + AndPat + OrPat + NotPat +
+
+  -- Types
+  UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
+  FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + VarTypeAst +
+  AppTypeAst

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1,9 +1,11 @@
 -- Language fragments of MExpr
 
-include "string.mc"
-include "name.mc"
 include "assoc.mc"
 include "info.mc"
+include "map.mc"
+include "name.mc"
+include "string.mc"
+include "stringid.mc"
 include "mexpr/info.mc"
 
 -----------
@@ -386,16 +388,179 @@ lang RefAst
   | TmRef t -> acc
 end
 
+-----------
+-- TYPES --
+-----------
+
+lang UnknownTypeAst
+  syn Type =
+  | TyUnknown {info : Info}
+
+  sem info =
+  | TyUnknown r -> r.info
+end
+
+lang BoolTypeAst
+  syn Type =
+  | TyBool {info  : Info}
+
+  sem info =
+  | TyBool r -> r.info
+end
+
+lang IntTypeAst
+  syn Type =
+  | TyInt {info : Info}
+
+  sem info =
+  | TyInt r -> r.info
+end
+
+lang FloatTypeAst
+  syn Type =
+  | TyFloat {info : Info}
+
+  sem info =
+  | TyFloat r -> r.info
+end
+
+lang CharTypeAst
+  syn Type =
+  | TyChar {info  : Info}
+
+  sem info =
+  | TyChar r -> r.info
+end
+
+lang FunTypeAst
+  syn Type =
+  | TyArrow {info : Info,
+             from : Type,
+             to   : Type}
+  sem info =
+  | TyArrow r -> r.info
+end
+
+lang SeqTypeAst
+  syn Type =
+  | TySeq {info : Info,
+           ty   : Type}
+  sem info =
+  | TySeq r -> r.info
+end
+
+lang RecordTypeAst
+  syn Type =
+  | TyRecord {info    : Info,
+              fields  : Map SID Type}
+  sem info =
+  | TyRecord r -> r.info
+end
+
+lang VariantTypeAst
+  syn Type =
+  | TyVariant {info     : Info,
+               constrs  : Map Name Type}
+  sem info =
+  | TyVariant r -> r.info
+end
+
+lang VarTypeAst
+  syn Type =
+  | TyVar {info   : Info,
+           ident  : Name}
+  sem info =
+  | TyVar r -> r.info
+end
+
+lang AppTypeAst
+  syn Type =
+  | TyApp {info : Info,
+           lhs  : Type,
+           rhs  : Type}
+  sem info =
+  | TyApp r -> r.info
+end
 
 ---------------
 -- CONSTANTS --
 ---------------
--- All constants in boot have not been implemented. Missing ones can be added
--- as needed.
+
+let tyint_ = use IntTypeAst in
+  TyInt {info = NoInfo ()}
+
+let tyfloat_ = use FloatTypeAst in
+  TyFloat {info = NoInfo ()}
+
+let tybool_ = use BoolTypeAst in
+  TyBool {info = NoInfo ()}
+
+let tychar_ = use CharTypeAst in
+  TyChar {info = NoInfo ()}
+
+let tyunknown_ = use UnknownTypeAst in
+  TyUnknown {info = NoInfo ()}
+
+let tyseq_ = use SeqTypeAst in
+  lam ty.
+  TySeq {ty = ty, info = NoInfo ()}
+
+let tystr_ = tyseq_ tychar_
+
+let tyarrow_ = use FunTypeAst in
+  lam from. lam to.
+  TyArrow {from = from, to = to, info = NoInfo ()}
+
+let tyarrows_ = use FunTypeAst in
+  lam tys.
+  foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
+
+let tyrecord_ = use RecordTypeAst in
+  lam fields.
+  TyRecord {
+    fields = mapFromList cmpSID (map (lam b. (stringToSid b.0, b.1)) fields),
+    info = NoInfo ()
+  }
+
+let tytuple_ = lam tys.
+  tyrecord_ (mapi (lam i. lam ty. (int2string i, ty)) tys)
+
+let tyunit_ = tyrecord_ []
+
+let tyvariant_ = use VariantTypeAst in
+  lam constrs.
+  TyVariant {
+    constrs = mapFromList nameCmp constrs,
+    info = NoInfo ()
+  }
+
+let tyapp_ = use AppTypeAst in
+  lam lhs. lam rhs.
+  TyApp {lhs = lhs, rhs = rhs, info = NoInfo ()}
+
+let ntyvar_ = use VarTypeAst in
+  lam n.
+  TyVar {ident = n, info = NoInfo ()}
+
+let tyvar_ = lam s.
+  ntyvar_ (nameNoSym s)
+
+-- The types defined below are used for documentation purposes.
+let tysym_ = tyunknown_
+let tyref_ = tyunknown_
+let tymap_ = tyunknown_
+let tytensor_ = lam ty. tyunknown_
+let tybootparsetree_ = tyunknown_
+let tygeneric_ = lam id. tyunknown_
+let tygenericseq_ = lam id. tyseq_ (tygeneric_ id)
+let tygenerictensor_ = lam id. tytensor_ (tygeneric_ id)
 
 lang IntAst = ConstAst
   syn Const =
   | CInt {val : Int}
+
+  sem tyConst =
+  | CInt _ -> tyint_
 end
 
 lang ArithIntAst = ConstAst + IntAst
@@ -406,6 +571,14 @@ lang ArithIntAst = ConstAst + IntAst
   | CDivi {}
   | CNegi {}
   | CModi {}
+
+  sem tyConst =
+  | CAddi _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CSubi _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CMuli _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CDivi _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CNegi _ -> tyarrow_ tyint_ tyint_
+  | CModi _ -> tyarrows_ [tyint_, tyint_, tyint_]
 end
 
 lang ShiftIntAst = ConstAst + IntAst
@@ -413,11 +586,19 @@ lang ShiftIntAst = ConstAst + IntAst
   | CSlli {}
   | CSrli {}
   | CSrai {}
+
+  sem tyConst =
+  | CSlli _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CSrli _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CSrai _ -> tyarrows_ [tyint_, tyint_, tyint_]
 end
 
 lang FloatAst = ConstAst
   syn Const =
   | CFloat {val : Float}
+
+  sem tyConst =
+  | CFloat _ -> tyfloat_
 end
 
 lang ArithFloatAst = ConstAst + FloatAst
@@ -427,6 +608,13 @@ lang ArithFloatAst = ConstAst + FloatAst
   | CMulf {}
   | CDivf {}
   | CNegf {}
+
+  sem tyConst =
+  | CAddf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CSubf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CMulf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CDivf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CNegf _ -> tyarrow_ tyfloat_ tyfloat_
 end
 
 lang FloatIntConversionAst = IntAst + FloatAst
@@ -435,11 +623,20 @@ lang FloatIntConversionAst = IntAst + FloatAst
   | CCeilfi {}
   | CRoundfi {}
   | CInt2float {}
+
+  sem tyConst =
+  | CFloorfi _ -> tyarrow_ tyfloat_ tyint_
+  | CCeilfi _ -> tyarrow_ tyfloat_ tyint_
+  | CRoundfi _ -> tyarrow_ tyfloat_ tyint_
+  | CInt2float _ -> tyarrow_ tyint_ tyfloat_
 end
 
 lang BoolAst = ConstAst
   syn Const =
   | CBool {val : Bool}
+
+  sem tyConst =
+  | CBool _ -> tybool_
 end
 
 lang CmpIntAst = IntAst + BoolAst
@@ -450,6 +647,14 @@ lang CmpIntAst = IntAst + BoolAst
   | CGti {}
   | CLeqi {}
   | CGeqi {}
+
+  sem tyConst =
+  | CEqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CNeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CLti _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CGti _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CLeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CGeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
 end
 
 lang CmpFloatAst = FloatAst + BoolAst
@@ -460,27 +665,48 @@ lang CmpFloatAst = FloatAst + BoolAst
   | CGtf {}
   | CGeqf {}
   | CNeqf {}
+
+  sem tyConst =
+  | CEqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CLtf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CLeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CGtf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CGeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CNeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
 end
 
 lang CharAst = ConstAst
   syn Const =
   | CChar {val : Char}
+
+  sem tyConst =
+  | CChar _ -> tychar_
 end
 
 lang CmpCharAst = CharAst + BoolAst
   syn Const =
   | CEqc {}
+
+  sem tyConst =
+  | CEqc _ -> tyarrows_ [tychar_, tychar_, tybool_]
 end
 
 lang IntCharConversionAst = IntAst + CharAst
   syn Const =
   | CInt2Char {}
   | CChar2Int {}
+
+  sem tyConst =
+  | CInt2Char _ -> tyarrow_ tyint_ tychar_
+  | CChar2Int _ -> tyarrow_ tychar_ tyint_
 end
 
 lang FloatStringConversionAst = SeqAst + FloatAst
   syn Const =
   | CString2float {}
+
+  sem tyConst =
+  | CString2float _ -> tyarrow_ tystr_ tyfloat_
 end
 
 lang SymbAst = ConstAst
@@ -488,11 +714,19 @@ lang SymbAst = ConstAst
   | CSymb {val : Symb}
   | CGensym {}
   | CSym2hash {}
+
+  sem tyConst =
+  | CSymb _ -> tysym_
+  | CGensym _ -> tyarrow_ tyunit_ tysym_
+  | CSym2hash _ -> tyarrow_ tysym_ tyint_
 end
 
 lang CmpSymbAst = SymbAst + BoolAst
   syn Const =
   | CEqsym {}
+
+  sem tyConst =
+  | CEqsym _ -> tyarrows_ [tysym_, tysym_, tybool_]
 end
 
 lang SeqOpAst = SeqAst
@@ -507,6 +741,23 @@ lang SeqOpAst = SeqAst
   | CCreate {}
   | CSplitAt {}
   | CSubsequence {}
+
+  sem tyConst =
+  | CSet _ -> tyarrows_ [tygenericseq_ "a", tyint_,
+                         tygeneric_ "a", tygenericseq_ "a"]
+  | CGet _ -> tyarrows_ [tygenericseq_ "a", tyint_, tygeneric_ "a"]
+  | CCons _ -> tyarrows_ [tygeneric_ "a", tygenericseq_ "a", tygenericseq_ "a"]
+  | CSnoc _ -> tyarrows_ [tygenericseq_ "a", tygeneric_ "a", tygenericseq_ "a"]
+  | CConcat _ -> tyarrows_ [tygenericseq_ "a", tygenericseq_ "a",
+                            tygenericseq_ "a"]
+  | CLength _ -> tyarrow_ (tygenericseq_ "a") tyint_
+  | CReverse _ -> tyarrow_ (tygenericseq_ "a") (tygenericseq_ "a")
+  | CCreate _ -> tyarrows_ [tyint_, tyarrow_ tyint_ (tygeneric_ "a"),
+                            tygenericseq_ "a"]
+  | CSplitAt _ -> tyarrows_ [tygenericseq_ "a", tyint_,
+                             tytuple_ [tygenericseq_ "a", tygenericseq_ "a"]]
+  | CSubsequence _ -> tyarrows_ [tygenericseq_ "a", tyint_, tyint_,
+                                 tygenericseq_ "a"]
 end
 
 lang FileOpAst = ConstAst
@@ -515,20 +766,12 @@ lang FileOpAst = ConstAst
   | CFileWrite {}
   | CFileExists {}
   | CFileDelete {}
-end
 
-lang TensorOpAst
-  syn Const =
-  | CTensorCreate {}
-  | CTensorGetExn {}
-  | CTensorSetExn {}
-  | CTensorRank {}
-  | CTensorShape {}
-  | CTensorReshapeExn {}
-  | CTensorCopyExn {}
-  | CTensorSliceExn {}
-  | CTensorSubExn {}
-  | CTensorIteri {}
+  sem tyConst =
+  | CFileRead _ -> tyarrow_ tystr_ tystr_
+  | CFileWrite _ -> tyarrows_ [tystr_, tystr_, tyunit_]
+  | CFileExists _ -> tyarrow_ tystr_ tybool_
+  | CFileDelete _ -> tyarrow_ tystr_ tyunit_
 end
 
 lang IOAst = ConstAst
@@ -537,12 +780,22 @@ lang IOAst = ConstAst
   | CDPrint {}
   | CReadLine {}
   | CReadBytesAsString {}
+
+  sem tyConst =
+  | CPrint _ -> tyarrow_ tystr_ tyunit_
+  | CDPrint _ -> tyarrow_ tystr_ tyunit_
+  | CReadLine _ -> tyarrow_ tyunit_ tystr_
+  | CReadBytesAsString _ -> tyarrow_ tyint_ (tytuple_ [tystr_, tystr_])
 end
 
 lang RandomNumberGeneratorAst = ConstAst
   syn Const =
   | CRandIntU {}
   | CRandSetSeed {}
+
+  sem tyConst =
+  | CRandIntU _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CRandSetSeed _ -> tyarrow_ tyint_ tyunit_
 end
 
 lang SysAst = ConstAst
@@ -550,12 +803,21 @@ lang SysAst = ConstAst
   | CExit {}
   | CError {}
   | CArgv {}
+
+  sem tyConst =
+  | CExit _ -> tyarrow_ tyint_ tyunknown_
+  | CError _ -> tyarrow_ tyint_ tyunknown_
+  | CArgv _ -> tyseq_ tystr_
 end
 
 lang TimeAst = ConstAst
   syn Const =
   | CWallTimeMs {}
   | CSleepMs {}
+
+  sem tyConst =
+  | CWallTimeMs _ -> tyarrow_ tyunit_ tyfloat_
+  | CSleepMs _ -> tyarrow_ tyint_ tyunit_
 end
 
 lang RefOpAst = ConstAst + RefAst
@@ -563,6 +825,11 @@ lang RefOpAst = ConstAst + RefAst
   | CRef {}
   | CModRef {}
   | CDeRef {}
+
+  sem tyConst =
+  | CRef _ -> tyarrow_ (tygeneric_ "a") tyref_
+  | CModRef _ -> tyarrow_ tyref_ (tygeneric_ "a")
+  | CDeRef _ -> tyarrows_ [tyref_, tygeneric_ "a", tyunit_]
 end
 
 lang MapAst = ConstAst
@@ -583,9 +850,42 @@ lang MapAst = ConstAst
   | CMapEq {}
   | CMapCmp {}
   | CMapGetCmpFun {}
+
+  sem tyConst =
+  | CMapEmpty _ -> tyarrow_ (tyarrows_ [tygeneric_ "a", tygeneric_ "a", tyint_])
+                            tymap_
+  | CMapInsert _ -> tyarrows_ [tygeneric_ "a", tygeneric_ "b", tymap_, tymap_]
+  | CMapRemove _ -> tyarrows_ [tygeneric_ "a", tymap_, tymap_]
+  | CMapFindWithExn _ -> tyarrows_ [tygeneric_ "a", tymap_, tygeneric_ "b"]
+  | CMapFindOrElse _ -> tyarrows_ [tyarrow_ tyunit_ (tygeneric_ "b"),
+                                   tygeneric_ "a", tymap_, tygeneric_ "b"]
+  | CMapFindApplyOrElse _ ->
+    tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
+               tyarrow_ tyunit_ (tygeneric_ "c"), tygeneric_ "a",
+               tymap_, tygeneric_ "c"]
+  | CMapBindings _ -> tyarrow_ tymap_
+                               (tyseq_ (tytuple_ [tygeneric_ "a", tygeneric_ "b"]))
+  | CMapSize _ -> tyarrow_ tymap_ tyint_
+  | CMapMem _ -> tyarrows_ [tygeneric_ "a", tymap_, tyint_]
+  | CMapAny _ -> tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tybool_],
+                            tymap_, tybool_]
+  | CMapMap _ -> tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
+                            tymap_, tymap_]
+  | CMapMapWithKey _ ->
+    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tygeneric_ "c"],
+               tymap_, tymap_]
+  | CMapFoldWithKey _ ->
+    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b",
+                          tygeneric_ "c", tygeneric_ "c"],
+               tygeneric_ "c", tymap_, tygeneric_ "c"]
+  | CMapEq _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tybool_],
+                           tymap_, tymap_, tybool_]
+  | CMapCmp _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tyint_],
+                            tymap_, tymap_, tyint_]
+  | CMapGetCmpFun _ -> tyarrows_ [tymap_, tygeneric_ "a", tygeneric_ "a", tyint_]
 end
 
-lang TensorAst = ConstAst
+lang TensorOpAst = ConstAst
   syn Const =
   | CTensorCreate {}
   | CTensorGetExn {}
@@ -597,6 +897,28 @@ lang TensorAst = ConstAst
   | CTensorSliceExn {}
   | CTensorSubExn {}
   | CTensorIteri {}
+
+  sem tyConst =
+  | CTensorCreate _ -> tyarrows_ [tyseq_ tyint_,
+                                  tyarrow_ (tyseq_ tyint_) (tygeneric_ "a"),
+                                  tygenerictensor_ "a"]
+  | CTensorGetExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
+                                  tygeneric_ "a"]
+  | CTensorSetExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
+                                  tygeneric_ "a", tyunit_]
+  | CTensorRank _ -> tyarrow_ (tygenerictensor_ "a") tyint_
+  | CTensorShape _ -> tyarrow_ (tygenerictensor_ "a") (tyseq_ tyint_)
+  | CTensorReshapeExn _ -> tyarrows_ [tygenerictensor_ "a",
+                                      tyseq_ tyint_, tygenerictensor_ "a"]
+  | CTensorCopyExn _ -> tyarrows_ [tygenerictensor_ "a", tygenerictensor_ "a",
+                                   tyunit_]
+  | CTensorSliceExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
+                                    tygenerictensor_ "a"]
+  | CTensorSubExn _ -> tyarrows_ [tygenerictensor_ "a", tyint_, tyint_,
+                                  tygenerictensor_ "a"]
+  | CTensorIteri _ -> tyarrows_ [tyarrows_ [tyint_, tygenerictensor_ "a",
+                                            tyunit_],
+                                 tygenerictensor_ "a", tyunit_]
 end
 
 lang BootParserAst = ConstAst
@@ -613,6 +935,20 @@ lang BootParserAst = ConstAst
   | CBootParserGetConst {}
   | CBootParserGetPat {}
   | CBootParserGetInfo {}
+
+  sem tyConst =
+  | CBootParserParseMExprString _ -> tyarrow_ tystr_ tybootparsetree_
+  | CBootParserParseMCoreFile _ -> tyarrow_ tystr_ tybootparsetree_
+  | CBootParserGetId _ -> tyarrow_ tybootparsetree_ tyint_
+  | CBootParserGetTerm _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetType _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetString _ -> tyarrow_ tybootparsetree_ tystr_
+  | CBootParserGetInt _ -> tyarrow_ tybootparsetree_ tyint_
+  | CBootParserGetFloat _ -> tyarrow_ tybootparsetree_ tyfloat_
+  | CBootParserGetListLength _ -> tyarrow_ tybootparsetree_ tyint_
+  | CBootParserGetConst _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetPat _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetInfo _ -> tyarrow_ tybootparsetree_ tybootparsetree_
 end
 
 --------------
@@ -796,101 +1132,6 @@ lang NotPat
   | PatNot {subpat = p} -> f acc p
 end
 
------------
--- TYPES --
------------
-
-lang UnknownTypeAst
-  syn Type =
-  | TyUnknown {info : Info}
-
-  sem info =
-  | TyUnknown r -> r.info
-end
-
-lang BoolTypeAst
-  syn Type =
-  | TyBool {info  : Info}
-
-  sem info =
-  | TyBool r -> r.info
-end
-
-lang IntTypeAst
-  syn Type =
-  | TyInt {info : Info}
-
-  sem info =
-  | TyInt r -> r.info
-end
-
-lang FloatTypeAst
-  syn Type =
-  | TyFloat {info : Info}
-
-  sem info =
-  | TyFloat r -> r.info
-end
-
-lang CharTypeAst
-  syn Type =
-  | TyChar {info  : Info}
-
-  sem info =
-  | TyChar r -> r.info
-end
-
-lang FunTypeAst
-  syn Type =
-  | TyArrow {info : Info,
-             from : Type,
-             to   : Type}
-  sem info =
-  | TyArrow r -> r.info
-end
-
-lang SeqTypeAst
-  syn Type =
-  | TySeq {info : Info,
-           ty   : Type}
-  sem info =
-  | TySeq r -> r.info
-end
-
-lang RecordTypeAst
-  syn Type =
-  | TyRecord {info    : Info,
-              fields  : Map SID Type}
-  sem info =
-  | TyRecord r -> r.info
-end
-
-lang VariantTypeAst
-  syn Type =
-  | TyVariant {info     : Info,
-               constrs  : Map Name Type}
-  sem info =
-  | TyVariant r -> r.info
-end
-
-lang VarTypeAst
-  syn Type =
-  | TyVar {info   : Info,
-           ident  : Name}
-  sem info =
-  | TyVar r -> r.info
-end
-
-lang AppTypeAst
-  syn Type =
-  | TyApp {info : Info,
-           lhs  : Type,
-           rhs  : Type}
-  sem info =
-  | TyApp r -> r.info
-end
-
-
 ------------------------
 -- MEXPR AST FRAGMENT --
 ------------------------
@@ -901,19 +1142,19 @@ lang MExprAst =
   VarAst + AppAst + LamAst + RecordAst + LetAst + TypeAst + RecLetsAst +
   ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst + RefAst +
 
+  -- Types
+  UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
+  FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + VarTypeAst +
+  AppTypeAst +
+
   -- Constants
   IntAst + ArithIntAst + ShiftIntAst + FloatAst + ArithFloatAst + BoolAst +
   CmpIntAst + IntCharConversionAst + CmpFloatAst + CharAst + CmpCharAst +
   SymbAst + CmpSymbAst + SeqOpAst + FileOpAst + IOAst +
   RandomNumberGeneratorAst + SysAst + FloatIntConversionAst +
-  FloatStringConversionAst + TimeAst + RefOpAst + MapAst + TensorAst +
-  TensorOpAst + BootParserAst +
+  FloatStringConversionAst + TimeAst + RefOpAst + MapAst + TensorOpAst +
+  BootParserAst +
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +
-  BoolPat + AndPat + OrPat + NotPat +
-
-  -- Types
-  UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
-  FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + VarTypeAst +
-  AppTypeAst
+  BoolPat + AndPat + OrPat + NotPat

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -307,7 +307,7 @@ utest l_info "  \n lam x.x" with r_info 2 1 2 8 in
 utest info (match parseMExprString s with TmLet r then r.body else ())
 with r_info 1 8 1 15 in
 utest l_info "  let x = 4 in y  " with r_info 1 2 1 14 in
-let s = "print x; 10" in
+let s = "printLn x; 10" in
 utest lside s with rside s in
 
 -- TmRecLets, TmLam

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -145,17 +145,3 @@ let builtinNameTypeMap : Map Name Type =
         tyConst c
       else never)
     builtinEnv
-
-let builtinPprintNameMap =
-  mapFromList nameCmp (map (lam n. (n, nameGetStr n)) builtinNames)
-
-let builtinPprintCount =
-  mapFromList cmpString (map (lam n. (nameGetStr n, 1)) builtinNames)
-
-let builtinPprintStrings = mapMap (lam. 0) builtinPprintCount
-
-let builtinPprintEnv =
-  { nameMap = builtinPprintNameMap
-  , count = builtinPprintCount
-  , strings = builtinPprintStrings
-  }

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -2,257 +2,148 @@ include "mexpr/ast.mc"
 include "map.mc"
 include "stringid.mc"
 
-let _intType = use MExprAst in TyInt {info = NoInfo ()}
-let _floatType = use MExprAst in TyFloat {info = NoInfo ()}
-let _boolType = use MExprAst in TyBool {info = NoInfo ()}
-let _charType = use MExprAst in TyChar {info = NoInfo ()}
-let _unknownType = use MExprAst in TyUnknown {info = NoInfo ()}
-
-let _seqType = use MExprAst in
-  lam elemTy.
-  TySeq {ty = elemTy, info = NoInfo ()}
-let _strType = _seqType _charType
-let _arrowType = use MExprAst in
-  lam from. lam to.
-  TyArrow {from = from, to = to, info = NoInfo ()}
-let _recordType = use MExprAst in
-  lam fields.
-  TyRecord {
-    fields = mapFromList cmpSID (map (lam b. (stringToSid b.0, b.1)) fields),
-    info = NoInfo ()
-  }
-let _tupleType = lam types.
-  _recordType (mapi (lam i. lam ty. (int2string i, ty)) types)
-let _unitType = _recordType []
-
--- Use TyUnknown as a placeholder for terms that cannot be represented using
--- the existing types.
-let _symType = _unknownType
-let _refType = _unknownType
-let _mapType = _unknownType
-let _tensorType = _unknownType
-let _parseTreeType = _unknownType
-let _genericType = _unknownType
-let _genericSeqType = _seqType _genericType
-
 let builtin = use MExprAst in
-  [ ("addi", CAddi (), _arrowType _intType (_arrowType _intType _intType))
-  , ("subi", CSubi (), _arrowType _intType (_arrowType _intType _intType))
-  , ("muli", CMuli (), _arrowType _intType (_arrowType _intType _intType))
-  , ("divi", CDivi (), _arrowType _intType (_arrowType _intType _intType))
-  , ("modi", CModi (), _arrowType _intType (_arrowType _intType _intType))
-  , ("negi", CNegi (), _arrowType _intType _intType)
-  , ("lti", CLti (), _arrowType _intType (_arrowType _intType _boolType))
-  , ("leqi", CLeqi (), _arrowType _intType (_arrowType _intType _boolType))
-  , ("gti", CGti (), _arrowType _intType (_arrowType _intType _boolType))
-  , ("geqi", CGeqi (), _arrowType _intType (_arrowType _intType _boolType))
-  , ("eqi", CEqi (), _arrowType _intType (_arrowType _intType _boolType))
-  , ("neqi", CNeqi (), _arrowType _intType (_arrowType _intType _boolType))
-  , ("slli", CSlli (), _arrowType _intType (_arrowType _intType _intType))
-  , ("srli", CSrli (), _arrowType _intType (_arrowType _intType _intType))
-  , ("srai", CSrai (), _arrowType _intType (_arrowType _intType _intType))
+  [ ("addi", CAddi ())
+  , ("subi", CSubi ())
+  , ("muli", CMuli ())
+  , ("divi", CDivi ())
+  , ("modi", CModi ())
+  , ("negi", CNegi ())
+  , ("lti", CLti ())
+  , ("leqi", CLeqi ())
+  , ("gti", CGti ())
+  , ("geqi", CGeqi ())
+  , ("eqi", CEqi ())
+  , ("neqi", CNeqi ())
+  , ("slli", CSlli ())
+  , ("srli", CSrli ())
+  , ("srai", CSrai ())
   -- , ("arity", Carity ())   -- Arity is not yet implemented
   -- Floating-point numbers
-  , ("addf", CAddf (), _arrowType _floatType (_arrowType _floatType _floatType))
-  , ("subf", CSubf (), _arrowType _floatType (_arrowType _floatType _floatType))
-  , ("mulf", CMulf (), _arrowType _floatType (_arrowType _floatType _floatType))
-  , ("divf", CDivf (), _arrowType _floatType (_arrowType _floatType _floatType))
-  , ("negf", CNegf (), _arrowType _floatType _floatType)
-  , ("ltf", CLtf (), _arrowType _floatType (_arrowType _floatType _boolType))
-  , ("leqf", CLeqf (), _arrowType _floatType (_arrowType _floatType _boolType))
-  , ("gtf", CGtf (), _arrowType _floatType (_arrowType _floatType _boolType))
-  , ("geqf", CGeqf (), _arrowType _floatType (_arrowType _floatType _boolType))
-  , ("eqf", CEqf (), _arrowType _floatType (_arrowType _floatType _boolType))
-  , ("neqf", CNeqf (), _arrowType _floatType (_arrowType _floatType _boolType))
-  , ("floorfi", CFloorfi (), _arrowType _floatType _intType)
-  , ("ceilfi", CCeilfi (), _arrowType _floatType _intType)
-  , ("roundfi", CRoundfi (), _arrowType _floatType _intType)
-  , ("int2float", CInt2float (), _arrowType _intType _floatType)
-  , ("string2float", CString2float (), _arrowType _strType _floatType)
+  , ("addf", CAddf ())
+  , ("subf", CSubf ())
+  , ("mulf", CMulf ())
+  , ("divf", CDivf ())
+  , ("negf", CNegf ())
+  , ("ltf", CLtf ())
+  , ("leqf", CLeqf ())
+  , ("gtf", CGtf ())
+  , ("geqf", CGeqf ())
+  , ("eqf", CEqf ())
+  , ("neqf", CNeqf ())
+  , ("floorfi", CFloorfi ())
+  , ("ceilfi", CCeilfi ())
+  , ("roundfi", CRoundfi ())
+  , ("int2float", CInt2float ())
+  , ("string2float", CString2float ())
   -- Characters
-  , ("eqc", CEqc (), _arrowType _charType (_arrowType _charType _boolType))
-  , ("char2int", CChar2Int (), _arrowType _intType _charType)
-  , ("int2char", CInt2Char (), _arrowType _charType _intType)
+  , ("eqc", CEqc ())
+  , ("char2int", CChar2Int ())
+  , ("int2char", CInt2Char ())
   -- Sequences
-  , ("create", CCreate (),
-      _arrowType
-        _intType
-        (_arrowType (_arrowType _intType _genericType)
-                    _genericSeqType))
-  , ("length", CLength (), _arrowType _genericSeqType _intType)
-  , ("concat", CConcat (),
-      _arrowType _genericSeqType
-                 (_arrowType _genericSeqType _genericSeqType))
-  , ("get", CGet (),
-      _arrowType _genericSeqType
-                 (_arrowType _intType _genericSeqType))
-  , ("set", CSet (),
-      _arrowType _genericSeqType
-                 (_arrowType _intType (_arrowType _genericType _genericSeqType)))
-  , ("cons", CCons (),
-      _arrowType _genericType
-                 (_arrowType _genericSeqType _genericSeqType))
-  , ("snoc", CSnoc (),
-      _arrowType _genericSeqType
-                 (_arrowType _genericType _genericSeqType))
-  , ("splitAt", CSplitAt (),
-      _arrowType _genericSeqType
-                 (_arrowType _intType
-                             (_tupleType [_genericSeqType, _genericSeqType])))
-  , ("reverse", CReverse (), _arrowType _genericSeqType _genericSeqType)
-  , ("subsequence", CSubsequence (),
-      _arrowType _genericSeqType
-                 (_arrowType _intType
-                             (_arrowType _intType _genericSeqType)))
+  , ("create", CCreate ())
+  , ("length", CLength ())
+  , ("concat", CConcat ())
+  , ("get", CGet ())
+  , ("set", CSet ())
+  , ("cons", CCons ())
+  , ("snoc", CSnoc ())
+  , ("splitAt", CSplitAt ())
+  , ("reverse", CReverse ())
+  , ("subsequence", CSubsequence ())
   -- Random numbers
-  , ("randIntU", CRandIntU (),
-      _arrowType _intType (_arrowType _intType _intType))
-  , ("randSetSeed", CRandSetSeed (), _arrowType _intType _unitType)
+  , ("randIntU", CRandIntU ())
+  , ("randSetSeed", CRandSetSeed ())
   -- MCore intrinsics: Time
-  , ("wallTimeMs", CWallTimeMs (), _arrowType _unitType _floatType)
-  , ("sleepMs", CSleepMs (), _arrowType _intType _unitType)
+  , ("wallTimeMs", CWallTimeMs ())
+  , ("sleepMs", CSleepMs ())
   -- MCore intrinsics: Debug and I/O
-  , ("print", CPrint (), _arrowType _strType _unitType)
-  , ("dprint", CDPrint (), _arrowType _strType _unitType)
-  , ("readLine", CReadLine (), _arrowType _unitType _strType)
-  , ("readBytesAsString", CReadBytesAsString (),
-      _arrowType _intType (_tupleType [_strType, _strType]))
-  , ("argv", CArgv (), _seqType _strType)
-  , ("readFile", CFileRead (), _arrowType _strType _strType)
-  , ("writeFile", CFileWrite (),
-      _arrowType _strType (_arrowType _strType _unitType))
-  , ("fileExists", CFileExists (), _arrowType _strType _boolType)
-  , ("deleteFile", CFileDelete (), _arrowType _strType _unitType)
-  , ("error", CError (), _arrowType _intType _unknownType)
-  , ("exit", CExit (), _arrowType _intType _unknownType)
+  , ("print", CPrint ())
+  , ("dprint", CDPrint ())
+  , ("readLine", CReadLine ())
+  , ("readBytesAsString", CReadBytesAsString ())
+  , ("argv", CArgv ())
+  , ("readFile", CFileRead ())
+  , ("writeFile", CFileWrite ())
+  , ("fileExists", CFileExists ())
+  , ("deleteFile", CFileDelete ())
+  , ("error", CError ())
+  , ("exit", CExit ())
   -- Symbols
-  , ("eqsym", CEqsym (), _arrowType _symType (_arrowType _symType _boolType))
-  , ("gensym", CGensym (), _arrowType _unitType _symType)
-  , ("sym2hash", CSym2hash (), _arrowType _symType _intType)
+  , ("eqsym", CEqsym ())
+  , ("gensym", CGensym ())
+  , ("sym2hash", CSym2hash ())
   -- References
-  , ("ref", CRef (), _arrowType _genericType _refType)
-  , ("deref", CDeRef (), _arrowType _refType _genericType)
-  , ("modref", CModRef (), _arrowType _refType (_arrowType _genericType _unitType))
+  , ("ref", CRef ())
+  , ("deref", CDeRef ())
+  , ("modref", CModRef ())
   -- Maps
-  , ("mapEmpty", CMapEmpty (),
-      _arrowType (_arrowType _genericType (_arrowType _genericType _intType)) _mapType)
-  , ("mapSize", CMapSize (), _arrowType _mapType _intType)
-  , ("mapGetCmpFun", CMapGetCmpFun (),
-      _arrowType _mapType
-                 (_arrowType _genericType (_arrowType _genericType _intType)))
-  , ("mapInsert", CMapInsert (),
-      _arrowType _genericType (_arrowType _genericType (_arrowType _mapType _mapType)))
-  , ("mapRemove", CMapRemove (),
-      _arrowType _genericType (_arrowType _genericType _mapType))
-  , ("mapFindWithExn", CMapFindWithExn (),
-      _arrowType _genericType (_arrowType _mapType _genericType))
-  , ("mapFindOrElse", CMapFindOrElse (),
-      _arrowType (_arrowType _unitType _genericType)
-                 (_arrowType _genericType (_arrowType _mapType _mapType)))
-  , ("mapFindApplyOrElse", CMapFindApplyOrElse (),
-      _arrowType (_arrowType _genericType _genericType)
-                 (_arrowType (_arrowType _unitType _genericType)
-                             (_arrowType _genericType
-                                         (_arrowType _mapType _genericType))))
-  , ("mapAny", CMapAny (),
-      _arrowType (_arrowType _genericType (_arrowType _genericType _boolType))
-                 (_arrowType _mapType _boolType))
-  , ("mapMem", CMapMem (),
-     _arrowType _genericType (_arrowType _mapType _boolType))
-  , ("mapMap", CMapMap (),
-      _arrowType (_arrowType _genericType _genericType)
-                 (_arrowType _mapType _mapType))
-  , ("mapMapWithKey", CMapMapWithKey (),
-      _arrowType (_arrowType _genericType (_arrowType _genericType _genericType))
-                 (_arrowType _mapType _mapType))
-  , ("mapFoldWithKey", CMapFoldWithKey (),
-      _arrowType
-        (_arrowType _genericType
-                    (_arrowType _genericType
-                                (_arrowType _genericType _genericType)))
-        (_arrowType _genericType (_arrowType _mapType _mapType)))
-  , ("mapBindings", CMapBindings (),
-      _arrowType _mapType (_seqType (_tupleType [_genericType, _genericType])))
-  , ("mapEq", CMapEq (),
-      _arrowType (_arrowType _genericType (_arrowType _genericType _boolType))
-                 (_arrowType _mapType (_arrowType _mapType _boolType)))
-  , ("mapCmp", CMapCmp (),
-      _arrowType (_arrowType _genericType (_arrowType _genericType _intType))
-                 (_arrowType _mapType (_arrowType _mapType _intType)))
+  , ("mapEmpty", CMapEmpty ())
+  , ("mapSize", CMapSize ())
+  , ("mapGetCmpFun", CMapGetCmpFun ())
+  , ("mapInsert", CMapInsert ())
+  , ("mapRemove", CMapRemove ())
+  , ("mapFindWithExn", CMapFindWithExn ())
+  , ("mapFindOrElse", CMapFindOrElse ())
+  , ("mapFindApplyOrElse", CMapFindApplyOrElse ())
+  , ("mapAny", CMapAny ())
+  , ("mapMem", CMapMem ())
+  , ("mapMap", CMapMap ())
+  , ("mapMapWithKey", CMapMapWithKey ())
+  , ("mapFoldWithKey", CMapFoldWithKey ())
+  , ("mapBindings", CMapBindings ())
+  , ("mapEq", CMapEq ())
+  , ("mapCmp", CMapCmp ())
   -- Tensors
-  , ("tensorCreate", CTensorCreate (),
-      _arrowType (_seqType _intType)
-                 (_arrowType (_seqType _intType) _tensorType))
-  , ("tensorGetExn", CTensorGetExn (),
-      _arrowType _tensorType
-                 (_arrowType (_seqType _intType) _tensorType))
-  , ("tensorSetExn", CTensorSetExn (),
-      _arrowType _tensorType
-                 (_arrowType (_seqType _intType)
-                             (_arrowType _unknownType _unitType)))
-  , ("tensorRank", CTensorRank (), _arrowType _tensorType _intType)
-  , ("tensorShape", CTensorShape (), _arrowType _tensorType (_seqType _intType))
-  , ("tensorReshapeExn", CTensorReshapeExn (),
-      _arrowType _tensorType (_arrowType (_seqType _intType) _tensorType))
-  , ("tensorCopyExn", CTensorCopyExn (),
-      _arrowType _tensorType (_arrowType _tensorType _unknownType))
-  , ("tensorSliceExn", CTensorSliceExn (),
-      _arrowType _tensorType (_arrowType (_seqType _intType) _tensorType))
-  , ("tensorSubExn", CTensorSubExn (),
-      _arrowType _tensorType
-                 (_arrowType _intType (_arrowType _intType _tensorType)))
-  , ("tensorIteri", CTensorIteri (),
-      _arrowType (_arrowType _intType (_arrowType _tensorType _unitType))
-                 (_arrowType _tensorType _unitType))
+  , ("tensorCreate", CTensorCreate ())
+  , ("tensorGetExn", CTensorGetExn ())
+  , ("tensorSetExn", CTensorSetExn ())
+  , ("tensorRank", CTensorRank ())
+  , ("tensorShape", CTensorShape ())
+  , ("tensorReshapeExn", CTensorReshapeExn ())
+  , ("tensorCopyExn", CTensorCopyExn ())
+  , ("tensorSliceExn", CTensorSliceExn ())
+  , ("tensorSubExn", CTensorSubExn ())
+  , ("tensorIteri", CTensorIteri ())
   -- Boot parser
-  , ("bootParserParseMExprString", CBootParserParseMExprString (),
-      _arrowType _strType _parseTreeType)
-  , ("bootParserParseMCoreFile", CBootParserParseMCoreFile (),
-      _arrowType _strType _parseTreeType)
-  , ("bootParserGetId", CBootParserGetId (),
-      _arrowType _parseTreeType _intType)
-  , ("bootParserGetTerm", CBootParserGetTerm (),
-      _arrowType _parseTreeType _parseTreeType)
-  , ("bootParserGetType", CBootParserGetType (),
-      _arrowType _parseTreeType _parseTreeType)
-  , ("bootParserGetString", CBootParserGetString (),
-      _arrowType _parseTreeType _strType)
-  , ("bootParserGetInt", CBootParserGetInt (),
-      _arrowType _parseTreeType _intType)
-  , ("bootParserGetFloat", CBootParserGetFloat (),
-      _arrowType _parseTreeType _floatType)
-  , ("bootParserGetListLength", CBootParserGetListLength (),
-      _arrowType _parseTreeType _intType)
-  , ("bootParserGetConst", CBootParserGetConst (),
-      _arrowType _parseTreeType _parseTreeType)
-  , ("bootParserGetPat", CBootParserGetPat (),
-      _arrowType _parseTreeType _parseTreeType)
-  , ("bootParserGetInfo", CBootParserGetInfo (),
-      _arrowType _parseTreeType _parseTreeType)
+  , ("bootParserParseMExprString", CBootParserParseMExprString ())
+  , ("bootParserParseMCoreFile", CBootParserParseMCoreFile ())
+  , ("bootParserGetId", CBootParserGetId ())
+  , ("bootParserGetTerm", CBootParserGetTerm ())
+  , ("bootParserGetType", CBootParserGetType ())
+  , ("bootParserGetString", CBootParserGetString ())
+  , ("bootParserGetInt", CBootParserGetInt ())
+  , ("bootParserGetFloat", CBootParserGetFloat ())
+  , ("bootParserGetListLength", CBootParserGetListLength ())
+  , ("bootParserGetConst", CBootParserGetConst ())
+  , ("bootParserGetPat", CBootParserGetPat ())
+  , ("bootParserGetInfo", CBootParserGetInfo ())
   ]
 
-let builtinStrNodeType = use MExprAst in
-  map
-    (lam x.
-      match x with (s,c,ty) then
-        ( nameSym s
-        , TmConst {val = c, ty = TyUnknown (), info = NoInfo ()}
-        , ty)
-      else never)
-    builtin
+let builtinEnv : Map Name Expr = use MExprAst in
+  mapFromList
+    nameCmp
+    (map
+      (lam x.
+        match x with (s,c) then
+          (nameSym s, TmConst {val = c, ty = TyUnknown (), info = NoInfo ()})
+        else never)
+      builtin)
 
-let builtinEnv = use MExprAst in
-  map (lam x. (x.0, x.1)) builtinStrNodeType
-
-let builtinNames : [Name] = map (lam intr. intr.0) builtinEnv
+let builtinNames : [Name] = mapKeys builtinEnv
 
 let builtinNameMap : Map String Name =
-  mapFromList cmpString (map (lam x. (nameGetStr x.0, x.0)) builtinEnv)
+  mapFromList cmpString (map (lam x. (nameGetStr x, x)) builtinNames)
 
 let builtinIntrinsicName : String -> Name = lam str.
   match mapLookup str builtinNameMap with Some name then
     name
   else error (join ["Could not find intrinsic: ", str])
 
-let builtinNameTypeMap : Map Name Type =
-  mapFromList nameCmp (map (lam x. (x.0, x.2)) builtinStrNodeType)
+let builtinNameTypeMap : Map Name Type = use MExprAst in
+  mapMap
+    (lam v.
+      match v with TmConst {val = c} then
+        tyConst c
+      else never)
+    builtinEnv

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -1,4 +1,5 @@
 include "mexpr/ast.mc"
+include "mexpr/const-types.mc"
 include "map.mc"
 include "stringid.mc"
 
@@ -135,15 +136,26 @@ let builtinNames : [Name] = mapKeys builtinEnv
 let builtinNameMap : Map String Name =
   mapFromList cmpString (map (lam x. (nameGetStr x, x)) builtinNames)
 
-let builtinIntrinsicName : String -> Name = lam str.
-  match mapLookup str builtinNameMap with Some name then
-    name
-  else error (join ["Could not find intrinsic: ", str])
-
-let builtinNameTypeMap : Map Name Type = use MExprAst in
+let builtinNameTypeMap : Map Name Type =
+  use ConstAst in
+  use MExprConstType in
   mapMap
     (lam v.
       match v with TmConst {val = c} then
         tyConst c
       else never)
     builtinEnv
+
+let builtinPprintNameMap =
+  mapFromList nameCmp (map (lam n. (n, nameGetStr n)) builtinNames)
+
+let builtinPprintCount =
+  mapFromList cmpString (map (lam n. (nameGetStr n, 1)) builtinNames)
+
+let builtinPprintStrings = mapMap (lam. 0) builtinPprintCount
+
+let builtinPprintEnv =
+  { nameMap = builtinPprintNameMap
+  , count = builtinPprintCount
+  , strings = builtinPprintStrings
+  }

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -2,121 +2,176 @@ include "ast.mc"
 include "ast-builder.mc"
 
 let builtin = use MExprAst in
-  [ ("addi", CAddi ())
-  , ("subi", CSubi ())
-  , ("muli", CMuli ())
-  , ("divi", CDivi ())
-  , ("modi", CModi ())
-  , ("negi", CNegi ())
-  , ("lti", CLti ())
-  , ("leqi", CLeqi ())
-  , ("gti", CGti ())
-  , ("geqi", CGeqi ())
-  , ("eqi", CEqi ())
-  , ("neqi", CNeqi ())
-  , ("slli", CSlli ())
-  , ("srli", CSrli ())
-  , ("srai", CSrai ())
+  [ ("addi", CAddi (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("subi", CSubi (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("muli", CMuli (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("divi", CDivi (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("modi", CModi (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("negi", CNegi (), tyarrow_ tyint_ tyint_)
+  , ("lti", CLti (), tyarrow_ tyint_ (tyarrow_ tyint_ tybool_))
+  , ("leqi", CLeqi (), tyarrow_ tyint_ (tyarrow_ tyint_ tybool_))
+  , ("gti", CGti (), tyarrow_ tyint_ (tyarrow_ tyint_ tybool_))
+  , ("geqi", CGeqi (), tyarrow_ tyint_ (tyarrow_ tyint_ tybool_))
+  , ("eqi", CEqi (), tyarrow_ tyint_ (tyarrow_ tyint_ tybool_))
+  , ("neqi", CNeqi (), tyarrow_ tyint_ (tyarrow_ tyint_ tybool_))
+  , ("slli", CSlli (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("srli", CSrli (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("srai", CSrai (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
   -- , ("arity", Carity ())   -- Arity is not yet implemented
   -- Floating-point numbers
-  , ("addf", CAddf ())
-  , ("subf", CSubf ())
-  , ("mulf", CMulf ())
-  , ("divf", CDivf ())
-  , ("negf", CNegf ())
-  , ("ltf", CLtf ())
-  , ("leqf", CLeqf ())
-  , ("gtf", CGtf ())
-  , ("geqf", CGeqf ())
-  , ("eqf", CEqf ())
-  , ("neqf", CNeqf ())
-  , ("floorfi", CFloorfi ())
-  , ("ceilfi", CCeilfi ())
-  , ("roundfi", CRoundfi ())
-  , ("int2float", CInt2float ())
-  , ("string2float", CString2float ())
+  , ("addf", CAddf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_))
+  , ("subf", CSubf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_))
+  , ("mulf", CMulf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_))
+  , ("divf", CDivf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_))
+  , ("negf", CNegf (), tyarrow_ tyfloat_ tyfloat_)
+  , ("ltf", CLtf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_))
+  , ("leqf", CLeqf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_))
+  , ("gtf", CGtf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_))
+  , ("geqf", CGeqf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_))
+  , ("eqf", CEqf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_))
+  , ("neqf", CNeqf (), tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_))
+  , ("floorfi", CFloorfi (), tyarrow_ tyfloat_ tyint_)
+  , ("ceilfi", CCeilfi (), tyarrow_ tyfloat_ tyint_)
+  , ("roundfi", CRoundfi (), tyarrow_ tyfloat_ tyint_)
+  , ("int2float", CInt2float (), tyarrow_ tyint_ tyfloat_)
+  , ("string2float", CString2float (), tyarrow_ tystr_ tyfloat_)
   -- Characters
-  , ("eqc", CEqc ())
-  , ("char2int", CChar2Int ())
-  , ("int2char", CInt2Char ())
+  , ("eqc", CEqc (), tyarrow_ tychar_ (tyarrow_ tychar_ tybool_))
+  , ("char2int", CChar2Int (), tyarrow_ tyint_ tychar_)
+  , ("int2char", CInt2Char (), tyarrow_ tychar_ tyint_)
   -- Sequences
-  , ("create", CCreate ())
-  , ("length", CLength ())
-  , ("concat", CConcat ())
-  , ("get", CGet ())
-  , ("set", CSet ())
-  , ("cons", CCons ())
-  , ("snoc", CSnoc ())
-  , ("splitAt", CSplitAt ())
-  , ("reverse", CReverse ())
-  , ("subsequence", CSubsequence ())
+  , ("create", CCreate (),
+     tyarrow_ tyint_ (tyarrow_ (tyarrow_ tyint_ tyunknown_) utyseq_))
+  , ("length", CLength (), tyarrow_ utyseq_ tyint_)
+  , ("concat", CConcat (), tyarrow_ utyseq_ (tyarrow_ utyseq_ utyseq_))
+  , ("get", CGet (), tyarrow_ utyseq_ (tyarrow_ tyint_ utyseq_))
+  , ("set", CSet (),
+     tyarrow_ utyseq_ (tyarrow_ tyint_ (tyarrow_ tyunknown_ utyseq_)))
+  , ("cons", CCons (), tyarrow_ tyunknown_ (tyarrow_ utyseq_ utyseq_))
+  , ("snoc", CSnoc (), tyarrow_ utyseq_ (tyarrow_ tyunknown_ utyseq_))
+  , ("splitAt", CSplitAt (),
+     tyarrow_ utyseq_ (tyarrow_ tyint_ (tytuple_ [utyseq_, utyseq_])))
+  , ("reverse", CReverse (), tyarrow_ utyseq_ utyseq_)
+  , ("subsequence", CSubsequence (),
+     tyarrow_ utyseq_ (tyarrow_ tyint_ (tyarrow_ tyint_ utyseq_)))
   -- Random numbers
-  , ("randIntU", CRandIntU ())
-  , ("randSetSeed", CRandSetSeed ())
+  , ("randIntU", CRandIntU (), tyarrow_ tyint_ (tyarrow_ tyint_ tyint_))
+  , ("randSetSeed", CRandSetSeed (), tyarrow_ tyint_ tyunit_)
   -- MCore intrinsics: Time
-  , ("wallTimeMs", CWallTimeMs ())
-  , ("sleepMs", CSleepMs ())
+  , ("wallTimeMs", CWallTimeMs (), tyarrow_ tyunit_ tyfloat_)
+  , ("sleepMs", CSleepMs (), tyarrow_ tyint_ tyunit_)
   -- MCore intrinsics: Debug and I/O
-  , ("print", CPrint ())
-  , ("dprint", CDPrint ())
-  , ("readLine", CReadLine ())
-  , ("readBytesAsString", CReadBytesAsString ())
-  , ("argv", CArgv ())
-  , ("readFile", CFileRead ())
-  , ("writeFile", CFileWrite ())
-  , ("fileExists", CFileExists ())
-  , ("deleteFile", CFileDelete ())
-  , ("error", CError ())
-  , ("exit", CExit ())
+  , ("print", CPrint (), tyarrow_ tystr_ tyunit_)
+  , ("dprint", CDPrint (), tyarrow_ tystr_ tyunit_)
+  , ("readLine", CReadLine (), tyarrow_ tyunit_ tystr_)
+  , ("readBytesAsString", CReadBytesAsString (),
+     tyarrow_ tyint_ (tytuple_ [tystr_, tystr_]))
+  , ("argv", CArgv (), tyseq_ tystr_)
+  , ("readFile", CFileRead (), tyarrow_ tystr_ tystr_)
+  , ("writeFile", CFileWrite (), tyarrow_ tystr_ (tyarrow_ tystr_ tyunit_))
+  , ("fileExists", CFileExists (), tyarrow_ tystr_ tybool_)
+  , ("deleteFile", CFileDelete (), tyarrow_ tystr_ tyunit_)
+  , ("error", CError (), tyarrow_ tyint_ tyunknown_)
+  , ("exit", CExit (), tyarrow_ tyint_ tyunknown_)
   -- Symbols
-  , ("eqsym", CEqsym ())
-  , ("gensym", CGensym ())
-  , ("sym2hash", CSym2hash ())
+  , ("eqsym", CEqsym (), tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_))
+  , ("gensym", CGensym (), tyarrow_ tyunit_ tyunknown_)
+  , ("sym2hash", CSym2hash (), tyarrow_ tyunknown_ tyint_)
   -- References
-  , ("ref", CRef ())
-  , ("deref", CDeRef ())
-  , ("modref", CModRef ())
+  , ("ref", CRef (), tyarrow_ tyunknown_ tyunknown_)
+  , ("deref", CDeRef (), tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunit_))
+  , ("modref", CModRef (), tyarrow_ tyunknown_ tyunknown_)
   -- Maps
-  , ("mapEmpty", CMapEmpty ())
-  , ("mapSize", CMapSize ())
-  , ("mapGetCmpFun", CMapGetCmpFun ())
-  , ("mapInsert", CMapInsert ())
-  , ("mapRemove", CMapRemove ())
-  , ("mapFindWithExn", CMapFindWithExn ())
-  , ("mapFindOrElse", CMapFindOrElse ())
-  , ("mapFindApplyOrElse", CMapFindApplyOrElse ())
-  , ("mapAny", CMapAny ())
-  , ("mapMem", CMapMem ())
-  , ("mapMap", CMapMap ())
-  , ("mapMapWithKey", CMapMapWithKey ())
-  , ("mapFoldWithKey", CMapFoldWithKey ())
-  , ("mapBindings", CMapBindings ())
-  , ("mapEq", CMapEq ())
-  , ("mapCmp", CMapCmp ())
+  , ("mapEmpty", CMapEmpty (),
+     tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyint_)) tyunknown_)
+  , ("mapSize", CMapSize (), tyarrow_ tyunknown_ tyint_)
+  , ("mapGetCmpFun", CMapGetCmpFun (),
+     tyarrow_ tyunknown_ (tyarrow_ tyunknown_
+                         (tyarrow_ tyunknown_ tyint_)))
+  , ("mapInsert", CMapInsert (),
+     tyarrow_ tyunknown_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)))
+  , ("mapRemove", CMapRemove (),
+     tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_))
+  , ("mapFindWithExn", CMapFindWithExn (),
+     tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_))
+  , ("mapFindOrElse", CMapFindOrElse (),
+     tyarrow_ (tyarrow_ tyunit_ tyunknown_)
+              (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)))
+  , ("mapFindApplyOrElse", CMapFindApplyOrElse (),
+     tyarrow_ (tyarrow_ tyunknown_ tyunknown_)
+              (tyarrow_ (tyarrow_ tyunit_ tyunknown_)
+                        (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_))))
+  , ("mapAny", CMapAny (),
+     tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_))
+              (tyarrow_ tyunknown_ tybool_))
+  , ("mapMem", CMapMem (),
+     tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_))
+  , ("mapMap", CMapMap (),
+     tyarrow_ (tyarrow_ tyunknown_ tyunknown_)
+              (tyarrow_ tyunknown_ tyunknown_))
+  , ("mapMapWithKey", CMapMapWithKey (),
+     tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_))
+              (tyarrow_ tyunknown_ tyunknown_))
+  , ("mapFoldWithKey", CMapFoldWithKey (),
+     tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)))
+              (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)))
+  , ("mapBindings", CMapBindings (),
+     tyarrow_ tyunknown_ (tyseq_ (tytuple_ [tyunknown_, tyunknown_])))
+  , ("mapEq", CMapEq (),
+     tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_))
+              (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_)))
+  , ("mapCmp", CMapCmp (),
+     tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyint_))
+              (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyint_)))
   -- Tensors
-  , ("tensorCreate", CTensorCreate ())
-  , ("tensorGetExn", CTensorGetExn ())
-  , ("tensorSetExn", CTensorSetExn ())
-  , ("tensorRank", CTensorRank ())
-  , ("tensorShape", CTensorShape ())
-  , ("tensorReshapeExn", CTensorReshapeExn ())
-  , ("tensorCopyExn", CTensorCopyExn ())
-  , ("tensorSliceExn", CTensorSliceExn ())
-  , ("tensorSubExn", CTensorSubExn ())
-  , ("tensorIteri", CTensorIteri ())
+  , ("tensorCreate", CTensorCreate (),
+     tyarrow_ (tyseq_ tyint_)
+              (tyarrow_ (tyseq_ tyint_) tyunknown_))
+  , ("tensorGetExn", CTensorGetExn (),
+     tyarrow_ tyunknown_
+              (tyarrow_ (tyseq_ tyint_) tyunknown_))
+  , ("tensorSetExn", CTensorSetExn (),
+     tyarrow_ tyunknown_
+              (tyarrow_ (tyseq_ tyint_)
+                        (tyarrow_ tyunknown_ tyunit_)))
+  , ("tensorRank", CTensorRank (), tyarrow_ tyunknown_ tyint_)
+  , ("tensorShape", CTensorShape (), tyarrow_ tyunknown_ (tyseq_ tyint_))
+  , ("tensorReshapeExn", CTensorReshapeExn (),
+     tyarrow_ tyunknown_ (tyarrow_ (tyseq_ tyint_) tyunknown_))
+  , ("tensorCopyExn", CTensorCopyExn (), tyarrow_ tyunknown_ tyunknown_)
+  , ("tensorSliceExn", CTensorSliceExn (),
+     tyarrow_ tyunknown_ (tyarrow_ (tyseq_ tyint_) tyunknown_))
+  , ("tensorSubExn", CTensorSubExn (),
+     tyarrow_ tyunknown_
+              (tyarrow_ tyint_ (tyarrow_ tyint_ tyunknown_)))
+  , ("tensorIteri", CTensorIteri (),
+     tyarrow_ (tyarrow_ tyint_ (tyarrow_ tyunknown_ tyunit_))
+              (tyarrow_ tyunknown_ tyunit_))
   -- Boot parser
-  , ("bootParserParseMExprString", CBootParserParseMExprString ())
-  , ("bootParserParseMCoreFile", CBootParserParseMCoreFile ())
-  , ("bootParserGetId", CBootParserGetId ())
-  , ("bootParserGetTerm", CBootParserGetTerm ())
-  , ("bootParserGetType", CBootParserGetType ())
-  , ("bootParserGetString", CBootParserGetString ())
-  , ("bootParserGetInt", CBootParserGetInt ())
-  , ("bootParserGetFloat", CBootParserGetFloat ())
-  , ("bootParserGetListLength", CBootParserGetListLength ())
-  , ("bootParserGetConst", CBootParserGetConst ())
-  , ("bootParserGetPat", CBootParserGetPat ())
-  , ("bootParserGetInfo", CBootParserGetInfo ())
+  , ("bootParserParseMExprString", CBootParserParseMExprString (),
+     tyarrow_ tystr_ tyunknown_)
+  , ("bootParserParseMCoreFile", CBootParserParseMCoreFile (),
+     tyarrow_ tystr_ tyunknown_)
+  , ("bootParserGetId", CBootParserGetId (),
+     tyarrow_ tyunknown_ tyint_)
+  , ("bootParserGetTerm", CBootParserGetTerm (),
+     tyarrow_ tyunknown_ tyunknown_)
+  , ("bootParserGetType", CBootParserGetType (),
+     tyarrow_ tyunknown_ tyunknown_)
+  , ("bootParserGetString", CBootParserGetString (),
+     tyarrow_ tyunknown_ tystr_)
+  , ("bootParserGetInt", CBootParserGetInt (),
+     tyarrow_ tyunknown_ tyint_)
+  , ("bootParserGetFloat", CBootParserGetFloat (),
+     tyarrow_ tyunknown_ tyfloat_)
+  , ("bootParserGetListLength", CBootParserGetListLength (),
+     tyarrow_ tyunknown_ tyint_)
+  , ("bootParserGetConst", CBootParserGetConst (),
+     tyarrow_ tyunknown_ tyunknown_)
+  , ("bootParserGetPat", CBootParserGetPat (),
+     tyarrow_ tyunknown_ tyunknown_)
+  , ("bootParserGetInfo", CBootParserGetInfo (),
+     tyarrow_ tyunknown_ tyunknown_)
   ]
 
-let builtinEnv = map (lam x. match x with (s,c) then (nameSym s, const_ c) else never) builtin
+let builtinEnv = map (lam x. match x with (s,c,ty) then (nameSym s, const_ c, ty) else never) builtin

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -1,0 +1,250 @@
+-- Defines the types of MExpr constants. A semantic function `tyConst` is
+-- provided.
+
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+
+-- The types defined below are only used for documentation purposes, as these
+-- cannot be properly represented using the existing types.
+let tysym_ = tyunknown_
+let tyref_ = tyunknown_
+let tymap_ = tyunknown_
+let tytensor_ = lam ty. tyunknown_
+let tybootparsetree_ = tyunknown_
+let tygeneric_ = lam id. tyunknown_
+let tygenericseq_ = lam id. tyseq_ (tygeneric_ id)
+let tygenerictensor_ = lam id. tytensor_ (tygeneric_ id)
+
+lang LiteralTypeAst = IntAst + FloatAst + BoolAst + CharAst
+  sem tyConst =
+  | CInt _ -> tyint_
+  | CFloat _ -> tyfloat_
+  | CBool _ -> tybool_
+  | CChar _ -> tychar_
+end
+
+lang ArithIntTypeAst = ArithIntAst
+  sem tyConst =
+  | CAddi _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CSubi _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CMuli _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CDivi _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CNegi _ -> tyarrow_ tyint_ tyint_
+  | CModi _ -> tyarrows_ [tyint_, tyint_, tyint_]
+end
+
+lang ShiftIntTypeAst = ShiftIntAst
+  sem tyConst =
+  | CSlli _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CSrli _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CSrai _ -> tyarrows_ [tyint_, tyint_, tyint_]
+end
+
+lang ArithFloatTypeAst = ArithFloatAst
+  sem tyConst =
+  | CAddf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CSubf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CMulf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CDivf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
+  | CNegf _ -> tyarrow_ tyfloat_ tyfloat_
+end
+
+lang FloatIntConversionTypeAst = FloatIntConversionAst
+  sem tyConst =
+  | CFloorfi _ -> tyarrow_ tyfloat_ tyint_
+  | CCeilfi _ -> tyarrow_ tyfloat_ tyint_
+  | CRoundfi _ -> tyarrow_ tyfloat_ tyint_
+  | CInt2float _ -> tyarrow_ tyint_ tyfloat_
+end
+
+lang CmpIntTypeAst = CmpIntAst
+  sem tyConst =
+  | CEqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CNeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CLti _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CGti _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CLeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
+  | CGeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
+end
+
+lang CmpFloatTypeAst = CmpFloatAst
+  sem tyConst =
+  | CEqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CLtf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CLeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CGtf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CGeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+  | CNeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
+end
+
+lang CmpCharTypeAst = CmpCharAst
+  sem tyConst =
+  | CEqc _ -> tyarrows_ [tychar_, tychar_, tybool_]
+end
+
+lang IntCharConversionTypeAst = IntCharConversionAst
+  sem tyConst =
+  | CInt2Char _ -> tyarrow_ tyint_ tychar_
+  | CChar2Int _ -> tyarrow_ tychar_ tyint_
+end
+
+lang FloatStringConversionTypeAst = FloatStringConversionAst
+  sem tyConst =
+  | CString2float _ -> tyarrow_ tystr_ tyfloat_
+end
+
+lang SymbTypeAst = SymbAst
+  sem tyConst =
+  | CSymb _ -> tysym_
+  | CGensym _ -> tyarrow_ tyunit_ tysym_
+  | CSym2hash _ -> tyarrow_ tysym_ tyint_
+end
+
+lang CmpSymbTypeAst = CmpSymbAst
+  sem tyConst =
+  | CEqsym _ -> tyarrows_ [tysym_, tysym_, tybool_]
+end
+
+lang SeqOpTypeAst = SeqOpAst
+  sem tyConst =
+  | CSet _ -> tyarrows_ [tygenericseq_ "a", tyint_,
+                         tygeneric_ "a", tygenericseq_ "a"]
+  | CGet _ -> tyarrows_ [tygenericseq_ "a", tyint_, tygeneric_ "a"]
+  | CCons _ -> tyarrows_ [tygeneric_ "a", tygenericseq_ "a", tygenericseq_ "a"]
+  | CSnoc _ -> tyarrows_ [tygenericseq_ "a", tygeneric_ "a", tygenericseq_ "a"]
+  | CConcat _ -> tyarrows_ [tygenericseq_ "a", tygenericseq_ "a",
+                            tygenericseq_ "a"]
+  | CLength _ -> tyarrow_ (tygenericseq_ "a") tyint_
+  | CReverse _ -> tyarrow_ (tygenericseq_ "a") (tygenericseq_ "a")
+  | CCreate _ -> tyarrows_ [tyint_, tyarrow_ tyint_ (tygeneric_ "a"),
+                            tygenericseq_ "a"]
+  | CSplitAt _ -> tyarrows_ [tygenericseq_ "a", tyint_,
+                             tytuple_ [tygenericseq_ "a", tygenericseq_ "a"]]
+  | CSubsequence _ -> tyarrows_ [tygenericseq_ "a", tyint_, tyint_,
+                                 tygenericseq_ "a"]
+end
+
+lang FileOpTypeAst = FileOpAst
+  sem tyConst =
+  | CFileRead _ -> tyarrow_ tystr_ tystr_
+  | CFileWrite _ -> tyarrows_ [tystr_, tystr_, tyunit_]
+  | CFileExists _ -> tyarrow_ tystr_ tybool_
+  | CFileDelete _ -> tyarrow_ tystr_ tyunit_
+end
+
+lang IOTypeAst = IOAst
+  sem tyConst =
+  | CPrint _ -> tyarrow_ tystr_ tyunit_
+  | CDPrint _ -> tyarrow_ tystr_ tyunit_
+  | CReadLine _ -> tyarrow_ tyunit_ tystr_
+  | CReadBytesAsString _ -> tyarrow_ tyint_ (tytuple_ [tystr_, tystr_])
+end
+
+lang RandomNumberGeneratorTypeAst = RandomNumberGeneratorAst
+  sem tyConst =
+  | CRandIntU _ -> tyarrows_ [tyint_, tyint_, tyint_]
+  | CRandSetSeed _ -> tyarrow_ tyint_ tyunit_
+end
+
+lang SysTypeAst = SysAst
+  sem tyConst =
+  | CExit _ -> tyarrow_ tyint_ tyunknown_
+  | CError _ -> tyarrow_ tyint_ tyunknown_
+  | CArgv _ -> tyseq_ tystr_
+end
+
+lang TimeTypeAst = TimeAst
+  sem tyConst =
+  | CWallTimeMs _ -> tyarrow_ tyunit_ tyfloat_
+  | CSleepMs _ -> tyarrow_ tyint_ tyunit_
+end
+
+lang RefOpTypeAst = RefOpAst
+  sem tyConst =
+  | CRef _ -> tyarrow_ (tygeneric_ "a") tyref_
+  | CModRef _ -> tyarrow_ tyref_ (tygeneric_ "a")
+  | CDeRef _ -> tyarrows_ [tyref_, tygeneric_ "a", tyunit_] end
+
+lang MapTypeAst = MapAst
+  sem tyConst =
+  | CMapEmpty _ -> tyarrow_ (tyarrows_ [tygeneric_ "a", tygeneric_ "a", tyint_])
+                            tymap_
+  | CMapInsert _ -> tyarrows_ [tygeneric_ "a", tygeneric_ "b", tymap_, tymap_]
+  | CMapRemove _ -> tyarrows_ [tygeneric_ "a", tymap_, tymap_]
+  | CMapFindWithExn _ -> tyarrows_ [tygeneric_ "a", tymap_, tygeneric_ "b"]
+  | CMapFindOrElse _ -> tyarrows_ [tyarrow_ tyunit_ (tygeneric_ "b"),
+                                   tygeneric_ "a", tymap_, tygeneric_ "b"]
+  | CMapFindApplyOrElse _ ->
+    tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
+               tyarrow_ tyunit_ (tygeneric_ "c"), tygeneric_ "a",
+               tymap_, tygeneric_ "c"]
+  | CMapBindings _ -> tyarrow_ tymap_
+                               (tyseq_ (tytuple_ [tygeneric_ "a", tygeneric_ "b"]))
+  | CMapSize _ -> tyarrow_ tymap_ tyint_
+  | CMapMem _ -> tyarrows_ [tygeneric_ "a", tymap_, tyint_]
+  | CMapAny _ -> tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tybool_],
+                            tymap_, tybool_]
+  | CMapMap _ -> tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
+                            tymap_, tymap_]
+  | CMapMapWithKey _ ->
+    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tygeneric_ "c"],
+               tymap_, tymap_]
+  | CMapFoldWithKey _ ->
+    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b",
+                          tygeneric_ "c", tygeneric_ "c"],
+               tygeneric_ "c", tymap_, tygeneric_ "c"]
+  | CMapEq _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tybool_],
+                           tymap_, tymap_, tybool_]
+  | CMapCmp _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tyint_],
+                            tymap_, tymap_, tyint_]
+  | CMapGetCmpFun _ -> tyarrows_ [tymap_, tygeneric_ "a", tygeneric_ "a", tyint_]
+end
+
+lang TensorOpTypeAst = TensorOpAst
+  sem tyConst =
+  | CTensorCreate _ -> tyarrows_ [tyseq_ tyint_,
+                                  tyarrow_ (tyseq_ tyint_) (tygeneric_ "a"),
+                                  tygenerictensor_ "a"]
+  | CTensorGetExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
+                                  tygeneric_ "a"]
+  | CTensorSetExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
+                                  tygeneric_ "a", tyunit_]
+  | CTensorRank _ -> tyarrow_ (tygenerictensor_ "a") tyint_
+  | CTensorShape _ -> tyarrow_ (tygenerictensor_ "a") (tyseq_ tyint_)
+  | CTensorReshapeExn _ -> tyarrows_ [tygenerictensor_ "a",
+                                      tyseq_ tyint_, tygenerictensor_ "a"]
+  | CTensorCopyExn _ -> tyarrows_ [tygenerictensor_ "a", tygenerictensor_ "a",
+                                   tyunit_]
+  | CTensorSliceExn _ -> tyarrows_ [tygenerictensor_ "a", tyseq_ tyint_,
+                                    tygenerictensor_ "a"]
+  | CTensorSubExn _ -> tyarrows_ [tygenerictensor_ "a", tyint_, tyint_,
+                                  tygenerictensor_ "a"]
+  | CTensorIteri _ -> tyarrows_ [tyarrows_ [tyint_, tygenerictensor_ "a",
+                                            tyunit_],
+                                 tygenerictensor_ "a", tyunit_]
+end
+
+lang BootParserTypeAst = BootParserAst
+  sem tyConst =
+  | CBootParserParseMExprString _ -> tyarrow_ tystr_ tybootparsetree_
+  | CBootParserParseMCoreFile _ -> tyarrow_ tystr_ tybootparsetree_
+  | CBootParserGetId _ -> tyarrow_ tybootparsetree_ tyint_
+  | CBootParserGetTerm _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetType _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetString _ -> tyarrow_ tybootparsetree_ tystr_
+  | CBootParserGetInt _ -> tyarrow_ tybootparsetree_ tyint_
+  | CBootParserGetFloat _ -> tyarrow_ tybootparsetree_ tyfloat_
+  | CBootParserGetListLength _ -> tyarrow_ tybootparsetree_ tyint_
+  | CBootParserGetConst _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetPat _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+  | CBootParserGetInfo _ -> tyarrow_ tybootparsetree_ tybootparsetree_
+end
+
+lang MExprConstType =
+  LiteralTypeAst + ArithIntTypeAst + ShiftIntTypeAst + ArithFloatTypeAst +
+  CmpIntTypeAst + IntCharConversionTypeAst + CmpFloatTypeAst + CmpCharTypeAst +
+  SymbTypeAst + CmpSymbTypeAst + SeqOpTypeAst + FileOpTypeAst + IOTypeAst +
+  RandomNumberGeneratorTypeAst + SysTypeAst + FloatIntConversionTypeAst +
+  FloatStringConversionTypeAst + TimeTypeAst + RefOpTypeAst + MapTypeAst +
+  TensorOpTypeAst + BootParserTypeAst
+end

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -579,7 +579,7 @@ let print = if printEnabled then print else lam x. x in
 -- Enable/disable eval
 let evalEnabled = false in
 let evalE = lam expr. lam expected.
-  if evalEnabled then eval {env = []} expr else expected in
+  if evalEnabled then eval {env = builtinEnv} expr else expected in
 
 -- Prettyprinting
 let pprint = lam ast.

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -548,8 +548,7 @@ lang MExprEq =
   MatchEq + UtestEq + SeqEq + NeverEq
 
   -- Constants
-  + IntEq + ArithEq + FloatEq + ArithFloatEq + BoolEq + CmpIntEq + CmpFloatEq +
-  CharEq + SymbEq + CmpSymbEq + SeqOpEq + TensorOpEq
+  + IntEq + FloatEq + BoolEq + CharEq + SymbEq
 
   -- Patterns
   + NamedPatEq + SeqTotPatEq + SeqEdgePatEq + RecordPatEq + DataPatEq + IntPatEq +

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -277,44 +277,16 @@ lang IntEq = IntAst
   | CInt {val = v2} -> match lhs with CInt {val = v1} then eqi v1 v2 else false
 end
 
-lang ArithEq = ArithIntAst
-  sem eqConst (lhs : Const) =
-  | CAddi {} -> match lhs with CAddi _ then true else false
-  | CSubi {} -> match lhs with CSubi _ then true else false
-  | CMuli {} -> match lhs with CMuli _ then true else false
-end
-
 lang FloatEq = FloatAst
   sem eqConst (lhs : Const) =
   | CFloat {val = v2} ->
     match lhs with CFloat {val = v1} then eqf v1 v2 else false
 end
 
-lang ArithFloatEq = ArithFloatAst
-  sem eqConst (lhs : Const) =
-  | CAddf {} -> match lhs with CAddf _ then true else false
-  | CSubf {} -> match lhs with CSubf _ then true else false
-  | CMulf {} -> match lhs with CMulf _ then true else false
-  | CDivf {} -> match lhs with CDivf _ then true else false
-  | CNegf {} -> match lhs with CNegf _ then true else false
-end
-
 lang BoolEq = BoolAst
   sem eqConst (lhs : Const) =
   | CBool {val = v2} ->
     match lhs with CBool {val = v1} then eqBool v1 v2 else false
-end
-
-lang CmpIntEq = CmpIntAst
-  sem eqConst (lhs : Const) =
-  | CEqi {} -> match lhs with CEqi _ then true else false
-  | CLti {} -> match lhs with CLti _ then true else false
-end
-
-lang CmpFloatEq = CmpFloatAst
-  sem eqConst (lhs : Const) =
-  | CEqf {} -> match lhs with CEqf _ then true else false
-  | CLtf {} -> match lhs with CLtf _ then true else false
 end
 
 lang CharEq = CharAst
@@ -327,39 +299,6 @@ lang SymbEq = SymbAst
   sem eqConst (lhs : Const) =
   | CSymb {val = v2} ->
     match lhs with CSymb {val = v1} then eqsym v1 v2 else false
-end
-
-lang CmpSymbEq = CmpSymbAst
-  sem eqConst (lhs : Const) =
-  | CEqsym {} -> match lhs with CEqsym _ then true else false
-end
-
--- TODO(dlunde,2020-09-29): Remove constants no longer available in boot?
-lang SeqOpEq = SeqOpAst
-  sem eqConst (lhs : Const) =
-  | CGet {} -> match lhs with CGet _ then true else false
-  | CSet {} -> match lhs with CSet _ then true else false
-  | CCreate {} -> match lhs with CCreate _ then true else false
-  | CCons {} -> match lhs with CCons _ then true else false
-  | CSnoc {} -> match lhs with CSnoc _ then true else false
-  | CConcat {} -> match lhs with CConcat _ then true else false
-  | CLength {} -> match lhs with CLength _ then true else false
-  | CReverse {} -> match lhs with CReverse _ then true else false
-  | CSplitAt {} -> match lhs with CSplitAt _ then true else false
-end
-
-lang TensorOpEq = TensorOpAst
-  sem eqConst (lhs : Const) =
-  | CTensorCreate {} -> match lhs with CTensorCreate _ then true else false
-  | CTensorGetExn {} -> match lhs with CTensorGetExn _ then true else false
-  | CTensorSetExn {} -> match lhs with CTensorSetExn _ then true else false
-  | CTensorRank {} -> match lhs with CTensorRank _ then true else false
-  | CTensorShape {} -> match lhs with CTensorShape _ then true else false
-  | CTensorReshapeExn {} -> match lhs with CTensorReshapeExn _ then true else false
-  | CTensorCopyExn {} -> match lhs with CTensorCopyExn _ then true else false
-  | CTensorSliceExn {} -> match lhs with CTensorSliceExn _ then true else false
-  | CTensorSubExn {} -> match lhs with CTensorSubExn _ then true else false
-  | CTensorIteri {} -> match lhs with CTensorIteri _ then true else false
 end
 
 --------------

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -277,16 +277,44 @@ lang IntEq = IntAst
   | CInt {val = v2} -> match lhs with CInt {val = v1} then eqi v1 v2 else false
 end
 
+lang ArithEq = ArithIntAst
+  sem eqConst (lhs : Const) =
+  | CAddi {} -> match lhs with CAddi _ then true else false
+  | CSubi {} -> match lhs with CSubi _ then true else false
+  | CMuli {} -> match lhs with CMuli _ then true else false
+end
+
 lang FloatEq = FloatAst
   sem eqConst (lhs : Const) =
   | CFloat {val = v2} ->
     match lhs with CFloat {val = v1} then eqf v1 v2 else false
 end
 
+lang ArithFloatEq = ArithFloatAst
+  sem eqConst (lhs : Const) =
+  | CAddf {} -> match lhs with CAddf _ then true else false
+  | CSubf {} -> match lhs with CSubf _ then true else false
+  | CMulf {} -> match lhs with CMulf _ then true else false
+  | CDivf {} -> match lhs with CDivf _ then true else false
+  | CNegf {} -> match lhs with CNegf _ then true else false
+end
+
 lang BoolEq = BoolAst
   sem eqConst (lhs : Const) =
   | CBool {val = v2} ->
     match lhs with CBool {val = v1} then eqBool v1 v2 else false
+end
+
+lang CmpIntEq = CmpIntAst
+  sem eqConst (lhs : Const) =
+  | CEqi {} -> match lhs with CEqi _ then true else false
+  | CLti {} -> match lhs with CLti _ then true else false
+end
+
+lang CmpFloatEq = CmpFloatAst
+  sem eqConst (lhs : Const) =
+  | CEqf {} -> match lhs with CEqf _ then true else false
+  | CLtf {} -> match lhs with CLtf _ then true else false
 end
 
 lang CharEq = CharAst
@@ -299,6 +327,38 @@ lang SymbEq = SymbAst
   sem eqConst (lhs : Const) =
   | CSymb {val = v2} ->
     match lhs with CSymb {val = v1} then eqsym v1 v2 else false
+end
+
+lang CmpSymbEq = CmpSymbAst
+  sem eqConst (lhs : Const) =
+  | CEqsym {} -> match lhs with CEqsym _ then true else false
+end
+
+lang SeqOpEq = SeqOpAst
+  sem eqConst (lhs : Const) =
+  | CGet {} -> match lhs with CGet _ then true else false
+  | CSet {} -> match lhs with CSet _ then true else false
+  | CCreate {} -> match lhs with CCreate _ then true else false
+  | CCons {} -> match lhs with CCons _ then true else false
+  | CSnoc {} -> match lhs with CSnoc _ then true else false
+  | CConcat {} -> match lhs with CConcat _ then true else false
+  | CLength {} -> match lhs with CLength _ then true else false
+  | CReverse {} -> match lhs with CReverse _ then true else false
+  | CSplitAt {} -> match lhs with CSplitAt _ then true else false
+end
+
+lang TensorOpEq = TensorOpAst
+  sem eqConst (lhs : Const) =
+  | CTensorCreate {} -> match lhs with CTensorCreate _ then true else false
+  | CTensorGetExn {} -> match lhs with CTensorGetExn _ then true else false
+  | CTensorSetExn {} -> match lhs with CTensorSetExn _ then true else false
+  | CTensorRank {} -> match lhs with CTensorRank _ then true else false
+  | CTensorShape {} -> match lhs with CTensorShape _ then true else false
+  | CTensorReshapeExn {} -> match lhs with CTensorReshapeExn _ then true else false
+  | CTensorCopyExn {} -> match lhs with CTensorCopyExn _ then true else false
+  | CTensorSliceExn {} -> match lhs with CTensorSliceExn _ then true else false
+  | CTensorSubExn {} -> match lhs with CTensorSubExn _ then true else false
+  | CTensorIteri {} -> match lhs with CTensorIteri _ then true else false
 end
 
 --------------
@@ -548,7 +608,8 @@ lang MExprEq =
   MatchEq + UtestEq + SeqEq + NeverEq
 
   -- Constants
-  + IntEq + FloatEq + BoolEq + CharEq + SymbEq
+  + IntEq + ArithEq + FloatEq + ArithFloatEq + BoolEq + CmpIntEq + CmpFloatEq +
+  CharEq + SymbEq + CmpSymbEq + SeqOpEq + TensorOpEq
 
   -- Patterns
   + NamedPatEq + SeqTotPatEq + SeqEdgePatEq + RecordPatEq + DataPatEq + IntPatEq +

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -18,7 +18,7 @@ include "mexpr/pprint.mc"
 
 type Symbol = Int
 
-type Env = AssocMap Name Expr
+type Env = Map Name Expr
 
 let _eqn =
   lam n1. lam n2.
@@ -27,8 +27,8 @@ let _eqn =
     else
       error "Found name without symbol in eval. Did you run symbolize?"
 
-let _evalLookup = assocLookup {eq = _eqn}
-let _evalInsert = assocInsert {eq = _eqn}
+let _evalLookup = mapLookup
+let _evalInsert = mapInsert
 
 -------------
 -- HELPERS --
@@ -211,7 +211,7 @@ lang MatchEval = MatchAst
   sem eval (ctx : {env : Env}) =
   | TmMatch t ->
     match tryMatch ctx.env (eval ctx t.target) t.pat with Some newEnv then
-      eval {ctx with env = concat newEnv ctx.env} t.thn
+      eval {ctx with env = mapUnion newEnv ctx.env} t.thn
     else eval ctx t.els
 
   sem tryMatch (env : Env) (t : Expr) =

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1212,7 +1212,7 @@ use TestLang in
 
 -- Evaluation shorthand used in tests below
 let evalNoSymbolize =
-  lam t. eval {env = assocEmpty} t in
+  lam t. eval {env = builtinEnv} t in
 
 let eval =
   lam t. evalNoSymbolize (symbolize t) in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -211,7 +211,7 @@ lang MatchEval = MatchAst
   sem eval (ctx : {env : Env}) =
   | TmMatch t ->
     match tryMatch ctx.env (eval ctx t.target) t.pat with Some newEnv then
-      eval {ctx with env = mapUnion newEnv ctx.env} t.thn
+      eval {ctx with env = newEnv} t.thn
     else eval ctx t.els
 
   sem tryMatch (env : Env) (t : Expr) =

--- a/stdlib/mexpr/infix.mc
+++ b/stdlib/mexpr/infix.mc
@@ -73,7 +73,7 @@ lang MExprExt = MExprAst + MExprParserExt + MExprEval + MExprPrettyPrint + MExpr
 
 -- Evaluate an expression into a value expression
 let evalExpr : Expr -> Expr =
-  use MExprExt in lam t. eval {env = assocEmpty} (symbolize t)
+  use MExprExt in lam t. eval {env = builtinEnv} (symbolize t)
 
 -- Parse a string and then evaluate into a value expression
 let evalStr : String -> Expr =

--- a/stdlib/mexpr/mexpr.mc
+++ b/stdlib/mexpr/mexpr.mc
@@ -15,7 +15,7 @@ lang MExpr = MExprAst + MExprParser + MExprEval + MExprPrettyPrint + MExprSym
 
 -- Evaluate an expression into a value expression
 let evalExpr : Expr -> Expr =
-  use MExpr in lam t. eval {env = assocEmpty} (symbolize t)
+  use MExpr in lam t. eval {env = builtinEnv} (symbolize t)
 
 -- Parse a string and then evaluate into a value expression
 let evalStr : String -> Expr =

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -189,8 +189,21 @@ lang PrettyPrint = IdentifierPrettyPrint
   -- Intentionally left blank
 
   sem expr2str =
-  | expr -> match pprintCode 0 pprintEnvEmpty expr with (_,str)
-            then str else never
+  | expr ->
+    let builtinNameMap =
+      mapFromList
+        nameCmp
+        (map (lam n. (n, nameGetStr n)) builtinNames) in
+    let builtinCount =
+      mapFromList
+        cmpString
+        (map (lam n. (nameGetStr n, 1)) builtinNames) in
+    let builtinStrings = mapMapWithKey (lam str. lam. (str, 0)) builtinCount in
+    let defaultPprintEnv = {{{pprintEnvEmpty with nameMap = builtinNameMap}
+                                             with count = builtinCount}
+                                             with strings = builtinStrings} in
+    match pprintCode 0 defaultPprintEnv expr with (_,str)
+    then str else never
 
   -- Helper function for printing parentheses
   sem printParen (indent : Int) (env: PprintEnv) =

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -51,6 +51,18 @@ let pprintEnvEmpty = { nameMap = mapEmpty nameCmp,
                        count = mapEmpty cmpString,
                        strings = mapEmpty cmpString }
 
+-- Definition of a pprint environment including the names of the builtin
+-- functions.
+let builtinPprintNameMap =
+  mapFromList nameCmp (map (lam n. (n, nameGetStr n)) builtinNames)
+let builtinPprintCount = mapMap (lam. 1) builtinNameMap
+let builtinPprintStrings = mapMap (lam. 0) builtinPprintCount
+let builtinPprintEnv =
+  { nameMap = builtinPprintNameMap
+  , count = builtinPprintCount
+  , strings = builtinPprintStrings
+  }
+
 -- Look up the string associated with a name in the environment
 let pprintEnvLookup : Name -> PprintEnv -> Option String = lam name. lam env.
   match env with { nameMap = nameMap } then

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -9,6 +9,7 @@ include "map.mc"
 
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
+include "mexpr/builtin.mc"
 
 ----------------------------
 -- PRETTY PRINT INDENTING --
@@ -190,19 +191,7 @@ lang PrettyPrint = IdentifierPrettyPrint
 
   sem expr2str =
   | expr ->
-    let builtinNameMap =
-      mapFromList
-        nameCmp
-        (map (lam n. (n, nameGetStr n)) builtinNames) in
-    let builtinCount =
-      mapFromList
-        cmpString
-        (map (lam n. (nameGetStr n, 1)) builtinNames) in
-    let builtinStrings = mapMapWithKey (lam str. lam. (str, 0)) builtinCount in
-    let defaultPprintEnv = {{{pprintEnvEmpty with nameMap = builtinNameMap}
-                                             with count = builtinCount}
-                                             with strings = builtinStrings} in
-    match pprintCode 0 defaultPprintEnv expr with (_,str)
+    match pprintCode 0 builtinPprintEnv expr with (_,str)
     then str else never
 
   -- Helper function for printing parentheses

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -30,7 +30,7 @@ let symEnvEmpty =
 
 let symVarNameEnv = lam varNameEnv : [Name].
   {symEnvEmpty with varEnv = map (lam x. (nameGetStr x, x)) varNameEnv}
- 
+
 -----------
 -- TERMS --
 -----------
@@ -41,7 +41,9 @@ lang Sym
 
   -- Symbolize with empty environments
   sem symbolize =
-  | expr -> symbolizeExpr symEnvEmpty expr
+  | expr ->
+    let env = symVarNameEnv builtinNames in
+    symbolizeExpr env expr
 end
 
 lang VarSym = Sym + VarAst

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -4,9 +4,9 @@
 -- NOTE(dlunde,2020-09-25):
 -- * Add support for unbound variables and constructors (similarly to eq.mc)?
 
+include "map.mc"
 include "name.mc"
 include "string.mc"
-include "assoc.mc"
 
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
@@ -20,16 +20,13 @@ include "mexpr/pprint.mc"
 -- use strings directly.
 
 type SymEnv = {
-  varEnv: AssocMap String Name,
-  conEnv: AssocMap String Name,
-  tyEnv: AssocMap String Name
+  varEnv: Map String Name,
+  conEnv: Map String Name,
+  tyEnv: Map String Name
 }
 
 let symEnvEmpty =
-  {varEnv = assocEmpty, conEnv = assocEmpty, tyEnv = assocEmpty}
-
-let symVarNameEnv = lam varNameEnv : [Name].
-  {symEnvEmpty with varEnv = map (lam x. (nameGetStr x, x)) varNameEnv}
+  {varEnv = mapEmpty cmpString, conEnv = mapEmpty cmpString, tyEnv = mapEmpty cmpString}
 
 -----------
 -- TERMS --
@@ -42,7 +39,7 @@ lang Sym
   -- Symbolize with empty environments
   sem symbolize =
   | expr ->
-    let env = symVarNameEnv builtinNames in
+    let env = {symEnvEmpty with varEnv = builtinNameMap} in
     symbolizeExpr env expr
 end
 
@@ -53,7 +50,7 @@ lang VarSym = Sym + VarAst
       if nameHasSym t.ident then TmVar t
       else
         let str = nameGetStr t.ident in
-        match assocLookup {eq=eqString} str varEnv with Some ident then
+        match mapLookup str varEnv with Some ident then
           TmVar {t with ident = ident}
         else error (concat "Unknown variable in symbolizeExpr: " str)
     else never
@@ -84,7 +81,7 @@ lang LamSym = Sym + LamAst + VarSym + AppSym
       else
         let ident = nameSetNewSym ident in
         let str = nameGetStr ident in
-        let varEnv = assocInsert {eq=eqString} str ident varEnv in
+        let varEnv = mapInsert str ident varEnv in
         let env = {env with varEnv = varEnv} in
         TmLam {ident = ident,
                tyIdent = tyIdent,
@@ -120,7 +117,7 @@ lang LetSym = Sym + LetAst
       else
         let ident = nameSetNewSym t.ident in
         let str = nameGetStr ident in
-        let varEnv = assocInsert {eq=eqString} str ident varEnv in
+        let varEnv = mapInsert str ident varEnv in
         let env = {env with varEnv = varEnv} in
         TmLet {{{{t with ident = ident}
                     with tyBody = tyBody}
@@ -144,7 +141,7 @@ lang TypeSym = Sym + TypeAst
       else
         let ident = nameSetNewSym ident in
         let str = nameGetStr ident in
-        let tyEnv = assocInsert {eq=eqString} str ident tyEnv in
+        let tyEnv = mapInsert str ident tyEnv in
         let env = {env with tyEnv = tyEnv} in
         TmType {ident = ident, tyIdent = tyIdent,
                 ty = ty, inexpr = symbolizeExpr env inexpr}
@@ -167,7 +164,7 @@ lang RecLetsSym = Sym + RecLetsAst
     let varEnv =
       foldl
         (lam varEnv. lam bind.
-           assocInsert {eq=eqString} (nameGetStr bind.ident) bind.ident varEnv)
+           mapInsert (nameGetStr bind.ident) bind.ident varEnv)
         varEnv bindings in
     let env = {env with varEnv = varEnv} in
 
@@ -205,7 +202,7 @@ lang DataSym = Sym + DataAst
       else
         let str = nameGetStr ident in
         let ident = nameSetNewSym ident in
-        let conEnv = assocInsert {eq=eqString} str ident conEnv in
+        let conEnv = mapInsert str ident conEnv in
         let env = {env with conEnv = conEnv} in
         TmConDef {ident = ident,
                   tyIdent = tyIdent,
@@ -224,7 +221,7 @@ lang DataSym = Sym + DataAst
                   info = info}
       else
         let str = nameGetStr ident in
-        match assocLookup {eq=eqString} str conEnv with Some ident then
+        match mapLookup str conEnv with Some ident then
           TmConApp {ident = ident,
                     body = symbolizeExpr env body,
                     ty = ty,
@@ -240,15 +237,14 @@ lang MatchSym = Sym + MatchAst
   -- nice to pass via state monad or something.  env is the
   -- environment from the outside, plus the names added thus far in
   -- the pattern patEnv is only the newly added names
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   -- Intentionally left blank
 
   sem symbolizeExpr (env : SymEnv) =
   | TmMatch t ->
-    match symbolizePat env assocEmpty t.pat
+    match symbolizePat env (mapEmpty cmpString) t.pat
     with (thnVarEnv, pat) then
-      let m = assocMergePreferRight {eq=eqString} in
-      let thnPatEnv = {env with varEnv = m env.varEnv thnVarEnv} in
+      let thnPatEnv = {env with varEnv = mapUnion env.varEnv thnVarEnv} in
       TmMatch {{{{t with target = symbolizeExpr env t.target}
                     with pat = pat}
                     with thn = symbolizeExpr thnPatEnv t.thn}
@@ -334,7 +330,7 @@ lang VarTypeSym = VarTypeAst
       if nameHasSym ident then ty
       else
         let str = nameGetStr ident in
-        match assocLookup {eq=eqString} str tyEnv with Some ident then
+        match mapLookup str tyEnv with Some ident then
           TyVar {ident = ident}
         else error (concat "Unknown type variable in symbolizeExpr: " str)
     else never
@@ -356,18 +352,18 @@ let _symbolize_patname: SymEnv -> PatName -> (SymEnv, PatName) =
       if nameHasSym name then (varEnv, PName name)
       else
         let str = nameGetStr name in
-        let res = assocLookup {eq=eqString} str varEnv in
+        let res = mapLookup str varEnv in
         match res with Some name then (varEnv, PName name)
         else match res with None () then
           let name = nameSetNewSym name in
-          let varEnv = assocInsert {eq=eqString} str name varEnv in
+          let varEnv = mapInsert str name varEnv in
           (varEnv, PName name)
         else never
     else match pname with PWildcard () then (varEnv, PWildcard ())
     else never
 
 lang NamedPatSym = NamedPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatNamed p ->
     match _symbolize_patname patEnv p.ident with (patEnv, patname) then
       (patEnv, PatNamed {p with ident = patname})
@@ -375,14 +371,14 @@ lang NamedPatSym = NamedPat
 end
 
 lang SeqTotPatSym = SeqTotPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatSeqTot p ->
     let res = mapAccumL (symbolizePat env) patEnv p.pats in
     (res.0, PatSeqTot {p with pats = res.1})
 end
 
 lang SeqEdgePatSym = SeqEdgePat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatSeqEdge p ->
     let preRes = mapAccumL (symbolizePat env) patEnv p.prefix in
     let midRes = _symbolize_patname preRes.0 p.middle in
@@ -392,7 +388,7 @@ lang SeqEdgePatSym = SeqEdgePat
 end
 
 lang RecordPatSym = RecordPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatRecord {bindings = bindings, info = info} ->
     match mapMapAccum
             (lam patEnv. lam. lam p. symbolizePat env patEnv p) patEnv bindings
@@ -402,14 +398,14 @@ lang RecordPatSym = RecordPat
 end
 
 lang DataPatSym = DataPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatCon {ident = ident, subpat = subpat, info = info} ->
     match env with {conEnv = conEnv} then
       let ident =
         if nameHasSym ident then ident
         else
           let str = nameGetStr ident in
-          match assocLookup {eq=eqString} str conEnv with Some ident then ident
+          match mapLookup str conEnv with Some ident then ident
           else error (concat "Unknown constructor in symbolizeExpr: " str)
       in
       match symbolizePat env patEnv subpat with (patEnv, subpat) then
@@ -419,22 +415,22 @@ lang DataPatSym = DataPat
 end
 
 lang IntPatSym = IntPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatInt i -> (patEnv, PatInt i)
 end
 
 lang CharPatSym = CharPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatChar c -> (patEnv, PatChar c)
 end
 
 lang BoolPatSym = BoolPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatBool b -> (patEnv, PatBool b)
 end
 
 lang AndPatSym = AndPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatAnd p ->
     let lRes = symbolizePat env patEnv p.lpat in
     let rRes = symbolizePat env lRes.0 p.rpat in
@@ -442,7 +438,7 @@ lang AndPatSym = AndPat
 end
 
 lang OrPatSym = OrPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatOr p ->
     let lRes = symbolizePat env patEnv p.lpat in
     let rRes = symbolizePat env lRes.0 p.rpat in
@@ -450,7 +446,7 @@ lang OrPatSym = OrPat
 end
 
 lang NotPatSym = NotPat
-  sem symbolizePat (env : SymEnv) (patEnv : AssocMap String Name) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatNot p ->
     -- NOTE(vipa, 2020-09-23): new names in a not-pattern do not
     -- matter since they will never bind (it should probably be an

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -158,12 +158,9 @@ lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
     else never
 end
 
-lang ConstTypeAnnot = TypeAnnot + ConstAst
-  sem typeConst =
-  -- Intentionally left blank
-
+lang ConstTypeAnnot = TypeAnnot + MExprAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmConst t -> TmConst {t with ty = typeConst t.val}
+  | TmConst t -> TmConst {t with ty = tyConst t.val}
 end
 
 lang SeqTypeAnnot = TypeAnnot + SeqAst + MExprEq
@@ -268,42 +265,10 @@ lang NeverTypeAnnot = TypeAnnot + NeverAst
   | TmNever t -> TmNever {t with ty = tyunknown_}
 end
 
-lang IntTypeAnnot = ConstTypeAnnot + IntAst
-  sem typeConst =
-  | CInt _ -> tyint_
-end
-
-lang FloatTypeAnnot = ConstTypeAnnot + FloatAst
-  sem typeConst =
-  | CFloat _ -> tyfloat_
-end
-
-lang BoolTypeAnnot = ConstTypeAnnot + BoolAst
-  sem typeConst =
-  | CBool _ -> tybool_
-end
-
-lang CharTypeAnnot = ConstTypeAnnot + CharAst
-  sem typeConst =
-  | CChar _ -> tychar_
-end
-
--- NOTE(larshum, 2021-03-08): There is currently no type for symbols, so they
--- are considered to be of an unknown type.
-lang SymbTypeAnnot = ConstTypeAnnot + SymbAst
-  sem typeConst =
-  | CSymb _ -> tyunknown_
-end
-
 lang MExprTypeAnnot =
-
-  -- Terms
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +
   TypeTypeAnnot + RecLetsTypeAnnot + ConstTypeAnnot + DataTypeAnnot +
-  MatchTypeAnnot + UtestTypeAnnot + SeqTypeAnnot + NeverTypeAnnot +
-
-  -- Constants
-  IntTypeAnnot + FloatTypeAnnot + BoolTypeAnnot + CharTypeAnnot + SymbTypeAnnot
+  MatchTypeAnnot + UtestTypeAnnot + SeqTypeAnnot + NeverTypeAnnot
 end
 
 lang TestLang = MExprTypeAnnot + MExprPrettyPrint + MExprEq

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -10,6 +10,7 @@
 -- Requires that the types of constructors are included in the `tyIdent` field.
 include "assoc-seq.mc"
 include "mexpr/ast.mc"
+include "mexpr/const-types.mc"
 include "mexpr/eq.mc"
 include "mexpr/pprint.mc"
 
@@ -158,7 +159,7 @@ lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
     else never
 end
 
-lang ConstTypeAnnot = TypeAnnot + MExprAst
+lang ConstTypeAnnot = TypeAnnot + MExprConstType
   sem typeAnnotExpr (env : TypeEnv) =
   | TmConst t -> TmConst {t with ty = tyConst t.val}
 end

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -62,7 +62,9 @@ lang TypeAnnot
   -- Intentionally left blank
 
   sem typeAnnot =
-  | expr -> typeAnnotExpr _typeEnvEmpty expr
+  | expr ->
+    let env = {_typeEnvEmpty with varEnv = builtinNameTypeMap} in
+    typeAnnotExpr env expr
 end
 
 lang VarTypeAnnot = TypeAnnot + VarAst
@@ -271,43 +273,9 @@ lang IntTypeAnnot = ConstTypeAnnot + IntAst
   | CInt _ -> tyint_
 end
 
-lang ArithIntTypeAnnot = ConstTypeAnnot + ArithIntAst
-  sem typeConst =
-  | CAddi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CSubi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CMuli _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CDivi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CNegi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CModi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-end
-
-lang ShiftIntTypeAnnot = ConstTypeAnnot + ShiftIntAst
-  sem typeConst =
-  | CSlli _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CSrli _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CSrai _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-end
-
 lang FloatTypeAnnot = ConstTypeAnnot + FloatAst
   sem typeConst =
   | CFloat _ -> tyfloat_
-end
-
-lang ArithFloatTypeAnnot = ConstTypeAnnot + ArithFloatAst
-  sem typeConst =
-  | CAddf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
-  | CSubf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
-  | CMulf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
-  | CDivf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
-  | CNegf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tyfloat_)
-end
-
-lang FloatIntConversionTypeAnnot = ConstTypeAnnot + FloatIntConversionAst
-  sem typeConst =
-  | CFloorfi _ -> tyarrow_ tyfloat_ tyint_
-  | CCeilfi _ -> tyarrow_ tyfloat_ tyint_
-  | CRoundfi _ -> tyarrow_ tyfloat_ tyint_
-  | CInt2float _ -> tyarrow_ tyint_ tyfloat_
 end
 
 lang BoolTypeAnnot = ConstTypeAnnot + BoolAst
@@ -315,45 +283,9 @@ lang BoolTypeAnnot = ConstTypeAnnot + BoolAst
   | CBool _ -> tybool_
 end
 
-lang CmpIntTypeAnnot = ConstTypeAnnot + CmpIntAst
-  sem typeConst =
-  | CEqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
-  | CNeqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
-  | CLti _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
-  | CGti _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
-  | CLeqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
-  | CGeqi _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tybool_)
-end
-
-lang CmpFloatTypeAnnot = ConstTypeAnnot + CmpFloatAst
-  sem typeConst =
-  | CEqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
-  | CNeqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
-  | CLtf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
-  | CGtf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
-  | CLeqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
-  | CGeqf _ -> tyarrow_ tyfloat_ (tyarrow_ tyfloat_ tybool_)
-end
-
 lang CharTypeAnnot = ConstTypeAnnot + CharAst
   sem typeConst =
   | CChar _ -> tychar_
-end
-
-lang CmpCharTypeAnnot = ConstTypeAnnot + CmpCharAst
-  sem typeConst =
-  | CEqc _ -> tyarrow_ tychar_ (tyarrow_ tychar_ tybool_)
-end
-
-lang IntCharConversionTypeAnnot = ConstTypeAnnot + IntCharConversionAst
-  sem typeConst =
-  | CInt2Char _ -> tyarrow_ tyint_ tychar_
-  | CChar2Int _ -> tyarrow_ tychar_ tyint_
-end
-
-lang FloatStringConversionTypeAnnot = ConstTypeAnnot + FloatStringConversionAst
-  sem typeConst =
-  | CString2float _ -> tyarrow_ tystr_ tyfloat_
 end
 
 -- NOTE(larshum, 2021-03-08): There is currently no type for symbols, so they
@@ -361,116 +293,6 @@ end
 lang SymbTypeAnnot = ConstTypeAnnot + SymbAst
   sem typeConst =
   | CSymb _ -> tyunknown_
-  | CGensym _ -> tyarrow_ tyunit_ tyunknown_
-  | CSym2hash _ -> tyarrow_ tyunknown_ tyint_
-end
-
-lang CmpSymbTypeAnnot = ConstTypeAnnot + CmpSymbAst
-  sem typeConst =
-  | CEqsym _ -> tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_)
-end
-
-lang SeqOpTypeAnnot = ConstTypeAnnot + SeqOpAst
-  sem typeConst =
-  | CSet _ -> tyarrow_ utyseq_ (tyarrow_ tyint_ (tyarrow_ tyunknown_ utyseq_))
-  | CGet _ -> tyarrow_ utyseq_ (tyarrow_ tyint_ utyseq_)
-  | CCons _ -> tyarrow_ tyunknown_ (tyarrow_ utyseq_ utyseq_)
-  | CSnoc _ -> tyarrow_ utyseq_ (tyarrow_ tyunknown_ utyseq_)
-  | CConcat _ -> tyarrow_ utyseq_ (tyarrow_ utyseq_ utyseq_)
-  | CLength _ -> tyarrow_ utyseq_ tyint_
-  | CReverse _ -> tyarrow_ utyseq_ utyseq_
-  | CCreate _ -> tyarrow_ tyint_ (tyarrow_ (tyarrow_ tyint_ tyunknown_) utyseq_)
-  | CSplitAt _ -> tyarrow_ utyseq_ (tyarrow_ tyint_ (tytuple_ [utyseq_, utyseq_]))
-  | CSubsequence _ -> tyarrow_ utyseq_ (tyarrow_ tyint_ (tyarrow_ tyint_ utyseq_))
-end
-
-lang FileOpTypeAnnot = ConstTypeAnnot + FileOpAst
-  sem typeConst =
-  | CFileRead _ -> tyarrow_ tystr_ tystr_
-  | CFileWrite _ -> tyarrow_ tystr_ (tyarrow_ tystr_ tyunit_)
-  | CFileExists _ -> tyarrow_ tystr_ tybool_
-  | CFileDelete _ -> tyarrow_ tystr_ tyunit_
-end
-
-lang IOTypeAnnot = ConstTypeAnnot + IOAst
-  sem typeConst =
-  | CPrint _ -> tyarrow_ tystr_ tyunit_
-  | CReadLine _ -> tyarrow_ tyunit_ tystr_
-  | CReadBytesAsString _ -> tyarrow_ tyint_ (tytuple_ [tystr_, tyint_])
-end
-
-lang RandomNumberGeneratorTypeAnnot = ConstTypeAnnot + RandomNumberGeneratorAst
-  sem typeConst =
-  | CRandIntU _ -> tyarrow_ tyint_ (tyarrow_ tyint_ tyint_)
-  | CRandSetSeed _ -> tyarrow_ tyint_ tyunit_
-end
-
-lang SysTypeAnnot = ConstTypeAnnot + SysAst
-  sem typeConst =
-  | CExit _ -> tyarrow_ tyint_ tyunknown_
-  | CError _ -> tyarrow_ tystr_ tyunknown_
-  | CArgv _ -> tyseq_ tystr_
-end
-
-lang TimeTypeAnnot = ConstTypeAnnot + TimeAst
-  sem typeConst =
-  | CWallTimeMs _ -> tyarrow_ tyunit_ tyfloat_
-  | CSleepMs _ -> tyarrow_ tyint_ tyunit_
-end
-
--- NOTE(larshum, 2021-03-08): There is currently no reference type in MExpr, so
--- they are considered to be of an unknown type.
-lang RefOpTypeAnnot = ConstTypeAnnot + RefOpAst
-  sem typeConst =
-  | CRef _ -> tyarrow_ tyunknown_ tyunknown_
-  | CModRef _ -> tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunit_)
-  | CDeRef _ -> tyarrow_ tyunknown_ tyunknown_
-end
-
-lang MapTypeAnnot = ConstTypeAnnot + MapAst
-  sem typeConst =
-  | CMapEmpty _ ->
-    tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyint_)) tyunknown_
-  | CMapInsert _ ->
-    tyarrow_ tyunknown_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_))
-  | CMapRemove _ ->
-    tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)
-  | CMapFindWithExn _ ->
-    tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)
-  | CMapFindOrElse _ ->
-    tyarrow_ (tyarrow_ tyunit_ tyunknown_)
-             (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_))
-  | CMapFindApplyOrElse _ ->
-    tyarrow_ (tyarrow_ tyunknown_ tyunknown_)
-             (tyarrow_ (tyarrow_ tyunit_ tyunknown_)
-                       (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)))
-  | CMapBindings _ ->
-    tyarrow_ tyunknown_ (tyseq_ (tytuple_ [tyunknown_, tyunknown_]))
-  | CMapSize _ ->
-    tyarrow_ tyunknown_ tyint_
-  | CMapMem _ ->
-    tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_)
-  | CMapAny _ ->
-    tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_))
-             (tyarrow_ tyunknown_ tybool_)
-  | CMapMap _ ->
-    tyarrow_ (tyarrow_ tyunknown_ tyunknown_)
-             (tyarrow_ tyunknown_ tyunknown_)
-  | CMapMapWithKey _ ->
-    tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_))
-             (tyarrow_ tyunknown_ tyunknown_)
-  | CMapFoldWithKey _ ->
-    tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)))
-             tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyunknown_)
-  | CMapEq _ ->
-    tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_))
-             (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tybool_))
-  | CMapCmp _ ->
-    tyarrow_ (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyint_))
-             (tyarrow_ tyunknown_ (tyarrow_ tyunknown_ tyint_))
-  | CMapGetCmpFun _ ->
-    tyarrow_ tyunknown_ (tyarrow_ tyunknown_
-                        (tyarrow_ tyunknown_ tyint_))
 end
 
 lang MExprTypeAnnot =
@@ -481,13 +303,7 @@ lang MExprTypeAnnot =
   MatchTypeAnnot + UtestTypeAnnot + SeqTypeAnnot + NeverTypeAnnot +
 
   -- Constants
-  IntTypeAnnot + ArithIntTypeAnnot + ShiftIntTypeAnnot + FloatTypeAnnot +
-  ArithFloatTypeAnnot + FloatIntConversionTypeAnnot + BoolTypeAnnot +
-  CmpIntTypeAnnot + CmpFloatTypeAnnot + CharTypeAnnot + CmpCharTypeAnnot +
-  IntCharConversionTypeAnnot + FloatStringConversionTypeAnnot + SymbTypeAnnot +
-  CmpSymbTypeAnnot + SeqOpTypeAnnot + FileOpTypeAnnot + IOTypeAnnot +
-  RandomNumberGeneratorTypeAnnot + SysTypeAnnot + TimeTypeAnnot +
-  RefOpTypeAnnot
+  IntTypeAnnot + FloatTypeAnnot + BoolTypeAnnot + CharTypeAnnot + SymbTypeAnnot
 end
 
 lang TestLang = MExprTypeAnnot + MExprPrettyPrint + MExprEq

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -67,12 +67,10 @@ in
 ()
 "
 
-let _builtinNames = map (lam intr. intr.0) builtinEnv
-
 let utestRunner =
   use BootParser in
   use MExprSym in
-  symbolizeExpr (symVarNameEnv _builtinNames)
+  symbolizeExpr (symVarNameEnv builtinNames)
                 (parseMExprString _utestRunnerStr)
 
 -- Get the name of a string identifier in an expression
@@ -212,7 +210,7 @@ let utest_info_ =
 in
 
 let t = typeAnnot (utest_info_ (int_ 1) (int_ 0) unit_) in
--- eval {env = _builtinEnv} (symbolizeExpr (symVarNameEnv _names) (utestGen t));
+-- eval {env = builtinEnv} (symbolizeExpr (symVarNameEnv builtinNames) (utestGen t));
 
 utest utestStrip t with unit_ using eqExpr in
 

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -70,8 +70,7 @@ in
 let utestRunner =
   use BootParser in
   use MExprSym in
-  symbolizeExpr (symVarNameEnv builtinNames)
-                (parseMExprString _utestRunnerStr)
+  symbolize (parseMExprString _utestRunnerStr)
 
 -- Get the name of a string identifier in an expression
 let findName : String -> Expr -> Option Name = use MExprAst in

--- a/stdlib/multicore/eval.mc
+++ b/stdlib/multicore/eval.mc
@@ -130,7 +130,7 @@ use MExprParEval in
 
 -- Evaluation shorthand used in tests below
 let eval =
-  lam t. eval {env = assocEmpty} (symbolize t) in
+  lam t. eval {env = builtinEnv} (symbolize t) in
 
 -- Atomic references
 let p = ulet_ "r" (atomicMake_ (int_ 0)) in

--- a/stdlib/multicore/eval.mc
+++ b/stdlib/multicore/eval.mc
@@ -70,7 +70,7 @@ lang ThreadEval = ThreadAst + IntAst + UnknownTypeAst + RecordAst + AppEval
     let app =
       TmApp {lhs = arg, rhs = unit_, info = NoInfo (), ty = TyUnknown ()}
     in
-    TmConst {val = CThread {thread = threadSpawn (lam. eval {env = []} app)}
+    TmConst {val = CThread {thread = threadSpawn (lam. eval {env = builtinEnv} app)}
             , info = NoInfo ()
             , ty = TyUnknown ()
             }
@@ -110,7 +110,7 @@ lang ThreadEval = ThreadAst + IntAst + UnknownTypeAst + RecordAst + AppEval
   | CThreadCriticalSection _ ->
     let app =
       TmApp {lhs = arg, rhs = unit_, info = NoInfo (), ty = TyUnknown ()}
-    in threadCriticalSection (lam. eval {env = []} app)
+    in threadCriticalSection (lam. eval {env = builtinEnv} app)
   | CThreadCPURelax _ ->
     let err = "Argument to threadCPURelax is not unit" in
     match arg with TmRecord {bindings = bindings} then

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -120,9 +120,39 @@ lang OCamlPrettyPrint =
 
   sem getConstStringCode (indent : Int) =
   | CInt {val = i} -> int2string i
+  | CAddi _ -> "(+)"
+  | CSubi _ -> "(-)"
+  | CMuli _ -> "( * )"
+  | CDivi _ -> "(/)"
+  | CModi _ -> "(mod)"
+  | CNegi _ -> "(~-)"
   | CFloat {val = f} -> float2string f
+  | CAddf _ -> "(+.)"
+  | CSubf _ -> "(-.)"
+  | CMulf _ -> "( *. )"
+  | CDivf _ -> "(/.)"
+  | CNegf _ -> "(~-.)"
   | CBool {val = b} -> if b then "true" else "false"
+  | CEqi _ -> "(=)"
+  | CLti _ -> "(<)"
+  | CLeqi _ -> "(<=)"
+  | CGti _ -> "(>)"
+  | CGeqi _ -> "(>=)"
+  | CNeqi _ -> "(!=)"
+  | CSlli _ -> "Int.shift_left"
+  | CSrli _ -> "Int.shift_right_logical"
+  | CSrai _ -> "Int.shift_right"
+  | CEqf _ -> "(=)"
+  | CLtf _ -> "(<)"
+  | CLeqf _ -> "(<=)"
+  | CGtf _ -> "(>)"
+  | CGeqf _ -> "(>=)"
+  | CNeqf _ -> "(!=)"
+  | CInt2float _ -> "float_of_int"
   | CChar {val = c} -> show_char c
+  | CEqc _ -> "(=)"
+  | CChar2Int _ -> "int_of_char"
+  | CInt2Char _ -> "char_of_int"
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | OTmVariantTypeDecl t ->

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -120,45 +120,9 @@ lang OCamlPrettyPrint =
 
   sem getConstStringCode (indent : Int) =
   | CInt {val = i} -> int2string i
-  | CAddi _ -> "(+)"
-  | CSubi _ -> "(-)"
-  | CMuli _ -> "( * )"
-  | CDivi _ -> "(/)"
-  | CModi _ -> "(mod)"
-  | CNegi _ -> "(~-)"
   | CFloat {val = f} -> float2string f
-  | CAddf _ -> "(+.)"
-  | CSubf _ -> "(-.)"
-  | CMulf _ -> "( *. )"
-  | CDivf _ -> "(/.)"
-  | CNegf _ -> "(~-.)"
-  | CBool {val = b} ->
-      match b with true then
-        "true"
-      else
-        match b with false then
-          "false"
-        else never
-  | CEqi _ -> "(=)"
-  | CLti _ -> "(<)"
-  | CLeqi _ -> "(<=)"
-  | CGti _ -> "(>)"
-  | CGeqi _ -> "(>=)"
-  | CNeqi _ -> "(!=)"
-  | CSlli _ -> "Int.shift_left"
-  | CSrli _ -> "Int.shift_right_logical"
-  | CSrai _ -> "Int.shift_right"
-  | CEqf _ -> "(=)"
-  | CLtf _ -> "(<)"
-  | CLeqf _ -> "(<=)"
-  | CGtf _ -> "(>)"
-  | CGeqf _ -> "(>=)"
-  | CNeqf _ -> "(!=)"
-  | CInt2float _ -> "float_of_int"
+  | CBool {val = b} -> if b then "true" else "false"
   | CChar {val = c} -> show_char c
-  | CEqc _ -> "(=)"
-  | CChar2Int _ -> "int_of_char"
-  | CInt2Char _ -> "char_of_int"
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | OTmVariantTypeDecl t ->


### PR DESCRIPTION
Moves the type information of all intrinsics to `builtin.mc` and updates existing code to use these intrinsic definitions. The changes were:
* The AST builder now produces a `TmVar` with the name of the intrinsic instead of an intrinsic AST node. For example, `addi_` now generates a `TmVar` containing the name of `addi` according to `builtin.mc` instead of the AST node `CAddi ()`.
* The `info` field was added to types.
* Updated `mexpr/pprint.mc`, `mexpr/symbolize.mc` and `mexpr/type-annot.mc` to use an environment consisting of the builtin intrinsics by default. Also calls to `eval` have been updated to use the `builtinEnv`.