### PR TITLE
External libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ interpreters to achieve the same thing.
 
 
 
-## Externals
+## Externals (builtin)
 
 As part of the experimental setup of Miking, we currently support a way
 to use external libraries without interfering with the development of
@@ -1293,6 +1293,70 @@ dune install
 
 after building miking with python intrinsics support.
 
+## Externals
+Externals are currently only compiled.
+
+As example of how you define an external see
+[./stdlib/ext/batteries.mc](./stdlib/ext/batteries.mc) and
+[./stdlib/ext/batteries.ext-ocaml.mc](./stdlib/ext/batteries.ext-ocaml.mc).
+
+[./stdlib/ext/batteries.mc](./stdlib/ext/batteries.mc) defines the MLang part
+of the definition, e.g.
+
+```
+external batteriesZero : Int
+```
+
+which makes an external value `batteriesZero` of type `Int` available at the
+top-level. The corresponding MCore syntax is:
+
+```
+external ident : Type in expr
+```
+
+If the external has side-effects it should be annotated with a `!` after the
+identifier, e.g.
+
+```
+external print ! : String -> () in expr
+```
+
+Each external identifier can only be defined once and externals cannot be
+partially applied.
+
+[./stdlib/ext/batteries.ext-ocaml.mc](./stdlib/ext/batteries.ext-ocaml.mc)
+defines the OCaml part of the external definition:
+
+```
+include "ocaml/ast.mc"
+
+let batteries =
+  use OCamlTypeAst in
+  mapFromList cmpString
+  [
+    ("batteriesZero", [
+      { ident = "BatInt.zero", ty = tyint_, libraries = ["batteries"] }
+    ])
+  ]
+```
+
+As a temporary solution, this definition is written as an MLang program and
+should define a map from external identifiers to a list of records defining
+implementations associated with this external identifier. The record field
+`ident` defines an OCaml identifier, the field `ty` defines the OCaml type of
+this identifier (see [./stdlib/ocaml/ast.mc](./stdlib/ocaml/ast.mc)), and the
+field `libraries` defines a sequence of libraries this external depends on.
+
+Programs defining externals should be placed under [./stdlib/ext](./stdlib/ext)
+and follow the above naming convention to avoid failing test for the
+interpreter. Additionally, the implementation map, in this case `batteries`,
+should be added to `globalExternalMap` in
+[./stdlib/ocaml/external-includes.mc](./stdlib/ocaml/external-includes.mc).
+
+Morever, depending on the type of the external you might have to extend the
+`externalMarshal` and `externalMarshalCost` function in
+[./stdlib/ocaml/external.mc](./stdlib/ocaml/external.mc).
+
 ## Contributing
 
 1. Before making a pull request please make sure that all tests pass. Run
@@ -1343,6 +1407,7 @@ These instructions are adapted from
 [https://github.com/psf/black](https://github.com/psf/black). See
 [https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt)
 for documentation on the `--ignore-revs-file` option.
+
 
 ## MIT License
 Miking is licensed under the MIT license.

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -11,11 +11,13 @@ include "mexpr/utesttrans.mc"
 include "ocaml/ast.mc"
 include "ocaml/generate.mc"
 include "ocaml/pprint.mc"
+include "ocaml/external-includes.mc"
 
 lang MCoreCompile =
   BootParser +
   MExprSym + MExprTypeAnnot + MExprUtestTrans +
-  OCamlPrettyPrint + OCamlTypeDeclGenerate + OCamlGenerate + OCamlObjWrap
+  OCamlPrettyPrint + OCamlTypeDeclGenerate + OCamlGenerate +
+  OCamlGenerateExternalNaive + OCamlObjWrap
 end
 
 let pprintMcore = lam ast.
@@ -50,6 +52,17 @@ let generateTests = lam ast. lam testsEnabled.
     let symEnv = symEnvEmpty in
     (symEnv, utestStrip ast)
 
+let collectLibraries = lam extNameMap : ExternalNameMap.
+  let f = lam libs. lam lib. setInsert lib libs in
+  let g =
+    lam libs. lam impl :  ExternalImpl. foldl f libs impl.libraries
+  in
+  let h = lam libs. lam. lam impls. foldl g libs impls in
+  let libs =
+    mapFoldWithKey h (setEmpty cmpString) extNameMap
+  in
+  setToSeq libs
+
 -- NOTE(larshum, 2021-03-22): This does not work for Windows file paths.
 let filename = lam path.
   match strLastIndex '/' path with Some idx then
@@ -61,11 +74,16 @@ let filenameWithoutExtension = lam filename.
     subsequence filename 0 idx
   else filename
 
-let ocamlCompile = lam options : Options. lam sourcePath. lam ocamlProg.
+let ocamlCompile =
+  lam options : Options. lam libs. lam sourcePath. lam ocamlProg.
   let compileOptions : CompileOptions =
-    if options.disableOptimizations then
-      {defaultCompileOptions with optimize = false}
-    else defaultCompileOptions
+    {
+      (if options.disableOptimizations then
+        {defaultCompileOptions with optimize = false}
+       else defaultCompileOptions)
+
+       with libraries = libs
+    }
   in
   let p : CompileResult = ocamlCompileWithConfig compileOptions ocamlProg in
   let destinationFile = filenameWithoutExtension (filename sourcePath) in
@@ -93,25 +111,30 @@ let compile = lam files. lam options : Options. lam args.
       let ast = symbolizeExpr symEnv ast in
       let ast = typeAnnot ast in
 
-      -- Translate the MExpr AST into an OCaml AST
-      let ocamlAst =
-        match typeLift ast with (env, ast) then
-          match generateTypeDecl env ast with (env, ast) then
+      -- Translate the MExpr AST into an OCaml AST and Compile
+      match typeLift ast with (env, ast) then
+        match generateTypeDecl env ast with (env, ast) then
+          match chooseAndGenerateExternals globalExternalMap ast
+          with (extNameMap, ast) then
             let ast = generate env ast in
             let ast = objWrap ast in
-            _withPreamble ast
+            let ast = _withPreamble ast in
+
+            -- Collect external library dependencies
+            let libs = collectLibraries extNameMap in
+
+            let ocamlProg = pprintOcaml ast in
+
+            -- Print the AST after code generation
+            (if options.debugGenerate then printLn ocamlProg else ());
+
+            -- Compile OCaml AST
+            if options.exitBefore then exit 0
+            else ocamlCompile options libs file ocamlProg
+
           else never
         else never
-      in
-
-      let ocamlProg = pprintOcaml ocamlAst in
-
-      -- Print the AST after code generation
-      (if options.debugGenerate then printLn ocamlProg else ());
-
-      -- Compile OCaml AST
-      if options.exitBefore then exit 0
-      else ocamlCompile options file ocamlProg
+      else never
     else never
   in
   iter compileFile files

--- a/stdlib/ext/batteries.ext-ocaml.mc
+++ b/stdlib/ext/batteries.ext-ocaml.mc
@@ -1,0 +1,10 @@
+include "ocaml/ast.mc"
+
+let batteries =
+  use OCamlTypeAst in
+  mapFromList cmpString
+  [
+    ("batteriesZero", [
+      { ident = "BatInt.zero", ty = tyint_, libraries = ["batteries"] }
+    ])
+  ]

--- a/stdlib/ext/batteries.mc
+++ b/stdlib/ext/batteries.mc
@@ -1,5 +1,6 @@
 -- This program tests an external function from the batteries library
 
-external testBatZero : Int
+external batteriesZero : Int
 mexpr
-testBatZero
+utest batteriesZero with 0 in
+()

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -5,15 +5,15 @@ let mathExtMap =
   mapFromList cmpString
   [
     ("exp", [
-      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
+      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
     ]),
     ("atan", [
-      { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_ }
+      { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
     ]),
     ("sin", [
-      { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_ }
+      { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
     ]),
     ("cos", [
-      { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_ }
+      { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
     ])
   ]

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -43,7 +43,7 @@ lang BootParser = MExprAst + ConstTransformer
     constTransform (matchTerm t (bootParserGetId t))
 
   -- Get term help function
-  sem gterm (t:Unkown) =
+  sem gterm (t:Unknown) =
   | n -> let t2 = bootParserGetTerm t n in
          matchTerm t2 (bootParserGetId t2)
 
@@ -192,7 +192,7 @@ lang BootParser = MExprAst + ConstTransformer
               ty = gtype t 0}
 
   -- Get constant help function
-  sem gconst(t:Unkown) =
+  sem gconst(t:Unknown) =
   | n -> let t2 = bootParserGetConst t n in
          matchConst t2 (bootParserGetId t2)
 

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -2,7 +2,8 @@ include "string.mc"
 include "sys.mc"
 
 type CompileOptions = {
-  optimize : Bool
+  optimize : Bool,
+  libraries : [String]
 }
 
 type Program = String -> [String] -> ExecResult
@@ -13,12 +14,17 @@ type CompileResult = {
 }
 
 let defaultCompileOptions : CompileOptions = {
-  optimize = true
+  optimize = true,
+  libraries = []
 }
 
 let ocamlCompileWithConfig : CompileOptions -> String -> CompileResult =
   lam options : CompileOptions. lam p.
+  let libstr =
+    strJoin " " (distinct eqString (cons "boot" options.libraries))
+  in
   let dunefile =
+   join [
    "(env
       (dev
         (flags (:standard -w -a))
@@ -28,7 +34,7 @@ let ocamlCompileWithConfig : CompileOptions -> String -> CompileResult =
         (flags (:standard -w -a))
         (ocamlc_flags (-without-runtime))
         (ocamlopt_flags (-O3))))
-    (executable (name program) (libraries boot))" in
+    (executable (name program) (libraries ", libstr , "))"] in
   let td = sysTempDirMake () in
   let dir = sysTempDirName td in
   let tempfile = lam f. sysJoinPath dir f in

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -1,39 +1,52 @@
 include "ext/math-ext.ext-ocaml.mc"
 
-type ExternalImpl = {name : Name, extIdent : String, extTy : Type}
+type ExternalImplDef = {ident : String, ty : Type, libraries : [String]}
+
+type ExternalImpl =
+  {name : Name, extIdent : String, extTy : Type, libraries : [String]}
+
+type ExternalMap = Map String [ExternalImpl]
 
 let _testExternals =
   use OCamlTypeAst in
   mapFromList cmpString
   [
     ("testZero", [
-      { ident = "Float.zero", ty = tyfloat_ }
+      { ident = "Float.zero", ty = tyfloat_, libraries = [] }
     ]),
     ("testExp", [
-      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
+      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
     ]),
     ("testListMap", [
       { ident = "List.map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (tyvar_ "b"),
                         tylist_ (tyvar_ "a"),
-                        tylist_ (tyvar_ "b")] }
+                        tylist_ (tyvar_ "b")],
+        libraries = [] }
     ]),
     ("testListConcatMap", [
       { ident = "List.concat_map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (tylist_ (tyvar_ "b")),
                         tylist_ (tyvar_ "a"),
-                        tylist_ (tyvar_ "b")] }
+                        tylist_ (tyvar_ "b")],
+        libraries = [] }
+    ]),
+    ("testNonExistant", [
+      { ident = "none", ty = tyint_, libraries = ["no-lib"] }
     ])
   ]
 
 -- NOTE(oerikss, 2021-04-30) Add your external maps here. This is a temporary
 -- solution. In the end we want to provide these definitions outside the
 -- compiler (which will require some parsing).
-let externalMap =
+let globalExternalMap : ExternalMap =
   mapMapWithKey
   (lam id : String.
-    map (lam imp : {ident : String, ty : Type}.
-          {name = nameSym id, extIdent = imp.ident, extTy = imp.ty}))
+    map (lam imp : ExternalImplDef.
+          {name = nameSym id,
+           extIdent = imp.ident,
+           extTy = imp.ty,
+           libraries = imp.libraries}))
   (foldl1 mapUnion
     [
       _testExternals, -- For testing purposes

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -33,6 +33,9 @@ let _testExternals =
     ]),
     ("testNonExistant", [
       { ident = "none", ty = tyint_, libraries = ["no-lib"] }
+    ]),
+    ("testBatZero", [
+      { ident = "BatInt.zero", ty = tyint_, libraries = ["batteries"] }
     ])
   ]
 

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -1,4 +1,6 @@
+include "ext/batteries.ext-ocaml.mc" -- For testing
 include "ext/math-ext.ext-ocaml.mc"
+
 
 type ExternalImplDef = {ident : String, ty : Type, libraries : [String]}
 
@@ -33,9 +35,6 @@ let _testExternals =
     ]),
     ("testNonExistant", [
       { ident = "none", ty = tyint_, libraries = ["no-lib"] }
-    ]),
-    ("testBatZero", [
-      { ident = "BatInt.zero", ty = tyint_, libraries = ["batteries"] }
     ])
   ]
 
@@ -53,5 +52,6 @@ let globalExternalMap : ExternalMap =
   (foldl1 mapUnion
     [
       _testExternals, -- For testing purposes
+      batteries,      -- For testing purposes
       mathExtMap
     ])

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -1,134 +1,199 @@
 include "ocaml/external-includes.mc"
 include "ocaml/ast.mc"
 include "ocaml/intrinsics-ops.mc"
+include "ocaml/pprint.mc"
 
 lang OCamlMarshalData = OCamlTypeAst + SeqTypeAst + TensorTypeAst
 
--- Constructs a sequence of Types from a Type split at ->.
-let _typesSeq : Type -> [Type] =
+let externalMarshalCost : Type -> Type -> Int =
   use OCamlMarshalData in
-  lam ty.
-  recursive let recur = lam ty.
-    match ty with TyArrow {from = from, to = to} then
-      cons from (recur to)
-    else [ty]
+  recursive let recur = lam ty1. lam ty2.
+    let tt = (ty1, ty2) in
+    match tt with (TyVar _, _) then 0
+    else match tt with (_, TyVar _) then 0
+    else match tt with (TyInt _, TyInt _) then 0
+    else match tt with (TyFloat _, TyFloat _) then 0
+    else match tt with (TySeq _, TySeq _) then 0
+    else match tt with (TyList _, TyList _) then 0
+    else match tt with (TySeq _, TyList _) then 3
+    else match tt with (TyList _, TySeq _) then 3
+    else match tt
+    with (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22})
+    then
+      addi (recur ty21 ty11) (recur ty12 ty22)
+    else error "Cannot compute marshal data cost"
   in
-  recur ty
+  recur
 
-
--- Marshals tm of type mcoreTy to type ocamlTy,
--- returning {cost : Int, tm : Expr}, where tm is the result and cost the cost
--- of the marshaling, repsectivly.
-
-
-let externalMarshal = lam tm. lam mcoreTy. lam ocamlTy.
-
-  recursive
-  let marshal : Expr -> (Type, Type) -> {cost : Int, tm : Expr} =
-  use OCamlMarshalData in
-  lam tm. lam tt.
-    match tt with (TyVar _, _) then
-      {tm = tm, cost = 0}
-    else match tt with (_, TyVar _) then
-      {tm = tm, cost = 0}
-    else match tt with (TyInt _, TyInt _) then
-      {tm = tm, cost = 0}
-    else match tt with (TyFloat _, TyFloat _) then
-      {tm = tm, cost = 0}
-    else match tt with (TySeq _, TySeq _) then
-      {tm = tm, cost = 0}
-    else match tt with (TyList _, TyList _) then
-      {tm = tm, cost = 0}
-    else match tt with (TySeq _, TyList _) then
-      -- NOTE(oerikss, 2021-04-24) we would like the cost to be proportional
-      -- to the length of the sequence. This applies to other types as well.
-      {tm = app_ (intrinsicOpSeq "Helpers.to_list") tm, cost = 3}
-    else match tt with (TyList _, TySeq _) then
-      {tm = app_ (intrinsicOpSeq "Helpers.of_list") tm, cost = 3}
-    else error "Cannot marshal data"
-
-  let recur : Expr -> Type -> Type -> {cost : Int, tm : Expr} =
-  lam tm. lam ty1. lam ty2.
-    let tys1 = _typesSeq ty1 in
-    let tys2 = _typesSeq ty2 in
-    let ntys1 = length tys1 in
-    if neqi ntys1 (length tys2) then
-      error "From and to type have different arity"
-    else if eqi ntys1 1 then
-      -- TODO(oerikss, 2021-04-30) We wrap external constants in a lambdas in
-      -- order for the Obj warpping to work correctly. Ideally we would like
-      -- not having to do this.
-      let r = marshal tm (ty2, ty1) in
-      {r with tm = app_ (nulam_ (nameSym "x") r.tm) unit_}
-    else
-      let nargs = subi ntys1 1 in
-
-      let names : [Name] =
-        unfoldr
-          (lam b. if geqi b nargs then None ()
-                  else Some(nameSym (cons 'x' (int2string b)), addi b 1))
-          0
-      in
-
-      let tmp : [{tm : Expr, cost : Int}] =
-        let zapp = zipWith (lam f. lam x. f x) in
-        let vars = map nvar_ names in
-        let fs = map recur vars in
-        zapp (zapp fs (init tys2)) (init tys1)
-      in
-
-      let tm = appSeq_
-                    tm
-                    (map (lam x : {cost : Int, tm : Expr}. x.tm) tmp)
-      in
-
-      match marshal tm (last tys2, last tys1)
-      with {tm = body, cost = cost} then
-        let cost =
-          addi
-            cost
-            (foldl (lam c : Int. lam x : {cost : Int, tm : Expr}.
-                      addi c x.cost)
-                    0
-                    tmp)
-        in
-        {tm = nulams_ names body, cost = cost}
-      else never
-  in
-  recur tm mcoreTy ocamlTy
-
+utest externalMarshalCost tyint_ tyint_ with 0
+utest externalMarshalCost (tylist_ tyint_) (tyseq_ tyint_) with 3
 utest
-  match externalMarshal
-          (var_ "f")
-          (tyarrow_ tyint_ tyfloat_)
-          (tyarrow_ tyint_ tyfloat_)
-  with {cost = cost} then cost else (negi 1)
-with 0
-
-utest
-  let r =
-    externalMarshal
-            (var_ "f")
-            (tyarrow_ (tyseq_ tyint_) (tyseq_ tyint_))
-            (tyarrow_ (tylist_ tyint_) (tylist_ tyint_))
-  in
-  match r with {cost = cost} then cost else (negi 1)
+  externalMarshalCost
+    (tyarrow_ (tyseq_ tyint_) (tylist_ tyint_))
+    (tyarrow_ (tylist_ tyint_) (tyseq_ tyint_))
 with 6
-
 utest
-  match externalMarshal
-          (var_ "f")
-          (tyarrow_ (tyseq_ tyint_) tyint_)
-          (tyarrow_ (tylist_ tyint_) tyint_)
-   with {cost = cost} then cost else (negi 1)
-with 3
+  externalMarshalCost
+    (tyarrows_ [tyseq_ tyint_, tylist_ tyint_, tyseq_ tyint_])
+    (tyarrows_ [tylist_ tyint_, tyseq_ tyint_, tylist_ tyint_])
+with 9
 
-utest
-  let r =
-    externalMarshal
-      (var_ "f")
-      (tyarrow_ (tyarrow_ (tyseq_ tyint_) tyint_) tyint_)
-      (tyarrow_ (tyarrow_ (tylist_ tyint_) tyint_) tyint_)
+
+let externalMarshal : Expr -> Type -> Type -> Expr =
+  use OCamlMarshalData in
+  lam t. lam ty1. lam ty2.
+  recursive let recur = lam t. lam ty1. lam ty2.
+    let tt = (ty1, ty2) in
+    match tt with (TyVar _, _) then t
+    else match tt with (_, TyVar _) then t
+    else match tt with (TyInt _, TyInt _) then t
+    else match tt with (TyFloat _, TyFloat _) then t
+    else match tt with (TySeq _, TySeq _) then t
+    else match tt with (TyList _, TyList _) then t
+    else match tt with (TySeq _, TyList _) then
+      app_ (intrinsicOpSeq "Helpers.to_list") t
+    else match tt with (TyList _, TySeq _) then
+      app_ (intrinsicOpSeq "Helpers.of_list") t
+    else match tt
+    with (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22})
+    then
+      let n = nameSym "x" in
+      let arg = recur (nvar_ n) ty21 ty11 in
+      let body = recur (app_ t arg) ty12 ty22 in
+      nulam_ n body
+    else error "Cannot marshal data"
   in
-  match r with {cost = cost} then cost else (negi 1)
-with 3
+
+  -- TODO(oerikss, 2021-05-07) We wrap external constants in a lambdas in order
+  -- for the Obj warpping to work correctly. Ideally, this should not be
+  -- necessary.
+  match ty1 with TyArrow _ then
+    recur t ty1 ty2
+  else
+    let n = nameSym "x" in
+    app_ (nulam_ n (recur t ty1 ty2)) unit_
+
+-- let x =
+-- use OCamlPrettyPrint in
+-- printLn "";
+-- printLn (expr2str
+-- (
+--   externalMarshal
+--     (var_ "f")
+--     (tylist_ tyint_)
+--     (tyseq_ tyint_)
+-- )
+-- )
+
+-- let x =
+-- use OCamlPrettyPrint in
+-- printLn "";
+-- printLn (expr2str
+-- (
+--   externalMarshal
+--     (var_ "f")
+--     (tyarrow_ (tyint_) (tylist_ tyint_))
+--     (tyarrow_ (tyint_) (tyseq_ tyint_))
+-- )
+-- )
+
+
+-- let x =
+-- use OCamlPrettyPrint in
+-- printLn "";
+-- printLn (expr2str
+-- (
+--   externalMarshal
+--     (var_ "f")
+--     (tyarrow_ (tylist_ tyint_) (tylist_ tyint_))
+--     (tyarrow_ (tyseq_ tyint_) (tyseq_ tyint_))
+-- )
+-- )
+
+-- let x =
+-- use OCamlPrettyPrint in
+-- printLn "";
+-- printLn (expr2str
+-- (
+--   externalMarshal
+--     (var_ "f")
+--     (tyarrows_ [tylist_ tyint_, tylist_ tyint_, tylist_ tyint_])
+--     (tyarrows_ [tyseq_ tyint_, tyseq_ tyint_, tyseq_ tyint_])
+-- )
+-- )
+
+-- let x =
+-- use OCamlPrettyPrint in
+-- printLn "";
+-- printLn (expr2str
+-- (
+--   externalMarshal
+--     (var_ "f")
+--     (tyarrow_ (tyarrow_ (tylist_ tyint_) (tylist_ tyint_)) tyint_)
+--     (tyarrow_ (tyarrow_ (tyseq_ tyint_) (tyseq_ tyint_)) tyint_)
+-- )
+-- )
+
+-- type ExternalNameMap = Map Name ExternalImpl
+
+-- lang OCamlGenerateExternal
+--   sem buildExternalNameMap (extMap : ExternalMap) (extNameMap : ExternalNameMap) =
+--   -- Intentionally left blank
+
+--   sem generateExternals (extNameMap : ExternalNameMap) =
+--   -- Intentionally left blank
+
+--   sem buildAndGenerateExternals (extMap : ExternalMap) =
+--   | t ->
+--     let extNameMap = buildExternalNameMap extMap (mapEmpty nameCmp) t in
+--     (extNameMap, generateExternals extNameMap t)
+-- end
+
+-- -- A naive implementation of external generation where we just pick the
+-- -- implementation with the least cost with respect to the type given at the
+-- -- external term definition.
+-- lang OCamlGenerateExternalNaive = OCamlGenerateExternal
+--   sem buildExternalNameMap (extMap : ExternalMap) (extNameMap : ExternalNameMap) =
+--   | TmExt {ident = ident, ty = ty, inexpr = inexpr} ->
+--     let identStr = nameGetStr ident in
+--     let impls = mapLookup identStr env.externalMap in
+--     match impls with Some (![] & impls) then
+--       let rs =
+--         map
+--           (lam impl: ExternalImpl.
+--             lexternalMarshal (oext_ impl.extIdent) ty impl.extTy)
+--           impls
+--       in
+--       let r : CostExpr =
+--         minOrElse
+--           (lam. error "impossible")
+--           (lam r1 : CostExpr. lam r2 : CostExpr.
+--             subi r1.cost r2.cost)
+--         rs
+--       in
+--       bind_ (nulet_ ident r.tm) (generate env inexpr)
+--     else
+--       error (join ["No implementation for external ", identStr])
+
+--   sem generateExternal (env : ExternalEnv) =
+--   | TmExt {ident = ident, ty = ty, inexpr = inexpr} ->
+--     let identStr = nameGetStr ident in
+--     let impls = mapLookup identStr env.externalMap in
+--     match impls with Some (![] & impls) then
+--       let rs =
+--         map
+--           (lam impl: ExternalImpl.
+--             lexternalMarshal (oext_ impl.extIdent) ty impl.extTy)
+--           impls
+--       in
+--       let r : CostExpr =
+--         minOrElse
+--           (lam. error "impossible")
+--           (lam r1 : CostExpr. lam r2 : CostExpr.
+--             subi r1.cost r2.cost)
+--         rs
+--       in
+--       bind_ (nulet_ ident r.tm) (generate env inexpr)
+--     else
+--       error (join ["No implementation for external ", identStr])
+-- end

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -1,7 +1,6 @@
 include "ocaml/external-includes.mc"
 include "ocaml/ast.mc"
 include "ocaml/intrinsics-ops.mc"
-include "ocaml/pprint.mc"
 
 lang OCamlMarshalData = OCamlTypeAst + SeqTypeAst + TensorTypeAst
 

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -5,6 +5,7 @@ include "ocaml/pprint.mc"
 
 lang OCamlMarshalData = OCamlTypeAst + SeqTypeAst + TensorTypeAst
 
+-- Computes the cost `Int` of marshaling data from `Type` to `Type`.
 let externalMarshalCost : Type -> Type -> Int =
   use OCamlMarshalData in
   recursive let recur = lam ty1. lam ty2.
@@ -39,6 +40,8 @@ utest
 with 9
 
 
+-- Marshals expression `Exp` of type `Type` to expression `Expr` of type
+-- `Type`.
 let externalMarshal : Expr -> Type -> Type -> Expr =
   use OCamlMarshalData in
   lam t. lam ty1. lam ty2.
@@ -77,9 +80,16 @@ let externalMarshal : Expr -> Type -> Type -> Expr =
 type ExternalNameMap = Map Name [ExternalImpl]
 
 lang OCamlGenerateExternal
+
+  -- Takes a map `ExternalMap` and constructs a map `ExternalNameMap` of
+  -- external implementations used in a program `Expr`.
   sem buildExternalNameMap (extMap : ExternalMap) (extNameMap : ExternalNameMap) =
   -- Intentionally left blank
 
+
+  -- Generates code given an map `ExternalNameMap` of external implementations
+  -- in a program `Expr`. The resulting program should be free of `TmExt`
+  -- terms.
   sem generateExternals (extNameMap : ExternalNameMap) =
   -- Intentionally left blank
 

--- a/stdlib/regex.mc
+++ b/stdlib/regex.mc
@@ -17,7 +17,7 @@ let prec = lam reg.
   match reg with Union _ then 1 else
   match reg with Concat _ then 1 else
   match reg with Kleene _ then 1 else
-  error "Unkown regex in prec"
+  error "Unknown regex in prec"
 
 let regEx2str = lam sym2str. lam reg.
   recursive

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -17,6 +17,7 @@ let setUnion : Set a -> Set a -> Set a = lam s1. lam s2. mapUnion s1 s2
 let setOfSeq : (a -> a -> Int) -> [a] -> Set a =
 lam cmp. lam seq.
   foldr setInsert (setEmpty cmp) seq
+let setToSeq : Set a -> [a] = lam s. mapKeys s
 
 mexpr
 
@@ -37,10 +38,15 @@ utest setSize s2 with 2 in
 utest setMem 2 s2 with true in
 utest setMem 3 s2 with true in
 
-let s3 = setUnion s1 s2 in
-utest setSize s3 with 3 in
-utest setMem 1 s3 with true in
+let s3 = setOfSeq subi (setToSeq s2) in
+utest setSize s3 with 2 in
 utest setMem 2 s3 with true in
 utest setMem 3 s3 with true in
+
+let s4 = setUnion s1 s2 in
+utest setSize s4 with 3 in
+utest setMem 1 s4 with true in
+utest setMem 2 s4 with true in
+utest setMem 3 s4 with true in
 
 ()

--- a/test/examples/external/ext-bat-zero.mc
+++ b/test/examples/external/ext-bat-zero.mc
@@ -1,0 +1,5 @@
+-- This program tests an external function from the batteries library
+
+external testBatZero : Int
+mexpr
+testBatZero

--- a/test/examples/external/ext-list-concat-map.mc
+++ b/test/examples/external/ext-list-concat-map.mc
@@ -1,3 +1,6 @@
+-- This program tests an external function with a callback and marshaling of
+-- data
+
 include "string.mc"
 
 external testListConcatMap : (a -> [b]) -> [a] -> [b]

--- a/test/examples/external/ext-list-map.mc
+++ b/test/examples/external/ext-list-map.mc
@@ -1,3 +1,5 @@
+-- This program tests an external functions which needs marshaling of data
+
 include "string.mc"
 
 external testListMap : (a -> b) -> [a] -> [b]

--- a/test/examples/external/ext-non-existant-lib.mc
+++ b/test/examples/external/ext-non-existant-lib.mc
@@ -1,2 +1,2 @@
--- This program tests removal of unused externals defined in external library
+-- This program tests removal of unused externals which defines a library
 external testNonExistant : Int

--- a/test/examples/external/ext-non-existant-lib.mc
+++ b/test/examples/external/ext-non-existant-lib.mc
@@ -1,0 +1,1 @@
+external testNonExistant : Int

--- a/test/examples/external/ext-non-existant-lib.mc
+++ b/test/examples/external/ext-non-existant-lib.mc
@@ -1,1 +1,2 @@
+-- This program tests removal of unused externals defined in external library
 external testNonExistant : Int

--- a/test/examples/external/ext-not-fully-applied-parse-error.mc
+++ b/test/examples/external/ext-not-fully-applied-parse-error.mc
@@ -1,3 +1,5 @@
+-- This program gives a parse error since the external is partially applied
+
 mexpr
 external addi : Int -> Int -> Int in
-addi 1 
+addi 1

--- a/test/examples/external/ext-parse.mc
+++ b/test/examples/external/ext-parse.mc
@@ -1,3 +1,5 @@
+-- This program will parse but note compile
+
 mexpr
 external addi : Int -> Int -> Int in
 addi 1 2

--- a/test/examples/external/ext-removal.mc
+++ b/test/examples/external/ext-removal.mc
@@ -1,0 +1,35 @@
+-- This program should parse to the following
+--
+-- external foo! : (Float) -> ((Float) -> (Float))
+-- in
+-- external boo! : Int
+-- in
+-- let c =
+--   foo
+--     1.0e-0
+--     2.0e+0
+-- in
+-- let d =
+--   boo
+-- in
+-- {}
+
+
+external foo! : Float -> Float -> Float
+
+external boo! : Int
+
+external boo2! : Int
+
+external bar : Int
+
+
+let a = foo
+
+let b = foo 1.0
+
+let c = foo 1.0 2.0
+
+let d = boo
+
+let e = bar

--- a/test/examples/external/ext-shadow-parse.mc
+++ b/test/examples/external/ext-shadow-parse.mc
@@ -1,3 +1,5 @@
+-- This program tests shadowing of externals, it will parse but note compile
+
 mexpr
 external addi : Int -> Int -> Int in
 let addi = lam x. lam y. x in

--- a/test/examples/external/ext-side-effect.mc
+++ b/test/examples/external/ext-side-effect.mc
@@ -1,1 +1,6 @@
+-- This program tests removal of externals with side-effects.
+--
+-- Extected output:
+-- {}
+
 external print ! : String -> ()

--- a/test/examples/external/ext-unused-side-effect.mc
+++ b/test/examples/external/ext-unused-side-effect.mc
@@ -1,0 +1,1 @@
+external ext ! : ()

--- a/test/examples/external/ext-unused-side-effect.mc
+++ b/test/examples/external/ext-unused-side-effect.mc
@@ -1,1 +1,6 @@
+-- This program tests removal of externals with side-effects.
+--
+-- Extected output:
+-- {}
+
 external ext ! : ()

--- a/test/examples/external/ext-unused.mc
+++ b/test/examples/external/ext-unused.mc
@@ -1,0 +1,1 @@
+external ext : ()

--- a/test/examples/external/ext-unused.mc
+++ b/test/examples/external/ext-unused.mc
@@ -1,1 +1,6 @@
+-- This program tests removal of externals without side-effects.
+--
+-- Extected output:
+-- {}
+
 external ext : ()

--- a/test/examples/external/multiple-ext-parse-error.mc
+++ b/test/examples/external/multiple-ext-parse-error.mc
@@ -1,3 +1,5 @@
+-- This program gives a parse error since an external is defined multiple times.
+
 mexpr
 external addi : Int -> Int -> Int in
 external addi : Int -> Int -> Int in

--- a/test/examples/external/top-ext-parse.mc
+++ b/test/examples/external/top-ext-parse.mc
@@ -1,1 +1,0 @@
-external addi : Int -> Int -> Int


### PR DESCRIPTION
In this PR:
- Add library definitions to external definitions.
- Collect used libraries and generate appropriate dune file when compiling to OCaml.
- Simplify data marshaling and separate data marshaling and the cost of data marshaling.
- Move external code generation to `ocaml/external.mc`
- Add some test programs using externals.
- Add `setToSeq` function.