### PR TITLE
Let type propagation

### DIFF
--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -22,7 +22,7 @@ let assocLength : AssocMap k v -> Int =
 -- ('k','v') is stored. If 'k' is already a key in 'm', its old value will be
 -- overwritten.
 let assocInsert : AssocTraits k -> k -> v -> AssocMap k v -> AssocMap k v =
-  lam traits : {eq : k -> k -> Bool}. lam k. lam v. lam m.
+  lam traits. lam k. lam v. lam m.
     optionMapOrElse (lam. cons (k,v) m)
                     (lam i. set m i (k,v))
                     (index (lam t : (k, v). traits.eq k t.0) m)
@@ -43,7 +43,7 @@ let assoc2seq : AssocTraits k -> AssocMap k v -> [(k,v)] =
 -- 'assocRemove traits k m' returns a new map, where 'k' is not a key. If 'k' is
 -- not a key in 'm', the map remains unchanged after the operation.
 let assocRemove : AssocTraits k -> k -> AssocMap k v -> AssocMap k v =
-  lam traits : {eq : k -> k -> Bool}. lam k. lam m.
+  lam traits. lam k. lam m.
     optionMapOr m
                 (lam i.
                   let spl : ([(k, v)], [(k, v)]) = splitAt m i in
@@ -55,7 +55,7 @@ let assocRemove : AssocTraits k -> k -> AssocMap k v -> AssocMap k v =
 -- If 'm' has the key 'k' stored, its value is returned, otherwise None () is
 -- returned.
 let assocLookup : AssocTraits k -> k -> AssocMap k v -> Option v =
-  lam traits : {eq : k -> k -> Bool}. lam k. lam m.
+  lam traits. lam k. lam m.
     optionMapOr (None ())
                 (lam t : (k, v). Some t.1)
                 (find (lam t : (k, v). traits.eq k t.0) m)

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -261,11 +261,18 @@ lang LamTypeAnnot = TypeAnnot + LamAst + FunTypeAst
     else never
 end
 
-lang LetTypeAnnot = TypeAnnot + LetAst
+lang TypePropagation = TypeAnnot
+  sem propagateExpectedType (tyEnv : Map Name Type) =
+  | (_, t) -> t
+end
+
+lang LetTypeAnnot = TypeAnnot + TypePropagation + LetAst +  UnknownTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmLet t ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
-      let body = typeAnnotExpr env t.body in
+      let body = match t.tyBody with TyUnknown _ then t.body else
+        propagateExpectedType tyEnv (t.tyBody, t.body) in
+      let body = typeAnnotExpr env body in
       match compatibleType tyEnv t.tyBody (ty body) with Some tyBody then
         if _isTypeAscription t then
           withType tyBody body
@@ -286,6 +293,31 @@ lang LetTypeAnnot = TypeAnnot + LetAst
     else never
 end
 
+lang PropagateLetType = TypePropagation + LetAst
+  sem propagateExpectedType (tyEnv : Map Name Type) =
+  | (ty, TmLet t) -> TmLet {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}
+end
+
+lang PropagateRecLetsType = TypePropagation + RecLetsAst
+  sem propagateExpectedType (tyEnv : Map Name Type) =
+  | (ty, TmRecLets t) -> TmRecLets {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}
+end
+
+lang PropagateArrowLambda = TypePropagation + FunTypeAst + LamAst
+  sem propagateExpectedType (tyEnv : Map Name Type) =
+  | (TyArrow {from = from, to = to}, TmLam t) ->
+    match compatibleType tyEnv from t.tyIdent with Some ty then
+      TmLam {{t with tyIdent = ty}
+                with body = propagateExpectedType tyEnv (to, t.body)}
+    else
+      let msg = join [
+        "Inconsistent type annotation of let-expression and lambda\n",
+        "Type from let: ", _pprintType from, "\n",
+        "Type from lambda: ", _pprintType t.tyIdent
+      ] in
+      infoErrorExit t.info msg
+end
+
 lang ExpTypeAnnot = TypeAnnot + ExtAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmExt t ->
@@ -296,7 +328,7 @@ lang ExpTypeAnnot = TypeAnnot + ExtAst
     else never
 end
 
-lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
+lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsAst + LamAst + UnknownTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmRecLets t ->
     -- Add mapping from binding identifier to annotated type before doing type
@@ -310,7 +342,9 @@ lang RecLetsTypeAnnot = TypeAnnot + RecLetsAst + LamAst
       mapInsert binding.ident binding.ty acc
     in
     let annotBinding = lam env : TypeEnv. lam binding : RecLetBinding.
-      let body = typeAnnotExpr env binding.body in
+      let body = match binding.tyBody with TyUnknown _ then binding.body else
+        propagateExpectedType env.tyEnv (binding.tyBody, binding.body) in
+      let body = typeAnnotExpr env body in
       match env with {tyEnv = tyEnv} then
         let tyBody =
           match compatibleType tyEnv binding.tyBody (ty body) with Some tyBody then
@@ -588,6 +622,7 @@ lang MExprTypeAnnot =
   IntCompatibleType + FloatCompatibleType + CharCompatibleType +
   FunCompatibleType + SeqCompatibleType + TensorCompatibleType +
   RecordCompatibleType + VariantCompatibleType + AppCompatibleType +
+  PropagateArrowLambda + PropagateLetType +
 
   -- Terms
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +


### PR DESCRIPTION
This change makes `type-annot` aware of type annotations on `let`-bindings, in particular it now propagates function types to the parameters of lambdas, making things like the following work:

```
let snd: (a, b) -> b =
  lam x. x.1
```

Previously we would not have needed an additional annotation on `x`:

```
let snd: (a, b) -> b =
  lam x: (a, b). x.1
```

Sidenote: we're moving ever closer to a very ad-hoc typechecker with this, we should probably do something a bit more rigorous about that sooner rather than later.

WIP while tests are running