### PR TITLE
Compilation of references

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -870,3 +870,6 @@ let mapCmp_ = use MExprAst in
 let mapGetCmpFun_ = use MExprAst in
   lam m.
   appf1_ (const_ (CMapGetCmpFun ())) m
+
+-- Sequencing (;)
+let semi_ = lam expr1. lam expr2. bind_ (ulet_ "" expr1) expr2

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -372,24 +372,6 @@ lang NeverAst
   | TmNever _ & t -> acc
 end
 
-
--- TmRef --
--- TODO (dbro, 2020-02-16): this term should be moved into an evaluation term
--- in the same way as for closures. Eventually, this should be a rank 0 tensor.
-lang RefAst
-  syn Expr =
-  | TmRef {ref : Ref}
-
-  sem info =
-  | TmRef r -> NoInfo ()
-
-  sem smap_Expr_Expr (f : Expr -> a) =
-  | TmRef t -> TmRef t
-
-  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
-  | TmRef t -> acc
-end
-
 ---------------
 -- CONSTANTS --
 ---------------
@@ -545,7 +527,7 @@ lang TimeAst = ConstAst
   | CSleepMs {}
 end
 
-lang RefOpAst = ConstAst + RefAst
+lang RefOpAst = ConstAst
   syn Const =
   | CRef {}
   | CModRef {}
@@ -885,7 +867,7 @@ lang MExprAst =
 
   -- Terms
   VarAst + AppAst + LamAst + RecordAst + LetAst + TypeAst + RecLetsAst +
-  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst + RefAst +
+  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst +
 
   -- Constants
   IntAst + ArithIntAst + ShiftIntAst + FloatAst + ArithFloatAst + BoolAst +

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -243,7 +243,11 @@ lang NeverEval = NeverAst
   --TODO(?,?)
 end
 
-lang RefEval = RefAst
+-- TODO (oerikss, 2020-03-26): Eventually, this should be a rank 0 tensor.
+lang RefEval
+  syn Expr =
+  | TmRef {ref : Ref}
+
   sem eval (ctx : {env : Env}) =
   | TmRef r -> TmRef r
 end
@@ -1040,7 +1044,7 @@ lang TimeEval = TimeAst + IntAst
     float_ (wallTimeMs ())
 end
 
-lang RefOpEval = RefOpAst + IntAst
+lang RefOpEval = RefOpAst + RefEval + IntAst
   syn Const =
   | CModRef2 Ref
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -552,14 +552,6 @@ lang SeqPrettyPrint = PrettyPrint + SeqAst + ConstPrettyPrint + CharAst
     else never
 end
 
-lang RefPrettyPrint = PrettyPrint + RefAst
-  sem isAtomic =
-  | TmRef _ -> true
-
-  sem pprintCode (indent : Int) (env : PprintEnv) =
-  | TmRef _ -> (env, "(ref)")
-end
-
 lang NeverPrettyPrint = PrettyPrint + NeverAst
   sem isAtomic =
   | TmNever _ -> true
@@ -982,7 +974,7 @@ lang MExprPrettyPrint =
   VarPrettyPrint + AppPrettyPrint + LamPrettyPrint + RecordPrettyPrint +
   LetPrettyPrint + TypePrettyPrint + RecLetsPrettyPrint + ConstPrettyPrint +
   DataPrettyPrint + MatchPrettyPrint + UtestPrettyPrint + SeqPrettyPrint +
-  NeverPrettyPrint + RefPrettyPrint +
+  NeverPrettyPrint +
 
   -- Constants
   IntPrettyPrint + ArithIntPrettyPrint + FloatPrettyPrint +

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -131,7 +131,7 @@ lang OCamlAst = LamAst + LetAst + RecLetsAst + RecordAst + ArithIntAst
                 + IntPat + CharPat + BoolPat + OCamlTuple + OCamlArray
                 + OCamlData + OCamlExternal + FloatIntConversionAst
                 + IntCharConversionAst + OCamlTypeDeclAst + OCamlPreambleHack
-                + OCamlRecord + OCamlString
+                + OCamlRecord + OCamlString + RefOpAst
 end
 
 mexpr

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -153,6 +153,9 @@ lang OCamlPrettyPrint =
   | CEqc _ -> "(=)"
   | CChar2Int _ -> "int_of_char"
   | CInt2Char _ -> "char_of_int"
+  | CRef _ -> "ref"
+  | CModRef _ -> "(:=)"
+  | CDeRef _ -> "(!)"
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | OTmVariantTypeDecl t ->


### PR DESCRIPTION
This PR includes compilation of references to OCaml. It also removes `TmRef` from `ast.mc` and adds it as an evaluation term in `eval.mc`. Down the line references should be replaced with rank zero tensors. Additionally a `semi_` function is included in `ast-builder.mc` for sequencing.