### PR TITLE
Catch boot errors in compiled code

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -120,7 +120,7 @@ let ocamlCompileAst = lam options : Options. lam sourcePath. lam mexprAst.
         -- Collect external library dependencies
         let libs = collectLibraries env.exts in
 
-        let ocamlProg = pprintOcaml ast in
+        let ocamlProg = pprintOcaml (tryWithCatchBootError ast) in
 
         -- Print the AST after code generation
         (if options.debugGenerate then printLn ocamlProg else ());

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -137,6 +137,19 @@ lang OCamlLabel
   | OTmLabel t -> OTmLabel { t with arg = f t.arg }
 end
 
+lang OCamlTryWith
+  syn Expr =
+  | OTmTryWith { body : Expr,  arms : [(Pat, Expr)] }
+
+  sem smap_Expr_Expr (f : Expr -> a) =
+  | OTmTryWith t ->
+    OTmTryWith {{t with body = f t.body}
+                   with arms = map (lam p : (Pat, Expr). (p.0, f p.1)) t.arms}
+
+  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
+  | OTmTryWith t -> foldl (lam acc. lam a : (Pat, Expr). f acc a.1) (f acc t.body) t.arms
+end
+
 lang OCamlTypeAst =
   BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst + RecordTypeAst +
   FunTypeAst + OCamlLabel
@@ -174,6 +187,7 @@ lang OCamlAst =
   -- Terms
   LamAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
   OCamlArray + OCamlData + OCamlTypeDeclAst + OCamlRecord + OCamlLabel +
+  OCamlTryWith +
 
   -- Constants
   ArithIntAst + ShiftIntAst + ArithFloatAst + BoolAst + FloatIntConversionAst +

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -18,6 +18,55 @@ include "ocaml/generate-env.mc"
 include "ocaml/external.mc"
 include "common.mc"
 
+-- Wraps a generated MExpr program in a try-with to catch exceptions raised by
+-- the boot parser. The wrapping is performed after type declarations, as they
+-- have to be placed at the toplevel.
+recursive let tryWithCatchBootError = use OCamlAst in use MExprAst in
+  lam expr : Expr.
+  match expr with OTmVariantTypeDecl t then
+    OTmVariantTypeDecl {t with inexpr = tryWithCatchBootError t.inexpr}
+  else
+    let msg = nameSym "msg" in
+    let printErrorMessageAndExit = TmLet {
+      ident = nameNoSym "",
+      tyBody = TyUnknown {info = NoInfo ()},
+      body = TmApp {
+        lhs = TmApp {
+          lhs = OTmVarExt {ident = "Printf.fprintf"},
+          rhs = OTmVarExt {ident = "stderr"},
+          ty = TyUnknown {info = NoInfo ()},
+          info = NoInfo ()
+        },
+        rhs = OTmString {text = "%s\\n"},
+        ty = TyUnknown {info = NoInfo ()},
+        info = NoInfo ()
+      },
+      inexpr = TmApp {
+        lhs = OTmVarExt {ident = "exit"},
+        rhs = TmConst {val = CInt {val = 1}, ty = TyUnknown {info = NoInfo ()},
+                       info = NoInfo ()},
+        ty = TyUnknown {info = NoInfo ()},
+        info = NoInfo ()
+      },
+      ty = TyUnknown {info = NoInfo ()},
+      info = NoInfo ()
+    } in
+    OTmTryWith {
+      body = expr,
+      arms = [
+        (OPatConExt {
+          ident = "Boot.Msg.Error",
+          args = [PatNamed {ident = PName msg, info = NoInfo ()}]},
+        TmApp {
+          lhs = printErrorMessageAndExit,
+          rhs = TmVar {ident = msg, ty = TyUnknown {info = NoInfo ()},
+                       info = NoInfo ()},
+          ty = TyUnknown {info = NoInfo ()},
+          info = NoInfo ()
+        })]
+    }
+end
+
 -- Input is a map from name to be introduced to name containing the value to be bound to that location
 -- Output is essentially `M.toList input & unzip & \(pats, exprs) -> (OPatTuple pats, TmTuple exprs)`
 -- alternatively output is made such that if (_mkFinalPatExpr ... = (pat, expr)) then let 'pat = 'expr

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -485,6 +485,23 @@ lang OCamlPrettyPrint =
     match pprintCode indent env tm with (env, tm) then
       (env, join [tm, ".", field])
     else never
+  | OTmTryWith {body = body, arms = arms} ->
+    let i = indent in
+    let ii = pprintIncr i in
+    let iii = pprintIncr ii in
+    match pprintCode ii env body with (env, body) then
+      let pprintArm = lam env. lam arm. match arm with (pat, expr) then
+        match getPatStringCode ii env pat with (env, pat) then
+          match printParen iii env expr with (env, expr) then
+            (env, join [pprintNewline i, "| ", pat, " ->", pprintNewline iii, expr])
+          else never
+        else never
+      else never in
+      match mapAccumL pprintArm env arms with (env, arms) then
+        (env, join ["try", pprintNewline ii, body, pprintNewline i,
+                    "with", join arms])
+      else never
+    else never
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
   | OPatRecord {bindings = bindings} ->


### PR DESCRIPTION
This PR fixes #383 by wrapping the generated OCaml code in a `try-with` expression. All exceptions of type `Boot.Msg.Error` are caught and their message is printed to `stdout` before exiting with exit code 1 (the same behaviour as in the boot evaluator). Most of the code was borrowed from commits in an old PR (#321) which were scrapped because a `try-with` was overkill for that problem.

**NOTE:** There is a slight difference in the error messages produced when running `mi` and `boot`. The former seems to only include the filename where the error occurred (`file.txt`) in the error message while the latter includes the entire filepath (`path/to/file.txt`).