### PR TITLE
Smap stuff

### DIFF
--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -8,7 +8,7 @@ include "ast-builder.mc"
 include "symbolize.mc"
 include "eq.mc"
 
-lang FunCPS = LamSym + LamEq + UnknownTypeSym + UnknownTypeEq
+lang FunCPS = LamSym + LamEq + UnknownTypeAst + UnknownTypeEq
 
   sem cpsK (cont: Expr -> Expr) =
   | TmLam t -> cont (cpsM (TmLam t))

--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -47,7 +47,7 @@ let infoVal : String -> Int -> Int -> Int -> Int -> Info =
   lam filename. lam r1. lam c1. lam r2. lam c2.
   Info {filename = filename, row1 = r1, col1 = c1, row2 = r2, col2 = c2}
 
--- Generate an info error stirng
+-- Generate an info error string
 let infoErrorString : Info -> String -> String = lam fi. lam str.
   let infoStr =
     match fi with NoInfo () then "[No file info] " else

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -32,12 +32,24 @@ let symEnvEmpty =
 -- TERMS --
 -----------
 
-lang Sym
+lang Sym = Ast
   sem symbolizeType (env : SymEnv) =
-  -- Intentionally left blank
+  | t -> smap_Type_Type (symbolizeType env) t
 
   -- Symbolize with an environment
   sem symbolizeExpr (env : SymEnv) =
+  | t ->
+    let t = smap_Expr_Expr (symbolizeExpr env) t in
+    withType (symbolizeType env (ty t)) t
+
+  -- TODO(vipa, 2020-09-23): env is constant throughout symbolizePat,
+  -- so it would be preferrable to pass it in some other way, a reader
+  -- monad or something. patEnv on the other hand changes, it would be
+  -- nice to pass via state monad or something.  env is the
+  -- environment from the outside, plus the names added thus far in
+  -- the pattern patEnv is only the newly added names
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
+  | t -> smapAccumL_Pat_Pat (symbolizePat env) patEnv t
 
   -- Symbolize with builtin environment
   sem symbolize =
@@ -60,15 +72,7 @@ lang VarSym = Sym + VarAst
     else never
 end
 
-lang AppSym = Sym + AppAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmApp t ->
-    TmApp {{{t with lhs = symbolizeExpr env t.lhs}
-               with rhs = symbolizeExpr env t.rhs}
-               with ty = symbolizeType env t.ty}
-end
-
-lang LamSym = Sym + LamAst + VarSym + AppSym
+lang LamSym = Sym + LamAst + VarSym
   sem symbolizeExpr (env : SymEnv) =
   | TmLam t ->
     match env with {varEnv = varEnv} then
@@ -90,22 +94,7 @@ lang LamSym = Sym + LamAst + VarSym + AppSym
     else never
 end
 
-lang RecordSym = Sym + RecordAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmRecord t ->
-    TmRecord {{t with bindings = mapMap (symbolizeExpr env) t.bindings}
-                 with ty = symbolizeType env t.ty}
-
-  | TmRecordUpdate t ->
-    TmRecordUpdate {{{t with rec = symbolizeExpr env t.rec}
-                        with value = symbolizeExpr env t.value}
-                        with ty = symbolizeType env t.ty}
-end
-
 lang LetSym = Sym + LetAst
-  sem symbolizeType (env : SymEnv) =
-  -- Intentinally left blank
-
   sem symbolizeExpr (env : SymEnv) =
   | TmLet t ->
     match env with {varEnv = varEnv} then
@@ -131,9 +120,6 @@ lang LetSym = Sym + LetAst
 end
 
 lang ExtSym = Sym + ExtAst
-  sem symbolizeType (env : SymEnv) =
-  -- Intentinally left blank
-
   sem symbolizeExpr (env : SymEnv) =
   | TmExt t ->
     match env with {varEnv = varEnv} then
@@ -153,9 +139,6 @@ lang ExtSym = Sym + ExtAst
 end
 
 lang TypeSym = Sym + TypeAst
-  sem symbolizeType (env : SymEnv) =
-  -- Intentinally left blank
-
   sem symbolizeExpr (env : SymEnv) =
   | TmType t ->
     match env with {tyEnv = tyEnv} then
@@ -178,9 +161,6 @@ lang TypeSym = Sym + TypeAst
 end
 
 lang RecLetsSym = Sym + RecLetsAst
-  sem symbolizeType (env : SymEnv) =
-  -- Intentionally left blank
-
   sem symbolizeExpr (env : SymEnv) =
   | TmRecLets t ->
     match env with {varEnv = varEnv} then
@@ -214,15 +194,7 @@ lang RecLetsSym = Sym + RecLetsAst
     else never
 end
 
-lang ConstSym = Sym + ConstAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmConst t -> TmConst t
-end
-
 lang DataSym = Sym + DataAst
-  sem symbolizeType (env : SymEnv) =
-  -- Intentinally left blank
-
   sem symbolizeExpr (env : SymEnv) =
   | TmConDef t ->
     match env with {conEnv = conEnv} then
@@ -260,15 +232,6 @@ lang DataSym = Sym + DataAst
 end
 
 lang MatchSym = Sym + MatchAst
-  -- TODO(vipa, 2020-09-23): env is constant throughout symbolizePat,
-  -- so it would be preferrable to pass it in some other way, a reader
-  -- monad or something. patEnv on the other hand changes, it would be
-  -- nice to pass via state monad or something.  env is the
-  -- environment from the outside, plus the names added thus far in
-  -- the pattern patEnv is only the newly added names
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  -- Intentionally left blank
-
   sem symbolizeExpr (env : SymEnv) =
   | TmMatch t ->
     match symbolizePat env (mapEmpty cmpString) t.pat
@@ -282,80 +245,9 @@ lang MatchSym = Sym + MatchAst
     else never
 end
 
-lang UtestSym = Sym + UtestAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmUtest t ->
-    let tusing = optionMap (symbolizeExpr env) t.tusing in
-    TmUtest {{{{{t with test = symbolizeExpr env t.test}
-                   with expected = symbolizeExpr env t.expected}
-                   with next = symbolizeExpr env t.next}
-                   with tusing = tusing}
-                   with ty = symbolizeType env t.ty}
-end
-
-lang SeqSym = Sym + SeqAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmSeq t ->
-    TmSeq {{t with tms = map (symbolizeExpr env) t.tms}
-              with ty = symbolizeType env t.ty}
-end
-
-lang NeverSym = Sym + NeverAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmNever t -> TmNever {t with ty = symbolizeType env t.ty}
-end
-
 -----------
 -- TYPES --
 -----------
-
-lang UnknownTypeSym = UnknownTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyUnknown _ & ty -> ty
-end
-
-lang BoolTypeSym = BoolTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyBool _ & ty -> ty
-end
-
-lang IntTypeSym = IntTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyInt _ & ty -> ty
-end
-
-lang FloatTypeSym = FloatTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyFloat _ & ty -> ty
-end
-
-lang CharTypeSym = CharTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyChar _ & ty -> ty
-end
-
-lang FunTypeSym = FunTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyArrow t ->
-    TyArrow {{t with from = symbolizeType env t.from}
-                with to = symbolizeType env t.to}
-end
-
-lang SeqTypeSym = SeqTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TySeq t -> TySeq {t with ty = symbolizeType env t.ty}
-end
-
-lang TensorTypeSym = TensorTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyTensor t -> TyTensor {t with ty = symbolizeType env t.ty}
-end
-
-lang RecordTypeSym = RecordTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyRecord t ->
-    TyRecord {t with fields = mapMap (symbolizeType env) t.fields}
-end
 
 lang VariantTypeSym = VariantTypeAst
   sem symbolizeType (env : SymEnv) =
@@ -378,13 +270,6 @@ lang VarTypeSym = VarTypeAst + UnknownTypeAst
           -- as TyUnknown for now.
           TyUnknown {info = t.info}
     else never
-end
-
-lang AppTypeSym = AppTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyApp t ->
-    TyApp {{t with lhs = symbolizeType env t.lhs}
-              with rhs = symbolizeType env t.rhs}
 end
 
 --------------
@@ -417,13 +302,6 @@ lang NamedPatSym = NamedPat
     else never
 end
 
-lang SeqTotPatSym = SeqTotPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatSeqTot p ->
-    let res = mapAccumL (symbolizePat env) patEnv p.pats in
-    (res.0, PatSeqTot {p with pats = res.1})
-end
-
 lang SeqEdgePatSym = SeqEdgePat
   sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | PatSeqEdge p ->
@@ -432,16 +310,6 @@ lang SeqEdgePatSym = SeqEdgePat
     let postRes = mapAccumL (symbolizePat env) midRes.0 p.postfix in
     (postRes.0, PatSeqEdge
       {{{p with prefix = preRes.1} with middle = midRes.1} with postfix = postRes.1})
-end
-
-lang RecordPatSym = RecordPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatRecord {bindings = bindings, info = info} ->
-    match mapMapAccum
-            (lam patEnv. lam. lam p. symbolizePat env patEnv p) patEnv bindings
-    with (env,bindings) then
-      (env, PatRecord {bindings = bindings, info = info})
-    else never
 end
 
 lang DataPatSym = DataPat
@@ -459,37 +327,6 @@ lang DataPatSym = DataPat
         (patEnv, PatCon {ident = ident, subpat = subpat, info = info})
       else never
     else never
-end
-
-lang IntPatSym = IntPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatInt i -> (patEnv, PatInt i)
-end
-
-lang CharPatSym = CharPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatChar c -> (patEnv, PatChar c)
-end
-
-lang BoolPatSym = BoolPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatBool b -> (patEnv, PatBool b)
-end
-
-lang AndPatSym = AndPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatAnd p ->
-    let lRes : (SymEnv, Pat) = symbolizePat env patEnv p.lpat in
-    let rRes : (SymEnv, Pat) = symbolizePat env lRes.0 p.rpat in
-    (rRes.0, PatAnd {{p with lpat = lRes.1} with rpat = rRes.1})
-end
-
-lang OrPatSym = OrPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatOr p ->
-    let lRes : (SymEnv, Pat) = symbolizePat env patEnv p.lpat in
-    let rRes : (SymEnv, Pat) = symbolizePat env lRes.0 p.rpat in
-    (rRes.0, PatOr {{p with lpat = lRes.1} with rpat = rRes.1})
 end
 
 lang NotPatSym = NotPat
@@ -510,18 +347,26 @@ end
 
 lang MExprSym =
 
-  -- Terms
-  VarSym + AppSym + LamSym + RecordSym + LetSym + TypeSym + RecLetsSym +
-  ConstSym + DataSym + MatchSym + UtestSym + SeqSym + NeverSym + ExtSym +
+  -- Default implementations (Terms)
+  RecordAst + ConstAst + UtestAst + SeqAst + NeverAst +
 
-  -- Types
-  UnknownTypeSym + BoolTypeSym + IntTypeSym + FloatTypeSym + CharTypeSym +
-  FunTypeSym + SeqTypeSym + RecordTypeSym + VariantTypeSym + VarTypeSym +
-  AppTypeSym + TensorTypeSym +
+  -- Default implementations (Types)
+  UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
+  FunTypeAst + SeqTypeAst + TensorTypeAst + RecordTypeAst + AppTypeAst +
 
-  -- Patterns
-  NamedPatSym + SeqTotPatSym + SeqEdgePatSym + RecordPatSym + DataPatSym +
-  IntPatSym + CharPatSym + BoolPatSym + AndPatSym + OrPatSym + NotPatSym
+  -- Default implementations (Patterns)
+  SeqTotPat + RecordPat + IntPat + CharPat + BoolPat + AndPat + OrPat +
+
+  -- Non-default implementations (Terms)
+  VarSym + LamSym + LetSym + ExtSym + TypeSym + RecLetsSym + DataSym +
+  MatchSym +
+
+  -- Non-default implementations (Types)
+  VariantTypeSym + VarTypeSym +
+
+  -- Non-default implementations (Patterns)
+  NamedPatSym + SeqEdgePatSym + DataPatSym + NotPatSym
+
 
 -----------
 -- TESTS --

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -98,9 +98,9 @@ lang VarCompatibleType = CompatibleType + VarTypeAst
     if nameEq t1.ident t2.ident then Some ty1 else None ()
 
   sem reduceType (tyEnv : TypeEnv) =
-  | TyVar {ident = id} ->
+  | TyVar {info = info, ident = id} ->
     match mapLookup id tyEnv with Some ty then Some ty else
-      error (concat "Unbound TyVar in reduceType: " (nameGetStr id))
+      infoErrorExit info (concat "Unbound TyVar in reduceType: " (nameGetStr id))
 
 end
 

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -123,10 +123,20 @@ lang TypeLift = Cmp
   -- Intentionally left blank
 
   sem typeLiftExpr (env : TypeLiftEnv) =
-  -- Intentionally left blank
+  | t ->
+    -- Lift all sub-expressions
+    match smapAccumL_Expr_Expr typeLiftExpr env t with (env, t) then
+      -- Lift the contained types
+      match smapAccumL_Expr_Type typeLiftType env t with (env, t) then
+        -- Lift the annotated type
+        match typeLiftType env (ty t) with (env, ty) then
+          (env, withType ty t)
+        else never
+      else never
+    else never
 
   sem typeLiftType (env : TypeLiftEnv) =
-  -- Intentionally left blank
+  | t -> smapAccumL_Type_Type typeLiftType env t
 
   -- Lifts all records, variants and type aliases from the given expression
   -- `e`. The result is returned as an environment containing tuples of names
@@ -150,122 +160,6 @@ lang TypeLift = Cmp
     match typeLiftExpr emptyTypeLiftEnv e with (env, t) then
       let typeEnv = _replaceVariantNamesInTypeEnv env in
       (typeEnv, t)
-    else never
-end
-
-lang VarTypeLift = TypeLift + VarAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmVar t ->
-    match typeLiftType env t.ty with (env, ty) then
-      (env, TmVar {t with ty = ty})
-    else never
-end
-
-lang AppTypeLift = TypeLift + AppAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmApp t ->
-    match typeLiftExpr env t.lhs with (env, lhs) then
-      match typeLiftExpr env t.rhs with (env, rhs) then
-        match typeLiftType env t.ty with (env, ty) then
-          (env, TmApp {{{t with lhs = lhs}
-                           with rhs = rhs}
-                           with ty = ty})
-        else never
-      else never
-    else never
-end
-
-lang LamTypeLift = TypeLift + LamAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmLam t ->
-    match typeLiftType env t.tyIdent with (env, tyIdent) then
-      match typeLiftExpr env t.body with (env, body) then
-        match typeLiftType env t.ty with (env, ty) then
-          (env, TmLam {{{t with tyIdent = tyIdent}
-                           with body = body}
-                           with ty = ty})
-        else never
-      else never
-    else never
-end
-
-lang LetTypeLift = TypeLift + LetAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmLet t ->
-    match typeLiftExpr env t.body with (env, body) then
-      match typeLiftType env t.tyBody with (env, tyBody) then
-        match typeLiftExpr env t.inexpr with (env, inexpr) then
-          match typeLiftType env t.ty with (env, ty) then
-            (env, TmLet {{{{t with body = body}
-                              with tyBody = tyBody}
-                              with inexpr = inexpr}
-                              with ty = ty})
-          else never
-        else never
-      else never
-    else never
-end
-
-lang RecLetsTypeLift = TypeLift + RecLetsAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmRecLets t ->
-    let f = lam env. lam binding : RecLetBinding.
-      match typeLiftExpr env binding.body with (env, body) then
-        (env, {binding with body = body})
-      else never
-    in
-    match mapAccumL f env t.bindings with (env, bindings) then
-      match typeLiftExpr env t.inexpr with (env, inexpr) then
-        match typeLiftType env t.ty with (env, ty) then
-          (env, TmRecLets {{{t with bindings = bindings}
-                               with inexpr = inexpr}
-                               with ty = ty})
-        else never
-      else never
-    else never
-end
-
-lang ConstTypeLift = TypeLift + ConstAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmConst t ->
-    match typeLiftType env t.ty with (env, ty) then
-      (env, TmConst {t with ty = ty})
-    else never
-end
-
-lang SeqTypeLift = TypeLift + SeqAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmSeq t ->
-    match mapAccumL typeLiftExpr env t.tms with (env, tms) then
-      match typeLiftType env t.ty with (env, ty) then
-        (env, TmSeq {{t with tms = tms}
-                        with ty = ty})
-      else never
-    else never
-end
-
-lang RecordTypeLift = TypeLift + RecordAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  -- Intentionally left blank
-
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmRecord t ->
-    let f = lam env. lam. lam v. typeLiftExpr env v in
-    match mapMapAccum f env t.bindings with (env, bindings) then
-      match typeLiftType env t.ty with (env, ty) then
-        (env, TmRecord {{t with bindings = bindings}
-                           with ty = ty})
-      else never
-    else never
-  | TmRecordUpdate t ->
-    match typeLiftExpr env t.rec with (env, rec) then
-      match typeLiftExpr env t.value with (env, value) then
-        match typeLiftType env t.ty with (env, ty) then
-          (env, TmRecordUpdate {{{t with rec = rec}
-                                    with value = value}
-                                    with ty = ty})
-        else never
-      else never
     else never
 end
 
@@ -302,9 +196,6 @@ lang TypeTypeLift = TypeLift + TypeAst + VariantTypeAst + UnknownTypeAst +
 end
 
 lang DataTypeLift = TypeLift + DataAst + FunTypeAst + VarTypeAst + AppTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  -- Intentionally left blank
-
   sem typeLiftExpr (env : TypeLiftEnv) =
   | TmConDef t ->
     recursive let unwrapTypeVarIdent = lam ty : Type.
@@ -331,13 +222,6 @@ lang DataTypeLift = TypeLift + DataAst + FunTypeAst + VarTypeAst + AppTypeAst
     in
     match typeLiftExpr env t.inexpr with (env, inexpr) then
       (env, inexpr)
-    else never
-  | TmConApp t ->
-    match typeLiftExpr env t.body with (env, body) then
-      match typeLiftType env t.ty with (env, ty) then
-        (env, TmConApp {{t with body = body}
-                           with ty = ty})
-      else never
     else never
 end
 
@@ -380,108 +264,9 @@ lang MatchTypeLift = TypeLift + MatchAst + RecordPat + RecordTypeAst
     else never
 end
 
-lang UtestTypeLift = TypeLift + UtestAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmUtest t ->
-    match typeLiftExpr env t.test with (env, test) then
-      match typeLiftExpr env t.expected with (env, expected) then
-        match typeLiftExpr env t.next with (env, next) then
-          match typeLiftType env t.ty with (env, ty) then
-            match t.tusing with Some tusing then
-              match typeLiftExpr env tusing with (env, tusing) then
-                (env, TmUtest {{{{{t with test = test}
-                                     with expected = expected}
-                                     with next = next}
-                                     with tusing = Some tusing}
-                                     with ty = ty})
-              else never
-            else (env, TmUtest {{{{{t with test = test}
-                                      with expected = expected}
-                                      with next = next}
-                                      with tusing = t.tusing}
-                                      with ty = ty})
-          else never
-        else never
-      else never
-    else never
-end
-
-lang NeverTypeLift = TypeLift + NeverAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmNever t ->
-    match typeLiftType env t.ty with (env, ty) then
-      (env, TmNever {t with ty = ty})
-    else never
-end
-
-lang ExtTypeLift = TypeLift + ExtAst
-  sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmExt t ->
-    match typeLiftType env t.tyIdent with (env, tyIdent) then
-      match typeLiftExpr env t.inexpr with (env, inexpr) then
-        match typeLiftType env t.ty with (env, ty) then
-          (env, TmExt {{{t with tyIdent = tyIdent}
-                           with inexpr = inexpr}
-                           with ty = ty})
-        else never
-      else never
-    else never
-end
-
 -----------
 -- TYPES --
 -----------
-
-lang UnknownTypeTypeLift = TypeLift + UnknownTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyUnknown t -> (env, TyUnknown t)
-end
-
-lang BoolTypeTypeLift = TypeLift + BoolTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyBool t -> (env, TyBool t)
-end
-
-lang IntTypeTypeLift = TypeLift + IntTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyInt t -> (env, TyInt t)
-end
-
-lang FloatTypeTypeLift = TypeLift + FloatTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyFloat t -> (env, TyFloat t)
-end
-
-lang CharTypeTypeLift = TypeLift + CharTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyChar t -> (env, TyChar t)
-end
-
-lang FunTypeTypeLift = TypeLift + FunTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyArrow t ->
-    match typeLiftType env t.from with (env, from) then
-      match typeLiftType env t.to with (env, to) then
-        (env, TyArrow {{t with from = from} with to = to})
-      else never
-    else never
-end
-
-lang SeqTypeTypeLift = TypeLift + SeqTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TySeq t ->
-    match typeLiftType env t.ty with (env, ty) then
-      (env, TySeq {t with ty = ty})
-    else never
-end
-
-lang TensorTypeTypeLift = TypeLift + TensorTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyTensor t ->
-    match typeLiftType env t.ty with (env, ty) then
-      (env, TyTensor {t with ty = ty})
-    else never
-end
 
 lang RecordTypeTypeLift = TypeLift + RecordTypeAst
   sem typeLiftType (env : TypeLiftEnv) =
@@ -495,16 +280,6 @@ lang RecordTypeTypeLift = TypeLift + RecordTypeAst
       else never
 end
 
-lang VariantTypeTypeLift = TypeLift + VariantTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyVariant t -> (env, TyVariant t)
-end
-
-lang VarTypeTypeLift = TypeLift + VarTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyVar t -> (env, TyVar t)
-end
-
 lang AppTypeTypeLift = TypeLift + AppTypeAst
   sem typeLiftType (env : TypeLiftEnv) =
   | TyApp t ->
@@ -513,25 +288,24 @@ lang AppTypeTypeLift = TypeLift + AppTypeAst
     else never
 end
 
-lang VariantNameTypeTypeLift = TypeLift + VariantNameTypeAst
-  sem typeLiftType (env : TypeLiftEnv) =
-  | TyVariantName t -> (env, TyVariantName t)
-end
-
 lang MExprTypeLift =
   -- Compare
   MExprCmp +
 
-  -- Terms
-  VarTypeLift + AppTypeLift + LamTypeLift + LetTypeLift + RecLetsTypeLift +
-  ConstTypeLift + SeqTypeLift + RecordTypeLift + TypeTypeLift + DataTypeLift +
-  MatchTypeLift + UtestTypeLift + NeverTypeLift + ExtTypeLift +
+  -- Default implementations (Terms)
+  VarAst + AppAst + LamAst + LetAst + RecLetsAst + ConstAst + SeqAst +
+  UtestAst + NeverAst + ExtAst +
 
-  -- Types
-  UnknownTypeTypeLift + BoolTypeTypeLift + IntTypeTypeLift +
-  FloatTypeTypeLift + CharTypeTypeLift + FunTypeTypeLift + SeqTypeTypeLift +
-  RecordTypeTypeLift + VariantTypeTypeLift + VarTypeTypeLift +
-  AppTypeTypeLift + VariantNameTypeTypeLift + TensorTypeTypeLift
+  -- Default implementations (Types)
+  UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
+  FunTypeAst + SeqTypeAst + TensorTypeAst + VariantTypeAst + VarTypeAst +
+  VariantNameTypeAst +
+
+  -- Non-default implementations (Terms)
+  TypeTypeLift + DataTypeLift + MatchTypeLift +
+
+  -- Non-default implementations (Types)
+  RecordTypeTypeLift + AppTypeTypeLift
 end
 
 lang MExprTypeLiftOrderedRecordsCmpClosed =

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -13,11 +13,11 @@ let _symbolizeVarName = lam env : SymEnv. lam ident.
   else never
 
 lang OCamlSym =
-  VarSym + AppSym + LamSym + LetSym + RecLetsSym + RecordSym + ConstSym
-  + NamedPatSym + IntPatSym + CharPatSym + BoolPatSym + RecordSym
+  VarSym + AppAst + LamSym + LetSym + RecLetsSym + RecordAst + ConstAst
+  + NamedPatSym + IntPat + CharPat + BoolPat + RecordAst
   + OCamlTypeDeclAst + OCamlMatch + OCamlTuple + OCamlData
-  + UnknownTypeSym + IntTypeSym + BoolTypeSym + FloatTypeSym + CharTypeSym
-  + RecordTypeSym + VarTypeSym + OCamlExternal
+  + UnknownTypeAst + IntTypeAst + BoolTypeAst + FloatTypeAst + CharTypeAst
+  + RecordTypeAst + VarTypeSym + OCamlExternal
   + OCamlString + OCamlRecord + OCamlLabel
 
   sem symbolizeExpr (env : SymEnv) =

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -31,6 +31,16 @@ let optionMap: (a -> b) -> Option a -> Option b = lam f. lam o.
 utest optionMap (addi 1) (None ()) with (None ()) using optionEq eqi
 utest optionMap (addi 1) (Some 1) with (Some 2) using optionEq eqi
 
+let optionMapAccum: (a -> (acc, b)) -> acc -> Option a -> (acc, Option b) =
+  lam f. lam acc. lam o.
+    match o with Some a then
+      match f acc a with (acc, b) then
+        (acc, Some b)
+      else never
+    else (acc, o)
+
+-- TODO(vipa, 2021-05-28): Write tests for optionMapAccum
+
 let optionJoin: Option (Option a) -> Option a = lam o.
     match o with Some t then
       t


### PR DESCRIPTION
This PR switches the `smap` and `sfold` implementations to use `smapAccumL` (and also adds the latter) for everything in `mexpr/ast.mc`. Additionally, it removes a lot of boilerplate in `type-lift` and `symbolize` by using these instead.

I believe that most of the changes themselves should be fairly uncontroversial, but there appears to be some performance implications of these changes during bootstrapping. Below are some highly unscientific performance numbers (one run per commit and switch).

I feel like these are things that we want to be able to optimize later, to have them be zero-cost relative to manually written  
boilerplate, but for now we'd take a penalty by including them, so I figured it was worth bringing up.

UPDATE: the timings seem fairly unstable when I rerun them today, so I'm not sure how much this actually shows. Yesterday it felt like it was fairly consistent that runs at the end of the commits were slower than before them, but that's not as obvious now. I haven't run these super-properly, I was still using the laptop in the meanwhile (30 min per switch, it would have been dreadfully boring otherwise).

## 4.10.0+multicore+no-effect-syntax

| Commit | Phase 1 (s) | Phase 2 (s) |
| --- | --- | --- |
| Pre | 196.95 | 18.81 |
| "smapAccumL_Pat_Pat" | 202.93 | 19.81 |
| "smapAccumL_Expr_Expr" | 212.58 | 20.83 |
| "smapAccumL_Type_Type" | 213.93 | 22.00 |
| "smapAccumL_Expr_Type" | 218.43 | 23.59 |
| "minor-fixes" | 218.18 | 24.67 |
| "smapAccumL-in-type-lift" | 212.65 | 23.56 |
| "smap-in-symbolize" | 217.44 | 22.83 |

## 4.12.0+flambda

| Commit | Phase 1 (s) | Phase 2 (s) |
| --- | --- | --- |
| Pre | 191.99 | 24.10 |
| "smapAccumL_Pat_Pat" | 193.25 | 21.58 |
| "smapAccumL_Expr_Expr" | 198.30 | 23.84 |
| "smapAccumL_Type_Type" | 210.14 | 24.71 |
| "smapAccumL_Expr_Type" | 201.35 | 24.73 |
| "minor-fixes" | 204.21 | 26.04 |
| "smapAccumL-in-type-lift" | 204.86 | 24.89 |
| "smap-in-symbolize" | 201.62 | 26.11 |

## 4.12.0+domains+flambda

| Commit | Phase 1 (s) | Phase 2 (s) |
| --- | --- | --- |
| Pre | 197.08user | 19.50user |
| "smapAccumL_Pat_Pat" |  201.43user | 19.64user |
| "smapAccumL_Expr_Expr" |  206.97user | 19.41user |
| "smapAccumL_Type_Type" |  220.55user | 22.41user |
| "smapAccumL_Expr_Type" |  212.19user | 24.07user |
| "minor-fixes" |  223.85user | 24.07user |
| "smapAccumL-in-type-lift" |  214.55user | 23.75user |
| "smap-in-symbolize" |  214.64user | 23.53user |
