### PR TITLE
Remove remaining `batteries` dependencies for `boot` package

### DIFF
--- a/boot.opam
+++ b/boot.opam
@@ -6,7 +6,7 @@ Miking is a meta language-system for creating DSLs.
 This is the Miking bootstrap interpreter.
 """
 maintainer: ["David Broman <dbro@kth.se>"]
-depends: ["dune" "batteries" "linenoise"]
+depends: ["dune" "linenoise"]
 build: [
   ["dune" "subst"] {pinned}
   [

--- a/dune-project
+++ b/dune-project
@@ -11,5 +11,4 @@
  )
  (depends
   dune
-  batteries
   linenoise))


### PR DESCRIPTION
Should have been removed in #425. The `boot.opam` and `dune-project` still listed `batteries` as a dependency, which caused problems when installing the `boot` package.