### PR TITLE
Collect nested matches

### DIFF
--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -177,7 +177,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
   | TmMatch ({pat = PatChar pc} & t) ->
     let pat = PatInt {val = char2int pc.val, info = pc.info, ty = pc.ty} in
     _omatch_ (generate env t.target)
-      [(pat, generate env t.thn), (pvarw_ generate env t.els)]
+      [(pat, generate env t.thn), (pvarw_, generate env t.els)]
   | TmMatch ({pat = PatNamed {ident = PWildcard _, ty = tyunknown_}} & t) ->
     generate env t.thn
   | TmMatch ({pat = PatNamed {ident = PName n}} & t) ->
@@ -198,7 +198,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
             let pat = PatNamed p in
             let precord = OPatRecord {bindings = mapFromSeq cmpSID [(fieldLabel, pat)]} in
             _omatch_ (objMagic (generate env t.target))
-              [(OPatCon {ident = name, args = [precord]}, nvar_ patName)]
+              [(OPatCon {ident = name, args = [precord]}, objMagic (nvar_ patName))]
           else error "Record type not handled by type-lifting"
         else infoErrorExit info "Unknown record type"
       else generateDefaultMatchCase env t

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -152,7 +152,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
     match
       collectNestedMatches env
         (lam pat. match pat with PatInt _ then true else false) []
-        (lam acc. lam t. snoc acc (t.pat, generate env t.thn)) t
+        (lam acc. lam t : MatchRecord. snoc acc (t.pat, generate env t.thn)) t
     with (arms, defaultCase) then
       _omatch_ (generate env t.target)
         (snoc arms (pvarw_, generate env defaultCase))
@@ -164,7 +164,7 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
     match
       collectNestedMatches env
         (lam pat. match pat with PatChar _ then true else false) []
-        (lam acc. lam t.
+        (lam acc. lam t : MatchRecord.
           match t.pat with PatChar pc then
             let pat =
               PatInt {val = char2int pc.val, info = pc.info, ty = pc.ty}

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -140,8 +140,8 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst
   | TmMatch ({pat = (PatBool {val = false})} & t) ->
     _if (objMagic (generate env t.target)) (generate env t.els) (generate env t.thn)
   | TmMatch ({pat = PatInt {val = i}} & t) ->
-    let cond = generate env (eqi_ (int_ i) t.target) in
-    _if (objMagic cond) (generate env t.thn) (generate env t.els)
+    _omatch_ (generate env t.target)
+      [(t.pat, generate env t.thn), (pvarw_, generate env t.els)]
   | TmMatch ({pat = PatChar {val = c}} & t) ->
     let cond = generate env (eqc_ (char_ c) t.target) in
     _if cond (generate env t.thn) (generate env t.els)

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -6,22 +6,22 @@ include "char.mc"
 include "name.mc"
 include "intrinsics-ops.mc"
 
-let isValidChar = lam c.
+let _isValidChar = lam c.
   or (isAlphanum c) (or (eqChar c '_') (eqChar c '\''))
 
-let escapeChar = lam c.
-  if isValidChar c then c else '_'
+let _escapeChar = lam c.
+  if _isValidChar c then c else '_'
 
-utest map escapeChar "abcABC/:@_'" with "abcABC____'"
+utest map _escapeChar "abcABC/:@_'" with "abcABC____'"
 
 let escapeVarString = lam s.
-  concat "v_" (map escapeChar s)
+  concat "v_" (map _escapeChar s)
 
 let escapeConString = lam s.
-  concat "C" (map escapeChar s)
+  concat "C" (map _escapeChar s)
 
 let escapeLabelString = lam s.
-  concat "l" (map escapeChar s)
+  concat "l" (map _escapeChar s)
 
 utest escapeVarString "abcABC/:@_'" with "v_abcABC____'"
 utest escapeVarString "" with "v_"

--- a/test/examples/match-int.mc
+++ b/test/examples/match-int.mc
@@ -1,3 +1,7 @@
 mexpr
 let v = 1 in
-match v with 2 then v else v
+match v with 3 then 1
+else match v with 2 then 2
+else match v with 4 then 3
+else match v with 5 then 4
+else 42


### PR DESCRIPTION
This PR collects some nested matches in the compiler, making `switch` statements "survive" compilation better. The collection is added for integer and char patterns. The basic logic of the collection is in the semantic function `collectNestedMatches`. The already implemented collection of nested constructor patterns is refactored to use this function too.

Before this PR, this program:
```
mexpr
let v = 1 in
match v with 3 then 1
else match v with 2 then 2
else match v with 4 then 3
else match v with 5 then 4
else 42
```
was compiled into:
```ocaml
let v_v'146753 =
  1
in
if
  Obj.magic
    (Obj.magic
       Int.equal
       3
       v_v'146753)
then
  1
else
  Obj.magic
    (if
       Obj.magic
         (Obj.magic
            Int.equal
            2
            v_v'146753)
     then
       2
     else
       Obj.magic
         (if
            Obj.magic
              (Obj.magic
                 Int.equal
                 4
                 v_v'146753)
          then
            3
          else
            Obj.magic
              (if
                 Obj.magic
                   (Obj.magic
                      Int.equal
                      5
                      v_v'146753)
               then
                 4
               else
                 Obj.magic
                   42)))
```
It now compiles into:
```ocaml
let v_v'146901 =
  1
in
match
  v_v'146901
with
| 3 ->
    1
| 2 ->
    (Obj.magic
       2)
| 4 ->
    (Obj.magic
       3)
| 5 ->
    (Obj.magic
       4)
| _ ->
    (Obj.magic
       42)
```

I checked the result of the generated `dlambda` representation in OCaml.
Before:
```
(seq
  (let (v_v'146753/85 =[int] 1)
    (if (apply (field_imm 7 (global Stdlib__int!)) 3 v_v'146753/85) 1
      (if (apply (field_imm 7 (global Stdlib__int!)) 2 v_v'146753/85) 2
        (if (apply (field_imm 7 (global Stdlib__int!)) 4 v_v'146753/85) 3
          (if (apply (field_imm 7 (global Stdlib__int!)) 5 v_v'146753/85) 4
            42)))))
  0)
```
After:
```
(seq
  (let (v_v'146901/85 =[int] 1 switcher/165 =a (-2+ v_v'146901/85))
    (if (isout 3 switcher/165) 42
      (switch* switcher/165
       case int 0: 2
       case int 1: 1
       case int 2: 3
       case int 3: 4)))
  0)
```

Additionally, it fixes a bug in `ocaml/pprint.mc` where `escapeChar` accidentally overwrote `escapeChar` in `char.mc`.