### PR TITLE
Clean up environment for C compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
   boot\
   test\
   install\
+  install-boot\
   lint\
   fix\
   clean\
@@ -39,7 +40,10 @@ build/mi: boot
 
 test: test-boot-base
 
-install:
+install: build/mi boot
+	@./make install
+
+install-boot: boot
 	@./make install
 
 lint:

--- a/make
+++ b/make
@@ -50,8 +50,12 @@ install() {
     bin_path=$HOME/.local/bin/
     lib_path=$HOME/.local/lib/mcore/stdlib
     mkdir -p $bin_path $lib_path
-    cp -f build/$BOOT_NAME $bin_path/$BOOT_NAME; chmod +x $bin_path/$BOOT_NAME
-    cp -f build/$MI_NAME $bin_path/$MI_NAME; chmod +x $bin_path/$MI_NAME
+    if [ -e build/$BOOT_NAME ]; then
+      cp -f build/$BOOT_NAME $bin_path/$BOOT_NAME; chmod +x $bin_path/$BOOT_NAME
+    fi
+    if [ -e build/$MI_NAME ]; then
+      cp -f build/$MI_NAME $bin_path/$MI_NAME; chmod +x $bin_path/$MI_NAME
+    fi
     rm -rf $lib_path; cp -rf stdlib $lib_path
 }
 
@@ -105,7 +109,6 @@ case $1 in
         fix
         ;;
     install)
-        build
         install
         ;;
     clean)

--- a/make
+++ b/make
@@ -23,6 +23,7 @@ build_boot(){
     mkdir -p build
     dune build
     cp -f _build/install/default/bin/boot.mi build/$BOOT_NAME
+    dune install > /dev/null 2>&1
 }
 
 

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -67,13 +67,16 @@ let raise_parse_error_on_partially_applied_external t =
   let _ = recur (SymbMap.empty, 0, NoInfo) t in
   t
 
+(* Current working directory standard library path *)
+let stdlib_cwd = Sys.getcwd () ^ Filename.dir_sep ^ "stdlib"
+
 (* Standard lib default local path on unix (used by make install) *)
 let stdlib_loc_unix =
   match Sys.getenv_opt "HOME" with
   | Some home ->
       home ^ "/.local/lib/mcore/stdlib"
   | None ->
-      "@@@"
+      stdlib_cwd
 
 let stdlib_loc =
   match Sys.getenv_opt "MCORE_STDLIB" with
@@ -82,7 +85,8 @@ let stdlib_loc =
   | None ->
       if Sys.os_type = "Unix" && Sys.file_exists stdlib_loc_unix then
         stdlib_loc_unix
-      else "@@@"
+      else
+        stdlib_cwd
 
 let prog_argv : string list ref = ref []
 

--- a/stdlib/c/ast.mc
+++ b/stdlib/c/ast.mc
@@ -16,9 +16,6 @@
 
 -- NOTE(dlunde,2020-10-30):
 --
--- * Identifiers are _not_ checked for validity. You must make sure they are
---   valid C identifiers in your own code.
---
 -- * Definitions have optional identifiers and initializers to allow for
 --   declaring struct/union/enum types without instantiating them
 --

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -29,11 +29,12 @@ lang ANF = LetAst + VarAst + UnknownTypeAst
       ty = ty n,
       info = NoInfo {}
     } in
+    let inexpr = k var in
     TmLet {ident = ident,
            tyBody = ty n,
            body = n,
-           inexpr = k var,
-           ty = tyunknown_,
+           inexpr = inexpr,
+           ty = ty inexpr,
            info = NoInfo{}}
 
   sem normalizeName (k : Expr -> Expr) =

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -218,6 +218,7 @@ lang LetAst = Ast + VarAst
     else never
 end
 
+-- NOTE(dlunde,2021-08-10): The types `Type` and `Expr` are not visible here.
 type RecLetBinding =
   { ident : Name
   , tyBody : Type


### PR DESCRIPTION
- Cleanup environment for C compiler (possible after switching record labels from strings to names).
- Fix bug in ANF where type was discarded.
- Added `install-boot` rule to Makefile (not really needed after #421, but it might come in handy).
- Set cwd/stdlib as stdlib location when there is no stdlib set.
