### PR TITLE
Fix obj-wrapping of nested records in `TmRecordUpdate` 

### DIFF
--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -253,7 +253,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
       match mapLookup ident env.constrs with Some (TyRecord {fields = fields}) then
         let fieldTypes = ocamlTypedFields fields in
         match mapLookup fieldTypes env.records with Some id then
-          let rec = generate env t.rec in
+          let rec = objMagic (generate env t.rec) in
           let key = sidToString t.key in
           let value = objRepr (generate env t.value) in
           let inlineRecordName = nameSym "rec" in

--- a/test/mexpr/records.mc
+++ b/test/mexpr/records.mc
@@ -20,4 +20,8 @@ let bumpAge = lam r : {age : Int, name : String}. {r with age = addi r.age 1} in
 
 utest bumpAge r1 with r2 in
 
+let nested = {a = {b = 1}} in
+let arec = {nested.a with b = addi nested.a.b 1} in
+utest arec.b with 2 in
+
 ()


### PR DESCRIPTION
This PR adds `Obj.magic` wrapping around the `rec` of a `TmRecordUpdate`. This is needed in situations where we are updating a nested record, as in
```
let nested = {a = {b = 1}} in
let arec = {nested.a with b = addi nested.a.b 1} in
```
Without the extra obj-wrapping the OCaml compilation fails with an error like:
```
File "program.ml", line 96, characters 4-28:
96 |     CRec'146780 v_rec'146789
         ^^^^^^^^^^^^^^^^^^^^^^^^
Error: This pattern matches values of type v_record'146783
       but a pattern was expected which matches values of type Obj.t
```