### PR TITLE
support utf-8 format in compiler

### DIFF
--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -785,14 +785,14 @@ let ocamlEvalBool = lam ast.
 in
 
 let ocamlEvalChar = lam ast.
-  ocamlEval (wrapOCamlAstInPrint ast (printf "'%c'"))
+  ocamlEval (wrapOCamlAstInPrint ast (ulam_ "x" (app_ (printf ("'%c'")) (int2char_ (var_ "x")))))
 in
 
 utest ocamlEvalInt (int_ 1) with int_ 1 using eqExpr in
 utest ocamlEvalFloat (float_ 1.) with float_ 1. using eqExpr in
 utest ocamlEvalBool true_ with true_ using eqExpr in
 utest ocamlEvalChar (char_ '1') with char_ '1' using eqExpr in
-
+utest '島'with '島' in
 -- Compares evaluation of [mexprAst] as a mexpr and evaluation of
 -- [ocamlAst] as a OCaml expression.
 let sameSemantics = lam mexprAst. lam ocamlAst.

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -792,7 +792,7 @@ utest ocamlEvalInt (int_ 1) with int_ 1 using eqExpr in
 utest ocamlEvalFloat (float_ 1.) with float_ 1. using eqExpr in
 utest ocamlEvalBool true_ with true_ using eqExpr in
 utest ocamlEvalChar (char_ '1') with char_ '1' using eqExpr in
-utest '島'with '島' in
+utest ocamlEvalChar (char_ '島') with char_ '島' in
 -- Compares evaluation of [mexprAst] as a mexpr and evaluation of
 -- [ocamlAst] as a OCaml expression.
 let sameSemantics = lam mexprAst. lam ocamlAst.

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -148,7 +148,7 @@ lang OCamlPrettyPrint =
   | CGeqf _ -> "((>=) : float -> float -> bool)"
   | CNeqf _ -> "((!=) : float -> float -> bool)"
   | CInt2float _ -> "float_of_int"
-  | CChar {val = c} -> showChar c
+  | CChar {val = c} -> int2string (char2int c)
   | CEqc _ -> "((=) : char -> char -> bool)"
   | CChar2Int _ -> "int_of_char"
   | CInt2Char _ -> "char_of_int"


### PR DESCRIPTION
This PR adds support for utf-8 encoding for chars in compiler (also utest in `generate.mc`).
The only concern is that the efficiency of printing all characters as chars [ `int2string (char2int c)` ]