### PR TITLE
Dead code elimination after parsing in Boot

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -21,6 +21,8 @@ let enable_debug_after_symbolize = ref false
 
 let enable_debug_after_dead_code_elimination = ref false
 
+let enable_debug_dead_code_info = ref false
+
 let enable_debug_after_mlang = ref false
 
 let enable_debug_symbol_print = ref false

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -19,6 +19,8 @@ let enable_debug_after_parse = ref false
 
 let enable_debug_after_symbolize = ref false
 
+let enable_debug_after_dead_code_elimination = ref false
+
 let enable_debug_after_mlang = ref false
 
 let enable_debug_symbol_print = ref false

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -391,13 +391,11 @@ let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) = function
   | TmLet (_, _, _, _, t1, t2) ->
       f (f acc t1) t2
   | TmRecLets (_, lst, tm) ->
-      f
-        (f acc (List.fold_left (fun acc (_, _, _, _, t) -> f acc t) acc lst))
-        tm
+      f (List.fold_left (fun acc (_, _, _, _, t) -> f acc t) acc lst) tm
   | TmConst (_, _) ->
       acc
   | TmSeq (_, tms) ->
-      Mseq.Helpers.fold_right f tms acc
+      Mseq.Helpers.fold_left f acc tms
   | TmRecord (_, r) ->
       Record.fold (fun _ t acc -> f acc t) r acc
   | TmRecordUpdate (_, r, _, t) ->
@@ -477,6 +475,139 @@ let ty_info = function
   | TyVar (fi, _, _)
   | TyApp (fi, _, _) ->
       fi
+
+let const_has_side_effect = function
+  | CBool _
+  | CInt _
+  | Caddi _
+  | Csubi _
+  | Cmuli _
+  | Cdivi _
+  | Cmodi _
+  | Cnegi
+  | Clti _
+  | Cleqi _
+  | Cgti _
+  | Cgeqi _
+  | Ceqi _
+  | Cneqi _
+  | Cslli _
+  | Csrli _
+  | Csrai _
+  | Carity ->
+      false
+  (* MCore intrinsics: Floating-point numbers *)
+  | CFloat _
+  | Caddf _
+  | Csubf _
+  | Cmulf _
+  | Cdivf _
+  | Cnegf
+  | Cltf _
+  | Cleqf _
+  | Cgtf _
+  | Cgeqf _
+  | Ceqf _
+  | Cneqf _
+  | Cfloorfi
+  | Cceilfi
+  | Croundfi
+  | Cint2float
+  | Cstring2float ->
+      false
+  (* MCore intrinsics: Characters *)
+  | CChar _ | Ceqc _ | Cchar2int | Cint2char ->
+      false
+  (* MCore intrinsic: sequences *)
+  | Ccreate _
+  | Clength
+  | Cconcat _
+  | Cget _
+  | Cset _
+  | Ccons _
+  | Csnoc _
+  | CsplitAt _
+  | Creverse
+  | Csubsequence _ ->
+      false
+  (* MCore intrinsics: Random numbers *)
+  | CrandIntU _ ->
+      true
+  | CrandSetSeed ->
+      true
+  (* MCore intrinsics: Time *)
+  | CwallTimeMs ->
+      true
+  | CsleepMs ->
+      true
+  (* MCore intrinsics: Debug and I/O *)
+  | Cprint
+  | Cdprint
+  | CreadLine
+  | CreadBytesAsString
+  | CreadFile
+  | CwriteFile _
+  | CfileExists
+  | CdeleteFile
+  | Cerror
+  | Cexit ->
+      true
+  (* MCore intrinsics: Symbols *)
+  | CSymb _ | Cgensym | Ceqsym _ | Csym2hash ->
+      true
+  (* MCore intrinsics: References *)
+  | Cref | CmodRef _ | CdeRef ->
+      true
+  (* MCore intrinsics: Maps *)
+  (* NOTE(Linnea, 2021-01-27): Obj.t denotes the type of the internal map (I was so far unable to express it properly) *)
+  | CMap _
+  | CmapEmpty
+  | CmapSize
+  | CmapGetCmpFun
+  | CmapInsert _
+  | CmapRemove _
+  | CmapFindWithExn _
+  | CmapFindOrElse _
+  | CmapFindApplyOrElse _
+  | CmapMem _
+  | CmapAny _
+  | CmapMap _
+  | CmapMapWithKey _
+  | CmapFoldWithKey _
+  | CmapBindings
+  | CmapEq _
+  | CmapCmp _ ->
+      false
+  (* MCore intrinsics: Tensors *)
+  | CtensorCreate _
+  | CtensorGetExn _
+  | CtensorSetExn _
+  | CtensorRank
+  | CtensorShape
+  | CtensorCopyExn _
+  | CtensorReshapeExn _
+  | CtensorSliceExn _
+  | CtensorSubExn _
+  | CtensorIteri _ ->
+      true
+  (* MCore intrinsics: Boot parser *)
+  | CbootParserTree _
+  | CbootParserParseMExprString
+  | CbootParserParseMCoreFile
+  | CbootParserGetId
+  | CbootParserGetTerm _
+  | CbootParserGetType _
+  | CbootParserGetString _
+  | CbootParserGetInt _
+  | CbootParserGetFloat _
+  | CbootParserGetListLength _
+  | CbootParserGetConst _
+  | CbootParserGetPat _
+  | CbootParserGetInfo _ ->
+      true
+  (* External functions *)
+  | CPar _ | CExt _ | CSd _ | CPy _ ->
+      true
 
 (* Converts a sequence of terms to a ustring *)
 let tmseq2ustring fi s =

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -33,6 +33,8 @@ let enable_debug_stack_trace = ref false
 
 let enable_debug_profiling = ref false
 
+let disable_dead_code_elimination = ref false
+
 let utest = ref false (* Set to true if unit testing is enabled *)
 
 let utest_ok = ref 0 (* Counts the number of successful unit tests *)
@@ -480,6 +482,8 @@ let ty_info = function
   | TyApp (fi, _, _) ->
       fi
 
+(* Checks if a constant _may_ have a side effect. It is conservative
+   and returns only false if it is _sure_ to not have a side effect *)
 let const_has_side_effect = function
   | CBool _
   | CInt _
@@ -563,7 +567,6 @@ let const_has_side_effect = function
   | Cref | CmodRef _ | CdeRef ->
       true
   (* MCore intrinsics: Maps *)
-  (* NOTE(Linnea, 2021-01-27): Obj.t denotes the type of the internal map (I was so far unable to express it properly) *)
   | CMap _
   | CmapEmpty
   | CmapSize

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -36,7 +36,7 @@ let collect_lets t =
   in
   work (SymbMap.empty, SymbSet.empty) t
 
-(* Returns a new namp, where it is marked with true everywhere we have
+(* Returns a new nmap, where it is marked with true everywhere we have
    a let that is used. Use depth-first search (DFS) in the graph with
    color marking. Returns the nmap. *)
 let mark_used_lets (nmap, free) =
@@ -94,7 +94,7 @@ let elimination t =
     pprint_nmap !_symbmap nmap |> uprint_endline ;
     print_endline "-- Dead code info: free variables --" ;
     pprint_named_symbset !_symbmap free |> uprint_endline ) ;
-  (* Mark all lets that used in the graph *)
+  (* Mark all lets that are used in the graph *)
   let nmap = mark_used_lets (nmap, free) in
   if !enable_debug_dead_code_info then (
     print_endline "\n-- Dead code info: marked used lets --" ;

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -2,7 +2,28 @@ open Ast
 open Symbutils
 open Ustring.Op
 
+(* Can be used when debugging symbol maps *)
 let _symbmap = ref SymbMap.empty
+
+(* Checks if a term _may_ have a side effect. It is conservative
+   and returns only false if it is _sure_ to not have a side effect.
+   The 'nmap' contains information (third element of the tuple) if
+   a symbol may contain a side effect. *)
+let rec tm_has_side_effect nmap acc = function
+  | TmVar (_, _, s) -> (
+      if acc then true
+      else
+        match SymbMap.find_opt s nmap with
+        | Some (_, _, effect) ->
+            effect
+        | None ->
+            true )
+  | TmConst (_, c) ->
+      if acc then true else const_has_side_effect c
+  | TmRef (_, _) | TmTensor (_, _) ->
+      true
+  | t ->
+      if acc then true else sfold_tm_tm (tm_has_side_effect nmap) acc t
 
 (* Help function that collects all variables in a term *)
 let rec collect_vars (free : SymbSet.t) = function
@@ -11,18 +32,21 @@ let rec collect_vars (free : SymbSet.t) = function
   | t ->
       sfold_tm_tm collect_vars free t
 
+(* Help function that collects free variables in a body in a let *)
 let collect_in_body s nmap free = function
   | TmLam (_, _, _, _, tlam) ->
       let vars = collect_vars SymbSet.empty tlam in
-      (SymbMap.add s (vars, false) nmap, free)
+      ( SymbMap.add s (vars, false, tm_has_side_effect nmap false tlam) nmap
+      , free )
   | body ->
       let vars = collect_vars SymbSet.empty body in
-      (SymbMap.add s (vars, true) nmap, SymbSet.union vars free)
+      let se = tm_has_side_effect nmap false body in
+      (SymbMap.add s (vars, se, se) nmap, SymbSet.union vars free)
 
 (* Collect all mappings for lets (mapping symbol name of the let
    to the set of variables in the let body). It also collects
    all variables that are free, not under a lambda in a let *)
-let collect_lets t =
+let collect_lets nmap t =
   let rec work (nmap, free) = function
     | TmVar (_, _, s) ->
         (nmap, SymbSet.add s free)
@@ -34,7 +58,7 @@ let collect_lets t =
     | t ->
         sfold_tm_tm work (nmap, free) t
   in
-  work (SymbMap.empty, SymbSet.empty) t
+  work (nmap, SymbSet.empty) t
 
 (* Returns a new nmap, where it is marked with true everywhere we have
    a let that is used. Use depth-first search (DFS) in the graph with
@@ -45,8 +69,8 @@ let mark_used_lets (nmap, free) =
     else
       let visited = SymbSet.add s visited in
       match SymbMap.find_opt s nmap with
-      | Some (symset, _) ->
-          let nmap = SymbMap.add s (symset, true) nmap in
+      | Some (symset, _, se) ->
+          let nmap = SymbMap.add s (symset, true, se) nmap in
           SymbSet.fold dfs symset (visited, nmap)
       | None ->
           (visited, nmap)
@@ -55,15 +79,16 @@ let mark_used_lets (nmap, free) =
 
 (* Removes all lets that have not been marked as 'used'. *)
 let rec remove_lets nmap = function
-  | TmLet (fi, x, s, ty, t1, t2) ->
-      (* Is the let marked as used? *)
-      if SymbMap.find s nmap |> snd then
+  | TmLet (fi, x, s, ty, t1, t2) -> (
+    (* Is the let marked as used? *)
+    match SymbMap.find s nmap with
+    | _, true, _ ->
         TmLet (fi, x, s, ty, t1, remove_lets nmap t2)
-      else remove_lets nmap t2
+    | _ ->
+        remove_lets nmap t2 )
   | TmRecLets (fi, lst, tt) ->
-      let lst =
-        List.filter (fun (_, _, s, _, _) -> SymbMap.find s nmap |> snd) lst
-      in
+      let f (_, _, s, _, _) = match SymbMap.find s nmap with _, b, _ -> b in
+      let lst = List.filter f lst in
       if List.length lst = 0 then remove_lets nmap tt
       else TmRecLets (fi, lst, remove_lets nmap tt)
   | t ->
@@ -71,33 +96,56 @@ let rec remove_lets nmap = function
 
 (* Helper function for pretty printing a nmap *)
 let pprint_nmap symbmap nmap =
-  let f k (ss, used) acc =
+  let f k (ss, used, se) acc =
     acc ^. us "let "
     ^. pprint_named_symb symbmap k
     ^. us " -> "
     ^. pprint_named_symbset symbmap ss
     ^. us " used = "
     ^. us (if used then "true" else "false")
+    ^. us ", side effect = "
+    ^. us (if se then "true" else "false")
     ^. us "\n"
   in
   SymbMap.fold f nmap (us "")
 
+(* Helper that creates a nmap with side effect info for builtin constants *)
+let make_builtin_nmap builtin_sym2term =
+  let f acc (s, t) =
+    let v = (SymbSet.empty, false, tm_has_side_effect SymbMap.empty false t) in
+    SymbMap.add s v acc
+  in
+  List.fold_left f SymbMap.empty builtin_sym2term
+
+(* Helper for extending the symbmap wiht built in names *)
+let extend_symb_map_builtin builtin_name2sym symbmap =
+  let f acc (xsid, s) =
+    let x =
+      match xsid with IdVar sid -> ustring_of_sid sid | _ -> failwith "error"
+    in
+    SymbMap.add s x acc
+  in
+  List.fold_left f symbmap builtin_name2sym
+
 (* The main dead code elimination function 
    of flag utest is false, then utests are also removed
 *)
-let elimination t =
-  (* Collect all lets and store a graph in 'nmap' and free variable in 'free' *)
-  let nmap, free = collect_lets t in
-  if !enable_debug_dead_code_info then (
-    _symbmap := symbmap t ;
-    print_endline "-- Dead code info: collected lets --" ;
-    pprint_nmap !_symbmap nmap |> uprint_endline ;
-    print_endline "-- Dead code info: free variables --" ;
-    pprint_named_symbset !_symbmap free |> uprint_endline ) ;
-  (* Mark all lets that are used in the graph *)
-  let nmap = mark_used_lets (nmap, free) in
-  if !enable_debug_dead_code_info then (
-    print_endline "\n-- Dead code info: marked used lets --" ;
-    pprint_nmap !_symbmap nmap |> uprint_endline ) ;
-  (* Remove all lets that are not used *)
-  remove_lets nmap t
+let elimination builtin_sym2term builtin_name2sym t =
+  if !disable_dead_code_elimination then t
+  else (
+    if !enable_debug_dead_code_info then
+      _symbmap := extend_symb_map_builtin builtin_name2sym (symbmap t) ;
+    (* Collect all lets and store a graph in 'nmap' and free variable in 'free' *)
+    let nmap, free = collect_lets (make_builtin_nmap builtin_sym2term) t in
+    if !enable_debug_dead_code_info then (
+      print_endline "-- Dead code info: collected lets --" ;
+      pprint_nmap !_symbmap nmap |> uprint_endline ;
+      print_endline "-- Dead code info: free variables --" ;
+      pprint_named_symbset !_symbmap free |> uprint_endline ) ;
+    (* Mark all lets that are used in the graph *)
+    let nmap = mark_used_lets (nmap, free) in
+    if !enable_debug_dead_code_info then (
+      print_endline "\n-- Dead code info: marked used lets --" ;
+      pprint_nmap !_symbmap nmap |> uprint_endline ) ;
+    (* Remove all lets that are not used *)
+    remove_lets nmap t )

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -1,0 +1,95 @@
+open Ast
+open Intrinsics
+
+module SymbOrd = struct
+  type t = Symb.t
+
+  let compare = Symb.compare
+end
+
+module SymbSet = Set.Make (SymbOrd)
+module SymbMap = Map.Make (SymbOrd)
+
+(*
+let pbool s b = Printf.printf "%s: %s\n" s (if b then "true" else "false") 
+
+let testen =
+  let s1 = Symb.gensym () in
+  let s2 = Symb.gensym () in
+  let s3 = s2 in
+  pbool "s1 = s2" (s1 = s2) ;
+  pbool "s2 = s3" (s2 = s3) ;
+  let a = SymbSet.empty in
+  let b = SymbSet.add s1 a in
+  pbool "s1 set mem" (SymbSet.mem s1 b) ;
+  pbool "s2 set mem" (SymbSet.mem s2 b) ;
+  let m1 = SymbMap.empty in
+  let m2 = SymbMap.add s2 a m1 in
+  pbool "s1 map mem" (SymbMap.mem s1 m2) ;
+  pbool "s2 map mem" (SymbMap.mem s2 m2) ;
+  Printf.printf ""
+ *)
+
+(* Help function that collects all variables in a term *)
+let rec collect_vars (free : SymbSet.t) = function
+  | TmVar (_, _, s) ->
+      SymbSet.add s free
+  | t ->
+      sfold_tm_tm collect_vars free t
+
+(* Collect all mappings for lets (mapping symbol name of the let
+   to the set of variables in the let body). It also collects
+   all variables that are free, not under a lambda in a let *)
+let collect_lets t =
+  let rec work (nmap, free) = function
+    | TmVar (_, _, s) ->
+        (nmap, SymbSet.add s free)
+    | TmLet (_, _, s, _, t1, t2) ->
+        let nmap, free =
+          match t1 with
+          | TmLam (_, _, _, _, tlam) ->
+              let vars = collect_vars SymbSet.empty tlam in
+              (SymbMap.add s (vars, false) nmap, free)
+          | body ->
+              let vars = collect_vars SymbSet.empty body in 
+              (SymbMap.add s (vars, true) nmap, SymbSet.union vars free)
+               (* TODO: handle lets without side effects *)
+        in
+        work (nmap, free) t2
+    (* TODO: add let rec *)
+    | t ->
+        sfold_tm_tm work (nmap, free) t
+  in
+  work (SymbMap.empty, SymbSet.empty) t
+
+(* Returns a new namp, where it is marked with true everywhere we have
+   a let that is used. Use depth-first search (DFS) in the graph with
+   color marking.  *)
+let mark_used_lets nmap free =
+  let rec dfs s (visited, nmap) =
+    if SymbSet.mem s visited then (visited, nmap)
+    else
+      let visited = SymbSet.add s visited in
+      let (symset, _) = SymbMap.find s nmap in
+      let nmap = SymbMap.add s (symset, true) nmap in
+      SymbSet.fold dfs symset (visited, nmap) 
+  in
+  SymbSet.fold dfs free (SymbSet.empty, nmap) |> snd
+  
+
+(* Removes all lets which have not been marked as used *)
+let rec remove_lets nmap = function
+  | TmLet (fi, x, s, ty, t1, t2) ->
+     (* Is the let marked as used? *)
+     if SymbMap.find s nmap |> snd then
+       TmLet (fi, x, s, ty, t1, remove_lets nmap t2)
+     else
+       remove_lets nmap t2
+  | t -> smap_tm_tm (remove_lets nmap) t
+  
+ 
+
+let elimination t =
+  
+  (* Printf.printf "%s\n" "**********" ; *)
+  t

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -1,4 +1,3 @@
-
 open Ast
 open Symbutils
 open Ustring.Op
@@ -12,6 +11,14 @@ let rec collect_vars (free : SymbSet.t) = function
   | t ->
       sfold_tm_tm collect_vars free t
 
+let collect_in_body s nmap free = function
+  | TmLam (_, _, _, _, tlam) ->
+      let vars = collect_vars SymbSet.empty tlam in
+      (SymbMap.add s (vars, false) nmap, free)
+  | body ->
+      let vars = collect_vars SymbSet.empty body in
+      (SymbMap.add s (vars, true) nmap, SymbSet.union vars free)
+
 (* Collect all mappings for lets (mapping symbol name of the let
    to the set of variables in the let body). It also collects
    all variables that are free, not under a lambda in a let *)
@@ -20,18 +27,10 @@ let collect_lets t =
     | TmVar (_, _, s) ->
         (nmap, SymbSet.add s free)
     | TmLet (_, _, s, _, t1, t2) ->
-        let nmap, free =
-          match t1 with
-          | TmLam (_, _, _, _, tlam) ->
-              let vars = collect_vars SymbSet.empty tlam in
-              (SymbMap.add s (vars, false) nmap, free)
-          | body ->
-              let vars = collect_vars SymbSet.empty body in
-              (SymbMap.add s (vars, true) nmap, SymbSet.union vars free)
-          (* TODO: handle lets without side effects *)
-        in
-        work (nmap, free) t2
-    (* TODO: add let rec *)
+        work (collect_in_body s nmap free t1) t2
+    | TmRecLets (_, lst, tt) ->
+        let f (nmap, free) (_, _, s, _, t) = collect_in_body s nmap free t in
+        work (List.fold_left f (nmap, free) lst) tt
     | t ->
         sfold_tm_tm work (nmap, free) t
   in
@@ -46,10 +45,11 @@ let mark_used_lets (nmap, free) =
     else
       let visited = SymbSet.add s visited in
       match SymbMap.find_opt s nmap with
-      | Some (symset, _) ->  
-         let nmap = SymbMap.add s (symset, true) nmap in
-         SymbSet.fold dfs symset (visited, nmap)
-      | None -> (visited, nmap)
+      | Some (symset, _) ->
+          let nmap = SymbMap.add s (symset, true) nmap in
+          SymbSet.fold dfs symset (visited, nmap)
+      | None ->
+          (visited, nmap)
   in
   SymbSet.fold dfs free (SymbSet.empty, nmap) |> snd
 
@@ -60,35 +60,44 @@ let rec remove_lets nmap = function
       if SymbMap.find s nmap |> snd then
         TmLet (fi, x, s, ty, t1, remove_lets nmap t2)
       else remove_lets nmap t2
+  | TmRecLets (fi, lst, tt) ->
+      let lst =
+        List.filter (fun (_, _, s, _, _) -> SymbMap.find s nmap |> snd) lst
+      in
+      if List.length lst = 0 then remove_lets nmap tt
+      else TmRecLets (fi, lst, remove_lets nmap tt)
   | t ->
       smap_tm_tm (remove_lets nmap) t
 
 (* Helper function for pretty printing a nmap *)
 let pprint_nmap symbmap nmap =
-  let f k (ss, used) acc = acc ^. us"let " ^. pprint_named_symb symbmap k ^.
-                           us" -> " ^. pprint_named_symbset symbmap ss  ^.
-                           us" used = " ^. us(if used then "true" else "false") ^. us"\n" in
-  SymbMap.fold f nmap (us"")
-
+  let f k (ss, used) acc =
+    acc ^. us "let "
+    ^. pprint_named_symb symbmap k
+    ^. us " -> "
+    ^. pprint_named_symbset symbmap ss
+    ^. us " used = "
+    ^. us (if used then "true" else "false")
+    ^. us "\n"
+  in
+  SymbMap.fold f nmap (us "")
 
 (* The main dead code elimination function 
    of flag utest is false, then utests are also removed
 *)
 let elimination t =
   (* Collect all lets and store a graph in 'nmap' and free variable in 'free' *)
-  let (nmap, free) = collect_lets t in
+  let nmap, free = collect_lets t in
   if !enable_debug_dead_code_info then (
-    _symbmap := symbmap t;
-    print_endline "-- Dead code info: collected lets --";
-    pprint_nmap !_symbmap nmap |> uprint_endline; 
-    print_endline "-- Dead code info: free variables --";
-    pprint_named_symbset !_symbmap free |> uprint_endline);
+    _symbmap := symbmap t ;
+    print_endline "-- Dead code info: collected lets --" ;
+    pprint_nmap !_symbmap nmap |> uprint_endline ;
+    print_endline "-- Dead code info: free variables --" ;
+    pprint_named_symbset !_symbmap free |> uprint_endline ) ;
   (* Mark all lets that used in the graph *)
   let nmap = mark_used_lets (nmap, free) in
   if !enable_debug_dead_code_info then (
-    print_endline "\n-- Dead code info: marked used lets --";
-    pprint_nmap !_symbmap nmap |> uprint_endline);
+    print_endline "\n-- Dead code info: marked used lets --" ;
+    pprint_nmap !_symbmap nmap |> uprint_endline ) ;
   (* Remove all lets that are not used *)
   remove_lets nmap t
-
-

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -27,7 +27,8 @@ let evalprog filename =
       |> merge_includes (Filename.dirname filename) [filename]
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
       |> Symbolize.symbolize builtin_name2sym
-      |> debug_after_symbolize |> Deadcode.elimination
+      |> debug_after_symbolize
+      |> Deadcode.elimination builtin_sym2term builtin_name2sym
       |> debug_after_dead_code_elimination
       |> Mexpr.eval builtin_sym2term
       |> fun _ -> ()

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -24,10 +24,11 @@ let evalprog filename =
   ( try
       let parsed = local_parse_mcore_file filename in
       parsed
-      |> merge_includes (Filename.dirname filename) [filename] 
+      |> merge_includes (Filename.dirname filename) [filename]
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
-      |> Symbolize.symbolize builtin_name2sym |> debug_after_symbolize
-      |> Deadcode.elimination |> debug_after_dead_code_elimination
+      |> Symbolize.symbolize builtin_name2sym
+      |> debug_after_symbolize |> Deadcode.elimination
+      |> debug_after_dead_code_elimination
       |> Mexpr.eval builtin_sym2term
       |> fun _ -> ()
     with (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -27,7 +27,7 @@ let evalprog filename =
       |> merge_includes (Filename.dirname filename) [filename]
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
       |> Symbolize.symbolize builtin_name2sym
-      |> debug_after_symbolize
+      |> Deadcode.elimination |> debug_after_symbolize
       |> Mexpr.eval builtin_sym2term
       |> fun _ -> ()
     with (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -24,7 +24,7 @@ let evalprog filename =
   ( try
       let parsed = local_parse_mcore_file filename in
       parsed
-      |> merge_includes (Filename.dirname filename) [filename]
+      |> merge_includes (Filename.dirname filename) [filename] 
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
       |> Symbolize.symbolize builtin_name2sym |> debug_after_symbolize
       |> Deadcode.elimination |> debug_after_dead_code_elimination

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -26,8 +26,8 @@ let evalprog filename =
       parsed
       |> merge_includes (Filename.dirname filename) [filename]
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
-      |> Symbolize.symbolize builtin_name2sym
-      |> Deadcode.elimination |> debug_after_symbolize
+      |> Symbolize.symbolize builtin_name2sym |> debug_after_symbolize
+      |> Deadcode.elimination |> debug_after_dead_code_elimination
       |> Mexpr.eval builtin_sym2term
       |> fun _ -> ()
     with (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -42,6 +42,8 @@ module Mseq = struct
 
     let map = Rope.map_array_array
 
+    let fold_left = Rope.foldl_array
+
     let fold_right = Rope.foldr_array
 
     let combine = Rope.combine_array_array
@@ -66,6 +68,8 @@ end
 module Symb = struct
   type t = int
 
+  type symbtype = int
+
   let symid = ref 0
 
   let gensym _ =
@@ -75,6 +79,8 @@ module Symb = struct
   let eqsym l r = l = r
 
   let hash s = s
+
+  let compare = Stdlib.compare
 
   module Helpers = struct
     let nosym = -1

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -42,6 +42,8 @@ module Mseq : sig
 
     val map : ('a -> 'b) -> 'a t -> 'b t
 
+    val fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+
     val fold_right : ('a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
 
     val combine : 'a t -> 'b t -> ('a * 'b) t
@@ -67,11 +69,15 @@ end
 module Symb : sig
   type t
 
+  type symbtype
+
   val gensym : unit -> t
 
   val eqsym : t -> t -> bool
 
   val hash : t -> int
+
+  val compare : t -> t -> int
 
   module Helpers : sig
     val nosym : t

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1355,6 +1355,7 @@ let delta eval env fi c v =
       let t =
         Parserutils.parse_mcore_file (tmseq2ustring fi seq)
         |> Symbolize.symbolize builtin_name2sym
+        |> Deadcode.elimination
       in
       TmConst (fi, CbootParserTree (PTreeTm t))
   | CbootParserParseMCoreFile, _ ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1355,7 +1355,7 @@ let delta eval env fi c v =
       let t =
         Parserutils.parse_mcore_file (tmseq2ustring fi seq)
         |> Symbolize.symbolize builtin_name2sym
-        |> Deadcode.elimination
+        |> Deadcode.elimination 
       in
       TmConst (fi, CbootParserTree (PTreeTm t))
   | CbootParserParseMCoreFile, _ ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1355,7 +1355,7 @@ let delta eval env fi c v =
       let t =
         Parserutils.parse_mcore_file (tmseq2ustring fi seq)
         |> Symbolize.symbolize builtin_name2sym
-        |> Deadcode.elimination 
+        |> Deadcode.elimination
       in
       TmConst (fi, CbootParserTree (PTreeTm t))
   | CbootParserParseMCoreFile, _ ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1355,7 +1355,7 @@ let delta eval env fi c v =
       let t =
         Parserutils.parse_mcore_file (tmseq2ustring fi seq)
         |> Symbolize.symbolize builtin_name2sym
-        |> Deadcode.elimination
+        |> Deadcode.elimination builtin_sym2term builtin_name2sym
       in
       TmConst (fi, CbootParserTree (PTreeTm t))
   | CbootParserParseMCoreFile, _ ->

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -45,7 +45,7 @@ let debug_after_parse t =
   if !enable_debug_after_parse then (
     printf "\n-- After parsing (only mexpr part) --\n" ;
     uprint_endline (ustring_of_program t) ;
-    print_endline "";
+    print_endline "" ;
     t )
   else t
 

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -56,6 +56,14 @@ let debug_after_symbolize t =
     t )
   else t
 
+(* Debug printing after dead code elimination *)
+let debug_after_dead_code_elimination t =
+  if !enable_debug_after_dead_code_elimination then (
+    printf "\n-- After dead code elimination --\n" ;
+    uprint_endline (ustring_of_tm ~margin:80 t) ;
+    t )
+  else t
+
 (* Debug mlang to mexpr transform *)
 let debug_after_mlang t =
   if !enable_debug_after_mlang then (

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -45,6 +45,7 @@ let debug_after_parse t =
   if !enable_debug_after_parse then (
     printf "\n-- After parsing (only mexpr part) --\n" ;
     uprint_endline (ustring_of_program t) ;
+    print_endline "";
     t )
   else t
 

--- a/src/boot/lib/symbutils.ml
+++ b/src/boot/lib/symbutils.ml
@@ -1,0 +1,44 @@
+
+open Ustring.Op
+open Intrinsics
+open Ast
+
+module SymbOrd = struct
+  type t = Symb.t
+
+  let compare = Symb.compare
+end
+
+module SymbSet = Set.Make (SymbOrd)
+module SymbMap = Map.Make (SymbOrd)
+
+
+(* From a term, create the map from symbols to text strings *)
+let symbmap t =
+  let rec work acc = function
+  | TmVar(_, x, s) -> SymbMap.add s x acc
+  | TmLam(_, x, s, _, t) | TmType(_, x, s, _, t) |
+    TmConDef(_, x, s, _, t) | TmConApp(_, x, s,  t)-> work (SymbMap.add s x acc) t
+  | TmLet(_, x, s, _, t1, t2) -> work (work (SymbMap.add s x acc) t1) t2
+  | TmRecLets(_, lst, t1) ->
+     work (List.fold_left (fun acc (_,x,s,_,t) -> work (SymbMap.add s x acc) t) acc lst) t1
+  | t -> sfold_tm_tm work acc t
+  in work SymbMap.empty t
+
+let pprint_symb s = us (Printf.sprintf "%d" (Symb.hash s)) 
+
+let pprint_named_symb symbmap s = SymbMap.find s symbmap
+
+let pprint_symbset ss =
+  us"{" ^. (ss |> SymbSet.elements |> List.map pprint_symb |> Ustring.concat (us", ")) ^. us"}"
+
+let pprint_named_symbset symbmap ss =
+  us"{" ^. (ss |> SymbSet.elements |> List.map (fun s -> SymbMap.find s symbmap)
+               |> Ustring.concat (us", ")) ^. us"}"
+
+let pprint_symbmap symbmap =
+  let f k x acc = acc ^. x ^. us" -> " ^. pprint_symb k in
+  SymbMap.fold f symbmap (us"")
+
+
+

--- a/src/boot/lib/symbutils.ml
+++ b/src/boot/lib/symbutils.ml
@@ -1,4 +1,3 @@
-
 open Ustring.Op
 open Intrinsics
 open Ast
@@ -12,33 +11,46 @@ end
 module SymbSet = Set.Make (SymbOrd)
 module SymbMap = Map.Make (SymbOrd)
 
-
 (* From a term, create the map from symbols to text strings *)
 let symbmap t =
   let rec work acc = function
-  | TmVar(_, x, s) -> SymbMap.add s x acc
-  | TmLam(_, x, s, _, t) | TmType(_, x, s, _, t) |
-    TmConDef(_, x, s, _, t) | TmConApp(_, x, s,  t)-> work (SymbMap.add s x acc) t
-  | TmLet(_, x, s, _, t1, t2) -> work (work (SymbMap.add s x acc) t1) t2
-  | TmRecLets(_, lst, t1) ->
-     work (List.fold_left (fun acc (_,x,s,_,t) -> work (SymbMap.add s x acc) t) acc lst) t1
-  | t -> sfold_tm_tm work acc t
-  in work SymbMap.empty t
+    | TmVar (_, x, s) ->
+        SymbMap.add s x acc
+    | TmLam (_, x, s, _, t)
+    | TmType (_, x, s, _, t)
+    | TmConDef (_, x, s, _, t)
+    | TmConApp (_, x, s, t) ->
+        work (SymbMap.add s x acc) t
+    | TmLet (_, x, s, _, t1, t2) ->
+        work (work (SymbMap.add s x acc) t1) t2
+    | TmRecLets (_, lst, t1) ->
+        work
+          (List.fold_left
+             (fun acc (_, x, s, _, t) -> work (SymbMap.add s x acc) t)
+             acc lst )
+          t1
+    | t ->
+        sfold_tm_tm work acc t
+  in
+  work SymbMap.empty t
 
-let pprint_symb s = us (Printf.sprintf "%d" (Symb.hash s)) 
+let pprint_symb s = us (Printf.sprintf "%d" (Symb.hash s))
 
 let pprint_named_symb symbmap s = SymbMap.find s symbmap
 
 let pprint_symbset ss =
-  us"{" ^. (ss |> SymbSet.elements |> List.map pprint_symb |> Ustring.concat (us", ")) ^. us"}"
+  us "{"
+  ^. ( ss |> SymbSet.elements |> List.map pprint_symb
+     |> Ustring.concat (us ", ") )
+  ^. us "}"
 
 let pprint_named_symbset symbmap ss =
-  us"{" ^. (ss |> SymbSet.elements |> List.map (fun s -> SymbMap.find s symbmap)
-               |> Ustring.concat (us", ")) ^. us"}"
+  us "{"
+  ^. ( ss |> SymbSet.elements
+     |> List.map (fun s -> SymbMap.find s symbmap)
+     |> Ustring.concat (us ", ") )
+  ^. us "}"
 
 let pprint_symbmap symbmap =
-  let f k x acc = acc ^. x ^. us" -> " ^. pprint_symb k in
-  SymbMap.fold f symbmap (us"")
-
-
-
+  let f k x acc = acc ^. x ^. us " -> " ^. pprint_symb k in
+  SymbMap.fold f symbmap (us "")

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -108,6 +108,9 @@ let main =
       , Arg.Set Boot.Mlang.enable_subsumption_analysis
       , " Enables subsumption analysis of language fragments in mlang \
          transformations." )
+    ; ( "--disable-dead-code-elim"
+      , Arg.Set disable_dead_code_elimination
+      , " Disables dead code elimination." )
     ; ( "--no-line-edit"
       , Arg.Set Boot.Repl.no_line_edit
       , " Disable line editing funcionality in the REPL." ) ]

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -75,12 +75,10 @@ let main =
       )
     ; ( "--debug-dead-code-elim"
       , Arg.Set enable_debug_after_dead_code_elimination
-      , " Enables output of the mexpr program after dead code elimination."
-      )
+      , " Enables output of the mexpr program after dead code elimination." )
     ; ( "--debug-dead-code-info"
       , Arg.Set enable_debug_dead_code_info
-      , " Enables output of dead code elimination info."
-      )
+      , " Enables output of dead code elimination info." )
     ; ( "--debug-eval-tm"
       , Arg.Set enable_debug_eval_tm
       , " Enables output of terms in each eval step." )

--- a/src/boot/mi.ml
+++ b/src/boot/mi.ml
@@ -73,6 +73,14 @@ let main =
       , Arg.Set enable_debug_after_symbolize
       , " Enables output of the mexpr program after symbolize transformations."
       )
+    ; ( "--debug-dead-code-elim"
+      , Arg.Set enable_debug_after_dead_code_elimination
+      , " Enables output of the mexpr program after dead code elimination."
+      )
+    ; ( "--debug-dead-code-info"
+      , Arg.Set enable_debug_dead_code_info
+      , " Enables output of dead code elimination info."
+      )
     ; ( "--debug-eval-tm"
       , Arg.Set enable_debug_eval_tm
       , " Enables output of terms in each eval step." )


### PR DESCRIPTION
This PR adds dead code elimination, as an analysis and transformation step after parsing. The task is performed in Boot, and affects all parts of the compiler, including analysis, transformations, and code generation.  

Currently, the time for compiling and running all tests went down from approximately 6min and 20 seconds to 2 min and 53 seconds. However, there might still be room for some more improvements.

Although the PR makes quite a big change in performance, there are a few potential improvements in the future:
1. Recursive lets cannot be eliminated in certain cases because the analysis cannot exclude side effects (the recursive variable is not available during the analysis. E.g.
```
recursive
let fax = lam f. lam e. f (fax f) e in

let fact = fax (lam recur. lam n.
  if eqi n 0
    then 1
    else muli n (recur (subi n 1)))
in
()
```

2. Elimination of unused constructors is not yet implemented.
3. If a let starts with a partial application and not a lambda, it cannot be detect right now that it is OK in some cases. For instance, just run `include "stdlib/mexpr/pprint.mc"` in an empty file.