### PR TITLE
Partial marshaling of tensors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,13 @@ old:
 	@./make old
 
 test-all:\
+	test-boot-compile\
   test-compile\
   test-run\
   test-boot
+
+test-boot-compile:
+	@$(MAKE) -s -f test-boot-compile.mk all
 
 test-compile: build/mi
 	@$(MAKE) -s -f test-compile.mk all
@@ -85,4 +89,3 @@ test-boot-py: build/mi
 
 test-boot-ocaml: build/mi
 	@$(MAKE) -s -f test-boot.mk ocaml
-

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ boot:
 build/mi:
 	@./make
 
-test:
-	@./make test
+test: test-boot-base
 
 install:
 	@./make install

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ old:
 	@./make old
 
 test-all:\
-	test-boot-compile\
+  test-boot-compile\
   test-compile\
   test-run\
   test-boot

--- a/README.md
+++ b/README.md
@@ -1350,7 +1350,7 @@ field `libraries` defines a sequence of libraries this external depends on.
 Programs defining externals should be placed under [./stdlib/ext](./stdlib/ext)
 and follow the above naming convention to avoid failing test for the
 interpreter. Additionally, the implementation map, in this case `batteries`,
-should be added to `globalExternalMap` in
+should be added to `globalExternalImplsMap` in
 [./stdlib/ocaml/external-includes.mc](./stdlib/ocaml/external-includes.mc).
 
 Morever, depending on the type of the external you might have to extend the

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -59,12 +59,14 @@ module T : sig
     | CArrayFloat of (float, Tensor.CArray.float_elt) Tensor.CArray.t
     | Dense of 'a Tensor.Dense.t
 
-  type 'a u =
-    | TCArrayInt : (int, Tensor.CArray.int_elt) Tensor.CArray.t -> int u
+  type ('a, 'b) u =
+    | TCArrayInt :
+        (int, Tensor.CArray.int_elt) Tensor.CArray.t
+        -> (int, Tensor.CArray.int_elt) u
     | TCArrayFloat :
         (float, Tensor.CArray.float_elt) Tensor.CArray.t
-        -> float u
-    | TDense : 'a Tensor.Dense.t -> 'a u
+        -> (float, Tensor.CArray.float_elt) u
+    | TDense : 'a Tensor.Dense.t -> ('a, 'b) u
 
   val carray_int : (int, Tensor.CArray.int_elt) Tensor.CArray.t -> 'a t
 
@@ -72,29 +74,31 @@ module T : sig
 
   val dense : 'a Tensor.Dense.t -> 'a t
 
-  val create_carray_int : int Mseq.t -> (int Mseq.t -> int) -> int u
+  val create_carray_int :
+    int Mseq.t -> (int Mseq.t -> int) -> (int, Tensor.CArray.int_elt) u
 
-  val create_carray_float : int Mseq.t -> (int Mseq.t -> float) -> float u
+  val create_carray_float :
+    int Mseq.t -> (int Mseq.t -> float) -> (float, Tensor.CArray.float_elt) u
 
-  val create_dense : int Mseq.t -> (int Mseq.t -> 'a) -> 'a u
+  val create_dense : int Mseq.t -> (int Mseq.t -> 'a) -> ('a, 'a) u
 
-  val get_exn : 'a u -> int Mseq.t -> 'a
+  val get_exn : ('a, 'b) u -> int Mseq.t -> 'a
 
-  val set_exn : 'a u -> int Mseq.t -> 'a -> unit
+  val set_exn : ('a, 'b) u -> int Mseq.t -> 'a -> unit
 
-  val rank : 'a u -> int
+  val rank : ('a, 'b) u -> int
 
-  val shape : 'a u -> int Mseq.t
+  val shape : ('a, 'b) u -> int Mseq.t
 
-  val copy_exn : 'a u -> 'a u -> unit
+  val copy_exn : ('a, 'b) u -> ('a, 'b) u -> unit
 
-  val reshape_exn : 'a u -> int Mseq.t -> 'a u
+  val reshape_exn : ('a, 'b) u -> int Mseq.t -> ('a, 'b) u
 
-  val slice_exn : 'a u -> int Mseq.t -> 'a u
+  val slice_exn : ('a, 'b) u -> int Mseq.t -> ('a, 'b) u
 
-  val sub_exn : 'a u -> int -> int -> 'a u
+  val sub_exn : ('a, 'b) u -> int -> int -> ('a, 'b) u
 
-  val iteri : (int -> 'a u -> unit) -> 'a u -> unit
+  val iteri : (int -> ('a, 'b) u -> unit) -> ('a, 'b) u -> unit
 
   module CArray : sig
     val create_int :
@@ -152,6 +156,11 @@ module T : sig
     val sub_exn : 'a Tensor.Dense.t -> int -> int -> 'a Tensor.Dense.t
 
     val iteri : (int -> 'a Tensor.Dense.t -> unit) -> 'a Tensor.Dense.t -> unit
+  end
+
+  module Helpers : sig
+    val to_genarray_clayout :
+      ('a, 'b) u -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
   end
 end
 

--- a/src/boot/lib/tensor.mli
+++ b/src/boot/lib/tensor.mli
@@ -1,21 +1,13 @@
 module CArray : sig
-  type ('a, 'b) t
+  type ('a, 'b) t = ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
 
-  type float_elt
+  type float_elt = Bigarray.float64_elt
 
-  type int_elt
+  type int_elt = Bigarray.int_elt
 
-  type ('a, 'b) kind =
-    | CArrayFloat : (float, float_elt) kind
-    | Int : (int, int_elt) kind
+  val create_int : int array -> (int array -> int) -> (int, int_elt) t
 
-  val kind : ('a, 'b) t -> ('a, 'b) kind
-
-  val float : (float, float_elt) kind
-
-  val int : (int, int_elt) kind
-
-  val create : ('a, 'b) kind -> int array -> (int array -> 'a) -> ('a, 'b) t
+  val create_float : int array -> (int array -> float) -> (float, float_elt) t
 
   val get_exn : ('a, 'b) t -> int array -> 'a
 
@@ -34,8 +26,6 @@ module CArray : sig
   val sub_exn : ('a, 'b) t -> int -> int -> ('a, 'b) t
 
   val iteri : (int -> ('a, 'b) t -> unit) -> ('a, 'b) t -> unit
-
-  val of_array : ('a, 'b) kind -> 'a array -> ('a, 'b) t
 
   val data_to_array : ('a, 'b) t -> 'a array
 end

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -111,6 +111,9 @@ let compile = lam files. lam options : Options. lam args.
       let ast = symbolizeExpr symEnv ast in
       let ast = typeAnnot ast in
 
+      -- If option --debug-type-annot, then pretty print the AST
+      (if options.debugTypeAnnot then printLn (pprintMcore ast) else ());
+
       -- Translate the MExpr AST into an OCaml AST and Compile
       match typeLift ast with (env, ast) then
         match generateTypeDecl env ast with (env, ast) then

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -118,8 +118,9 @@ let compile = lam files. lam options : Options. lam args.
       match typeLift ast with (env, ast) then
         match generateTypeDecl env ast with (env, ast) then
           let env : GenerateEnv = env in
-          let extEnv : ExternalGenerateEnv =
-            chooseExternalImpls (externalInitialEnv env.aliases) ast
+          let extEnv : ExternalEnv =
+            let env = externalInitialEnv env.aliases env.constrs in
+            chooseExternalImpls env ast
           in
           let ast = generateExternals extEnv ast in
           let ast = generate env ast in

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -120,7 +120,7 @@ let compile = lam files. lam options : Options. lam args.
           let env : GenerateEnv = env in
           let extEnv : ExternalEnv =
             let env = externalInitialEnv env.aliases env.constrs in
-            chooseExternalImpls env ast
+            chooseExternalImpls globalExternalImplsMap env ast
           in
           let ast = generateExternals extEnv ast in
           let ast = generate env ast in

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -6,6 +6,7 @@ include "string.mc"
 type Options = {
   debugParse : Bool,
   debugGenerate : Bool,
+  debugTypeAnnot : Bool,
   exitBefore : Bool,
   runTests : Bool,
   disableOptimizations : Bool
@@ -15,6 +16,7 @@ type Options = {
 let options = {
   debugParse = false,
   debugGenerate = false,
+  debugTypeAnnot = false,
   exitBefore = false,
   runTests = false,
   disableOptimizations = false
@@ -24,6 +26,7 @@ let options = {
 let optionsMap = [
 ("--debug-parse", lam o : Options. {o with debugParse = true}),
 ("--debug-generate", lam o : Options. {o with debugGenerate = true}),
+("--debug-type-annot", lam o : Options. {o with debugTypeAnnot = true}),
 ("--exit-before", lam o : Options. {o with exitBefore = true}),
 ("--test", lam o : Options. {o with runTests = true}),
 ("--disable-optimizations", lam o : Options. {o with disableOptimizations = true})

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -990,10 +990,10 @@ utest testCompile typedefs with strJoin "\n" [
 ] using eqString in
 
 let leaf_ = lam v.
-  conapp_ "Leaf" (record_ [("v", int_ v)]) in
+  conapp_ "Leaf" (urecord_ [("v", int_ v)]) in
 
 let node_ = lam v. lam left. lam right.
-  conapp_ "Node" (record_ [("v", int_ v), ("l", left), ("r", right)]) in
+  conapp_ "Node" (urecord_ [("v", int_ v), ("l", left), ("r", right)]) in
 
 let trees = bindall_ [
 

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -1,3 +1,4 @@
+include "map.mc"
 include "ocaml/ast.mc"
 
 let mathExtMap =

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -316,7 +316,7 @@ utest _anf apps with
 using eqExpr in
 
 let record =
-  record_ [
+  urecord_ [
     ("a",(app_ (int_ 1) (app_ (int_ 2) (int_ 3)))),
     ("b", (int_ 4)),
     ("c", (app_ (int_ 5) (int_ 6)))
@@ -347,7 +347,7 @@ utest _anf factorial with
         ),
         var_ "t1"
       ])),
-    ulet_ "t5" unit_,
+    ulet_ "t5" uunit_,
     var_ "t5"
   ]
 using eqExpr in

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -235,13 +235,16 @@ let bindall_ = use MExprAst in
   lam exprs.
   foldr1 bind_ exprs
 
-let unit_ = use MExprAst in
+let uunit_ = use MExprAst in
   TmRecord {bindings = mapEmpty cmpSID, ty = tyunknown_, info = NoInfo ()}
+
+let unit_ = use MExprAst in
+  TmRecord {bindings = mapEmpty cmpSID, ty = tyunit_, info = NoInfo ()}
 
 let nlet_ = use MExprAst in
   lam n. lam ty. lam body.
   TmLet {ident = n, tyBody = ty, body = body,
-  inexpr = unit_, ty = tyunknown_, info = NoInfo ()}
+  inexpr = uunit_, ty = tyunknown_, info = NoInfo ()}
 
 let let_ = use MExprAst in
   lam s. lam ty. lam body.
@@ -257,7 +260,7 @@ let ulet_ = use MExprAst in
 
 let next_ = use MExprAst in
   lam n. lam e. lam ty.
-  TmExt {ident = n, effect = e, ty = ty, inexpr = unit_, info = NoInfo ()}
+  TmExt {ident = n, effect = e, ty = ty, inexpr = uunit_, info = NoInfo ()}
 
 let ext_ = use MExprAst in
   lam s. lam e. lam ty.
@@ -265,7 +268,7 @@ let ext_ = use MExprAst in
 
 let ntype_ = use MExprAst in
   lam n. lam ty.
-  TmType {ident = n, tyIdent = ty, ty = tyunknown_, inexpr = unit_, info = NoInfo ()}
+  TmType {ident = n, tyIdent = ty, ty = tyunknown_, inexpr = uunit_, info = NoInfo ()}
 
 let type_ = use MExprAst in
   lam s. lam ty.
@@ -282,7 +285,7 @@ let nreclets_ = use MExprAst in
     }
   in
   TmRecLets {bindings = map bindingMapFunc bs,
-             inexpr = unit_, ty = tyunknown_, info = NoInfo ()}
+             inexpr = uunit_, ty = tyunknown_, info = NoInfo ()}
 
 let reclets_ = use MExprAst in
   lam bs.
@@ -339,7 +342,7 @@ let ureclets_add = use MExprAst in
 let ncondef_ = use MExprAst in
   lam n. lam ty.
   TmConDef {ident = n, tyIdent = ty, ty = tyunknown_,
-            inexpr = unit_, info = NoInfo ()}
+            inexpr = uunit_, info = NoInfo ()}
 
 let condef_ = use MExprAst in
   lam s. lam ty.
@@ -419,17 +422,25 @@ let seq_ = use MExprAst in
 
 let record_ = use MExprAst in
   lam bindings.
+  lam ty.
   let bindingMapFunc = lam b : (String, Expr). (stringToSid b.0, b.1) in
   TmRecord {
     bindings = mapFromList cmpSID (map bindingMapFunc bindings),
-    ty = tyunknown_,
+    ty = ty,
     info = NoInfo ()
   }
 
-let tuple_ = use MExprAst in
-  lam tms.
-  record_ (mapi (lam i. lam t. (int2string i,t)) tms)
+let urecord_ = use MExprAst in
+  lam bindings. record_ bindings tyunknown_
 
+let tuple_ = use MExprAst in
+  lam tms. lam ty.
+  record_ (mapi (lam i. lam t. (int2string i,t)) tms) ty
+
+let utuple_ = use MExprAst in
+  lam tms. tuple_ tms tyunknown_
+
+let urecord_empty = uunit_
 let record_empty = unit_
 
 let record_add = use MExprAst in

--- a/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -96,11 +96,11 @@ let tmSeq = seq_ [tmApp11, tmConst2, tmConst3] in
 utest smap_Expr_Expr map2varX tmSeq with seq_ [tmVarX, tmVarX, tmVarX] using eqExpr in
 utest sfold_Expr_Expr fold2seq [] tmSeq with [tmConst3, tmConst2, tmApp11] using eqSeq eqExpr in
 
-let mkTmRecordXY = lam x. lam y. record_ [("x", x), ("y", y)] in
+let mkTmRecordXY = lam x. lam y. urecord_ [("x", x), ("y", y)] in
 let tmRecordI = mkTmRecordXY tmApp11 tmConst3 in
 
 utest smap_Expr_Expr map2varX tmRecordI
-with record_ [("x", tmVarX), ("y", tmVarX)] using eqExpr in
+with urecord_ [("x", tmVarX), ("y", tmVarX)] using eqExpr in
 
 -- TODO(vipa, 2020-09-24): the best test here would be one that collects all the children to see that we see all of them. The issue is that we shouldn't depend on the enumeration order, so we would like to collect the (multi-)set of children, not a sequence.
 -- We would thus like something like `sfold_Expr_Expr (lam acc. lam c. eqsetInsert c acc) emptySet tmRecordI with setFromList [tmConst3, tmApp11] using eqsetEqual`

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -380,7 +380,7 @@ utest lsideClosed s with rside s in
 let s = "{a = 5}" in
 utest lsideClosed s with rside s in
 let s = "{bar = \"Hello\", foo = 123}" in
-let t = record_ [("bar", str_ "Hello"), ("foo", int_ 123)] in
+let t = urecord_ [("bar", str_ "Hello"), ("foo", int_ 123)] in
 utest parseMExprString [] s with t using eqExpr in
 utest l_infoClosed " {} " with r_info 1 1 1 3 in
 utest l_infoClosed " {foo = 123} " with r_info 1 1 1 12 in
@@ -389,7 +389,7 @@ utest l_infoClosed " {foo = 123} " with r_info 1 1 1 12 in
 let s = "{a with foo = 5}" in
 utest lside ["a"] s with rside s in
 let s = "{{bar='a', foo=7} with bar = 'b'}" in
-let t = recordupdate_ (record_ [("bar", char_ 'a'), ("foo", int_ 7)]) "bar" (char_ 'b') in
+let t = recordupdate_ (urecord_ [("bar", char_ 'a'), ("foo", int_ 7)]) "bar" (char_ 'b') in
 utest parseMExprString [] s with t using eqExpr in
 utest l_info ["foo"] " {foo with a = 18 } " with r_info 1 1 1 19 in
 

--- a/stdlib/mexpr/decision-points.mc
+++ b/stdlib/mexpr/decision-points.mc
@@ -680,7 +680,7 @@ let constant = {
 -- let foo = lam x. x in ()
 let identity = {
   ast = ulet_ "foo" (ulam_ "x" (var_ "x")),
-  expected = unit_,
+  expected = uunit_,
   vs = ["top", "foo"],
   calls = []
 } in
@@ -690,7 +690,7 @@ let identity = {
 let funCall = {
   ast = bind_ (ulet_ "foo" (ulam_ "x" (var_ "x")))
               (ulet_ "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))),
-  expected = unit_,
+  expected = uunit_,
   vs = ["top", "foo", "bar"],
   calls = [("bar", "foo")]
 } in
@@ -737,7 +737,7 @@ let innerFun = {
             addi_ (app_ (var_ "bar")
                         (var_ "b"))
                   (var_ "a")))))),
-  expected = unit_,
+  expected = uunit_,
   vs = ["top", "foo", "bar"],
   calls = [("foo", "bar")]
 } in

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -724,11 +724,11 @@ utest a1 with a2 using eqExpr in
 utest eqExpr a1 lam1 with false in
 
 -- Records
-let r1 = record_ [("a",lam1), ("b",a1), ("c",a2)] in
-let r2 = record_ [("b",a1), ("a",lam2), ("c",a2)] in
-let r3e = record_ [("a",lam1), ("b",a1), ("d",a2)] in
-let r4e = record_ [("a",lam1), ("b",a1), ("c",lam2)] in
-let r5e = record_ [("a",lam1), ("b",a1), ("c",a2), ("d",lam2)] in
+let r1 = urecord_ [("a",lam1), ("b",a1), ("c",a2)] in
+let r2 = urecord_ [("b",a1), ("a",lam2), ("c",a2)] in
+let r3e = urecord_ [("a",lam1), ("b",a1), ("d",a2)] in
+let r4e = urecord_ [("a",lam1), ("b",a1), ("c",lam2)] in
+let r5e = urecord_ [("a",lam1), ("b",a1), ("c",a2), ("d",lam2)] in
 utest r1 with r2 using eqExpr in
 utest eqExpr r1 r3e with false in
 utest eqExpr r1 r4e with false in

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -794,13 +794,13 @@
 -- -- TEMPORARY: Debug print to check why include order messes with the MLang
 -- --            uses, remove once fixed.
 -- --let _ = print "\n" in
--- --let _ = dprint (let_ "foo" (None ()) unit_) in
+-- --let _ = dprint (let_ "foo" (None ()) uunit_) in
 -- --let _ = print "\n\n" in
 -- --let _ = use MExprLLandPPandEval in
 -- --  dprint (TmLet {ident = "foo",
 -- --                 tpe = None (),
--- --                 body = unit_,
--- --                 inexpr = unit_})
+-- --                 body = uunit_,
+-- --                 inexpr = uunit_})
 -- --in
 -- --let _ = print "\n" in
 --
@@ -905,7 +905,7 @@
 --           )
 --         ),
 --         appf1_ (var_ "bar") (app_ (confun_ "MyCon")
---                                   (unit_))
+--                                   (uunit_))
 --       ]
 --     ),
 --     var_ "foo"
@@ -992,7 +992,7 @@
 --           )
 --         ),
 --         appf1_ (var_ "bar") (app_ (confun_ "MyCon")
---                                   (unit_))
+--                                   (uunit_))
 --       ]
 --     ),
 --     var_ "foo"

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1212,7 +1212,7 @@ let func_recget =
     ulet_ "recget" (
         record_add "i" (int_ 5) (
         record_add "s" (str_ "hel\nlo!")
-        record_empty))
+        urecord_empty))
 in
 
 -- let recconcs = lam rec. lam s. {rec with s = concat rec.s s} in

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -538,7 +538,7 @@ use TestLang in
 
 let base = (ulam_ "x" (ulam_ "y" (app_ (var_ "x") (var_ "y")))) in
 
-let rec = record_ [("k1", base), ("k2", (int_ 1)), ("k3", (int_ 2))] in
+let rec = urecord_ [("k1", base), ("k2", (int_ 1)), ("k3", (int_ 2))] in
 
 let letin = bind_ (ulet_ "x" rec) (app_ (var_ "x") base) in
 
@@ -556,25 +556,25 @@ let const = int_ 1 in
 
 let data = bind_ (ucondef_ "Test") (conapp_ "Test" base) in
 
-let varpat = match_ unit_ (pvar_ "x") (var_ "x") base in
+let varpat = match_ uunit_ (pvar_ "x") (var_ "x") base in
 
 let recpat =
   match_ base
     (prec_ [("k1", (pvar_ "x")), ("k2", pvarw_), ("k3", (pvar_ "x"))])
-    (var_ "x") unit_ in
+    (var_ "x") uunit_ in
 
 let datapat =
   bind_ (ucondef_ "Test")
-    (match_ unit_ (pcon_ "Test" (pvar_ "x")) (var_ "x") unit_) in
+    (match_ uunit_ (pcon_ "Test" (pvar_ "x")) (var_ "x") uunit_) in
 
 let litpat =
-  match_ unit_ (pint_ 1)
-    (match_ unit_ (pchar_ 'c')
-       (match_ unit_ (ptrue_)
+  match_ uunit_ (pint_ 1)
+    (match_ uunit_ (pchar_ 'c')
+       (match_ uunit_ (ptrue_)
             base
-          unit_)
-       unit_)
-    unit_ in
+          uunit_)
+       uunit_)
+    uunit_ in
 
 let ut = utest_ base base base in
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -637,11 +637,11 @@ utest ty (typeAnnot letAscription) with tyint_ using eqTypeEmptyEnv in
 
 let recLets = typeAnnot (bindall_ [
   nreclets_ [
-    (x, tyarrow_ tyunit_ tyint_, nlam_ n tyunit_ (app_ (nvar_ y) unit_)),
-    (y, tyunknown_, nlam_ n tyunit_ (app_ (nvar_ x) unit_)),
-    (z, tyunknown_, nlam_ n tyunit_ (addi_ (app_ (nvar_ y) unit_) (int_ 1)))
+    (x, tyarrow_ tyunit_ tyint_, nlam_ n tyunit_ (app_ (nvar_ y) uunit_)),
+    (y, tyunknown_, nlam_ n tyunit_ (app_ (nvar_ x) uunit_)),
+    (z, tyunknown_, nlam_ n tyunit_ (addi_ (app_ (nvar_ y) uunit_) (int_ 1)))
   ],
-  unit_
+  uunit_
 ]) in
 utest ty recLets with tyunit_ using eqTypeEmptyEnv in
 
@@ -676,14 +676,14 @@ utest ty intMatrix with tyseq_ (tyseq_ tyint_) using eqTypeEmptyEnv in
 let unknownSeq = typeAnnot (seq_ [nvar_ x, nvar_ y]) in
 utest ty unknownSeq with tyseq_ tyunknown_ using eqTypeEmptyEnv in
 
-let emptyRecord = typeAnnot unit_ in
+let emptyRecord = typeAnnot uunit_ in
 utest ty emptyRecord with tyunit_ using eqTypeEmptyEnv in
 
-let record = typeAnnot (record_ [
-  ("a", int_ 0), ("b", float_ 2.718), ("c", record_ []),
-  ("d", record_ [
+let record = typeAnnot (urecord_ [
+  ("a", int_ 0), ("b", float_ 2.718), ("c", urecord_ []),
+  ("d", urecord_ [
     ("e", seq_ [int_ 1, int_ 2]),
-    ("f", record_ [
+    ("f", urecord_ [
       ("x", nvar_ x), ("y", nvar_ y), ("z", nvar_ z)
     ])
   ])
@@ -701,7 +701,7 @@ utest ty record with expectedRecordType using eqTypeEmptyEnv in
 let recordUpdate = typeAnnot (recordupdate_ record "x" (int_ 1)) in
 utest ty recordUpdate with expectedRecordType using eqTypeEmptyEnv in
 
-let typeDecl = bind_ (ntype_ n tyunknown_) unit_ in
+let typeDecl = bind_ (ntype_ n tyunknown_) uunit_ in
 utest ty (typeAnnot typeDecl) with tyunit_ using eqTypeEmptyEnv in
 
 let conApp = bindall_ [
@@ -760,9 +760,9 @@ let matchTree = bindall_ [
   type_ "Tree" tyunknown_,
   condef_ "Branch" (tyarrow_ (tytuple_ [tyvar_ "Tree", tyvar_ "Tree"]) (tyvar_ "Tree")),
   condef_ "Leaf" (tyarrow_ (tyseq_ tyint_) (tyvar_ "Tree")),
-  ulet_ "t" (conapp_ "Branch" (tuple_ [
+  ulet_ "t" (conapp_ "Branch" (utuple_ [
     conapp_ "Leaf" (seq_ [int_ 1, int_ 2, int_ 3]),
-    conapp_ "Branch" (tuple_ [
+    conapp_ "Branch" (utuple_ [
       conapp_ "Leaf" (seq_ [int_ 2]),
       conapp_ "Leaf" (seq_ [])])])),
   (match_ (var_ "t")

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -371,8 +371,11 @@ end
 lang ExtTypeLift = TypeLift + ExtAst
   sem typeLiftExpr (env : TypeLiftEnv) =
   | TmExt t ->
-    match typeLiftExpr env t.inexpr with (env, inexpr) then
-      (env, TmExt {t with inexpr = inexpr})
+    match typeLiftType env t.ty with (env, ty) then
+      match typeLiftExpr env t.inexpr with (env, inexpr) then
+        (env, TmExt {{t with ty = ty}
+                        with inexpr = inexpr})
+      else never
     else never
 end
 
@@ -510,7 +513,7 @@ in
 
 let unitNotLifted = typeAnnot (symbolize (bindall_ [
   ulet_ "x" (int_ 2),
-  unit_
+  uunit_
 ])) in
 (match typeLift unitNotLifted with (env, t) then
   utest env with [] using eqEnv in
@@ -539,14 +542,14 @@ let variant = typeAnnot (symbolize (bindall_ [
     ntyvar_ treeName,
     ntyvar_ treeName]) (ntyvar_ treeName)),
   ncondef_ leafName (tyarrow_ tyint_ (ntyvar_ treeName)),
-  unit_
+  uunit_
 ])) in
 (match typeLift variant with (_, t) then
-  utest t with unit_ using eqExpr in
+  utest t with uunit_ using eqExpr in
   ()
 else never);
 
-let lastTerm = nconapp_ branchName (record_ [
+let lastTerm = nconapp_ branchName (urecord_ [
   ("lhs", nconapp_ leafName (int_ 1)),
   ("rhs", nconapp_ leafName (int_ 2))
 ]) in
@@ -575,15 +578,15 @@ let variantWithRecords = typeAnnot (symbolize (bindall_ [
 else never);
 
 let nestedRecord = typeAnnot (symbolize (bindall_ [
-  ulet_ "r" (record_ [
-    ("a", record_ [
+  ulet_ "r" (urecord_ [
+    ("a", urecord_ [
       ("x", int_ 2),
       ("y", float_ 3.14),
-      ("z", unit_)
+      ("z", uunit_)
     ]),
     ("b", int_ 7)
   ]),
-  unit_
+  uunit_
 ])) in
 (match typeLift nestedRecord with (env, t) then
   let fstid = (get env 0).0 in
@@ -605,9 +608,9 @@ let nestedRecord = typeAnnot (symbolize (bindall_ [
 else never);
 
 let recordsSameFieldsDifferentTypes = typeAnnot (symbolize (bindall_ [
-  ulet_ "x" (record_ [("a", int_ 0), ("b", int_ 1)]),
-  ulet_ "y" (record_ [("a", int_ 2), ("b", true_)]),
-  unit_
+  ulet_ "x" (urecord_ [("a", int_ 0), ("b", int_ 1)]),
+  ulet_ "y" (urecord_ [("a", int_ 2), ("b", true_)]),
+  uunit_
 ])) in
 (match typeLift recordsSameFieldsDifferentTypes with (env, t) then
   let fstid = (get env 0).0 in
@@ -622,9 +625,9 @@ let recordsSameFieldsDifferentTypes = typeAnnot (symbolize (bindall_ [
 else never);
 
 let recordsSameFieldsSameTypes = typeAnnot (symbolize (bindall_ [
-  ulet_ "x" (record_ [("a", int_ 0), ("b", int_ 1)]),
-  ulet_ "y" (record_ [("a", int_ 3), ("b", int_ 6)]),
-  unit_
+  ulet_ "x" (urecord_ [("a", int_ 0), ("b", int_ 1)]),
+  ulet_ "y" (urecord_ [("a", int_ 3), ("b", int_ 6)]),
+  uunit_
 ])) in
 (match typeLift recordsSameFieldsSameTypes with (env, t) then
   let recid = (get env 0).0 in
@@ -636,7 +639,7 @@ let recordsSameFieldsSameTypes = typeAnnot (symbolize (bindall_ [
   ()
 else never);
 
-let record = typeAnnot (symbolize (record_ [
+let record = typeAnnot (symbolize (urecord_ [
   ("a", int_ 2),
   ("b", float_ 1.5)
 ])) in
@@ -650,7 +653,7 @@ let record = typeAnnot (symbolize (record_ [
 else never);
 
 let recordUpdate = typeAnnot (symbolize (bindall_ [
-  ulet_ "x" (record_ [("a", int_ 0), ("b", int_ 1)]),
+  ulet_ "x" (urecord_ [("a", int_ 0), ("b", int_ 1)]),
   recordupdate_ (var_ "x") "a" (int_ 2)
 ])) in
 let recordType = tyrecord_ [("a", tyint_), ("b", tyint_)] in
@@ -670,9 +673,9 @@ let typeAliases = typeAnnot (symbolize (bindall_ [
     ("global", tyvar_ "GlobalEnv"),
     ("local", tyvar_ "LocalEnv")
   ]),
-  ulet_ "env" (record_ [
-    ("global", seq_ [tuple_ [str_ "x", int_ 4]]),
-    ("local", seq_ [tuple_ [str_ "a", int_ 0]])
+  ulet_ "env" (urecord_ [
+    ("global", seq_ [utuple_ [str_ "x", int_ 4]]),
+    ("local", seq_ [utuple_ [str_ "a", int_ 0]])
   ]),
   var_ "env"
 ])) in

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -1,3 +1,4 @@
+include "map.mc"
 include "mexpr/ast.mc"
 
 -- Unwraps type alias `ty` from `aliases`.

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -1,0 +1,11 @@
+include "mexpr/ast.mc"
+
+-- Unwraps type alias `ty` from `aliases`.
+recursive let typeUnwrapAlias = use MExprAst in
+  lam aliases : Map Name Type. lam ty : Type.
+  match ty with TyVar {ident = ident} then
+    match mapLookup ident aliases with Some ty then
+      typeUnwrapAlias aliases ty
+    else ty
+  else ty
+end

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -405,7 +405,7 @@ let _equalRecord = use MExprAst in
     else appf2_ (var_ "all") (ulam_ "b" (var_ "b")) (seq_ equalFuncs)
   in
   lam_ "a" ty (lam_ "b" ty
-    (match_ (tuple_ [var_ "a", var_ "b"])
+    (match_ (utuple_ [var_ "a", var_ "b"])
       matchPattern
       allEqual
       never_))
@@ -434,7 +434,7 @@ let _equalVariant = lam env. lam ty. lam constrs.
       pcon_ (nameGetStr constrId) (npvar_ lhsId),
       pcon_ (nameGetStr constrId) (npvar_ rhsId)
     ] in
-    match_ (tuple_ [var_ "a", var_ "b"])
+    match_ (utuple_ [var_ "a", var_ "b"])
       constructorPattern
       (appf2_ (nvar_ equalFuncId) (nvar_ lhsId) (nvar_ rhsId))
       cont
@@ -541,7 +541,7 @@ let generateUtestFunctions =
   in
   match unzip (mapFoldWithKey f [] env.typeFunctions) with (pprints, equals) then
     if null pprints then
-      unit_
+      uunit_
     else
       bind_ (nreclets_ pprints) (nreclets_ equals)
   else never
@@ -551,7 +551,7 @@ let utestRunnerCall =
   lam eqFunc. lam l. lam r.
   appf6_
     (nvar_ (utestRunnerName ()))
-    (record_ [
+    (urecord_ [
       ("row", str_ info.row)])
     lPprintFunc
     rPprintFunc
@@ -712,22 +712,22 @@ let utestu_info_ =
           , info = default_info}
 in
 
-let intNoUsing = typeAnnot (utest_info_ (int_ 1) (int_ 0) unit_) in
+let intNoUsing = typeAnnot (utest_info_ (int_ 1) (int_ 0) uunit_) in
 -- eval {env = builtinEnv} (symbolize (utestGen intNoUsing));
-utest utestStrip intNoUsing with unit_ using eqExpr in
+utest utestStrip intNoUsing with uunit_ using eqExpr in
 
 let intWithUsing = typeAnnot (
-  utestu_info_ (int_ 1) (int_ 0) unit_ (uconst_ (CGeqi{}))) in
+  utestu_info_ (int_ 1) (int_ 0) uunit_ (uconst_ (CGeqi{}))) in
 -- eval {env = builtinEnv} (symbolize (utestGen intWithUsing));
-utest utestStrip intWithUsing with unit_ using eqExpr in
+utest utestStrip intWithUsing with uunit_ using eqExpr in
 
 let lhs = seq_ [seq_ [int_ 1, int_ 2], seq_ [int_ 3, int_ 4]] in
 let rhs = reverse_ (seq_ [
   reverse_ (seq_ [int_ 4, int_ 3]),
   reverse_ (seq_ [int_ 2, int_ 1])]) in
-let nestedSeqInt = typeAnnot (utest_info_ lhs rhs unit_) in
+let nestedSeqInt = typeAnnot (utest_info_ lhs rhs uunit_) in
 -- eval {env = builtinEnv} (symbolize (utestGen nestedSeqInt));
-utest utestStrip nestedSeqInt with unit_ using eqExpr in
+utest utestStrip nestedSeqInt with uunit_ using eqExpr in
 
 let lhs = seq_ [
   float_ 6.5, float_ 1.0, float_ 0.0, float_ 3.14
@@ -739,13 +739,13 @@ let elemEq = uconst_ (CEqf ()) in
 let seqEq =
   ulam_ "a"
     (ulam_ "b" (appf3_ (var_ "eqSeq") elemEq (var_ "a") (var_ "b"))) in
-let floatSeqWithUsing = typeAnnot (utestu_info_ lhs rhs unit_ seqEq) in
+let floatSeqWithUsing = typeAnnot (utestu_info_ lhs rhs uunit_ seqEq) in
 -- eval {env = builtinEnv} (symbolize (utestGen floatSeqWithUsing));
-utest utestStrip floatSeqWithUsing with unit_ using eqExpr in
+utest utestStrip floatSeqWithUsing with uunit_ using eqExpr in
 
-let charNoUsing = typeAnnot (utest_info_ (char_ 'a') (char_ 'A') unit_) in
+let charNoUsing = typeAnnot (utest_info_ (char_ 'a') (char_ 'A') uunit_) in
 -- eval {env = builtinEnv} (symbolize (utestGen charNoUsing));
-utest utestStrip charNoUsing with unit_ using eqExpr in
+utest utestStrip charNoUsing with uunit_ using eqExpr in
 
 let charWithUsing = typeAnnot (bindall_ [
   ulet_ "leqChar" (ulam_ "c1" (ulam_ "c2" (
@@ -768,7 +768,7 @@ let charWithUsing = typeAnnot (bindall_ [
         (eqc_
           (app_ (var_ "char2lower") (var_ "a"))
           (app_ (var_ "char2lower") (var_ "b"))))),
-  utestu_info_ (char_ 'a') (char_ 'A') unit_ (var_ "charEqIgnoreCase")
+  utestu_info_ (char_ 'a') (char_ 'A') uunit_ (var_ "charEqIgnoreCase")
 ]) in
 -- eval {env = builtinEnv} (symbolize (utestGen charWithUsing));
 
@@ -777,25 +777,25 @@ let baseRecordFields = [
   ("b", true_),
   ("c", char_ 'x'),
   ("d", seq_ [int_ 1, int_ 2, int_ 4, int_ 8]),
-  ("e", record_ [
+  ("e", urecord_ [
     ("x", int_ 1),
     ("y", int_ 0)
   ])
 ] in
-let r = record_ baseRecordFields in
-let recordNoUsing = typeAnnot (utest_info_ r r unit_) in
+let r = urecord_ baseRecordFields in
+let recordNoUsing = typeAnnot (utest_info_ r r uunit_) in
 -- eval {env = builtinEnv} (symbolize (utestGen recordNoUsing));
-utest utestStrip recordNoUsing with unit_ using eqExpr in
+utest utestStrip recordNoUsing with uunit_ using eqExpr in
 
-let lhs = record_ (cons ("k", int_ 4) baseRecordFields) in
-let rhs = record_ (cons ("k", int_ 2) baseRecordFields) in
+let lhs = urecord_ (cons ("k", int_ 4) baseRecordFields) in
+let rhs = urecord_ (cons ("k", int_ 2) baseRecordFields) in
 let recordEq =
   ulam_ "r1" (ulam_ "r2" (
     eqi_ (recordproj_ "k" (var_ "r1")) (recordproj_ "k" (var_ "r2"))
   ))
 in
-let recordWithUsing = typeAnnot (utestu_info_ lhs rhs unit_ recordEq) in
+let recordWithUsing = typeAnnot (utestu_info_ lhs rhs uunit_ recordEq) in
 -- eval {env = builtinEnv} (symbolize (utestGen recordWithUsing));
-utest utestStrip recordWithUsing with unit_ using eqExpr in
+utest utestStrip recordWithUsing with uunit_ using eqExpr in
 
 ()

--- a/stdlib/multicore/eval.mc
+++ b/stdlib/multicore/eval.mc
@@ -68,7 +68,7 @@ lang ThreadEval = ThreadAst + IntAst + UnknownTypeAst + RecordAst + AppEval
   sem delta (arg : Expr) =
   | CThreadSpawn _ ->
     let app =
-      TmApp {lhs = arg, rhs = unit_, info = NoInfo (), ty = tyunknown_}
+      TmApp {lhs = arg, rhs = uunit_, info = NoInfo (), ty = tyunknown_}
     in
     TmConst {val = CThread {thread = threadSpawn (lam. eval {env = mapEmpty nameCmp} app)}
             , info = NoInfo ()
@@ -99,24 +99,24 @@ lang ThreadEval = ThreadAst + IntAst + UnknownTypeAst + RecordAst + AppEval
     match arg with TmRecord {bindings = bindings} then
       if mapIsEmpty bindings then
         threadWait ();
-        unit_
+        uunit_
       else error err
     else error err
   | CThreadNotify _ ->
     match arg with TmConst ({val = CThreadID {id = id}} & t) then
       threadNotify id;
-      unit_
+      uunit_
     else error "Argument to threadNotify not a thread ID"
   | CThreadCriticalSection _ ->
     let app =
-      TmApp {lhs = arg, rhs = unit_, info = NoInfo (), ty = tyunknown_}
+      TmApp {lhs = arg, rhs = uunit_, info = NoInfo (), ty = tyunknown_}
     in threadCriticalSection (lam. eval {env = mapEmpty nameCmp} app)
   | CThreadCPURelax _ ->
     let err = "Argument to threadCPURelax is not unit" in
     match arg with TmRecord {bindings = bindings} then
       if mapIsEmpty bindings then
         threadCPURelax ();
-        unit_
+        uunit_
       else error err
     else error err
 end
@@ -180,9 +180,9 @@ with true_ in
 
 let waitForFlag = ureclet_ "waitForFlag" (ulam_ "flag"
   (if_ (atomicGet_ (var_ "flag"))
-       unit_
+       uunit_
        (bind_
-          (ulet_ "_" (threadCPURelax_ unit_))
+          (ulet_ "_" (threadCPURelax_ uunit_))
           (app_ (var_ "waitForFlag") (var_ "flag")))))
 in
 
@@ -193,7 +193,7 @@ utest eval (bindall_
       (ulam_ "_" (
         bindall_
           [ ulet_ "_" (atomicExchange_ (var_ "inCriticalSection") true_)
-          , ulet_ "_" (threadWait_ unit_)
+          , ulet_ "_" (threadWait_ uunit_)
           , ulet_ "_" (sleepMs_ (int_ 100))
           , ulet_ "_" (atomicExchange_ (var_ "afterWait") true_)
           , int_ 42

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -50,16 +50,27 @@ end
 lang OCamlTuple
   syn Expr =
   | OTmTuple { values : [Expr] }
+  | OTmTupleProj { tm : Expr, index : Int }
 
   syn Pat =
   | OPatTuple { pats : [Pat] }
 
   sem smap_Expr_Expr (f : Expr -> a) =
   | OTmTuple t -> OTmTuple {t with values = map f t.values}
+  | OTmTupleProj t -> OTmTupleProj { t with tm = map f t.tm }
 
   sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
   | OTmTuple t -> foldl f acc t.values
+  | OTmTupleProj t -> f acc t.tm
 end
+
+let otuple_ = use OCamlTuple in
+  lam values. OTmTuple { values = values }
+
+let ounit_ = otuple_ []
+
+let otupleproj_ = use OCamlTuple in
+  lam t. lam i. OTmTupleProj { tm = t, index = i }
 
 lang OCamlData
   syn Expr =
@@ -170,6 +181,8 @@ let otygenarrayclayoutfloat_ = use OCamlTypeAst in
 
 let otytuple_ = use OCamlTypeAst in
   lam tys. OTyTuple {info = NoInfo (), tys = tys}
+
+let otyunit_ = otytuple_ []
 
 lang OCamlAst =
   -- Terms

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -132,29 +132,44 @@ lang OCamlTypeAst =
   RecordTypeAst + VarTypeAst
 
   syn Type =
-  | TyList {info : Info, ty : Type}
-  | TyArray {info : Info, ty : Type}
-  | TyGenArray {info : Info, ty : Type}
-  | TyTuple {info : Info, tys : [Type]}
+  | OTyList {info : Info, ty : Type}
+  | OTyArray {info : Info, ty : Type}
+  | OTyTuple {info : Info, tys : [Type]}
+  | OTyBigArrayGenArray {info : Info, tys : [Type]}
+  | OTyBigArrayFloat64Elt {info : Info}
+  | OTyBigArrayIntElt {info : Info}
+  | OTyBigArrayClayout {info : Info}
 
   sem infoTy =
-  | TyList r -> r.info
-  | TyArray r -> r.info
-  | TyGenArray r -> r.info
-  | TyTuple r -> r.info
+  | OTyList r -> r.info
+  | OTyArray r -> r.info
+  | OTyTuple r -> r.info
+  | OTyBigArrayGenArray r -> r.info
+  | OTyBigArrayFloat64Elt r -> r.info
+  | OTyBigArrayIntElt r -> r.info
+  | OTyBigArrayClayout r -> r.info
 end
 
-let tylist_ = use OCamlTypeAst in
-  lam ty. TyList {info = NoInfo (), ty = ty}
+let otylist_ = use OCamlTypeAst in
+  lam ty. OTyList {info = NoInfo (), ty = ty}
 
-let tyarray_ = use OCamlTypeAst in
-  lam ty. TyArray {info = NoInfo (), ty = ty}
+let otyarray_ = use OCamlTypeAst in
+  lam ty. OTyArray {info = NoInfo (), ty = ty}
 
-let tygenarray_ = use OCamlTypeAst in
-  lam ty. TyGenArray {info = NoInfo (), ty = ty}
+let otygenarray_ = use OCamlTypeAst in
+  lam tys. OTyBigArrayGenArray {info = NoInfo (), tys = tys}
 
-let tyotuple_ = use OCamlTypeAst in
-  lam tys. TyTuple {info = NoInfo (), tys = tys}
+let oclayout_ = use OCamlTypeAst in
+  OTyBigArrayClayout {info = NoInfo ()}
+
+let otygenarrayclayoutint_ = use OCamlTypeAst in
+  otygenarray_ [tyint_, OTyBigArrayIntElt {info = NoInfo ()}, oclayout_]
+
+let otygenarrayclayoutfloat_ = use OCamlTypeAst in
+  otygenarray_ [tyfloat_, OTyBigArrayFloat64Elt {info = NoInfo ()}, oclayout_]
+
+let otytuple_ = use OCamlTypeAst in
+  lam tys. OTyTuple {info = NoInfo (), tys = tys}
 
 lang OCamlAst =
   -- Terms

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -59,6 +59,19 @@ let _testExternals =
                         otyarray_ tyint_,
                         otygenarrayclayoutfloat_],
         libraries = [] }
+    ]),
+    ("testIdUnit", [
+      { ident = "Fun.id", ty = tyarrow_ otyunit_ otyunit_, libraries = [] }
+    ]),
+    ("testIdArrayInt", [
+      { ident = "Fun.id",
+        ty = tyarrow_ (otyarray_ tyint_) (otyarray_ tyint_),
+        libraries = [] }
+    ]),
+    ("testIdTupleInt", [
+      { ident = "Fun.id",
+        ty = tyarrow_ (otytuple_ [tyint_, tyint_]) (otytuple_ [tyint_, tyint_]),
+        libraries = [] }
     ])
   ]
 

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -22,19 +22,43 @@ let _testExternals =
     ("testListMap", [
       { ident = "List.map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (tyvar_ "b"),
-                        tylist_ (tyvar_ "a"),
-                        tylist_ (tyvar_ "b")],
+                        otylist_ (tyvar_ "a"),
+                        otylist_ (tyvar_ "b")],
         libraries = [] }
     ]),
     ("testListConcatMap", [
       { ident = "List.concat_map",
-        ty = tyarrows_ [tyarrow_ (tyvar_ "a") (tylist_ (tyvar_ "b")),
-                        tylist_ (tyvar_ "a"),
-                        tylist_ (tyvar_ "b")],
+        ty = tyarrows_ [tyarrow_ (tyvar_ "a") (otylist_ (tyvar_ "b")),
+                        otylist_ (tyvar_ "a"),
+                        otylist_ (tyvar_ "b")],
         libraries = [] }
     ]),
     ("testNonExistant", [
       { ident = "none", ty = tyint_, libraries = ["no-lib"] }
+    ]),
+    ("testGenarrIntNumDims", [
+      { ident = "Bigarray.Genarray.num_dims",
+        ty = tyarrow_ otygenarrayclayoutint_ tyint_,
+        libraries = [] }
+    ]),
+    ("testGenarrFloatNumDims", [
+      { ident = "Bigarray.Genarray.num_dims",
+        ty = tyarrow_ otygenarrayclayoutfloat_ tyint_,
+        libraries = [] }
+    ]),
+    ("testGenarrIntSliceLeft", [
+      { ident = "Bigarray.Genarray.slice_left",
+        ty = tyarrows_ [otygenarrayclayoutint_,
+                        otyarray_ tyint_,
+                        otygenarrayclayoutint_],
+        libraries = [] }
+    ]),
+    ("testGenarrFloatSliceLeft", [
+      { ident = "Bigarray.Genarray.slice_left",
+        ty = tyarrows_ [otygenarrayclayoutfloat_,
+                        otyarray_ tyint_,
+                        otygenarrayclayoutfloat_],
+        libraries = [] }
     ])
   ]
 

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -1,13 +1,14 @@
+include "ocaml/ast.mc"
 include "ext/batteries.ext-ocaml.mc" -- For testing
 include "ext/math-ext.ext-ocaml.mc"
-
+include "ext/solver.ext-ocaml.mc"
 
 type ExternalImplDef = {ident : String, ty : Type, libraries : [String]}
 
 type ExternalImpl =
   {name : Name, extIdent : String, extTy : Type, libraries : [String]}
 
-type ExternalMap = Map String [ExternalImpl]
+type ExternalImplsMap = Map String [ExternalImpl]
 
 let _testExternals =
   use OCamlTypeAst in
@@ -78,7 +79,7 @@ let _testExternals =
 -- NOTE(oerikss, 2021-04-30) Add your external maps here. This is a temporary
 -- solution. In the end we want to provide these definitions outside the
 -- compiler (which will require some parsing).
-let globalExternalMap : ExternalMap =
+let globalExternalImplsMap : ExternalImplsMap =
   mapMapWithKey
   (lam id : String.
     map (lam imp : ExternalImplDef.
@@ -90,5 +91,6 @@ let globalExternalMap : ExternalMap =
     [
       _testExternals, -- For testing purposes
       batteries,      -- For testing purposes
-      mathExtMap
+      mathExtMap,
+      solverExtMap
     ])

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -1,144 +1,114 @@
 include "ocaml/external-includes.mc"
 include "ocaml/ast.mc"
 include "ocaml/intrinsics-ops.mc"
+include "mexpr/type.mc"
+
+type ExternalNameMap = Map Name [ExternalImpl]
+
+type ExternalEnv = {
+  -- A mapping from external string identifiers to available implementations.
+  impls : ExternalMap,
+
+  -- A mapping from external names to used implementations.
+  usedImpls : ExternalNameMap ,
+
+  -- Type aliases map
+  aliases : Map Name Type,
+
+  -- Record constructors
+  constrs : Map Name Type
+}
+
+let externalInitialEnv =
+  lam aliases : Map Name Type. lam constrs : Map Name Type.
+  {
+    impls = globalExternalMap,
+    usedImpls = mapEmpty nameCmp,
+    aliases = aliases,
+    constrs = constrs
+  }
 
 lang OCamlMarshalData = OCamlTypeAst + SeqTypeAst + TensorTypeAst + AppTypeAst
 
--- Computes the cost `Int` of marshaling data from `Type` to `Type`.
-let externalMarshalCost : Type -> Type -> Int =
+let _externalMarshal : ExternalEnv -> Expr -> Type -> Type -> (Int, Expr) =
   use OCamlMarshalData in
-  recursive let recur = lam ty1. lam ty2.
-    let tt = (ty1, ty2) in
-    match tt with (TyVar _, _) | (_, TyVar _) | (TyApp _, _) | (_, TyApp _)
-    then 0
-    else match tt with (TyInt _, TyInt _) | (TyFloat _, TyFloat _) then 0
-    else match tt with (TySeq _, TySeq _) then 0
-    else match tt with (OTyList _, OTyList _) then 0
-    else match tt with (TySeq _, OTyList _) then 5
-    else match tt with (OTyList _, TySeq _) then 5
-    else match tt with (OTyArray _, OTyArray _) then 0
-    else match tt with (OTyArray _, TySeq _) then 2
-    else match tt with (TySeq _, OTyArray _) then 2
-    else match tt with
-      (OTyBigArrayGenArray
-        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
-      ,OTyBigArrayGenArray
-        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
-    then 0
-    else match tt with
-      (OTyBigArrayGenArray
-        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
-      ,OTyBigArrayGenArray
-        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
-    then 0
-    else match tt with
-      (TyTensor {ty = TyInt _}
-      ,OTyBigArrayGenArray
-        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
-    then 2
-    else match tt with
-      (OTyBigArrayGenArray
-        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
-      ,TyTensor {ty = TyInt _})
-    then 1
-    else match tt with
-      (TyTensor {ty = TyFloat _}
-      ,OTyBigArrayGenArray
-        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
-    then 2
-    else match tt with
-      (OTyBigArrayGenArray
-        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
-      ,TyTensor {ty = TyFloat _})
-    then 1
-    else match tt
-    with (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22})
-    then
-      addi (recur ty21 ty11) (recur ty12 ty22)
-    else error "Cannot compute marshal cost"
-  in
-  recur
-
-utest externalMarshalCost tyint_ tyint_ with 0
-utest externalMarshalCost (otylist_ tyint_) (tyseq_ tyint_) with 3
-utest
-  externalMarshalCost
-    (tyarrow_ (tyseq_ tyint_) (otylist_ tyint_))
-    (tyarrow_ (otylist_ tyint_) (tyseq_ tyint_))
-with 6
-utest
-  externalMarshalCost
-    (tyarrows_ [tyseq_ tyint_, otylist_ tyint_, tyseq_ tyint_])
-    (tyarrows_ [otylist_ tyint_, tyseq_ tyint_, otylist_ tyint_])
-with 9
-
-
--- Marshals expression `Exp` of type `Type` to expression `Expr` of type
--- `Type`.
-let externalMarshal : Expr -> Type -> Type -> Expr =
-  use OCamlMarshalData in
-  lam t. lam ty1. lam ty2.
+  lam env. lam t. lam ty1. lam ty2.
   recursive let recur = lam t. lam ty1. lam ty2.
     let tt = (ty1, ty2) in
     match tt with (TyVar _, _) | (_, TyVar _) | (TyApp _, _) | (_, TyApp _)
-    then t
-    else match tt with (TyInt _, TyInt _) | (TyFloat _, TyFloat _) then t
-    else match tt with (TySeq _, TySeq _) then t
-    else match tt with (OTyList _, OTyList _) then t
+    then
+      (0, t)
+    else match tt with (TyInt _, TyInt _) | (TyFloat _, TyFloat _) then
+      (0, t)
+    else match tt with (TySeq _, TySeq _) then
+      (0, t)
+    else match tt with (OTyList _, OTyList _) then
+      (0, t)
     else match tt with (TySeq _, OTyList _) then
-      app_ (intrinsicOpSeq "Helpers.to_list") t
+      (5, app_ (intrinsicOpSeq "Helpers.to_list") t)
     else match tt with (OTyList _, TySeq _) then
-      app_ (intrinsicOpSeq "Helpers.of_list") t
-    else match tt with (OTyArray _, OTyArray _) then t
+      (5, app_ (intrinsicOpSeq "Helpers.of_list") t)
+    else match tt with (OTyArray _, OTyArray _) then
+      (0, t)
     else match tt with (TySeq _, OTyArray _) then
-      app_ (intrinsicOpSeq "Helpers.to_array") t
+      (2, app_ (intrinsicOpSeq "Helpers.to_array") t)
     else match tt with (OTyArray _, TySeq _) then
-      app_ (intrinsicOpSeq "Helpers.of_array") t
+      (2, app_ (intrinsicOpSeq "Helpers.of_array") t)
+    else match tt with (TyRecord {fields = fields}, OTyTuple {tys = []}) then
+      if eqi (mapSize fields) 0  then
+        (0, ounit_)
+      else error "Cannot marshal non-empty record to empty tuple"
+    else match tt with (OTyTuple {tys = []}, TyRecord {fields = fields}) then
+      if eqi (mapSize fields) 0  then
+        (0, uunit_)
+      else error "Cannot marshal empty tuple to non-empty record"
     else match tt with
       (OTyBigArrayGenArray
         {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
       ,OTyBigArrayGenArray
         {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
     then
-      t
+      (0, t)
     else match tt with
       (OTyBigArrayGenArray
         {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
       ,OTyBigArrayGenArray
         {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
     then
-      t
+      (0, t)
     else match tt with
       (TyTensor {ty = TyInt _}
       ,OTyBigArrayGenArray
         {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
     then
-      app_ (intrinsicOpTensor "Helpers.to_genarray_clayout") t
+      (1, app_ (intrinsicOpTensor "Helpers.to_genarray_clayout") t)
     else match tt with
       (OTyBigArrayGenArray
         {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
       ,TyTensor {ty = TyInt _})
     then
-      app_ (intrinsicOpTensor "carray_int") t
+      (1, app_ (intrinsicOpTensor "carray_int") t)
     else match tt with
       (TyTensor {ty = TyFloat _}
       ,OTyBigArrayGenArray
         {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
     then
-      app_ (intrinsicOpTensor "Helpers.to_genarray_clayout") t
+      (1, app_ (intrinsicOpTensor "Helpers.to_genarray_clayout") t)
     else match tt with
       (OTyBigArrayGenArray
         {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
       ,TyTensor {ty = TyFloat _})
     then
-      app_ (intrinsicOpTensor "carray_float") t
+      (1, app_ (intrinsicOpTensor "carray_float") t)
     else match tt
     with (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22})
     then
       let n = nameSym "x" in
-      let arg = recur (nvar_ n) ty21 ty11 in
-      let body = recur (app_ t arg) ty12 ty22 in
-      nulam_ n body
+      match recur (nvar_ n) ty21 ty11 with (cost1, arg) then
+        match recur (app_ t arg) ty12 ty22 with (cost2, body) then
+          (addi cost1 cost2, nulam_ n body)
+        else never
+      else never
     else error "Cannot marshal data"
   in
 
@@ -149,47 +119,34 @@ let externalMarshal : Expr -> Type -> Type -> Expr =
     recur t ty1 ty2
   else
     let n = nameSym "x" in
-    app_ (nulam_ n (recur t ty1 ty2)) unit_
+    match recur t ty1 ty2 with (cost, body) then
+      (cost, app_ (nulam_ n body) uunit_)
+    else never
 
+-- Marshals expression `Exp` of type `Type` to expression `Expr` of type
+-- `Type`.
+let externalMarshal : ExternalEnv -> Expr -> Type -> Type -> Expr =
+  lam env. lam t. lam ty1. lam ty2.
+  match _externalMarshal env t ty1 ty2 with (_, t) then t
+  else never
 
-type ExternalNameMap = Map Name [ExternalImpl]
-
-type ExternalChooseEnv = {
-  -- A mapping from external string identifiers to available implementations.
-  impls : ExternalMap,
-
-  -- A mapping from external names to used implementations.
-  usedImpls : ExternalNameMap ,
-
-  -- Type aliases map
-  aliases : Map Name Type
-}
-
-type ExternalGenerateEnv = {
-  -- A mapping from external names to used implementations.
-  usedImpls : ExternalNameMap ,
-
-  -- Type aliases map
-  aliases : Map Name Type
-}
-
-let externalInitialEnv = lam aliases : Map Name Type.
-  {
-    impls = globalExternalMap,
-    usedImpls = mapEmpty nameCmp,
-    aliases = aliases
-  }
+-- Computes the cost of Marshaling the expression `Exp` of type `Type` to
+-- expression `Expr` of type `Type`.
+let externalMarshalCost : ExternalEnv -> Type -> Type -> Int =
+  lam env. lam ty1. lam ty2.
+  match _externalMarshal env never_ ty1 ty2 with (cost, _) then cost
+  else never
 
 lang OCamlGenerateExternal
 
   -- Popluates `env` by chosing external implementations.
-  sem chooseExternalImpls (env : ExternalChooseEnv) /- : Expr -> ExternalGenerateEnv -/=
+  sem chooseExternalImpls (env : ExternalEnv) /- : Expr -> ExternalEnv -/=
   -- Intentionally left blank
 
 
   -- Generates code for externals. The resulting program should be free of
   -- `TmExt` terms.
-  sem generateExternals (env : ExternalGenerateEnv) =
+  sem generateExternals (env : ExternalEnv) =
   -- Intentionally left blank
 
 end
@@ -198,7 +155,7 @@ end
 -- implementation with the lowest cost with respect to the type given at the
 -- external term definition.
 lang OCamlGenerateExternalNaive = OCamlGenerateExternal + ExtAst
-  sem _chooseExternalImpls (env : ExternalChooseEnv) =
+  sem chooseExternalImpls (env : ExternalEnv) =
   | TmExt {ident = ident, ty = ty, inexpr = inexpr} ->
     let identStr = nameGetStr ident in
     let impls = mapLookup identStr env.impls in
@@ -214,23 +171,18 @@ lang OCamlGenerateExternalNaive = OCamlGenerateExternal + ExtAst
         impls
       in
       let env = {env with usedImpls = mapInsert ident [impl] env.usedImpls} in
-      _chooseExternalImpls env inexpr
+      chooseExternalImpls env inexpr
     else
       error (join ["No implementation for external ", identStr])
-  | t -> sfold_Expr_Expr _chooseExternalImpls env t
+  | t -> sfold_Expr_Expr chooseExternalImpls env t
 
-  sem chooseExternalImpls (env : ExternalChooseEnv) =
-  | t ->
-    let env : ExternalChooseEnv = _chooseExternalImpls env t in
-    { usedImpls = env.usedImpls, aliases = env.aliases }
-
-  sem generateExternals (env : ExternalGenerateEnv) =
+  sem generateExternals (env : ExternalEnv) =
   | TmExt {ident = ident, ty = ty, inexpr = inexpr} ->
     let ty = typeUnwrapAlias env.aliases ty in
     match mapLookup ident env.usedImpls
     with Some r then
       let r : ExternalImpl = head r in
-      let t = externalMarshal (oext_ r.extIdent) r.extTy ty in
+      let t = externalMarshal env (oext_ r.extIdent) r.extTy ty in
       bind_ (nulet_ ident t) (generateExternals env inexpr)
     else
       error (join ["No implementation for external ", nameGetStr ident])

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -35,14 +35,13 @@ let _externalMarshal : ExternalEnv -> Expr -> Type -> Type -> (Int, Expr) =
   lam env. lam t. lam ty1. lam ty2.
   recursive let recur = lam t. lam ty1. lam ty2.
     let tt = (ty1, ty2) in
-    match tt with (TyVar _, _) | (_, TyVar _) | (TyApp _, _) | (_, TyApp _)
+    match tt with
+      (TyVar _, _) | (_, TyVar _) |
+      (TyApp {lhs = TyVar _}, _) | (_, TyApp {lhs = TyVar _}) |
+      (TyInt _, TyInt _) | (TyFloat _, TyFloat _) |
+      (TySeq _, TySeq _) |
+      (OTyList _, OTyList _)
     then
-      (0, t)
-    else match tt with (TyInt _, TyInt _) | (TyFloat _, TyFloat _) then
-      (0, t)
-    else match tt with (TySeq _, TySeq _) then
-      (0, t)
-    else match tt with (OTyList _, OTyList _) then
       (0, t)
     else match tt with (TySeq _, OTyList _) then
       (5, app_ (intrinsicOpSeq "Helpers.to_list") t)

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -14,9 +14,44 @@ let externalMarshalCost : Type -> Type -> Int =
     else match tt with (TyInt _, TyInt _) then 0
     else match tt with (TyFloat _, TyFloat _) then 0
     else match tt with (TySeq _, TySeq _) then 0
-    else match tt with (TyList _, TyList _) then 0
-    else match tt with (TySeq _, TyList _) then 3
-    else match tt with (TyList _, TySeq _) then 3
+    else match tt with (OTyList _, OTyList _) then 0
+    else match tt with (TySeq _, OTyList _) then 5
+    else match tt with (OTyList _, TySeq _) then 5
+    else match tt with (OTyArray _, OTyArray _) then 0
+    else match tt with (OTyArray _, TySeq _) then 2
+    else match tt with (TySeq _, OTyArray _) then 2
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
+      ,OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
+    then 0
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
+      ,OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
+    then 0
+    else match tt with
+      (TyTensor {ty = TyInt _}
+      ,OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
+    then 2
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
+      ,TyTensor {ty = TyInt _})
+    then 1
+    else match tt with
+      (TyTensor {ty = TyFloat _}
+      ,OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
+    then 2
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
+      ,TyTensor {ty = TyFloat _})
+    then 1
     else match tt
     with (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22})
     then
@@ -26,16 +61,16 @@ let externalMarshalCost : Type -> Type -> Int =
   recur
 
 utest externalMarshalCost tyint_ tyint_ with 0
-utest externalMarshalCost (tylist_ tyint_) (tyseq_ tyint_) with 3
+utest externalMarshalCost (otylist_ tyint_) (tyseq_ tyint_) with 3
 utest
   externalMarshalCost
-    (tyarrow_ (tyseq_ tyint_) (tylist_ tyint_))
-    (tyarrow_ (tylist_ tyint_) (tyseq_ tyint_))
+    (tyarrow_ (tyseq_ tyint_) (otylist_ tyint_))
+    (tyarrow_ (otylist_ tyint_) (tyseq_ tyint_))
 with 6
 utest
   externalMarshalCost
-    (tyarrows_ [tyseq_ tyint_, tylist_ tyint_, tyseq_ tyint_])
-    (tyarrows_ [tylist_ tyint_, tyseq_ tyint_, tylist_ tyint_])
+    (tyarrows_ [tyseq_ tyint_, otylist_ tyint_, tyseq_ tyint_])
+    (tyarrows_ [otylist_ tyint_, tyseq_ tyint_, otylist_ tyint_])
 with 9
 
 
@@ -51,11 +86,54 @@ let externalMarshal : Expr -> Type -> Type -> Expr =
     else match tt with (TyInt _, TyInt _) then t
     else match tt with (TyFloat _, TyFloat _) then t
     else match tt with (TySeq _, TySeq _) then t
-    else match tt with (TyList _, TyList _) then t
-    else match tt with (TySeq _, TyList _) then
+    else match tt with (OTyList _, OTyList _) then t
+    else match tt with (TySeq _, OTyList _) then
       app_ (intrinsicOpSeq "Helpers.to_list") t
-    else match tt with (TyList _, TySeq _) then
+    else match tt with (OTyList _, TySeq _) then
       app_ (intrinsicOpSeq "Helpers.of_list") t
+    else match tt with (OTyArray _, OTyArray _) then t
+    else match tt with (TySeq _, OTyArray _) then
+      app_ (intrinsicOpSeq "Helpers.to_array") t
+    else match tt with (OTyArray _, TySeq _) then
+      app_ (intrinsicOpSeq "Helpers.of_array") t
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
+      ,OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
+    then
+      t
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
+      ,OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
+    then
+      t
+    else match tt with
+      (TyTensor {ty = TyInt _}
+      ,OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]})
+    then
+      app_ (intrinsicOpTensor "Helpers.to_genarray_clayout") t
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyInt _, OTyBigArrayIntElt _, OTyBigArrayClayout _]}
+      ,TyTensor {ty = TyInt _})
+    then
+      app_ (intrinsicOpTensor "carray_int") t
+    else match tt with
+      (TyTensor {ty = TyFloat _}
+      ,OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]})
+    then
+      app_ (intrinsicOpTensor "Helpers.to_genarray_clayout") t
+    else match tt with
+      (OTyBigArrayGenArray
+        {tys = [TyFloat _, OTyBigArrayFloat64Elt _, OTyBigArrayClayout _]}
+      ,TyTensor {ty = TyFloat _})
+    then
+      app_ (intrinsicOpTensor "carray_float") t
     else match tt
     with (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22})
     then

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -2467,7 +2467,10 @@ let generateWithExternals = lam ast.
     match generateTypeDecl env ast with (env, ast) then
       let env =
         let env : GenerateEnv = env in
-        chooseExternalImpls (externalInitialEnv env.aliases env.constrs) ast
+        chooseExternalImpls
+          globalExternalImplsMap
+          (externalInitialEnv env.aliases env.constrs)
+          ast
       in
       let ast = generateExternals env ast in
       generateEmptyEnv ast

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -232,7 +232,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
         let toNestedMatch = lam target : Expr. lam patExpr : [(Pat, Expr)].
           assocSeqFold
             (lam acc. lam pat. lam thn. match_ target pat thn acc)
-            (app_ (nvar_ defaultCaseName) unit_)
+            (app_ (nvar_ defaultCaseName) uunit_)
             patExpr
         in
         let f = lam arm : (Name, [(Pat, Expr)]).
@@ -258,7 +258,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
             arms =
               snoc
                 (map f (mapBindings arms))
-                (pvarw_, (app_ (nvar_ defaultCaseName) unit_))
+                (pvarw_, (app_ (nvar_ defaultCaseName) uunit_))
           } in
           bind_ defaultCaseLet flattenedMatch
       else never

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -2526,5 +2526,54 @@ in
 utest ocamlEvalInt (generateWithExternals extListConcatMapTest)
 with int_ 1 using eqExpr in
 
+-- Externals and Tensors
+let extGenarrIntNumDims = symbolize (
+bind_
+  (ext_ "testGenarrIntNumDims"
+        false
+        (tyarrow_ (tytensor_ tyint_) tyint_))
+    (app_ (var_ "testGenarrIntNumDims")
+          (tensorCreateInt_ (seq_ []) (ulam_ "x" (int_ 1)))))
+in
+utest ocamlEvalInt (generateWithExternals extGenarrIntNumDims)
+with int_ 0 using eqExpr in
+
+let extGenarrFloatNumDims = symbolize (
+bind_
+  (ext_ "testGenarrFloatNumDims"
+        false
+        (tyarrow_ (tytensor_ tyfloat_) tyint_))
+    (app_ (var_ "testGenarrFloatNumDims")
+          (tensorCreateFloat_ (seq_ []) (ulam_ "x" (float_ 1.)))))
+in
+utest ocamlEvalInt (generateWithExternals extGenarrFloatNumDims)
+with int_ 0 using eqExpr in
+
+let extGenarrIntSliceLeft = symbolize (
+bind_
+  (ext_ "testGenarrIntSliceLeft"
+        false
+        (tyarrows_ [tytensor_ tyint_, tyseq_ tyint_, tytensor_ tyint_]))
+    (tensorRank_ tyint_
+      (appSeq_ (var_ "testGenarrIntSliceLeft")
+               [tensorCreateInt_ (seq_ [int_ 1]) (ulam_ "x" (int_ 1)),
+                seq_ [int_ 0]])))
+in
+utest ocamlEvalInt (generateWithExternals extGenarrIntSliceLeft)
+with int_ 0 using eqExpr in
+
+let extGenarrFloatSliceLeft = symbolize (
+bind_
+  (ext_ "testGenarrFloatSliceLeft"
+        false
+        (tyarrows_ [tytensor_ tyfloat_, tyseq_ tyint_, tytensor_ tyfloat_]))
+    (tensorRank_ tyfloat_
+      (appSeq_ (var_ "testGenarrFloatSliceLeft")
+               [tensorCreateInt_ (seq_ [int_ 1]) (ulam_ "x" (float_ 1.)),
+                seq_ [int_ 0]])))
+in
+utest ocamlEvalInt (generateWithExternals extGenarrFloatSliceLeft)
+with int_ 0 using eqExpr in
+
 -- TODO(larshum, 2021-03-06): Add tests for boot parser intrinsics
 ()

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -2591,15 +2591,5 @@ in
 utest ocamlEvalInt (generateWithExternals extIdUnitTest)
 with int_ 0 using eqExpr in
 
--- let extIdTupleIntTest =
---   bind_
---     (ext_ "testIdTupleInt" false (tyarrow_ (tytuple_ [tyint_, tyint_])
---                                            (tytuple_ [tyint_, tyint_])))
---     (tupleproj_ 0 (app_ (var_ "testIdTupleInt")
---                         (utuple_ [int_ 0, int_ 1])))
--- in
--- utest ocamlEvalInt (generateWithExternals extIdTupleIntTest)
--- with int_ 0 using eqExpr in
-
 -- TODO(larshum, 2021-03-06): Add tests for boot parser intrinsics
 ()

--- a/stdlib/ocaml/intrinsics-ops.mc
+++ b/stdlib/ocaml/intrinsics-ops.mc
@@ -27,12 +27,6 @@ let intrinsicOpTime = use OCamlAst in
 let intrinsicOpTensor = use OCamlAst in
   lam op. OTmVarExt {ident = concat "Boot.Intrinsics.T." op}
 
-let intrinsicOpTensorNum = use OCamlAst in
-  lam op. OTmVarExt {ident = concat "Boot.Intrinsics.T.Num." op}
-
-let intrinsicOpTensorNoNum = use OCamlAst in
-  lam op. OTmVarExt {ident = concat "Boot.Intrinsics.T.NoNum." op}
-
 let intrinsicOpBootparser = use OCamlAst in
   lam op. OTmVarExt {ident = concat "Boot.Bootparser." op}
 

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -148,6 +148,7 @@ lang OCamlPrettyPrint =
   | OTmVarExt _ -> true
   | OTmConAppExt _ -> false
   | OTmString _ -> true
+  | OTmArgLabel _ -> false
 
   sem patIsAtomic =
   | OPatRecord _ -> false
@@ -387,6 +388,10 @@ lang OCamlPrettyPrint =
       (env, join [t.text, inexpr])
     else never
   | OTmString t -> (env, join ["\"", t.text, "\""])
+  | OTmArgLabel t ->
+    match pprintCode indent env t.arg with (env, arg) then
+      (env, join [t.label, ":", arg])
+    else never
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
   | OPatRecord {bindings = bindings} ->
@@ -555,6 +560,10 @@ let testTupleProj =
   OTmTupleProj { tm = OTmTuple {values = [true_, false_]} , index = 1}
 in
 
+let testArgLabel =
+  OTmArgLabel { label = "label", arg = int_ 0}
+in
+
 let asts = [
   testAddInt1,
   testAddInt2,
@@ -584,7 +593,8 @@ let asts = [
   testIfNested,
   testPatLet,
   testTuple,
-  testTupleProj
+  testTupleProj,
+  testArgLabel
 ] in
 
 map pprintProg asts;

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -430,7 +430,7 @@ lang TestLang = OCamlPrettyPrint + OCamlSym
 mexpr
 use TestLang in
 
-let debugPrint = true in
+let debugPrint = false in
 
 let pprintProg = lam ast.
   if debugPrint then

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -141,6 +141,7 @@ lang OCamlPrettyPrint =
   | OTmArray _ -> true
   | OTmMatch _ -> false
   | OTmTuple _ -> true
+  | OTmTupleProj _ -> false
   | OTmConApp {args = []} -> true
   | OTmConApp _ -> false
   | OTmVariantTypeDecl _ -> false
@@ -325,6 +326,10 @@ lang OCamlPrettyPrint =
     with (env, values) then
       (env, join ["(", strJoin ", " values, ")"])
     else never
+  | OTmTupleProj {tm = tm, index = index} ->
+    match pprintCode indent env tm with (env, tm) then
+      (env, join [tm, ".", int2string index])
+    else never
   | OTmMatch {
     target = target,
     arms
@@ -425,7 +430,7 @@ lang TestLang = OCamlPrettyPrint + OCamlSym
 mexpr
 use TestLang in
 
-let debugPrint = false in
+let debugPrint = true in
 
 let pprintProg = lam ast.
   if debugPrint then
@@ -546,6 +551,10 @@ let testTuple =
   , arms = [(OPatTuple {pats = [pvar_ "a", pvar_ "b"]}, OTmTuple {values = [var_ "b", var_ "a"]})]}
 in
 
+let testTupleProj =
+  OTmTupleProj { tm = OTmTuple {values = [true_, false_]} , index = 1}
+in
+
 let asts = [
   testAddInt1,
   testAddInt2,
@@ -574,7 +583,8 @@ let asts = [
   testIf,
   testIfNested,
   testPatLet,
-  testTuple
+  testTuple,
+  testTupleProj
 ] in
 
 map pprintProg asts;

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -46,6 +46,8 @@ lang OCamlSym =
     OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
   | OTmTuple { values = values } ->
     OTmTuple { values = map (symbolizeExpr env) values }
+  | OTmTupleProj t ->
+    OTmTupleProj { t with tm = symbolizeExpr env t.tm }
   | OTmConApp t ->
     match _symbolizeVarName env t.ident with (env, ident) then
       let args = map (symbolizeExpr env) t.args in

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -60,6 +60,7 @@ lang OCamlSym =
   | OTmPreambleText t ->
     OTmPreambleText {t with inexpr = symbolizeExpr env t.inexpr}
   | OTmString t -> OTmString t
+  | OTmArgLabel t -> OTmArgLabel {t with arg = symbolizeExpr env t.arg }
 
   sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
   | OPatTuple { pats = pats } ->

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -299,7 +299,7 @@ lang CarriedTypeHelpers = CarriedTypeBase
               , match_
                 (mkNew accName valName)
                 (ptuple_ [npvar_ accName, npvar_ valName])
-                (tuple_ [nvar_ accName, nconapp_ constructor.name (nvar_ valName)])
+                (utuple_ [nvar_ accName, nconapp_ constructor.name (nvar_ valName)])
                 never_
               )
             ]
@@ -325,7 +325,7 @@ let _mkSFuncStubs
         , (accName, tyvar_ "a")
         ]
       , cases =
-        [ (npvar_ valName, tuple_ [nvar_ accName, nvar_ valName])
+        [ (npvar_ valName, utuple_ [nvar_ accName, nvar_ valName])
         ]
       } in
     let smap =
@@ -337,8 +337,8 @@ let _mkSFuncStubs
         [ ( npvar_ valName
           , tupleproj_ 1
             (smapAccumL_
-              (ulam_ "" (nulam_ valName (tuple_ [unit_, appf1_ (nvar_ fName) (nvar_ valName)])))
-              unit_
+              (ulam_ "" (nulam_ valName (utuple_ [uunit_, appf1_ (nvar_ fName) (nvar_ valName)])))
+              uunit_
               (nvar_ valName))
           )
         ]
@@ -353,7 +353,7 @@ let _mkSFuncStubs
         [ ( npvar_ valName
           , tupleproj_ 0
             (smapAccumL_
-              (nulam_ accName (nulam_ valName (tuple_ [appf2_ (nvar_ fName) (nvar_ accName) (nvar_ valName), nvar_ valName])))
+              (nulam_ accName (nulam_ valName (utuple_ [appf2_ (nvar_ fName) (nvar_ accName) (nvar_ valName), nvar_ valName])))
               (nvar_ accName)
               (nvar_ valName))
           )
@@ -439,7 +439,7 @@ lang CarriedRecord = CarriedTypeBase
           mappingFields
         in match mappedFields with (constr, mappedFields) then
           constr
-            (tuple_
+            (utuple_
               [ nvar_ accName
               , (foldl
                   (lam acc. lam update.

--- a/stdlib/parser/generator.mc
+++ b/stdlib/parser/generator.mc
@@ -297,8 +297,8 @@ let _semanticAtom_ = nconapp_ _semanticAtomName
 let _semanticPrefix_ = nconapp_ _semanticPrefixName
 let _semanticInfix_ = nconapp_ _semanticInfixName
 let _semanticPostfix_ = nconapp_ _semanticPostfixName
-let _semanticDefaultIn_ = nconapp_ _semanticDefaultInName unit_
-let _semanticDefaultNotIn_ = nconapp_ _semanticDefaultNotInName unit_
+let _semanticDefaultIn_ = nconapp_ _semanticDefaultInName uunit_
+let _semanticDefaultNotIn_ = nconapp_ _semanticDefaultNotInName uunit_
 let _semanticInt_ = nvar_ _semanticIntName
 let _semanticFloat_ = nvar_ _semanticFloatName
 let _semanticOperator_ = nvar_ _semanticOperatorName
@@ -431,13 +431,13 @@ let generatorProd
       let stagedSpec =
         let stagedProdType =
           match prodType with GeneratorAtom {self = self} then
-            _semanticAtom_ (record_ [("self", _stageInclude self)])
+            _semanticAtom_ (urecord_ [("self", _stageInclude self)])
           else match prodType with GeneratorPrefix {self = self, right = right} then
-            _semanticPrefix_ (record_ [("self", _stageInclude self), ("right", _stageInclude right)])
+            _semanticPrefix_ (urecord_ [("self", _stageInclude self), ("right", _stageInclude right)])
           else match prodType with GeneratorInfix {self = self, left = left, right = right} then
-            _semanticInfix_ (record_ [("self", _stageInclude self), ("left", _stageInclude left), ("right", _stageInclude right)])
+            _semanticInfix_ (urecord_ [("self", _stageInclude self), ("left", _stageInclude left), ("right", _stageInclude right)])
           else match prodType with GeneratorPostfix {self = self, left = left} then
-            _semanticPostfix_ (record_ [("self", _stageInclude self), ("left", _stageInclude left)])
+            _semanticPostfix_ (urecord_ [("self", _stageInclude self), ("left", _stageInclude left)])
           else never in
         let stageField = lam sym.
           let simpleResult = lam field. lam conName.
@@ -476,19 +476,19 @@ let generatorProd
           let paramName = nameSym "syms" in
           nulam_ paramName
             (_nulet_ infoName (_symSeqInfo_ (nvar_ paramName))
-              (tuple_
+              (utuple_
                 [ nvar_ infoName
                 , match unzip (map stageField wrappedSyntax) with (pats, fields) then
                     match_ (nvar_ paramName) (pseqtot_ (mapOption identity pats))
                       (nconapp_ constructorName
-                        (record_
+                        (urecord_
                           (cons ("info", nvar_ infoName)
                             (mapOption identity fields))))
                       never_
                   else never
                 ]))
         in
-        record_
+        urecord_
           [ ("name", str_ constructorStr)
           , ("nt", var_ nonTerminal)
           , ("ptype", stagedProdType)
@@ -532,7 +532,7 @@ let generatorBracket
           let valName = nameSym "val" in
           nulam_ paramName
             (_nulet_ infoName (_symSeqInfo_ (nvar_ paramName))
-              (tuple_
+              (utuple_
                 [ nvar_ infoName
                 , match_ (get_ (nvar_ paramName) (int_ (length leftBracket)))
                   (npcon_ _ll1UserSymName (ptuple_ [pvarw_, npvar_ valName]))
@@ -540,10 +540,10 @@ let generatorBracket
                   never_
                 ]))
         in
-        record_
+        urecord_
           [ ("name", str_ (concat "grouping " nonTerminal))
           , ("nt", var_ nonTerminal)
-          , ("ptype", _semanticAtom_ (record_ [("self", _stageInclude (DefaultIn ()))]))
+          , ("ptype", _semanticAtom_ (urecord_ [("self", _stageInclude (DefaultIn ()))]))
           , ("rhs", seq_ (mapOption _stageSymbol allSymbols))
           , ("action", stagedAction)
           ]
@@ -599,19 +599,19 @@ let generatorGrammar
           let construct =
             match o with GeneratorLeftChild _ then _semanticLeftChild_ else _semanticRightChild_ in
           construct
-            (record_
+            (urecord_
               [ ("child", nvar_ (prodSymToName child.sym))
               , ("parent", nvar_ (prodSymToName parent.sym))
               ])
         else never in
       let stagePrecedence = lam prec.
         match prec with ((l, r), {mayGroupLeft = mayGroupLeft, mayGroupRight = mayGroupRight}) then
-          tuple_
-            [ tuple_
+          utuple_
+            [ utuple_
               [ nvar_ (prodSymToName l.sym)
               , nvar_ (prodSymToName r.sym)
               ]
-            , record_
+            , urecord_
               [ ("mayGroupLeft", bool_ mayGroupLeft)
               , ("mayGroupRight", bool_ mayGroupRight)
               ]
@@ -632,7 +632,7 @@ let generatorGrammar
           (name, nulet_ name (_semanticProduction_ prod.stagedSpec)))
         productions in
       match unzip productions with (prodNames, prodLets) then
-        let semanticGrammar = record_
+        let semanticGrammar = urecord_
           [ ("start", var_ start)
           , ("productions", seq_ (map nvar_ prodNames))
           , ("overrideAllow", seq_ (map stageOverride overrideAllow))
@@ -778,7 +778,7 @@ let unknownTyP = g.prod
 -- solve it later (more or less running symbolize before printing),
 -- but not at present.
 match unknownTyP with {constructor = Some {name = unknownTyConstructorName}} then
-let tyField = g.nonsyntax "ty" (untargetableType (tyvar_ "Type")) (nconapp_ unknownTyConstructorName unit_) in
+let tyField = g.nonsyntax "ty" (untargetableType (tyvar_ "Type")) (nconapp_ unknownTyConstructorName uunit_) in
 
 let varP = g.prod
   { constructorName = "TmVar"

--- a/test-boot-compile.mk
+++ b/test-boot-compile.mk
@@ -137,4 +137,4 @@ compile_files += stdlib/ext/math-ext.mc
 all: ${compile_files}
 
 ${compile_files}::
-	-@./make compile-test $@ "build/mi compile --test --disable-optimizations"
+	-@./make compile-test $@ "build/boot eval src/main/mi.mc -- compile --test --disable-optimizations"


### PR DESCRIPTION
This PR contains:
- Partial marshaling of `Tensor[Float]` and `Tensor[Int]` to `Genarrays` (and vice-versa). The marshaling requires that the tensors have been created with `tensorCreateCArrayFloat` or `tensorCreateCArrayInt`, respectivly, otherwise a runtime error will occur.
- Marshaling of the unit type.
- A new option `--debug-type-annot` to pretty-print the program after type annotation.
- Separation of the evaluated compiler and compiled compiler tests. A new make target `make test-boot-compile` runs test compiling with the evaluated compiler. The make target `make test-compile` runs test compiling with the compiled compiler.