### PR TITLE
Put type annotations on `Pat`

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -7,88 +7,6 @@ include "info.mc"
 include "stringid.mc"
 include "map.mc"
 
--- Patterns --
-
-let npvar_ = use MExprAst in
-  lam n : Name.
-  PatNamed {ident = PName n, info = NoInfo ()}
-
-let pvar_ = use MExprAst in
-  lam s.
-  npvar_ (nameNoSym s)
-
-let pvarw_ = use MExprAst in
-  PatNamed {ident = PWildcard (), info = NoInfo()}
-
-let punit_ = use MExprAst in
-  PatRecord { bindings = mapEmpty cmpSID, info = NoInfo() }
-
-let pint_ = use MExprAst in
-  lam i.
-  PatInt {val = i, info = NoInfo()}
-
-let pchar_ = use MExprAst in
-  lam c.
-  PatChar {val = c, info = NoInfo()}
-
-let ptrue_ = use MExprAst in
-  PatBool {val = true, info = NoInfo()}
-
-let pfalse_ = use MExprAst in
-  PatBool {val = false, info = NoInfo()}
-
-let npcon_ = use MExprAst in
-  lam n. lam cp.
-  PatCon {ident = n, subpat = cp, info = NoInfo()}
-
-let pcon_ = use MExprAst in
-  lam cs. lam cp.
-  npcon_ (nameNoSym cs) cp
-
-let patRecord = use MExprAst in
-  lam bindings : [(String, Pat)].
-  lam info : Info.
-  let bindingMapFunc = lam b : (String, a). (stringToSid b.0, b.1) in
-  PatRecord {
-    bindings = mapFromSeq cmpSID (map bindingMapFunc bindings),
-    info = info
-  }
-
-let prec_ = lam bindings. patRecord bindings (NoInfo ())
-
-let patTuple = lam ps : [Pat]. lam info : Info.
-  patRecord (mapi (lam i. lam p. (int2string i, p)) ps) info
-
-let ptuple_ = lam ps. patTuple ps (NoInfo ())
-
-let pseqtot_ = use MExprAst in
-  lam ps.
-  PatSeqTot {pats = ps, info = NoInfo()}
-
-let pseqedgew_ = use MExprAst in
-  lam pre. lam post.
-  PatSeqEdge {prefix = pre, middle = PWildcard (), postfix = post, info = NoInfo()}
-
-let pseqedgen_ = use MExprAst in
-  lam pre. lam middle : Name. lam post.
-  PatSeqEdge {prefix = pre, middle = PName middle, postfix = post, info = NoInfo()}
-
-let pseqedge_ = use MExprAst in
-  lam pre. lam middle. lam post.
-  pseqedgen_ pre (nameNoSym middle) post
-
-let pand_ = use MExprAst in
-  lam l. lam r.
-  PatAnd {lpat = l, rpat = r, info = NoInfo()}
-
-let por_ = use MExprAst in
-  lam l. lam r.
-  PatOr {lpat = l, rpat = r, info = NoInfo()}
-
-let pnot_ = use MExprAst in
-  lam p.
-  PatNot {subpat = p, info = NoInfo()}
-
 -- Types --
 
 let tyint_ = use IntTypeAst in
@@ -227,6 +145,89 @@ let tytensoriteri_ = lam ty.
                         , tyunit_ ]
             , tytensor_ ty
             , tyunit_ ]
+
+-- Patterns --
+
+let npvar_ = use MExprAst in
+  lam n : Name.
+  PatNamed {ident = PName n, info = NoInfo (), ty = tyunknown_}
+
+let pvar_ = use MExprAst in
+  lam s.
+  npvar_ (nameNoSym s)
+
+let pvarw_ = use MExprAst in
+  PatNamed {ident = PWildcard (), info = NoInfo(), ty = tyunknown_}
+
+let punit_ = use MExprAst in
+  PatRecord { bindings = mapEmpty cmpSID, info = NoInfo(), ty = tyunknown_ }
+
+let pint_ = use MExprAst in
+  lam i.
+  PatInt {val = i, info = NoInfo(), ty = tyint_}
+
+let pchar_ = use MExprAst in
+  lam c.
+  PatChar {val = c, info = NoInfo(), ty = tychar_}
+
+let ptrue_ = use MExprAst in
+  PatBool {val = true, info = NoInfo(), ty = tybool_}
+
+let pfalse_ = use MExprAst in
+  PatBool {val = false, info = NoInfo(), ty = tybool_}
+
+let npcon_ = use MExprAst in
+  lam n. lam cp.
+  PatCon {ident = n, subpat = cp, info = NoInfo(), ty = tyunknown_}
+
+let pcon_ = use MExprAst in
+  lam cs. lam cp.
+  npcon_ (nameNoSym cs) cp
+
+let patRecord = use MExprAst in
+  lam bindings : [(String, Pat)].
+  lam info : Info.
+  let bindingMapFunc = lam b : (String, a). (stringToSid b.0, b.1) in
+  PatRecord {
+    bindings = mapFromSeq cmpSID (map bindingMapFunc bindings),
+    info = info,
+    ty = tyunknown_
+  }
+
+let prec_ = lam bindings. patRecord bindings (NoInfo ())
+
+let patTuple = lam ps : [Pat]. lam info : Info.
+  patRecord (mapi (lam i. lam p. (int2string i, p)) ps) info
+
+let ptuple_ = lam ps. patTuple ps (NoInfo ())
+
+let pseqtot_ = use MExprAst in
+  lam ps.
+  PatSeqTot {pats = ps, info = NoInfo(), ty = tyunknown_}
+
+let pseqedgew_ = use MExprAst in
+  lam pre. lam post.
+  PatSeqEdge {prefix = pre, middle = PWildcard (), postfix = post, info = NoInfo(), ty = tyunknown_}
+
+let pseqedgen_ = use MExprAst in
+  lam pre. lam middle : Name. lam post.
+  PatSeqEdge {prefix = pre, middle = PName middle, postfix = post, info = NoInfo(), ty = tyunknown_}
+
+let pseqedge_ = use MExprAst in
+  lam pre. lam middle. lam post.
+  pseqedgen_ pre (nameNoSym middle) post
+
+let pand_ = use MExprAst in
+  lam l. lam r.
+  PatAnd {lpat = l, rpat = r, info = NoInfo(), ty = tyunknown_}
+
+let por_ = use MExprAst in
+  lam l. lam r.
+  PatOr {lpat = l, rpat = r, info = NoInfo(), ty = tyunknown_}
+
+let pnot_ = use MExprAst in
+  lam p.
+  PatNot {subpat = p, info = NoInfo(), ty = tyunknown_}
 
 -- Terms --
 -- Methods of binding an expression into a chain of lets/reclets/condefs --

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -29,6 +29,12 @@ lang Ast
   sem withType (ty : Type) =
   -- Intentionally left blank
 
+  sem tyPat =
+  -- Intentionally left blank
+
+  sem withTypePat (ty : Type) =
+  -- Intentionally left blank
+
   -- TODO(vipa, 2021-05-27): Replace smap and sfold with smapAccumL for Expr and Type as well
   sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
   | p -> (acc, p)
@@ -792,19 +798,33 @@ con PWildcard : () -> PatName
 lang NamedPat = MatchAst
   syn Pat =
   | PatNamed {ident : PatName,
-              info : Info}
+              info : Info,
+              ty : Type}
 
   sem infoPat =
   | PatNamed r -> r.info
+
+  sem tyPat =
+  | PatNamed r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatNamed r -> PatNamed {r with ty = ty}
 end
 
 lang SeqTotPat = MatchAst
   syn Pat =
   | PatSeqTot {pats : [Pat],
-               info : Info}
+               info : Info,
+               ty : Type}
 
   sem infoPat =
   | PatSeqTot r -> r.info
+
+  sem tyPat =
+  | PatSeqTot r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatSeqTot r -> PatSeqTot {r with ty = ty}
 
   sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
   | PatSeqTot r ->
@@ -818,10 +838,17 @@ lang SeqEdgePat = MatchAst
   | PatSeqEdge {prefix : [Pat],
                 middle: PatName,
                 postfix : [Pat],
-                info: Info}
+                info: Info,
+                ty: Type}
 
   sem infoPat =
   | PatSeqEdge r -> r.info
+
+  sem tyPat =
+  | PatSeqEdge r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatSeqEdge r -> PatSeqEdge {r with ty = ty}
 
   sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
   | PatSeqEdge p ->
@@ -835,10 +862,17 @@ end
 lang RecordPat = MatchAst
   syn Pat =
   | PatRecord {bindings : Map SID Pat,
-               info: Info}
+               info: Info,
+               ty: Type}
 
   sem infoPat =
   | PatRecord r -> r.info
+
+  sem tyPat =
+  | PatRecord r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatRecord r -> PatRecord {r with ty = ty}
 
   sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
   | PatRecord p ->
@@ -851,10 +885,17 @@ lang DataPat = MatchAst + DataAst
   syn Pat =
   | PatCon {ident : Name,
             subpat : Pat,
-            info : Info}
+            info : Info,
+            ty : Type}
 
   sem infoPat =
   | PatCon r -> r.info
+
+  sem tyPat =
+  | PatCon r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatCon r -> PatCon {r with ty = ty}
 
   sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
   | PatCon c ->
@@ -866,38 +907,66 @@ end
 lang IntPat = MatchAst + IntAst
   syn Pat =
   | PatInt {val : Int,
-          info : Info}
+            info : Info,
+            ty : Type}
 
   sem infoPat =
   | PatInt r -> r.info
+
+  sem tyPat =
+  | PatInt r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatInt r -> PatInt {r with ty = ty}
 end
 
 lang CharPat = MatchAst
   syn Pat =
   | PatChar {val : Char,
-             info : Info}
+             info : Info,
+             ty : Type}
 
   sem infoPat =
   | PatChar r -> r.info
+
+  sem tyPat =
+  | PatChar r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatChar r -> PatChar {r with ty = ty}
 end
 
 lang BoolPat = MatchAst + BoolAst
   syn Pat =
   | PatBool {val : Bool,
-             info : Info}
+             info : Info,
+             ty : Type}
 
   sem infoPat =
   | PatBool r -> r.info
+
+  sem tyPat =
+  | PatBool r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatBool r -> PatBool {r with ty = ty}
 end
 
 lang AndPat = MatchAst
   syn Pat =
   | PatAnd {lpat : Pat,
             rpat : Pat,
-            info : Info}
+            info : Info,
+            ty : Type}
 
   sem infoPat =
   | PatAnd r -> r.info
+
+  sem tyPat =
+  | PatAnd r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatAnd r -> PatAnd {r with ty = ty}
 
   sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
   | PatAnd p ->
@@ -912,10 +981,17 @@ lang OrPat = MatchAst
   syn Pat =
   | PatOr {lpat : Pat,
            rpat : Pat,
-           info : Info}
+           info : Info,
+           ty : Type}
 
   sem infoPat =
   | PatOr r -> r.info
+
+  sem tyPat =
+  | PatOr r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatOr r -> PatOr {r with ty = ty}
 
   sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
   | PatOr p ->
@@ -929,10 +1005,17 @@ end
 lang NotPat = MatchAst
   syn Pat =
   | PatNot {subpat : Pat,
-            info : Info}
+            info : Info,
+            ty : Type}
 
   sem infoPat =
   | PatNot r -> r.info
+
+  sem tyPat =
+  | PatNot r -> r.ty
+
+  sem withTypePat (ty : Type) =
+  | PatNot r -> PatNot {r with ty = ty}
 
   sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
   | PatNot p ->

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -209,47 +209,57 @@ lang BootParser = MExprAst + ConstTransformer
   sem matchPat (t:Unknown) =
   | 400 /-PatNamed-/ ->
     PatNamed {ident = strToPatName (gstr t 0),
-            info = ginfo t 0}
+            info = ginfo t 0,
+            ty = tyunknown_}
   | 401 /-PatSeqTot-/ ->
     PatSeqTot {pats = create (glistlen t 0) (lam n. gpat t n),
-             info = ginfo t 0}
+             info = ginfo t 0,
+             ty = tyunknown_}
   | 402 /-PatSeqEdge-/ ->
     let len = glistlen t 0 in
     PatSeqEdge {prefix = create len (lam n. gpat t n),
               middle = strToPatName (gstr t 0),
               postfix = create (glistlen t 1) (lam n. gpat t (addi n len)),
-              info = ginfo t 0}
+              info = ginfo t 0,
+              ty = tyunknown_}
   | 403 /-PatRecord-/ ->
     let lst = create (glistlen t 0) (lam n. (gstr t n, gpat t n)) in
     PatRecord {bindings =
                mapFromSeq cmpSID
                  (map (lam b : (a,b). (stringToSid b.0, b.1)) lst),
-               info = ginfo t 0}
+               info = ginfo t 0,
+               ty = tyunknown_}
   | 404 /-PatCon-/ ->
      PatCon {ident = gname t 0,
              subpat = gpat t 0,
-             info = ginfo t 0}
-  | 405 /-PatInt-/ ->
+             info = ginfo t 0,
+             ty = tyunknown_}
+ | 405 /-PatInt-/ ->
      PatInt {val = gint t 0,
-             info = ginfo t 0}
-  | 406 /-PatChar-/ ->
+             info = ginfo t 0,
+             ty = tyint_}
+ | 406 /-PatChar-/ ->
      PatChar {val = int2char (gint t 0),
-              info = ginfo t 0}
-  | 407 /-PatBool-/ ->
+              info = ginfo t 0,
+              ty = tychar_}
+ | 407 /-PatBool-/ ->
      PatBool {val = eqi (gint t 0) 1,
-              info = ginfo t 0}
-  | 408 /-PatAnd-/ ->
+              info = ginfo t 0,
+              ty = tybool_}
+ | 408 /-PatAnd-/ ->
      PatAnd {lpat = gpat t 0,
              rpat = gpat t 1,
-             info = ginfo t 0}
-  | 409 /-PatOr-/ ->
+             info = ginfo t 0,
+             ty = tyunknown_}
+ | 409 /-PatOr-/ ->
      PatOr {lpat = gpat t 0,
             rpat = gpat t 1,
-            info = ginfo t 0}
-  | 410 /-PatNot-/ ->
+            info = ginfo t 0,
+            ty = tyunknown_}
+ | 410 /-PatNot-/ ->
      PatNot {subpat = gpat t 0,
-             info = ginfo t 0}
-
+             info = ginfo t 0,
+             ty = tyunknown_}
 
   -- Get info help function
   sem ginfo (t:Unknown) =

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -299,7 +299,7 @@ lang IfParser =
      let e2 : ParseResult = parseExprMain r1.pos 0 r1.str in
      let r2 : StrPos = matchKeyword "else" e2.pos e2.str  in
      let e3 : ParseResult = parseExprMain r2.pos 0 r2.str in
-     {val = TmMatch {target = e1.val, pat = PatBool {val = true, info = NoInfo ()},
+     {val = TmMatch {target = e1.val, pat = ptrue_,
                      thn = e2.val, els = e3.val, ty = tyunknown_,
                      info = makeInfo p e3.pos},
       pos = e3.pos,

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1040,8 +1040,9 @@ lang RecordTypePrettyPrint = RecordTypeAst
         if all (lam t : (a,b). stringIsInt t.0) seq then
           let seq = map (lam t : (a,b). (string2int t.0, t.1)) seq in
           let seq : [(a,b)] = sort (lam l : (a,b). lam r : (a,b). subi l.0 r.0) seq in
-          let first = (head seq).0 in
-          let last = (last seq).0 in
+          let fst = lam x: (a, b). x.0 in
+          let first = fst (head seq) in
+          let last = fst (last seq) in
           if eqi first 0 then
             if eqi last (subi (length seq) 1) then
               Some (map (lam t : (a,b). t.1) seq)

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -314,17 +314,17 @@ end
 
 lang DataPatSym = DataPat
   sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | PatCon {ident = ident, subpat = subpat, info = info} ->
+  | PatCon r ->
     match env with {conEnv = conEnv} then
       let ident =
-        if nameHasSym ident then ident
+        if nameHasSym r.ident then r.ident
         else
-          let str = nameGetStr ident in
+          let str = nameGetStr r.ident in
           match mapLookup str conEnv with Some ident then ident
           else error (concat "Unknown constructor in symbolizeExpr: " str)
       in
-      match symbolizePat env patEnv subpat with (patEnv, subpat) then
-        (patEnv, PatCon {ident = ident, subpat = subpat, info = info})
+      match symbolizePat env patEnv r.subpat with (patEnv, subpat) then
+        (patEnv, PatCon {{r with ident = ident} with subpat = subpat})
       else never
     else never
 end

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -14,6 +14,7 @@ include "const-types.mc"
 include "eq.mc"
 include "pprint.mc"
 include "builtin.mc"
+include "mexpr/type.mc"
 
 type TypeEnv = {
   varEnv: Map Name Type,
@@ -558,6 +559,7 @@ end
 lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatRecord t ->
+    let expectedTy = typeUnwrapAlias env.tyEnv expectedTy in
     let expectedTy = match expectedTy with TyRecord _ then expectedTy else
       -- TODO(vipa, 2021-05-31): This will trigger on things like `foo.0` as well (but not `foo.1`, which can cause incorrect code to be generated.
       match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length) then

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -559,7 +559,8 @@ lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatRecord t ->
     let expectedTy = match expectedTy with TyRecord _ then expectedTy else
-      match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length & !1) then
+      -- TODO(vipa, 2021-05-31): This will trigger on things like `foo.0` as well (but not `foo.1`, which can cause incorrect code to be generated.
+      match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length) then
         -- NOTE(vipa, 2021-05-26): This looks like a tuple pattern, so
         -- we assume that the type is exactly that tuple type. This is
         -- technically a hack, and so has some cases where it breaks

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -561,8 +561,7 @@ lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
   | PatRecord t ->
     let expectedTy = typeUnwrapAlias env.tyEnv expectedTy in
     let expectedTy = match expectedTy with TyRecord _ then expectedTy else
-      -- TODO(vipa, 2021-05-31): This will trigger on things like `foo.0` as well (but not `foo.1`, which can cause incorrect code to be generated.
-      match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length) then
+      match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length & !1) then
         -- NOTE(vipa, 2021-05-26): This looks like a tuple pattern, so
         -- we assume that the type is exactly that tuple type. This is
         -- technically a hack, and so has some cases where it breaks

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -472,20 +472,19 @@ lang MatchTypeAnnot = TypeAnnot + MatchAst + MExprEq
   sem typeAnnotExpr (env : TypeEnv) =
   | TmMatch t ->
     let target = typeAnnotExpr env t.target in
-    let thnEnv = typeAnnotPat env (ty target) t.pat in
-    let thn = typeAnnotExpr thnEnv t.thn in
-    let els = typeAnnotExpr env t.els in
-    let ty =
-      match env with {tyEnv = tyEnv} then
-        match compatibleType tyEnv (ty thn) (ty els) with Some ty then
-          ty
-        else (ityunknown_ t.info)
-      else never
-    in
-    TmMatch {{{{t with target = target}
-                  with thn = thn}
-                  with els = els}
-                  with ty = ty}
+    match typeAnnotPat env (ty target) t.pat with (thnEnv, pat) then
+      let thn = typeAnnotExpr thnEnv t.thn in
+      let els = typeAnnotExpr env t.els in
+      let ty =
+        match compatibleType env.tyEnv (ty thn) (ty els) with Some ty
+        then ty
+        else (ityunknown_ t.info) in
+      TmMatch {{{{{t with target = target}
+                     with thn = thn}
+                     with els = els}
+                     with ty = ty}
+                     with pat = pat}
+    else never
 end
 
 lang UtestTypeAnnot = TypeAnnot + UtestAst + MExprEq
@@ -515,61 +514,72 @@ end
 lang NamedPatTypeAnnot = TypeAnnot + NamedPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatNamed t ->
-    match t.ident with PName n then
-      {env with varEnv = mapInsert n expectedTy env.varEnv}
-    else env
+    let env =
+      match t.ident with PName n then
+        {env with varEnv = mapInsert n expectedTy env.varEnv}
+      else env in
+    (env, PatNamed {t with ty = expectedTy})
 end
 
 lang SeqTotPatTypeAnnot = TypeAnnot + SeqTotPat + UnknownTypeAst + SeqTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatSeqTot t ->
     let elemTy =
-      match expectedTy with TySeq {ty = elemTy} then Some elemTy
-      else match expectedTy with TyUnknown _ then Some (ityunknown_ t.info)
-      else None ()
+      match expectedTy with TySeq {ty = elemTy} then elemTy
+      else ityunknown_ t.info
     in
-    match elemTy with Some ty then
-      foldl (lam acc. lam pat. typeAnnotPat acc ty pat) env t.pats
-    else env
+    match mapAccumL (lam acc. lam pat. typeAnnotPat acc elemTy pat) env t.pats with (env, pats) then
+      (env, PatSeqTot {{t with pats = pats} with ty = tyseq_ elemTy})
+    else never
 end
 
 lang SeqEdgePatTypeAnnot = TypeAnnot + SeqEdgePat + UnknownTypeAst + SeqTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatSeqEdge t ->
     let elemTy =
-      match expectedTy with TySeq {ty = elemTy} then Some elemTy
-      else match expectedTy with TyUnknown _ then Some (ityunknown_ t.info)
-      else None ()
-    in
-    match elemTy with Some ty then
-      let env : TypeEnv =
-        foldl (lam acc. lam pat. typeAnnotPat env ty pat) env t.prefix
-      in
-      let env =
+      match expectedTy with TySeq {ty = elemTy} then elemTy
+      else ityunknown_ t.info in
+    let expectedTy = match expectedTy with TySeq _
+      then expectedTy
+      else tyseq_ elemTy in
+    match mapAccumL (lam acc. lam pat. typeAnnotPat acc elemTy pat) env t.prefix with (env, prefix) then
+      let env: TypeEnv = env in
+      let env: TypeEnv =
         match t.middle with PName n then
           {env with varEnv = mapInsert n expectedTy env.varEnv}
         else env
       in
-      foldl (lam acc. lam pat. typeAnnotPat env ty pat) env t.postfix
-    else env
+      match mapAccumL (lam acc. lam pat. typeAnnotPat acc elemTy pat) env t.postfix with (env, postfix) then
+        (env, PatSeqEdge {{{t with prefix = prefix} with postfix = postfix} with ty = expectedTy})
+      else never
+    else never
 end
 
 lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatRecord t ->
-    match expectedTy with TyRecord {fields = fields} then
-      let annotFields = lam fields. lam acc. lam k. lam pat.
-        match mapLookup k fields with Some ty then
-          typeAnnotPat acc ty pat
-        else acc
-      in
-      mapFoldWithKey (annotFields fields) env t.bindings
-    else match expectedTy with TyUnknown _ then
-      let annotUnknown = lam acc. lam. lam pat.
-        typeAnnotPat acc (ityunknown_ t.info) pat
-      in
-      mapFoldWithKey annotUnknown env t.bindings
-    else env
+    let expectedTy = match expectedTy with TyRecord _ then expectedTy else
+      match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length & !1) then
+        -- NOTE(vipa, 2021-05-26): This looks like a tuple pattern, so
+        -- we assume that the type is exactly that tuple type. This is
+        -- technically a hack, and so has some cases where it breaks
+        -- things, but in the common case it is fine. Once we have
+        -- exact record patterns, and tuple patterns desugar to that,
+        -- this can be removed.
+        tytuple_ (make length tyunknown_)
+      else expectedTy
+    in
+    let lookup =
+      match expectedTy with TyRecord {fields = fields} then
+        lam field. optionGetOr (ityunknown_ t.info) (mapLookup field fields)
+      else
+        lam. ityunknown_ t.info
+    in
+    let annotField = lam env. lam field. lam pat.
+      typeAnnotPat env (lookup field) pat in
+    match mapMapAccum annotField env t.bindings with (env, bindings) then
+      (env, PatRecord {{t with bindings = bindings} with ty = expectedTy})
+    else never
 end
 
 lang DataPatTypeAnnot = TypeAnnot + DataPat + VariantTypeAst + VarTypeAst +
@@ -577,43 +587,54 @@ lang DataPatTypeAnnot = TypeAnnot + DataPat + VariantTypeAst + VarTypeAst +
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatCon t ->
     match mapLookup t.ident env.conEnv
-    with Some (TyArrow {from = argTy, to = _}) then
-      typeAnnotPat env argTy t.subpat
-    else env
+    with Some (TyArrow {from = argTy, to = to}) then
+      match typeAnnotPat env argTy t.subpat with (env, subpat) then
+        (env, PatCon {{t with subpat = subpat} with ty = to})
+      else never
+    else (env, PatCon t)
 end
 
 lang IntPatTypeAnnot = TypeAnnot + IntPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
-  | PatInt _ -> env
+  | PatInt r -> (env, PatInt {r with ty = tyint_})
 end
 
 lang CharPatTypeAnnot = TypeAnnot + CharPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
-  | PatChar _ -> env
+  | PatChar r -> (env, PatChar {r with ty = tychar_})
 end
 
 lang BoolPatTypeAnnot = TypeAnnot + BoolPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
-  | PatBool _ -> env
+  | PatBool r -> (env, PatBool {r with ty = tybool_})
 end
 
 lang AndPatTypeAnnot = TypeAnnot + AndPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatAnd t ->
-    let env = typeAnnotPat env expectedTy t.lpat in
-    typeAnnotPat env expectedTy t.rpat
+    match typeAnnotPat env expectedTy t.lpat with (env, lpat) then
+      match typeAnnotPat env expectedTy t.rpat with (env, rpat) then
+        (env, PatAnd {{{t with lpat = lpat} with rpat = rpat} with ty = expectedTy})
+      else never
+    else never
 end
 
 lang OrPatTypeAnnot = TypeAnnot + OrPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatOr t ->
-    let env = typeAnnotPat env expectedTy t.lpat in
-    typeAnnotPat env expectedTy t.rpat
+    match typeAnnotPat env expectedTy t.lpat with (env, lpat) then
+      match typeAnnotPat env expectedTy t.rpat with (env, rpat) then
+        (env, PatOr {{{t with lpat = lpat} with rpat = rpat} with ty = expectedTy})
+      else never
+    else never
 end
 
 lang NotPatTypeAnnot = TypeAnnot + NotPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
-  | PatNot t -> typeAnnotPat env expectedTy t.subpat
+  | PatNot t ->
+    match typeAnnotPat env expectedTy t.subpat with (env, subpat) then
+      (env, PatNot {{t with subpat = subpat} with ty = expectedTy})
+    else never
 end
 
 lang MExprTypeAnnot =

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -312,6 +312,8 @@ mexpr
 
 use TestLang in
 
+let fst = lam x: (a, b). x.0 in
+
 let eqType : EqTypeEnv -> Type -> Type -> Bool =
   lam env. lam l : Type. lam r : Type.
   eqType env l r
@@ -379,7 +381,7 @@ let variantWithRecords = typeAnnot (symbolize (bindall_ [
   lastTerm
 ])) in
 (match typeLift variantWithRecords with (env, t) then
-  let recid = (get env 0).0 in
+  let recid = fst (get env 0) in
   let expectedEnv = [
     (recid, tyrecord_ [
       ("lhs", ntyvar_ treeName), ("rhs", ntyvar_ treeName)
@@ -406,8 +408,8 @@ let nestedRecord = typeAnnot (symbolize (bindall_ [
   uunit_
 ])) in
 (match typeLift nestedRecord with (env, t) then
-  let fstid = (get env 0).0 in
-  let sndid = (get env 1).0 in
+  let fstid = fst (get env 0) in
+  let sndid = fst (get env 1) in
   let expectedEnv = [
     (fstid, tyrecord_ [
       ("a", ntyvar_ sndid),
@@ -430,8 +432,8 @@ let recordsSameFieldsDifferentTypes = typeAnnot (symbolize (bindall_ [
   uunit_
 ])) in
 (match typeLift recordsSameFieldsDifferentTypes with (env, t) then
-  let fstid = (get env 0).0 in
-  let sndid = (get env 1).0 in
+  let fstid = fst (get env 0) in
+  let sndid = fst (get env 1) in
   let expectedEnv = [
     (fstid, tyrecord_ [("a", tyint_), ("b", tybool_)]),
     (sndid, tyrecord_ [("a", tyint_), ("b", tyint_)])
@@ -447,7 +449,7 @@ let recordsSameFieldsSameTypes = typeAnnot (symbolize (bindall_ [
   uunit_
 ])) in
 (match typeLift recordsSameFieldsSameTypes with (env, t) then
-  let recid = (get env 0).0 in
+  let recid = fst (get env 0) in
   let expectedEnv = [
     (recid, tyrecord_ [("a", tyint_), ("b", tyint_)])
   ] in
@@ -500,7 +502,7 @@ let typeAliases = typeAnnot (symbolize (bindall_ [
   -- Note that records and variants are added to the front of the environment
   -- as they are processed, so the last record in the given term will be first
   -- in the environment.
-  let ids = map (lam p. p.0) env in
+  let ids = map (lam p: (a, b). p.0) env in
   let fstRecordId = get ids 5 in -- type Rec1 = {0 : [Char], 1 : Int}
   let globalEnvId = get ids 4 in -- type GlobalEnv = [Rec1]
   let localEnvId = get ids 3 in  -- type LocalEnv = [Rec1]

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -363,7 +363,7 @@ let _pprintRecord = use MExprAst in
       mapMapWithKey (lam id. lam. pvar_ (sidToString id)) fields
     in
     let recordPattern =
-      PatRecord {bindings = recordBindings, info = NoInfo ()}
+      PatRecord {bindings = recordBindings, info = NoInfo (), ty = tyunknown_}
     in
     let pprintSeq =
       match record2tuple fields with Some types then
@@ -407,8 +407,8 @@ let _equalRecord = use MExprAst in
   let rhsPrefix = "rhs_" in
   let matchPattern =
     ptuple_ [
-      PatRecord {bindings = recordBindings lhsPrefix, info = NoInfo ()},
-      PatRecord {bindings = recordBindings rhsPrefix, info = NoInfo ()}] in
+      PatRecord {bindings = recordBindings lhsPrefix, info = NoInfo (), ty = tyunknown_},
+      PatRecord {bindings = recordBindings rhsPrefix, info = NoInfo (), ty = tyunknown_}] in
   let fieldEquals = lam seq. lam id. lam fieldTy.
     let fieldEqName = getEqualFuncName env fieldTy in
     let lhs = var_ (join [lhsPrefix, sidToString id]) in

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -94,7 +94,7 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
   | tys ->
     let ns = create (length tys) (lam. nameSym "t") in
     let pvars =
-      map (lam n. PatNamed { ident = PName n, info = info }) ns
+      map (lam n. PatNamed { ident = PName n, info = info, ty = tyunknown_ }) ns
     in
     let tpat = OPatTuple { pats = pvars } in
     let costsTs =
@@ -269,7 +269,8 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
               (lam n.
                 PatNamed {
                   ident = PName n,
-                  info = info
+                  info = info,
+                  ty = tyunknown_
                 })
               ns
           in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -171,7 +171,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
   | TmMatch ({pat = PatChar {val = c}} & t) ->
     let cond = generate env (eqc_ (char_ c) t.target) in
     _if cond (generate env t.thn) (generate env t.els)
-  | TmMatch ({pat = PatNamed {ident = PWildcard _}} & t) ->
+  | TmMatch ({pat = PatNamed {ident = PWildcard _, ty = tyunknown_}} & t) ->
     generate env t.thn
   | TmMatch ({pat = PatNamed {ident = PName n}} & t) ->
     generate env (bind_

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -86,37 +86,11 @@ type MatchRecord = {target : Expr, pat : Pat, thn : Expr,
                     els : Expr, ty : Type, info : Info}
 
 lang OCamlMatchGenerate = MExprAst + OCamlAst
-  sem matchTargetType (env : GenerateEnv) =
-  | t ->
-    let t : MatchRecord = t in
-    let ty = ty t.target in
-    -- If we don't know the type of the target and the pattern describes a
-    -- tuple, then we assume the target has that type. We do this to
-    -- eliminate the need to add type annotations when matching on tuples,
-    -- which happens frequently.
-    match ty with TyUnknown _ then
-      match t.pat with PatRecord {bindings = bindings} then
-        if mapIsEmpty bindings then ty else
-        match record2tuple bindings with Some _ then
-          let bindingTypes = mapMap (lam. tyunknown_) bindings in
-          match mapLookup bindingTypes env.records with Some id then
-            ntyvar_ id
-          else
-            let msg = join [
-              "Pattern specifies undefined tuple type.\n",
-              "This was caused by an error in type-lifting."
-            ] in
-            infoErrorExit t.info msg
-        else ty
-      else ty
-    else ty
-
   sem generateDefaultMatchCase (env : GenerateEnv) =
   | t ->
     let t : MatchRecord = t in
     let tname = nameSym "_target" in
-    let targetTy = matchTargetType env t in
-    match generatePat env targetTy tname t.pat with (nameMap, wrap) then
+    match generatePat env tname t.pat with (nameMap, wrap) then
       match _mkFinalPatExpr nameMap with (pat, expr) then
         _optMatch
           (objMagic
@@ -184,7 +158,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
     let binds : [(SID, Pat)] = mapBindings pr.bindings in
     match binds with [(fieldLabel, PatNamed ({ident = PName patName} & p))] then
       if nameEq patName thnv.ident then
-        let targetTy = typeUnwrapAlias env.aliases (matchTargetType env t) in
+        let targetTy = typeUnwrapAlias env.aliases pr.ty in
         match lookupRecordFields targetTy env.constrs with Some fields then
           let fieldTypes = ocamlTypedFields fields in
           match mapLookup fieldTypes env.records with Some name then
@@ -193,7 +167,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
             _omatch_ (objMagic (generate env t.target))
               [(OPatCon {ident = name, args = [precord]}, nvar_ patName)]
           else error "Record type not handled by type-lifting"
-        else error (infoErrorString info "Unknown record type")
+        else infoErrorExit info "Unknown record type"
       else generateDefaultMatchCase env t
     else generateDefaultMatchCase env t
   | TmMatch ({target = TmVar _, pat = PatCon pc, els = TmMatch em} & t) ->
@@ -243,7 +217,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
     else generateDefaultMatchCase env t
   | TmMatch t -> generateDefaultMatchCase env t
 
-  sem generatePat (env : GenerateEnv) (targetTy : Type) (targetName : Name) =
+  sem generatePat (env : GenerateEnv) (targetName : Name) =
 end
 
 lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExternalNaive
@@ -386,7 +360,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
   | t -> smap_Expr_Expr (generate env) t
 
   /- : Pat -> (AssocMap Name Name, Expr -> Expr) -/
-  sem generatePat (env : GenerateEnv) (targetTy : Type) (targetName : Name) =
+  sem generatePat (env : GenerateEnv) (targetName : Name) =
   | PatNamed {ident = PWildcard _} ->
     (assocEmpty, identity)
   | PatNamed {ident = PName n} ->
@@ -402,17 +376,12 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
   | PatChar {val = val} ->
     (assocEmpty, lam cont. _if (eqc_ (nvar_ targetName) (char_ val)) cont _none)
   | PatSeqTot {pats = pats} ->
-    let elemTy =
-      match targetTy with TySeq {ty = elemTy} then
-        elemTy
-      else tyunknown_
-    in
     let genOne = lam i. lam pat.
       let n = nameSym "_seqElem" in
-      match generatePat env elemTy n pat with (names, innerWrap) then
+      match generatePat env n pat with (names, innerWrap) then
         let wrap = lam cont.
           bind_
-            (nlet_ n tyunknown_ (get_ (nvar_ targetName) (int_ i)))
+            (nulet_ n (get_ (nvar_ targetName) (int_ i)))
             (innerWrap cont)
         in (names, wrap)
       else never in
@@ -433,14 +402,9 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
     let tempName = nameSym "_splitTemp" in
     let midName = nameSym "_middle" in
     let postName = nameSym "_postfix" in
-    let elemTy =
-      match targetTy with TySeq {ty = elemTy} then
-        elemTy
-      else tyunknown_
-    in
     let genOne = lam targetName. lam i. lam pat.
       let n = nameSym "_seqElem" in
-      match generatePat env elemTy n pat with (names, innerWrap) then
+      match generatePat env n pat with (names, innerWrap) then
         let wrap = lam cont.
           bind_
             (nlet_ n tyunknown_ (get_ (nvar_ targetName) (int_ i)))
@@ -463,8 +427,8 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
       else never
     else never
   | PatOr {lpat = lpat, rpat = rpat} ->
-    match generatePat env targetTy targetName lpat with (lnames, lwrap) then
-      match generatePat env targetTy targetName rpat with (rnames, rwrap) then
+    match generatePat env targetName lpat with (lnames, lwrap) then
+      match generatePat env targetName rpat with (rnames, rwrap) then
         match _mkFinalPatExpr lnames with (lpat, lexpr) then
           match _mkFinalPatExpr rnames with (_, rexpr) then  -- NOTE(vipa, 2020-12-03): the pattern is identical between the two, assuming the two branches bind exactly the same names, which they should
             let names = assocMapWithKey {eq=nameEqSym} (lam k. lam. k) lnames in
@@ -485,15 +449,15 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
       else never
     else never
   | PatAnd {lpat = lpat, rpat = rpat} ->
-    match generatePat env targetTy targetName lpat with (lnames, lwrap) then
-      match generatePat env targetTy targetName rpat with (rnames, rwrap) then
+    match generatePat env targetName lpat with (lnames, lwrap) then
+      match generatePat env targetName rpat with (rnames, rwrap) then
         let names = assocMergePreferRight {eq=nameEqSym} lnames rnames in
         let wrap = lam cont. lwrap (rwrap cont) in
         (names, wrap)
       else never
     else never
   | PatNot {subpat = pat} ->
-    match generatePat env targetTy targetName pat with (_, innerWrap) then
+    match generatePat env targetName pat with (_, innerWrap) then
       let wrap = lam cont.
         _optMatch (innerWrap (_some (OTmTuple {values = []})))
           pvarw_
@@ -512,7 +476,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
             (join ["Field ", sidToString id, " not found in record with fields {", strFields, "}"])
       in
       match mapLookup id patNames with Some n then
-        match generatePat env ty n pat with (names, innerWrap) then
+        match generatePat env n pat with (names, innerWrap) then
           let wrap = lam cont. innerWrap cont in
           (names, wrap)
         else never
@@ -525,7 +489,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
       in
       (assocEmpty, wrap)
     else match env with {records = records, constrs = constrs} then
-      let targetTy = typeUnwrapAlias env.aliases targetTy in
+      let targetTy = typeUnwrapAlias env.aliases t.ty in
       match lookupRecordFields targetTy constrs with Some fields then
         let fieldTypes = ocamlTypedFields fields in
         match mapLookup fieldTypes records with Some name then
@@ -574,7 +538,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
             targetName
           else conVarName
         in
-        match generatePat env innerTy innerTargetName t.subpat with (names, subwrap) then
+        match generatePat env innerTargetName t.subpat with (names, subwrap) then
           let isUnit = match innerTy with TyRecord {fields = fields} then
             mapIsEmpty fields else false in
           let wrap = lam cont.


### PR DESCRIPTION
(Note that this PR builds on #393 and also contains #399, so both of those should be merged before this one. You can see a better view of the files changed [here](https://github.com/miking-lang/miking/pull/400/files/5b37b4ea8b865bf23393e436f624fe6ac8e1d734..8d70fe5997731eb917151c96d76ea2dd4e6300fa))

This PR puts `ty` annotations on all `Pat`s, to mirror `Expr`, which lets us move some type logic from `generate` and `type-lift` to `type-annot`, which I suspect will be essentially necessary once we implement a proper typechecker.

In particular, this moves the tuple pattern hack from `type-lift` and multiple places in `generate` to one place in `type-annot`. As a side-effect this also makes it a bit more consistently applied; previously you could construct nested patterns that contained a tuple-pattern as a sub-pattern that would not have this trigger.

Finally, this PR also makes the hack a bit more strict: previously we'd look at an expression `x.0`, which is expanded to `match x with {#label"0" = x} then x else never`, and see a complete tuple pattern, whereby we'd conclude that the type of `x` is a unary tuple. This happens to give the right result most of the time because the only records we declare that have `#label"0"` have it first, because of the order we're allocating `SID`s and the like, but it's possible for it to generate incorrect code:

```
mexpr

-- NOTE(vipa, 2021-05-25): The following lines ensure that `foo` gets
-- a lower SID than `0`, meaning that `y.0` will believe it is reading
-- a unary tuple, thus reading from the first spot, which is in fact
-- where `foo` is stored.
let y = {foo = 8} in
utest y.foo with 8 in

-- NOTE(vipa, 2021-06-08): Create a record, then give it to the
-- identity function to hide its type from type-annot
let y = (lam x. x) {#label"0" = 0, foo = 8} in

-- NOTE(vipa, 2021-06-08): This utest now gives the following:
utest y.0 with 0 in
-- ** Unit test FAILED on line 15 **
--    LHS: 8
--    RHS: 0
()
```

Before this PR the example compiles just fine and behaves as the comments suggest, after it instead gives a compile error:

```
FILE "minimal.mc" 15:6-15:9 ERROR: Unknown record type
```

As an interesting sidenote, when I first wrote the example the first two lines (that give `foo` a lower `SID`) had to be last in the file, but something apparently changed in the meanwhile.