### PR TITLE
Improved handling of info fields and some C compiler updates

### DIFF
--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -172,7 +172,7 @@ top:
 toplet:
   | LET var_ident ty_op EQ mexpr
     { let fi = mkinfo $1.i $4.i in
-      Let (fi, $2.v, $3, $5) }
+      Let (fi, $2.v, $3 $1.i, $5) }
 
 toptype:
   | TYPE type_ident type_params
@@ -192,7 +192,7 @@ topRecLet:
 topcon:
   | CON con_ident ty_op
     { let fi = mkinfo $1.i $2.i in
-      Con (fi, $2.v, $3) }
+      Con (fi, $2.v, $3 $1.i) }
 
 toputest:
   | UTEST mexpr WITH mexpr
@@ -256,13 +256,13 @@ constrs:
 constr:
   | BAR con_ident constr_params
     { let fi = mkinfo $1.i $2.i in
-      CDecl(fi, $2.v, $3) }
+      CDecl(fi, $2.v, $3 $1.i) }
 
 constr_params:
   | ty
-    { $1 }
+    { fun _ -> $1 }
   |
-    { tyUnit NoInfo }
+    { fun i -> tyUnit i }
 
 params:
   | LPAREN var_ident COLON ty RPAREN params
@@ -301,19 +301,19 @@ mexpr:
          TmRecLets(fi,lst,$4) }
   | LET var_ident ty_op EQ mexpr IN mexpr
       { let fi = mkinfo $1.i $6.i in
-        TmLet(fi,$2.v,Symb.Helpers.nosym,$3,$5,$7) }
+        TmLet(fi,$2.v,Symb.Helpers.nosym,$3 $1.i,$5,$7) }
   | LAM var_ident ty_op DOT mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
-        TmLam(fi,$2.v,Symb.Helpers.nosym,$3,$5) }
+        TmLam(fi,$2.v,Symb.Helpers.nosym,$3 $1.i,$5) }
   | LAM DOT mexpr
       { let fi = mkinfo $1.i (tm_info $3) in
         TmLam(fi,us"",Symb.Helpers.nosym,TyUnknown(fi),$3) }
   | IF mexpr THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $6) in
-        TmMatch(fi,$2,PatBool(NoInfo,true),$4,$6) }
+        TmMatch(fi,$2,PatBool(fi,true),$4,$6) }
   | CON con_ident ty_op IN mexpr
       { let fi = mkinfo $1.i $4.i in
-        TmConDef(fi,$2.v,Symb.Helpers.nosym,$3,$5)}
+        TmConDef(fi,$2.v,Symb.Helpers.nosym,$3 $1.i,$5)}
   | MATCH mexpr WITH pat THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $8) in
          TmMatch(fi,$2,$4,$6,$8) }
@@ -336,17 +336,17 @@ mexpr:
 lets:
   | LET var_ident ty_op EQ mexpr
       { let fi = mkinfo $1.i (tm_info $5) in
-        [(fi, $2.v, $3, $5)] }
+        [(fi, $2.v, $3 $1.i, $5)] }
   | LET var_ident ty_op EQ mexpr lets
       { let fi = mkinfo $1.i (tm_info $5) in
-        (fi, $2.v, $3, $5)::$6 }
+        (fi, $2.v, $3 $1.i, $5)::$6 }
 
 sequence:
   | left
      { $1 }
   | left SEMI mexpr
      { let fi = tm_info $1 in
-       TmLet(fi, us"", Symb.Helpers.nosym, TyUnknown(NoInfo), $1, $3) }
+       TmLet(fi, us"", Symb.Helpers.nosym, TyUnknown(fi), $1, $3) }
 
 left:
   | atom
@@ -496,9 +496,9 @@ pat_list:
 
 ty_op:
   | COLON ty
-      { $2 }
+      { fun _ -> $2 }
   |
-      { TyUnknown NoInfo }
+      { fun i -> TyUnknown i }
 
 
 ty:

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -49,10 +49,10 @@
 include "name.mc"
 include "option.mc"
 
--------------
--- C TYPES --
--------------
-lang CTypeAst
+-----------------------------
+-- C TYPES AND EXPRESSIONS --
+-----------------------------
+lang CExprTypeAst
 
   syn CType =
   | CTyVar    { id: Name }
@@ -62,18 +62,10 @@ lang CTypeAst
   | CTyVoid   {}
   | CTyPtr    { ty: CType }
   | CTyFun    { ret: CType, params: [CType] }
-  | CTyArray  { ty: CType, size: Option Int }
+  | CTyArray  { ty: CType, size: Option CExpr }
   | CTyStruct { id: Option Name, mem: Option [(CType,Option String)] }
   | CTyUnion  { id: Option Name, mem: Option [(CType,Option String)] }
   | CTyEnum   { id: Option Name, mem: Option [Name] }
-
-end
-
-
--------------------
--- C EXPRESSIONS --
--------------------
-lang CExprAst = CTypeAst
 
   syn CExpr =
   | CEVar        /- Variables -/            { id: Name }
@@ -154,7 +146,7 @@ end
 --------------------
 -- C INITIALIZERS --
 --------------------
-lang CInitAst = CExprAst
+lang CInitAst = CExprTypeAst
 
   syn CInit =
   | CIExpr { expr: CExpr }
@@ -173,7 +165,7 @@ end
 ------------------
 -- C STATEMENTS --
 ------------------
-lang CStmtAst = CTypeAst + CInitAst + CExprAst
+lang CStmtAst = CInitAst + CExprTypeAst
   -- We force if, switch, and while to introduce new scopes (by setting the
   -- body type to [CStmt] rather than CStmt). It is allowed in C to have a
   -- single (i.e., not compound) statement as the body, but this statement is
@@ -257,7 +249,7 @@ end
 -----------------
 -- C TOP-LEVEL --
 -----------------
-lang CTopAst = CTypeAst + CInitAst + CStmtAst
+lang CTopAst = CExprTypeAst + CInitAst + CStmtAst
 
   syn CTop =
   -- Type definitions are supported at this level.
@@ -280,7 +272,7 @@ end
 -----------------------
 -- COMBINED FRAGMENT --
 -----------------------
-lang CAst = CExprAst + CTypeAst + CInitAst + CStmtAst + CTopAst
+lang CAst = CExprTypeAst + CInitAst + CStmtAst + CTopAst
 
 
 ---------------

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -214,14 +214,19 @@ lang MExprCCompile = MExprAst + CAst
           (t.0, cons 'd' (int2string i), t.1)) constrLs in
       let constrData = foldl (lam acc. lam t: (Name,String,CType).
         assocSeqInsert t.0 t.1 acc) constrData constrLs in
+      let nameEnum = nameSym "constrs" in
+      let enum = CTDef {
+        ty = CTyEnum {
+          id = Some nameEnum,
+          mem = Some (map (lam t. t.0) constrLs)
+        },
+        id = None (), init = None ()
+      } in
       let def = CTDef {
         ty = CTyStruct {
           id = Some name,
           mem = Some [
-            (CTyEnum {
-               id = None (),
-               mem = Some (map (lam t. t.0) constrLs)
-             }, Some _constrKey),
+            (CTyEnum { id = Some nameEnum, mem = None () }, Some _constrKey),
             (CTyUnion {
                id = None (),
                mem = Some (map
@@ -231,7 +236,7 @@ lang MExprCCompile = MExprAst + CAst
         id = None (), init = None ()
       }
       in
-      (constrData, cons def postDefs)
+      (constrData, concat [enum,def] postDefs)
     else never
 
   | _ -> acc
@@ -279,8 +284,8 @@ lang MExprCCompile = MExprAst + CAst
       CTyPtr { ty = CTyStruct { id = Some ident, mem = None() } }
     else CTyVar { id = ident }
 
-  -- | TyUnknown _ -> CTyChar {}
-  | TyUnknown _ -> error "Unknown type in compileType"
+  | TyUnknown _ -> CTyChar {}
+  -- | TyUnknown _ -> error "Unknown type in compileType"
 
   | TySeq { ty = TyChar _ } -> CTyPtr { ty = CTyChar {} }
 
@@ -1034,7 +1039,8 @@ utest testCompile typedefs with strJoin "\n" [
   "typedef Integer Integer2;",
   "struct Rec2 {Integer2 v;};",
   "struct Rec3 {int v; struct Tree (*l); struct Tree (*r);};",
-  "struct Tree {enum {Leaf, Node} constr; union {struct Rec2 (*d0); struct Rec3 (*d1);};};",
+  "enum constrs {Leaf, Node};",
+  "struct Tree {enum constrs constr; union {struct Rec2 (*d0); struct Rec3 (*d1);};};",
   "int main(int argc, char (*argv[])) {",
   "  return 0;",
   "}"
@@ -1043,7 +1049,7 @@ utest testCompile typedefs with strJoin "\n" [
 -- Potentially tricky case with type aliases
 let alias = bindall_ [
   type_ "MyRec" (tyrecord_ [("k", tyint_)]),
-  let_ "myRec" (tyvar_ "MyRec") (record_ [("k", int_ 0)]),
+  let_ "myRec" (tyvar_ "MyRec") (urecord_ [("k", int_ 0)]),
   int_ 0
 ] in
 utest testCompile alias with strJoin "\n" [
@@ -1107,7 +1113,8 @@ utest testCompile trees with strJoin "\n" [
   "struct Tree;",
   "struct Rec {int v;};",
   "struct Rec1 {int v; struct Tree (*l); struct Tree (*r);};",
-  "struct Tree {enum {Leaf, Node} constr; union {struct Rec (*d0); struct Rec1 (*d1);};};",
+  "enum constrs {Leaf, Node};",
+  "struct Tree {enum constrs constr; union {struct Rec (*d0); struct Rec1 (*d1);};};",
   "struct Rec alloc;",
   "struct Rec (*t);",
   "struct Tree alloc1;",

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -106,9 +106,17 @@ let tychar_ = use CharTypeAst in
 let tyunknown_ = use UnknownTypeAst in
   TyUnknown {info = NoInfo ()}
 
+let ityunknown_ = use UnknownTypeAst in
+  lam i: Info.
+  TyUnknown {info = i}
+
+let ityseq_ = use SeqTypeAst in
+  lam info. lam ty.
+  TySeq {ty = ty, info = info}
+
 let tyseq_ = use SeqTypeAst in
   lam ty.
-  TySeq {ty = ty, info = NoInfo ()}
+  ityseq_ (NoInfo ()) ty
 
 let tystr_ = tyseq_ tychar_
 
@@ -116,9 +124,13 @@ let tytensor_ = use TensorTypeAst in
   lam ty.
   TyTensor {ty = ty, info = NoInfo ()}
 
+let ityarrow_ = use FunTypeAst in
+  lam info. lam from. lam to.
+  TyArrow {from = from, to = to, info = info}
+
 let tyarrow_ = use FunTypeAst in
   lam from. lam to.
-  TyArrow {from = from, to = to, info = NoInfo ()}
+  ityarrow_ (NoInfo ()) from to
 
 let tyarrows_ = use FunTypeAst in
   lam tys.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -34,6 +34,9 @@ lang VarAst = Ast
   sem ty =
   | TmVar t -> t.ty
 
+  sem withInfo (info : Info) =
+  | TmVar t -> TmVar {t with info = info}
+
   sem withType (ty : Type) =
   | TmVar t -> TmVar {t with ty = ty}
 
@@ -58,6 +61,9 @@ lang AppAst = Ast
 
   sem ty =
   | TmApp t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmApp t -> TmApp {t with info = info}
 
   sem withType (ty : Type) =
   | TmApp t -> TmApp {t with ty = ty}
@@ -87,6 +93,9 @@ lang LamAst = Ast + VarAst + AppAst
   sem ty =
   | TmLam t -> t.ty
 
+  sem withInfo (info : Info) =
+  | TmLam t -> TmLam {t with info = info}
+
   sem withType (ty : Type) =
   | TmLam t -> TmLam {t with ty = ty}
 
@@ -113,6 +122,9 @@ lang LetAst = Ast + VarAst
 
   sem ty =
   | TmLet t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmLet t -> TmLet {t with info = info}
 
   sem withType (ty : Type) =
   | TmLet t -> TmLet {t with ty = ty}
@@ -144,6 +156,9 @@ lang RecLetsAst = Ast + VarAst
 
   sem ty =
   | TmRecLets t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmRecLets t -> TmRecLets {t with info = info}
 
   sem withType (ty : Type) =
   | TmRecLets t -> TmRecLets {t with ty = ty}
@@ -182,6 +197,9 @@ lang ConstAst = Ast
   sem ty =
   | TmConst t -> t.ty
 
+  sem withInfo (info : Info) =
+  | TmConst t -> TmConst {t with info = info}
+
   sem withType (ty : Type) =
   | TmConst t -> TmConst {t with ty = ty}
 
@@ -204,6 +222,9 @@ lang SeqAst = Ast
 
   sem ty =
   | TmSeq t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmSeq t -> TmSeq {t with info = info}
 
   sem withType (ty : Type) =
   | TmSeq t -> TmSeq {t with ty = ty}
@@ -236,6 +257,10 @@ lang RecordAst = Ast
   | TmRecord t -> t.ty
   | TmRecordUpdate t -> t.ty
 
+  sem withInfo (info : Info) =
+  | TmRecord t -> TmRecord {t with info = info}
+  | TmRecordUpdate t -> TmRecordUpdate {t with info = info}
+
   sem withType (ty : Type) =
   | TmRecord t -> TmRecord {t with ty = ty}
   | TmRecordUpdate t -> TmRecordUpdate {t with ty = ty}
@@ -264,6 +289,9 @@ lang TypeAst = Ast
 
   sem ty =
   | TmType t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmType t -> TmType {t with info = info}
 
   sem withType (ty : Type) =
   | TmType t -> TmType {t with ty = ty}
@@ -295,6 +323,10 @@ lang DataAst = Ast
   sem ty =
   | TmConDef t -> t.ty
   | TmConApp t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmConDef t -> TmConDef {t with info = info}
+  | TmConApp t -> TmConApp {t with info = info}
 
   sem withType (ty : Type) =
   | TmConDef t -> TmConDef {t with ty = ty}
@@ -328,6 +360,9 @@ lang MatchAst = Ast
   sem ty =
   | TmMatch t -> t.ty
 
+  sem withInfo (info : Info) =
+  | TmMatch t -> TmMatch {t with info = info}
+
   sem withType (ty : Type) =
   | TmMatch t -> TmMatch {t with ty = ty}
 
@@ -356,6 +391,9 @@ lang UtestAst = Ast
 
   sem ty =
   | TmUtest t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmUtest t -> TmUtest {t with info = info}
 
   sem withType (ty : Type) =
   | TmUtest t -> TmUtest {t with ty = ty}
@@ -386,6 +424,9 @@ lang NeverAst = Ast
   sem ty =
   | TmNever t -> t.ty
 
+  sem withInfo (info : Info) =
+  | TmNever t -> TmNever {t with info = info}
+
   sem withType (ty : Type) =
   | TmNever t -> TmNever {t with ty = ty}
 
@@ -410,6 +451,9 @@ lang ExtAst = Ast + VarAst
 
   sem ty =
   | TmExt t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmExt t -> TmExt {t with info = info}
 
   sem withType (ty : Type) =
   | TmExt t -> TmExt {t with ty = ty}
@@ -826,6 +870,12 @@ lang UnknownTypeAst = Ast
   syn Type =
   | TyUnknown {info : Info}
 
+  sem tyWithInfo (info : Info) =
+  | TyUnknown t -> TyUnknown {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyUnknown t -> TyUnknown t
+
   sem infoTy =
   | TyUnknown r -> r.info
 end
@@ -833,6 +883,12 @@ end
 lang BoolTypeAst = Ast
   syn Type =
   | TyBool {info  : Info}
+
+  sem tyWithInfo (info : Info) =
+  | TyBool t -> TyBool {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyBool t -> TyBool t
 
   sem infoTy =
   | TyBool r -> r.info
@@ -842,6 +898,12 @@ lang IntTypeAst = Ast
   syn Type =
   | TyInt {info : Info}
 
+  sem tyWithInfo (info : Info) =
+  | TyInt t -> TyInt {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyInt t -> TyInt t
+
   sem infoTy =
   | TyInt r -> r.info
 end
@@ -850,6 +912,12 @@ lang FloatTypeAst = Ast
   syn Type =
   | TyFloat {info : Info}
 
+  sem tyWithInfo (info : Info) =
+  | TyFloat t -> TyFloat {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyFloat t -> TyFloat t
+
   sem infoTy =
   | TyFloat r -> r.info
 end
@@ -857,6 +925,12 @@ end
 lang CharTypeAst = Ast
   syn Type =
   | TyChar {info  : Info}
+
+  sem tyWithInfo (info : Info) =
+  | TyChar t -> TyChar {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyChar t -> TyChar t
 
   sem infoTy =
   | TyChar r -> r.info
@@ -867,6 +941,13 @@ lang FunTypeAst = Ast
   | TyArrow {info : Info,
              from : Type,
              to   : Type}
+
+  sem tyWithInfo (info : Info) =
+  | TyArrow t -> TyArrow {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyArrow t -> TyArrow {{t with from = f t.from} with to = f t.to}
+
   sem infoTy =
   | TyArrow r -> r.info
 end
@@ -875,6 +956,13 @@ lang SeqTypeAst = Ast
   syn Type =
   | TySeq {info : Info,
            ty   : Type}
+
+  sem tyWithInfo (info : Info) =
+  | TySeq t -> TySeq {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TySeq t -> TySeq {t with ty = f t.ty}
+
   sem infoTy =
   | TySeq r -> r.info
 end
@@ -883,6 +971,13 @@ lang TensorTypeAst = Ast
   syn Type =
   | TyTensor {info : Info,
               ty   : Type}
+
+  sem tyWithInfo (info : Info) =
+  | TyTensor t -> TyTensor {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyTensor t -> TyTensor {t with ty = f t.ty}
+
   sem infoTy =
   | TyTensor r -> r.info
 end
@@ -892,6 +987,13 @@ lang RecordTypeAst = Ast
   | TyRecord {info    : Info,
               fields  : Map SID Type,
               labels  : [SID]}
+
+  sem tyWithInfo (info : Info) =
+  | TyRecord t -> TyRecord {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyRecord t -> TyRecord {t with fields = mapMap f t.fields}
+
   sem infoTy =
   | TyRecord r -> r.info
 end
@@ -900,6 +1002,13 @@ lang VariantTypeAst = Ast
   syn Type =
   | TyVariant {info     : Info,
                constrs  : Map Name Type}
+
+  sem tyWithInfo (info : Info) =
+  | TyVariant t -> TyVariant {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyVariant t -> TyVariant {t with constrs = mapMap f t.constrs}
+
   sem infoTy =
   | TyVariant r -> r.info
 end
@@ -908,6 +1017,13 @@ lang VarTypeAst = Ast
   syn Type =
   | TyVar {info   : Info,
            ident  : Name}
+
+  sem tyWithInfo (info : Info) =
+  | TyVar t -> TyVar {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyVar t -> TyVar t
+
   sem infoTy =
   | TyVar r -> r.info
 end
@@ -917,6 +1033,13 @@ lang AppTypeAst = Ast
   | TyApp {info : Info,
            lhs  : Type,
            rhs  : Type}
+
+  sem tyWithInfo (info : Info) =
+  | TyApp t -> TyApp {t with info = info}
+
+  sem smap_Type_Type (f : Type -> a) =
+  | TyApp t -> TyApp {{t with lhs = f t.lhs} with rhs = f t.rhs}
+
   sem infoTy =
   | TyApp r -> r.info
 end

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -51,17 +51,17 @@ lang BootParser = MExprAst + ConstTransformer
   sem matchTerm (t:Unknown) =
   | 100 /-TmVar-/ ->
       TmVar {ident = gname t 0,
-             ty = tyunknown_,
+             ty = TyUnknown { info = ginfo t 0 },
              info = ginfo t 0}
   | 101 /-TmApp-/ ->
       TmApp {lhs = gterm t 0,
              rhs = gterm t 1,
-             ty = tyunknown_,
+             ty = TyUnknown { info = ginfo t 0 },
              info = ginfo t 0}
   | 102 /-TmLam-/ ->
       TmLam {ident = gname t 0,
              tyIdent = gtype t 0,
-             ty = tyunknown_,
+             ty = TyUnknown { info = ginfo t 0 },
              info = ginfo t 0,
              body = gterm t 0}
   | 103 /-TmLet-/ ->
@@ -69,64 +69,64 @@ lang BootParser = MExprAst + ConstTransformer
              tyBody = gtype t 0,
              body = gterm t 0,
              inexpr = gterm t 1,
-             ty = tyunknown_,
+             ty = TyUnknown { info = ginfo t 0 },
              info = ginfo t 0}
   | 104 /-TmRecLets-/ ->
       TmRecLets {bindings =
                    makeSeq (lam n. {ident = gname t n,
                                     tyBody = gtype t n,
                                     body = gterm t n,
-                                    ty = tyunknown_,
+                                    ty = TyUnknown { info = ginfo t 0 },
                                     info = ginfo t (addi n 1)})
                                       (glistlen t 0),
                  inexpr = gterm t (glistlen t 0),
-                 ty = tyunknown_,
+                 ty = TyUnknown { info = ginfo t 0 },
                  info = ginfo t 0}
   | 105 /-TmConst-/ ->
       let c = gconst t 0 in
       TmConst {val = gconst t 0,
-               ty = tyunknown_,
+               ty = TyUnknown { info = ginfo t 0 },
                info = ginfo t 0}
   | 106 /-TmSeq-/ ->
       TmSeq {tms = makeSeq (lam n. gterm t n) (glistlen t 0),
-             ty =  tyunknown_,
+             ty =  TyUnknown { info = ginfo t 0 },
              info = ginfo t 0}
   | 107 /-TmRecord-/ ->
      let lst = makeSeq (lam n. (gstr t n, gterm t n)) (glistlen t 0) in
       TmRecord {bindings =
                  mapFromList cmpSID
                    (map (lam b : (a,b). (stringToSid b.0, b.1)) lst),
-               ty = tyunknown_,
+               ty = TyUnknown { info = ginfo t 0 },
                info = ginfo t 0}
   | 108 /-TmRecordUpdate-/ ->
      TmRecordUpdate {rec = gterm t 0,
                     key = stringToSid (gstr t 0),
                     value = gterm t 1,
-                    ty = tyunknown_,
+                    ty = TyUnknown { info = ginfo t 0 },
                     info = ginfo t 0}
   | 109 /-TmType-/ ->
       TmType {ident = gname t 0,
               tyIdent = gtype t 0,
-              ty = tyunknown_,
+              ty = TyUnknown { info = ginfo t 0 },
               inexpr = gterm t 0,
               info = ginfo t 0}
   | 110 /-TmConDef-/ ->
      TmConDef {ident = gname t 0,
                tyIdent = gtype t 0,
                inexpr = gterm t 0,
-               ty = tyunknown_,
+               ty = TyUnknown { info = ginfo t 0 },
                info = ginfo t 0}
   | 111 /-TmConApp-/ ->
      TmConApp {ident = gname t 0,
                body = gterm t 0,
-               ty = tyunknown_,
+               ty = TyUnknown { info = ginfo t 0 },
                info = ginfo t 0}
   | 112 /-TmMatch-/ ->
      TmMatch {target = gterm t 0,
               pat = gpat t 0,
               thn = gterm t 1,
               els = gterm t 2,
-              ty = tyunknown_,
+              ty = TyUnknown { info = ginfo t 0 },
               info = ginfo t 0}
   | 113 /-TmUtest-/ ->
      let tusing = match (glistlen t 0) with 4 then
@@ -136,10 +136,10 @@ lang BootParser = MExprAst + ConstTransformer
               expected = gterm t 1,
               next = gterm t 2,
               tusing = tusing,
-              ty = tyunknown_,
+              ty = TyUnknown { info = ginfo t 0 },
               info = ginfo t 0}
   | 114 /-TmNever-/ ->
-     TmNever {ty = tyunknown_,
+     TmNever {ty = TyUnknown { info = ginfo t 0 },
               info = ginfo t 0}
   | 115 /-TmExt-/ ->
     TmExt {ident = gname t 0,

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -241,8 +241,8 @@ lang AppTypeAnnot = TypeAnnot + AppAst + FunTypeAst + MExprEq
       match (ty lhs, ty rhs) with (TyArrow {from = from, to = to}, ty) then
         match compatibleType env.tyEnv from ty with Some _ then
           to
-        else tyunknown_
-      else tyunknown_
+        else (ityunknown_ t.info)
+      else (ityunknown_ t.info)
     in
     TmApp {{{t with lhs = lhs}
                with rhs = rhs}
@@ -255,7 +255,7 @@ lang LamTypeAnnot = TypeAnnot + LamAst + FunTypeAst
     match env with {varEnv = varEnv} then
       let env = {env with varEnv = mapInsert t.ident t.tyIdent varEnv} in
       let body = typeAnnotExpr env t.body in
-      let ty = tyarrow_ t.tyIdent (ty body) in
+      let ty = ityarrow_ t.info t.tyIdent (ty body) in
       TmLam {{t with body = body}
                 with ty = ty}
     else never
@@ -341,7 +341,10 @@ end
 
 lang ConstTypeAnnot = TypeAnnot + MExprConstType
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmConst t -> TmConst {t with ty = tyConst t.val}
+  | TmConst t ->
+    recursive let f = lam ty. smap_Type_Type f (tyWithInfo t.info ty) in
+    let ty = f (tyConst t.val) in
+    TmConst {t with ty = ty }
 end
 
 lang SeqTypeAnnot = TypeAnnot + SeqAst + MExprEq
@@ -349,15 +352,16 @@ lang SeqTypeAnnot = TypeAnnot + SeqAst + MExprEq
   | TmSeq t ->
     let tms = map (typeAnnotExpr env) t.tms in
     let elemTy =
-      if eqi (length tms) 0 then tyunknown_
+      if eqi (length tms) 0 then ityunknown_ t.info
       else
         let types = map (lam term. ty term) tms in
-        match optionFoldlM (compatibleType env.tyEnv) tyunknown_ types with Some ty then
+        match optionFoldlM (compatibleType env.tyEnv) (ityunknown_ t.info) types
+        with Some ty then
           ty
-        else tyunknown_
+        else (ityunknown_ t.info)
     in
     TmSeq {{t with tms = tms}
-              with ty = tyseq_ elemTy}
+              with ty = ityseq_ t.info elemTy}
 end
 
 lang RecordTypeAnnot = TypeAnnot + RecordAst + RecordTypeAst
@@ -404,7 +408,7 @@ lang DataTypeAnnot = TypeAnnot + DataAst + MExprEq
             recursive let tyvar = lam ty.
               match ty with TyVar _ then ty
               else match ty with TyApp t then tyvar t.lhs
-              else tyunknown_
+              else (ityunknown_ t.info)
             in
             match compatibleType tyEnv (ty body) from with Some _ then
               tyvar to
@@ -415,7 +419,7 @@ lang DataTypeAnnot = TypeAnnot + DataAst + MExprEq
                 ", but the actual type was ", _pprintType (ty body)
               ] in
               infoErrorExit t.info msg
-          else tyunknown_
+          else (ityunknown_ t.info)
         else
           let msg = join ["Application of untyped constructor: ",
                           nameGetStr t.ident] in
@@ -440,7 +444,7 @@ lang MatchTypeAnnot = TypeAnnot + MatchAst + MExprEq
       match env with {tyEnv = tyEnv} then
         match compatibleType tyEnv (ty thn) (ty els) with Some ty then
           ty
-        else tyunknown_
+        else (ityunknown_ t.info)
       else never
     in
     TmMatch {{{{t with target = target}
@@ -465,7 +469,7 @@ end
 
 lang NeverTypeAnnot = TypeAnnot + NeverAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmNever t -> TmNever {t with ty = tyunknown_}
+  | TmNever t -> TmNever {t with ty = (ityunknown_ t.info)}
 end
 
 
@@ -486,7 +490,7 @@ lang SeqTotPatTypeAnnot = TypeAnnot + SeqTotPat + UnknownTypeAst + SeqTypeAst
   | PatSeqTot t ->
     let elemTy =
       match expectedTy with TySeq {ty = elemTy} then Some elemTy
-      else match expectedTy with TyUnknown _ then Some tyunknown_
+      else match expectedTy with TyUnknown _ then Some (ityunknown_ t.info)
       else None ()
     in
     match elemTy with Some ty then
@@ -499,7 +503,7 @@ lang SeqEdgePatTypeAnnot = TypeAnnot + SeqEdgePat + UnknownTypeAst + SeqTypeAst
   | PatSeqEdge t ->
     let elemTy =
       match expectedTy with TySeq {ty = elemTy} then Some elemTy
-      else match expectedTy with TyUnknown _ then Some tyunknown_
+      else match expectedTy with TyUnknown _ then Some (ityunknown_ t.info)
       else None ()
     in
     match elemTy with Some ty then
@@ -527,7 +531,7 @@ lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
       mapFoldWithKey (annotFields fields) env t.bindings
     else match expectedTy with TyUnknown _ then
       let annotUnknown = lam acc. lam. lam pat.
-        typeAnnotPat acc tyunknown_ pat
+        typeAnnotPat acc (ityunknown_ t.info) pat
       in
       mapFoldWithKey annotUnknown env t.bindings
     else env


### PR DESCRIPTION
- Improve handling of info fields
  * `parser.mly` now generates unknown types with appropriate info fields.
  * `boot-parser.mc` now generates unknown types with appropriate info fields.
  * `type-annot.mc` attaches appropriate info fields to generated types.
  * `const-transformer.mc` no longer discards info fields when replacing variables with constants.
  * New semantic functions `tyWithInfo` and `withInfo`.
  * C compiler now exits with `infoErrorExit` on type errors.
- Added smap_Type_Type (tested indirectly through `type-lift.mc`)
- Move enum in C compiler to top level for compatibility with C++
- CTyArray now has a CExpr as size (previously Int)

