### PR TITLE
Various updates, mostly related to the C compiler

### DIFF
--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -171,6 +171,12 @@ lang CTopAst = CTypeAst + CInitAst + CStmtAst
 
 end
 
+-----------------------
+-- COMBINED FRAGMENT --
+-----------------------
+lang CAst = CExprAst + CTypeAst + CInitAst + CStmtAst + CTopAst
+
+
 ---------------
 -- C PROGRAM --
 ---------------
@@ -181,8 +187,3 @@ lang CProgAst = CTopAst
   | CPProg { includes: [String], tops: [CTop] }
 
 end
-
------------------------
--- COMBINED FRAGMENT --
------------------------
-lang CAst = CExprAst + CTypeAst + CInitAst + CStmtAst + CTopAst + CProgAst

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -174,6 +174,18 @@ lang CStmtAst = CTypeAst + CInitAst + CExprAst
   | CSBreak   {}
   | CSNop     {}
 
+  sem smap_CStmt_CStmt (f: CStmt -> a) =
+  | CSDef t -> CSDef t
+  | CSIf t -> CSIf {{ t with thn = map f t.thn } with els = map f t.els }
+  | CSSwitch t -> error "TODO"
+  | CSWhile t -> error "TODO"
+  | CSExpr t -> CSExpr t
+  | CSComp t -> error "TODO"
+  | CSRet t -> CSRet t
+  | CSCont t -> CSCont t
+  | CSBreak t -> CSBreak t
+  | CSNop t -> CSNop t
+
   sem sfold_CStmt_CExpr (f: a -> CExpr -> a) (acc: a) =
   | CSDef t -> optionMapOrElse (lam. acc) (sfold_CInit_CExpr f acc) t.init
   | CSIf t ->
@@ -188,6 +200,21 @@ lang CStmtAst = CTypeAst + CInitAst + CExprAst
   | CSBreak _ -> acc
   | CSNop _ -> acc
 
+  sem sreplace_CStmt_CStmt (f: CStmt -> [CStmt]) =
+  | CSDef t -> CSDef t
+  | CSIf t ->
+    let thn = join (map f t.thn) in
+    let els = join (map f t.els) in
+    CSIf {{ t with thn = thn } with els = els }
+  | CSSwitch t -> error "TODO"
+  | CSWhile t -> error "TODO"
+  | CSExpr t -> CSExpr t
+  | CSComp t -> error "TODO"
+  | CSRet t -> CSRet t
+  | CSCont t -> CSCont t
+  | CSBreak t -> CSBreak t
+  | CSNop t -> CSNop t
+
 end
 
 
@@ -201,6 +228,11 @@ lang CTopAst = CTypeAst + CInitAst + CStmtAst
   | CTTyDef { ty: CType, id: Name }
   | CTDef { ty: CType, id: Option Name, init: Option CInit }
   | CTFun { ret: CType, id: Name, params: [(CType,Name)], body: [CStmt] }
+
+  sem sreplace_CTop_CStmt (f: CStmt -> [CStmt]) =
+  | CTTyDef _ & t -> t
+  | CTDef _ & t -> t
+  | CTFun t -> CTFun { t with body = join (map f t.body) }
 
 end
 

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -743,6 +743,10 @@ lang Test =
   MExprCCompileGCC + MExprPrettyPrint + MExprTypeAnnot + MExprANF +
   MExprSym + BootParser + MExprTypeLiftUnOrderedRecords
 
+  -- Whenever MExprCmp, or any fragment including it, will be used, a typeIndex
+  -- function must be provided (here through MExprCmpTypeIndex)
+  MExprTypeLift + MExprCmpTypeIndex
+
 mexpr
 use Test in
 

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -798,7 +798,7 @@ let printCompiledCProg = use CProgPrettyPrint in
 
 lang Test =
   MExprCCompileGCC + MExprPrettyPrint + MExprTypeAnnot + MExprANF +
-  MExprSym + BootParser + MExprTypeLiftUnOrderedRecords
+  MExprSym + BootParser + MExprTypeLiftUnOrderedRecords +
 
   -- Whenever MExprCmp, or any fragment including it, will be used, a typeIndex
   -- function must be provided (here through MExprCmpTypeIndex)

--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -20,7 +20,7 @@ let _joinSpace = lam fst. lam snd.
 
 let pprintEnvGetStr = lam env. lam id.
   -- Set this to true to print names with their symbols (for debugging)
-  if true then
+  if false then
     (env,join [
       nameGetStr id,
       match nameGetSym id with Some sym then int2string (sym2hash sym) else ""

--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -18,6 +18,15 @@ let _par = lam str. join ["(",str,")"]
 let _joinSpace = lam fst. lam snd.
   if eqString "" snd then fst else join [fst, " ", snd]
 
+let pprintEnvGetStr = lam env. lam id.
+  -- Set this to true to print names with their symbols (for debugging)
+  if true then
+    (env,join [
+      nameGetStr id,
+      match nameGetSym id with Some sym then int2string (sym2hash sym) else ""
+    ])
+  else pprintEnvGetStr env id -- Note that this is not a recursive call!
+
 -- Similar to pprintEnvGetStr in mexpr/pprint.mc, but takes an Option Name as
 -- argument. If it is None (), the returned string is "".
 let pprintEnvGetOptStr = lam env. lam id.
@@ -27,7 +36,6 @@ let pprintEnvGetOptStr = lam env. lam id.
 -- C TYPES --
 -------------
 lang CTypePrettyPrint = CTypeAst
-
 
   sem printCType (decl: String) (env: PprintEnv) =
 

--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -363,6 +363,14 @@ lang CTopPrettyPrint =
 end
 
 
+-----------------------
+-- COMBINED FRAGMENT --
+-----------------------
+lang CPrettyPrint =
+  CExprPrettyPrint + CTypePrettyPrint + CInitPrettyPrint + CStmtPrettyPrint +
+  CTopPrettyPrint
+
+
 ---------------
 -- C PROGRAM --
 ---------------
@@ -383,21 +391,14 @@ lang CProgPrettyPrint = CProgAst + CTopPrettyPrint
 
 end
 
-
------------------------
--- COMBINED FRAGMENT --
------------------------
-lang CPrettyPrint =
-  CExprPrettyPrint + CTypePrettyPrint + CInitPrettyPrint + CStmtPrettyPrint +
-  CTopPrettyPrint + CProgPrettyPrint
-
-
 ----------------
 -- UNIT TESTS --
 ----------------
 
+lang Test = CPrettyPrint + CProgPrettyPrint
+
 mexpr
-use CPrettyPrint in
+use Test in
 
 let funname = nameSym "fun" in
 let mainname = nameSym "main" in

--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -3,6 +3,7 @@
 
 include "ast.mc"
 include "string.mc"
+include "char.mc"
 
 include "mexpr/pprint.mc"
 
@@ -18,14 +19,33 @@ let _par = lam str. join ["(",str,")"]
 let _joinSpace = lam fst. lam snd.
   if eqString "" snd then fst else join [fst, " ", snd]
 
-let pprintEnvGetStr = lam env. lam id.
+-- Replace invalid characters with underscore
+let replaceInvalidChar = lam c.
+  if isAlphaOrUnderscore c then c
+  else if isDigit c then c
+  else '_'
+
+-- Ensure string is a valid C identifier
+let escapeIdentifier = lam str: String.
+  match str with [h] ++ t then
+    let h =
+      if isAlphaOrUnderscore h then [h]
+      else if isDigit h then cons '_' [h]
+      else "_"
+    in
+    concat h (map replaceInvalidChar t)
+  else "_"
+
+let pprintEnvGetStr = lam env. lam id: Name.
   -- Set this to true to print names with their symbols (for debugging)
   if false then
     (env,join [
       nameGetStr id,
       match nameGetSym id with Some sym then int2string (sym2hash sym) else ""
     ])
-  else pprintEnvGetStr env id -- Note that this is not a recursive call!
+  else
+    let id = nameSetStr id (escapeIdentifier (nameGetStr id)) in
+    pprintEnvGetStr env id -- Note that this is not a recursive call!
 
 -- Similar to pprintEnvGetStr in mexpr/pprint.mc, but takes an Option Name as
 -- argument. If it is None (), the returned string is "".
@@ -66,7 +86,8 @@ lang CTypePrettyPrint = CTypeAst
     match idtup with (env,id) then
       match mem with Some mem then
         let f = lam env. lam t: (CType,Option String).
-          printCType (match t.1 with Some n then n else "") env t.0  in
+          printCType (match t.1 with Some n then escapeIdentifier n else "")
+            env t.0  in
         match mapAccumL f env mem with (env,mem) then
           let mem = map (lam s. join [s,";"]) mem in
           let mem = strJoin " " mem in
@@ -81,7 +102,8 @@ lang CTypePrettyPrint = CTypeAst
     match idtup with (env,id) then
       match mem with Some mem then
         let f = lam env. lam t: (CType, Option String).
-          printCType (match t.1 with Some n then n else "") env t.0 in
+          printCType (match t.1 with Some n then escapeIdentifier n else "")
+            env t.0 in
         match mapAccumL f env mem with (env,mem) then
           let mem = map (lam s. join [s,";"]) mem in
           let mem = strJoin " " mem in
@@ -142,12 +164,12 @@ lang CExprPrettyPrint = CExprAst + CTypePrettyPrint
 
   | CEMember { lhs = lhs, id = id } ->
     match printCExpr env lhs with (env,lhs) then
-      (env, _par (join [lhs, ".", id]))
+      (env, _par (join [lhs, ".", escapeIdentifier id]))
     else never
 
   | CEArrow { lhs = lhs, id = id } ->
     match printCExpr env lhs with (env,lhs) then
-      (env, _par (join [lhs, "->", id]))
+      (env, _par (join [lhs, "->", escapeIdentifier id]))
     else never
 
   | CECast { ty = ty, rhs = rhs } ->
@@ -435,6 +457,13 @@ utest print (wrapTop deftop) with
   "int x;"
 in
 
+let escapedName = CTDef {
+  ty = CTyInt {}, id = Some (nameSym "0@a[A"), init = None ()
+} in
+utest print (wrapTop escapedName) with
+  "int _0_a_A;"
+in
+
 let tydeftop = CTTyDef { ty = CTyInt {}, id = tyname } in
 utest print (wrapTop tydeftop) with
   "typedef int Ty;"
@@ -459,7 +488,7 @@ let structtop = CTDef {
   ty = CTyStruct {
     id = Some structtyname,
     mem = Some [
-      (CTyInt {}, Some "x"),
+      (CTyInt {}, Some "0x"),
       (CTyDouble {}, Some "y")
     ]
   },
@@ -467,7 +496,7 @@ let structtop = CTDef {
   init = None ()
 } in
 utest print (wrapTop structtop) with
-  "struct structty {int x; double y;};"
+  "struct structty {int _0x; double y;};"
 in
 
 let nestedstructtop = CTDef {
@@ -596,17 +625,17 @@ utest print (wrapStmt struct) with
 using eqString in
 
 let memb = CSExpr {
-  expr = CEMember { lhs = CEVar { id = structname }, id = "x" }
+  expr = CEMember { lhs = CEVar { id = structname }, id = "0x" }
 } in
 utest print (wrapStmt memb) with
-  wrapStmtString "(s.x);"
+  wrapStmtString "(s._0x);"
 using eqString in
 
 let arrow = CSExpr {
-  expr = CEArrow { lhs = CEVar { id = structname }, id = "x" }
+  expr = CEArrow { lhs = CEVar { id = structname }, id = "0x" }
 } in
 utest print (wrapStmt arrow) with
-  wrapStmtString "(s->x);"
+  wrapStmtString "(s->_0x);"
 using eqString in
 
 let nop = CSNop {} in
@@ -653,7 +682,7 @@ let union = CSDef {
   ty = CTyUnion {
     id = Some (nameSym "unionty"),
     mem = Some (
-      [(CTyInt {}, Some "x"),
+      [(CTyInt {}, Some "0x"),
        (CTyDouble {}, Some "y")]
     )
   },
@@ -661,7 +690,7 @@ let union = CSDef {
   init = None ()
 } in
 utest print (wrapStmt union) with
-  wrapStmtString "union unionty {int x; double y;};"
+  wrapStmtString "union unionty {int _0x; double y;};"
 using eqString in
 
 let enum = CSDef {
@@ -710,7 +739,7 @@ utest print (wrapStmt switch) with
     "    (fun(1, 'a'));",
     "    break;",
     "  default:",
-    "    (s.x);",
+    "    (s._0x);",
     "}"
   ])
 using eqString in
@@ -733,10 +762,10 @@ utest print (wrapStmt while) with
     "  (fun(1, 'a'));",
     "  {",
     "    x;",
-    "    (s.x);",
+    "    (s._0x);",
     "  }",
     "  continue;",
-    "  (s.x);",
+    "  (s._0x);",
     "}"
   ])
 using eqString in
@@ -802,15 +831,15 @@ utest printCProg [mainname] prog with strJoin "\n" [
   "#include <stdio.h>",
   "int x;",
   "char y = 'c';",
-  "struct structty {int x; double y;};",
+  "struct structty {int _0x; double y;};",
   "int arrinit[][3] = {{1, 2, 3}, {4, 5, 6}};",
   "char (*fun(int main1, char arg2))(int, double) {",
   "  double x = 0.1;",
   "  char strinit[] = \"strinit\";",
   "  struct structty s;",
-  "  union unionty {int x; double y;};",
+  "  union unionty {int _0x; double y;};",
   "  enum enumty {CONST, CONST1};",
-  "  (s.x);",
+  "  (s._0x);",
   "  (( struct structty (*(*(*)(char))(int (double))) ) 1);",
   "  (sizeof(struct structty (*(*(*)(char))(int (double)))));",
   "  (x = ((-1) * 3));",
@@ -831,16 +860,16 @@ utest printCProg [mainname] prog with strJoin "\n" [
   "      (fun(1, 'a'));",
   "      break;",
   "    default:",
-  "      (s.x);",
+  "      (s._0x);",
   "  }",
   "  while (42) {",
   "    (fun(1, 'a'));",
   "    {",
   "      x;",
-  "      (s.x);",
+  "      (s._0x);",
   "    }",
   "    continue;",
-  "    (s.x);",
+  "    (s._0x);",
   "  }",
   "}",
   "void noreturn() {",

--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -91,6 +91,16 @@ let isAlpha = lam c. or (isLowerAlpha c) (isUpperAlpha c)
 let isLowerAlphaOrUnderscore = lam c.
   or (isLowerAlpha c) (eqChar c '_')
 
+let isAlphaOrUnderscore = lam c.
+  if isAlpha c then true
+  else eqChar c '_'
+
+utest isAlphaOrUnderscore '1' with false
+utest isAlphaOrUnderscore 'a' with true
+utest isAlphaOrUnderscore 'A' with true
+utest isAlphaOrUnderscore '_' with true
+utest isAlphaOrUnderscore '{' with false
+
 utest isAlpha 'a' with true
 utest isAlpha 'm' with true
 utest isAlpha 'z' with true

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -101,10 +101,11 @@ end
 --------------------
 
 lang MExprCmp =
-
   UnknownTypeCmp + BoolTypeCmp + IntTypeCmp + FloatTypeCmp + CharTypeCmp +
   FunTypeCmp + SeqTypeCmp + TensorTypeCmp + RecordTypeCmp + VariantTypeCmp +
   VarTypeCmp + AppTypeCmp
+
+lang MExprCmpTypeIndex = MExprAst
 
   -- NOTE(dlunde,2021-05-11): This function cannot be defined in isolation for
   -- each component fragment (as with cmpTypeH). Optimally, this would be
@@ -125,13 +126,15 @@ lang MExprCmp =
 
 end
 
+lang MExprCmpClosed = MExprCmp + MExprCmpTypeIndex
+
 -----------
 -- TESTS --
 -----------
 
 mexpr
 
-use MExprCmp in
+use MExprCmpClosed in
 
 utest cmpType tyunknown_ tyunknown_ with 0 in
 utest cmpType tybool_ tybool_ with 0 in

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -323,8 +323,9 @@ lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
             ] in
             infoErrorExit t.info msg
         in
-        {{binding with body = body}
-                  with ty = tyBody}
+        {{{binding with body = body}
+                   with ty = tyBody}
+                   with tyBody = tyBody}
       else never
     in
     match env with {varEnv = varEnv} then

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -531,9 +531,12 @@ lang MExprTypeLift =
   AppTypeTypeLift + VariantNameTypeTypeLift + TensorTypeTypeLift
 end
 
-lang MExprTypeLiftOrderedRecords = MExprTypeLift + TypeLiftAddRecordToEnvOrdered
+lang MExprTypeLiftOrderedRecordsCmpClosed =
+  MExprTypeLift + TypeLiftAddRecordToEnvOrdered + MExprCmpTypeIndex
+lang MExprTypeLiftUnOrderedRecords =
+  MExprTypeLift + TypeLiftAddRecordToEnvUnOrdered
 lang MExprTypeLiftUnOrderedRecordsCmpClosed =
-  MExprTypeLift + TypeLiftAddRecordToEnvUnOrdered + MExprCmpTypeIndex
+  MExprTypeLiftUnOrderedRecords + MExprCmpTypeIndex
 
 lang TestLang =
   MExprTypeLiftUnOrderedRecordsCmpClosed + MExprSym + MExprTypeAnnot +

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -532,10 +532,12 @@ lang MExprTypeLift =
 end
 
 lang MExprTypeLiftOrderedRecords = MExprTypeLift + TypeLiftAddRecordToEnvOrdered
-lang MExprTypeLiftUnOrderedRecords = MExprTypeLift + TypeLiftAddRecordToEnvUnOrdered
+lang MExprTypeLiftUnOrderedRecordsCmpClosed =
+  MExprTypeLift + TypeLiftAddRecordToEnvUnOrdered + MExprCmpTypeIndex
 
-lang TestLang = MExprTypeLiftUnOrderedRecords + MExprSym + MExprTypeAnnot +
-                MExprPrettyPrint
+lang TestLang =
+  MExprTypeLiftUnOrderedRecordsCmpClosed + MExprSym + MExprTypeAnnot +
+  MExprPrettyPrint
 
 mexpr
 

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -304,7 +304,7 @@ let collectKnownProgramTypes = use MExprAst in
   let emptyUtestTypeEnv = {
     variants = mapEmpty nameCmp,      -- Map Name Type
     aliases = mapEmpty nameCmp,       -- Map Name Type
-    typeFunctions = use MExprCmp in mapEmpty cmpType -- Map Type (Name, Name)
+    typeFunctions = use MExprCmpClosed in mapEmpty cmpType -- Map Type (Name, Name)
   } in
   collectTypes emptyUtestTypeEnv expr
 

--- a/stdlib/ocaml/generate-env.mc
+++ b/stdlib/ocaml/generate-env.mc
@@ -10,7 +10,7 @@ type GenerateEnv = {
   exts : Map Name [ExternalImpl]
 }
 
-let _emptyGenerateEnv = use MExprCmp in {
+let _emptyGenerateEnv = use MExprCmpClosed in {
   constrs = mapEmpty nameCmp,
   records = mapEmpty (mapCmp cmpType),
   aliases = mapEmpty nameCmp,

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -644,7 +644,7 @@ let _addTypeDeclarations = lam typeLiftEnvMap. lam typeLiftEnv. lam t.
       else (t, recordFieldsToName)
     else never
   in
-  let init = use MExprCmp in (t, mapEmpty (mapCmp cmpType)) in
+  let init = use MExprCmpClosed in (t, mapEmpty (mapCmp cmpType)) in
   assocSeqFold f init typeLiftEnv
 
 let _typeLiftEnvToGenerateEnv = use MExprAst in
@@ -665,7 +665,7 @@ let _typeLiftEnvToGenerateEnv = use MExprAst in
   assocSeqFold f _emptyGenerateEnv typeLiftEnv
 
 
-lang OCamlTypeDeclGenerate = MExprTypeLiftOrderedRecords
+lang OCamlTypeDeclGenerate = MExprTypeLiftOrderedRecordsCmpClosed
   sem generateTypeDecl (env : AssocSeq Name Type) =
   | expr ->
     let typeLiftEnvMap = mapFromList nameCmp env in


### PR DESCRIPTION
 - Add `test` as an alias for `test-boot-base`.
 - Partially add various `sfold`s, `smap`s, and `sreplace`s to C AST.
 - Various updates to the C compiler
 - Ensure identifiers are printed with valid C variable names in C pprint.
 - Fix an issue in `type-annot.mc` where the `tyBody` in `TmRecLets` bindings were not updated correctly.
 - Changes to `MExprTypeLift` fragment (you should now use `MExprTypeLiftCmpClosed` instead unless you want to extend `MExprTypeLift` to some other fragment)