### PR TITLE
Solve type application bug

### DIFF
--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -500,9 +500,7 @@ lang AppTypeTypeLift = TypeLift + AppTypeAst
   sem typeLiftType (env : TypeLiftEnv) =
   | TyApp t ->
     match typeLiftType env t.lhs with (env, lhs) then
-      match typeLiftType env t.rhs with (env, rhs) then
-        (env, TyApp {{t with lhs = lhs} with rhs = rhs})
-      else never
+      (env, lhs)
     else never
 end
 


### PR DESCRIPTION
This PR includes a fix for a bug that caused compilation of `stdlib/digraph.mc` to fail when **not** using the `--test` flag.