### PR TITLE
Small compiler improvements

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -84,8 +84,9 @@ end
 -- Records and record updates can be seen as sequences of applications.
 lang RecordANF = ANF + RecordAst
   sem isValue =
-  | TmRecord _ -> false
-  | TmRecord {bindings = []} -> true
+  | TmRecord t ->
+    if mapIsEmpty t.bindings then true
+    else false
   | TmRecordUpdate _ -> false
 
   sem normalize (k : Expr -> Expr) =


### PR DESCRIPTION
This PR performs some minor improvements to the compiler:
* Replaces an invalid match pattern that led to a segmentation fault with an if-else-expression
* Adds special OCaml code generation for projections
* Breaks out the generate cases for `TmMatch` into a separate language fragment