### PR TITLE
Functions in fields of inlined records

### DIFF
--- a/stdlib/ocaml/generate-env.mc
+++ b/stdlib/ocaml/generate-env.mc
@@ -22,14 +22,5 @@ let objRepr = use OCamlAst in
 let objMagic = use OCamlAst in
   lam t. app_ (OTmVarExt {ident = "Obj.magic"}) t
 
-let toOCamlType = use MExprAst in
-  lam ty : Type.
-  recursive let work = lam nested : Bool. lam ty : Type.
-    match ty with TyRecord t then
-      if or (mapIsEmpty t.fields) nested then tyunknown_
-      else TyRecord {t with fields = mapMap (work true) t.fields}
-    else tyunknown_
-  in work false ty
-
 let ocamlTypedFields = lam fields : Map SID Type.
-  mapMap toOCamlType fields
+  mapMap (lam. tyunknown_) fields

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -1281,6 +1281,19 @@ let recordWithLam = symbolize (
 utest recordWithLam with generateTypeAnnotated recordWithLam
 using sameSemantics in
 
+let foo = nameSym "Foo" in
+let tyFoo = ntyvar_ foo in
+let fooCon = nameSym "FooCon" in
+let tyFooCon = tyrecord_ [("foo", tyarrow_ tyunknown_ tyunknown_)] in
+let conWithRecArrowTy = symbolize (bindall_
+  [ ntype_ foo tyunknown_
+  , ncondef_ fooCon (tyarrow_ tyFooCon tyFoo)
+  , ulet_ "" (nconapp_ fooCon (urecord_ [("foo", ulam_ "" (uunit_))]))
+  , int_ 42
+  ]) in
+utest conWithRecArrowTy with generateTypeAnnotated conWithRecArrowTy
+using sameSemantics in
+
 -- Ints
 let addInt1 = addi_ (int_ 1) (int_ 2) in
 utest addInt1 with generateEmptyEnv addInt1 using sameSemantics in

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -616,7 +616,12 @@ let _addTypeDeclarations = lam typeLiftEnvMap. lam typeLiftEnv. lam t.
             inexpr = t
           }, recordFieldsToName)
       else match ty with TyVariant {constrs = constrs} then
-        let constrs = mapMap (typeUnwrapAlias typeLiftEnvMap) constrs in
+        let fixConstrType = lam ty.
+          let ty = typeUnwrapAlias typeLiftEnvMap ty in
+          match ty with TyRecord tr then
+            TyRecord {tr with fields = ocamlTypedFields tr.fields}
+          else tyunknown_ in
+        let constrs = mapMap fixConstrType constrs in
         if mapIsEmpty constrs then (t, recordFieldsToName)
         else
           (OTmVariantTypeDecl {


### PR DESCRIPTION
One of the intents of #376 was to make inlined records in constructors behave uniformly, in particular, make it so that every field has exactly type `Obj.t`. In actuality, it made things work this way when applying a constructor to an inlined record, but it did not make the appropriate change to the *declaration* of the constructor. Apparently none of our tests use a constructor with an explicit record, where at least one field has a function type, thus this did not trigger.

This PR fixes the type declarations.