### PR TITLE
Refactor the pattern analysis for sequences

### DIFF
--- a/src/boot/lib/patterns.ml
+++ b/src/boot/lib/patterns.ml
@@ -30,6 +30,7 @@ type simple_con =
   | BoolCon of bool
   | ConCon of ustring
   | RecCon
+  | SeqCon
 
 module SimpleConOrd = struct
   type t = simple_con
@@ -37,6 +38,14 @@ module SimpleConOrd = struct
   (* NOTE(?,?): I can't just use the polymorphic compare in the standard library
    * since ustring has internal mutation that would be visible to it, but
    * shouldn't affect the result *)
+  let con_idx = function
+    | IntCon _ -> 0
+    | CharCon _ -> 1
+    | BoolCon _ -> 2
+    | ConCon _ -> 3
+    | RecCon -> 4
+    | SeqCon -> 5
+
   let compare a b =
     match (a, b) with
     | IntCon a, IntCon b ->
@@ -47,66 +56,59 @@ module SimpleConOrd = struct
         Bool.compare a b
     | ConCon a, ConCon b ->
         Ustring.compare a b
-    | RecCon, RecCon ->
-        0
-    | IntCon _, (CharCon _ | BoolCon _ | ConCon _ | RecCon) ->
-        -1
-    | (CharCon _ | BoolCon _ | ConCon _ | RecCon), IntCon _ ->
-        1
-    | CharCon _, (BoolCon _ | ConCon _ | RecCon) ->
-        -1
-    | (BoolCon _ | ConCon _ | RecCon), CharCon _ ->
-        1
-    | BoolCon _, (ConCon _ | RecCon) ->
-        -1
-    | (ConCon _ | RecCon), BoolCon _ ->
-        1
-    | ConCon _, RecCon ->
-        -1
-    | RecCon, ConCon _ ->
-        1
+    | _ -> Int.compare (con_idx a) (con_idx b)
 end
 
 module ConSet = Set.Make (SimpleConOrd)
 
-type simple_pat =
-  | SPatInt of int
-  | SPatChar of int
-  | SPatBool of bool
-  | SPatCon of ustring * npat
-
-and npat =
-  | NSPat of simple_pat
+type snpat =
+  | NPatInt of int
+  | NPatChar of int
+  | NPatBool of bool
+  | NPatCon of ustring * npat
   | NPatRecord of npat Record.t * UstringSet.t (* The set is disallowed labels *)
   | NPatSeqTot of npat list
-  | NPatSeqEdge of npat list * npat list
-  | NPatNot of
-      IntSet.t option
-      (* Some lengths -> the disallowed sequence lengths, None -> no sequences allowed *)
-      * ConSet.t
+  | NPatSeqEdge of npat list * IntSet.t (* The set of disallowed lengths *) * npat list
+
+and npat =
+  | SNPat of snpat
+  | NPatNot of ConSet.t
 
 (* The disallowed simple constructors *)
 
-let wildpat = NPatNot (Some IntSet.empty, ConSet.empty)
+let wildpat = NPatNot ConSet.empty
 
-let notpat_simple c = NPatNot (Some IntSet.empty, ConSet.singleton c)
-
-let notpat_seq_len n = NPatNot (Some (IntSet.singleton n), ConSet.empty)
-
-let notpat_seq = NPatNot (None, ConSet.empty)
+let notpat_simple c = NPatNot (ConSet.singleton c)
 
 let simple_con_of_simple_pat = function
-  | SPatInt i ->
+  | NPatInt i ->
       IntCon i
-  | SPatChar c ->
+  | NPatChar c ->
       CharCon c
-  | SPatBool b ->
+  | NPatBool b ->
       BoolCon b
-  | SPatCon (c, _) ->
+  | NPatCon (c, _) ->
       ConCon c
+  | NPatRecord _ ->
+      RecCon
+  | NPatSeqTot _ | NPatSeqEdge _ ->
+      SeqCon
 
 module NPatOrd = struct
   type t = npat
+
+  let snpat_idx = function
+    | NPatInt _ -> 0
+    | NPatChar _ -> 1
+    | NPatBool _ -> 2
+    | NPatCon _ -> 3
+    | NPatRecord _ -> 4
+    | NPatSeqTot _ -> 5
+    | NPatSeqEdge _ -> 6
+
+  let npat_idx = function
+    | SNPat _ -> 0
+    | NPatNot _ -> 1
 
   let rec compare_list a b =
     match (a, b) with
@@ -120,61 +122,37 @@ module NPatOrd = struct
     | _ :: _, [] ->
         1
 
-  and compare_simple a b =
+  and compare_snpat a b =
     match (a, b) with
-    | SPatInt a, SPatInt b ->
+    | NPatInt a, NPatInt b ->
         Int.compare a b
-    | SPatChar a, SPatChar b ->
+    | NPatChar a, NPatChar b ->
         Int.compare a b
-    | SPatBool a, SPatBool b ->
+    | NPatBool a, NPatBool b ->
         Bool.compare a b
-    | SPatCon (str1, p1), SPatCon (str2, p2) ->
+    | NPatCon (str1, p1), NPatCon (str2, p2) ->
         let str_res = Ustring.compare str1 str2 in
         if str_res = 0 then compare p1 p2 else str_res
-    | SPatInt _, (SPatChar _ | SPatBool _ | SPatCon _) ->
-        -1
-    | (SPatChar _ | SPatBool _ | SPatCon _), SPatInt _ ->
-        1
-    | SPatChar _, (SPatBool _ | SPatCon _) ->
-        -1
-    | (SPatBool _ | SPatCon _), SPatChar _ ->
-        1
-    | SPatBool _, SPatCon _ ->
-        -1
-    | SPatCon _, SPatBool _ ->
-        -1
-
-  and compare a b =
-    match (a, b) with
-    | NSPat a, NSPat b ->
-        compare_simple a b
     | NPatRecord (a1, d1), NPatRecord (a2, d2) ->
         let rec_res = Record.compare compare a1 a2 in
         if rec_res = 0 then UstringSet.compare d1 d2 else rec_res
     | NPatSeqTot a, NPatSeqTot b ->
         compare_list a b
-    | NPatSeqEdge (pre1, post1), NPatSeqEdge (pre2, post2) ->
+    | NPatSeqEdge (pre1, len1, post1), NPatSeqEdge (pre2, len2, post2) ->
         let pre_res = compare_list pre1 pre2 in
-        if pre_res = 0 then compare_list post1 post2 else pre_res
-    | NPatNot (seqs1, cons1), NPatNot (seqs2, cons2) ->
-        let seq_res = Option.compare IntSet.compare seqs1 seqs2 in
-        if seq_res <> 0 then seq_res else ConSet.compare cons1 cons2
-    | NSPat _, (NPatRecord _ | NPatSeqTot _ | NPatSeqEdge _ | NPatNot _) ->
-        -1
-    | (NPatRecord _ | NPatSeqTot _ | NPatSeqEdge _ | NPatNot _), NSPat _ ->
-        1
-    | NPatRecord _, (NPatSeqTot _ | NPatSeqEdge _ | NPatNot _) ->
-        -1
-    | (NPatSeqTot _ | NPatSeqEdge _ | NPatNot _), NPatRecord _ ->
-        1
-    | NPatSeqTot _, (NPatSeqEdge _ | NPatNot _) ->
-        -1
-    | (NPatSeqEdge _ | NPatNot _), NPatSeqTot _ ->
-        1
-    | NPatSeqEdge _, NPatNot _ ->
-        -1
-    | NPatNot _, NPatSeqEdge _ ->
-        -1
+        if pre_res <> 0 then pre_res else
+        let mid_res = IntSet.compare len1 len2 in
+        if mid_res <> 0 then mid_res else
+        compare_list post1 post2
+    | _ -> Int.compare (snpat_idx a) (snpat_idx b)
+
+  and compare a b =
+    match (a, b) with
+    | SNPat a, SNPat b ->
+        compare_snpat a b
+    | NPatNot cons1, NPatNot cons2 ->
+        ConSet.compare cons1 cons2
+    | _ -> Int.compare (npat_idx a) (npat_idx b)
 end
 
 module NPatSet = Set.Make (NPatOrd)
@@ -249,21 +227,21 @@ let rec list_complement (constr : npat list -> npat) (l : npat list) : normpat
 
 (* construct a normpat *)
 and npat_complement : npat -> normpat = function
-  | NSPat (SPatInt i) ->
+  | SNPat (NPatInt i) ->
       notpat_simple (IntCon i) |> NPatSet.singleton
-  | NSPat (SPatChar c) ->
+  | SNPat (NPatChar c) ->
       notpat_simple (CharCon c) |> NPatSet.singleton
-  | NSPat (SPatBool b) ->
+  | SNPat (NPatBool b) ->
       notpat_simple (BoolCon b) |> NPatSet.singleton
-  | NSPat (SPatCon (c, p)) ->
+  | SNPat (NPatCon (c, p)) ->
       npat_complement p
-      |> NPatSet.map (fun p -> NSPat (SPatCon (c, p)))
+      |> NPatSet.map (fun p -> SNPat (NPatCon (c, p)))
       |> NPatSet.add (notpat_simple (ConCon c))
-  | NPatRecord (pats, neg_labels) ->
+  | SNPat (NPatRecord (pats, neg_labels)) ->
       let with_forbidden_labels =
         UstringSet.elements neg_labels
         |> List.map (fun label ->
-               NPatRecord (Record.add label wildpat pats, UstringSet.empty) )
+               SNPat (NPatRecord (Record.add label wildpat pats, UstringSet.empty)))
         |> NPatSet.of_list
       in
       let labels, pats = Record.bindings pats |> List.split in
@@ -271,199 +249,154 @@ and npat_complement : npat -> normpat = function
         list_complement
           (fun pats ->
             List.combine labels pats |> List.to_seq |> Record.of_seq
-            |> fun x -> NPatRecord (x, UstringSet.empty) )
+            |> fun x -> SNPat (NPatRecord (x, UstringSet.empty)) )
           pats
       in
       let missing_labels =
         labels
         |> List.map (fun label ->
-               NPatRecord (Record.empty, UstringSet.singleton label) )
+               SNPat (NPatRecord (Record.empty, UstringSet.singleton label)) )
         |> NPatSet.of_list
       in
       NPatSet.union complemented_product missing_labels
       |> NPatSet.union with_forbidden_labels
-  | NPatSeqTot pats ->
-      list_complement (fun pats -> NPatSeqTot pats) pats
-      |> NPatSet.add (notpat_seq_len <| List.length pats)
-  | NPatSeqEdge (pre, post) ->
+  | SNPat (NPatSeqTot pats) ->
+      list_complement (fun pats -> SNPat (NPatSeqTot pats)) pats
+      |> NPatSet.add (SNPat (NPatSeqEdge ([], List.length pats |> IntSet.singleton, [])))
+  | SNPat (NPatSeqEdge (pre, lens, post)) ->
       let lenPre, lenPost = (List.length pre, List.length post) in
       let complemented_product =
         list_complement
           (fun pats ->
             let pre, post = split_at lenPre pats in
-            NPatSeqEdge (pre, post) )
+            SNPat (NPatSeqEdge (pre, lens, post)) )
           (pre @ post)
       in
       let allowed_lengths =
-        List.init (lenPre + lenPost) (fun n -> NPatSeqTot (repeat n wildpat))
+        List.init (lenPre + lenPost)
+          (fun n -> if IntSet.mem n lens then None else Some (SNPat (NPatSeqTot (repeat n wildpat))))
+        |> List.filter_map (fun x -> x)
         |> NPatSet.of_list
       in
       NPatSet.union complemented_product allowed_lengths
-      |> NPatSet.add notpat_seq
-  | NPatNot (seq_lens, cons) ->
-      let seqs =
-        match seq_lens with
-        | None ->
-            NPatSeqEdge ([], []) |> NPatSet.singleton
-        | Some seq_lens ->
-            IntSet.elements seq_lens
-            |> List.map (fun n -> NPatSeqTot (repeat n wildpat))
-            |> NPatSet.of_list
-      in
-      let cons =
-        ConSet.elements cons
-        |> List.map (function
-             | IntCon i ->
-                 NSPat (SPatInt i)
-             | CharCon c ->
-                 NSPat (SPatChar c)
-             | BoolCon b ->
-                 NSPat (SPatBool b)
-             | ConCon c ->
-                 NSPat (SPatCon (c, wildpat))
-             | RecCon ->
-                 NPatRecord (Record.empty, UstringSet.empty) )
-        |> NPatSet.of_list
-      in
-      NPatSet.union seqs cons
+      |> NPatSet.add (notpat_simple SeqCon)
+  | NPatNot cons ->
+      ConSet.elements cons
+      |> List.map (function
+           | IntCon i ->
+               SNPat (NPatInt i)
+           | CharCon c ->
+               SNPat (NPatChar c)
+           | BoolCon b ->
+               SNPat (NPatBool b)
+           | ConCon c ->
+               SNPat (NPatCon (c, wildpat))
+           | SeqCon ->
+               SNPat (NPatSeqEdge ([], IntSet.empty, []))
+           | RecCon ->
+               SNPat (NPatRecord (Record.empty, UstringSet.empty)))
+      |> NPatSet.of_list
 
 and npat_intersect (a : npat) (b : npat) : normpat =
   match (a, b) with
-  | NPatNot (seqs1, cons1), NPatNot (seqs2, cons2) ->
-      let seqs =
-        match (seqs1, seqs2) with
-        | None, _ | _, None ->
-            None
-        | Some a, Some b ->
-            Some (IntSet.union a b)
-      in
-      let cons = ConSet.union cons1 cons2 in
-      NPatSet.singleton (NPatNot (seqs, cons))
-  | NPatNot (_, cons), (NSPat sp as pat) | (NSPat sp as pat), NPatNot (_, cons)
+  | NPatNot cons1, NPatNot cons2 ->
+      NPatSet.singleton (NPatNot (ConSet.union cons1 cons2))
+  | NPatNot cons, (SNPat sp as pat) | (SNPat sp as pat), NPatNot cons
     ->
       if ConSet.mem (simple_con_of_simple_pat sp) cons then NPatSet.empty
       else NPatSet.singleton pat
-  | NPatNot (_, cons), (NPatRecord _ as pat)
-  | (NPatRecord _ as pat), NPatNot (_, cons) ->
-      if ConSet.mem RecCon cons then NPatSet.empty else NPatSet.singleton pat
-  | NPatNot (None, _), (NPatSeqTot _ | NPatSeqEdge _)
-  | (NPatSeqTot _ | NPatSeqEdge _), NPatNot (None, _) ->
-      NPatSet.empty
-  | NPatNot (Some lens, _), (NPatSeqTot pats as pat)
-  | (NPatSeqTot pats as pat), NPatNot (Some lens, _) ->
-      if IntSet.mem (List.length pats) lens then NPatSet.empty
-      else NPatSet.singleton pat
-  | NPatNot (Some lens, _), (NPatSeqEdge (pre, post) as pat)
-  | (NPatSeqEdge (pre, post) as pat), NPatNot (Some lens, _) -> (
-    match IntSet.max_elt_opt lens with
-    | None ->
-        NPatSet.singleton pat
-    | Some max_forbidden_len ->
-        let min_len = List.length pre + List.length post in
-        if min_len > max_forbidden_len then NPatSet.singleton pat
-        else
-          List.init (max_forbidden_len - min_len) (fun n -> n)
-          |> List.filter (fun n -> IntSet.mem (n + min_len) lens |> not)
-          |> List.map (fun n_extras ->
-                 NPatSeqTot
-                   (pre @ List.rev_append (repeat n_extras wildpat) post) )
-          |> NPatSet.of_list
-          |> NPatSet.add
-               (NPatSeqEdge
-                  ( pre
-                  , List.rev_append
-                      (repeat (max_forbidden_len - min_len + 1) wildpat)
-                      post ) ) )
-  | NSPat p1, NSPat p2 -> (
+  | SNPat p1, SNPat p2 -> (
     match (p1, p2) with
-    | SPatInt i1, SPatInt i2 when i1 = i2 ->
+    | NPatInt i1, NPatInt i2 when i1 = i2 ->
         NPatSet.singleton a
-    | SPatChar c1, SPatChar c2 when c1 = c2 ->
+    | NPatChar c1, NPatChar c2 when c1 = c2 ->
         NPatSet.singleton a
-    | SPatBool b1, SPatBool b2 when b1 = b2 ->
+    | NPatBool b1, NPatBool b2 when b1 = b2 ->
         NPatSet.singleton a
-    | SPatCon (s1, p1), SPatCon (s2, p2) when s1 = s2 ->
-        npat_intersect p1 p2 |> NPatSet.map (fun p -> NSPat (SPatCon (s1, p)))
-    | _ ->
-        NPatSet.empty )
-  | NSPat _, (NPatRecord _ | NPatSeqTot _ | NPatSeqEdge _)
-  | (NPatRecord _ | NPatSeqTot _ | NPatSeqEdge _), NSPat _ ->
-      NPatSet.empty
-  | NPatRecord (r1, neg1), NPatRecord (r2, neg2) ->
-      if
-        Record.exists (fun label _ -> UstringSet.mem label neg2) r1
-        || Record.exists (fun label _ -> UstringSet.mem label neg1) r2
-      then NPatSet.empty
-      else
-        let neg = UstringSet.union neg1 neg2 in
-        let merge_f _ a b =
-          match (a, b) with
-          | None, None ->
-              None
-          | Some a, Some b ->
-              Some (npat_intersect a b |> NPatSet.elements)
-          | Some a, _ | _, Some a ->
-              Some [a]
+    | NPatCon (s1, p1), NPatCon (s2, p2) when s1 = s2 ->
+        npat_intersect p1 p2 |> NPatSet.map (fun p -> SNPat (NPatCon (s1, p)))
+    | NPatRecord (r1, neg1), NPatRecord (r2, neg2) ->
+        if
+          Record.exists (fun label _ -> UstringSet.mem label neg2) r1
+          || Record.exists (fun label _ -> UstringSet.mem label neg1) r2
+        then NPatSet.empty
+        else
+          let neg = UstringSet.union neg1 neg2 in
+          let merge_f _ a b =
+            match (a, b) with
+            | None, None ->
+                None
+            | Some a, Some b ->
+                Some (npat_intersect a b |> NPatSet.elements)
+            | Some a, _ | _, Some a ->
+                Some [a]
+          in
+          Record.merge merge_f r1 r2 |> Record.bindings
+          |> traverse (fun (k, vs) -> List.map (fun v -> (k, v)) vs)
+          |> List.map (fun bindings ->
+                 SNPat (NPatRecord (List.to_seq bindings |> Record.of_seq, neg)) )
+          |> NPatSet.of_list
+    | NPatSeqTot pats1, NPatSeqTot pats2 ->
+        if List.length pats1 <> List.length pats2 then NPatSet.empty
+        else
+          List.map2 npat_intersect pats1 pats2
+          |> traverse NPatSet.elements
+          |> List.map (fun pats -> SNPat (NPatSeqTot pats))
+          |> NPatSet.of_list
+    | NPatSeqEdge (pre1, lens1, post1), NPatSeqEdge (pre2, lens2, post2) ->
+        let lens = IntSet.union lens1 lens2 in
+        let pre = map2_keep_extras npat_intersect pre1 pre2 in
+        let rev_post =
+          map2_keep_extras npat_intersect (List.rev post1) (List.rev post2)
         in
-        Record.merge merge_f r1 r2 |> Record.bindings
-        |> traverse (fun (k, vs) -> List.map (fun v -> (k, v)) vs)
-        |> List.map (fun bindings ->
-               NPatRecord (List.to_seq bindings |> Record.of_seq, neg) )
-        |> NPatSet.of_list
-  | NPatRecord _, (NPatSeqTot _ | NPatSeqEdge _)
-  | (NPatSeqTot _ | NPatSeqEdge _), NPatRecord _ ->
-      NPatSet.empty
-  | NPatSeqTot pats1, NPatSeqTot pats2 ->
-      if List.length pats1 <> List.length pats2 then NPatSet.empty
-      else
-        List.map2 npat_intersect pats1 pats2
-        |> traverse NPatSet.elements
-        |> List.map (fun pats -> NPatSeqTot pats)
-        |> NPatSet.of_list
-  | NPatSeqEdge (pre1, post1), NPatSeqEdge (pre2, post2) ->
-      let pre = map2_keep_extras npat_intersect pre1 pre2 in
-      let rev_post =
-        map2_keep_extras npat_intersect (List.rev post1) (List.rev post2)
-      in
-      let simple =
-        let pre = include_tail NPatSet.singleton pre in
-        let post = List.rev (include_tail NPatSet.singleton rev_post) in
-        pre @ post |> traverse NPatSet.elements
-        |> List.map (fun pats ->
-               let pre, post = split_at (List.length pre) pats in
-               NPatSeqEdge (pre, post) )
-        |> NPatSet.of_list
-      in
-      let overlapping =
-        match (pre, rev_post) with
-        | ( (Some (pre_dir, pre_extras), pre)
-          , (Some (post_dir, rev_post_extras), rev_post) )
-          when pre_dir <> post_dir ->
-            let post = List.rev rev_post in
-            let post_extras = List.rev rev_post_extras in
-            List.init (List.length pre_extras) (fun n ->
-                List.rev_append (repeat n wildpat) post_extras
-                |> map2_with_extras npat_intersect wildpat wildpat pre_extras
-                |> fun mid -> pre @ mid @ post )
-            |> concat_map ~f:(traverse NPatSet.elements)
-            |> List.map (fun pats -> NPatSeqTot pats)
-            |> NPatSet.of_list
-        | _ ->
-            NPatSet.empty
-      in
-      NPatSet.union simple overlapping
-  | NPatSeqEdge (pre, post), NPatSeqTot pats
-  | NPatSeqTot pats, NPatSeqEdge (pre, post) ->
-      let len_pre, len_post, len_pats =
-        (List.length pre, List.length post, List.length pats)
-      in
-      if len_pre + len_post > len_pats then NPatSet.empty
-      else
-        pre @ repeat (len_pats - len_pre - len_post) wildpat @ post
-        |> List.map2 npat_intersect pats
-        |> traverse NPatSet.elements
-        |> List.map (fun pats -> NPatSeqTot pats)
-        |> NPatSet.of_list
+        let simple =
+          let pre = include_tail NPatSet.singleton pre in
+          let post = List.rev (include_tail NPatSet.singleton rev_post) in
+          pre @ post |> traverse NPatSet.elements
+          |> List.map (fun pats ->
+                 let pre, post = split_at (List.length pre) pats in
+                 SNPat (NPatSeqEdge (pre, lens, post)) )
+          |> NPatSet.of_list
+        in
+        (* NOTE(vipa, 2021-08-23): We need to consider when the
+          opposite ends of the two patterns overlap, e.g.,
+          `([1] ++ _) & (_ ++ [1])` should match the list `[1]`,
+          i.e., `[1] ++ _ ++ [1]` is not enough. *)
+        let overlapping =
+          match (pre, rev_post) with
+          | ( (Some (pre_dir, pre_extras), pre)
+            , (Some (post_dir, rev_post_extras), rev_post) )
+            when pre_dir <> post_dir ->
+              let post = List.rev rev_post in
+              let post_extras = List.rev rev_post_extras in
+              List.init (List.length pre_extras) (fun n ->
+                  List.rev_append (repeat n wildpat) post_extras
+                  |> map2_with_extras npat_intersect wildpat wildpat pre_extras
+                  |> fun mid -> pre @ mid @ post )
+              |> concat_map ~f:(traverse NPatSet.elements)
+              |> List.map (fun pats -> SNPat (NPatSeqTot pats))
+              |> NPatSet.of_list
+          | _ ->
+              NPatSet.empty
+        in
+        NPatSet.union simple overlapping
+    | NPatSeqEdge (pre, lens, post), NPatSeqTot pats
+    | NPatSeqTot pats, NPatSeqEdge (pre, lens, post) ->
+        let len_pre, len_post, len_pats =
+          (List.length pre, List.length post, List.length pats)
+        in
+        if IntSet.mem len_pats lens then NPatSet.empty else
+        if len_pre + len_post > len_pats then NPatSet.empty
+        else
+          pre @ repeat (len_pats - len_pre - len_post) wildpat @ post
+          |> List.map2 npat_intersect pats
+          |> traverse NPatSet.elements
+          |> List.map (fun pats -> SNPat (NPatSeqTot pats))
+          |> NPatSet.of_list
+    | _ ->
+        if SimpleConOrd.compare (simple_con_of_simple_pat p1) (simple_con_of_simple_pat p2) <> 0 then
+          NPatSet.empty
+        else Msg.raise_error NoInfo "Impossible")
 
 and normpat_complement (np : normpat) : normpat =
   NPatSet.elements np |> List.map npat_complement
@@ -488,31 +421,32 @@ let rec pat_to_normpat = function
   | PatSeqTot (_, pats) ->
       Mseq.Helpers.to_list pats
       |> traverse (fun p -> pat_to_normpat p |> NPatSet.elements)
-      |> List.map (fun pats -> NPatSeqTot pats)
+      |> List.map (fun pats -> SNPat (NPatSeqTot pats))
       |> NPatSet.of_list
   | PatSeqEdge (_, pre, _, post) ->
       Mseq.concat pre post |> Mseq.Helpers.to_list
       |> traverse (fun p -> pat_to_normpat p |> NPatSet.elements)
       |> List.map (fun pats ->
              let pre, post = split_at (Mseq.length pre) pats in
-             NPatSeqEdge (pre, post) )
+             SNPat (NPatSeqEdge (pre, IntSet.empty, post)) )
       |> NPatSet.of_list
   | PatRecord (_, r) ->
       Record.bindings r
       |> traverse (fun (k, p) ->
              pat_to_normpat p |> NPatSet.elements |> List.map (fun p -> (k, p)) )
       |> List.map (fun bindings ->
-             NPatRecord
-               (List.to_seq bindings |> Record.of_seq, UstringSet.empty) )
+             SNPat
+              (NPatRecord
+                (List.to_seq bindings |> Record.of_seq, UstringSet.empty)) )
       |> NPatSet.of_list
   | PatCon (_, c, _, p) ->
-      pat_to_normpat p |> NPatSet.map (fun p -> NSPat (SPatCon (c, p)))
+      pat_to_normpat p |> NPatSet.map (fun p -> SNPat (NPatCon (c, p)))
   | PatInt (_, i) ->
-      NPatSet.singleton (NSPat (SPatInt i))
+      NPatSet.singleton (SNPat (NPatInt i))
   | PatChar (_, c) ->
-      NPatSet.singleton (NSPat (SPatChar c))
+      NPatSet.singleton (SNPat (NPatChar c))
   | PatBool (_, b) ->
-      NPatSet.singleton (NSPat (SPatBool b))
+      NPatSet.singleton (SNPat (NPatBool b))
   | PatAnd (_, a, b) ->
       normpat_intersect (pat_to_normpat a) (pat_to_normpat b)
   | PatOr (_, a, b) ->
@@ -525,15 +459,15 @@ let pat_example_gives_complete_pattern = ref false
 let pat_example normpat =
   let wildpat = PatNamed (NoInfo, NameWildcard) in
   let rec npat_to_pat = function
-    | NSPat (SPatInt i) ->
+    | SNPat (NPatInt i) ->
         PatInt (NoInfo, i)
-    | NSPat (SPatChar c) ->
+    | SNPat (NPatChar c) ->
         PatChar (NoInfo, c)
-    | NSPat (SPatBool b) ->
+    | SNPat (NPatBool b) ->
         PatBool (NoInfo, b)
-    | NSPat (SPatCon (str, np)) ->
+    | SNPat (NPatCon (str, np)) ->
         PatCon (NoInfo, str, Symb.Helpers.nosym, npat_to_pat np)
-    | NPatRecord (r, neg) -> (
+    | SNPat (NPatRecord (r, neg)) -> (
         let pos = PatRecord (NoInfo, Record.map npat_to_pat r) in
         UstringSet.elements neg
         |> List.map (fun label ->
@@ -547,25 +481,19 @@ let pat_example normpat =
                 (NoInfo, List.fold_left (fun a b -> PatOr (NoInfo, a, b)) x xs)
             in
             if Record.is_empty r then neg else PatAnd (NoInfo, pos, neg) )
-    | NPatSeqTot nps ->
+    | SNPat (NPatSeqTot nps) ->
         PatSeqTot (NoInfo, List.map npat_to_pat nps |> Mseq.Helpers.of_list)
-    | NPatSeqEdge (pre, post) ->
-        PatSeqEdge
+    | SNPat (NPatSeqEdge (pre, lens, post)) ->
+        let rem_len acc len =
+          PatAnd (NoInfo, acc, PatSeqTot (NoInfo, repeat len wildpat |> Mseq.Helpers.of_list))
+        in
+        let base = PatSeqEdge
           ( NoInfo
           , List.map npat_to_pat pre |> Mseq.Helpers.of_list
           , NameWildcard
           , List.map npat_to_pat post |> Mseq.Helpers.of_list )
-    | NPatNot (seqs, cons) -> (
-        let seqs =
-          match seqs with
-          | None ->
-              [PatSeqEdge (NoInfo, Mseq.empty, NameWildcard, Mseq.empty)]
-          | Some lens ->
-              IntSet.elements lens
-              |> List.map (fun len ->
-                     PatSeqTot
-                       (NoInfo, repeat len wildpat |> Mseq.Helpers.of_list) )
-        in
+        in List.fold_left rem_len base (IntSet.elements lens)
+    | NPatNot cons -> (
         let cons =
           ConSet.elements cons
           |> List.map (function
@@ -577,10 +505,12 @@ let pat_example normpat =
                    PatBool (NoInfo, b)
                | ConCon str ->
                    PatCon (NoInfo, str, Symb.Helpers.nosym, wildpat)
+               | SeqCon ->
+                   PatSeqEdge (NoInfo, Mseq.empty, NameWildcard, Mseq.empty)
                | RecCon ->
                    PatRecord (NoInfo, Record.empty) )
         in
-        match seqs @ cons with
+        match cons with
         | [] ->
             wildpat
         | p :: ps ->


### PR DESCRIPTION
This PR refactors the pattern analysis for sequences to be more in line with how it's done for records. The core idea is as follows:
- There is one shared negative pattern, `NPatNot`, which states whether a particular kind of data is allowed or not (e.g., "a record of any shape", "a sequence of any shape", "an application of the `Foo` constructor").
- Information about sub-patterns are expressed through sub-patterns as usual
- Both negative and positive information about the internal structure of a value is contained in a specific pattern for that kind of pattern.
  - For sequences the only structurally interesting information is their length, thus the flexible sequence pattern (`NPatSeqEdge`) must contain negative information of this kind, i.e., a set of forbidden lengths.
  - For records with subset patterns (which is what we have now; it's ok to have more labels in the value than in the pattern) we end up caring about whether particular labels are present, i.e., `NPatRecord` must contain a set of forbidden labels. For exact record patterns (which will be added eventually, but aren't there yet) we'll also start caring about the full structure of a record, so `NPatRecord` will have to additionally carry a set of sets of labels.