### PR TITLE
Declare the type of `syn`s in MLang translation

### DIFF
--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -70,6 +70,10 @@ let idCFloat = 302
 
 let idCChar = 303
 
+let idCdprint = 304
+
+let idCerror = 305
+
 (* Patterns *)
 let idPatNamed = 400
 
@@ -199,6 +203,10 @@ let getData = function
       (idCFloat, [], [], [], [], [], [], [v], [], [])
   | PTreeConst (CChar v) ->
       (idCChar, [], [], [], [], [], [v], [], [], [])
+  | PTreeConst Cdprint ->
+      (idCdprint, [], [], [], [], [], [], [], [], [])
+  | PTreeConst Cerror ->
+      (idCerror, [], [], [], [], [], [], [], [], [])
   (* Patterns *)
   | PTreePat (PatNamed (fi, x)) ->
       (idPatNamed, [fi], [], [], [], [patNameToStr x], [], [], [], [])

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -309,8 +309,12 @@ let translate_cases f target cases =
   let no_match =
     let_ (us "_") Symb.Helpers.nosym
       (* TODO(?,?): we should probably have a special sort for let with wildcards *)
-      (app (TmConst (NoInfo, Cdprint)) target)
-      (app (TmConst (NoInfo, Cerror)) (TmSeq (NoInfo, msg)))
+      (app
+         (TmVar (NoInfo, Ustring.from_utf8 "dprint", Symb.Helpers.nosym))
+         target )
+      (app
+         (TmVar (NoInfo, Ustring.from_utf8 "error", Symb.Helpers.nosym))
+         (TmSeq (NoInfo, msg)) )
   in
   List.fold_right translate_case cases no_match
 

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -309,12 +309,8 @@ let translate_cases f target cases =
   let no_match =
     let_ (us "_") Symb.Helpers.nosym
       (* TODO(?,?): we should probably have a special sort for let with wildcards *)
-      (app
-         (TmVar (NoInfo, Ustring.from_utf8 "dprint", Symb.Helpers.nosym))
-         target )
-      (app
-         (TmVar (NoInfo, Ustring.from_utf8 "error", Symb.Helpers.nosym))
-         (TmSeq (NoInfo, msg)) )
+      (app (TmConst (NoInfo, Cdprint)) target)
+      (app (TmConst (NoInfo, Cerror)) (TmSeq (NoInfo, msg)))
   in
   List.fold_right translate_case cases no_match
 

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -514,8 +514,11 @@ let desugar_top (nss, (stack : (tm -> tm) list)) = function
       let wrap_data decl tm =
         match decl with
         (* TODO(vipa,?): this does not declare the type itself *)
-        | Data (_, name, cdecls) ->
-            List.fold_right (wrap_con name) cdecls tm
+        | Data (fi, name, cdecls) ->
+            let tydecl inexpr =
+              TmType (fi, mangle name, Symb.Helpers.nosym, TyUnknown fi, inexpr)
+            in
+            tydecl (List.fold_right (wrap_con (mangle name)) cdecls tm)
         | _ ->
             tm
       in

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -187,10 +187,12 @@ lang BootParser = MExprAst
 
   -- Match constant from ID
   sem matchConst (t:Unknown) =
-  | 300 /-CBool-/  -> CBool {val = eqi (gint t 0) 1 }
-  | 301 /-CInt-/   -> CInt {val = gint t 0 }
-  | 302 /-CFloat-/ -> CFloat {val = gfloat t 0}
-  | 303 /-CChar-/  -> CChar {val = int2char (gint t 0)}
+  | 300 /-CBool-/   -> CBool {val = eqi (gint t 0) 1 }
+  | 301 /-CInt-/    -> CInt {val = gint t 0 }
+  | 302 /-CFloat-/  -> CFloat {val = gfloat t 0}
+  | 303 /-CChar-/   -> CChar {val = int2char (gint t 0)}
+  | 304 /-Cdprint-/ -> CDPrint {}
+  | 305 /-Cerror-/  -> CError {}
 
   -- Get pattern help function
   sem gpat (t:Unkown) =

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -698,6 +698,13 @@ lang MapPrettyPrint = MapAst + ConstPrettyPrint
   | CMapGetCmpFun _ -> "mapGetCmpFun"
 end
 
+lang IOPrettyPrint = IOAst + ConstPrettyPrint
+  sem getConstStringCode (indent : Int) =
+  | CPrint _ -> "print"
+  | CDPrint _ -> "dprint"
+  | CReadLine _ -> "readLine"
+  | CReadBytesAsString _ -> "readBytesAsString"
+end
 
 --------------
 -- PATTERNS --
@@ -981,7 +988,7 @@ lang MExprPrettyPrint =
   ArithFloatPrettyPrint + BoolPrettyPrint + CmpIntPrettyPrint +
   CmpFloatPrettyPrint + CharPrettyPrint + CmpCharPrettyPrint +
   SymbPrettyPrint + CmpSymbPrettyPrint + SeqOpPrettyPrint + RefOpPrettyPrint +
-  TensorOpPrettyPrint + MapPrettyPrint + SysPrettyPrint +
+  TensorOpPrettyPrint + MapPrettyPrint + SysPrettyPrint + IOPrettyPrint +
 
   -- Patterns
   NamedPatPrettyPrint + SeqTotPatPrettyPrint + SeqEdgePatPrettyPrint +


### PR DESCRIPTION
This PR
* Declares the types of `syn`s in translation to MExpr. The approach declares each unique `syn` once, without namespacing. For example 
```
lang A
  syn Expr =
  | TmFoo ()
end
lang B
  syn Expr =
  | TmLet ()
end
```
is translated into:
```
type Expr
in
con A_TmFoo: (()) -> (Expr) in
recursive
  
in
con B_TmLet: (()) -> (Expr) in
recursive
  
in
{}
```
The empty `recursive in` is a bug in the pretty printer that is fixed in #313.

* The use of `Cdprint` and `Cerror` in `mlang.ml` causes the boot parser to crash on many programs because it doesn't handle those constants ([see this Slack thread](https://miking.slack.com/archives/CN2F2TB0U/p1617090195032100)). The approach used here is to call them as variables instead of constants. A slightly unexpected result is that declaring local versions of `dprint` and `error` will cause those local functions to be used instead. Perhaps it's better to handle the `Cdprint` and `Cerror` in the boot parser instead.