### PR TITLE
Made the bootstrapped compiler the default mi command

### DIFF
--- a/compile-all.sh
+++ b/compile-all.sh
@@ -7,7 +7,7 @@
 # Compile and run a file
 compile() {
   output=$1
-  output="$output\n$(build/mi src/main/mi.mc -- compile --test $1)"
+  output="$output\n$(build/boot src/main/mi.mc -- compile --test $1)"
   if [ $? -eq 0 ]
   then
     binary=$(basename "$1" .mc)

--- a/compile-all.sh
+++ b/compile-all.sh
@@ -7,7 +7,7 @@
 # Compile and run a file
 compile() {
   output=$1
-  output="$output\n$(build/boot src/main/mi.mc -- compile --test $1)"
+  output="$output\n$($2 $1)"
   if [ $? -eq 0 ]
   then
     binary=$(basename "$1" .mc)
@@ -148,7 +148,15 @@ files="${files} src/main/compile.mc"
 files="${files} src/main/run.mc"
 
 export MCORE_STDLIB='stdlib'
+
+# Compile using boot
 for f in $files; do
-    compile "$f" &
+    compile "$f" "build/boot src/main/mi.mc -- compile --test" &
+done
+wait
+
+# Compile using the bootstrapped compiler
+for f in $files; do
+    compile "$f" "build/mi compile --test" &
 done
 wait

--- a/make
+++ b/make
@@ -22,15 +22,16 @@ cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 build() {
     mkdir -p build
     dune build
+    dune install > /dev/null 2>&1 
     cp -f _build/install/default/bin/boot.mi build/$BOOT_NAME
     if [ -e build/$MI_NAME ]
     then
         echo "Bootstrapped compiler already exists. Run 'make clean' before to recompile. "
     else
         echo "Bootstrapping the Miking compiler (1st round, might take a few minutes)"
-        time (build/$BOOT_NAME src/main/mi.mc -- compile src/main/mi.mc)
-        echo "Bootstrapping the Miking compiler (2st round, might take some more time)"
-        time ($MI_NAME compile src/main/mi.mc)
+        time build/$BOOT_NAME src/main/mi.mc -- compile src/main/mi.mc
+        echo "Bootstrapping the Miking compiler (2nd round, might take some more time)"
+        time ./$MI_NAME compile src/main/mi.mc
         mv -f $MI_NAME build/$MI_NAME
         rm -f mi
     fi
@@ -44,7 +45,6 @@ install() {
     cp -f build/$BOOT_NAME $bin_path/$BOOT_NAME; chmod +x $bin_path/$BOOT_NAME
     cp -f build/$MI_NAME $bin_path/$MI_NAME; chmod +x $bin_path/$MI_NAME
     rm -rf $lib_path; cp -rf stdlib $lib_path
-    dune install
 }
 
 # Run the test suite for parallel programming

--- a/make
+++ b/make
@@ -29,9 +29,8 @@ build() {
     else
         echo "Bootstrapping the Miking compiler (1st round, might take a few minutes)"
         time (build/$BOOT_NAME src/main/mi.mc -- compile src/main/mi.mc)
-        mv -f $MI_NAME build/$MI_NAME
         echo "Bootstrapping the Miking compiler (2st round, might take some more time)"
-        time (build/$MI_NAME compile src/main/mi.mc)
+        time ($MI_NAME compile src/main/mi.mc)
         mv -f $MI_NAME build/$MI_NAME
         rm -f mi
     fi

--- a/make
+++ b/make
@@ -13,6 +13,7 @@
 set -e
 
 export BOOT_NAME=boot
+export MI_NAME=mi
 
 # Setup environment variable to find standard library
 cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
@@ -22,6 +23,18 @@ build() {
     mkdir -p build
     dune build
     cp -f _build/install/default/bin/boot.mi build/$BOOT_NAME
+    if [ -e build/$MI_NAME ]
+    then
+        echo "Bootstrapped compiler already exists. Run 'make clean' before to recompile. "
+    else
+        echo "Bootstrapping the Miking compiler (1st round, might take a few minutes)"
+        time (build/$BOOT_NAME src/main/mi.mc -- compile src/main/mi.mc)
+        mv -f $MI_NAME build/$MI_NAME
+        echo "Bootstrapping the Miking compiler (2st round, might take some more time)"
+        time (build/$MI_NAME compile src/main/mi.mc)
+        mv -f $MI_NAME build/$MI_NAME
+        rm -f mi
+    fi
 }
 
 # Install the boot interpreter locally for the current user
@@ -30,6 +43,7 @@ install() {
     lib_path=$HOME/.local/lib/mcore/stdlib
     mkdir -p $bin_path $lib_path
     cp -f build/$BOOT_NAME $bin_path/$BOOT_NAME; chmod +x $bin_path/$BOOT_NAME
+    cp -f build/$MI_NAME $bin_path/$MI_NAME; chmod +x $bin_path/$MI_NAME
     rm -rf $lib_path; cp -rf stdlib $lib_path
     dune install
 }
@@ -37,43 +51,43 @@ install() {
 # Run the test suite for parallel programming
 runtests_par() {
     (cd test
-     ../build/$BOOT_NAME test multicore/*)
-    build/$BOOT_NAME test stdlib/multicore/*
+     ../build/$BOOT_NAME multicore/* --test)
+    build/$BOOT_NAME stdlib/multicore/* --test
 }
 
 # Run the test suite for sundials
 runtests_sundials() {
     (cd test
-     ../build/$BOOT_NAME test sundials/*)
-    build/$BOOT_NAME test stdlib/sundials/*
+     ../build/$BOOT_NAME sundials/* --test)
+    build/$BOOT_NAME stdlib/sundials/* --test
 }
 
 # Run the test suite for python intrinsic tests
 runtests_py() {
     (cd test
-     ../build/$BOOT_NAME test py/*)
+     ../build/$BOOT_NAME py/* --test)
 }
 
 # Run the test suite for OCaml compiler
 runtests_ocaml() {
     (cd stdlib
-     ../build/$BOOT_NAME test ocaml/*)
+     ../build/$BOOT_NAME ocaml/* --test)
 }
 
 # Run the test suite
 runtests() {
     (cd test
-    ../build/$BOOT_NAME test mexpr &
-    ../build/$BOOT_NAME test mlang &
+    ../build/$BOOT_NAME mexpr --test &
+    ../build/$BOOT_NAME mlang --test&
     cd ../stdlib
-    ../build/$BOOT_NAME test mexpr &
-    ../build/$BOOT_NAME test c &
-    ../build/$BOOT_NAME test ad &
-    ../build/$BOOT_NAME test ext &
-    ../build/$BOOT_NAME test parser &
+    ../build/$BOOT_NAME mexpr --test &
+    ../build/$BOOT_NAME c --test &
+    ../build/$BOOT_NAME ad --test&
+    ../build/$BOOT_NAME ext --test &
+    ../build/$BOOT_NAME parser --test&
     cd ..
     export MCORE_STDLIB='@@@'
-    build/$BOOT_NAME test stdlib &)
+    build/$BOOT_NAME stdlib --test &)
     if [ -n "$MI_TEST_PAR" ]; then
         runtests_par &
     fi

--- a/make
+++ b/make
@@ -12,6 +12,8 @@
 # Forces the script to exit on error
 set -e
 
+export BOOT_NAME=boot
+
 # Setup environment variable to find standard library
 cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 
@@ -19,7 +21,7 @@ cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 build() {
     mkdir -p build
     dune build
-    cp -f _build/install/default/bin/boot.mi build/mi
+    cp -f _build/install/default/bin/boot.mi build/$BOOT_NAME
 }
 
 # Install the boot interpreter locally for the current user
@@ -27,7 +29,7 @@ install() {
     bin_path=$HOME/.local/bin/
     lib_path=$HOME/.local/lib/mcore/stdlib
     mkdir -p $bin_path $lib_path
-    cp -f build/mi $bin_path/mi; chmod +x $bin_path/mi
+    cp -f build/$BOOT_NAME $bin_path/$BOOT_NAME; chmod +x $bin_path/$BOOT_NAME
     rm -rf $lib_path; cp -rf stdlib $lib_path
     dune install
 }
@@ -35,43 +37,43 @@ install() {
 # Run the test suite for parallel programming
 runtests_par() {
     (cd test
-     ../build/mi test multicore/*)
-    build/mi test stdlib/multicore/*
+     ../build/$BOOT_NAME test multicore/*)
+    build/$BOOT_NAME test stdlib/multicore/*
 }
 
 # Run the test suite for sundials
 runtests_sundials() {
     (cd test
-     ../build/mi test sundials/*)
-    build/mi test stdlib/sundials/*
+     ../build/$BOOT_NAME test sundials/*)
+    build/$BOOT_NAME test stdlib/sundials/*
 }
 
 # Run the test suite for python intrinsic tests
 runtests_py() {
     (cd test
-     ../build/mi test py/*)
+     ../build/$BOOT_NAME test py/*)
 }
 
 # Run the test suite for OCaml compiler
 runtests_ocaml() {
     (cd stdlib
-     ../build/mi test ocaml/*)
+     ../build/$BOOT_NAME test ocaml/*)
 }
 
 # Run the test suite
 runtests() {
     (cd test
-    ../build/mi test mexpr &
-    ../build/mi test mlang &
+    ../build/$BOOT_NAME test mexpr &
+    ../build/$BOOT_NAME test mlang &
     cd ../stdlib
-    ../build/mi test mexpr &
-    ../build/mi test c &
-    ../build/mi test ad &
-    ../build/mi test ext &
-    ../build/mi test parser &
+    ../build/$BOOT_NAME test mexpr &
+    ../build/$BOOT_NAME test c &
+    ../build/$BOOT_NAME test ad &
+    ../build/$BOOT_NAME test ext &
+    ../build/$BOOT_NAME test parser &
     cd ..
     export MCORE_STDLIB='@@@'
-    build/mi test stdlib &)
+    build/$BOOT_NAME test stdlib &)
     if [ -n "$MI_TEST_PAR" ]; then
         runtests_par &
     fi

--- a/run-all.sh
+++ b/run-all.sh
@@ -7,7 +7,7 @@
 # Run a file
 run() {
     output=$1
-    output="$output\n$(build/mi src/main/mi.mc -- run --test $1)\n"
+    output="$output\n$(build/boot src/main/mi.mc -- run --test $1)\n"
     echo $output
 }
 

--- a/run-all.sh
+++ b/run-all.sh
@@ -8,6 +8,7 @@
 run() {
     output=$1
     output="$output\n$(build/boot src/main/mi.mc -- run --test $1)\n"
+    output="$output\n$(build/mi run --test $1)\n"
     echo $output
 }
 

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -2,7 +2,7 @@
    Miking is licensed under the MIT license.
    Copyright (C) David Broman. See file LICENSE.txt
 
-   mi.ml is the main entry point for first stage of the
+   boot.ml is the main entry point for first stage of the
    bootstrapped Miking compiler. The bootstapper is interpreted and
    implemented in OCaml. Note that the Miking bootstrapper
    only implements a subset of the Ragnar language.
@@ -56,7 +56,7 @@ let testprog lst =
 let runrepl _ = start_repl ()
 
 (* Print out main menu *)
-let usage_msg = "Usage: mi [run|repl|test] <files>\n\nOptions:"
+let usage_msg = "Usage: boot [run|repl|test] <files>\n\nOptions:"
 
 (* Main function. Checks arguments and reads file names *)
 let main =

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -38,6 +38,8 @@ let files_of_folders lst =
       else v :: a )
     [] lst
 
+let enable_test = ref false
+
 (* Iterate over all potential test files and run tests *)
 let testprog lst =
   utest := true ;
@@ -56,14 +58,15 @@ let testprog lst =
 let runrepl _ = start_repl ()
 
 (* Print out main menu *)
-let usage_msg = "Usage: boot [run|repl|test] <files>\n\nOptions:"
+let usage_msg = "Usage: boot [run|repl] <files>\n\nOptions:"
 
 (* Main function. Checks arguments and reads file names *)
 let main =
   (* A list of command line arguments *)
   let speclist =
     [ (* First character in description string must be a space for alignment! *)
-      ( "--debug-parse"
+      ("--test", Arg.Set enable_test, " Run unit tests.")
+    ; ( "--debug-parse"
       , Arg.Set enable_debug_after_parse
       , " Enables output of parsing." )
     ; ( "--debug-mlang"
@@ -126,15 +129,12 @@ let main =
   if List.length !lst = 0 then Arg.usage speclist usage_msg
   else
     match List.rev !lst with
-    (* Run tests on one or more files *)
-    | "test" :: lst | "t" :: lst ->
-        testprog lst
     (* Start the MCore REPL *)
     | "repl" :: lst ->
         runrepl lst
     (* Run one program with program arguments without typechecking *)
-    | "run" :: name :: _ | name :: _ ->
-        evalprog name
+    | "run" :: (name :: _ as lst) | (name :: _ as lst) ->
+        if !enable_test then testprog lst else evalprog name
     (* Show the menu *)
     | _ ->
         Arg.usage speclist usage_msg

--- a/src/boot/dune
+++ b/src/boot/dune
@@ -1,4 +1,4 @@
 (executable
- (name mi)
+ (name boot)
  (public_name boot.mi)
  (libraries boot))


### PR DESCRIPTION
In this PR, I have renamed the boot interpreter to `boot` and also added compilation of the bootstrapped compiler when running `make`. The the new bootstrapped compiler is now called `mi`. The bootstrapped compiler is only recompiled if it does not exist. Both `mi` and `boot` are installed when run `make install` (in the future, we might actually not install `boot`). All tests are still running `boot` as before. I have also changed so that the `boot` command invokes tests by using the flag `--test`, as is done in the bootstrapped compiler. 