### PR TITLE
Document the time complexities of MSeq intrinsics

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -172,16 +172,7 @@ module Mseq = struct
       | Rope s1, Rope s2 ->
           Rope.equal_array f s1 s2
       | List s1, List s2 ->
-          let rec equal f s1 s2 =
-            match (s1, s2) with
-            | [], [] ->
-                true
-            | [], _ | _, [] ->
-                false
-            | x :: xs, y :: ys ->
-                f x y && equal f xs ys
-          in
-          equal f s1 s2
+          List.equal f s1 s2
       | _ ->
           raise (Invalid_argument "Mseq.equal")
 
@@ -211,7 +202,7 @@ module Mseq = struct
       | Rope s1, Rope s2 ->
           Rope.foldr2_array f s1 s2 a
       | List s1, List s2 ->
-          List.fold_right (fun (a, b) acc -> f a b acc) (List.combine s1 s2) a
+          List.fold_right2 f s1 s2 a
       | _ ->
           raise (Invalid_argument "Mseq.fold_right2")
 


### PR DESCRIPTION
This PR adds documentation comments in `intrinsics.mli` for the `MSeq` operations on their complexity, and whether they flatten a rope they're given. It also changes two previously manual implementations of functions to those already available in OCaml's `List`.

Co-authored-by: Linnea Ingmar <lingmar@kth.se>
Co-authored-by: Lars Hummelgren <larshum@kth.se