### PR TITLE
Naive parallel make and tests

### DIFF
--- a/compile-all.sh
+++ b/compile-all.sh
@@ -6,15 +6,16 @@
 
 # Compile and run a file
 compile() {
-    echo $1
-    build/mi src/main/mi.mc -- compile --test $1
-    if [ $? -eq 0 ]
-    then
-        binary=$(basename "$1" .mc)
-        ./$binary
-        rm $binary
-        echo ""
-    fi
+  output=$1
+  output="$output\n$(build/mi src/main/mi.mc -- compile --test $1)"
+  if [ $? -eq 0 ]
+  then
+    binary=$(basename "$1" .mc)
+    output="$output$(./$binary)"
+    rm $binary
+    output="$output\n"
+  fi
+  echo $output
 }
 
 files=""
@@ -145,5 +146,6 @@ files="${files} stdlib/char.mc"
 
 export MCORE_STDLIB='stdlib'
 for f in $files; do
-    compile "$f"
+    compile "$f" &
 done
+wait

--- a/make
+++ b/make
@@ -61,29 +61,30 @@ runtests_ocaml() {
 # Run the test suite
 runtests() {
     (cd test
-    ../build/mi test mexpr
-    ../build/mi test mlang
+    ../build/mi test mexpr &
+    ../build/mi test mlang &
     cd ../stdlib
-    ../build/mi test mexpr
-    ../build/mi test c
-    ../build/mi test ad
-    ../build/mi test ext
-    ../build/mi test parser
+    ../build/mi test mexpr &
+    ../build/mi test c &
+    ../build/mi test ad &
+    ../build/mi test ext &
+    ../build/mi test parser &
     cd ..
     export MCORE_STDLIB='@@@'
-    build/mi test stdlib)
+    build/mi test stdlib &)
     if [ -n "$MI_TEST_PAR" ]; then
-        runtests_par
+        runtests_par &
     fi
     if [ -n "$MI_TEST_PYTHON" ]; then
-        runtests_py
+        runtests_py &
     fi
     if [ -n "$MI_TEST_SUNDIALS" ]; then
-        runtests_sundials
+        runtests_sundials &
     fi
     if [ -n "$MI_TEST_OCAML" ]; then
-        runtests_ocaml
+        runtests_ocaml &
     fi
+    wait
 }
 
 # Lint ocaml source code

--- a/run-all.sh
+++ b/run-all.sh
@@ -6,8 +6,9 @@
 
 # Run a file
 run() {
-    echo $1
-    build/mi src/main/mi.mc -- run --test $1
+    output=$1
+    output="$output\n$(build/mi src/main/mi.mc -- run --test $1)\n"
+    echo $output
 }
 
 files=""
@@ -28,7 +29,6 @@ files="${files} test/mexpr/time.mc"
 # files="${files} test/mexpr/effects.mc"
 files="${files} test/mexpr/symbs.mc"
 # files="${files} test/mexpr/random-test.mc"
-
 # files="${files} test/mexpr/types.mc"
 files="${files} test/mexpr/float-test.mc"
 files="${files} test/mexpr/nestedpatterns.mc"
@@ -139,5 +139,6 @@ files="${files} stdlib/char.mc"
 
 export MCORE_STDLIB='stdlib'
 for f in $files; do
-    run "$f"
+    run "$f" &
 done
+wait


### PR DESCRIPTION
Add naive parallelism to `make test` (+ `make test-all`), `compile-all.sh` and `run-all.sh`. Basically just spawns a new process for each run of `build/mi`. Make sure to have lots of memory... `run-all.sh` went from 3 min to 1 min on my very mediocre 4-core system with 8 GiB of memory (but I'm afraid I will run out of memory when we uncomment more files). Be aware that printing is not synchronized, so you could get scrambled output in some cases.

`make test-all` did not improve that much, since the biggest source of time spent is in a single run of `build/mi`.
Also, I noticed that the OCaml compiler tests basically use very little CPU and memory, but writes over 1 GiB to disk (which is why it is taking so long). I guess this is not a surprise?

This PR should of course just be seen as a temporary hack. In the future, we should use a proper process pool. I think you can achieve quite nice results with `make`, or even just building a simple process pool with an OCaml script if we do not want to depend on `make`.