### PR TITLE
Bug fix in compilation of wildcard patterns

### DIFF
--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -585,7 +585,7 @@ and print_tm' fmt t =
       let ty = ty |> ustring_of_ty |> string_of_ustring in
       fprintf fmt "@[<hov 0>@[<hov %d>type %s =@ %s in@]@ %a@]" !ref_indent x
         ty print_tm (Match, t1)
-  | TmRecLets (_, lst, t2) ->
+  | TmRecLets (_, lst, t2) -> (
       let print (_, x, s, ty, t) =
         let x = string_of_ustring (ustring_of_var x s) in
         let ty = ty |> ustring_of_ty |> string_of_ustring in
@@ -593,9 +593,13 @@ and print_tm' fmt t =
           fprintf fmt "@[<hov %d>let %s%s =@ %a@]" !ref_indent x
             (print_ty_if_known ty) print_tm (Match, t)
       in
-      let inner = List.map print lst in
-      fprintf fmt "@[<hov 0>@[<hov %d>recursive@ @[<hov 0>%a@] in@]@ %a@]"
-        !ref_indent concat (Space, inner) print_tm (Match, t2)
+      match lst with
+      | [] ->
+          fprintf fmt "@[<hov 0>%a@]" print_tm (Match, t2)
+      | _ ->
+          let inner = List.map print lst in
+          fprintf fmt "@[<hov 0>@[<hov %d>recursive@ @[<hov 0>%a@] in@]@ %a@]"
+            !ref_indent concat (Space, inner) print_tm (Match, t2) )
   | TmApp (_, t1, (TmApp _ as t2)) ->
       fprintf fmt "@[<hv 0>%a@ %a@]" print_tm (App, t1) print_tm (Atom, t2)
   | TmApp (_, t1, t2) ->

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -413,6 +413,7 @@ lang RecLetsPrettyPrint = PrettyPrint + RecLetsAst + UnknownTypeAst
     in
     match mapAccumL f env t.bindings with (env,bindings) then
       match pprintCode indent env t.inexpr with (env,inexpr) then
+        match bindings with [] then (env, inexpr) else
         let bindings = strJoin (pprintNewline ii) bindings in
         (env,join ["recursive", pprintNewline ii,
                    bindings, pprintNewline i,

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -162,8 +162,11 @@ lang OCamlGenerate = MExprAst + OCamlAst
 
   /- : Pat -> (AssocMap Name Name, Expr -> Expr) -/
   sem generatePat (env : GenerateEnv) (targetTy : Type) (targetName : Name) =
-  | PatNamed {ident = PWildcard _} -> (assocEmpty, identity)
-  | PatNamed {ident = PName n} -> (assocInsert {eq=nameEqSym} n targetName assocEmpty, identity)
+  | PatNamed {ident = PWildcard _} ->
+    (assocEmpty, lam cont. _if true_ cont _none)
+  | PatNamed {ident = PName n} ->
+    (assocInsert {eq=nameEqSym} n targetName assocEmpty,
+     lam cont. _if true_ cont _none)
   | PatBool {val = val} ->
     let wrap = lam cont.
       _if (nvar_ targetName)
@@ -845,6 +848,20 @@ let stripTypeDecls = lam t.
 in
 
 -- Match
+let matchWild1 = symbolize
+  (match_ (int_ 1)
+     pvarw_
+     true_
+     false_) in
+utest matchWild1 with generateEmptyEnv matchWild1 using sameSemantics in
+
+let matchWild2 = symbolize
+  (match_ (int_ 1)
+     (pvar_ "n")
+     true_
+     false_) in
+utest matchWild2 with generateEmptyEnv matchWild2 using sameSemantics in
+
 let matchChar1 = symbolize
  (match_ (char_ 'a')
    (pchar_ 'a')


### PR DESCRIPTION
* Does a bug fix and tests compilation of wildcard patterns 
* Bug fix in `pprint.mc` and `pprint.ml` (an empty reclet was printed as `recursive in`)