### PR TITLE
Compile `utest` to `match` when comparing with a literal

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -170,11 +170,14 @@ let pchar_ = use MExprAst in
   lam c.
   PatChar {val = c, info = NoInfo(), ty = tychar_}
 
+let pbool_ = use MExprAst in
+  lam b. PatBool {val = b, info = NoInfo(), ty = tybool_}
+
 let ptrue_ = use MExprAst in
-  PatBool {val = true, info = NoInfo(), ty = tybool_}
+  pbool_ true
 
 let pfalse_ = use MExprAst in
-  PatBool {val = false, info = NoInfo(), ty = tybool_}
+  pbool_ false
 
 let npcon_ = use MExprAst in
   lam n. lam cp.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -23,6 +23,9 @@ lang Ast
   syn Pat =
   -- Intentionally left blank
 
+  sem infoTm =
+  -- Intentionally left blank
+
   sem ty =
   -- Intentionally left blank
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -560,6 +560,7 @@ lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatRecord t ->
     let expectedTy = typeUnwrapAlias env.tyEnv expectedTy in
+    let expectedTy = match expectedTy with TyUnknown _ then t.ty else expectedTy in
     let expectedTy = match expectedTy with TyRecord _ then expectedTy else
       match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length & !1) then
         -- NOTE(vipa, 2021-05-26): This looks like a tuple pattern, so

--- a/test/mlang/utest.mc
+++ b/test/mlang/utest.mc
@@ -4,3 +4,12 @@ include "bool.mc"
 utest 15 with 15 using eqi
 utest 12 with 7 using gti
 utest addi 1 5 with addi 4 2 using lam x. lam y. not (lti x y)
+
+
+-- Utest where one of the compared values is under a type variable
+-- (here `a = {foo : Int}`)
+type Option a
+con Some : a -> Option a
+con None : () -> Option a
+
+utest Some {foo = 1} with Some {foo = 1}


### PR DESCRIPTION
(This PR requires #400, which in turn has some further dependencies, so this one should be merged last. [Here](https://github.com/miking-lang/miking/pull/404/files/0f5a2b631c035059a6b59175c83d6ceacf8af576..737f7260b991afe4c002ad422dfff780b3696740) is a better view of the changes actually introduced by this PR)

This PR provides an alternate compilation strategy for `utest`: look at the `expected` value, make as much of it as possible into a `Pat`, then use the default comparison functions for the rest, if possible.

Previously, when compiling something like this:

```
utest parse " ; println foo" with
  { token = SemiTok {info = infoVal "file" 1 1 1 2}
  , lit = ";"
  , info = infoVal "file" 1 1 1 2
  , stream = {pos = posVal "file" 1 2, str = " println foo"}
  } in
<...>
```

we couldn't figure out enough information about the type to generate an equality function, I believe because we don't handle parameterized types with any rigor yet. This PR makes the observation that the right-hand side looks a lot like a pattern, so we can compile the `utest` to a pattern and get something that behaves the way we want it to. The generated code is equivalent with the following:

```diff
 utest parse " ; println foo" with
   { token = SemiTok {info = infoVal "file" 1 1 1 2}
   , lit = ";"
   , info = infoVal "file" 1 1 1 2
   , stream = {pos = posVal "file" 1 2, str = " println foo"}
+  } using lam l. lam. match l with
+  { token = SemiTok {info = x1}
+  , lit = ";"
+  , info = x2
+  , stream = {pos = x3, str = " println foo"}
+  } then
+    and (eqPos x3 (posVal "file" 1 2))
+    (and (eqInfo x1 (infoVal "file" 1 1 1 2)))
+    <...some more anded equalities omitted...>
  in
  <...>
```

Note that all the literals become patterns directly, while other things (in this case only function applications) are bound by name and then compared with an equality function. The equality function used is picked using the normal mechanism based on the types of the expressions in question; for `Info` and `Pos` the types are simple enough to get these equality functions for free, even without having an explicit literal there.

Finally, it's worth mentioning that the generated code has the `ty` field on the record patterns set to something sensible, and `type-annot` has had a minor modification to retain the `ty` field if the `expectedTy` is unknown.