### PR TITLE
Make `run` and `compile` work for `stdlib/bool.mc`

### DIFF
--- a/compile-all.sh
+++ b/compile-all.sh
@@ -4,10 +4,17 @@
 #  Copyright (C) David Broman. See file LICENSE.txt
 ###################################################
 
-# Compile a file
+# Compile and run a file
 compile() {
     echo $1
     build/mi src/main/mi.mc -- compile --test $1
+    if [ $? -eq 0 ]
+    then
+        binary=$(basename "$1" .mc)
+        ./$binary
+        rm $binary
+        echo ""
+    fi
 }
 
 files=(

--- a/compile-all.sh
+++ b/compile-all.sh
@@ -118,7 +118,7 @@ files=(
 # "stdlib/matrix.mc"
 # "stdlib/either.mc"
 # "stdlib/vec.mc"
-# "stdlib/bool.mc"
+  "stdlib/bool.mc"
 # "stdlib/stringid.mc"
 # "stdlib/graph.mc"
 # "stdlib/char.mc"

--- a/run-all.sh
+++ b/run-all.sh
@@ -111,7 +111,7 @@ files=(
 # "stdlib/matrix.mc"
 # "stdlib/either.mc"
 # "stdlib/vec.mc"
-# "stdlib/bool.mc"
+  "stdlib/bool.mc"
 # "stdlib/stringid.mc"
 # "stdlib/graph.mc"
 # "stdlib/char.mc"

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -70,7 +70,7 @@ let compile = lam files. lam options.
     in
 
     -- Symbolize the MExpr AST and annotate it with types
-    let ast = symbolizeExpr (symVarNameEnv builtinNames) ast in
+    let ast = symbolize ast in
     let ast = typeAnnot ast in
 
     -- Translate the MExpr AST into an OCaml AST

--- a/src/main/run.mc
+++ b/src/main/run.mc
@@ -33,6 +33,6 @@ let run = lam files. lam options.
     in
 
     -- Evaluate the symbolized program
-    eval {env = builtinEnv} (symbolizeExpr (symVarNameEnv builtinNames) ast)
+    eval {env = builtinEnv} (symbolize ast)
   in
   iter runFile files


### PR DESCRIPTION
In #294 I made a change that broke the `run` and `compile` commands. This PR solves that problem. The `compile-all.sh` now runs the binary file it produces, and both runner-scripts (`run-all.sh` and `compile-all.sh`) now run on `stdlib/bool.mc`.