### PR TITLE
Add basic support for externals in C compiler, and fix bugs related to `TmExt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ all: build/mi
 
 boot:
 	@./make boot
-build/mi:
+
+build/mi: boot
 	@./make
 
 test: test-boot-base
@@ -80,11 +81,11 @@ test-boot:\
 test-boot-base: boot
 	@$(MAKE) -s -f test-boot.mk base
 
-test-boot-par: build/mi
+test-boot-par: boot
 	@$(MAKE) -s -f test-boot.mk par
 
-test-boot-py: build/mi
+test-boot-py: boot
 	@$(MAKE) -s -f test-boot.mk py
 
-test-boot-ocaml: build/mi
+test-boot-ocaml: boot
 	@$(MAKE) -s -f test-boot.mk ocaml

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -193,7 +193,7 @@ let merge_lang_data fi {inters= i1; syns= s1} {inters= i2; syns= s2} :
         else if List.length p1 <> List.length p2 then
           raise_error fi1
             ( "Different number of parameters for interpreter '"
-            ^ Ustring.to_utf8 name ^ "' compared to previous definitian at "
+            ^ Ustring.to_utf8 name ^ "' compared to previous definition at "
             ^ Ustring.to_utf8 (info2str fi2) )
         else
           let c2 =

--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -55,7 +55,9 @@ utest xnor false false with true
 
 -- Boolean equality
 let eqBool: Bool -> Bool -> Bool =
-  lam b1: Bool. lam b2: Bool. or (and b1 b2) (and (not b1) (not b2))
+  lam b1: Bool. lam b2: Bool.
+  if b1 then b2 else (if b2 then false else true)
+
 utest eqBool false false with true
 utest eqBool false true  with false
 utest eqBool true  false with false

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -1146,7 +1146,7 @@ utest testCompile alias with strJoin "\n" [
   "}"
 ] using eqString in
 
--- Potentially tricky case with type aliases
+-- Externals test
 let ext = bindall_ [
   ext_ "externalLog" false (tyarrow_ tyfloat_ tyfloat_),
   let_ "x" (tyfloat_) (app_ (var_ "externalLog") (float_ 2.)),

--- a/stdlib/ext/math-ext.ext-c.mc
+++ b/stdlib/ext/math-ext.ext-c.mc
@@ -1,0 +1,14 @@
+include "map.mc"
+
+let mathExtMap: ExtMap =
+  mapFromSeq cmpString [
+
+    ( "externalExp"
+    , { ident = "exp", header = "<math.h>" }
+    ),
+
+    ( "externalLog"
+    , { ident = "log", header = "<math.h>" }
+    )
+
+  ]

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -23,7 +23,7 @@ let exp = lam x. externalExp x
 utest exp 0. with 1. using eqf
 
 external externalLog : Float -> Float
-let log = lam x. externalLog x
+let log = lam x: Float. externalLog x
 utest log (exp 7.) with 7. using eqf
 utest exp (log 7.) with 7. using _eqf
 

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -235,7 +235,7 @@ lang ExtANF = ANF + ExtAst
 
   sem normalize (k : Expr -> Expr) =
   | TmExt ({inexpr = inexpr} & t) ->
-    k (TmExt {t with inexpr = normalizeTerm inexpr})
+    TmExt {t with inexpr = normalize k t.inexpr}
 end
 
 lang MExprANF =

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -276,7 +276,8 @@ let ulet_ = use MExprAst in
 
 let next_ = use MExprAst in
   lam n. lam e. lam ty.
-  TmExt {ident = n, effect = e, ty = ty, inexpr = uunit_, info = NoInfo ()}
+  TmExt {ident = n, tyIdent = ty, effect = e, ty = tyunknown_,
+         inexpr = uunit_, info = NoInfo ()}
 
 let ext_ = use MExprAst in
   lam s. lam e. lam ty.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -441,6 +441,7 @@ end
 lang ExtAst = Ast + VarAst
   syn Expr =
   | TmExt {ident : Name,
+           tyIdent : Type,
            inexpr : Expr,
            effect : Bool,
            ty : Type,

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -143,8 +143,9 @@ lang BootParser = MExprAst + ConstTransformer
               info = ginfo t 0}
   | 115 /-TmExt-/ ->
     TmExt {ident = gname t 0,
+           tyIdent = gtype t 0,
            effect = neqi (gint t 0) 0,
-           ty = gtype t 0,
+           ty = TyUnknown { info = ginfo t 0 },
            inexpr = gterm t 0,
            info = ginfo t 0}
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -371,7 +371,7 @@ lang ExtPrettyPrint = PrettyPrint + ExtAst + UnknownTypeAst
   | TmExt t ->
     match pprintVarName env t.ident with (env,str) then
       match pprintCode indent env t.inexpr with (env,inexpr) then
-        match getTypeStringCode indent env t.ty with (env,ty) then
+        match getTypeStringCode indent env t.tyIdent with (env,ty) then
           let e = if t.effect then "!" else "" in
           (env,
            join ["external ", str, e, " : ", ty, pprintNewline indent,

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -137,10 +137,10 @@ lang ExtSym = Sym + ExtAst
   sem symbolizeExpr (env : SymEnv) =
   | TmExt t ->
     match env with {varEnv = varEnv} then
-      let ty = symbolizeType env t.ty in
+      let tyIdent = symbolizeType env t.tyIdent in
       if nameHasSym t.ident then
         TmExt {{t with inexpr = symbolizeExpr env t.inexpr}
-                  with ty = ty}
+                  with tyIdent = tyIdent}
       else
         let ident = nameSetNewSym t.ident in
         let str = nameGetStr ident in
@@ -148,7 +148,7 @@ lang ExtSym = Sym + ExtAst
         let env = {env with varEnv = varEnv} in
         TmExt {{{t with ident = ident}
                    with inexpr = symbolizeExpr env t.inexpr}
-                   with ty = ty}
+                   with tyIdent = tyIdent}
     else never
 end
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -290,9 +290,10 @@ lang ExpTypeAnnot = TypeAnnot + ExtAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmExt t ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
-      let env = {env with varEnv = mapInsert t.ident t.ty varEnv} in
+      let env = {env with varEnv = mapInsert t.ident t.tyIdent varEnv} in
       let inexpr = typeAnnotExpr env t.inexpr in
-      TmExt {t with inexpr = inexpr}
+      TmExt {{t with inexpr = inexpr}
+                with ty = ty inexpr}
     else never
 end
 

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -417,10 +417,13 @@ end
 lang ExtTypeLift = TypeLift + ExtAst
   sem typeLiftExpr (env : TypeLiftEnv) =
   | TmExt t ->
-    match typeLiftType env t.ty with (env, ty) then
+    match typeLiftType env t.tyIdent with (env, tyIdent) then
       match typeLiftExpr env t.inexpr with (env, inexpr) then
-        (env, TmExt {{t with ty = ty}
-                        with inexpr = inexpr})
+        match typeLiftType env t.ty with (env, ty) then
+          (env, TmExt {{{t with tyIdent = tyIdent}
+                           with inexpr = inexpr}
+                           with ty = ty})
+        else never
       else never
     else never
 end

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -506,7 +506,7 @@ lang OCamlGenerateExternalNaive = OCamlGenerateExternal + ExtAst
         (implsMap : Map String [ExternalImpl])
         (env : GenerateEnv) =
 
-  | TmExt {ident = ident, ty = ty, inexpr = inexpr, info = info} ->
+  | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info} ->
     let identStr = nameGetStr ident in
     let impls = mapLookup identStr implsMap in
 
@@ -520,8 +520,8 @@ lang OCamlGenerateExternalNaive = OCamlGenerateExternal + ExtAst
         minOrElse
           (lam. error "impossible")
           (lam r1 : ExternalImpl. lam r2 : ExternalImpl.
-             let cost1 = cost r1.ty ty in
-             let cost2 = cost r2.ty ty in
+             let cost1 = cost r1.ty tyIdent in
+             let cost2 = cost r2.ty tyIdent in
              subi cost1 cost2)
         impls
       in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -383,15 +383,15 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
       info = NoInfo ()
     }
   -- TmExt Generation
-  | TmExt {ident = ident, ty = ty, inexpr = inexpr, info = info} ->
+  | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info} ->
     match mapLookup ident env.exts with Some r then
       let r : ExternalImpl = head r in
-      match convertData info env (OTmVarExt { ident = r.ident }) r.ty ty
+      match convertData info env (OTmVarExt { ident = r.ident }) r.ty tyIdent
       with (_, body) then
         let inexpr = generate env inexpr in
         TmLet {
           ident = ident,
-          tyBody = ty,
+          tyBody = tyIdent,
           body = body,
           inexpr = inexpr,
           ty = TyUnknown { info = info },


### PR DESCRIPTION
### Major
- Add very basic support for externals in C compiler.
- Fix incorrect handling of `TmExt` in `mexpr/anf.mc`.
- Fix incorrect handling of `TmExt` in `mexpr/type-annot.mc` (resulting in an AST change for `TmExt` as well)

### Minor
- Remove `eqBool` dependence on `or`, `and`, and `not`.
- Fix some things in `Makefile`.