### PR TITLE
Updates for removing TmExt during dead code elimination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 
 .PHONY :\
   all\
+  boot\
   test\
   install\
   lint\
@@ -30,6 +31,8 @@
 
 all: build/mi
 
+boot:
+	@./make boot
 build/mi:
 	@./make
 

--- a/make
+++ b/make
@@ -18,12 +18,18 @@ export MI_NAME=mi
 # Setup environment variable to find standard library
 cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 
-# General function for building the project
-build() {
+# Compile and build the boot interpreter
+build_boot(){
     mkdir -p build
     dune build
-    dune install > /dev/null 2>&1
     cp -f _build/install/default/bin/boot.mi build/$BOOT_NAME
+}
+
+
+# General function for building the project
+build() {
+    build_boot
+    dune install > /dev/null 2>&1
     if [ -e build/$MI_NAME ]
     then
         echo "Bootstrapped compiler already exists. Run 'make clean' before to recompile. "
@@ -36,6 +42,8 @@ build() {
         rm -f mi
     fi
 }
+
+
 
 # Install the boot interpreter locally for the current user
 install() {
@@ -78,6 +86,9 @@ run_test() {
 }
 
 case $1 in
+    boot)
+        build_boot
+        ;;
     run-test)
         run_test "$2"
         ;;

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -43,6 +43,8 @@ let utest_fail = ref 0 (* Counts the number of failed unit tests *)
 
 let utest_fail_local = ref 0 (* Counts local failed tests for one file *)
 
+type side_effect = bool
+
 (* Map type for record implementation *)
 module Record = Map.Make (Ustring)
 
@@ -261,7 +263,7 @@ and tm =
   (* Use a language *)
   | TmUse of info * ustring * tm
   (* External *)
-  | TmExt of info * ustring * Symb.t * bool * ty * tm
+  | TmExt of info * ustring * Symb.t * side_effect * ty * tm
   (* -- The rest is ONLY part of the runtime system *)
   (* Closure *)
   | TmClos of info * ustring * Symb.t * tm * env Lazy.t (* Closure *)

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -61,6 +61,12 @@ let rec lambdas_left nmap n se = function
   | t ->
       (max 0 n, se || tm_has_side_effect nmap false t)
 
+(* Count the number of lambdas (arrow types) in a type *)
+let rec lambdas_in_type = function
+  | TyArrow(_, _, ty2) -> 1 + lambdas_in_type ty2
+  | _ -> 0
+
+
 (* Help function that collects let information and free variables 
    Returns a tuple with two elements
    1. NMap: a mapping from a let symbol to a tuple with the following 4 elements: 
@@ -109,6 +115,9 @@ let collect_lets nmap t =
         in
         let nmap = List.fold_left handle_se nmap slst in
         work (nmap, free) tt
+    | TmExt(_, _, s, side_effect, ty, t1) ->
+       let nmap = SymbMap.add s (SymbSet.empty, false, side_effect, lambdas_in_type ty) nmap in
+       work (nmap, free) t1
     | t ->
         sfold_tm_tm work (nmap, free) t
   in
@@ -147,8 +156,14 @@ let rec remove_lets nmap = function
       let lst = List.filter f lst in
       if List.length lst = 0 then remove_lets nmap tt
       else TmRecLets (fi, lst, remove_lets nmap tt)
+  | TmExt(fi, x, s, se, ty, t1) ->
+     (match SymbMap.find s nmap with
+      | _, true, _, _ ->
+         TmExt(fi, x, s, se, ty, remove_lets nmap t1)
+      | _ ->
+         remove_lets nmap t1 )
   | t ->
-      smap_tm_tm (remove_lets nmap) t
+     smap_tm_tm (remove_lets nmap) t
 
 (* Helper function for pretty printing a nmap *)
 let pprint_nmap symbmap nmap =


### PR DESCRIPTION
This PR removed externals (TmExt) during dead code elimination, if the externals are not used in the program. It handles side effects and lambda counts based on the type signature of the external.

Also, this PR adds a make target `boot`, which makes it possible to compile boot only, without bootstrapping the whole compiler. To do this, just type `make boot`. This is useful when working on just the boot code in OCaml.