### PR TITLE
Pass list of keywords to `parseMCoreFile`

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -164,7 +164,7 @@ and const =
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree of ptree
   | CbootParserParseMExprString
-  | CbootParserParseMCoreFile
+  | CbootParserParseMCoreFile of ustring Mseq.t option
   | CbootParserGetId
   | CbootParserGetTerm of tm option
   | CbootParserGetType of tm option
@@ -606,7 +606,7 @@ let const_has_side_effect = function
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree _
   | CbootParserParseMExprString
-  | CbootParserParseMCoreFile
+  | CbootParserParseMCoreFile _
   | CbootParserGetId
   | CbootParserGetTerm _
   | CbootParserGetType _

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -163,7 +163,7 @@ and const =
   | CtensorIteri of tm option
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree of ptree
-  | CbootParserParseMExprString
+  | CbootParserParseMExprString of ustring Mseq.t option
   | CbootParserParseMCoreFile of ustring Mseq.t option
   | CbootParserGetId
   | CbootParserGetTerm of tm option
@@ -605,7 +605,7 @@ let const_has_side_effect = function
       true
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree _
-  | CbootParserParseMExprString
+  | CbootParserParseMExprString _
   | CbootParserParseMCoreFile _
   | CbootParserGetId
   | CbootParserGetTerm _

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -110,7 +110,15 @@ let sym = Symb.gensym ()
 
 let patNameToStr = function NameStr (x, _) -> x | NameWildcard -> us ""
 
-let parseMExprString str = PTreeTm (str |> Parserutils.parse_mexpr_string)
+let parseMExprString keywords str =
+  let symbolize_env =
+    builtin_name2sym
+    @ List.map
+        (fun k -> (IdVar (sid_of_ustring k), Intrinsics.Symb.gensym ()))
+        (Mseq.Helpers.to_list keywords)
+  in
+  PTreeTm
+    (str |> Parserutils.parse_mexpr_string |> Symbolize.symbolize symbolize_env)
 
 let parseMCoreFile keywords filename =
   let symbolize_env =

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -110,26 +110,24 @@ let sym = Symb.gensym ()
 
 let patNameToStr = function NameStr (x, _) -> x | NameWildcard -> us ""
 
+let symbolizeEnvWithKeywords keywords =
+  builtin_name2sym
+  @ List.map
+      (fun k ->
+        if Ustring.length k > 0 && is_ascii_upper_alpha (Ustring.get k 0) then
+          (IdCon (sid_of_ustring k), Intrinsics.Symb.gensym ())
+        else (IdVar (sid_of_ustring k), Intrinsics.Symb.gensym ()) )
+      (Mseq.Helpers.to_list keywords)
+
 let parseMExprString keywords str =
-  let symbolize_env =
-    builtin_name2sym
-    @ List.map
-        (fun k -> (IdVar (sid_of_ustring k), Intrinsics.Symb.gensym ()))
-        (Mseq.Helpers.to_list keywords)
-  in
   PTreeTm
-    (str |> Parserutils.parse_mexpr_string |> Symbolize.symbolize symbolize_env)
+    ( str |> Parserutils.parse_mexpr_string
+    |> Symbolize.symbolize (symbolizeEnvWithKeywords keywords) )
 
 let parseMCoreFile keywords filename =
-  let symbolize_env =
-    builtin_name2sym
-    @ List.map
-        (fun k -> (IdVar (sid_of_ustring k), Intrinsics.Symb.gensym ()))
-        (Mseq.Helpers.to_list keywords)
-  in
   PTreeTm
     ( filename |> Parserutils.parse_mcore_file
-    |> Symbolize.symbolize symbolize_env
+    |> Symbolize.symbolize (symbolizeEnvWithKeywords keywords)
     |> Deadcode.elimination builtin_sym2term builtin_name2sym )
 
 (* Returns a tuple with the following elements

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -129,7 +129,7 @@ let builtin =
   ; ("tensorSubExn", f (CtensorSubExn (None, None)))
   ; ("tensorIteri", f (CtensorIteri None)) (* MCore intrinsics: Boot parser *)
   ; ("bootParserParseMExprString", f CbootParserParseMExprString)
-  ; ("bootParserParseMCoreFile", f CbootParserParseMCoreFile)
+  ; ("bootParserParseMCoreFile", f (CbootParserParseMCoreFile None))
   ; ("bootParserGetId", f CbootParserGetId)
   ; ("bootParserGetTerm", f (CbootParserGetTerm None))
   ; ("bootParserGetType", f (CbootParserGetType None))

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -128,7 +128,7 @@ let builtin =
   ; ("tensorSliceExn", f (CtensorSliceExn None))
   ; ("tensorSubExn", f (CtensorSubExn (None, None)))
   ; ("tensorIteri", f (CtensorIteri None)) (* MCore intrinsics: Boot parser *)
-  ; ("bootParserParseMExprString", f CbootParserParseMExprString)
+  ; ("bootParserParseMExprString", f (CbootParserParseMExprString None))
   ; ("bootParserParseMCoreFile", f (CbootParserParseMCoreFile None))
   ; ("bootParserGetId", f CbootParserGetId)
   ; ("bootParserGetTerm", f (CbootParserGetTerm None))

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -362,7 +362,9 @@ let arity = function
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree _ ->
       0
-  | CbootParserParseMExprString ->
+  | CbootParserParseMExprString None ->
+      2
+  | CbootParserParseMExprString (Some _) ->
       1
   | CbootParserParseMCoreFile None ->
       2
@@ -1189,10 +1191,18 @@ let delta eval env fi c v =
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree _, _ ->
       fail_constapp fi
-  | CbootParserParseMExprString, TmSeq (fi, seq) ->
-      let t = Bootparser.parseMExprString (tmseq2ustring fi seq) in
+  | CbootParserParseMExprString None, TmSeq (fi, seq) ->
+      let keywords =
+        Mseq.Helpers.map
+          (function
+            | TmSeq (_, s) -> tmseq2ustring fi s | _ -> fail_constapp fi )
+          seq
+      in
+      TmConst (fi, CbootParserParseMExprString (Some keywords))
+  | CbootParserParseMExprString (Some keywords), TmSeq (fi, seq) ->
+      let t = Bootparser.parseMExprString keywords (tmseq2ustring fi seq) in
       TmConst (fi, CbootParserTree t)
-  | CbootParserParseMExprString, _ ->
+  | CbootParserParseMExprString _, _ ->
       fail_constapp fi
   | CbootParserParseMCoreFile None, TmSeq (fi, seq) ->
       let keywords =

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -3,7 +3,6 @@ open Printf
 open Ast
 open Pprint
 open Msg
-open Builtin
 module Option = BatOption
 
 (* Tab length when calculating the info field *)
@@ -146,8 +145,6 @@ let parse_mcore_file filename =
     local_parse_mcore_file filename
     |> merge_includes (Filename.dirname filename) [filename]
     |> Mlang.flatten |> Mlang.desugar_post_flatten
-    |> Symbolize.symbolize builtin_name2sym
-    |> Deadcode.elimination builtin_sym2term builtin_name2sym
   with (Lexer.Lex_error _ | Error _ | Parsing.Parse_error) as e ->
     let error_string = Ustring.to_utf8 (error_to_ustring e) in
     fprintf stderr "%s\n" error_string ;

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -482,7 +482,7 @@ let rec print_const fmt = function
       fprintf fmt "bootParseTree"
   | CbootParserParseMExprString ->
       fprintf fmt "bootParserParseMExprString"
-  | CbootParserParseMCoreFile ->
+  | CbootParserParseMCoreFile _ ->
       fprintf fmt "bootParserParseMCoreFile"
   | CbootParserGetId ->
       fprintf fmt "bootParserParseGetId"

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -480,7 +480,7 @@ let rec print_const fmt = function
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree _ ->
       fprintf fmt "bootParseTree"
-  | CbootParserParseMExprString ->
+  | CbootParserParseMExprString _ ->
       fprintf fmt "bootParserParseMExprString"
   | CbootParserParseMCoreFile _ ->
       fprintf fmt "bootParserParseMCoreFile"

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -73,7 +73,7 @@ let ocamlCompile = lam sourcePath. lam ocamlProg.
 let compile = lam files. lam options : Options.
   use MCoreCompile in
   let compileFile = lam file.
-    let ast = parseMCoreFile file in
+    let ast = parseMCoreFile [] file in
 
     -- If option --debug-parse, then pretty print the AST
     (if options.debugParse then printLn (pprintMcore ast) else ());

--- a/src/main/run.mc
+++ b/src/main/run.mc
@@ -31,7 +31,7 @@ let generateTests = lam ast. lam testsEnabled.
 let run = lam files. lam options : Options.
   use ExtMCore in
   let runFile = lam file.
-    let ast = parseMCoreFile file in
+    let ast = parseMCoreFile [] file in
 
     -- If option --debug-parse, then pretty print the AST
     (if options.debugParse then printLn (expr2str ast) else ());

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -866,7 +866,7 @@ let utensorIteri_ = tensorIteri_ tyunknown_
 
 -- Bootparser
 let bootParserParseMExprString_ = use MExprAst in
-  lam str. appf1_ (uconst_ (CBootParserParseMExprString ())) str
+  lam key. lam str. appf2_ (uconst_ (CBootParserParseMExprString ())) key str
 
 let bootParserParseMCoreFile_ = use MExprAst in
   lam key. lam str. appf2_ (uconst_ (CBootParserParseMCoreFile ())) key str

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -868,6 +868,9 @@ let utensorIteri_ = tensorIteri_ tyunknown_
 let bootParserParseMExprString_ = use MExprAst in
   lam str. appf1_ (uconst_ (CBootParserParseMExprString ())) str
 
+let bootParserParseMCoreFile_ = use MExprAst in
+  lam key. lam str. appf2_ (uconst_ (CBootParserParseMCoreFile ())) key str
+
 let bootParserGetId_ = use MExprAst in
   lam pt. appf1_ (uconst_ (CBootParserGetId ())) pt
 

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -36,9 +36,9 @@ lang BootParser = MExprAst
     matchTerm t (bootParserGetId t)
 
   -- Parses an MExpr string and returns the final MExpr AST
-  sem parseMExprString =
+  sem parseMExprString (keywords : [String]) =
   | str ->
-    let t = bootParserParseMExprString str in
+    let t = bootParserParseMExprString keywords str in
     matchTerm t (bootParserGetId t)
 
   -- Get term help function

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -399,11 +399,10 @@ let s = "con Foo : (Int) -> (Tree) in x" in
 utest lside ["x"] s with rside s in
 utest l_infoClosed "  con Bar in 10 " with r_info 1 2 1 12 in
 
--- Linnea
--- -- TmConApp
--- let s = "Foo {a = 5}" in
--- utest lsideClosed s with rside s in
--- utest l_infoClosed "  con Foo in Foo {foo = 7, b = 3} " with r_info 1 2 1 22 in
+-- TmConApp
+let s = "Foo {a = 5}" in
+utest lside ["Foo"] s with rside s in
+utest l_info ["Foo"] "  Foo {foo = 7, b = 3} " with r_info 1 2 1 22 in
 
 -- TmMatch, PatNamed
 let s =  "match 5 with x then x else 2" in
@@ -411,10 +410,9 @@ utest lsideClosed s with rside s in
 let s = "match foo with _ then 7 else 2" in
 utest lside ["foo"] s with rside s in
 utest l_infoClosed "match [4] with x then x else [] " with r_info 1 0 1 31 in
--- Linnea
--- let s = " match bar with Foo {a = x} then x else 2" in
--- utest match parseMExprString [] s with TmMatch r then infoPat r.pat else ()
--- with r_info 1 16 1 27 in
+let s = " match bar with Foo {a = x} then x else 2" in
+utest match parseMExprString ["Foo", "bar"] s with TmMatch r then infoPat r.pat else ()
+with r_info 1 16 1 27 in
 
 -- TmMatch, PatSeqTot, PatSeqEdge
 let s = "match x with \"\" then x else 2" in
@@ -450,11 +448,10 @@ utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 27 in
 
 --TmMatch, PatCon
--- Linnea
--- let s = "match x with Foo {foo = x} then x else 100" in
--- utest lside ["x"] s with rside s in
--- utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
--- with r_info 1 13 1 26 in
+let s = "match x with Foo {foo = x} then x else 100" in
+utest lside ["x", "Foo"] s with rside s in
+utest match parseMExprString ["x", "Foo"] s with TmMatch r then infoPat r.pat else ()
+with r_info 1 13 1 26 in
 
 --TmMatch, PatInt, PatBool, PatChar
 let s = "match x with [1,2,12] then x else x" in

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -285,52 +285,55 @@ let norm : String -> String = lam str.
   filter (lam x. not (or (or (eqChar x ' ') (eqChar x '\n')) (eqChar x '\t'))) str in
 
 -- Test the combination of parsing and pretty printing
-let parse = lam s. expr2str (parseMExprString s) in
-let lside : String -> String = lam s. norm (parse s) in
+let parse = lam ks. lam s. expr2str (parseMExprString ks s) in
+let lside : [String] -> String -> String = lam ks. lam s. norm (parse ks s) in
+let lsideClosed = lside [] in
 let rside : String -> String = norm in
 
 -- Test that info gives the right columns and rows
-let l_info : String -> Info = lam s. infoTm (parseMExprString s) in
+let l_info : [String] -> String -> Info = lam ks. lam s.
+  infoTm (parseMExprString ks s) in
+let l_infoClosed = l_info [] in
 let r_info : Int -> Int -> Int -> Int -> Info = lam r1. lam c1. lam r2. lam c2.
       Info {filename = "internal", row1 = r1, col1 = c1, row2 = r2, col2 = c2} in
 
 -- TmVar
 let s = "_asdXA123" in
-utest lside s with rside s in
-utest match parseMExprString "#var\"\"" with TmVar r
+utest lside ["_asdXA123"] s with rside s in
+utest match parseMExprString [""] "#var\"\"" with TmVar r
       then nameGetStr r.ident else "ERROR" with "" in
 
 -- TmApp
 let s = "f x" in
-utest lside s with rside s in
-utest l_info "   (foo f1) f2  " with r_info 1 4 1 14 in
+utest lside ["f", "x"] s with rside s in
+utest l_info ["f1", "f2", "foo"] "   (foo f1) f2  " with r_info 1 4 1 14 in
 
 -- TmLam
 let s = "lam x. lam y. x" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "(lam x. lam y. x) z1 z2" in
-utest lside s with rside s in
-utest l_info "  _aas_12 " with r_info 1 2 1 9 in
+utest lside ["z1", "z2"] s with rside s in
+utest l_info ["_aas_12"] "  _aas_12 " with r_info 1 2 1 9 in
 
 -- TmLet, TmLam
 let s = "let y = lam x.x in y" in
-utest lside s with rside s in
-utest l_info "  \n lam x.x" with r_info 2 1 2 8 in
-utest infoTm (match parseMExprString s with TmLet r then r.body else ())
+utest lsideClosed s with rside s in
+utest l_infoClosed "  \n lam x.x" with r_info 2 1 2 8 in
+utest infoTm (match parseMExprString [] s with TmLet r then r.body else ())
 with r_info 1 8 1 15 in
-utest l_info "  let x = 4 in y  " with r_info 1 2 1 14 in
+utest l_info ["y"] "  let x = 4 in y  " with r_info 1 2 1 14 in
 let s = "printLn x; 10" in
-utest lside s with rside s in
+utest lside ["printLn", "x"] s with rside s in
 
 -- TmRecLets, TmLam
 let s = "recursive let x = lam x.x in x" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "recursive let x = lam x.x let y = lam x. x in y" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "   recursive let x = 5 \n let foo = 7 in x " in
-utest l_info s with r_info 1 3 2 15 in
+utest l_infoClosed s with r_info 1 3 2 15 in
 utest
-  match parseMExprString s with TmRecLets r then
+  match parseMExprString [] s with TmRecLets r then
     let fst : RecLetBinding = head r.bindings in
     fst.info
   else never
@@ -338,204 +341,207 @@ with r_info 1 13 1 22 in
 
 -- TmConst
 let s = "true" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "false" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "123" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "1.70e+1" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "'a'" in
-utest lside s with rside s in
-utest l_info " true " with r_info 1 1 1 5 in
-utest l_info "  false " with r_info 1 2 1 7 in
-utest l_info " 1234 " with r_info 1 1 1 5 in
-utest l_info " 123.121 " with r_info 1 1 1 8 in
-utest l_info "\n  'A' " with r_info 2 2 2 5 in
+utest lsideClosed s with rside s in
+utest l_infoClosed " true " with r_info 1 1 1 5 in
+utest l_infoClosed "  false " with r_info 1 2 1 7 in
+utest l_infoClosed " 1234 " with r_info 1 1 1 5 in
+utest l_infoClosed " 123.121 " with r_info 1 1 1 8 in
+utest l_infoClosed "\n  'A' " with r_info 2 2 2 5 in
 
 -- TmSeq
 let s = "\"\"" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "[3,4,1123,21,91]" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "[[1],[12,42311],[23,21,91]]" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "\"Hello world\"" in
-utest lside s with rside s in
-utest l_info "  [12,2,1] " with r_info 1 2 1 10 in
+utest lsideClosed s with rside s in
+utest l_infoClosed "  [12,2,1] " with r_info 1 2 1 10 in
 
 -- TmRecord
 let s = "{}" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "{a = 5}" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "{bar = \"Hello\", foo = 123}" in
 let t = record_ [("bar", str_ "Hello"), ("foo", int_ 123)] in
-utest parseMExprString s with t using eqExpr in
-utest l_info " {} " with r_info 1 1 1 3 in
-utest l_info " {foo = 123} " with r_info 1 1 1 12 in
+utest parseMExprString [] s with t using eqExpr in
+utest l_infoClosed " {} " with r_info 1 1 1 3 in
+utest l_infoClosed " {foo = 123} " with r_info 1 1 1 12 in
 
 -- TmRecordUpdate
 let s = "{a with foo = 5}" in
-utest lside s with rside s in
+utest lside ["a"] s with rside s in
 let s = "{{bar='a', foo=7} with bar = 'b'}" in
 let t = recordupdate_ (record_ [("bar", char_ 'a'), ("foo", int_ 7)]) "bar" (char_ 'b') in
-utest parseMExprString s with t using eqExpr in
-utest l_info " {foo with a = 18 } " with r_info 1 1 1 19 in
+utest parseMExprString [] s with t using eqExpr in
+utest l_info ["foo"] " {foo with a = 18 } " with r_info 1 1 1 19 in
 
 -- NOTE(caylak, 2021-03-17): Commented out because test fails since parsing of TyVariant is not supported yet
 -- TmType
 let s = "type Foo=<> in x" in
---utest lside s with rside s in
-utest l_info "  type Bar in () " with r_info 1 2 1 13 in
+--utest lsideClosed s with rside s in
+utest l_infoClosed "  type Bar in () " with r_info 1 2 1 13 in
 
 -- TmConDef
 let s = "con Foo in x" in
-utest lside s with rside s in
+utest lside ["x"] s with rside s in
 let s = "con Foo : (Int) -> (Tree) in x" in
-utest lside s with rside s in
-utest l_info "  con Bar in 10 " with r_info 1 2 1 12 in
+utest lside ["x"] s with rside s in
+utest l_infoClosed "  con Bar in 10 " with r_info 1 2 1 12 in
 
--- TmConApp
-let s = "Foo {a = 5}" in
-utest lside s with rside s in
-utest l_info "  Foo {foo = 7, b = 3} " with r_info 1 2 1 22 in
+-- Linnea
+-- -- TmConApp
+-- let s = "Foo {a = 5}" in
+-- utest lsideClosed s with rside s in
+-- utest l_infoClosed "  con Foo in Foo {foo = 7, b = 3} " with r_info 1 2 1 22 in
 
 -- TmMatch, PatNamed
 let s =  "match 5 with x then x else 2" in
-utest lside s with rside s in
+utest lsideClosed s with rside s in
 let s = "match foo with _ then 7 else 2" in
-utest lside s with rside s in
-utest l_info "match [4] with x then x else [] " with r_info 1 0 1 31 in
-let s = " match bar with Foo {a = x} then x else 2" in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
-with r_info 1 16 1 27 in
+utest lside ["foo"] s with rside s in
+utest l_infoClosed "match [4] with x then x else [] " with r_info 1 0 1 31 in
+-- Linnea
+-- let s = " match bar with Foo {a = x} then x else 2" in
+-- utest match parseMExprString [] s with TmMatch r then infoPat r.pat else ()
+-- with r_info 1 16 1 27 in
 
 -- TmMatch, PatSeqTot, PatSeqEdge
 let s = "match x with \"\" then x else 2" in
-utest lside s with rside s in
+utest lside ["x"] s with rside s in
 let s = "match x with [x,y,z] then x else 2" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 20 in
 let s = " match x with [a] ++ v ++ [x,y,z] then x else 2" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 14 1 33 in
 let s = "match x with \"\" ++ x ++ [y] then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 27 in
 let s = "match x with [z] ++ x ++ \"\" then z else 2" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 27 in
 
 --TmMatch, PatRecord
 let s = "match x with {} then x else 2" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 15 in
 let s = "match x with {bar=_, foo=x} then x else 2" in
 let t = match_ (var_ "x")
                (prec_ [("bar", pvarw_), ("foo", pvar_ "x")])
                (var_ "x") (int_ 2) in
-utest parseMExprString s with t using eqExpr in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest parseMExprString ["x"] s with t using eqExpr in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 27 in
 
 --TmMatch, PatCon
-let s = "match x with Foo {foo = x} then x else 100" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
-with r_info 1 13 1 26 in
+-- Linnea
+-- let s = "match x with Foo {foo = x} then x else 100" in
+-- utest lside ["x"] s with rside s in
+-- utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+-- with r_info 1 13 1 26 in
 
 --TmMatch, PatInt, PatBool, PatChar
 let s = "match x with [1,2,12] then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 21 in
 let s = "match x with 'A' then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 16 in
 let s = "match x with [true,false] then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 25 in
 
 -- TmMatch, PatAnd, PatOr, PatNot
 let s = "match x with 1 & x then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 18 in
 let s = "match x with 1 | x then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 18 in
 let s = "match x with !y then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 13 1 15 in
 let s = "match 1 with (a & b) | (!c) then x else x" in
-utest lside s with rside s in
-utest match parseMExprString s with TmMatch r then infoPat r.pat else ()
+utest lside ["x"] s with rside s in
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
 with r_info 1 14 1 26 in
 
 -- TmUtest
 let s = "utest lam x.x with 4 in 0" in
-utest lside s with rside s in
-utest l_info "\n utest 3 with 4 in () " with r_info 2 1 2 18 in
+utest lsideClosed s with rside s in
+utest l_infoClosed "\n utest 3 with 4 in () " with r_info 2 1 2 18 in
 
 -- TmNever
 let s = "never" in
-utest lside s with rside s in
-utest l_info "  \n  never " with r_info 2 2 2 7 in
+utest lsideClosed s with rside s in
+utest l_infoClosed "  \n  never " with r_info 2 2 2 7 in
 
 -- TyUnknown
 let s = "let y:Unknown = lam x.x in y" in
-utest lside s with rside "let y = lam x.x in y" in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside "let y = lam x.x in y" in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 13 in
 let s = "lam x:Int. lam y:Char. x" in
-utest lside s with rside s in
-utest match parseMExprString " \n lam x:Int. lam y:Char. x" with TmLam l then infoTy l.tyIdent else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] " \n lam x:Int. lam y:Char. x" with TmLam l then infoTy l.tyIdent else ()
 with r_info 2 7 2 10 in
 
 -- TyInt
 let s = "let y:Int = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 9 in
 
 -- TyFloat
 let s = "let y:Float = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 11 in
 
 -- TyChar
 let s = "let y:Char = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 10 in
 
 -- TyArrow
 let s = "let y:(Int)->(Int) = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 7 1 17 in
 
 -- Nested TyArrow
 let s = "let y:([Float])->(Int) = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 7 1 21 in
 
 -- TySeq
 let s = "let y:[Int] = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 11 in
 
 -- Nested TySeq
@@ -550,14 +556,14 @@ let recTy = tyseq_ (tyrecord_ [
 let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
-utest parseMExprString s with typedLet recTy using eqExpr in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest parseMExprString [] s with typedLet recTy using eqExpr in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 56 in
 
 -- TyTensor
 let s = "let y:Tensor[Int] = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 17 in
 
 -- Nested TyTensor
@@ -570,15 +576,15 @@ in
 let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
-utest parseMExprString s with typedLet recTy using eqExpr in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest parseMExprString [] s with typedLet recTy using eqExpr in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 30 in
 
 -- TyRecord
 let s = "let y:{a:Int,b:[Char]} = lam x.x in y" in
 let recTy = tyrecord_ [("a", tyint_), ("b", tystr_)] in
-utest parseMExprString s with typedLet recTy using eqExpr in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest parseMExprString [] s with typedLet recTy using eqExpr in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 22 in
 
 -- Nested TyRecord
@@ -590,32 +596,32 @@ let recTy = tyrecord_ [
   ("b", tyrecord_ [
     ("b_1", tystr_),
     ("b_2", tyfloat_)])] in
-utest parseMExprString s with typedLet recTy using eqExpr in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest parseMExprString [] s with typedLet recTy using eqExpr in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 54 in
 
 -- TyVariant
 let s = "let y:<> = lam x.x in y" in
 -- NOTE(caylak,2021-03-17): Parsing of TyVariant is not supported yet
---utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+--utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 8 in
 
 -- TyVar
 let s = "let y:_asd = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 6 1 10 in
 
 -- TyApp
 let s = "let y:((Int)->(Int))(Int) = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 8 1 24 in
 
 -- Nested TyApp
 let s = "let y:((((Int)->(Int))(Int))->(Int))(Int) = lam x.x in y" in
-utest lside s with rside s in
-utest match parseMExprString s with TmLet l then infoTy l.tyBody else ()
+utest lsideClosed s with rside s in
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
 with r_info 1 10 1 40 in
 ()

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -30,9 +30,9 @@ lang BootParser = MExprAst
   -- Parse a complete MCore file, including MLang code
   -- This function returns the final MExpr AST. The MCore
   -- file can refer to other files using include statements
-  sem parseMCoreFile =
+  sem parseMCoreFile (keywords : [String]) =
   | filename ->
-    let t = bootParserParseMCoreFile filename in
+    let t = bootParserParseMCoreFile keywords filename in
     matchTerm t (bootParserGetId t)
 
   -- Parses an MExpr string and returns the final MExpr AST

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -184,7 +184,7 @@ in
 
 let utestRunner =
   use BootParser in
-  parseMExprString _utestRunnerStr
+  parseMExprString [] _utestRunnerStr
 
 -- Get the name of a string identifier in an expression
 let findName : String -> Expr -> Option Name = use MExprAst in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -752,7 +752,7 @@ let _preamble =
     , intr1 "randSetSeed" (appf1_ (_randOp "set_seed"))
     , intr1 "wallTimeMs" (appf1_ (_timeOp "get_wall_time_ms"))
     , intr1 "sleepMs" (appf1_ (_timeOp "sleep_ms"))
-    , intr1 "bootParserParseMExprString" (appf1_ (_bootparserOp "parseMExprString"))
+    , intr2 "bootParserParseMExprString" (appf2_ (_bootparserOp "parseMExprString"))
     , intr2 "bootParserParseMCoreFile" (appf2_ (_bootparserOp "parseMCoreFile"))
     , intr1 "bootParserGetId" (appf1_ (_bootparserOp "getId"))
     , intr2 "bootParserGetTerm" (appf2_ (_bootparserOp "getTerm"))

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -753,7 +753,7 @@ let _preamble =
     , intr1 "wallTimeMs" (appf1_ (_timeOp "get_wall_time_ms"))
     , intr1 "sleepMs" (appf1_ (_timeOp "sleep_ms"))
     , intr1 "bootParserParseMExprString" (appf1_ (_bootparserOp "parseMExprString"))
-    , intr1 "bootParserParseMCoreFile" (appf1_ (_bootparserOp "parseMCoreFile"))
+    , intr2 "bootParserParseMCoreFile" (appf2_ (_bootparserOp "parseMCoreFile"))
     , intr1 "bootParserGetId" (appf1_ (_bootparserOp "getId"))
     , intr2 "bootParserGetTerm" (appf2_ (_bootparserOp "getTerm"))
     , intr2 "bootParserGetType" (appf2_ (_bootparserOp "getType"))


### PR DESCRIPTION
This PR enables the use of KeywordMaker together with the boot parser.