### PR TITLE
Add pred succ functions to stdlib

### DIFF
--- a/src/boot/lib/rope.mli
+++ b/src/boot/lib/rope.mli
@@ -170,7 +170,8 @@ module Convert : sig
   val to_array_bigarray : ('a, 'b) ba t -> 'a array
 
   val of_array_array : 'a array -> 'a array t
-  (** [Rope.Convert.of_array_* a] converts the array [a] into a rope. *)
+  (** [Rope.Convert.of_array_* a] converts the array [a] into a rope. The
+      underlying data is a reference to [a] so no copying is performed. *)
 
   val of_array_int_bigarray : int array -> int_ba t
 

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -182,7 +182,7 @@ type Successors v l = {
   number : AssocMap v l,
   lowlink : AssocMap v l,
   stack : AssocMap v l,
-  comps : AssocMap v l
+  comps : [[v]]
 }
 
 -- Strongly connected components of g.

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -30,3 +30,11 @@ utest absi 1 with 1
 utest absi (negi 1) with 1
 
 utest addi 1 (negi 1) with 0
+
+let succ = lam x. addi x 1
+
+utest succ 0 with 1
+
+let pred = lam x. subi x 1
+
+utest pred 1 with 0


### PR DESCRIPTION
This PR: 
- Adds `pred` and `succ` functions to `math.mc`. Going forward we might want to split `math.mc` into `int.mc` and `float.mc`.
- Clarifies the semantics of `of_array_array` in function doc.
- Fixes a type signature error in `digraph.mc` 