### PR TITLE
Don't do `Obj.repr` on record bindings

### DIFF
--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -679,7 +679,7 @@ lang OCamlObjWrap = MExprAst + OCamlAst
     if mapIsEmpty t.bindings then
       _objRepr (TmRecord t)
     else
-      let bindings = mapMap (lam expr. _objRepr (objWrapRec expr)) t.bindings in
+      let bindings = mapMap (lam expr. objWrapRec expr) t.bindings in
       TmRecord {t with bindings = bindings}
   | (OTmArray _) & t -> _objRepr (smap_Expr_Expr objWrapRec t)
   | (OTmConApp _) & t -> _objRepr (smap_Expr_Expr objWrapRec t)
@@ -1272,6 +1272,16 @@ let recordUpdate2 = symbolize (
   ])
 in
 utest recordUpdate2 with generateTypeAnnotated recordUpdate2
+using sameSemantics in
+
+let recordWithLet = symbolize (
+  bindall_
+  [ ulet_ "r" (record_ [
+     ("f", bind_ (ulet_ "x" (int_ 3)) (addi_ (var_ "x") (int_ 1))),
+     ("g", ulam_ "x" (var_ "x"))])
+  , int_ 42
+  ]) in
+utest recordWithLet with generateTypeAnnotated recordWithLet
 using sameSemantics in
 
 -- Ints

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -230,7 +230,7 @@ lang OCamlPrettyPrint =
           let k = sidToString k in
           match pprintCode innerIndent env v with (env, str) then
             (env, join [pprintLabelString k, " =", pprintNewline innerIndent,
-                        str])
+                        "(", str, ")"])
           else never) env t.bindings
       with (env, binds) then
         let binds = mapValues binds in

--- a/stdlib/ocaml/process-helpers.mc
+++ b/stdlib/ocaml/process-helpers.mc
@@ -30,7 +30,7 @@ let phJoinPath = lam p1. lam p2.
   let p = pycall _pathlib "Path" (p1,) in
   pycall _blt "str" (pycall p "joinpath" (p2,),)
 
-let phRunCommand : String -> String -> String -> ExecResult =
+let phRunCommand : [String] -> String -> String -> ExecResult =
   lam cmd. lam stdin. lam cwd.
     let r = pycallkw _subprocess "run" (cmd,)
             { cwd=cwd,


### PR DESCRIPTION
* Bugfix: changes so that `Obj.repr` is *not* done on bindings in records.
* Bugfix: adds parentheses around bindings in pretty-printing of records (otherwise `;` might be interpreted as the sequence operator)
* Adds a test case that would fail without the changes in this PR.
* Fixes the type signature of `phRunCommand`