### PR TITLE
Switch to using OCamls maps for the environment in symbolize.ml

### DIFF
--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -157,7 +157,7 @@ let builtin =
   |> List.map (fun (x, t) -> (x, Symb.gensym (), t))
 
 (* Mapping name to symbol *)
-let builtin_name2sym = List.map (fun (x, s, _) -> (IdVar (usid x), s)) builtin
+let builtin_name2sym = List.fold_left (fun env (x, s, _) -> Symbolize.addsym (IdVar (usid x)) s env) Symbolize.empty_sym_env builtin
 
 (* Mapping sym to term *)
 let builtin_sym2term = List.map (fun (_, s, t) -> (s, t)) builtin

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -46,7 +46,7 @@ let rec lam_counts n nmap = function
   | _ ->
       n
 
-(* Helper function that counts the number of lambdas directly below in a term. 
+(* Helper function that counts the number of lambdas directly below in a term.
    If negative, it needs to be treated as an open let with side effects *)
 let rec lambdas_left nmap n se = function
   | TmApp (_, t1, t2) ->
@@ -68,13 +68,13 @@ let rec lambdas_in_type = function
   | _ ->
       0
 
-(* Help function that collects let information and free variables 
+(* Help function that collects let information and free variables
    Returns a tuple with two elements
-   1. NMap: a mapping from a let symbol to a tuple with the following 4 elements: 
+   1. NMap: a mapping from a let symbol to a tuple with the following 4 elements:
           (a) The symbol set of variables inside the let that points backwards
-          (c) Boolean flag saying if the let is used.  
+          (c) Boolean flag saying if the let is used.
           (b) Boolean stating if the let body has (possibly) side effects
-          (d) Lambda count. That is, how many lambdas that are at the top of the body 
+          (d) Lambda count. That is, how many lambdas that are at the top of the body
    2. Free Vars: A symbol set with all variables that are free (not under a lambda in a let) *)
 let collect_in_body s nmap free = function
   | TmLam (_, _, _, _, tlam) ->
@@ -219,6 +219,7 @@ let add_keywords nmap symKeywords =
 let elimination builtin_sym2term builtin_name2sym symKeywords t =
   if !disable_dead_code_elimination then t
   else (
+    let builtin_name2sym = Symbolize.sym_env_to_assoc builtin_name2sym in
     if !enable_debug_dead_code_info then
       _symbmap := extend_symb_map_builtin builtin_name2sym (symbmap t) ;
     (* Collect all lets and store a graph in 'nmap' and free variable in 'free' *)

--- a/src/boot/lib/repl.ml
+++ b/src/boot/lib/repl.ml
@@ -206,7 +206,7 @@ let keywords_and_identifiers () =
   in
   let _, nss, name2sym, _ = !repl_envs in
   let names_without_langs =
-    List.map (fun x -> x |> fst |> extract_name) name2sym
+    List.map (fun x -> x |> fst |> extract_name) (Symbolize.sym_env_to_assoc name2sym)
   in
   let replace_name name mangled_name names =
     names |> USSet.add name |> USSet.remove mangled_name

--- a/src/boot/lib/symbolize.ml
+++ b/src/boot/lib/symbolize.ml
@@ -3,8 +3,24 @@ open Ustring.Op
 open Msg
 open Ast
 
+type sym_env = {var: Symb.t sidmap; con: Symb.t sidmap; ty: Symb.t sidmap; label: Symb.t sidmap;}
+
+let empty_sym_env = {var = SidMap.empty; con = SidMap.empty; ty = SidMap.empty; label = SidMap.empty}
+
+let sym_env_to_assoc env =
+  let vars = List.map (fun (k, v) -> (IdVar k, v)) (SidMap.bindings env.var) in
+  let cons = List.map (fun (k, v) -> (IdCon k, v)) (SidMap.bindings env.con) in
+  let tys = List.map (fun (k, v) -> (IdType k, v)) (SidMap.bindings env.ty) in
+  let labels = List.map (fun (k, v) -> (IdLabel k, v)) (SidMap.bindings env.label) in
+  vars @ cons @ tys @ labels
+
 let findsym fi id env =
-  try List.assoc id env
+  try
+    match id with
+    | IdVar x -> SidMap.find x env.var
+    | IdCon x -> SidMap.find x env.con
+    | IdType x -> SidMap.find x env.ty
+    | IdLabel x -> SidMap.find x env.label
   with Not_found ->
     let x, kindstr =
       match id with
@@ -18,6 +34,24 @@ let findsym fi id env =
           (x, "label")
     in
     raise_error fi ("Unknown " ^ kindstr ^ " '" ^ string_of_sid x ^ "'")
+
+let findsym_opt id env =
+  match id with
+  | IdVar x -> SidMap.find_opt x env.var
+  | IdCon x -> SidMap.find_opt x env.con
+  | IdType x -> SidMap.find_opt x env.ty
+  | IdLabel x -> SidMap.find_opt x env.label
+
+let addsym id sym env =
+  match id with
+  | IdVar x -> {env with var = SidMap.add x sym env.var}
+  | IdCon x -> {env with con = SidMap.add x sym env.con}
+  | IdType x -> {env with ty = SidMap.add x sym env.ty}
+  | IdLabel x -> {env with label = SidMap.add x sym env.label}
+
+let merge_sym_envs_pick_left l r =
+  let pick_left _ x _ = Some x in
+  { var = SidMap.union pick_left l.var r.var; con = SidMap.union pick_left l.con r.con; ty = SidMap.union pick_left l.ty r.ty; label = SidMap.union pick_left l.label r.label; }
 
 let rec symbolize_type env ty =
   match ty with
@@ -47,7 +81,7 @@ let rec symbolize_type env ty =
 
 (* Add symbol associations between lambdas, patterns, and variables. The function also
    constructs TmConApp terms from the combination of variables and function applications.  *)
-let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
+let rec symbolize (env : sym_env) (t : tm) =
   (* add_name is only called in sPat and it reuses previously generated symbols.
    * This is imperative for or-patterns, since both branches should give the same symbols,
    * e.g., [a] | [a, _] should give the same symbol to both "a"s.
@@ -55,13 +89,13 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
    * in a pattern in other cases. In particular, this means that, e.g., the pattern
    * [a, a] assigns the same symbol to both "a"s, which may or may not be desirable. Which
    * introduced binding gets used then depends on what try_match does for the pattern. *)
-  let add_name (x : ident) (patEnv : (ident * Symb.t) list) =
-    match List.assoc_opt x patEnv with
+  let add_name (x : ident) (patEnv : sym_env) =
+    match findsym_opt x patEnv with
     | Some s ->
         (patEnv, s)
     | None ->
         let s = Symb.gensym () in
-        ((x, s) :: patEnv, s)
+        (addsym x s patEnv, s)
   in
   let rec s_pat_sequence patEnv pats =
     Mseq.Helpers.fold_right
@@ -69,7 +103,7 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
         let patEnv, p = sPat patEnv p in
         (patEnv, Mseq.cons p ps) )
       (patEnv, Mseq.empty) pats
-  and sPat (patEnv : (ident * Symb.t) list) = function
+  and sPat (patEnv : sym_env) = function
     | PatNamed (fi, NameStr (x, _)) ->
         let patEnv, s = add_name (IdVar (sid_of_ustring x)) patEnv in
         (patEnv, PatNamed (fi, NameStr (x, s)))
@@ -138,7 +172,7 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
         , x
         , s
         , symbolize_type env ty
-        , symbolize ((IdVar (sid_of_ustring x), s) :: env) t1 )
+        , symbolize (addsym (IdVar (sid_of_ustring x)) s env) t1 )
   | TmClos (_, _, _, _, _) ->
       failwith "Closures should not be available."
   | TmLet (fi, x, _, ty, t1, t2) ->
@@ -149,7 +183,7 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
         , s
         , symbolize_type env ty
         , symbolize env t1
-        , symbolize ((IdVar (sid_of_ustring x), s) :: env) t2 )
+        , symbolize (addsym (IdVar (sid_of_ustring x)) s env) t2 )
   | TmType (fi, x, _, ty, t1) ->
       (* TODO(dlunde,2020-11-23): Should type lets be recursive? Right now,
          they are not.*)
@@ -159,13 +193,13 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
         , x
         , s
         , symbolize_type env ty
-        , symbolize ((IdType (sid_of_ustring x), s) :: env) t1 )
+        , symbolize (addsym (IdType (sid_of_ustring x)) s env) t1 )
   | TmRecLets (fi, lst, tm) ->
       let env2 =
         List.fold_left
           (fun env (_, x, _, _, _) ->
             let s = Symb.gensym () in
-            (IdVar (sid_of_ustring x), s) :: env )
+            addsym (IdVar (sid_of_ustring x)) s env)
           env lst
       in
       TmRecLets
@@ -194,17 +228,17 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
         , x
         , s
         , symbolize_type env ty
-        , symbolize ((IdCon (sid_of_ustring x), s) :: env) t )
+        , symbolize (addsym (IdCon (sid_of_ustring x)) s env) t )
   | TmConApp (fi, x, _, t) ->
       TmConApp
         (fi, x, findsym fi (IdCon (sid_of_ustring x)) env, symbolize env t)
   | TmMatch (fi, t1, p, t2, t3) ->
-      let matchedEnv, p = sPat [] p in
+      let matchedEnv, p = sPat empty_sym_env p in
       TmMatch
         ( fi
         , symbolize env t1
         , p
-        , symbolize (matchedEnv @ env) t2
+        , symbolize (merge_sym_envs_pick_left matchedEnv env) t2
         , symbolize env t3 )
   | TmUse (fi, l, t) ->
       TmUse (fi, l, symbolize env t)
@@ -220,24 +254,24 @@ let rec symbolize (env : (ident * Symb.t) list) (t : tm) =
         , s
         , e
         , symbolize_type env ty
-        , symbolize ((IdVar (sid_of_ustring x), s) :: env) t )
+        , symbolize (addsym (IdVar (sid_of_ustring x)) s env) t )
   | TmConst _ | TmFix _ | TmNever _ | TmRef _ | TmTensor _ ->
       t
 
 (* Same as symbolize, but records all toplevel definitions and returns them
  along with the symbolized term. *)
-let rec symbolize_toplevel (env : (ident * Symb.t) list) = function
+let rec symbolize_toplevel (env : sym_env) = function
   | TmLet (fi, x, _, ty, t1, t2) ->
       let s = Symb.gensym () in
       let new_env, new_t2 =
-        symbolize_toplevel ((IdVar (sid_of_ustring x), s) :: env) t2
+        symbolize_toplevel (addsym (IdVar (sid_of_ustring x)) s env) t2
       in
       ( new_env
       , TmLet (fi, x, s, symbolize_type env ty, symbolize env t1, new_t2) )
   | TmType (fi, x, _, ty, t1) ->
       let s = Symb.gensym () in
       let new_env, new_t1 =
-        symbolize_toplevel ((IdType (sid_of_ustring x), s) :: env) t1
+        symbolize_toplevel (addsym (IdType (sid_of_ustring x)) s env) t1
       in
       (new_env, TmType (fi, x, s, symbolize_type env ty, new_t1))
   | TmRecLets (fi, lst, tm) ->
@@ -245,7 +279,7 @@ let rec symbolize_toplevel (env : (ident * Symb.t) list) = function
         List.fold_left
           (fun env (_, x, _, _, _) ->
             let s = Symb.gensym () in
-            (IdVar (sid_of_ustring x), s) :: env )
+            addsym (IdVar (sid_of_ustring x)) s env )
           env lst
       in
       let new_env, new_tm = symbolize_toplevel env2 tm in
@@ -264,13 +298,13 @@ let rec symbolize_toplevel (env : (ident * Symb.t) list) = function
   | TmConDef (fi, x, _, ty, t) ->
       let s = Symb.gensym () in
       let new_env, new_t2 =
-        symbolize_toplevel ((IdCon (sid_of_ustring x), s) :: env) t
+        symbolize_toplevel (addsym (IdCon (sid_of_ustring x)) s env) t
       in
       (new_env, TmConDef (fi, x, s, symbolize_type env ty, new_t2))
   | TmExt (fi, x, _, e, ty, t) ->
       let s = Symb.gensym () in
       let new_env, new_t =
-        symbolize_toplevel ((IdVar (sid_of_ustring x), s) :: env) t
+        symbolize_toplevel (addsym (IdVar (sid_of_ustring x)) s env) t
       in
       (new_env, TmExt (fi, x, s, e, symbolize_type env ty, new_t))
   | ( TmVar _

--- a/src/boot/lib/ustring.ml
+++ b/src/boot/lib/ustring.ml
@@ -259,6 +259,14 @@ module Op = struct
 
   type sidset = SidSet.t
 
+  module SidMap = Map.Make (struct
+    let compare = Stdlib.compare
+
+    type t = sid
+  end)
+
+  type 'a sidmap = 'a SidMap.t
+
   let ( ^. ) s1 s2 = ref (Branch (!s1, !s2))
 
   let ( ^.. ) s1 s2 =

--- a/src/boot/lib/ustring.mli
+++ b/src/boot/lib/ustring.mli
@@ -117,6 +117,85 @@ module Op : sig
 
   type sidset = SidSet.t
 
+  module SidMap : sig
+    type key = sid
+
+    type 'a t
+
+    val empty : 'a t
+
+    val is_empty : 'a t -> bool
+
+    val mem : key -> 'a t -> bool
+
+    val add : key -> 'a -> 'a t -> 'a t
+
+    val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
+
+    val singleton : key -> 'a -> 'a t
+
+    val remove : key -> 'a t -> 'a t
+
+    val merge : (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
+
+    val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+    val compare : ('a ->'a -> int) -> 'a t -> 'a t -> int
+
+    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+    val iter : (key -> 'a -> unit) -> 'a t -> unit
+
+    val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+
+    val for_all : (key -> 'a -> bool)-> 'a t -> bool
+
+    val exists : (key -> 'a -> bool)-> 'a t -> bool
+
+    val filter : (key -> 'a -> bool) -> 'a t -> 'a t
+
+    val filter_map : (key -> 'a -> 'b option) -> 'a t -> 'b t
+
+    val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
+
+    val cardinal : 'a t -> int
+
+    val bindings : 'a t -> (key * 'a) list
+
+    val min_binding : 'a t -> key * 'a
+
+    val min_binding_opt : 'a t -> (key * 'a) option
+
+    val max_binding : 'a t -> key * 'a
+
+    val max_binding_opt : 'a t -> (key * 'a) option
+
+    val choose : 'a t -> key * 'a
+
+    val choose_opt : 'a t -> (key * 'a) option
+
+    val split : key -> 'a t -> 'a t * 'a option * 'a t
+
+    val find : key -> 'a t -> 'a
+
+    val find_opt : key -> 'a t -> 'a option
+
+    val find_first : (key -> bool)-> 'a t -> key * 'a
+
+    val find_first_opt : (key -> bool)-> 'a t -> (key * 'a) option
+
+    val find_last : (key -> bool)-> 'a t -> key * 'a
+
+    val find_last_opt : (key -> bool)-> 'a t -> (key * 'a) option
+
+    val map : ('a -> 'b) -> 'a t -> 'b t
+
+    val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+  end
+
+
+  type 'a sidmap = 'a SidMap.t
+
   (* Set of string identifiers *)
 
   val ( ^. ) : ustring -> ustring -> ustring


### PR DESCRIPTION
I did some profiling to figure out what was causing the slowdown in #393 and found that `findSym` in `symbolize.ml` (note the `.ml`, it's in boot, not in the compiler) was taking a lot of time, for both steps of the bootstrapping process. This PR switches the environment used in `symbolize.ml` from a shared assoc-list to four separate OCaml `Map`s, which dropped the amount of time spent in `findSym` by a bunch.

In total, this changes step 2 of the bootstrapping process from ~20s to ~16s without #393, and ~30s to ~17s with it.

This is somewhat surprising, since previous experiences suggest that an assoc list is better for the access-patterns typically present in a compiler/interpreter, but this runs very much counter to that. I suspect it's because of two things:
- `symbolize.ml` has one environment containing all forms of identifiers, in particular, both expression variables and type variables live in the same environment.
- We haven't properly modeled our type-system yet, and the ad-hoc way we're using it has lots of type variables for parametric polymorphism in Haskell style, i.e., we expect them to be introduced and bound implicitly. This does not actually happen presently, they are instead unbound, and a `findSym` will look through the entire environment and then fail.

Sidenote: this PR fails `make test-all` with stack overflow in the OCaml compiler on `stdlib/mexpr/generate.mc` when using the flambda switch (on my computer anyway), but it seems to be the case on the current `develop` as well, so I suspect it's an unrelated change.