### PR TITLE
Add a dprint in OCaml that examines the value using Obj

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -614,7 +614,42 @@ end
 module IO = struct
   let print s = s |> Mseq.Helpers.to_ustring |> uprint_string
 
-  let dprint _ = ()
+  let dprint v =
+    let v = Obj.repr v in
+    let string_of_tag t =
+      let res = ref (string_of_int t) in
+      if t = Obj.lazy_tag then res := !res ^ " (lazy)";
+      if t = Obj.closure_tag then res := !res ^ " (closure)";
+      if t = Obj.object_tag then res := !res ^ " (object)";
+      if t = Obj.infix_tag then res := !res ^ " (infix)";
+      if t = Obj.forward_tag then res := !res ^ " (forward)";
+      if t = Obj.no_scan_tag then res := !res ^ " (no_scan)";
+      if t = Obj.abstract_tag then res := !res ^ " (abstract)";
+      if t = Obj.string_tag then res := !res ^ " (string)";
+      if t = Obj.double_tag then res := !res ^ " (double)";
+      if t = Obj.double_array_tag then res := !res ^ " (double_array)";
+      if t = Obj.custom_tag then res := !res ^ " (custom)";
+      if t = Obj.int_tag then res := !res ^ " (int)";
+      if t = Obj.out_of_heap_tag then res := !res ^ " (out_of_heap)";
+      if t = Obj.unaligned_tag then res := !res ^ " (unaligned)";
+      !res in
+    let rec work indent v =
+      if Obj.is_int v then
+        string_of_int (Obj.obj v) ^ "\n"
+      else if Obj.tag v = Obj.double_tag then
+        string_of_float (Obj.obj v) ^ "\n"
+      else if Obj.tag v = Obj.closure_tag then
+        "<closure>\n"
+      else
+        let istr = String.make indent ' ' in
+        let children = List.init (Obj.size v)
+          (fun i -> istr ^ ", " ^ work (indent + 2) (Obj.field v i)) in
+        begin
+          "{ tag: " ^ string_of_tag (Obj.tag v) ^ ", size: " ^ string_of_int (Obj.size v) ^ "\n" ^
+          String.concat "" children ^
+          istr ^ "}\n"
+        end
+    in print_string (work 0 v);;
 
   let read_line _ =
     let line = try read_line () with End_of_file -> "" in

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -276,7 +276,7 @@ end
 module IO : sig
   val print : int Mseq.t -> unit
 
-  val dprint : int Mseq.t -> unit
+  val dprint : 'a -> unit
 
   val read_line : unit -> int Mseq.t
 end


### PR DESCRIPTION
This PR gives us a slightly useful version of `dprint` when compiling to OCaml. Since types are mostly erased in OCaml we don't have access to constructor names and whatnot, only very low level stuff (since we don't have proper type checking and/or something like `derive`), so this function uses `Obj` to give that low level view of whatever it is passed. See below for an example program and its output when compiled and run.

Note that long-term this is probably not what we want, we'd rather want generated code that prints essentially what `boot` prints or a different mechanism entirely, but this is convenient for debugging the compiler right now.

```
type Either
con Left : a -> Either a b
con Right : b -> Either a b

type Option
con Some : a -> Option a
con None : () -> Option a

mexpr

dprint (Right (Some {foo = "red", bar = "blue"}), None ())
```

```
{ tag: 0, size: 2
, { tag: 1, size: 1
  , { tag: 0, size: 1
    , { tag: 0, size: 2
      , { tag: 2, size: 1
        , { tag: 0, size: 1
          , { tag: 0, size: 1
            , { tag: 0, size: 4
              , 98
              , 108
              , 117
              , 101
              }
            }
          }
        }
      , { tag: 2, size: 1
        , { tag: 0, size: 1
          , { tag: 0, size: 1
            , { tag: 0, size: 3
              , 114
              , 101
              , 100
              }
            }
          }
        }
      }
    }
  }
, 0
}
```

Note that this shows the underlying shape of the sequence of characters