### PR TITLE
Fix sfold and obj repr bug

### DIFF
--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -15,5 +15,10 @@ let mathExtMap =
     ]),
     ("cos", [
       { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+    ]),
+    ("externalAtan2", [
+      { ident = "Float.atan2",
+        ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_],
+        libraries = [] }
     ])
   ]

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -4,16 +4,16 @@ let mathExtMap =
   use OCamlTypeAst in
   mapFromList cmpString
   [
-    ("exp", [
+    ("externalExp", [
       { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
     ]),
-    ("atan", [
+    ("externalAtan", [
       { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
     ]),
-    ("sin", [
+    ("externalSin", [
       { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
     ]),
-    ("cos", [
+    ("externalCos", [
       { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
     ]),
     ("externalAtan2", [

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -18,19 +18,23 @@ utest maxf 0. 0. with 0. using eqf
 utest maxf 1. 0. with 1. using eqf
 utest maxf 0. 1. with 1. using eqf
 
-external exp : Float -> Float
+external externalExp : Float -> Float
+let exp = lam x. externalExp x
 utest exp 0. with 1. using eqf
 
-external atan : Float -> Float
+external externalAtan : Float -> Float
+let atan = lam x. externalAtan x
 utest atan 0. with 0. using eqf
 
 let pi = mulf 4. (atan 1.)
 
-external sin : Float -> Float
+external externalSin : Float -> Float
+let sin = lam x. externalSin x
 utest sin (divf pi 2.) with 1. using eqf
 utest sin 0. with 0. using eqf
 
-external cos : Float -> Float
+external externalCos : Float -> Float
+let cos = lam x. externalCos x
 utest cos (divf pi 2.) with 0. using _eqf
 utest cos 0. with 1. using eqf
 

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -36,3 +36,7 @@ utest cos 0. with 1. using eqf
 
 utest addf (mulf (sin 1.) (sin 1.)) (mulf (cos 1.) (cos 1.)) with 1.
 using eqf
+
+external externalAtan2 : Float -> Float -> Float
+let atan2 = lam x. lam y. externalAtan2 x y
+utest atan2 0. 1. with 0. using eqf

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -10,8 +10,7 @@ lang OCamlTypeDeclAst
     OTmVariantTypeDecl {t with inexpr = f t.inexpr}
 
   sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
-  | OTmVariantTypeDecl t ->
-    sfold_Expr_Expr f acc t.inexpr
+  | OTmVariantTypeDecl t -> f acc t.inexpr
 end
 
 lang OCamlRecord

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -941,12 +941,12 @@ lang OCamlObjWrap = MExprAst + OCamlAst
 
   sem objWrapRec (isApp : Bool) =
   | (TmConst {val = (CInt _) | (CFloat _) | (CChar _) | (CBool _)}) & t ->
-    _objRepr t
+    _objMagic t
   | TmConst {val = c} -> intrinsic2name c
   | TmApp t ->
     if _isIntrinsicApp (TmApp t) then
       TmApp {{t with lhs = objWrapRec true t.lhs}
-                with rhs = _objRepr (objWrapRec false t.rhs)}
+                with rhs = _objMagic (objWrapRec false t.rhs)}
     else
       TmApp {{t with lhs =
                   if isApp then
@@ -956,7 +956,7 @@ lang OCamlObjWrap = MExprAst + OCamlAst
                 with rhs = objWrapRec false t.rhs}
   | TmRecord t ->
     if mapIsEmpty t.bindings then
-      _objRepr (TmRecord t)
+      _objMagic (TmRecord t)
     else
       let bindings = mapMap (lam expr. objWrapRec false expr) t.bindings in
       TmRecord {t with bindings = bindings}
@@ -967,15 +967,15 @@ lang OCamlObjWrap = MExprAst + OCamlAst
       then true else false
     ) tms in
     if isPrimitiveArray then
-      _objRepr t
+      _objMagic t
     else
-      _objRepr (smap_Expr_Expr (objWrapRec false) t)
-  | (OTmConApp _) & t -> _objRepr (smap_Expr_Expr (objWrapRec false) t)
+      _objMagic (smap_Expr_Expr (objWrapRec false) t)
+  | (OTmConApp _) & t -> _objMagic (smap_Expr_Expr (objWrapRec false) t)
   | OTmMatch t ->
     _objObj
     (OTmMatch {{t with target = _objMagic (objWrapRec false t.target)}
                   with arms = map (lam p : (Pat, Expr).
-                                    (p.0, _objRepr (objWrapRec false p.1)))
+                                    (p.0, _objMagic (objWrapRec false p.1)))
                                   t.arms})
   | t -> smap_Expr_Expr (objWrapRec false) t
 


### PR DESCRIPTION
This PR fixes a bug in the `sfold_Expr_Expr` implementation of `OTmVariantTypeDecl`. Moreover, `Obj.repr` are replaced by `Obj.magic` in when obj wrapping to fix a bug related to applying external functions to literals.

Additionally, external math functions are wrapped in lambdas to allow partial application. 