### PR TITLE
Make use of tuning files explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ tags
 .ctags
 .DS_Store
 *.install
-*.tune

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -64,12 +64,14 @@ let filenameWithoutExtension = lam filename.
 
 let insertTunedOrDefaults = lam ast. lam file.
   use MCoreCompile in
-  let tuneFile = tuneFileName file in
-  if fileExists tuneFile then
-    let table = tuneReadTable tuneFile in
-    let ast = symbolize ast in
-    let ast = normalizeTerm ast in
-    insert [] table ast
+  if options.useTuned then
+    let tuneFile = tuneFileName file in
+    if fileExists tuneFile then
+      let table = tuneReadTable tuneFile in
+      let ast = symbolize ast in
+      let ast = normalizeTerm ast in
+      insert [] table ast
+    else error (join ["Tune file ", tuneFile, " does not exist"])
   else default ast
 
 let ocamlCompile =

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -65,12 +65,14 @@ let filenameWithoutExtension = lam filename.
 
 let insertTunedOrDefaults = lam ast. lam file.
   use MCoreCompile in
-  let tuneFile = tuneFileName file in
-  if fileExists tuneFile then
-    let table = tuneReadTable tuneFile in
-    let ast = symbolize ast in
-    let ast = normalizeTerm ast in
-    insert [] table ast
+  if options.useTuned then
+    let tuneFile = tuneFileName file in
+    if fileExists tuneFile then
+      let table = tuneReadTable tuneFile in
+      let ast = symbolize ast in
+      let ast = normalizeTerm ast in
+      insert [] table ast
+    else error (join ["Tune file ", tuneFile, " does not exist"])
   else default ast
 
 let ocamlCompile =

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -9,7 +9,8 @@ type Options = {
   debugTypeAnnot : Bool,
   exitBefore : Bool,
   runTests : Bool,
-  disableOptimizations : Bool
+  disableOptimizations : Bool,
+  useTuned : Bool
 }
 
 -- Option structure
@@ -19,7 +20,8 @@ let options = {
   debugTypeAnnot = false,
   exitBefore = false,
   runTests = false,
-  disableOptimizations = false
+  disableOptimizations = false,
+  useTuned = false
 }
 
 -- Option map, maps strings to structure updates
@@ -29,7 +31,8 @@ let optionsMap = [
 ("--debug-type-annot", lam o : Options. {o with debugTypeAnnot = true}),
 ("--exit-before", lam o : Options. {o with exitBefore = true}),
 ("--test", lam o : Options. {o with runTests = true}),
-("--disable-optimizations", lam o : Options. {o with disableOptimizations = true})
+("--disable-optimizations", lam o : Options. {o with disableOptimizations = true}),
+("--use-tuned", lam o : Options. {o with useTuned = true})
 ]
 
 let mapStringLookup = assocLookup {eq=eqString}

--- a/stdlib/multicore/thread.ext-ocaml.mc
+++ b/stdlib/multicore/thread.ext-ocaml.mc
@@ -32,24 +32,6 @@ let threadExtMap =
       , libraries = []
       }]),
 
-    ("externalThreadWait", [
-      { ident = "Domain.Sync.wait"
-      , ty = tyarrow_ otyunit_ otyunit_
-      , libraries = []
-      }]),
-
-    ("externalThreadNotify", [
-      { ident = "Domain.Sync.notify"
-      , ty = tyarrow_ (tyathread_ "a") otyunit_
-      , libraries = []
-      }]),
-
-    ("externalThreadCriticalSection", [
-      { ident = "Domain.Sync.critical_section"
-      , ty = tyarrow_ (tyarrow_ otyunit_ (tygeneric_ "a")) (tyathread_ "a")
-      , libraries = []
-      }]),
-
     ("externalThreadCPURelax", [
       { ident = "Domain.Sync.cpu_relax"
       , ty = tyarrow_ otyunit_ otyunit_

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -1565,8 +1565,8 @@ utest testFileExists with generateEmptyEnv testFileExists using sameSemantics in
 let testPrint = symbolize (bind_ (ulet_ "_" (print_ (str_ ""))) (int_ 0)) in
 utest testPrint with generateEmptyEnv testPrint using sameSemantics in
 
-let testDPrint = symbolize (bind_ (ulet_ "_" (dprint_ (str_ ""))) (int_ 0)) in
-utest testDPrint with generateEmptyEnv testDPrint using sameSemantics in
+let testDPrint = symbolize (dprint_ (int_ 0)) in
+utest ocamlEval (generateEmptyEnv testDPrint) with int_ 0 using eqExpr in
 
 let testCommand = command_ (str_ "echo \"42\"") in
 utest ocamlEval (generateEmptyEnv testCommand) with int_ 42 using eqExpr in

--- a/test-par.mk
+++ b/test-par.mk
@@ -6,4 +6,4 @@ compile_files += stdlib/multicore/thread.mc
 all: ${compile_files}
 
 ${compile_files}::
-	-@./make compile-test $@ “build/mi compile --test --disable-optimizations”
+	-@./make compile-test $@ "build/mi compile --test --disable-optimizations"


### PR DESCRIPTION
* Adds a compile option `--use-tuned`. The `.tune` files are only used during compilation if this flag is provided.
* Remove `*.tune` from .gitignore
* Includes the fix from #407 
* Fixes the `dprint` test in `generate.mc`, which failed before
* Removes the externals `threadWait`, `threadNotify`, and `threadCriticalSection` since they are removed in multicore OCaml (I will replace them with something else soon).