### PR TITLE
Add an empty .mli file when compiling OCaml

### DIFF
--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -34,6 +34,7 @@ let ocamlCompileWithConfig : CompileOptions -> String -> CompileResult =
   let tempfile = lam f. sysJoinPath dir f in
 
   writeFile (tempfile "program.ml") p;
+  writeFile (tempfile "program.mli") "";
   writeFile (tempfile "dune") dunefile;
 
   let command =


### PR DESCRIPTION
By adding an empty `.mli` file when compiling the generated OCaml code the compilation seems to be significantly faster.

My hypothesis is that this becomes faster because when the public interface is empty the compiler is allowed to eliminate unused let-expressions at the top-level (similar to `static` functions in C).