### PR TITLE
Obj wrap fix for intrinsic functions returning functions

### DIFF
--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -762,14 +762,14 @@ lang OCamlObjWrap = MExprAst + OCamlAst
   | TmApp t ->
     if _isIntrinsicApp (TmApp t) then
       TmApp {{t with lhs = objWrapRec true t.lhs}
-                with rhs = _objRepr (objWrapRec true t.rhs)}
+                with rhs = _objRepr (objWrapRec false t.rhs)}
     else
       TmApp {{t with lhs =
                   if isApp then
                     objWrapRec true t.lhs
                   else
                     _objObj (_objRepr (objWrapRec true t.lhs))}
-                with rhs = objWrapRec true t.rhs}
+                with rhs = objWrapRec false t.rhs}
   | TmRecord t ->
     if mapIsEmpty t.bindings then
       _objRepr (TmRecord t)
@@ -1621,7 +1621,10 @@ utest int_ 3 with generateEmptyEnv fst using sameSemantics in
 let testGetFun = bindall_
 [ ulet_ "lst" (seq_ [ulam_ "x" (var_ "x")])
 , ulet_ "f" (get_ (var_ "lst") (int_ 0))
-, app_ (var_ "f") (int_ 1)
+, ulet_ "_" (app_ (var_ "f") (int_ 1))
+, ulet_ "_" (app_ (ulam_ "x" (var_ "x")) (app_ (var_ "f") (int_ 1)))
+, ulet_ "_" (addi_ (app_ (var_ "f") (int_ 1)) (int_ 1))
+, int_ 1
 ] in
 utest int_ 1 with generateEmptyEnv testGetFun using sameSemantics in
 

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -787,7 +787,7 @@ lang OCamlObjWrap = MExprAst + OCamlAst
   sem objWrap =
   | OTmVariantTypeDecl t ->
     OTmVariantTypeDecl {t with inexpr = objWrap t.inexpr}
-  | t -> objWrapRec false (_objObj t)
+  | t -> _objObj (objWrapRec false t)
 end
 
 lang OCamlTest = OCamlGenerate + OCamlTypeDeclGenerate + OCamlPrettyPrint +

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -1618,6 +1618,13 @@ utest int_ 2 with generateEmptyEnv (length_ testSubseq2) using sameSemantics in
 utest int_ 1 with generateEmptyEnv (length_ testSubseq3) using sameSemantics in
 utest int_ 3 with generateEmptyEnv fst using sameSemantics in
 
+let testGetFun = bindall_
+[ ulet_ "lst" (seq_ [ulam_ "x" (var_ "x")])
+, ulet_ "f" (get_ (var_ "lst") (int_ 0))
+, app_ (var_ "f") (int_ 1)
+] in
+utest int_ 1 with generateEmptyEnv testGetFun using sameSemantics in
+
 -- splitat
 let testStr = str_ "foobar" in
 let testSplit0 = (bindall_ [ ulet_ "y" (splitat_ testStr (int_ 3)), tupleproj_ 0 (var_ "y")]) in

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -90,7 +90,8 @@ end
 lang OCamlPrettyPrint =
   VarPrettyPrint + ConstPrettyPrint + OCamlAst +
   IdentifierPrettyPrint + NamedPatPrettyPrint + IntPatPrettyPrint +
-  CharPatPrettyPrint + BoolPatPrettyPrint + OCamlTypePrettyPrint
+  CharPatPrettyPrint + BoolPatPrettyPrint + OCamlTypePrettyPrint +
+  AppPrettyPrint
 
   sem _nameSymString (esc : Name -> Name) =
   | name ->
@@ -127,7 +128,6 @@ lang OCamlPrettyPrint =
   | TmLam _ -> false
   | TmLet _ -> false
   | TmRecLets _ -> false
-  | TmApp _ -> false
   | TmRecord _ -> true
   | TmRecordUpdate _ -> true
   | OTmArray _ -> true
@@ -299,12 +299,6 @@ lang OCamlPrettyPrint =
                      (zipWith fzip idents bodies),
                      pprintNewline indent, "in ", inexpr])
         else never
-      else never
-    else never
-  | TmApp t ->
-    match pprintCode indent env t.lhs with (env,l) then
-      match pprintCode indent env t.rhs with (env,r) then
-        (env, join ["(", l, ") (", r, ")"])
       else never
     else never
   | OTmArray t ->


### PR DESCRIPTION
Previously the following program did not compile:
```
let lst = [lam x. x] in
let f = get lst 0 in
f v
```
but after this PR it does.