### PR TITLE
Handle use of undefined type variables

### DIFF
--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -335,7 +335,10 @@ lang VarTypeSym = VarTypeAst + UnknownTypeAst
         let str = nameGetStr t.ident in
         match assocLookup {eq=eqString} str tyEnv with Some ident then
           TyVar {t with ident = ident}
-        else error (concat "Unknown type variable in symbolizeExpr: " str)
+        else
+          -- NOTE(larshum, 2021-03-24): Unknown type variables are symbolized
+          -- as TyUnknown for now.
+          TyUnknown {info = t.info}
     else never
 end
 


### PR DESCRIPTION
When using undefined type variables in a type annotation, such as
```
let map : (a -> b) -> [a] -> [b] = ...
```
`symbolize.mc` reports an error. This PR changes this behaviour so that it instead returns a `TyUnknown` in that case. It also includes a fix so that `info` fields in types are not lost in `symbolize.mc`.