### PR TITLE
Remove newline print from boot

### DIFF
--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -44,7 +44,7 @@ let evalprog filename =
       else fprintf stderr "%s\n" error_string ;
       exit 1 ) ;
   parsed_files := [] ;
-  if !utest && !utest_fail_local = 0 then printf " OK\n" else printf "\n" ;
+  if !utest && !utest_fail_local = 0 then printf " OK\n";
   if !enable_debug_profiling then
     let bindings =
       Hashtbl.fold (fun k v acc -> (k, v) :: acc) runtimes []


### PR DESCRIPTION
This PR removes the constant newline printed by `boot` upon every invocation.
This makes `mi run` and `boot eval` behave more like each other.

Suppose `my_file.mc` contains the following:

    mexpr print "Hello world!"

Running the code with the two interpreters produces the following results:

    aathn@batmobile ~/path/to/miking$ mi run my_file.mc 
    Hello world!aathn@batmobile ~/path/to/miking$ boot eval my_file.mc
    Hello world!
    aathn@batmobile ~/path/to/miking$ 

After this PR, we instead get the following behaviour:

    aathn@batmobile ~/path/to/miking$ mi run my_file.mc 
    Hello world!aathn@batmobile ~/path/to/miking$ boot eval my_file.mc
    Hello world!aathn@batmobile ~/path/to/miking$ 
