### PR TITLE
Externals: handle strings, labeled arguments, and c libraries

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -157,6 +157,12 @@ module Mseq = struct
       | List s ->
           Array.of_list s
 
+    let to_array_copy = function
+      | Rope s ->
+          Rope.Convert.to_array_array s |> Array.copy
+      | List s ->
+          Array.of_list s
+
     let of_ustring_rope u = Rope (Rope.Convert.of_ustring_array u)
 
     let of_ustring_list u = List (ustring2list u)
@@ -166,6 +172,8 @@ module Mseq = struct
           Rope.Convert.to_ustring_array s
       | List s ->
           list2ustring s
+
+    let to_utf8 s = to_ustring s |> Ustring.to_utf8
 
     let equal f s1 s2 =
       match (s1, s2) with
@@ -210,7 +218,11 @@ module Mseq = struct
 
     let of_array = of_array_rope
 
+    let of_array_copy a = Array.copy a |> of_array
+
     let of_ustring = of_ustring_rope
+
+    let of_utf8 s = Ustring.from_utf8 s |> of_ustring
   end
 end
 

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -154,11 +154,15 @@ module Mseq : sig
 
     val of_array : 'a array -> 'a t
 
+    val of_array_copy : 'a array -> 'a t
+
     val of_array_list : 'a array -> 'a t
 
     val of_array_rope : 'a array -> 'a t
 
     val to_array : 'a t -> 'a array
+
+    val to_array_copy : 'a t -> 'a array
 
     val of_ustring : ustring -> int t
 
@@ -167,6 +171,10 @@ module Mseq : sig
     val of_ustring_list : ustring -> int t
 
     val to_ustring : int t -> ustring
+
+    val to_utf8 : int t -> string
+
+    val of_utf8 : string -> int t
 
     (* Complexity:
      * rope (?): O(n*k), where n is the length of the sequence, k is the

--- a/src/boot/lib/rope.mli
+++ b/src/boot/lib/rope.mli
@@ -94,7 +94,7 @@ val foldr2_array : ('a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
 module Convert : sig
   val to_array_array : 'a t -> 'a array
   (** [Rope.Convert.to_array_* s] converts the rope [s] into an array. This
-      function collapses [s]. *)
+      function collapses [s] and returns a reference to the underlying data. *)
 
   val of_array_array : 'a array -> 'a t
   (** [Rope.Convert.of_array_* a] converts the array [a] into a rope. The

--- a/stdlib/ext/ext-test.ext-ocaml.mc
+++ b/stdlib/ext/ext-test.ext-ocaml.mc
@@ -1,39 +1,46 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let implWithLibs = lam arg : { ident : String, ty : Type, libraries : [String] }.
+  { ident = arg.ident, ty = arg.ty, libraries = arg.libraries, cLibraries = [] }
+
+let impl = lam arg : { ident : String, ty : Type }.
+  implWithLibs { ident = arg.ident, ty = arg.ty, libraries = [] }
+
 let extTestMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
   [
     ("extTestListOfLists", [
+      impl
       {
         ident = "Boot.Exttest.list_of_lists",
-        ty = otylist_ (otylist_ tyint_),
-        libraries = []
+        ty = otylist_ (otylist_ tyint_)
       }
     ]),
     ("extTestListHeadHead", [
+      impl
       {
         ident = "Boot.Exttest.list_hd_hd",
-        ty = tyarrow_ (otylist_ (otylist_ (otyparam_ "a"))) (otyparam_ "a"),
-        libraries = []
+        ty = tyarrow_ (otylist_ (otylist_ (otyparam_ "a"))) (otyparam_ "a")
       }
     ]),
     ("extTestArrayOfArrays", [
+      impl
       {
         ident = "Boot.Exttest.array_of_arrays",
-        ty = otyarray_ (otyarray_ tyint_),
-        libraries = []
+        ty = otyarray_ (otyarray_ tyint_)
       }
     ]),
     ("extTestArrayHeadHead", [
+      impl
       {
         ident = "Boot.Exttest.array_hd_hd",
-        ty = tyarrow_ (otyarray_ (otyarray_ (otyparam_ "a"))) (otyparam_ "a"),
-        libraries = []
+        ty = tyarrow_ (otyarray_ (otyarray_ (otyparam_ "a"))) (otyparam_ "a")
       }
     ]),
     ("extTestFlip", [
+      impl
       {
         ident = "Fun.flip",
         ty = tyarrows_ [tyarrows_ [(otyparam_ "a"),
@@ -42,91 +49,91 @@ let extTestMap =
                         (otyparam_ "b"),
                         (otyparam_ "a"),
                         (otyparam_ "c")
-                       ],
-        libraries = []
+                       ]
       }
     ]),
     ("extTestUnit1", [
+      impl
       {
         ident = "Boot.Exttest.unit1",
-        ty = tyarrow_ tyint_ (otytuple_ []),
-        libraries = []
+        ty = tyarrow_ tyint_ (otytuple_ [])
       }
     ]),
     ("extTestUnit2", [
+      impl
       {
         ident = "Boot.Exttest.unit2",
-        ty = tyarrow_ (otytuple_ []) tyint_,
-        libraries = []
+        ty = tyarrow_ (otytuple_ []) tyint_
       }
     ]),
     ("extTestTuple1", [
+      impl
       {
         ident = "Boot.Exttest.tuple1",
-        ty = otytuple_ [tyint_, tyfloat_],
-        libraries = []
+        ty = otytuple_ [tyint_, tyfloat_]
       }
     ]),
     ("extTestTuple2", [
+      impl
       {
         ident = "Boot.Exttest.tuple2",
-        ty = otytuple_ [otylist_ tyint_, tyint_],
-        libraries = []
+        ty = otytuple_ [otylist_ tyint_, tyint_]
       }
     ]),
     ("extTestTuple10th", [
+      impl
       {
         ident = "Boot.Exttest.tuple1_0th",
-        ty = tyarrow_ (otytuple_ [tyint_, tyfloat_]) tyint_,
-        libraries = []
+        ty = tyarrow_ (otytuple_ [tyint_, tyfloat_]) tyint_
       }
     ]),
     ("extTestTuple20th", [
+      impl
       {
         ident = "Boot.Exttest.tuple2_0th",
-        ty = tyarrow_ (otytuple_ [otylist_ tyint_, tyint_]) (otylist_ tyint_),
-        libraries = []
+        ty = tyarrow_ (otytuple_ [otylist_ tyint_, tyint_]) (otylist_ tyint_)
       }
     ]),
     ("extTestRecord1", [
+      impl
       {
         ident = "Boot.Exttest.myrec1",
         ty = otyrecord_
               (otyvarext_ "Boot.Exttest.myrec1_t" [])
-              [("a", tyint_), ("b", tyfloat_)],
-        libraries = []
+              [("a", tyint_), ("b", tyfloat_)]
       }
     ]),
     ("extTestRecord1A", [
+      impl
       {
         ident = "Boot.Exttest.myrec1_a",
         ty = tyarrow_ (otyrecord_
                         (otyvarext_ "Boot.Exttest.myrec1_t" [])
                         [("a", tyint_), ("b", tyfloat_)])
-                      tyint_,
-        libraries = []
+                      tyint_
       }
     ]),
     ("extTestRecord2", [
+      impl
       {
         ident = "Boot.Exttest.myrec2",
         ty = otyrecord_
               (otyvarext_ "Boot.Exttest.myrec2_t" [])
-              [("a", otylist_ tyint_), ("b", tyint_)],
-        libraries = []
+              [("a", otylist_ tyint_), ("b", tyint_)]
       }
     ]),
     ("extTestRecord2A", [
+      impl
       {
         ident = "Boot.Exttest.myrec2_a",
         ty = tyarrow_ (otyrecord_
                         (otyvarext_ "Boot.Exttest.myrec2_t" [])
                         [("a", otylist_ tyint_), ("b", tyint_)])
-                      (otylist_ tyint_),
-        libraries = []
+                      (otylist_ tyint_)
       }
     ]),
     ("extTestRecord3", [
+      impl
       {
         ident = "Boot.Exttest.myrec3",
         ty = otyrecord_
@@ -140,11 +147,11 @@ let extTestMap =
                 ,otyrecord_
                   (otyvarext_ "Boot.Exttest.myrec2_t" [])
                   [("a", otylist_ tyint_), ("b", tyint_)])
-              ],
-        libraries = []
+              ]
       }
     ]),
     ("extTestRecord3BA", [
+      impl
       {
         ident = "Boot.Exttest.myrec3_b_a",
         ty =
@@ -161,86 +168,105 @@ let extTestMap =
                   (otyvarext_ "Boot.Exttest.myrec2_t" [])
                   [("a", otylist_ tyint_), ("b", tyint_)])
               ])
-            (otylist_ tyint_),
-        libraries = []
+            (otylist_ tyint_)
       }
     ]),
     ("extTestArgLabel", [
+      impl
       {
         ident = "Boot.Exttest.arg_label",
-        ty = tyarrows_ [otylabel_ "b" tyint_, otylabel_ "a" tyint_, tyint_],
-        libraries = []
+        ty = tyarrows_ [otylabel_ "b" tyint_, otylabel_ "a" tyint_, tyint_]
       }
     ]),
     ("extTestGenarrIntNumDims", [
-      { ident = "Bigarray.Genarray.num_dims",
-        ty = tyarrow_ otygenarrayclayoutint_ tyint_,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.Genarray.num_dims",
+        ty = tyarrow_ otygenarrayclayoutint_ tyint_
+      }
     ]),
     ("extTestGenarrFloatNumDims", [
-      { ident = "Bigarray.Genarray.num_dims",
-        ty = tyarrow_ otygenarrayclayoutfloat_ tyint_,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.Genarray.num_dims",
+        ty = tyarrow_ otygenarrayclayoutfloat_ tyint_
+      }
     ]),
     ("extTestGenarrIntSliceLeft", [
-      { ident = "Bigarray.Genarray.slice_left",
+      impl
+      {
+        ident = "Bigarray.Genarray.slice_left",
         ty = tyarrows_ [otygenarrayclayoutint_,
                         otyarray_ tyint_,
-                        otygenarrayclayoutint_],
-        libraries = [] }
+                        otygenarrayclayoutint_]
+      }
     ]),
     ("extTestGenarrFloatSliceLeft", [
-      { ident = "Bigarray.Genarray.slice_left",
+      impl
+      {
+        ident = "Bigarray.Genarray.slice_left",
         ty = tyarrows_ [otygenarrayclayoutfloat_,
                         otyarray_ tyint_,
-                        otygenarrayclayoutfloat_],
-        libraries = [] }
+                        otygenarrayclayoutfloat_]
+      }
     ]),
     ("extTestArray2IntSliceLeft", [
-      { ident = "Bigarray.Array2.slice_left",
+      impl
+      {
+        ident = "Bigarray.Array2.slice_left",
         ty = tyarrows_ [otybaarrayclayoutint_ 2,
                          tyint_,
-                         otybaarrayclayoutint_ 1],
-        libraries = [] }
+                         otybaarrayclayoutint_ 1]
+      }
     ]),
     ("extTestArray2FloatSliceLeft", [
-      { ident = "Bigarray.Array2.slice_left",
+      impl
+      {
+        ident = "Bigarray.Array2.slice_left",
         ty = tyarrows_ [otybaarrayclayoutfloat_ 2,
                         tyint_,
-                        otybaarrayclayoutfloat_ 1],
-        libraries = [] }
+                        otybaarrayclayoutfloat_ 1]
+      }
     ]),
     ("extTestArray2IntOfGenarr", [
-      { ident = "Bigarray.array2_of_genarray",
-        ty = tyarrow_ otygenarrayclayoutint_ (otybaarrayclayoutint_ 2) ,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.array2_of_genarray",
+        ty = tyarrow_ otygenarrayclayoutint_ (otybaarrayclayoutint_ 2)
+      }
     ]),
     ("extTestArray2FloatOfGenarr", [
-      { ident = "Bigarray.array2_of_genarray",
-        ty = tyarrow_ otygenarrayclayoutfloat_ (otybaarrayclayoutfloat_ 2) ,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.array2_of_genarray",
+        ty = tyarrow_ otygenarrayclayoutfloat_ (otybaarrayclayoutfloat_ 2)
+      }
     ]),
     ("extTestZero", [
-      { ident = "Float.zero", ty = tyfloat_, libraries = [] }
+      impl { ident = "Float.zero", ty = tyfloat_ }
     ]),
     ("extTestExp", [
-      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("extTestListMap", [
-      { ident = "List.map",
+      impl
+      {
+        ident = "List.map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (tyvar_ "b"),
                         otylist_ (tyvar_ "a"),
-                        otylist_ (tyvar_ "b")],
-        libraries = [] }
+                        otylist_ (tyvar_ "b")]
+      }
     ]),
     ("extTestListConcatMap", [
-      { ident = "List.concat_map",
+      impl
+      {
+        ident = "List.concat_map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (otylist_ (tyvar_ "b")),
                         otylist_ (tyvar_ "a"),
-                        otylist_ (tyvar_ "b")],
-        libraries = [] }
+                        otylist_ (tyvar_ "b")]
+      }
     ]),
     ("extTestNonExistant", [
-      { ident = "none", ty = tyint_, libraries = ["no-lib"] }
+      implWithLibs { ident = "none", ty = tyint_, libraries = ["no-lib"] }
     ])
   ]

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -1,36 +1,34 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let impl = lam arg : { ident : String, ty : Type }.
+  { ident = arg.ident, ty = arg.ty, libraries = [], cLibraries = [] }
+
 let mathExtMap =
   use OCamlTypeAst in
-  mapFromSeq cmpString
-  [
+  mapFromSeq cmpString [
     ("externalExp", [
-      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
+      impl { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalLog", [
-      { ident = "Float.log", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
+      impl { ident = "Float.log", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalAtan", [
-      { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalSin", [
-      { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalCos", [
-      { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalAtan2", [
-      { ident = "Float.atan2",
-        ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_],
-        libraries = [] }
+      impl { ident = "Float.atan2", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
     ]),
     ("externalPow", [
-      { ident = "Float.pow",
-        ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_],
-        libraries = [] }
+      impl { ident = "Float.pow", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
     ]),
     ("externalSqrt", [
-      { ident = "Float.sqrt", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
+      impl { ident = "Float.sqrt", ty = tyarrow_ tyfloat_ tyfloat_ }
     ])
   ]

--- a/stdlib/multicore/atomic.ext-ocaml.mc
+++ b/stdlib/multicore/atomic.ext-ocaml.mc
@@ -1,6 +1,9 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let impl = lam arg : { ident : String, ty : Type }.
+  { ident = arg.ident, ty = arg.ty, libraries = [], cLibraries = [] }
+
 let tyaref_ = lam. tyunknown_
 let tygeneric_ = lam. tyunknown_
 
@@ -8,36 +11,36 @@ let atomicExtMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
   [ ("externalAtomicMake", [
+      impl
       { ident = "Atomic.make"
       , ty = tyarrow_ (tygeneric_ "a") (tyaref_ "a")
-      , libraries = []
       }]),
 
     ("externalAtomicGet", [
+      impl
       { ident = "Atomic.get"
       , ty = tyarrow_ (tyaref_ "a") (tygeneric_ "a")
-      , libraries = []
       }]),
 
     ("externalAtomicExchange", [
+      impl
       { ident = "Atomic.exchange"
       , ty = tyarrows_ [tyaref_ "a", tygeneric_ "a", tygeneric_ "a"]
-      , libraries = []
       }]),
 
     ("externalAtomicCAS", [
+      impl
       { ident = "Atomic.compare_and_set"
       , ty = tyarrows_ [ tyaref_ "a"
                        , tygeneric_ "a"
                        , tygeneric_ "a"
                        , tybool_
                        ]
-      , libraries = []
       }]),
 
     ("externalAtomicFetchAndAdd", [
+      impl
       { ident = "Atomic.fetch_and_add"
       , ty = tyarrows_ [tyaref_ "Int", tyint_, tyint_]
-      , libraries = []
       }])
   ]

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -137,6 +137,17 @@ lang OCamlLabel
   | OTmLabel t -> OTmLabel { t with arg = f t.arg }
 end
 
+lang OCamlLam
+  syn Expr =
+  | OTmLam {label : Option String, ident : Name, body : Expr}
+
+  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
+  | OTmLam t -> f acc t.body
+
+  sem smap_Expr_Expr (f : Expr -> a) =
+  | OTmLam t -> OTmLam { t with body = f t.body }
+end
+
 lang OCamlTypeAst =
   BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst + RecordTypeAst +
   FunTypeAst + OCamlLabel
@@ -154,6 +165,7 @@ lang OCamlTypeAst =
   | OTyVarExt {info : Info, ident : String, args : [Type]}
   | OTyParam {info : Info, ident : String}
   | OTyRecord {info : Info, fields : [(String, Type)], tyident : Type}
+  | OTyString {info: Info}
 
   sem infoTy =
   | OTyList r -> r.info
@@ -168,12 +180,14 @@ lang OCamlTypeAst =
   | OTyVarExt r -> r.info
   | OTyParam r -> r.info
   | OTyRecord r -> r.info
+  | OTyString r -> r.info
 end
 
 lang OCamlAst =
   -- Terms
   LamAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
   OCamlArray + OCamlData + OCamlTypeDeclAst + OCamlRecord + OCamlLabel +
+  OCamlLam +
 
   -- Constants
   ArithIntAst + ShiftIntAst + ArithFloatAst + BoolAst + FloatIntConversionAst +
@@ -240,6 +254,9 @@ let otylabel_ = use OCamlAst in
 let otyrecord_ = use OCamlAst in
   lam tyident. lam fields.
     OTyRecord {info = NoInfo (), tyident = tyident, fields = fields}
+
+let otystring_ = use OCamlAst in
+  OTyString {info = NoInfo ()}
 
 let otyopaque_ = otyvarext_ "opaque" []
 

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -5,7 +5,12 @@ include "sundials/sundials.ext-ocaml.mc"
 include "multicore/atomic.ext-ocaml.mc"
 include "multicore/thread.ext-ocaml.mc"
 
-type ExternalImpl = { ident : String, ty : Type, libraries : [String] }
+type ExternalImpl = {
+  ident : String,
+  ty : Type,
+  libraries : [String],
+  cLibraries : [String]
+}
 
 -- NOTE(oerikss, 2021-04-30) Add your external maps here. This is a temporary
 -- solution. In the end we want to provide these definitions outside the

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -161,6 +161,7 @@ lang OCamlPrettyPrint =
   | OTmLabel _ -> true
   | OTmRecord _ -> true
   | OTmProject _ -> true
+  | OTmLam _ -> false
 
   sem patIsAtomic =
   | OPatRecord _ -> false
@@ -346,6 +347,17 @@ lang OCamlPrettyPrint =
     else never
   | TmLam {ident = id, body = b} ->
     match pprintVarName env id with (env,str) then
+      match pprintCode (pprintIncr indent) env b with (env,body) then
+        (env,join ["fun ", str, " ->", pprintNewline (pprintIncr indent), body])
+      else never
+    else never
+  | OTmLam {label = label, ident = id, body = b} ->
+    match pprintVarName env id with (env,str) then
+      let str =
+        match label with Some label then join ["~", label, ":", str]
+        else match label with None _ then str
+        else never
+      in
       match pprintCode (pprintIncr indent) env b with (env,body) then
         (env,join ["fun ", str, " ->", pprintNewline (pprintIncr indent), body])
       else never

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -1,6 +1,9 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let impl = lam arg : { ident : String, ty : Type }.
+  { ident = arg.ident, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
+
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []
 let tyidatriple = otyvarext_ "Ida.triple"
 let tyidajacobianargra =
@@ -41,76 +44,80 @@ let sundialsExtMap =
   mapFromSeq cmpString
   [
     ("externalSundialsRealArrayCreate", [
-      { ident = "Sundials.RealArray.create",
-        ty = tyarrow_ tyint_ otyopaque_,
-        libraries = ["sundialsml"] }
+      impl { ident = "Sundials.RealArray.create", ty = tyarrow_ tyint_ otyopaque_}
     ]),
     ("externalNvectorSerialWrap", [
-      { ident = "Nvector_serial.wrap",
-        ty = tyarrow_ (otybaarrayclayoutfloat_ 1) otyopaque_,
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Nvector_serial.wrap",
+        ty = tyarrow_ (otybaarrayclayoutfloat_ 1) otyopaque_
+      }
     ]),
     ("externalNvectorSerialUnwrap", [
-      { ident = "Nvector_serial.unwrap",
-        ty = tyarrow_ otyopaque_ (otybaarrayclayoutfloat_ 1),
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Nvector_serial.unwrap",
+        ty = tyarrow_ otyopaque_ (otybaarrayclayoutfloat_ 1)
+      }
     ]),
     ("externalSundialsMatrixDense", [
-      { ident = "Sundials.Matrix.dense",
-        ty = tyarrows_ [tyint_, otyopaque_],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Sundials.Matrix.dense",
+        ty = tyarrows_ [tyint_, otyopaque_]
+      }
     ]),
     ("externalSundialsMatrixDenseUnwrap", [
-      { ident = "Sundials.Matrix.Dense.unwrap",
-        ty = tyarrows_ [otyopaque_, (otybaarrayclayoutfloat_ 2)],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Sundials.Matrix.Dense.unwrap",
+        ty = tyarrows_ [otyopaque_, (otybaarrayclayoutfloat_ 2)]
+      }
     ]),
     ("externalIdaDlsDense", [
-      { ident = "Ida.Dls.dense",
-        ty = tyarrows_ [otyopaque_, otyopaque_, otyopaque_],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Ida.Dls.dense",
+        ty = tyarrows_ [otyopaque_, otyopaque_, otyopaque_]
+      }
     ]),
     ("externalIdaDlsSolverJacf", [
-      { ident = "Ida.Dls.solver",
+      impl {
+        ident = "Ida.Dls.solver",
         ty =
           tyarrows_ [
             otylabel_ "jac" tyidajacf,
             otyopaque_,
             otyopaque_
-          ],
-        libraries = ["sundialsml"] }
+          ]
+      }
     ]),
     ("externalIdaDlsSolver", [
-      { ident = "Ida.Dls.solver",
+      impl {
+        ident = "Ida.Dls.solver",
         ty =
           tyarrows_ [
             otyopaque_,
             otyopaque_
-          ],
-        libraries = ["sundialsml"] }
+          ]
+      }
     ]),
     ("idaVarIdAlgebraic", [
-      { ident = "Ida.VarId.algebraic",
-        ty = tyfloat_,
-        libraries = ["sundialsml"] }
+      impl { ident = "Ida.VarId.algebraic", ty = tyfloat_ }
     ]),
     ("idaVarIdDifferential", [
-      { ident = "Ida.VarId.differential",
-        ty = tyfloat_,
-        libraries = ["sundialsml"] }
+      impl { ident = "Ida.VarId.differential", ty = tyfloat_ }
     ]),
     ("externalIdaSSTolerances", [
-      { ident = "Boot.Sundials_wrapper.ida_ss_tolerances",
-        ty = tyarrows_ [tyfloat_, tyfloat_, otyopaque_],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Boot.Sundials_wrapper.ida_ss_tolerances",
+        ty = tyarrows_ [tyfloat_, tyfloat_, otyopaque_]
+      }
     ]),
     ("externalIdaRetcode", [
-      { ident = "Boot.Sundials_wrapper.ida_retcode",
-        ty = tyarrow_ otyopaque_ tyint_,
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Boot.Sundials_wrapper.ida_retcode",
+        ty = tyarrow_ otyopaque_ tyint_
+      }
     ]),
     ("externalIdaInit", [
-      { ident = "Ida.init",
+      impl {
+        ident = "Ida.init",
         ty = tyarrows_ [
           otyopaque_,
           otyopaque_,
@@ -121,33 +128,36 @@ let sundialsExtMap =
           otyopaque_,
           otyopaque_,
           otyopaque_
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ]),
     ("externalIdaCalcICYaYd", [
-      { ident = "Ida.calc_ic_ya_yd'",
+      impl {
+        ident = "Ida.calc_ic_ya_yd'",
         ty = tyarrows_ [
                otyopaque_,
                tyfloat_,
                otylabel_ "y" otyopaque_,
                otylabel_ "y'" otyopaque_,
                otyunit_
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ]),
     ("externalIdaSolveNormal", [
-      { ident = "Ida.solve_normal",
+      impl {
+        ident = "Ida.solve_normal",
         ty = tyarrows_ [
                otyopaque_,
                tyfloat_,
                otyopaque_,
                otyopaque_,
                otytuple_ [tyfloat_, otyopaque_]
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ]),
     ("externalIdaReinit", [
-      { ident = "Ida.reinit",
+      impl {
+        ident = "Ida.reinit",
         ty = tyarrows_ [
           otyopaque_,
           otylabel_ "roots" (otytuple_ [tyint_, tyidarootf]),
@@ -155,7 +165,7 @@ let sundialsExtMap =
           otyopaque_,
           otyopaque_,
           otyunit_
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ])
   ]


### PR DESCRIPTION
This PR contains:
- Adds support for passing c libraries that are needed during linking when defining external implementations.
- Adds support for converting to and from strings.
- Adds support for callback functions with labeled arguments.
- Improves external documentation in the README, in particular on the conversion of values to and from OCaml.

*Note1: I added support for callback functions with labeled arguments by introducing a new term `OTmLam` in the `stdlib/ocaml/ast.mc`. This means that currently, the AST generated by `stdlib/ocaml/generate.mc` will contain both `TmLam` and `OTmLam` terms. As pointed out by @elegios, we probably want to instead handle this by a product extension in the future.*

*Note2: converting from an OCaml array or list to a sequence will always result in a sequence implemented as a rope.* 