### PR TITLE
Smaller fixes

### DIFF
--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -433,7 +433,7 @@ lang DataPatTypeAnnot = TypeAnnot + DataPat + VariantTypeAst + VarTypeAst +
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatCon t ->
     match mapLookup t.ident env.conEnv
-    with Some (TyArrow {from = argTy, to = TyVar _}) then
+    with Some (TyArrow {from = argTy, to = _}) then
       typeAnnotPat env argTy t.subpat
     else env
 end

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -583,7 +583,9 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate
         match mapLookup id fields with Some ty then
           ty
         else
-          infoErrorExit t.info (join ["Field ", sidToString id, " not found in record"])
+          let strFields = strJoin ", " (map sidToString (mapKeys fields)) in
+          infoErrorExit t.info
+            (join ["Field ", sidToString id, " not found in record with fields {", strFields, "}"])
       in
       match mapLookup id patNames with Some n then
         match generatePat env ty n pat with (names, innerWrap) then

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -229,7 +229,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
   | TmMatch ({pat = PatSeqTot {pats = []}} & t) ->
     let cond = generate env (eqi_ (int_ 0) (length_ t.target)) in
     _if cond (generate env t.thn) (generate env t.els)
-  | TmMatch ({pat = PatRecord pr, thn = TmVar thnv, els = TmNever _} & t) ->
+  | TmMatch ({info = info, pat = PatRecord pr, thn = TmVar thnv, els = TmNever _} & t) ->
     let binds : [(SID, Pat)] = mapBindings pr.bindings in
     match binds with [(fieldLabel, PatNamed ({ident = PName patName} & p))] then
       if nameEq patName thnv.ident then
@@ -244,7 +244,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
               arms = [(OPatCon {ident = name, args = [precord]}, nvar_ patName)]
             }
           else error "Record type not handled by type-lifting"
-        else error "Unknown record type"
+        else error (infoErrorString info "Unknown record type")
       else generateDefaultMatchCase env t
     else generateDefaultMatchCase env t
   | TmMatch ({target = TmVar _, pat = PatCon pc, els = TmMatch em} & t) ->


### PR DESCRIPTION
This PR adds some more info to some error messages I ran into that weren't as helpful as I would have liked, and makes the type-annotater use a bit more information for more complicated variant types. In particular, the situation I ran into was something like this:

```
lam x: Option Ty.
match x with Some (TyVar r) then r.info else ... 
```

Here the previous version would not pick up the shape of `r`, since the type of `Some` is a `TyArrow {to = TyApp ...}` rather than a `TyArrow {to = TyVar ...}`. I presume this was originally made because we haven't implemented proper handling of parameterized types, and so we can't fully know the shape of the constructors. However, this should be handled just fine by an unknown `TyVar` producing a `TyUnknown`. 