### PR TITLE
External term

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -267,6 +267,8 @@ and tm =
   | TmRef of info * tm ref
   (* Tensor *)
   | TmTensor of info * tm T.t
+  (* External *)
+  | TmExt of info * ustring * Symb.t * ty * tm
 
 (* Kind of pattern name *)
 and patName =
@@ -346,8 +348,6 @@ module Option = BatOption
 
 (* smap for terms *)
 let smap_tm_tm (f : tm -> tm) = function
-  | TmVar (_, _, _) as t ->
-      t
   | TmApp (fi, t1, t2) ->
       TmApp (fi, f t1, f t2)
   | TmLam (fi, x, s, ty, t1) ->
@@ -357,8 +357,6 @@ let smap_tm_tm (f : tm -> tm) = function
   | TmRecLets (fi, lst, tm) ->
       TmRecLets
         (fi, List.map (fun (fi, x, s, ty, t) -> (fi, x, s, ty, f t)) lst, f tm)
-  | TmConst (_, _) as t ->
-      t
   | TmSeq (fi, tms) ->
       TmSeq (fi, Mseq.Helpers.map f tms)
   | TmRecord (fi, r) ->
@@ -376,23 +374,16 @@ let smap_tm_tm (f : tm -> tm) = function
   | TmUtest (fi, t1, t2, tusing, tnext) ->
       let tusing_mapped = Option.map f tusing in
       TmUtest (fi, f t1, f t2, tusing_mapped, f tnext)
-  | TmNever _ as t ->
-      t
   | TmUse (fi, l, t1) ->
       TmUse (fi, l, f t1)
   | TmClos (fi, x, s, t1, env) ->
       TmClos (fi, x, s, f t1, env)
-  | TmFix _ as t ->
-      t
-  | TmRef _ as t ->
-      t
-  | TmTensor _ as t ->
+  | (TmVar _ | TmConst _ | TmNever _ | TmFix _ | TmRef _ | TmTensor _ | TmExt _)
+    as t ->
       t
 
 (* sfold over terms *)
 let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) = function
-  | TmVar (_, _, _) ->
-      acc
   | TmApp (_, t1, t2) ->
       f (f acc t1) t2
   | TmLam (_, _, _, _, t1) ->
@@ -401,8 +392,6 @@ let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) = function
       f (f acc t1) t2
   | TmRecLets (_, lst, tm) ->
       f (List.fold_left (fun acc (_, _, _, _, t) -> f acc t) acc lst) tm
-  | TmConst (_, _) ->
-      acc
   | TmSeq (_, tms) ->
       Mseq.Helpers.fold_left f acc tms
   | TmRecord (_, r) ->
@@ -420,17 +409,12 @@ let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) = function
   | TmUtest (_, t1, t2, tusing, tnext) ->
       let acc = f (f acc t1) t2 in
       f (match tusing with None -> acc | Some t -> f acc t) tnext
-  | TmNever _ ->
-      acc
   | TmUse (_, _, t1) ->
       f acc t1
   | TmClos (_, _, _, t1, _) ->
       f acc t1
-  | TmFix _ ->
-      acc
-  | TmRef _ ->
-      acc
-  | TmTensor _ ->
+  | TmVar _ | TmConst _ | TmNever _ | TmFix _ | TmRef _ | TmTensor _ | TmExt _
+    ->
       acc
 
 (* Returns the info field from a term *)
@@ -454,7 +438,8 @@ let tm_info = function
   | TmClos (fi, _, _, _, _)
   | TmFix fi
   | TmRef (fi, _)
-  | TmTensor (fi, _) ->
+  | TmTensor (fi, _)
+  | TmExt (fi, _, _, _, _) ->
       fi
 
 let pat_info = function

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -211,6 +211,8 @@ and con_decl = Con of info * ustring * ty
 
 and utest_top = Utest of info * tm * tm * tm option
 
+and ext_decl = Ext of info * ustring * ty
+
 and top =
   | TopLang of mlang
   | TopLet of let_decl
@@ -218,6 +220,7 @@ and top =
   | TopRecLet of rec_let_decl
   | TopCon of con_decl
   | TopUtest of utest_top
+  | TopExt of ext_decl
 
 and include_ = Include of info * ustring
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -420,6 +420,17 @@ let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) = function
     ->
       acc
 
+(* Returns arity given an type *)
+let rec ty_arity = function TyArrow (_, _, ty) -> 1 + ty_arity ty | _ -> 0
+
+(* Returns the applicaiton depth and the applied term *)
+let rec tm_app_depth = function
+  | TmApp (_, t1, _) ->
+      let t, d = tm_app_depth t1 in
+      (t, d + 1)
+  | t ->
+      (t, 0)
+
 (* Returns the info field from a term *)
 let tm_info = function
   | TmVar (fi, _, _)

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -423,14 +423,6 @@ let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) = function
 (* Returns arity given an type *)
 let rec ty_arity = function TyArrow (_, _, ty) -> 1 + ty_arity ty | _ -> 0
 
-(* Returns the applicaiton depth and the applied term *)
-let rec tm_app_depth = function
-  | TmApp (_, t1, _) ->
-      let t, d = tm_app_depth t1 in
-      (t, d + 1)
-  | t ->
-      (t, 0)
-
 (* Returns the info field from a term *)
 let tm_info = function
   | TmVar (fi, _, _)

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -39,6 +39,8 @@ let idTmUtest = 113
 
 let idTmNever = 114
 
+let idTmExt = 115
+
 (* Types *)
 let idTyUnknown = 200
 
@@ -187,6 +189,8 @@ let getData = function
         (idTmUtest, [fi], [3], [], [t1; t2; t3], [], [], [], [], []) )
   | PTreeTm (TmNever fi) ->
       (idTmNever, [fi], [], [], [], [], [], [], [], [])
+  | PTreeTm (TmExt (fi, x, _, ty, t)) ->
+      (idTmExt, [fi], [], [ty], [t], [x], [], [], [], [])
   (* Types *)
   | PTreeTy (TyUnknown fi) ->
       (idTyUnknown, [fi], [], [], [], [], [], [], [], [])

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -124,13 +124,17 @@ let symbolizeEnvWithKeywords keywords =
 let parseMExprString keywords str =
   PTreeTm
     ( str |> Parserutils.parse_mexpr_string
-    |> Symbolize.symbolize (symbolizeEnvWithKeywords keywords) )
+    |> Parserutils.raise_parse_error_on_non_unique_external_id
+    |> Symbolize.symbolize (symbolizeEnvWithKeywords keywords)
+    |> Parserutils.raise_parse_error_on_partially_applied_external )
 
 let parseMCoreFile keywords filename =
   PTreeTm
     ( filename |> Parserutils.parse_mcore_file
+    |> Parserutils.raise_parse_error_on_non_unique_external_id
     |> Symbolize.symbolize (symbolizeEnvWithKeywords keywords)
-    |> Deadcode.elimination builtin_sym2term builtin_name2sym )
+    |> Deadcode.elimination builtin_sym2term builtin_name2sym
+    |> Parserutils.raise_parse_error_on_partially_applied_external )
 
 (* Returns a tuple with the following elements
    1. ID field

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -29,10 +29,10 @@ let evalprog filename =
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
       |> raise_parse_error_on_non_unique_external_id
       |> Symbolize.symbolize builtin_name2sym
-      |> raise_parse_error_on_partially_applied_external
       |> debug_after_symbolize
       |> Deadcode.elimination builtin_sym2term builtin_name2sym
       |> debug_after_dead_code_elimination
+      |> raise_parse_error_on_partially_applied_external
       |> Mexpr.eval builtin_sym2term
       |> fun _ -> ()
     with (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -27,8 +27,9 @@ let evalprog filename =
       parsed
       |> merge_includes (Filename.dirname filename) [filename]
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
-      |> check_uniqe_external_ids
+      |> raise_parse_error_on_non_unique_external_id
       |> Symbolize.symbolize builtin_name2sym
+      |> raise_parse_error_on_partially_applied_external
       |> debug_after_symbolize
       |> Deadcode.elimination builtin_sym2term builtin_name2sym
       |> debug_after_dead_code_elimination

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -27,6 +27,7 @@ let evalprog filename =
       parsed
       |> merge_includes (Filename.dirname filename) [filename]
       |> Mlang.flatten |> Mlang.desugar_post_flatten |> debug_after_mlang
+      |> check_uniqe_external_ids
       |> Symbolize.symbolize builtin_name2sym
       |> debug_after_symbolize
       |> Deadcode.elimination builtin_sym2term builtin_name2sym

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -122,13 +122,9 @@ end
 module Symb = struct
   type t = int
 
-  type symbtype = int
-
   let symid = ref 0
 
-  let gensym _ =
-    symid := !symid + 1 ;
-    !symid
+  let gensym _ = incr symid ; !symid
 
   let eqsym l r = l = r
 

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -124,8 +124,6 @@ end
 module Symb : sig
   type t
 
-  type symbtype
-
   val gensym : unit -> t
 
   val eqsym : t -> t -> bool

--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -39,6 +39,7 @@ let reserved_strings = [
   ("include",       fun(i) -> Parser.INCLUDE{i=i;v=()});
   ("never",         fun(i) -> Parser.NEVER{i=i;v=()});
   ("using",         fun(i) -> Parser.USING{i=i;v=()});
+  ("external",      fun(i) -> Parser.EXTERNAL{i=i;v=()});
 
   (* Types *)
   ("Unknown",       fun(i) -> Parser.TUNKNOWN{i=i;v=()});

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1634,6 +1634,9 @@ let rec eval (env : (Symb.t * tm) list) (t : tm) =
   (* Use *)
   | TmUse (fi, _, _) ->
       raise_error fi "A 'use' of a language was not desugared"
+  (* External *)
+  | TmExt (fi, _, _, _, _) ->
+      raise_error fi "Cannot evaluate 'external'"
   (* Only at runtime *)
   | TmClos _ | TmFix _ | TmRef _ | TmTensor _ ->
       t
@@ -1677,5 +1680,6 @@ let rec eval_toplevel (env : (Symb.t * tm) list) = function
     | TmUtest _
     | TmNever _
     | TmRef _
-    | TmTensor _ ) as t ->
+    | TmTensor _
+    | TmExt _ ) as t ->
       (env, eval env t)

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -676,7 +676,7 @@ let rec desugar_tm nss env subs =
   | TmNever fi ->
       TmNever fi
   (* Non-recursive *)
-  | (TmConst _ | TmFix _ | TmRef _ | TmTensor _) as tm ->
+  | (TmConst _ | TmFix _ | TmRef _ | TmTensor _ | TmExt _) as tm ->
       tm
 
 (* add namespace to nss (overwriting) if relevant, prepend a tm -> tm function to stack, return updated tuple. Should use desugar_tm, as well as desugar both sem and syn *)

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -264,7 +264,8 @@ let data_to_lang info name includes {inters; syns} : mlang =
 
 let flatten_lang (prev_langs : lang_data Record.t) :
     top -> lang_data Record.t * top = function
-  | (TopLet _ | TopType _ | TopRecLet _ | TopCon _ | TopUtest _) as top ->
+  | (TopLet _ | TopType _ | TopRecLet _ | TopCon _ | TopUtest _ | TopExt _) as
+    top ->
       (prev_langs, top)
   | TopLang (Lang (info, name, includes, _) as lang) ->
       let self_data = compute_lang_data lang in
@@ -795,6 +796,11 @@ let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function
       (nss, langs, subs, syns, wrap :: stack)
   | TopUtest (Utest (fi, lhs, rhs, using)) ->
       let wrap tm' = TmUtest (fi, lhs, rhs, using, tm') in
+      (nss, langs, subs, syns, wrap :: stack)
+  | TopExt (Ext (fi, id, ty)) ->
+      let wrap tm' =
+        TmExt (fi, empty_mangle id, Symb.Helpers.nosym, ty, tm')
+      in
       (nss, langs, subs, syns, wrap :: stack)
 
 let desugar_post_flatten_with_nss nss (Program (_, tops, t)) =

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -69,6 +69,7 @@
 %token <unit Ast.tokendata> INCLUDE
 %token <unit Ast.tokendata> NEVER
 %token <unit Ast.tokendata> USING
+%token <unit Ast.tokendata> EXTERNAL
 
 /* Types */
 %token <unit Ast.tokendata> TUNKNOWN
@@ -315,6 +316,9 @@ mexpr:
   | UTEST mexpr WITH mexpr USING mexpr IN mexpr
       { let fi = mkinfo $1.i (tm_info $6) in
         TmUtest(fi,$2,$4,Some $6,$8) }
+  | EXTERNAL ident COLON ty IN mexpr
+      { let fi = mkinfo $1.i (tm_info $6) in
+        TmExt(fi,$2.v,Symb.Helpers.nosym,$4,$6) }
 
 lets:
   | LET var_ident ty_op EQ mexpr

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -166,6 +166,8 @@ top:
     { TopCon($1) }
   | toputest
     { TopUtest($1) }
+  | topext
+    { TopExt($1) }
 
 toplet:
   | LET var_ident ty_op EQ mexpr
@@ -208,6 +210,11 @@ mlang:
                  mkinfo $1.i $2.i
       in
       Lang (fi, $2.v, List.map (fun l -> l.v) $3, $4) }
+
+topext:
+  | EXTERNAL ident COLON ty
+    { let fi = mkinfo $1.i (ty_info $4) in
+      Ext (fi, $2.v, $4) }
 
 lang_includes:
   | EQ lang_list

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -58,7 +58,7 @@ let raise_parse_error_on_partially_applied_external t =
             if arity <> app_depth then
               raise
                 (Error
-                   (PARSE_ERROR, ERROR, fi, [id; us "partially not applied"])
+                   (PARSE_ERROR, ERROR, fi, [id; us "partially applied"])
                 )
             else acc
         | None ->

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -60,7 +60,7 @@ let raise_parse_error_on_partially_applied_external t =
                 else
                   raise
                     (Error
-                       (PARSE_ERROR, ERROR, fi, [id; us "not fully applied"])
+                       (PARSE_ERROR, ERROR, fi, [id; us "partially applied"])
                     )
             | None ->
                 acc )

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -208,8 +208,8 @@ let parse_mcore_file filename =
     |> Mlang.flatten |> Mlang.desugar_post_flatten
     |> raise_parse_error_on_non_unique_external_id
     |> Symbolize.symbolize builtin_name2sym
-    |> raise_parse_error_on_partially_applied_external
     |> Deadcode.elimination builtin_sym2term builtin_name2sym
+    |> raise_parse_error_on_partially_applied_external
   with (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->
     let error_string = Ustring.to_utf8 (error_to_ustring e) in
     fprintf stderr "%s\n" error_string ;

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -3,7 +3,6 @@ open Printf
 open Ast
 open Pprint
 open Msg
-open Builtin
 open Symbutils
 module Option = BatOption
 
@@ -187,11 +186,7 @@ let rec merge_includes root visited = function
 
 let parse_mexpr_string ustring =
   Lexer.init (us "internal") tablength ;
-  ustring |> Ustring.lexing_from_ustring
-  |> Parser.main_mexpr_tm Lexer.main
-  |> raise_parse_error_on_non_unique_external_id
-  |> Symbolize.symbolize builtin_name2sym
-  |> raise_parse_error_on_partially_applied_external
+  ustring |> Ustring.lexing_from_ustring |> Parser.main_mexpr_tm Lexer.main
 
 let parse_mcore_file filename =
   try
@@ -200,10 +195,6 @@ let parse_mcore_file filename =
     local_parse_mcore_file filename
     |> merge_includes (Filename.dirname filename) [filename]
     |> Mlang.flatten |> Mlang.desugar_post_flatten
-    |> raise_parse_error_on_non_unique_external_id
-    |> Symbolize.symbolize builtin_name2sym
-    |> Deadcode.elimination builtin_sym2term builtin_name2sym
-    |> raise_parse_error_on_partially_applied_external
   with (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->
     let error_string = Ustring.to_utf8 (error_to_ustring e) in
     fprintf stderr "%s\n" error_string ;

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -57,9 +57,7 @@ let raise_parse_error_on_partially_applied_external t =
         | Some arity ->
             if arity <> app_depth then
               raise
-                (Error
-                   (PARSE_ERROR, ERROR, fi, [id; us "partially applied"])
-                )
+                (Error (PARSE_ERROR, ERROR, fi, [id; us "partially applied"]))
             else acc
         | None ->
             acc )

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -43,7 +43,7 @@ let raise_parse_error_on_non_unique_external_id t =
   let _ = recur ExtIdMap.empty t in
   t
 
-(* NOTE(oerikss, 2021-04-22) this functions should be applied on a symbolized term *)
+(* NOTE(oerikss, 2021-04-22) this function should be applied on a symbolized term *)
 let raise_parse_error_on_partially_applied_external t =
   let rec recur acc = function
     | TmExt (_, _, s, ty, t) ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -534,7 +534,7 @@ and print_tm fmt (prec, t) =
     match t with
     | TmMatch (_, _, PatBool (_, true), _, _) ->
         If
-    | TmMatch _ | TmLet _ | TmType _ ->
+    | TmMatch _ | TmLet _ | TmType _ | TmExt _ ->
         Match
     | TmLam _ ->
         Lam
@@ -695,6 +695,11 @@ and print_tm' fmt t =
       let data' = List.map print (Array.to_list data) in
       fprintf fmt "Tensor([@[<hov 0>%a@]], [@[<hov 0>%a@]])" concat
         (Comma, shape') concat (Comma, data')
+  | TmExt (_, x, s, ty, t) ->
+      let x = string_of_ustring (ustring_of_var x s) in
+      let ty = ty |> ustring_of_ty |> string_of_ustring in
+      fprintf fmt "@[<hov 0>@[<hov %d>external %s : %s in@]@ %a@]" !ref_indent
+        x ty print_tm (Match, t)
 
 (** Print an environment on the given formatter. *)
 and print_env fmt env =

--- a/src/boot/lib/symbolize.ml
+++ b/src/boot/lib/symbolize.ml
@@ -212,6 +212,14 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
       let sym_using = Option.map (fun t -> symbolize env t) tusing in
       TmUtest
         (fi, symbolize env t1, symbolize env t2, sym_using, symbolize env tnext)
+  | TmExt (fi, x, _, ty, t) ->
+      let s = Symb.gensym () in
+      TmExt
+        ( fi
+        , x
+        , s
+        , symbolize_type env ty
+        , symbolize ((IdVar (sid_of_ustring x), s) :: env) t )
   | TmConst _ | TmFix _ | TmNever _ | TmRef _ | TmTensor _ ->
       t
 
@@ -258,6 +266,12 @@ let rec symbolize_toplevel (env : (ident * Symb.t) list) = function
         symbolize_toplevel ((IdCon (sid_of_ustring x), s) :: env) t
       in
       (new_env, TmConDef (fi, x, s, symbolize_type env ty, new_t2))
+  | TmExt (fi, x, _, ty, t) ->
+      let s = Symb.gensym () in
+      let new_env, new_t =
+        symbolize_toplevel ((IdVar (sid_of_ustring x), s) :: env) t
+      in
+      (new_env, TmExt (fi, x, s, symbolize_type env ty, new_t))
   | ( TmVar _
     | TmLam _
     | TmApp _

--- a/src/boot/lib/symbutils.ml
+++ b/src/boot/lib/symbutils.ml
@@ -29,7 +29,7 @@ let symbmap t =
              (fun acc (_, x, s, _, t) -> work (SymbMap.add s x acc) t)
              acc lst )
           t1
-    | TmExt (_, x, s, t) ->
+    | TmExt (_, x, s, _, t) ->
         work (SymbMap.add s x acc) t
     | t ->
         sfold_tm_tm work acc t

--- a/src/boot/lib/symbutils.ml
+++ b/src/boot/lib/symbutils.ml
@@ -29,6 +29,8 @@ let symbmap t =
              (fun acc (_, x, s, _, t) -> work (SymbMap.add s x acc) t)
              acc lst )
           t1
+    | TmExt (_, x, s, t) ->
+        work (SymbMap.add s x acc) t
     | t ->
         sfold_tm_tm work acc t
   in

--- a/src/boot/lib/tensor.ml
+++ b/src/boot/lib/tensor.ml
@@ -114,17 +114,17 @@ module NoNum = struct
   let iteri f t = mk_iteri rank shape slice_exn f t
 
   let equal eq t1 t2 =
-    if shape t1 = shape t2 then
+    if shape t1 = shape t2 then (
       let n = t1.size in
       let v1 = reshape_exn t1 [|n|] in
       let v2 = reshape_exn t2 [|n|] in
-      let rec work i =
-        if i < n then
-          if eq (get_exn v1 [|i|]) (get_exn v2 [|i|]) then work (i + 1)
-          else false
-        else true
-      in
-      work 0
+      let tmp = ref true in
+      let i = ref 0 in
+      while !tmp do
+        tmp := eq (get_exn v1 [|!i|]) (get_exn v2 [|!i|]) ;
+        incr i
+      done ;
+      !tmp )
     else false
 
   let of_array a =

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -32,12 +32,10 @@ let _preambleStr =
   let str = pprintOcaml (bind_ _preamble (int_ 0)) in
   subsequence str 0 (subi (length str) 1)
 
-recursive let _withPreamble = lam expr. lam options : Options.
+recursive let _withPreamble = lam expr.
   use OCamlAst in
   match expr with OTmVariantTypeDecl t then
-    OTmVariantTypeDecl {t with inexpr = _withPreamble t.inexpr options}
-  else if options.excludeIntrinsicsPreamble then
-    expr
+    OTmVariantTypeDecl {t with inexpr = _withPreamble t.inexpr}
   else
     OTmPreambleText {text = _preambleStr, inexpr = expr}
 end
@@ -92,7 +90,7 @@ let compile = lam files. lam options : Options.
           match generateTypeDecl env ast with (env, ast) then
             let ast = generate env ast in
             let ast = objWrap ast in
-            _withPreamble ast options
+            _withPreamble ast
           else never
         else never
       in

--- a/src/main/mi.mc
+++ b/src/main/mi.mc
@@ -21,7 +21,6 @@ let menu = strJoin "\n" [
   "  --debug-generate                 Print the AST after code generation",
   "  --exit-before                    Exit before evaluation or compilation",
   "  --test                           Generate utest code",
-  "  --exclude-intrinsics-preamble    Exclude the intinsics preamble",
   ""]
 in
 

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -25,8 +25,7 @@ let optionsMap = [
 ("--debug-parse", lam o : Options. {o with debugParse = true}),
 ("--debug-generate", lam o : Options. {o with debugGenerate = true}),
 ("--exit-before", lam o : Options. {o with exitBefore = true}),
-("--test", lam o : Options. {o with runTests = true}),
-("--exclude-intrinsics-preamble", lam o : Options. {o with excludeIntrinsicsPreamble = true})
+("--test", lam o : Options. {o with runTests = true})
 ]
 
 let mapStringLookup = assocLookup {eq=eqString}
@@ -39,4 +38,3 @@ let parseOptions = lam xs.
       then f accOps
       else printLn (concat "Unknown option " s); exit 1
     ) options xs
-

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -215,6 +215,8 @@ recursive let bind_ = use MExprAst in
     TmConDef {t with inexpr = bind_ t.inexpr expr}
   else match letexpr with TmType t then
     TmType {t with inexpr = bind_ t.inexpr expr}
+  else match letexpr with TmExt t then
+    TmExt {t with inexpr = bind_ t.inexpr expr}
   else
     expr -- Insert at the end of the chain
 end
@@ -242,6 +244,14 @@ let nulet_ = use MExprAst in
 let ulet_ = use MExprAst in
   lam s. lam body.
   let_ s tyunknown_ body
+
+let next_ = use MExprAst in
+  lam n. lam ty.
+  TmExt {ident = n, ty = ty, inexpr = unit_, info = NoInfo ()}
+
+let ext_ = use MExprAst in
+  lam s. lam ty.
+  next_ (nameNoSym s) ty
 
 let ntype_ = use MExprAst in
   lam n. lam ty.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -384,6 +384,30 @@ lang NeverAst
   | TmNever _ & t -> acc
 end
 
+-- TmExt --
+lang ExtAst = VarAst
+  syn Expr =
+  | TmExt {ident : Name,
+           inexpr : Expr,
+           ty : Type,
+           info : Info}
+
+  sem infoTm =
+  | TmExt r -> r.info
+
+  sem ty =
+  | TmExt t -> t.ty
+
+  sem withType (ty : Type) =
+  | TmExt t -> TmExt {t with ty = ty}
+
+  sem smap_Expr_Expr (f : Expr -> a) =
+  | TmExt t -> TmExt {t with inexpr = f t.inexpr}
+
+  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
+  | TmExt t -> f acc t.inexpr
+end
+
 ---------------
 -- CONSTANTS --
 ---------------
@@ -888,7 +912,7 @@ lang MExprAst =
 
   -- Terms
   VarAst + AppAst + LamAst + RecordAst + LetAst + TypeAst + RecLetsAst +
-  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst +
+  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst + ExtAst +
 
   -- Constants
   IntAst + ArithIntAst + ShiftIntAst + FloatAst + ArithFloatAst + BoolAst +

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -140,6 +140,11 @@ lang BootParser = MExprAst
   | 114 /-TmNever-/ ->
      TmNever {ty = tyunknown_,
               info = ginfo t 0}
+  | 115 /-TmExt-/ ->
+    TmExt {ident = gname t 0,
+           ty = gtype t 0,
+           inexpr = gterm t 0,
+           info = ginfo t 0}
 
   -- Get type help function
   sem gtype(t:Unknown) =
@@ -494,6 +499,11 @@ utest l_infoClosed "\n utest 3 with 4 in () " with r_info 2 1 2 18 in
 let s = "never" in
 utest lsideClosed s with rside s in
 utest l_infoClosed "  \n  never " with r_info 2 2 2 7 in
+
+-- TmExt
+let s = "external y : Int in y" in
+utest lside s with rside s in
+utest l_info "   \n  external y : Int in y" with r_info 2 2 2 23 in
 
 -- TyUnknown
 let s = "let y:Unknown = lam x.x in y" in

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -327,7 +327,7 @@ utest l_infoClosed "  \n lam x.x" with r_info 2 1 2 8 in
 utest infoTm (match parseMExprString [] s with TmLet r then r.body else ())
 with r_info 1 8 1 15 in
 utest l_info ["y"] "  let x = 4 in y  " with r_info 1 2 1 14 in
-let s = "printLn x; 10" in
+let s = "(printLn x); 10" in
 utest lside ["printLn", "x"] s with rside s in
 
 -- TmRecLets, TmLam
@@ -502,8 +502,8 @@ utest l_infoClosed "  \n  never " with r_info 2 2 2 7 in
 
 -- TmExt
 let s = "external y : Int in 1" in
-utest lside s with rside s in
-utest l_info "   \n  external y : Int in 1" with r_info 2 2 2 23 in
+utest lsideClosed s with rside s in
+utest l_infoClosed "   \n  external y : Int in 1" with r_info 2 2 2 23 in
 
 -- TyUnknown
 let s = "let y:Unknown = lam x.x in y" in

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -501,9 +501,9 @@ utest lsideClosed s with rside s in
 utest l_infoClosed "  \n  never " with r_info 2 2 2 7 in
 
 -- TmExt
-let s = "external y : Int in y" in
+let s = "external y : Int in 1" in
 utest lside s with rside s in
-utest l_info "   \n  external y : Int in y" with r_info 2 2 2 23 in
+utest l_info "   \n  external y : Int in 1" with r_info 2 2 2 23 in
 
 -- TyUnknown
 let s = "let y:Unknown = lam x.x in y" in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -273,6 +273,11 @@ lang TensorEval
   | TmTensor t -> TmTensor t
 end
 
+lang ExtEval = ExtAst
+  sem eval (ctx : {env : Env}) =
+  | TmExt r -> eval ctx r.inexpr -- nop
+end
+
 ---------------
 -- CONSTANTS --
 ---------------
@@ -982,7 +987,7 @@ lang MExprEval =
   -- Terms
   VarEval + AppEval + LamEval + FixEval + RecordEval + RecLetsEval +
   ConstEval + TypeEval + DataEval + MatchEval + UtestEval + SeqEval +
-  NeverEval + RefEval
+  NeverEval + RefEval + ExtEval
 
   -- Constants
   + ArithIntEval + ShiftIntEval + ArithFloatEval + CmpIntEval + CmpFloatEval +

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -365,6 +365,26 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
     else never
 end
 
+lang ExtPrettyPrint = PrettyPrint + ExtAst + UnknownTypeAst
+  sem isAtomic =
+  | TmExt _ -> false
+
+  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
+  -- Intentionally left blank
+
+  sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmExt t ->
+    match pprintVarName env t.ident with (env,str) then
+      match pprintCode indent env t.inexpr with (env,inexpr) then
+        match getTypeStringCode indent env t.ty with (env,ty) then
+          (env,
+           join ["external ", str, " : ", ty, "in", pprintNewline indent,
+                 inexpr])
+        else never
+      else never
+    else never
+end
+
 lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst
   sem isAtomic =
   | TmType _ -> false
@@ -993,7 +1013,7 @@ lang MExprPrettyPrint =
   VarPrettyPrint + AppPrettyPrint + LamPrettyPrint + RecordPrettyPrint +
   LetPrettyPrint + TypePrettyPrint + RecLetsPrettyPrint + ConstPrettyPrint +
   DataPrettyPrint + MatchPrettyPrint + UtestPrettyPrint + SeqPrettyPrint +
-  NeverPrettyPrint +
+  NeverPrettyPrint + ExtPrettyPrint +
 
   -- Constants
   IntPrettyPrint + ArithIntPrettyPrint + FloatPrettyPrint +

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -378,7 +378,8 @@ lang ExtPrettyPrint = PrettyPrint + ExtAst + UnknownTypeAst
       match pprintCode indent env t.inexpr with (env,inexpr) then
         match getTypeStringCode indent env t.ty with (env,ty) then
           (env,
-           join ["external ", str, " : ", ty, "in", pprintNewline indent,
+           join ["external ", str, " : ", ty, pprintNewline indent,
+                 "in", pprintNewline indent,
                  inexpr])
         else never
       else never
@@ -1243,6 +1244,11 @@ let empty_empty =
   bindall_ [nulet_ n1 (int_ 1), nulet_ n2 (int_ 2), addi_ (nvar_ n1) (nvar_ n2)]
 in
 
+-- external addi : Int -> Int -> Int in addi
+let external_addi =
+  bind_ (ext_ "addi" (tyarrows_ [tyint_, tyint_, tyint_])) (var_ "addi")
+in
+
 let sample_ast =
   bindall_ [
     func_foo,
@@ -1259,13 +1265,14 @@ let sample_ast =
     func_pedanticIsSome,
     func_is123,
     var_var,
-    empty_empty
+    empty_empty,
+    external_addi
   ]
 in
 
--- print "\n\n";
--- print (expr2str sample_ast);
--- print "\n\n";
+print "\n\n";
+print (expr2str sample_ast);
+print "\n\n";
 
 utest length (expr2str sample_ast) with 0 using geqi in
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1270,9 +1270,9 @@ let sample_ast =
   ]
 in
 
-print "\n\n";
-print (expr2str sample_ast);
-print "\n\n";
+-- print "\n\n";
+-- print (expr2str sample_ast);
+-- print "\n\n";
 
 utest length (expr2str sample_ast) with 0 using geqi in
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -346,21 +346,24 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmLet t ->
     match pprintVarName env t.ident with (env,str) then
-      match pprintCode (pprintIncr indent) env t.body with (env,body) then
-        match pprintCode indent env t.inexpr with (env,inexpr) then
-          match getTypeStringCode indent env t.tyBody with (env, ty) then
-            let ty = if eqString ty "Unknown" then "" else concat ": " ty in
-            (env,
-             if eqString (nameGetStr t.ident) "" then
-               join [body, pprintNewline indent, ";",
-                     inexpr]
-             else
-               join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
-                     body, pprintNewline indent,
-                     "in", pprintNewline indent,
-                     inexpr])
+      match pprintCode indent env t.inexpr with (env,inexpr) then
+        match getTypeStringCode indent env t.tyBody with (env, ty) then
+          let ty = if eqString ty "Unknown" then "" else concat ": " ty in
+          if eqString (nameGetStr t.ident) "" then
+             match printParen (pprintIncr indent) env t.body with (env,body)
+             then
+               (env, join [body, pprintNewline indent, ";", inexpr])
+             else never
+           else
+             match pprintCode (pprintIncr indent) env t.body with (env,body)
+             then
+               (env,
+                join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
+                      body, pprintNewline indent,
+                      "in", pprintNewline indent,
+                      inexpr])
+             else never
           else never
-        else never
       else never
     else never
 end

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -131,6 +131,24 @@ lang LetSym = Sym + LetAst
     else never
 end
 
+lang ExtSym = Sym + ExtAst
+  sem symbolizeType (env : SymEnv) =
+  -- Intentinally left blank
+
+  sem symbolizeExpr (env : SymEnv) =
+  | TmExt t ->
+    match env with {varEnv = varEnv} then
+      let ty = symbolizeType env t.ty in
+      let ident = nameSetNewSym t.ident in
+      let str = nameGetStr ident in
+      let varEnv = mapInsert str ident varEnv in
+      let env = {env with varEnv = varEnv} in
+      TmExt {{{t with ident = ident}
+                 with inexpr = symbolizeExpr env t.inexpr}
+                 with ty = ty}
+    else never
+end
+
 lang TypeSym = Sym + TypeAst
   sem symbolizeType (env : SymEnv) =
   -- Intentinally left blank

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -509,7 +509,7 @@ lang MExprSym =
 
   -- Terms
   VarSym + AppSym + LamSym + RecordSym + LetSym + TypeSym + RecLetsSym +
-  ConstSym + DataSym + MatchSym + UtestSym + SeqSym + NeverSym +
+  ConstSym + DataSym + MatchSym + UtestSym + SeqSym + NeverSym + ExtSym +
 
   -- Types
   UnknownTypeSym + BoolTypeSym + IntTypeSym + FloatTypeSym + CharTypeSym +

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -125,13 +125,40 @@ lang OCamlExternal
   | OTmConAppExt t -> OTmConAppExt {t with args = map f t.args}
 end
 
-lang OCamlAst = LamAst + LetAst + RecLetsAst + RecordAst + ArithIntAst
-                + ShiftIntAst + ArithFloatAst + BoolAst + CmpIntAst
-                + CmpFloatAst + CharAst + CmpCharAst + OCamlMatch + NamedPat
-                + IntPat + CharPat + BoolPat + OCamlTuple + OCamlArray
-                + OCamlData + OCamlExternal + FloatIntConversionAst
-                + IntCharConversionAst + OCamlTypeDeclAst + OCamlPreambleHack
-                + OCamlRecord + OCamlString + RefOpAst
+lang OCamlTypeAst =
+  BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst + FunTypeAst +
+  RecordTypeAst
+
+  syn Type =
+  | TyList {info : Info, ty : Type}
+  | TyArray {info : Info, ty : Type}
+  | TyGenArray {info : Info, ty : Type}
+  | TyTuple {info : Info, tys : [Type]}
+
+  sem infoTy =
+  | TyList r -> r.info
+  | TyArray r -> r.info
+  | TyGenArray r -> r.info
+  | TyTuple r -> r.info
+end
+
+lang OCamlAst =
+  -- Terms
+  LamAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
+  OCamlArray + OCamlData + OCamlTypeDeclAst + OCamlRecord +
+
+  -- Constants
+  ArithIntAst + ShiftIntAst + ArithFloatAst + BoolAst + FloatIntConversionAst +
+  IntCharConversionAst + OCamlString + RefOpAst +
+
+  -- Patterns
+  NamedPat + IntPat + CharPat + BoolPat +
+
+  -- Compares
+  CmpIntAst + CmpFloatAst + CharAst + CmpCharAst +
+
+  -- Other
+  OCamlExternal  + OCamlPreambleHack
 end
 
 mexpr

--- a/test/examples/external/ext-not-applied-parse-error.mc
+++ b/test/examples/external/ext-not-applied-parse-error.mc
@@ -1,3 +1,3 @@
 mexpr
 external addi : Int -> Int -> Int in
-addi 1 2
+addi 

--- a/test/examples/external/ext-not-fully-applied-parse-error.mc
+++ b/test/examples/external/ext-not-fully-applied-parse-error.mc
@@ -1,3 +1,3 @@
 mexpr
 external addi : Int -> Int -> Int in
-addi 1 2
+addi 1 

--- a/test/examples/external/ext-parse.mc
+++ b/test/examples/external/ext-parse.mc
@@ -1,0 +1,3 @@
+mexpr
+external addi : Int -> Int -> Int in
+()

--- a/test/examples/external/ext-shadow-parse.mc
+++ b/test/examples/external/ext-shadow-parse.mc
@@ -1,3 +1,4 @@
 mexpr
 external addi : Int -> Int -> Int in
-addi 1 2
+let addi = lam x. lam y. x in
+addi 1

--- a/test/examples/external/multiple-ext-parse-error.mc
+++ b/test/examples/external/multiple-ext-parse-error.mc
@@ -1,0 +1,4 @@
+mexpr
+external addi : Int -> Int -> Int in
+external addi : Int -> Int -> Int in
+()

--- a/test/examples/external/top-ext-parse.mc
+++ b/test/examples/external/top-ext-parse.mc
@@ -1,0 +1,1 @@
+external addi : Int -> Int -> Int


### PR DESCRIPTION
This PR adds a term for externals to boot and `ast.mc`. The syntax is as follows:
```
external ident : ty in expr
```
or
```
external ident : ty
``` 
at the toplevel.

External terms are not allowed to shadow other externals and cannot be partially applied (results in parse errors). In the interpreter externals are currently a nop.

Additionally the flag `--exclude-intrinsics-preamble` is removed and small changes made to the intrinsics implementation.