### PR TITLE
Improve Makefile setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
   lint\
   fix\
   clean\
+  uninstall\
   test\
   test-all\
   test-boot-compile\
@@ -55,6 +56,9 @@ fix:
 
 clean:
 	@./make clean
+
+uninstall:
+	@./make uninstall
 
 test: test-boot-base
 

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,13 @@ boot:
 install-boot: boot
 	@./make install-boot
 
-build: install-boot	# Run the complete bootstrapping process to compile `mi`.
+build: install-boot
+# Run the complete bootstrapping process to compile `mi`.
 	@./make
 
-build-mi:		# Build `mi` using the currently installed version.
+build-mi:
+# Build `mi` using the current version in `build`, skipping bootstrapping.
+# The result is named `build/mi-tmp`.
 	@./make build-mi
 
 install: build

--- a/Makefile
+++ b/Makefile
@@ -11,39 +11,36 @@
 .PHONY :\
   all\
   boot\
-  test\
-  install\
   install-boot\
+  build\
+  install\
   lint\
   fix\
   clean\
-  old\
-  test-compile\
-  test-run\
+  test\
   test-all\
+  test-boot-compile\
   test-compile\
   test-run\
   test-boot\
   test-boot-base\
-  test-sundials\
-  test-par\
   test-boot-py\
-  test-boot-ocaml
+  test-boot-ocaml\
+  test-sundials\
+  test-par
 
-all: build/mi
+all: build
 
 boot:
 	@./make boot
 
-build/mi: boot
+install-boot: boot
+	@./make install-boot
+
+build: install-boot	# Run the complete bootstrapping process to compile `mi`.
 	@./make
 
-test: test-boot-base
-
-install: build/mi boot
-	@./make install
-
-install-boot: boot
+install: build
 	@./make install
 
 lint:
@@ -55,8 +52,7 @@ fix:
 clean:
 	@./make clean
 
-old:
-	@./make old
+test: test-boot-base
 
 test-all:\
   test-boot-compile\
@@ -65,20 +61,14 @@ test-all:\
   test-par\
   test-boot
 
-test-boot-compile: build/mi
-	@$(MAKE) -s -f test-boot-compile.mk all
+test-boot-compile: boot
+	@$(MAKE) -s -f test-boot-compile.mk
 
-test-compile: build/mi
-	@$(MAKE) -s -f test-compile.mk all
+test-compile: build
+	@$(MAKE) -s -f test-compile.mk
 
-test-sundials: build/mi
-	@$(MAKE) -s -f test-sundials.mk all
-
-test-par: build/mi
-	@$(MAKE) -s -f test-par.mk all
-
-test-run: build/mi
-	@$(MAKE) -s -f test-run.mk all
+test-run: build
+	@$(MAKE) -s -f test-run.mk
 
 test-boot:\
   test-boot-base\
@@ -93,3 +83,9 @@ test-boot-py: boot
 
 test-boot-ocaml: boot
 	@$(MAKE) -s -f test-boot.mk ocaml
+
+test-sundials: build
+	@$(MAKE) -s -f test-sundials.mk
+
+test-par: build
+	@$(MAKE) -s -f test-par.mk

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
   boot\
   install-boot\
   build\
+  build-mi\
   install\
   lint\
   fix\
@@ -39,6 +40,9 @@ install-boot: boot
 
 build: install-boot	# Run the complete bootstrapping process to compile `mi`.
 	@./make
+
+build-mi:		# Build `mi` using the currently installed version.
+	@./make build-mi
 
 install: build
 	@./make install

--- a/README.md
+++ b/README.md
@@ -69,14 +69,20 @@ for example by running the following:
 
     cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 
-To install the executables along with the standard library for the current
+To install the compiler along with the standard library for the current
 user, issue:
 
 ```
 make install
 ```
 
-This will install the binaries to `$HOME/.local/bin` and the standard library to `$HOME/.local/lib/mcore/stdlib`, according to the [systemd file system hierarchy overview](https://www.freedesktop.org/software/systemd/man/file-hierarchy.html). If `MCORE_STDLIB` is unset, Miking will look in this installation folder as its default library location.
+This will install `mi` to `$HOME/.local/bin` and the standard library to `$HOME/.local/lib/mcore/stdlib`, according to the [systemd file system hierarchy overview](https://www.freedesktop.org/software/systemd/man/file-hierarchy.html). If `MCORE_STDLIB` is unset, Miking will look in this installation folder as its default library location.
+
+Conversely, to uninstall, issue:
+
+```
+make uninstall
+```
 
 ### The REPL
 The Miking bootstrap interpreter features a simple REPL, which lets

--- a/make
+++ b/make
@@ -12,52 +12,68 @@
 # Forces the script to exit on error
 set -e
 
-export BOOT_NAME=boot
-export MI_NAME=mi
+BOOT_NAME=boot
+MI_NAME=mi
+
+BIN_PATH=$HOME/.local/bin
+LIB_PATH=$HOME/.local/lib/mcore
 
 # Setup environment variable to find standard library
-cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
+export MCORE_STDLIB=`pwd`/stdlib
 
 # Compile and build the boot interpreter
 build_boot(){
-    mkdir -p build
     dune build
+    mkdir -p build
     cp -f _build/install/default/bin/boot build/$BOOT_NAME
+}
+
+install_boot(){
     dune install > /dev/null 2>&1
 }
 
+# Bootstrap the Miking compiler
+bootstrap_mi() {
+    time build/$BOOT_NAME eval src/main/mi.mc -- compile --disable-optimizations src/main/mi.mc
+    mv -f $MI_NAME build/$MI_NAME
+}
 
-# General function for building the project
+# Compile a new version of the compiler using the current one
+build_mi() {
+    if [ -e build/$MI_NAME ]
+    then
+        time build/$MI_NAME compile src/main/mi.mc
+        mv -f $MI_NAME build/$MI_NAME
+    else
+        echo "No existing compiler binary was found."
+        echo "Try running the bootstrapping phase first!"
+    fi
+}
+
+# Build the Miking compiler
 build() {
-    build_boot
-    dune install > /dev/null 2>&1
     if [ -e build/$MI_NAME ]
     then
         echo "Bootstrapped compiler already exists. Run 'make clean' before to recompile. "
     else
         echo "Bootstrapping the Miking compiler (1st round, might take a few minutes)"
-        time build/$BOOT_NAME eval src/main/mi.mc -- compile --disable-optimizations src/main/mi.mc
+        bootstrap_mi
         echo "Bootstrapping the Miking compiler (2nd round, might take some more time)"
-        time ./$MI_NAME compile src/main/mi.mc
-        mv -f $MI_NAME build/$MI_NAME
-        rm -f mi
+        build_mi
     fi
 }
 
-
-
-# Install the boot interpreter locally for the current user
+# Install the Miking compiler
 install() {
-    bin_path=$HOME/.local/bin/
-    lib_path=$HOME/.local/lib/mcore/stdlib
-    mkdir -p $bin_path $lib_path
-    if [ -e build/$BOOT_NAME ]; then
-      cp -f build/$BOOT_NAME $bin_path/$BOOT_NAME; chmod +x $bin_path/$BOOT_NAME
-    fi
     if [ -e build/$MI_NAME ]; then
-      cp -f build/$MI_NAME $bin_path/$MI_NAME; chmod +x $bin_path/$MI_NAME
+        set +e; rm -rf $LIB_PATH/stdlib; set -e
+        mkdir -p $BIN_PATH $LIB_PATH
+        cp -rf stdlib $LIB_PATH
+        cp -f build/$MI_NAME $BIN_PATH
+    else
+        echo "No existing compiler binary was found."
+        echo "Try compiling the project first!"
     fi
-    rm -rf $lib_path; cp -rf stdlib $lib_path
 }
 
 # Lint ocaml source code
@@ -96,6 +112,9 @@ run_test() {
 case $1 in
     boot)
         build_boot
+        ;;
+    install-boot)
+        install_boot
         ;;
     run-test)
         run_test "$2"

--- a/make
+++ b/make
@@ -22,7 +22,7 @@ cd stdlib; export MCORE_STDLIB=`pwd`; cd ..;
 build_boot(){
     mkdir -p build
     dune build
-    cp -f _build/install/default/bin/boot.mi build/$BOOT_NAME
+    cp -f _build/install/default/bin/boot build/$BOOT_NAME
     dune install > /dev/null 2>&1
 }
 

--- a/make
+++ b/make
@@ -14,6 +14,7 @@ set -e
 
 BOOT_NAME=boot
 MI_NAME=mi
+MI_TMP_NAME=mi-tmp
 
 BIN_PATH=$HOME/.local/bin
 LIB_PATH=$HOME/.local/lib/mcore
@@ -43,7 +44,7 @@ build_mi() {
     if [ -e build/$MI_NAME ]
     then
         time build/$MI_NAME compile src/main/mi.mc
-        mv -f $MI_NAME build/$MI_NAME
+        mv -f $MI_NAME build/$MI_TMP_NAME
     else
         echo "No existing compiler binary was found."
         echo "Try running the bootstrapping phase first!"
@@ -60,6 +61,7 @@ build() {
         bootstrap_mi
         echo "Bootstrapping the Miking compiler (2nd round, might take some more time)"
         build_mi
+        mv -f build/$MI_TMP_NAME build/$MI_NAME
     fi
 }
 

--- a/make
+++ b/make
@@ -76,6 +76,15 @@ install() {
     fi
 }
 
+# Uninstall the Miking bootstrap interpreter and compiler
+uninstall() {
+    set +e
+    dune uninstall > /dev/null 2>&1
+    rm -f $BIN_PATH/$MI_NAME
+    rm -rf $LIB_PATH/stdlib
+    set -e
+}
+
 # Lint ocaml source code
 lint () {
     dune build @fmt
@@ -133,6 +142,9 @@ case $1 in
         ;;
     install)
         install
+        ;;
+    uninstall)
+        uninstall
         ;;
     clean)
         rm -rf _build

--- a/make
+++ b/make
@@ -116,6 +116,9 @@ case $1 in
     install-boot)
         install_boot
         ;;
+    build-mi)
+        build_mi
+        ;;
     run-test)
         run_test "$2"
         ;;

--- a/src/boot/dune
+++ b/src/boot/dune
@@ -1,4 +1,4 @@
 (executable
  (name boot)
- (public_name boot.mi)
+ (public_name boot)
  (libraries boot))

--- a/test-boot-compile.mk
+++ b/test-boot-compile.mk
@@ -1,5 +1,4 @@
 
-compile_files =
 compile_files += test/mexpr/letlamif.mc
 compile_files += test/mexpr/fix.mc
 compile_files += test/mexpr/ident-test.mc
@@ -124,7 +123,9 @@ compile_files += src/main/run.mc
 compile_files += stdlib/ext/math-ext.mc
 compile_files += stdlib/ext/ext-test.mc
 
-all: ${compile_files}
+.PHONY: all $(compile_files)
 
-${compile_files}::
+all: $(compile_files)
+
+$(compile_files):
 	-@./make compile-test $@ "build/boot eval src/main/mi.mc -- compile --test --disable-optimizations"

--- a/test-boot.mk
+++ b/test-boot.mk
@@ -1,30 +1,31 @@
 
-BOOT_NAME=boot
+BOOT_NAME = boot
 
-base-files=
-base-files+=$(wildcard test/mexpr/*.mc)
-base-files+=$(wildcard test/mlang/*.mc)
-base-files+=$(wildcard stdlib/mexpr/*.mc)
-base-files+=$(wildcard stdlib/c/*.mc)
-base-files+=$(wildcard stdlib/ad/*.mc)
-base-files+=$(wildcard stdlib/parser/*.mc)
-base-files+=$(wildcard stdlib/*.mc)
+base-files += $(wildcard test/mexpr/*.mc)
+base-files += $(wildcard test/mlang/*.mc)
+base-files += $(wildcard stdlib/mexpr/*.mc)
+base-files += $(wildcard stdlib/c/*.mc)
+base-files += $(wildcard stdlib/ad/*.mc)
+base-files += $(wildcard stdlib/parser/*.mc)
+base-files += $(wildcard stdlib/*.mc)
 
-sundials-files=
-sundials-files+=$(wildcard test/sundials/*.mc)
-sundials-files+=$(wildcard stdlib/sundials/*.mc)
+sundials-files += $(wildcard test/sundials/*.mc)
+sundials-files += $(wildcard stdlib/sundials/*.mc)
 
-py-files=$(wildcard test/py/*.mc)
+py-files = $(wildcard test/py/*.mc)
 
-ocaml-files=$(wildcard stdlib/ocaml/*.mc)
+ocaml-files = $(wildcard stdlib/ocaml/*.mc)
+
+.PHONY: base sundials py ocaml\
+  $(base-files) $(sundials-files) $(py-files) $(ocaml-files)
 
 # Rules
 
-base: ${base-files}
-sundials: ${sundials-files}
-py: ${py-files}
-ocaml: ${ocaml-files}
+base: $(base-files)
+sundials: $(sundials-files)
+py: $(py-files)
+ocaml: $(ocaml-files)
 
 # File rule
-${base-files} ${sundials-files} ${py-files} ${ocaml-files}::
+$(base-files) $(sundials-files) $(py-files) $(ocaml-files):
 	-@MCORE_STDLIB=`pwd`/stdlib build/${BOOT_NAME} eval --test $@

--- a/test-boot.mk
+++ b/test-boot.mk
@@ -9,23 +9,19 @@ base-files += $(wildcard stdlib/ad/*.mc)
 base-files += $(wildcard stdlib/parser/*.mc)
 base-files += $(wildcard stdlib/*.mc)
 
-sundials-files += $(wildcard test/sundials/*.mc)
-sundials-files += $(wildcard stdlib/sundials/*.mc)
-
 py-files = $(wildcard test/py/*.mc)
 
 ocaml-files = $(wildcard stdlib/ocaml/*.mc)
 
-.PHONY: base sundials py ocaml\
-  $(base-files) $(sundials-files) $(py-files) $(ocaml-files)
+.PHONY: base py ocaml\
+  $(base-files) $(py-files) $(ocaml-files)
 
 # Rules
 
 base: $(base-files)
-sundials: $(sundials-files)
 py: $(py-files)
 ocaml: $(ocaml-files)
 
 # File rule
-$(base-files) $(sundials-files) $(py-files) $(ocaml-files):
+$(base-files) $(py-files) $(ocaml-files):
 	-@MCORE_STDLIB=`pwd`/stdlib build/${BOOT_NAME} eval --test $@

--- a/test-compile.mk
+++ b/test-compile.mk
@@ -1,5 +1,4 @@
 
-compile_files =
 compile_files += test/mexpr/letlamif.mc
 compile_files += test/mexpr/fix.mc
 compile_files += test/mexpr/ident-test.mc
@@ -124,7 +123,9 @@ compile_files += src/main/run.mc
 compile_files += stdlib/ext/math-ext.mc
 compile_files += stdlib/ext/ext-test.mc
 
-all: ${compile_files}
+.PHONY: all $(compile_files)
 
-${compile_files}::
+all: $(compile_files)
+
+$(compile_files):
 	-@./make compile-test $@ "build/mi compile --test --disable-optimizations"

--- a/test-par.mk
+++ b/test-par.mk
@@ -1,9 +1,10 @@
 
-compile_files =
 compile_files += stdlib/multicore/atomic.mc
 compile_files += stdlib/multicore/thread.mc
 
-all: ${compile_files}
+.PHONY: all $(compile-files)
 
-${compile_files}::
+all: $(compile_files)
+
+$(compile_files):
 	-@./make compile-test $@ "build/mi compile --test --disable-optimizations"

--- a/test-run.mk
+++ b/test-run.mk
@@ -1,5 +1,4 @@
 
-run_files =
 run_files += test/mexpr/letlamif.mc
 run_files += test/mexpr/fix.mc
 run_files += test/mexpr/ident-test.mc
@@ -123,7 +122,9 @@ run_files += stdlib/char.mc
 # run_files += src/main/compile.mc
 # run_files += src/main/run.mc
 
-all: ${run_files}
+.PHONY: all $(run_files)
 
-${run_files}::
+all: $(run_files)
+
+$(run_files):
 	-@./make run-test $@

--- a/test-sundials.mk
+++ b/test-sundials.mk
@@ -1,8 +1,9 @@
 
-compile_files =
 compile_files += stdlib/sundials/sundials.mc
 
-all: ${compile_files}
+.PHONY: all $(compile_files)
 
-${compile_files}::
+all: $(compile_files)
+
+$(compile_files):
 	-@./make compile-test $@ "build/mi compile --test --disable-optimizations"


### PR DESCRIPTION
This PR refactors `./make` and `Makefile` and adds some quality-of-life changes.

- Use dune's installation of the `boot` binary instead of copying `build/boot` to `~/.local/bin`
- Refactor `./make` and `Makefile` to make them more consistent and legible
- Add `build-mi` make target, which recompiles using the current version of `mi` (skipping bootstrapping), creating the binary `mi-tmp`
- Add `uninstall` make target, which uninstalls all installed files