### PR TITLE
Update C pattern compilation and switch to using names for C struct and union members

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,7 +1333,7 @@ include "ocaml/ast.mc"
 
 let batteries =
   use OCamlTypeAst in
-  mapFromList cmpString
+  mapFromSeq cmpString
   [
     ("batteriesZero", [
       { ident = "BatInt.zero", ty = tyint_, libraries = ["batteries"] }

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -46,12 +46,17 @@ let evalprog filename =
   parsed_files := [] ;
   if !utest && !utest_fail_local = 0 then printf " OK\n" else printf "\n" ;
   if !enable_debug_profiling then
-    Hashtbl.iter
-      (fun k (c, t) ->
+    let bindings =
+      Hashtbl.fold (fun k v acc -> (k, v) :: acc) runtimes []
+      |> List.sort (fun (_, (_, t1)) (_, (_, t2)) -> Float.compare t1 t2)
+      |> List.rev
+    in
+    List.iter
+      (fun (info, (count, ms)) ->
         printf "%s: %d call%s, %f ms\n"
-          (k |> info2str |> to_utf8)
-          c
-          (if c == 1 then "" else "s")
-          t )
-      runtimes
+          (info |> info2str |> to_utf8)
+          count
+          (if count == 1 then "" else "s")
+          ms )
+      bindings
   else ()

--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -54,7 +54,8 @@ utest xnor false false with true
 
 
 -- Boolean equality
-let eqBool = lam b1. lam b2. or (and b1 b2) (and (not b1) (not b2))
+let eqBool: Bool -> Bool -> Bool =
+  lam b1: Bool. lam b2: Bool. or (and b1 b2) (and (not b1) (not b2))
 utest eqBool false false with true
 utest eqBool false true  with false
 utest eqBool true  false with false

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -63,8 +63,8 @@ lang CExprTypeAst
   | CTyPtr    { ty: CType }
   | CTyFun    { ret: CType, params: [CType] }
   | CTyArray  { ty: CType, size: Option CExpr }
-  | CTyStruct { id: Option Name, mem: Option [(CType,Option String)] }
-  | CTyUnion  { id: Option Name, mem: Option [(CType,Option String)] }
+  | CTyStruct { id: Option Name, mem: Option [(CType,Option Name)] }
+  | CTyUnion  { id: Option Name, mem: Option [(CType,Option Name)] }
   | CTyEnum   { id: Option Name, mem: Option [Name] }
 
   syn CExpr =
@@ -78,8 +78,8 @@ lang CExprTypeAst
                                               lhs: CExpr,
                                               rhs: CExpr }
   | CEUnOp       /- Unary operators -/      { op: CUnOp, arg: CExpr }
-  | CEMember     /- lhs.id -/               { lhs: CExpr, id: String }
-  | CEArrow      /- lhs->id -/              { lhs: CExpr, id: String }
+  | CEMember     /- lhs.id -/               { lhs: CExpr, id: Name }
+  | CEArrow      /- lhs->id -/              { lhs: CExpr, id: Name }
   | CECast       /- (ty) rhs -/             { ty: CType, rhs: CExpr }
   | CESizeOfType /- sizeof(ty) -/           { ty: CType }
 

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -228,6 +228,18 @@ lang CStmtAst = CInitAst + CExprTypeAst
   | CSBreak _ & t -> t
   | CSNop _ & t -> t
 
+  sem sfold_CStmt_CStmt (f: a -> CStmt -> a) (acc: a) =
+  | CSDef t -> acc
+  | CSIf t -> foldl f (foldl f acc t.thn) t.els
+  | CSSwitch t -> error "TODO"
+  | CSWhile t -> error "TODO"
+  | CSExpr t -> acc
+  | CSComp t -> error "TODO"
+  | CSRet t -> acc
+  | CSCont _ -> acc
+  | CSBreak _ -> acc
+  | CSNop _ -> acc
+
   sem sreplace_CStmt_CStmt (f: CStmt -> [CStmt]) =
   | CSDef t -> CSDef t
   | CSIf t ->
@@ -266,6 +278,11 @@ lang CTopAst = CExprTypeAst + CInitAst + CStmtAst
   | CTTyDef _ & t -> t
   | CTDef _ & t -> t
   | CTFun t -> CTFun { t with body = join (map f t.body) }
+
+  sem sfold_CTop_CStmt (f: a -> CStmt -> a) (acc: a) =
+  | CTTyDef _ -> acc
+  | CTDef _ -> acc
+  | CTFun t -> foldl f acc t.body
 
 end
 

--- a/stdlib/ext/ext-test-batteries.ext-ocaml.mc
+++ b/stdlib/ext/ext-test-batteries.ext-ocaml.mc
@@ -2,7 +2,7 @@ include "ocaml/ast.mc"
 
 let extTestBatteriesMap =
   use OCamlTypeAst in
-  mapFromList cmpString
+  mapFromSeq cmpString
   [
     ("batteriesZero", [
       { ident = "BatInt.zero", ty = tyint_, libraries = ["batteries"] }

--- a/stdlib/ext/ext-test.ext-ocaml.mc
+++ b/stdlib/ext/ext-test.ext-ocaml.mc
@@ -3,7 +3,7 @@ include "ocaml/ast.mc"
 
 let extTestMap =
   use OCamlTypeAst in
-  mapFromList cmpString
+  mapFromSeq cmpString
   [
     ("extTestListOfLists", [
       {

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -3,7 +3,7 @@ include "ocaml/ast.mc"
 
 let mathExtMap =
   use OCamlTypeAst in
-  mapFromList cmpString
+  mapFromSeq cmpString
   [
     ("externalExp", [
       { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -44,6 +44,3 @@ using eqf
 external externalAtan2 : Float -> Float -> Float
 let atan2 = lam x. lam y. externalAtan2 x y
 utest atan2 0. 1. with 0. using eqf
-
-external log : Float -> Float
-utest log 1. with 0. using _eqf

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -44,3 +44,6 @@ using eqf
 external externalAtan2 : Float -> Float -> Float
 let atan2 = lam x. lam y. externalAtan2 x y
 utest atan2 0. 1. with 0. using eqf
+
+external log : Float -> Float
+utest log 1. with 0. using _eqf

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -43,6 +43,9 @@ let mapKeys : Map k v -> [k] = lam m.
 let mapValues : Map k v -> [v] = lam m.
   mapFoldWithKey (lam vs. lam. lam v. snoc vs v) [] m
 
+let mapToList : Map k v -> [(k,v)] = lam m.
+  zipWith (lam k. lam v. (k,v)) (mapKeys m) (mapValues m)
+
 let mapMapAccum : (acc -> k -> v1 -> (acc, v2)) -> acc -> Map k v1 -> (acc, Map k v2) =
   lam f. lam acc. lam m.
     mapFoldWithKey
@@ -115,6 +118,7 @@ utest mapLookup 3 m2 with mapLookup 3 m using optionEq eqString in
 
 utest mapKeys m2 with [1,2] in
 utest mapValues m2 with ["1blub","2"] in
+utest mapToList m2 with [(1,"1blub"), (2,"2")] in
 
 utest
 match mapMapAccum (lam acc. lam k. lam v. ((addi k acc), concat "x" v)) 0 merged

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -33,7 +33,7 @@ let mapUnion : Map k v -> Map k v -> Map k v = lam l. lam r.
   foldl (lam acc. lam binding : (k, v). mapInsert binding.0 binding.1 acc)
         l (mapBindings r)
 
-let mapFromList : (k -> k -> Int) -> [(k, v)] -> Map k v = lam cmp. lam bindings.
+let mapFromSeq : (k -> k -> Int) -> [(k, v)] -> Map k v = lam cmp. lam bindings.
   foldl (lam acc. lam binding : (k, v). mapInsert binding.0 binding.1 acc)
         (mapEmpty cmp) bindings
 
@@ -43,7 +43,7 @@ let mapKeys : Map k v -> [k] = lam m.
 let mapValues : Map k v -> [v] = lam m.
   mapFoldWithKey (lam vs. lam. lam v. snoc vs v) [] m
 
-let mapToList : Map k v -> [(k,v)] = lam m.
+let mapToSeq : Map k v -> [(k,v)] = lam m.
   zipWith (lam k. lam v. (k,v)) (mapKeys m) (mapValues m)
 
 let mapMapAccum : (acc -> k -> v1 -> (acc, v2)) -> acc -> Map k v1 -> (acc, Map k v2) =
@@ -103,7 +103,7 @@ utest mapFoldlOption
   (lam acc. lam k. lam v. if eqi k acc then None () else Some acc) 3 m
 with None () using optionEq eqString in
 
-let m = mapFromList subi
+let m = mapFromSeq subi
   [ (1, "1")
   , (2, "2")
   ] in
@@ -118,7 +118,7 @@ utest mapLookup 3 m2 with mapLookup 3 m using optionEq eqString in
 
 utest mapKeys m2 with [1,2] in
 utest mapValues m2 with ["1blub","2"] in
-utest mapToList m2 with [(1,"1blub"), (2,"2")] in
+utest mapToSeq m2 with [(1,"1blub"), (2,"2")] in
 
 utest
 match mapMapAccum (lam acc. lam k. lam v. ((addi k acc), concat "x" v)) 0 merged
@@ -127,7 +127,7 @@ then (acc, mapBindings m)
 else never
 with (9,[(negi 1,("x-1")),(1,("x1")),(2,("x22")),(3,("x3")),(4,("x44"))]) in
 
-let m = mapFromList subi
+let m = mapFromSeq subi
   [ (1, "1")
   , (2, "2")
   , (123, "123")

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -50,7 +50,7 @@ let patRecord = use MExprAst in
   lam info : Info.
   let bindingMapFunc = lam b : (String, a). (stringToSid b.0, b.1) in
   PatRecord {
-    bindings = mapFromList cmpSID (map bindingMapFunc bindings),
+    bindings = mapFromSeq cmpSID (map bindingMapFunc bindings),
     info = info
   }
 
@@ -140,7 +140,7 @@ let tyrecord_ = use RecordTypeAst in
   lam fields.
   let fieldMapFunc = lam b : (String, a). (stringToSid b.0, b.1) in
   TyRecord {
-    fields = mapFromList cmpSID (map fieldMapFunc fields),
+    fields = mapFromSeq cmpSID (map fieldMapFunc fields),
     labels = map (lam b : (String, a). stringToSid b.0) fields,
     info = NoInfo ()
   }
@@ -153,7 +153,7 @@ let tyunit_ = tyrecord_ []
 let tyvariant_ = use VariantTypeAst in
   lam constrs.
   TyVariant {
-    constrs = mapFromList nameCmp constrs,
+    constrs = mapFromSeq nameCmp constrs,
     info = NoInfo ()
   }
 
@@ -454,7 +454,7 @@ let tmRecord = use MExprAst in
   lam bindings : [(String, Expr)].
   let bindingMapFunc = lam b : (String, Expr). (stringToSid b.0, b.1) in
   TmRecord {
-    bindings = mapFromList cmpSID (map bindingMapFunc bindings),
+    bindings = mapFromSeq cmpSID (map bindingMapFunc bindings),
     ty = ty,
     info = NoInfo ()
   }

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -94,7 +94,7 @@ lang BootParser = MExprAst + ConstTransformer
   | 107 /-TmRecord-/ ->
      let lst = makeSeq (lam n. (gstr t n, gterm t n)) (glistlen t 0) in
       TmRecord {bindings =
-                 mapFromList cmpSID
+                 mapFromSeq cmpSID
                    (map (lam b : (a,b). (stringToSid b.0, b.1)) lst),
                ty = TyUnknown { info = ginfo t 0 },
                info = ginfo t 0}
@@ -175,7 +175,7 @@ lang BootParser = MExprAst + ConstTransformer
     let lst = makeSeq (lam n. (gstr t n, gtype t n)) (glistlen t 0) in
     TyRecord {info = ginfo t 0,
               labels = map (lam b : (String, a). stringToSid b.0) lst,
-              fields = mapFromList cmpSID (map (lam b : (a,b). (stringToSid b.0, b.1)) lst)}
+              fields = mapFromSeq cmpSID (map (lam b : (a,b). (stringToSid b.0, b.1)) lst)}
   | 208 /-TyVariant-/ ->
     if eqi (glistlen t 0) 0 then
       TyVariant {info = ginfo t 0,
@@ -229,7 +229,7 @@ lang BootParser = MExprAst + ConstTransformer
      let lst = makeSeq (lam n. (gstr t n, gpat t n)) (glistlen t 0) in
 
      PatRecord {bindings =
-                 mapFromList cmpSID
+                 mapFromSeq cmpSID
                    (map (lam b : (a,b). (stringToSid b.0, b.1)) lst),
               info = ginfo t 0}
   | 404 /-PatCon-/ ->

--- a/stdlib/mexpr/tuning/decision-points.mc
+++ b/stdlib/mexpr/tuning/decision-points.mc
@@ -209,7 +209,7 @@ lang HoleAst = IntAst + ANF + KeywordMaker
   | arg ->
     use RecordAst in
     match arg with TmRecord {bindings = bindings} then
-      let bindings = mapFromList cmpString
+      let bindings = mapFromSeq cmpString
         (map (lam t : (SID, Expr). (sidToString t.0, t.1))
            (mapBindings bindings)) in
       let default = _lookup "default" bindings in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -59,7 +59,7 @@ let _builtinNameMap : Map String Name =
       strs
     else never
   in
-  mapFromList cmpString
+  mapFromSeq cmpString
     (map (lam s. (s, nameSym s))
       (concat
         builtinStrs
@@ -206,7 +206,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
           let fieldTypes = ocamlTypedFields fields in
           match mapLookup fieldTypes env.records with Some name then
             let pat = PatNamed p in
-            let precord = OPatRecord {bindings = mapFromList cmpSID [(fieldLabel, pat)]} in
+            let precord = OPatRecord {bindings = mapFromSeq cmpSID [(fieldLabel, pat)]} in
             _omatch_ (_objMagic (generate env t.target))
               [(OPatCon {ident = name, args = [precord]}, nvar_ patName)]
           else error "Record type not handled by type-lifting"
@@ -668,7 +668,7 @@ let _typeLiftEnvToGenerateEnv = use MExprAst in
 lang OCamlTypeDeclGenerate = MExprTypeLiftOrderedRecordsCmpClosed
   sem generateTypeDecl (env : AssocSeq Name Type) =
   | expr ->
-    let typeLiftEnvMap = mapFromList nameCmp env in
+    let typeLiftEnvMap = mapFromSeq nameCmp env in
     let exprDecls = _addTypeDeclarations typeLiftEnvMap env expr in
     match exprDecls with (expr, recordFieldsToName) then
       let generateEnv = _typeLiftEnvToGenerateEnv typeLiftEnvMap

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -346,7 +346,7 @@ let breakableMapAllowSet
   -> AllowSet a
   -> AllowSet b
   = lam f. lam newCmp. lam s.
-    let convert = lam s. mapFromList newCmp (map (lam x. (f x.0, ())) (mapBindings s)) in
+    let convert = lam s. mapFromSeq newCmp (map (lam x. (f x.0, ())) (mapBindings s)) in
     match s with AllowSet s then AllowSet (convert s) else
     match s with DisallowSet s then DisallowSet (convert s) else
     never
@@ -374,7 +374,7 @@ let breakableGenGrammar
     in
 
     let prodLabelToOpId : Map prodLabel OpId =
-      mapFromList cmp (map (lam prod. (label prod, newOpId ())) grammar.productions) in
+      mapFromSeq cmp (map (lam prod. (label prod, newOpId ())) grammar.productions) in
     let toOpId : prodLabel -> OpId = lam label. mapFindWithExn label prodLabelToOpId in
 
     -- TODO(vipa, 2021-02-15): This map can contain more entries than
@@ -428,10 +428,10 @@ let breakableGenGrammar
           updateRef postfixes (cons (label, PostfixI {id = id, construct = c, leftAllow = l, precWhenThisIsRight = p}))
         else never);
 
-    { atoms = mapFromList cmp (deref atoms)
-    , prefixes = mapFromList cmp (deref prefixes)
-    , infixes = mapFromList cmp (deref infixes)
-    , postfixes = mapFromList cmp (deref postfixes)
+    { atoms = mapFromSeq cmp (deref atoms)
+    , prefixes = mapFromSeq cmp (deref prefixes)
+    , infixes = mapFromSeq cmp (deref infixes)
+    , postfixes = mapFromSeq cmp (deref postfixes)
     }
 
 let breakableInitState : () -> State res self ROpen
@@ -860,9 +860,9 @@ con IfA : {pos: Int, r: Ast} -> Ast in
 con ElseA : {pos: Int, l: Ast, r: Ast} -> Ast in
 con NonZeroA : {pos: Int, l: Ast} -> Ast in
 
-let allowAllBut = lam xs. DisallowSet (mapFromList cmpString (map (lam x. (x, ())) xs)) in
+let allowAllBut = lam xs. DisallowSet (mapFromSeq cmpString (map (lam x. (x, ())) xs)) in
 let allowAll = allowAllBut [] in
-let allowOnly = lam xs. AllowSet (mapFromList cmpString (map (lam x. (x, ())) xs)) in
+let allowOnly = lam xs. AllowSet (mapFromSeq cmpString (map (lam x. (x, ())) xs)) in
 
 let highLowPrec
   : [prodLabel]

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -310,7 +310,7 @@ let ll1GenParser : Grammar prodLabel -> Either (GenError prodLabel) (Table prodL
     -- let _ = mapMapWithKey dprintTablePair table in
 
     if deref hasLl1Error
-      then Left (mapFromList cmpString (filter (lam binding. not (null (mapBindings binding.1))) (mapBindings (mapMap deref ll1Errors))))
+      then Left (mapFromSeq cmpString (filter (lam binding. not (null (mapBindings binding.1))) (mapBindings (mapMap deref ll1Errors))))
       else Right {start = {nt = startNt, table = mapFindWithExn startNt table}, lits = lits}
   else never
 

--- a/stdlib/parser/semantic.mc
+++ b/stdlib/parser/semantic.mc
@@ -433,7 +433,7 @@ let semanticGrammar
             (lam prod. match _prodTypeSelf prod.spec.ptype with DefaultNotIn _ then true else false)
             productions in
           let syms = map (lam x. (x.sym, ())) defaultDisallow in
-          DisallowSet (mapFromList _cmpSym syms)
+          DisallowSet (mapFromSeq _cmpSym syms)
         in
 
         let baseAllowSet

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -197,7 +197,7 @@ recursive
   let any = lam p. lam seq.
     if null seq
     then false
-    else or (p (head seq)) (any p (tail seq))
+    else if p (head seq) then true else any p (tail seq)
 end
 
 utest any (lam x. eqi x 1) [0, 4, 1, 2] with true

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -38,7 +38,7 @@ let tyidarootf = tyidaresf
 
 let sundialsExtMap =
   use OCamlTypeAst in
-  mapFromList cmpString
+  mapFromSeq cmpString
   [
     ("externalSundialsRealArrayCreate", [
       { ident = "Sundials.RealArray.create",


### PR DESCRIPTION
## Major
- Change C pattern compilation to not generate nested derefs with ->
- Switch to using names, rather than strings, for C struct and union members.

## Minor
- Profiling patch from @lingmar  (prints in sorted order)
- Add some type annotations to `bool.mc` (needed for C compiler)
- Add `sfold_CStmt_CStmt` and `sfold_CTop_CStmt`.
- Add a few needed operators to C compiler.
- Add keywords handling in C pprint.
- Add external log function. **Discussion**: Naming, `log` vs `externalLog`?
- Add `mapToList` in `stdlib/map.mc` (makes dprinting maps more convenient)
- Improve performance of `any` in `stdlib/seq.mc` (now short-circuits)
