### PR TITLE
Remove uses of generate in convertData

### DIFF
--- a/src/boot/lib/exttest.ml
+++ b/src/boot/lib/exttest.ml
@@ -2,6 +2,8 @@ type myrec1_t = {a: int; b: float}
 
 type myrec2_t = {a: int list; b: int}
 
+type myrec3_t = {a: myrec1_t; b: myrec2_t}
+
 let list_of_lists = [[0]]
 
 let list_hd_hd ls = ls |> List.hd |> List.hd
@@ -18,7 +20,7 @@ let unit1 x =
 
 let unit2 = function () -> 1
 
-let tuple1 = (1, 2.)
+let tuple1 = (1, 3.)
 
 let tuple2 = ([1], 2)
 
@@ -26,10 +28,14 @@ let tuple1_0th (x, _) = x + 1
 
 let tuple2_0th (x, _) = List.map (( + ) 1) x
 
-let myrec1 : myrec1_t = {a= 1; b= 2.}
+let myrec1 : myrec1_t = {a= 1; b= 3.}
 
 let myrec1_a (r : myrec1_t) = r.a + 1
 
 let myrec2 : myrec2_t = {a= [1]; b= 2}
 
 let myrec2_a (r : myrec2_t) = List.map (( + ) 1) r.a
+
+let myrec3 : myrec3_t = {a= myrec1; b= myrec2}
+
+let myrec3_b_a (r : myrec3_t) = List.map (( + ) 1) r.b.a

--- a/stdlib/ext/ext-test.ext-ocaml.mc
+++ b/stdlib/ext/ext-test.ext-ocaml.mc
@@ -126,6 +126,45 @@ let extTestMap =
         libraries = []
       }
     ]),
+    ("extTestRecord3", [
+      {
+        ident = "Boot.Exttest.myrec3",
+        ty = otyrecord_
+              (otyvarext_ "Boot.Exttest.myrec3_t" [])
+              [
+                ("a"
+                ,otyrecord_
+                  (otyvarext_ "Boot.Exttest.myrec1_t" [])
+                  [("a", tyint_), ("b", tyfloat_)]),
+                ("b"
+                ,otyrecord_
+                  (otyvarext_ "Boot.Exttest.myrec2_t" [])
+                  [("a", otylist_ tyint_), ("b", tyint_)])
+              ],
+        libraries = []
+      }
+    ]),
+    ("extTestRecord3BA", [
+      {
+        ident = "Boot.Exttest.myrec3_b_a",
+        ty =
+          tyarrow_
+            (otyrecord_
+              (otyvarext_ "Boot.Exttest.myrec3_t" [])
+              [
+                ("a"
+                ,otyrecord_
+                  (otyvarext_ "Boot.Exttest.myrec1_t" [])
+                  [("a", tyint_), ("b", tyfloat_)]),
+                ("b"
+                ,otyrecord_
+                  (otyvarext_ "Boot.Exttest.myrec2_t" [])
+                  [("a", otylist_ tyint_), ("b", tyint_)])
+              ])
+            (otylist_ tyint_),
+        libraries = []
+      }
+    ]),
     ("extTestArgLabel", [
       {
         ident = "Boot.Exttest.arg_label",

--- a/stdlib/ext/ext-test.mc
+++ b/stdlib/ext/ext-test.mc
@@ -28,9 +28,11 @@ utest extTestUnit2 () with 1 in
 
 external extTestTuple1 : (Int, Float) in
 utest extTestTuple1.0 with 1 in
+utest extTestTuple1.1 with 3. using eqf in
 
 external extTestTuple2 : ([Int], Int) in
 utest extTestTuple2.0 with [1] in
+utest extTestTuple2.1 with 2 in
 
 external extTestTuple10th : (Int, Float) -> Int in
 utest extTestTuple10th (1, 3.) with 2 in
@@ -39,16 +41,29 @@ external extTestTuple20th : ([Int], Int) -> [Int] in
 utest extTestTuple20th ([1], 2) with [2] in
 
 external extTestRecord1 : {c : Int, d : Float} in
-utest (extTestRecord1).c with 1 in
+utest extTestRecord1.c with 1 in
+utest extTestRecord1.d with 3. using eqf in
 
 external extTestRecord1A : {c : Int, d : Float} -> Int in
 utest extTestRecord1A {c = 1, d = 3.} with 2 in
 
 external extTestRecord2 : {c : [Int], d : Int} in
-utest (extTestRecord2).c with [1] in
+utest extTestRecord2.c with [1] in
+utest extTestRecord2.d with 2 in
 
 external extTestRecord2A : {c : [Int], d : Int} -> [Int] in
 utest extTestRecord2A {c = [1], d = 2} with [2] in
+
+external extTestRecord3 : {c : {c : Int, d : Float}, d : {c : [Int], d : Int}} in
+utest extTestRecord3.c.c with 1 in
+utest extTestRecord3.c.d with 3. using eqf in
+utest extTestRecord3.d.c with [1] in
+utest extTestRecord3.d.d with 2 in
+
+external extTestRecord3BA
+  : {c : {c : Int, d : Float}, d : {c : [Int], d : Int}} -> [Int]
+in
+utest extTestRecord3BA {c = {c = 1, d = 3.}, d = {c = [1], d = 2}} with [2] in
 
 external extTestArgLabel : Int -> Int -> Int in
 utest extTestArgLabel 2 1 with 1 in

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -15,9 +15,6 @@ let _tupleConversionCost = 1
 let _recordConversionCost = 1
 
 lang OCamlGenerateExternal = OCamlAst + MExprAst
-
-  sem generate (env : GenerateEnv) =
-
   -- Popluates `env` by chosing external implementations.
   sem chooseExternalImpls
         (implsMap : Map String [ExternalImpl])
@@ -229,34 +226,34 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
       match mapLookup ident env.constrs
       with Some (TyRecord {fields = fields2, labels = labels2}) then
         let costsTms =
-          mapi
-            (lam i. lam field : (String, Type).
+          zipWith
+            (lam l2. lam field : (String, Type).
               match field with (l1, ty1) then
-                let l2 = get labels2 i in
                 match mapLookup l2 fields2 with Some ty2 then
                   convertData
                     info env (OTmProject { field = l1, tm = t }) ty1 ty2
                 else never
               else never)
-            fields1
+            labels2 fields1
         in
         match unzip costsTms with (costs, tms) then
-          -- NOTE(oerikss, 2021-05-23): We need to run generate since we create
-          -- an exclusive mexpr term.
           let ns = create (length labels2) (lam. nameSym "t") in
-          let vars =
-            map
-              (lam n.
-                TmVar
-                  { ident = n, ty = TyUnknown { info = info }, info = info })
-                ns
-          in
-          let labels2 = map sidToString labels2 in
-          let t = generate env (tmRecord info ty2 (zip labels2 vars)) in
-          let lets = zipWith nulet_ ns tms in
-          let t = bindall_ (snoc lets t) in
-          let cost = addi _recordConversionCost (foldl1 addi costs) in
-          (cost, t)
+          match mapLookup (ocamlTypedFields fields2) env.records
+          with Some id then
+            let bindings =
+              zipWith (lam label. lam t. (label, objRepr t)) labels2 tms
+            in
+            let record =
+              TmRecord {
+                bindings = mapFromSeq cmpSID bindings,
+                ty = ty2,
+                info = info
+               }
+            in
+            let t = OTmConApp { ident = id, args = [record] } in
+            let cost = addi _recordConversionCost (foldl1 addi costs) in
+            (cost, t)
+          else never
         else never
       else infoErrorExit info "Cannot convert record"
     else match tt with
@@ -264,73 +261,49 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
     then
       match mapLookup ident env.constrs
       with Some (TyRecord {fields = fields1, labels = labels1}) then
-        let ns = create (length labels1) (lam. nameSym "r") in
-        let pvars =
-          map (lam n. PatNamed { ident = PName n, info = info }) ns
-        in
-        let rpat = patRecord (zip (map sidToString labels1) pvars) info in
-        match unzip fields2 with (labels2, tys2) then
-          let costsTms =
-            mapi
-              (lam i. lam x : (Name, Type).
-                match x with (ident, ty2) then
-                  let l1 = get labels1 i in
-                  match mapLookup l1 fields1 with Some ty1 then
-                    let var =
-                      TmVar {
-                        ident = ident,
-                        ty = TyUnknown { info = info },
-                        info = info
-                      }
-                    in
-                    convertData info env var ty1 ty2
-                  else
-                    infoErrorExit info "Cannot convert record"
-                else never)
-              (zip ns tys2)
+        match mapLookup (ocamlTypedFields fields1) env.records
+        with Some id then
+          let ns = create (length labels1) (lam. nameSym "r") in
+          let pvars =
+            map
+              (lam n.
+                PatNamed {
+                  ident = PName n,
+                  info = info
+                })
+              ns
           in
-          match unzip costsTms with (costs, tms) then
-            let ident = nameSym "x" in
-            -- NOTE(oerikss, 2021-05-23): We use this binding in place of the
-            -- term t to convert since we do not want generate to run
-            -- recursivly on t. Generate introduces Obj.magic at places which
-            -- might remove type information necessary for the external
-            -- function to work properly.
-            let var =
-              TmVar {
-                ident = ident,
-                ty = ty1,       -- NOTE(oerikss, 2021-05-23): we need the type
-                                -- of the record here to allow generate to
-                                -- construct the correct match code.
-                info = info
-              }
+          let rpat =
+            OPatRecord { bindings = mapFromSeq cmpSID (zip labels1 pvars) }
+          in
+          match unzip fields2 with (labels2, tys2) then
+            let costsTms =
+              mapi
+                (lam i. lam x : (Name, Type).
+                  match x with (ident, ty2) then
+                    let l1 = get labels1 i in
+                    match mapLookup l1 fields1 with Some ty1 then
+                      let var =
+                        TmVar {
+                          ident = ident,
+                          ty = TyUnknown { info = info },
+                          info = info
+                        }
+                      in
+                      convertData info env (objMagic var) ty1 ty2
+                    else
+                      infoErrorExit info "impossible"
+                  else never)
+                (zip ns tys2)
             in
-            let inexpr =
-              TmMatch {
-                target = var,
-                pat = rpat,
-                thn =
-                  OTmRecord {
-                    bindings = zip labels2 tms, tyident = tyident
-                  },
-                els = TmNever { ty = TyUnknown { info = info }, info = info },
-                ty = TyUnknown { info = info },
-                info = info
-              }
-            in
-            let t =
-              TmLet {
-                ident = ident,
-                ty = TyUnknown { info = info },
-                body = t,
-                tyBody = TyUnknown { info = info },
-                -- NOTE(oerikss, 2021-05-23): We need to run generate on inexpr
-                -- since it is an exclusive MExpr term.
-                inexpr = generate env inexpr,
-                info = info
-              }
-            in
-            (foldl1 addi costs, t)
+            match unzip costsTms with (costs, tms) then
+              let rec =
+                OTmRecord { bindings = zip labels2 tms, tyident = tyident }
+              in
+              let cpat = OPatCon { ident = id, args = [rpat] } in
+              let t = OTmMatch { target = t, arms = [(cpat, rec)] } in
+              (foldl1 addi costs, t)
+            else never
           else never
         else never
       else infoErrorExit info "Cannot convert record"

--- a/stdlib/ocaml/generate-env.mc
+++ b/stdlib/ocaml/generate-env.mc
@@ -10,9 +10,26 @@ type GenerateEnv = {
   exts : Map Name [ExternalImpl]
 }
 
-let _emptyGenerateEnv = use MExprCmpClosed in {
+let emptyGenerateEnv = use MExprCmpClosed in {
   constrs = mapEmpty nameCmp,
   records = mapEmpty (mapCmp cmpType),
   aliases = mapEmpty nameCmp,
   exts = mapEmpty nameCmp
 }
+
+let objRepr = use OCamlAst in
+  lam t. app_ (OTmVarExt {ident = "Obj.repr"}) t
+let objMagic = use OCamlAst in
+  lam t. app_ (OTmVarExt {ident = "Obj.magic"}) t
+
+let toOCamlType = use MExprAst in
+  lam ty : Type.
+  recursive let work = lam nested : Bool. lam ty : Type.
+    match ty with TyRecord t then
+      if or (mapIsEmpty t.fields) nested then tyunknown_
+      else TyRecord {t with fields = mapMap (work true) t.fields}
+    else tyunknown_
+  in work false ty
+
+let ocamlTypedFields = lam fields : Map SID Type.
+  mapMap toOCamlType fields

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -30,15 +30,10 @@ let _mkFinalPatExpr : AssocMap Name Name -> (Pat, Expr) = use OCamlAst in lam na
     (OPatTuple {pats = map npvar_ patNames}, OTmTuple {values = map nvar_ exprNames})
   else never
 
-let _objRepr = use OCamlAst in
-  lam t. app_ (OTmVarExt {ident = "Obj.repr"}) t
-let _objMagic = use OCamlAst in
-  lam t. app_ (OTmVarExt {ident = "Obj.magic"}) t
-
 let _omatch_ = lam target. lam arms.
   use OCamlAst in
   match arms with [h] ++ rest
-  then OTmMatch { target = target, arms = cons h (map (lam x: (Unknown, Unknown). (x.0, _objMagic x.1)) rest) }
+  then OTmMatch { target = target, arms = cons h (map (lam x: (Unknown, Unknown). (x.0, objMagic x.1)) rest) }
   else OTmMatch { target = target, arms = arms }
 
 -- Construct a match expression that matches against an option
@@ -76,18 +71,6 @@ let _intrinsicName : String -> Name = lam str.
   match mapLookup str _builtinNameMap with Some name then
     name
   else error (join ["Unsupported intrinsic: ", str])
-
-let toOCamlType = use MExprAst in
-  lam ty : Type.
-  recursive let work = lam nested : Bool. lam ty : Type.
-    match ty with TyRecord t then
-      if or (mapIsEmpty t.fields) nested then tyunknown_
-      else TyRecord {t with fields = mapMap (work true) t.fields}
-    else tyunknown_
-  in work false ty
-
-let ocamlTypedFields = lam fields : Map SID Type.
-  mapMap toOCamlType fields
 
 let lookupRecordFields = use MExprAst in
   lam ty. lam constrs.
@@ -136,7 +119,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
     match generatePat env targetTy tname t.pat with (nameMap, wrap) then
       match _mkFinalPatExpr nameMap with (pat, expr) then
         _optMatch
-          (_objMagic
+          (objMagic
             (bind_ (nulet_ tname (generate env t.target))
                    (generate env (wrap (_some expr)))))
           pat
@@ -179,12 +162,12 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
 
   sem generate (env : GenerateEnv) =
   | TmMatch ({pat = (PatBool {val = true})} & t) ->
-    _if (_objMagic (generate env t.target)) (generate env t.thn) (generate env t.els)
+    _if (objMagic (generate env t.target)) (generate env t.thn) (generate env t.els)
   | TmMatch ({pat = (PatBool {val = false})} & t) ->
-    _if (_objMagic (generate env t.target)) (generate env t.els) (generate env t.thn)
+    _if (objMagic (generate env t.target)) (generate env t.els) (generate env t.thn)
   | TmMatch ({pat = PatInt {val = i}} & t) ->
     let cond = generate env (eqi_ (int_ i) t.target) in
-    _if (_objMagic cond) (generate env t.thn) (generate env t.els)
+    _if (objMagic cond) (generate env t.thn) (generate env t.els)
   | TmMatch ({pat = PatChar {val = c}} & t) ->
     let cond = generate env (eqc_ (char_ c) t.target) in
     _if cond (generate env t.thn) (generate env t.els)
@@ -207,7 +190,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
           match mapLookup fieldTypes env.records with Some name then
             let pat = PatNamed p in
             let precord = OPatRecord {bindings = mapFromSeq cmpSID [(fieldLabel, pat)]} in
-            _omatch_ (_objMagic (generate env t.target))
+            _omatch_ (objMagic (generate env t.target))
               [(OPatCon {ident = name, args = [precord]}, nvar_ patName)]
           else error "Record type not handled by type-lifting"
         else error (infoErrorString info "Unknown record type")
@@ -241,7 +224,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
             let pat = if isUnit
               then OPatCon {ident = arm.0, args = []}-- TODO(vipa, 2021-05-12): this will break if there actually is an inner pattern that wants to look at the unit
               else OPatCon {ident = arm.0, args = [npvar_ patVarName]} in
-            let innerPatternTerm = toNestedMatch (withType argTy (_objMagic target)) arm.1 in
+            let innerPatternTerm = toNestedMatch (withType argTy (objMagic target)) arm.1 in
             (pat, generate env innerPatternTerm)
           else
             let msg = join [
@@ -251,7 +234,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
             infoErrorExit t.info msg
         in
         let flattenedMatch =
-          _omatch_ (_objMagic (generate env t.target))
+          _omatch_ (objMagic (generate env t.target))
             (snoc
                 (map f (mapBindings arms))
                 (pvarw_, (app_ (nvar_ defaultCaseName) uunit_)))
@@ -270,9 +253,9 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
     let innerGenerate = lam tm.
       let tm = generate env tm in
       match tm with TmConst _ then tm
-      else _objMagic tm in
+      else objMagic tm in
     app_
-      (_objMagic (OTmVarExt {ident = (intrinsicOpSeq "Helpers.of_array")}))
+      (objMagic (OTmVarExt {ident = (intrinsicOpSeq "Helpers.of_array")}))
       (OTmArray {tms = map innerGenerate tms})
   | TmRecord t ->
     if mapIsEmpty t.bindings then TmRecord t
@@ -282,7 +265,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
         match mapLookup ident env.constrs with Some (TyRecord {fields = fields}) then
           let fieldTypes = ocamlTypedFields fields in
           match mapLookup fieldTypes env.records with Some id then
-            let bindings = mapMap (lam e. _objRepr (generate env e)) t.bindings in
+            let bindings = mapMap (lam e. objRepr (generate env e)) t.bindings in
             OTmConApp {
               ident = id,
               args = [TmRecord {t with bindings = bindings}]
@@ -298,7 +281,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
         match mapLookup fieldTypes env.records with Some id then
           let rec = generate env t.rec in
           let key = sidToString t.key in
-          let value = _objRepr (generate env t.value) in
+          let value = objRepr (generate env t.value) in
           let inlineRecordName = nameSym "rec" in
           _omatch_ rec
             [ ( OPatCon {ident = id, args = [npvar_ inlineRecordName]}
@@ -335,7 +318,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
           -- NOTE(vipa, 2021-05-11): We have an explicit record, use it directly
           OTmConApp {
             ident = t.ident,
-            args = [TmRecord {r with bindings = mapMap (lam e. _objRepr (generate env e)) r.bindings}]
+            args = [TmRecord {r with bindings = mapMap (lam e. objRepr (generate env e)) r.bindings}]
           }
         else
           -- NOTE(vipa, 2021-05-11): Not an explicit record, pattern match and reconstruct it
@@ -352,7 +335,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
               ty = ty t.body,
               info = infoTm t.body
             } in
-            _omatch_ (_objMagic (generate env t.body))
+            _omatch_ (objMagic (generate env t.body))
               [ ( OPatCon {ident = id, args = [pat]}
                 , OTmConApp {ident = t.ident, args = [reconstructedRecord]}
                 )
@@ -365,14 +348,14 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
       -- NOTE(vipa, 2021-05-11): Argument is not an explicit record, it should be `repr`ed
       OTmConApp {
         ident = t.ident,
-        args = [_objRepr (generate env t.body)]
+        args = [objRepr (generate env t.body)]
       }
   | TmApp (t & {lhs = lhs & !(TmApp _), rhs = rhs}) ->
   -- NOTE(vipa, 2021-05-17): Putting `magic` around the function in a
   -- function chain makes all the other types flexible, the arguments
   -- can be any type, and the result type can be any type, it's thus
   -- very economical
-    TmApp {{t with lhs = _objMagic (generate env lhs)}
+    TmApp {{t with lhs = objMagic (generate env lhs)}
               with rhs = generate env rhs}
   | TmNever t ->
     let msg = "Reached a never term, which should be impossible in a well-typed program." in
@@ -410,7 +393,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
     (assocInsert {eq=nameEqSym} n targetName assocEmpty, identity)
   | PatBool {val = val} ->
     let wrap = lam cont.
-      _if (_objMagic (nvar_ targetName))
+      _if (objMagic (nvar_ targetName))
         (if val then cont else _none)
         (if val then _none else cont)
     in (assocEmpty, wrap)
@@ -537,7 +520,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
     in
     if mapIsEmpty t.bindings then
       let wrap = lam cont.
-        _omatch_ (_objMagic (nvar_ targetName))
+        _omatch_ (objMagic (nvar_ targetName))
           [(OPatTuple {pats = []}, cont)]
       in
       (assocEmpty, wrap)
@@ -558,7 +541,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
             in
             let precord = OPatRecord {bindings = mapMapWithKey f t.bindings} in
             let wrap = lam cont.
-              _omatch_ (_objMagic (nvar_ targetName))
+              _omatch_ (objMagic (nvar_ targetName))
                 [ (OPatCon {ident = name, args = [precord]}, foldr (lam f. lam v. f v) cont allWraps)
                 ]
             in
@@ -595,7 +578,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
           let isUnit = match innerTy with TyRecord {fields = fields} then
             mapIsEmpty fields else false in
           let wrap = lam cont.
-            _omatch_ (_objMagic (nvar_ targetName))
+            _omatch_ (objMagic (nvar_ targetName))
               [ ( OPatCon
                   { ident = t.ident
                   , args = if isUnit then [] else [npvar_ conVarName] -- TODO(vipa, 2021-05-14): This will break if the sub-pattern actually examines the unit
@@ -662,7 +645,7 @@ let _typeLiftEnvToGenerateEnv = use MExprAst in
     else
       {env with aliases = mapInsert name ty env.aliases}
   in
-  assocSeqFold f _emptyGenerateEnv typeLiftEnv
+  assocSeqFold f emptyGenerateEnv typeLiftEnv
 
 
 lang OCamlTypeDeclGenerate = MExprTypeLiftOrderedRecordsCmpClosed
@@ -728,7 +711,7 @@ recursive let wrapOCamlAstInPrint = lam ast. lam printTerm.
   use OCamlAst in
   match ast with OTmVariantTypeDecl t then
     OTmVariantTypeDecl {t with inexpr = wrapOCamlAstInPrint t.inexpr printTerm}
-  else app_ printTerm (_objMagic ast)
+  else app_ printTerm (objMagic ast)
 in
 
 let printf = lam fmt.
@@ -796,7 +779,7 @@ let sameSemantics = lam mexprAst. lam ocamlAst.
 in
 
 let generateEmptyEnv = lam t.
-  generate _emptyGenerateEnv t
+  generate emptyGenerateEnv t
 in
 
 let generateTypeAnnotated = lam t.

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -473,11 +473,20 @@ lang OCamlPrettyPrint =
       (env, join ["~", label, ":(", arg, ")"])
     else never
   | OTmRecord {bindings = bindings, tyident = tyident} ->
+    let innerIndent = pprintIncr (pprintIncr indent) in
     match unzip bindings with (labels, tms) then
-      match mapAccumL (pprintCode indent) env tms with (env, tms) then
-        let strs = mapi (lam i. lam t. join [get labels i, " = ", t]) tms in
+      match mapAccumL (pprintCode innerIndent) env tms with (env, tms) then
+        let strs =
+          mapi
+            (lam i. lam t.
+              join [get labels i, " =", pprintNewline innerIndent, "(", t, ")"])
+            tms
+        in
         match getTypeStringCode indent env tyident with (env, tyident) then
-         (env, join ["({", strJoin ";" strs, "} : ", tyident, ")"])
+          let merged =
+            strJoin (concat ";" (pprintNewline (pprintIncr indent))) strs
+          in
+          (env, join ["({", merged , "} : ", tyident, ")"])
         else never
       else never
     else never


### PR DESCRIPTION
This PR removes the use of `generate` in `convertData`. OCaml AST nodes are instead always constructed directly. Moreover a bug in the pretty-printing of OCaml records was fixed. Additionally test were added that includes nested records in the type signature of externals.