### PR TITLE
Remove Rope `Bigarray` implementation

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -1,7 +1,7 @@
 open Ustring.Op
 
 module Mseq = struct
-  type 'a t = List of 'a List.t | Rope of 'a array Rope.t
+  type 'a t = List of 'a List.t | Rope of 'a Rope.t
 
   let create_rope n f = Rope (Rope.create_array n f)
 

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -1,7 +1,7 @@
 open Ustring.Op
 
 module Mseq : sig
-  type 'a t = List of 'a List.t | Rope of 'a array Rope.t
+  type 'a t = List of 'a List.t | Rope of 'a Rope.t
 
   val create : int -> (int -> 'a) -> 'a t
 

--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -1,11 +1,4 @@
-open Bigarray
 open Ustring.Op
-
-type ('a, 'b) ba = ('a, 'b, c_layout) Array1.t
-
-type int_ba = (int, int_elt) ba
-
-type float_ba = (float, float64_elt) ba
 
 (* The tree of a rope is either a Leaf or a Concat node.
 
@@ -16,60 +9,24 @@ type float_ba = (float, float64_elt) ba
    two recursive tree structures and a length field corresponding to the
    combined length of the two ropes, so that we can look up the length in
    constant time. *)
-type 'a u = Leaf of 'a | Concat of {lhs: 'a u; rhs: 'a u; len: int}
+type 'a u = Leaf of 'a array | Concat of {lhs: 'a u; rhs: 'a u; len: int}
 
 (* A rope is represented as a reference to its tree data structure. This lets
    us collapse the tree before performing an operation on it, which in turn
    allows constant time concatenation. *)
 type 'a t = 'a u ref
 
-let rec _bigarray_kind (s : ('a, 'b) ba u) : ('a, 'c) kind =
-  match s with
-  | Leaf a ->
-      Array1.kind a
-  | Concat {lhs; _} ->
-      _bigarray_kind lhs
-
-let _uninit_bigarray (k : ('a, 'b) kind) (n : int) : ('a, 'b) ba =
-  Array1.create k c_layout n
-
-let _create_bigarray (k : ('a, 'b) kind) (n : int) (f : int -> 'a) :
-    ('a, 'b) ba =
-  let a = _uninit_bigarray k n in
-  for i = 0 to n - 1 do
-    Array1.unsafe_set a i (f i)
-  done ;
-  a
-
-let create_array (n : int) (f : int -> 'a) : 'a array t =
+let create_array (n : int) (f : int -> 'a) : 'a t =
   ref (Leaf (Array.init n f))
-
-let create_int_bigarray (n : int) (f : int -> int) : int_ba t =
-  ref (Leaf (_create_bigarray Int n f))
-
-let create_float_bigarray (n : int) (f : int -> float) : float_ba t =
-  ref (Leaf (_create_bigarray Float64 n f))
 
 let empty_array = Obj.magic (ref (Leaf [||]))
 
-let _empty_bigarray (k : ('a, 'b) kind) : ('a, 'b) ba t =
-  ref (Leaf (_uninit_bigarray k 0))
-
-let empty_int_bigarray : int_ba t = _empty_bigarray Int
-
-let empty_float_bigarray : float_ba t = _empty_bigarray Float64
-
-let _length_array (s : 'a array u) : int =
+let _length_array (s : 'a u) : int =
   match s with Leaf a -> Array.length a | Concat {len; _} -> len
 
-let length_array (s : 'a array t) : int = _length_array !s
+let length_array (s : 'a t) : int = _length_array !s
 
-let _length_bigarray (s : ('a, 'b) ba u) : int =
-  match s with Leaf a -> Array1.dim a | Concat {len; _} -> len
-
-let length_bigarray (s : ('a, 'b) ba t) : int = _length_bigarray !s
-
-let rec _get_array (s : 'a array u) (i : int) : 'a =
+let rec _get_array (s : 'a u) (i : int) : 'a =
   match s with
   | Leaf a ->
       a.(i)
@@ -77,19 +34,9 @@ let rec _get_array (s : 'a array u) (i : int) : 'a =
       let n = _length_array lhs in
       if i < n then _get_array lhs i else _get_array rhs (i - n)
 
-let get_array (s : 'a array t) (i : int) : 'a = _get_array !s i
+let get_array (s : 'a t) (i : int) : 'a = _get_array !s i
 
-let rec _get_bigarray (s : ('a, 'b) ba u) (i : int) : 'a =
-  match s with
-  | Leaf a ->
-      Array1.unsafe_get a i
-  | Concat {lhs; rhs; _} ->
-      let n = _length_bigarray lhs in
-      if i < n then _get_bigarray lhs i else _get_bigarray rhs (i - n)
-
-let get_bigarray (s : ('a, 'b) ba t) (i : int) : 'a = _get_bigarray !s i
-
-let _collapse_array (s : 'a array t) : 'a array =
+let _collapse_array (s : 'a t) : 'a array =
   let rec collapse dst s i =
     match s with
     | Leaf a ->
@@ -109,40 +56,14 @@ let _collapse_array (s : 'a array t) : 'a array =
       s := Leaf dst ;
       dst
 
-let _collapse_bigarray (s : ('a, 'b) ba t) : ('a, 'b) ba =
-  let rec collapse dst s i =
-    match s with
-    | Leaf a ->
-        let n = Array1.dim a in
-        let dst_sub = Array1.sub dst i n in
-        Array1.blit a dst_sub ; i + n
-    | Concat {lhs; rhs; _} ->
-        collapse dst rhs (collapse dst lhs i)
-  in
-  match !s with
-  | Leaf a ->
-      a
-  | Concat {len; _} ->
-      let dst = Array1.create (_bigarray_kind !s) c_layout len in
-      let _ = collapse dst !s 0 in
-      s := Leaf dst ;
-      dst
-
-let concat_array (l : 'a array t) (r : 'a array t) : 'a array t =
+let concat_array (l : 'a t) (r : 'a t) : 'a t =
   let ln = length_array l in
   let rn = length_array r in
   if ln = 0 then r
   else if rn = 0 then l
   else ref (Concat {lhs= !l; rhs= !r; len= ln + rn})
 
-let concat_bigarray (l : ('a, 'b) ba t) (r : ('a, 'b) ba t) : ('a, 'b) ba t =
-  let ln = length_bigarray l in
-  let rn = length_bigarray r in
-  if ln = 0 then r
-  else if rn = 0 then l
-  else ref (Concat {lhs= !l; rhs= !r; len= ln + rn})
-
-let set_array (s : 'a array t) (idx : int) (v : 'a) : 'a array t =
+let set_array (s : 'a t) (idx : int) (v : 'a) : 'a t =
   let rec helper s i =
     match s with
     | Leaf a ->
@@ -155,46 +76,17 @@ let set_array (s : 'a array t) (idx : int) (v : 'a) : 'a array t =
   in
   ref (helper !s idx)
 
-let set_bigarray (s : ('a, 'b) ba t) (idx : int) (v : 'a) : ('a, 'b) ba t =
-  let k = _bigarray_kind !s in
-  let rec helper s i =
-    match s with
-    | Leaf a ->
-        let n = Array1.dim a in
-        let a' = _uninit_bigarray k n in
-        Array1.blit a a' ; Array1.unsafe_set a' i v ; Leaf a'
-    | Concat {lhs; rhs; len} ->
-        let n = _length_bigarray lhs in
-        if i < n then Concat {lhs= helper lhs i; rhs; len}
-        else Concat {lhs; rhs= helper rhs (i - n); len}
-  in
-  ref (helper !s idx)
-
-let cons_array (v : 'a) (s : 'a array t) : 'a array t =
+let cons_array (v : 'a) (s : 'a t) : 'a t =
   let n = length_array s in
   if n = 0 then ref (Leaf [|v|])
   else ref (Concat {lhs= Leaf [|v|]; rhs= !s; len= n + 1})
 
-let cons_bigarray (v : 'a) (s : ('a, 'b) ba t) : ('a, 'b) ba t =
-  let n = length_bigarray s in
-  let a = _uninit_bigarray (_bigarray_kind !s) 1 in
-  Array1.unsafe_set a 0 v ;
-  if n = 0 then ref (Leaf a)
-  else ref (Concat {lhs= Leaf a; rhs= !s; len= n + 1})
-
-let snoc_array (s : 'a array t) (v : 'a) : 'a array t =
+let snoc_array (s : 'a t) (v : 'a) : 'a t =
   let n = length_array s in
   if n = 0 then ref (Leaf [|v|])
   else ref (Concat {lhs= !s; rhs= Leaf [|v|]; len= n + 1})
 
-let snoc_bigarray (s : ('a, 'b) ba t) (v : 'a) : ('a, 'b) ba t =
-  let n = length_bigarray s in
-  let a = _uninit_bigarray (_bigarray_kind !s) 1 in
-  Array1.unsafe_set a 0 v ;
-  if n = 0 then ref (Leaf a)
-  else ref (Concat {lhs= Leaf a; rhs= !s; len= n + 1})
-
-let split_at_array (s : 'a array t) (idx : int) : 'a array t * 'a array t =
+let split_at_array (s : 'a t) (idx : int) : 'a t * 'a t =
   let n = length_array s in
   if idx = 0 then (empty_array, s)
   else if idx = n then (s, empty_array)
@@ -219,40 +111,7 @@ let split_at_array (s : 'a array t) (idx : int) : 'a array t * 'a array t =
     let _ = fill !s 0 in
     (ref (Leaf lhs), ref (Leaf rhs))
 
-let split_at_bigarray (s : ('a, 'b) ba t) (idx : int) :
-    ('a, 'b) ba t * ('a, 'b) ba t =
-  let k = _bigarray_kind !s in
-  let n = length_bigarray s in
-  if idx = 0 then (_empty_bigarray k, s)
-  else if idx = n then (s, _empty_bigarray k)
-  else
-    let lhs = _uninit_bigarray k idx in
-    let rhs = _uninit_bigarray k (n - idx) in
-    let rec fill s i =
-      match s with
-      | Leaf a ->
-          let n = Array1.dim a in
-          ( if i + n < idx then
-            let dst = Array1.sub lhs i n in
-            Array1.blit a dst
-          else if not (i < idx) then
-            let dst = Array1.sub rhs (i - idx) n in
-            Array1.blit a dst
-          else
-            let lhs_copy_length = idx - i in
-            let lsrc = Array1.sub a 0 lhs_copy_length in
-            let rsrc = Array1.sub a lhs_copy_length (n - lhs_copy_length) in
-            let ldst = Array1.sub lhs i lhs_copy_length in
-            let rdst = Array1.sub rhs 0 (n - lhs_copy_length) in
-            Array1.blit lsrc ldst ; Array1.blit rsrc rdst ) ;
-          i + n
-      | Concat {lhs; rhs; _} ->
-          fill rhs (fill lhs i)
-    in
-    let _ = fill !s 0 in
-    (ref (Leaf lhs), ref (Leaf rhs))
-
-let sub_array (s : 'a array t) (off : int) (cnt : int) : 'a array t =
+let sub_array (s : 'a t) (off : int) (cnt : int) : 'a t =
   let n = length_array s in
   if n = 0 then empty_array
   else
@@ -276,32 +135,7 @@ let sub_array (s : 'a array t) (off : int) (cnt : int) : 'a array t =
     let _ = fill !s 0 in
     ref (Leaf dst)
 
-let sub_bigarray (s : ('a, 'b) ba t) (off : int) (cnt : int) : ('a, 'b) ba t =
-  let k = _bigarray_kind !s in
-  let n = length_bigarray s in
-  let cnt = min (n - off) cnt in
-  let dst = _uninit_bigarray k cnt in
-  let rec fill s i =
-    match s with
-    | Leaf a ->
-        let n = Array1.dim a in
-        let src_offset = max (off - i) 0 in
-        let dst_offset = max (i - off) 0 in
-        let copy_len = min (n - src_offset) (cnt - dst_offset) in
-        let src_sub = Array1.sub a src_offset copy_len in
-        let dst_sub = Array1.sub dst dst_offset copy_len in
-        Array1.blit src_sub dst_sub ;
-        i + n
-    | Concat {lhs; rhs; _} ->
-        let n = _length_bigarray lhs in
-        if i + n < off then fill rhs (i + n)
-        else if off + cnt < i + n then fill lhs i
-        else fill rhs (fill lhs i)
-  in
-  let _ = fill !s 0 in
-  ref (Leaf dst)
-
-let iter_array (f : 'a -> unit) (s : 'a array t) : unit =
+let iter_array (f : 'a -> unit) (s : 'a t) : unit =
   let rec iter = function
     | Leaf a ->
         Array.iter f a
@@ -310,19 +144,7 @@ let iter_array (f : 'a -> unit) (s : 'a array t) : unit =
   in
   iter !s
 
-let iter_bigarray (f : 'a -> unit) (s : ('a, 'b) ba t) : unit =
-  let rec iter = function
-    | Leaf a ->
-        let n = Array1.dim a in
-        for i = 0 to n - 1 do
-          f (Array1.unsafe_get a i)
-        done
-    | Concat {lhs; rhs; _} ->
-        iter lhs ; iter rhs
-  in
-  iter !s
-
-let iteri_array (f : int -> 'a -> unit) (s : 'a array t) : unit =
+let iteri_array (f : int -> 'a -> unit) (s : 'a t) : unit =
   let rec iteri off = function
     | Leaf a ->
         Array.iteri (fun i e -> f (i + off) e) a ;
@@ -333,105 +155,19 @@ let iteri_array (f : int -> 'a -> unit) (s : 'a array t) : unit =
   in
   iteri 0 !s |> ignore
 
-let iteri_bigarray (f : int -> 'a -> unit) (s : ('a, 'b) ba t) : unit =
-  let rec iteri off = function
-    | Leaf a ->
-        let n = Array1.dim a in
-        for i = 0 to n - 1 do
-          f (off + i) (Array1.unsafe_get a i)
-        done ;
-        n
-    | Concat {lhs; rhs; _} ->
-        let n = iteri off lhs in
-        iteri (off + n) rhs
-  in
-  iteri 0 !s |> ignore
-
-let map_array_array (f : 'a -> 'b) (s : 'a array t) : 'b array t =
+let map_array_array (f : 'a -> 'b) (s : 'a t) : 'b t =
   let a = _collapse_array s in
   ref (Leaf (Array.map f a))
 
-let map_array_bigarray (k : ('b, 'c) kind) (f : 'a -> 'b) (s : 'a array t) :
-    ('b, 'c) ba t =
-  let a = _collapse_array s in
-  let n = Array.length a in
-  let dst = _uninit_bigarray k n in
-  for i = 0 to n - 1 do
-    Array1.unsafe_set dst i (f a.(i))
-  done ;
-  ref (Leaf dst)
-
-let map_bigarray_array (f : 'a -> 'b) (s : ('a, 'c) ba t) : 'b array t =
-  let a = _collapse_bigarray s in
-  let n = Array1.dim a in
-  if n = 0 then ref (Leaf [||])
-  else
-    let dst = Array.make n (f (Array1.unsafe_get a 0)) in
-    for i = 0 to n - 1 do
-      dst.(i) <- f (Array1.unsafe_get a i)
-    done ;
-    ref (Leaf dst)
-
-let map_bigarray_bigarray (k : ('b, 'd) kind) (f : 'a -> 'b) (s : ('a, 'c) ba t)
-    : ('b, 'd) ba t =
-  let a = _collapse_bigarray s in
-  let n = Array1.dim a in
-  let dst = _uninit_bigarray k n in
-  for i = 0 to n - 1 do
-    Array1.unsafe_set dst i (f (Array1.unsafe_get a i))
-  done ;
-  ref (Leaf dst)
-
-let mapi_array_array (f : int -> 'a -> 'b) (s : 'a array t) : 'b array t =
+let mapi_array_array (f : int -> 'a -> 'b) (s : 'a t) : 'b t =
   let a = _collapse_array s in
   ref (Leaf (Array.mapi f a))
 
-let mapi_array_bigarray (k : ('b, 'c) kind) (f : int -> 'a -> 'b)
-    (s : 'a array t) : ('b, 'c) ba t =
-  let a = _collapse_array s in
-  let n = Array.length a in
-  let dst = _uninit_bigarray k n in
-  for i = 0 to n - 1 do
-    Array1.unsafe_set dst i (f i a.(i))
-  done ;
-  ref (Leaf dst)
-
-let mapi_bigarray_array (f : int -> 'a -> 'b) (s : ('a, 'c) ba t) : 'b array t
-    =
-  let a = _collapse_bigarray s in
-  let n = Array1.dim a in
-  if n = 0 then ref (Leaf [||])
-  else
-    let dst = Array.make n (f 0 (Array1.unsafe_get a 0)) in
-    for i = 0 to n - 1 do
-      dst.(i) <- f i (Array1.unsafe_get a i)
-    done ;
-    ref (Leaf dst)
-
-let mapi_bigarray_bigarray (k : ('b, 'd) kind) (f : int -> 'a -> 'b)
-    (s : ('a, 'c) ba t) : ('b, 'd) ba t =
-  let a = _collapse_bigarray s in
-  let n = Array1.dim a in
-  let dst = _uninit_bigarray k n in
-  for i = 0 to n - 1 do
-    Array1.unsafe_set dst i (f i (Array1.unsafe_get a i))
-  done ;
-  ref (Leaf dst)
-
-let foldl_array (f : 'a -> 'b -> 'a) (acc : 'a) (s : 'b array t) : 'a =
+let foldl_array (f : 'a -> 'b -> 'a) (acc : 'a) (s : 'b t) : 'a =
   let a = _collapse_array s in
   Array.fold_left f acc a
 
-let foldl_bigarray (f : 'a -> 'b -> 'a) (acc : 'a) (s : ('b, 'c) ba t) : 'a =
-  let a = _collapse_bigarray s in
-  let r = ref acc in
-  let n = Array1.dim a in
-  for i = 0 to n - 1 do
-    r := f !r (Array1.unsafe_get a i)
-  done ;
-  !r
-
-let reverse_array (s : 'a array t) : 'a array t =
+let reverse_array (s : 'a t) : 'a t =
   let a = _collapse_array s in
   let a' = Array.copy a in
   let n = Array.length a' in
@@ -440,16 +176,7 @@ let reverse_array (s : 'a array t) : 'a array t =
   done ;
   ref (Leaf a')
 
-let reverse_bigarray (s : ('a, 'b) ba t) : ('a, 'b) ba t =
-  let a = _collapse_bigarray s in
-  let n = Array1.dim a in
-  let a' = _uninit_bigarray (_bigarray_kind !s) n in
-  for i = 0 to n - 1 do
-    Array1.unsafe_set a' i (Array1.unsafe_get a (n - i - 1))
-  done ;
-  ref (Leaf a')
-
-let combine_array_array (l : 'a array t) (r : 'b array t) : ('a * 'b) array t =
+let combine_array_array (l : 'a t) (r : 'b t) : ('a * 'b) t =
   let ln = length_array l in
   let rn = length_array r in
   if ln != rn then raise (Invalid_argument "Rope.combine")
@@ -457,49 +184,7 @@ let combine_array_array (l : 'a array t) (r : 'b array t) : ('a * 'b) array t =
     let a1, a2 = (_collapse_array l, _collapse_array r) in
     ref (Leaf (Array.map2 (fun x y -> (x, y)) a1 a2))
 
-let combine_array_bigarray (l : 'a array t) (r : ('b, 'c) ba t) :
-    ('a * 'b) array t =
-  let ln = length_array l in
-  let rn = length_bigarray r in
-  if ln != rn then raise (Invalid_argument "Rope.combine")
-  else if ln = 0 then empty_array
-  else
-    let a1, a2 = (_collapse_array l, _collapse_bigarray r) in
-    let dst = Array.make ln (a1.(0), Array1.unsafe_get a2 0) in
-    for i = 0 to ln - 1 do
-      dst.(i) <- (a1.(i), Array1.unsafe_get a2 i)
-    done ;
-    ref (Leaf dst)
-
-let combine_bigarray_array (l : ('a, 'c) ba t) (r : 'b array t) :
-    ('a * 'b) array t =
-  let ln = length_bigarray l in
-  let rn = length_array r in
-  if ln != rn then raise (Invalid_argument "Rope.combine")
-  else if ln = 0 then empty_array
-  else
-    let a1, a2 = (_collapse_bigarray l, _collapse_array r) in
-    let dst = Array.make ln (Array1.unsafe_get a1 0, a2.(0)) in
-    for i = 0 to ln - 1 do
-      dst.(i) <- (Array1.unsafe_get a1 i, a2.(i))
-    done ;
-    ref (Leaf dst)
-
-let combine_bigarray_bigarray (l : ('a, 'c) ba t) (r : ('b, 'd) ba t) :
-    ('a * 'b) array t =
-  let ln = length_bigarray l in
-  let rn = length_bigarray r in
-  if ln != rn then raise (Invalid_argument "Rope.combine")
-  else if ln = 0 then empty_array
-  else
-    let a1, a2 = (_collapse_bigarray l, _collapse_bigarray r) in
-    let dst = Array.make ln (Array1.unsafe_get a1 0, Array1.unsafe_get a2 0) in
-    for i = 0 to ln - 1 do
-      dst.(i) <- (Array1.unsafe_get a1 i, Array1.unsafe_get a2 i)
-    done ;
-    ref (Leaf dst)
-
-let equal_array (f : 'a -> 'a -> bool) (l : 'a array t) (r : 'a array t) : bool
+let equal_array (f : 'a -> 'a -> bool) (l : 'a t) (r : 'a t) : bool
     =
   let ln = length_array l in
   let rn = length_array r in
@@ -510,34 +195,11 @@ let equal_array (f : 'a -> 'a -> bool) (l : 'a array t) (r : 'a array t) : bool
     Array.iter2 (fun x y -> if f x y then () else r := false) a1 a2 ;
     !r
 
-let equal_bigarray (f : 'a -> 'a -> bool) (l : ('a, 'b) ba t)
-    (r : ('a, 'b) ba t) : bool =
-  let ln = length_bigarray l in
-  let rn = length_bigarray r in
-  if ln != rn then false
-  else
-    let a1, a2 = (_collapse_bigarray l, _collapse_bigarray r) in
-    let r = ref true in
-    for i = 0 to ln - 1 do
-      if f (Array1.unsafe_get a1 i) (Array1.unsafe_get a2 i) then ()
-      else r := false
-    done ;
-    !r
-
-let foldr_array (f : 'a -> 'b -> 'b) (s : 'a array t) (acc : 'b) : 'b =
+let foldr_array (f : 'a -> 'b -> 'b) (s : 'a t) (acc : 'b) : 'b =
   let a = _collapse_array s in
   Array.fold_right f a acc
 
-let foldr_bigarray (f : 'a -> 'b -> 'b) (s : ('a, 'c) ba t) (acc : 'b) : 'b =
-  let a = _collapse_bigarray s in
-  let n = Array1.dim a in
-  let r = ref acc in
-  for i = n - 1 downto 0 do
-    r := f (Array1.unsafe_get a i) !r
-  done ;
-  !r
-
-let foldr2_array (f : 'a -> 'b -> 'c -> 'c) (l : 'a array t) (r : 'b array t)
+let foldr2_array (f : 'a -> 'b -> 'c -> 'c) (l : 'a t) (r : 'b t)
     (acc : 'c) : 'c =
   let ln = length_array l in
   let rn = length_array r in
@@ -550,86 +212,20 @@ let foldr2_array (f : 'a -> 'b -> 'c -> 'c) (l : 'a array t) (r : 'b array t)
     done ;
     !r
 
-let foldr2_bigarray (f : 'a -> 'b -> 'c -> 'c) (l : ('a, 'd) ba t)
-    (r : ('b, 'e) ba t) (acc : 'c) : 'c =
-  let ln = length_bigarray l in
-  let rn = length_bigarray r in
-  if ln != rn then raise (Invalid_argument "Rope.foldr2")
-  else
-    let a1, a2 = (_collapse_bigarray l, _collapse_bigarray r) in
-    let r = ref acc in
-    for i = ln - 1 downto 0 do
-      r := f (Array1.unsafe_get a1 i) (Array1.unsafe_get a2 i) !r
-    done ;
-    !r
-
 module Convert = struct
-  let to_array_array (s : 'a array t) : 'a array = _collapse_array s
+  let to_array_array (s : 'a t) : 'a array = _collapse_array s
 
-  let to_array_bigarray (s : ('a, 'b) ba t) : 'a array =
-    let a = _collapse_bigarray s in
-    let n = Array1.dim a in
-    if n = 0 then [||]
-    else
-      let dst = Array.make n (Array1.unsafe_get a 0) in
-      for i = 0 to n - 1 do
-        dst.(i) <- Array1.unsafe_get a i
-      done ;
-      dst
+  let of_array_array (a : 'a array) : 'a t = ref (Leaf a)
 
-  let of_array_array (a : 'a array) : 'a array t = ref (Leaf a)
-
-  let of_array_int_bigarray (a : int array) : int_ba t =
-    let n = Array.length a in
-    let dst = _uninit_bigarray Int n in
-    for i = 0 to n - 1 do
-      Array1.unsafe_set dst i a.(i)
-    done ;
-    ref (Leaf dst)
-
-  let of_array_float_bigarray (a : float array) : float_ba t =
-    let n = Array.length a in
-    let dst = _uninit_bigarray Float64 n in
-    for i = 0 to n - 1 do
-      Array1.unsafe_set dst i a.(i)
-    done ;
-    ref (Leaf dst)
-
-  let to_list_array (s : 'a array t) : 'a list =
+  let to_list_array (s : 'a t) : 'a list =
     Array.to_list (to_array_array s)
 
-  let to_list_bigarray (s : ('a, 'b) ba t) : 'a list =
-    Array.to_list (to_array_bigarray s)
-
-  let of_list_array (l : 'a list) : 'a array t =
+  let of_list_array (l : 'a list) : 'a t =
     of_array_array (Array.of_list l)
 
-  let of_list_int_bigarray (l : int list) : int_ba t =
-    of_array_int_bigarray (Array.of_list l)
-
-  let of_list_float_bigarray (l : float list) : float_ba t =
-    of_array_float_bigarray (Array.of_list l)
-
-  let to_ustring_array (s : int array t) : ustring =
+  let to_ustring_array (s : int t) : ustring =
     array2ustring (to_array_array s)
 
-  let to_ustring_bigarray (s : int_ba t) : ustring =
-    array2ustring (to_array_bigarray s)
-
-  let of_ustring_array (u : ustring) : int array t =
+  let of_ustring_array (u : ustring) : int t =
     of_array_array (ustring2array u)
-
-  let of_ustring_bigarray (u : ustring) : int_ba t =
-    of_array_int_bigarray (ustring2array u)
-
-  let to_int_bigarray_array (s : int array t) : int_ba =
-    _collapse_bigarray (map_array_bigarray Int (fun x -> x) s)
-
-  let to_int_bigarray_bigarray (s : int_ba t) : int_ba = _collapse_bigarray s
-
-  let to_float_bigarray_array (s : float array t) : float_ba =
-    _collapse_bigarray (map_array_bigarray Float64 (fun x -> x) s)
-
-  let to_float_bigarray_bigarray (s : float_ba t) : float_ba =
-    _collapse_bigarray s
 end

--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -16,8 +16,7 @@ type 'a u = Leaf of 'a array | Concat of {lhs: 'a u; rhs: 'a u; len: int}
    allows constant time concatenation. *)
 type 'a t = 'a u ref
 
-let create_array (n : int) (f : int -> 'a) : 'a t =
-  ref (Leaf (Array.init n f))
+let create_array (n : int) (f : int -> 'a) : 'a t = ref (Leaf (Array.init n f))
 
 let empty_array = Obj.magic (ref (Leaf [||]))
 
@@ -184,8 +183,7 @@ let combine_array_array (l : 'a t) (r : 'b t) : ('a * 'b) t =
     let a1, a2 = (_collapse_array l, _collapse_array r) in
     ref (Leaf (Array.map2 (fun x y -> (x, y)) a1 a2))
 
-let equal_array (f : 'a -> 'a -> bool) (l : 'a t) (r : 'a t) : bool
-    =
+let equal_array (f : 'a -> 'a -> bool) (l : 'a t) (r : 'a t) : bool =
   let ln = length_array l in
   let rn = length_array r in
   if ln != rn then false
@@ -199,8 +197,8 @@ let foldr_array (f : 'a -> 'b -> 'b) (s : 'a t) (acc : 'b) : 'b =
   let a = _collapse_array s in
   Array.fold_right f a acc
 
-let foldr2_array (f : 'a -> 'b -> 'c -> 'c) (l : 'a t) (r : 'b t)
-    (acc : 'c) : 'c =
+let foldr2_array (f : 'a -> 'b -> 'c -> 'c) (l : 'a t) (r : 'b t) (acc : 'c) :
+    'c =
   let ln = length_array l in
   let rn = length_array r in
   if ln != rn then raise (Invalid_argument "Rope.foldr2")
@@ -217,15 +215,11 @@ module Convert = struct
 
   let of_array_array (a : 'a array) : 'a t = ref (Leaf a)
 
-  let to_list_array (s : 'a t) : 'a list =
-    Array.to_list (to_array_array s)
+  let to_list_array (s : 'a t) : 'a list = Array.to_list (to_array_array s)
 
-  let of_list_array (l : 'a list) : 'a t =
-    of_array_array (Array.of_list l)
+  let of_list_array (l : 'a list) : 'a t = of_array_array (Array.of_list l)
 
-  let to_ustring_array (s : int t) : ustring =
-    array2ustring (to_array_array s)
+  let to_ustring_array (s : int t) : ustring = array2ustring (to_array_array s)
 
-  let of_ustring_array (u : ustring) : int t =
-    of_array_array (ustring2array u)
+  let of_ustring_array (u : ustring) : int t = of_array_array (ustring2array u)
 end

--- a/src/boot/lib/rope.mli
+++ b/src/boot/lib/rope.mli
@@ -1,216 +1,118 @@
-open Bigarray
 open Ustring.Op
-
-type ('a, 'b) ba = ('a, 'b, c_layout) Array1.t
-
-type int_ba = (int, int_elt) ba
-
-type float_ba = (float, float64_elt) ba
 
 type 'a t
 
-val create_array : int -> (int -> 'a) -> 'a array t
+val create_array : int -> (int -> 'a) -> 'a t
 (** [Rope.create_* n f] returns a new rope of length [n] where the element at
     index [i] is initialized as the result of [f i]. *)
 
-val create_int_bigarray : int -> (int -> int) -> int_ba t
-
-val create_float_bigarray : int -> (int -> float) -> float_ba t
-
-val empty_array : 'a array t
+val empty_array : 'a t
 (** [Rope.empty_*] returns the representation of an empty rope. *)
 
-val empty_int_bigarray : int_ba t
-
-val empty_float_bigarray : float_ba t
-
-val length_array : 'a array t -> int
+val length_array : 'a t -> int
 (** [Rope.length_* s] returns the length of the rope. *)
 
-val length_bigarray : ('a, 'b) ba t -> int
-
-val concat_array : 'a array t -> 'a array t -> 'a array t
+val concat_array : 'a t -> 'a t -> 'a t
 (** [Rope.concat_* l r] returns a new rope representing the result of
     concatenating [l] and [r]. *)
 
-val concat_bigarray : ('a, 'b) ba t -> ('a, 'b) ba t -> ('a, 'b) ba t
-
-val get_array : 'a array t -> int -> 'a
+val get_array : 'a t -> int -> 'a
 (** [Rope.get_* s i] returns the element at index [i] of rope [s]. *)
 
-val get_bigarray : ('a, 'b) ba t -> int -> 'a
-
-val set_array : 'a array t -> int -> 'a -> 'a array t
+val set_array : 'a t -> int -> 'a -> 'a t
 (** [Rope.set_* s i v] returns a new rope representing the result of setting
     the value of [s] at index [i] to [v]. *)
 
-val set_bigarray : ('a, 'b) ba t -> int -> 'a -> ('a, 'b) ba t
-
-val cons_array : 'a -> 'a array t -> 'a array t
+val cons_array : 'a -> 'a t -> 'a t
 (** [Rope.cons_* v s] returns a new rope representing the result of prepending
     [v] to [s]. *)
 
-val cons_bigarray : 'a -> ('a, 'b) ba t -> ('a, 'b) ba t
-
-val snoc_array : 'a array t -> 'a -> 'a array t
+val snoc_array : 'a t -> 'a -> 'a t
 (** [Rope.snoc_* s v] returns a new rope representing the result of appending
     [v] to the end of [s]. *)
 
-val snoc_bigarray : ('a, 'b) ba t -> 'a -> ('a, 'b) ba t
-
-val split_at_array : 'a array t -> int -> 'a array t * 'a array t
+val split_at_array : 'a t -> int -> 'a t * 'a t
 (** [Rope.split_at_* s i] returns a pair of ropes representing the intervals
     0..i and i..n of [s], where n is the length of [s]. *)
 
-val split_at_bigarray : ('a, 'b) ba t -> int -> ('a, 'b) ba t * ('a, 'b) ba t
-
-val sub_array : 'a array t -> int -> int -> 'a array t
+val sub_array : 'a t -> int -> int -> 'a t
 (** [Rope.sub_* s off cnt] returns a sub-rope representing the interval
     off..off+x of [s], where x is the minimum of the length of [s] minus [off]
     and [cnt]. *)
 
-val sub_bigarray : ('a, 'b) ba t -> int -> int -> ('a, 'b) ba t
-
-val iter_array : ('a -> unit) -> 'a array t -> unit
+val iter_array : ('a -> unit) -> 'a t -> unit
 (** [Rope.iter_* f s] applies [f] to all elements in [s]. This function
     collapses [s].*)
 
-val iter_bigarray : ('a -> unit) -> ('a, 'b) ba t -> unit
-
-val iteri_array : (int -> 'a -> unit) -> 'a array t -> unit
+val iteri_array : (int -> 'a -> unit) -> 'a t -> unit
 (** [Rope.iteri_* f s] same as [Rope.iter_*] but [f] takes the index of the
     element as its first argument and the element as its second element. This
     function collapses [s] *)
 
-val iteri_bigarray : (int -> 'a -> unit) -> ('a, 'b) ba t -> unit
-
-val map_array_array : ('a -> 'b) -> 'a array t -> 'b array t
+val map_array_array : ('a -> 'b) -> 'a t -> 'b t
 (** [Rope.map_*_* f s] returns a rope representing the result of applying a
     function [f] on all elements of [s]. This function collapses [s]. *)
 
-val map_array_bigarray :
-  ('b, 'c) kind -> ('a -> 'b) -> 'a array t -> ('b, 'c) ba t
-
-val map_bigarray_array : ('a -> 'b) -> ('a, 'c) ba t -> 'b array t
-
-val map_bigarray_bigarray :
-  ('b, 'd) kind -> ('a -> 'b) -> ('a, 'c) ba t -> ('b, 'd) ba t
-
-val mapi_array_array : (int -> 'a -> 'b) -> 'a array t -> 'b array t
+val mapi_array_array : (int -> 'a -> 'b) -> 'a t -> 'b t
 (** [Rope.mapi_*_* f s] is the same as [Rope.map_*_* f s], but the function [f]
    is applied to the index of the element as its first element, and the element
    as its second argument. This function collapses [s]. *)
 
-val mapi_array_bigarray :
-  ('b, 'c) kind -> (int -> 'a -> 'b) -> 'a array t -> ('b, 'c) ba t
-
-val mapi_bigarray_array : (int -> 'a -> 'b) -> ('a, 'c) ba t -> 'b array t
-
-val mapi_bigarray_bigarray :
-  ('b, 'd) kind -> (int -> 'a -> 'b) -> ('a, 'c) ba t -> ('b, 'd) ba t
-
-val foldl_array : ('a -> 'b -> 'a) -> 'a -> 'b array t -> 'a
+val foldl_array : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 (** [Rope.foldl_* f acc s] returns the result of applying [f] on the
     accumulated value, which is initially [acc] and the elements of [s],
     starting from the leftmost element. This function collapses [s]. *)
 
-val foldl_bigarray : ('a -> 'b -> 'a) -> 'a -> ('b, 'c) ba t -> 'a
-
-val reverse_array : 'a array t -> 'a array t
+val reverse_array : 'a t -> 'a t
 (** [Rope.reverse_* s] returns a new rope containing the elements of [s] in
     reversed order. This function collapses [s]. *)
 
-val reverse_bigarray : ('a, 'b) ba t -> ('a, 'b) ba t
-
-val combine_array_array : 'a array t -> 'b array t -> ('a * 'b) array t
+val combine_array_array : 'a t -> 'b t -> ('a * 'b) t
 (** [Rope.combine_*_* l r] returns a new rope where each element is a pair
     such that the left value represents the corresponding element in [l] and
     the right value represents the corresponding element in [r]. This function
     collapses [l] and [r]. Raises exception [Invalid_argument "Rope.combine"]
     if the lengths of [l] and [r] are not equal. *)
 
-val combine_array_bigarray : 'a array t -> ('b, 'c) ba t -> ('a * 'b) array t
-
-val combine_bigarray_array : ('a, 'c) ba t -> 'b array t -> ('a * 'b) array t
-
-val combine_bigarray_bigarray :
-  ('a, 'c) ba t -> ('b, 'd) ba t -> ('a * 'b) array t
-
-val equal_array : ('a -> 'a -> bool) -> 'a array t -> 'a array t -> bool
+val equal_array : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 (** [Rope.equal_* f l r] returns true if [l] and [r] have the same lengths and
     all their elements are equal according to the comparison function [f]. This
     function collapses [l] and [r]. *)
 
-val equal_bigarray :
-  ('a -> 'a -> bool) -> ('a, 'b) ba t -> ('a, 'b) ba t -> bool
-
-val foldr_array : ('a -> 'b -> 'b) -> 'a array t -> 'b -> 'b
+val foldr_array : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
 (** [Rope.foldr_* f s acc] returns the result of applying [f] on the
     accumulated value, initially [acc], and the elements of [s], starting from
     the rightmost element. This function collapses [s]. *)
 
-val foldr_bigarray : ('a -> 'b -> 'b) -> ('a, 'c) ba t -> 'b -> 'b
-
 val foldr2_array :
-  ('a -> 'b -> 'c -> 'c) -> 'a array t -> 'b array t -> 'c -> 'c
+  ('a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
 (** [Rope.foldr2_* f l r acc] returns the result of applying [f] on an
     accumulated value and the elements of two ropes [l] and [r], starting from
     the rightmost element. This function collapses [l] and [r]. Raises
     exception [Invalid_argument "Rope.foldr2"] if the lengths of [l] and [r]
     are not equal. *)
 
-val foldr2_bigarray :
-  ('a -> 'b -> 'c -> 'c) -> ('a, 'd) ba t -> ('b, 'e) ba t -> 'c -> 'c
-
 module Convert : sig
-  val to_array_array : 'a array t -> 'a array
+  val to_array_array : 'a t -> 'a array
   (** [Rope.Convert.to_array_* s] converts the rope [s] into an array. This
       function collapses [s]. *)
 
-  val to_array_bigarray : ('a, 'b) ba t -> 'a array
-
-  val of_array_array : 'a array -> 'a array t
+  val of_array_array : 'a array -> 'a t
   (** [Rope.Convert.of_array_* a] converts the array [a] into a rope. The
       underlying data is a reference to [a] so no copying is performed. *)
 
-  val of_array_int_bigarray : int array -> int_ba t
-
-  val of_array_float_bigarray : float array -> float_ba t
-
-  val to_list_array : 'a array t -> 'a list
+  val to_list_array : 'a t -> 'a list
   (** [Rope.Convert.to_list_* s] converts the rope [s] into a list. This
       function collapses [s]. *)
 
-  val to_list_bigarray : ('a, 'b) ba t -> 'a list
-
-  val of_list_array : 'a list -> 'a array t
+  val of_list_array : 'a list -> 'a t
   (** [Rope.Convert.of_list_* l] converts the list [l] into a rope. *)
 
-  val of_list_int_bigarray : int list -> int_ba t
-
-  val of_list_float_bigarray : float list -> float_ba t
-
-  val to_ustring_array : int array t -> ustring
+  val to_ustring_array : int t -> ustring
   (** [Rope.Convert.to_ustring_* s] converts a rope of integers [s] into a
       ustring. This function collapses [s]. *)
 
-  val to_ustring_bigarray : int_ba t -> ustring
-
-  val of_ustring_array : ustring -> int array t
+  val of_ustring_array : ustring -> int t
   (** [Rope.Convert.of_ustring_* u] converts the ustring [u] into a rope of
       integers. *)
-
-  val of_ustring_bigarray : ustring -> int_ba t
-
-  val to_int_bigarray_array : int array t -> int_ba
-  (** [Rope.Convert.to_int_bigarray_* s] converts the rope of integers [s] into
-      a Bigarray of integers. This function collapses [s]. *)
-
-  val to_int_bigarray_bigarray : int_ba t -> int_ba
-
-  val to_float_bigarray_array : float array t -> float_ba
-  (** [Rope.Convert.to_int_bigarray_* s] converts the rope of floats [s] into
-      a Bigarray of floats. This function collapses [s]. *)
-
-  val to_float_bigarray_bigarray : float_ba t -> float_ba
 end

--- a/src/boot/lib/rope.mli
+++ b/src/boot/lib/rope.mli
@@ -84,8 +84,7 @@ val foldr_array : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
     accumulated value, initially [acc], and the elements of [s], starting from
     the rightmost element. This function collapses [s]. *)
 
-val foldr2_array :
-  ('a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
+val foldr2_array : ('a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
 (** [Rope.foldr2_* f l r acc] returns the result of applying [f] on an
     accumulated value and the elements of two ropes [l] and [r], starting from
     the rightmost element. This function collapses [l] and [r]. Raises


### PR DESCRIPTION
This PR removes all the code related to the `Bigarray` variation of `Rope`s, and makes some small simplifications to the existing code as well.