### PR TITLE
Ipopt interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@
   test-boot\
   test-boot-base\
   test-sundials\
+	test-ipopt\
   test-par\
   test-boot-py\
   test-boot-ocaml
@@ -73,6 +74,9 @@ test-compile: build/mi
 
 test-sundials: build/mi
 	@$(MAKE) -s -f test-sundials.mk all
+
+test-ipopt: build/mi
+	@$(MAKE) -s -f test-ipopt.mk all
 
 test-par: build/mi
 	@$(MAKE) -s -f test-par.mk all

--- a/README.md
+++ b/README.md
@@ -1235,7 +1235,6 @@ Please consult [stdlib/ext/ext-test.mc](stdlib/ext/ext-test.mc) and
 examples.
 
 ### Sundials
-
 A more involved example on the use of externals is an interface to the
 [Sundials](https://computing.llnl.gov/projects/sundials) numerical DAE solver.
 You find the implementation in
@@ -1285,6 +1284,39 @@ make test-sundials
 ```
 
 To install for the current user, run `make install` as usual.
+
+
+### Ipopt
+Another example use of externals is an interface to the constrained Non-Linear
+Program solver [Ipopt](https://coin-or.github.io/Ipopt/). This interface is
+defined in [stdlib/ipopt/ipopt.mc](stdlib/ipopt/ipopt.mc) and
+[stdlib/ipopt/ipopt.ext-ocaml.mc](stdlib/ipopt/ipopt.ext-ocaml.mc). This library
+depends on both the OCaml library [ipoptml](https://github.com/br4sco/ipoptml)
+and the ipopt c library.
+
+To use this library you need to do the following:
+
+Install the ipopt c library, which you can do on ubuntu 20.04 with
+```
+sudo apt-get install coinor-libipopt-dev
+```
+
+Install dependencies for [ipoptml](https://github.com/br4sco/ipoptml),
+```
+opam install ctypes ctypes-foreign
+```
+
+Clone the [ipoptml](https://github.com/br4sco/ipoptml) repo and in its root run
+```
+dune build
+dune install
+```
+
+You can then test the solver in Miking with
+
+```
+make test-ipopt
+```
 
 ### Parallel Programming
 Miking offers a set of externals for shared-memory parallelism using

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -157,6 +157,12 @@ module Mseq = struct
       | List s ->
           Array.of_list s
 
+    let to_array_copy = function
+      | Rope s ->
+          Rope.Convert.to_array_array s |> Array.copy
+      | List s ->
+          Array.of_list s
+
     let of_ustring_rope u = Rope (Rope.Convert.of_ustring_array u)
 
     let of_ustring_list u = List (ustring2list u)
@@ -166,6 +172,8 @@ module Mseq = struct
           Rope.Convert.to_ustring_array s
       | List s ->
           list2ustring s
+
+    let to_utf8 s = to_ustring s |> Ustring.to_utf8
 
     let equal f s1 s2 =
       match (s1, s2) with
@@ -210,7 +218,11 @@ module Mseq = struct
 
     let of_array = of_array_rope
 
+    let of_array_copy a = Array.copy a |> of_array
+
     let of_ustring = of_ustring_rope
+
+    let of_utf8 s = Ustring.from_utf8 s |> of_ustring
   end
 end
 

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -154,11 +154,15 @@ module Mseq : sig
 
     val of_array : 'a array -> 'a t
 
+    val of_array_copy : 'a array -> 'a t
+
     val of_array_list : 'a array -> 'a t
 
     val of_array_rope : 'a array -> 'a t
 
     val to_array : 'a t -> 'a array
+
+    val to_array_copy : 'a t -> 'a array
 
     val of_ustring : ustring -> int t
 
@@ -167,6 +171,10 @@ module Mseq : sig
     val of_ustring_list : ustring -> int t
 
     val to_ustring : int t -> ustring
+
+    val to_utf8 : int t -> string
+
+    val of_utf8 : string -> int t
 
     (* Complexity:
      * rope (?): O(n*k), where n is the length of the sequence, k is the

--- a/src/boot/lib/rope.mli
+++ b/src/boot/lib/rope.mli
@@ -94,7 +94,7 @@ val foldr2_array : ('a -> 'b -> 'c -> 'c) -> 'a t -> 'b t -> 'c -> 'c
 module Convert : sig
   val to_array_array : 'a t -> 'a array
   (** [Rope.Convert.to_array_* s] converts the rope [s] into an array. This
-      function collapses [s]. *)
+      function collapses [s] and returns a reference to the underlying data. *)
 
   val of_array_array : 'a array -> 'a t
   (** [Rope.Convert.of_array_* a] converts the array [a] into a rope. The

--- a/stdlib/ext/ext-test.ext-ocaml.mc
+++ b/stdlib/ext/ext-test.ext-ocaml.mc
@@ -1,39 +1,46 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let implWithLibs = lam arg : { ident : String, ty : Type, libraries : [String] }.
+  { ident = arg.ident, ty = arg.ty, libraries = arg.libraries, cLibraries = [] }
+
+let impl = lam arg : { ident : String, ty : Type }.
+  implWithLibs { ident = arg.ident, ty = arg.ty, libraries = [] }
+
 let extTestMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
   [
     ("extTestListOfLists", [
+      impl
       {
         ident = "Boot.Exttest.list_of_lists",
-        ty = otylist_ (otylist_ tyint_),
-        libraries = []
+        ty = otylist_ (otylist_ tyint_)
       }
     ]),
     ("extTestListHeadHead", [
+      impl
       {
         ident = "Boot.Exttest.list_hd_hd",
-        ty = tyarrow_ (otylist_ (otylist_ (otyparam_ "a"))) (otyparam_ "a"),
-        libraries = []
+        ty = tyarrow_ (otylist_ (otylist_ (otyparam_ "a"))) (otyparam_ "a")
       }
     ]),
     ("extTestArrayOfArrays", [
+      impl
       {
         ident = "Boot.Exttest.array_of_arrays",
-        ty = otyarray_ (otyarray_ tyint_),
-        libraries = []
+        ty = otyarray_ (otyarray_ tyint_)
       }
     ]),
     ("extTestArrayHeadHead", [
+      impl
       {
         ident = "Boot.Exttest.array_hd_hd",
-        ty = tyarrow_ (otyarray_ (otyarray_ (otyparam_ "a"))) (otyparam_ "a"),
-        libraries = []
+        ty = tyarrow_ (otyarray_ (otyarray_ (otyparam_ "a"))) (otyparam_ "a")
       }
     ]),
     ("extTestFlip", [
+      impl
       {
         ident = "Fun.flip",
         ty = tyarrows_ [tyarrows_ [(otyparam_ "a"),
@@ -42,91 +49,91 @@ let extTestMap =
                         (otyparam_ "b"),
                         (otyparam_ "a"),
                         (otyparam_ "c")
-                       ],
-        libraries = []
+                       ]
       }
     ]),
     ("extTestUnit1", [
+      impl
       {
         ident = "Boot.Exttest.unit1",
-        ty = tyarrow_ tyint_ (otytuple_ []),
-        libraries = []
+        ty = tyarrow_ tyint_ (otytuple_ [])
       }
     ]),
     ("extTestUnit2", [
+      impl
       {
         ident = "Boot.Exttest.unit2",
-        ty = tyarrow_ (otytuple_ []) tyint_,
-        libraries = []
+        ty = tyarrow_ (otytuple_ []) tyint_
       }
     ]),
     ("extTestTuple1", [
+      impl
       {
         ident = "Boot.Exttest.tuple1",
-        ty = otytuple_ [tyint_, tyfloat_],
-        libraries = []
+        ty = otytuple_ [tyint_, tyfloat_]
       }
     ]),
     ("extTestTuple2", [
+      impl
       {
         ident = "Boot.Exttest.tuple2",
-        ty = otytuple_ [otylist_ tyint_, tyint_],
-        libraries = []
+        ty = otytuple_ [otylist_ tyint_, tyint_]
       }
     ]),
     ("extTestTuple10th", [
+      impl
       {
         ident = "Boot.Exttest.tuple1_0th",
-        ty = tyarrow_ (otytuple_ [tyint_, tyfloat_]) tyint_,
-        libraries = []
+        ty = tyarrow_ (otytuple_ [tyint_, tyfloat_]) tyint_
       }
     ]),
     ("extTestTuple20th", [
+      impl
       {
         ident = "Boot.Exttest.tuple2_0th",
-        ty = tyarrow_ (otytuple_ [otylist_ tyint_, tyint_]) (otylist_ tyint_),
-        libraries = []
+        ty = tyarrow_ (otytuple_ [otylist_ tyint_, tyint_]) (otylist_ tyint_)
       }
     ]),
     ("extTestRecord1", [
+      impl
       {
         ident = "Boot.Exttest.myrec1",
         ty = otyrecord_
               (otyvarext_ "Boot.Exttest.myrec1_t" [])
-              [("a", tyint_), ("b", tyfloat_)],
-        libraries = []
+              [("a", tyint_), ("b", tyfloat_)]
       }
     ]),
     ("extTestRecord1A", [
+      impl
       {
         ident = "Boot.Exttest.myrec1_a",
         ty = tyarrow_ (otyrecord_
                         (otyvarext_ "Boot.Exttest.myrec1_t" [])
                         [("a", tyint_), ("b", tyfloat_)])
-                      tyint_,
-        libraries = []
+                      tyint_
       }
     ]),
     ("extTestRecord2", [
+      impl
       {
         ident = "Boot.Exttest.myrec2",
         ty = otyrecord_
               (otyvarext_ "Boot.Exttest.myrec2_t" [])
-              [("a", otylist_ tyint_), ("b", tyint_)],
-        libraries = []
+              [("a", otylist_ tyint_), ("b", tyint_)]
       }
     ]),
     ("extTestRecord2A", [
+      impl
       {
         ident = "Boot.Exttest.myrec2_a",
         ty = tyarrow_ (otyrecord_
                         (otyvarext_ "Boot.Exttest.myrec2_t" [])
                         [("a", otylist_ tyint_), ("b", tyint_)])
-                      (otylist_ tyint_),
-        libraries = []
+                      (otylist_ tyint_)
       }
     ]),
     ("extTestRecord3", [
+      impl
       {
         ident = "Boot.Exttest.myrec3",
         ty = otyrecord_
@@ -140,11 +147,11 @@ let extTestMap =
                 ,otyrecord_
                   (otyvarext_ "Boot.Exttest.myrec2_t" [])
                   [("a", otylist_ tyint_), ("b", tyint_)])
-              ],
-        libraries = []
+              ]
       }
     ]),
     ("extTestRecord3BA", [
+      impl
       {
         ident = "Boot.Exttest.myrec3_b_a",
         ty =
@@ -161,86 +168,105 @@ let extTestMap =
                   (otyvarext_ "Boot.Exttest.myrec2_t" [])
                   [("a", otylist_ tyint_), ("b", tyint_)])
               ])
-            (otylist_ tyint_),
-        libraries = []
+            (otylist_ tyint_)
       }
     ]),
     ("extTestArgLabel", [
+      impl
       {
         ident = "Boot.Exttest.arg_label",
-        ty = tyarrows_ [otylabel_ "b" tyint_, otylabel_ "a" tyint_, tyint_],
-        libraries = []
+        ty = tyarrows_ [otylabel_ "b" tyint_, otylabel_ "a" tyint_, tyint_]
       }
     ]),
     ("extTestGenarrIntNumDims", [
-      { ident = "Bigarray.Genarray.num_dims",
-        ty = tyarrow_ otygenarrayclayoutint_ tyint_,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.Genarray.num_dims",
+        ty = tyarrow_ otygenarrayclayoutint_ tyint_
+      }
     ]),
     ("extTestGenarrFloatNumDims", [
-      { ident = "Bigarray.Genarray.num_dims",
-        ty = tyarrow_ otygenarrayclayoutfloat_ tyint_,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.Genarray.num_dims",
+        ty = tyarrow_ otygenarrayclayoutfloat_ tyint_
+      }
     ]),
     ("extTestGenarrIntSliceLeft", [
-      { ident = "Bigarray.Genarray.slice_left",
+      impl
+      {
+        ident = "Bigarray.Genarray.slice_left",
         ty = tyarrows_ [otygenarrayclayoutint_,
                         otyarray_ tyint_,
-                        otygenarrayclayoutint_],
-        libraries = [] }
+                        otygenarrayclayoutint_]
+      }
     ]),
     ("extTestGenarrFloatSliceLeft", [
-      { ident = "Bigarray.Genarray.slice_left",
+      impl
+      {
+        ident = "Bigarray.Genarray.slice_left",
         ty = tyarrows_ [otygenarrayclayoutfloat_,
                         otyarray_ tyint_,
-                        otygenarrayclayoutfloat_],
-        libraries = [] }
+                        otygenarrayclayoutfloat_]
+      }
     ]),
     ("extTestArray2IntSliceLeft", [
-      { ident = "Bigarray.Array2.slice_left",
+      impl
+      {
+        ident = "Bigarray.Array2.slice_left",
         ty = tyarrows_ [otybaarrayclayoutint_ 2,
                          tyint_,
-                         otybaarrayclayoutint_ 1],
-        libraries = [] }
+                         otybaarrayclayoutint_ 1]
+      }
     ]),
     ("extTestArray2FloatSliceLeft", [
-      { ident = "Bigarray.Array2.slice_left",
+      impl
+      {
+        ident = "Bigarray.Array2.slice_left",
         ty = tyarrows_ [otybaarrayclayoutfloat_ 2,
                         tyint_,
-                        otybaarrayclayoutfloat_ 1],
-        libraries = [] }
+                        otybaarrayclayoutfloat_ 1]
+      }
     ]),
     ("extTestArray2IntOfGenarr", [
-      { ident = "Bigarray.array2_of_genarray",
-        ty = tyarrow_ otygenarrayclayoutint_ (otybaarrayclayoutint_ 2) ,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.array2_of_genarray",
+        ty = tyarrow_ otygenarrayclayoutint_ (otybaarrayclayoutint_ 2)
+      }
     ]),
     ("extTestArray2FloatOfGenarr", [
-      { ident = "Bigarray.array2_of_genarray",
-        ty = tyarrow_ otygenarrayclayoutfloat_ (otybaarrayclayoutfloat_ 2) ,
-        libraries = [] }
+      impl
+      {
+        ident = "Bigarray.array2_of_genarray",
+        ty = tyarrow_ otygenarrayclayoutfloat_ (otybaarrayclayoutfloat_ 2)
+      }
     ]),
     ("extTestZero", [
-      { ident = "Float.zero", ty = tyfloat_, libraries = [] }
+      impl { ident = "Float.zero", ty = tyfloat_ }
     ]),
     ("extTestExp", [
-      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("extTestListMap", [
-      { ident = "List.map",
+      impl
+      {
+        ident = "List.map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (tyvar_ "b"),
                         otylist_ (tyvar_ "a"),
-                        otylist_ (tyvar_ "b")],
-        libraries = [] }
+                        otylist_ (tyvar_ "b")]
+      }
     ]),
     ("extTestListConcatMap", [
-      { ident = "List.concat_map",
+      impl
+      {
+        ident = "List.concat_map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (otylist_ (tyvar_ "b")),
                         otylist_ (tyvar_ "a"),
-                        otylist_ (tyvar_ "b")],
-        libraries = [] }
+                        otylist_ (tyvar_ "b")]
+      }
     ]),
     ("extTestNonExistant", [
-      { ident = "none", ty = tyint_, libraries = ["no-lib"] }
+      implWithLibs { ident = "none", ty = tyint_, libraries = ["no-lib"] }
     ])
   ]

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -1,36 +1,34 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let impl = lam arg : { ident : String, ty : Type }.
+  { ident = arg.ident, ty = arg.ty, libraries = [], cLibraries = [] }
+
 let mathExtMap =
   use OCamlTypeAst in
-  mapFromSeq cmpString
-  [
+  mapFromSeq cmpString [
     ("externalExp", [
-      { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
+      impl { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalLog", [
-      { ident = "Float.log", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
+      impl { ident = "Float.log", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalAtan", [
-      { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalSin", [
-      { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalCos", [
-      { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_, libraries = [] }
+      impl { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalAtan2", [
-      { ident = "Float.atan2",
-        ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_],
-        libraries = [] }
+      impl { ident = "Float.atan2", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
     ]),
     ("externalPow", [
-      { ident = "Float.pow",
-        ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_],
-        libraries = [] }
+      impl { ident = "Float.pow", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
     ]),
     ("externalSqrt", [
-      { ident = "Float.sqrt", ty = tyarrow_ tyfloat_ tyfloat_ , libraries = [] }
+      impl { ident = "Float.sqrt", ty = tyarrow_ tyfloat_ tyfloat_ }
     ])
   ]

--- a/stdlib/ipopt/ipopt.ext-ocaml.mc
+++ b/stdlib/ipopt/ipopt.ext-ocaml.mc
@@ -1,0 +1,78 @@
+include "map.mc"
+include "ocaml/ast.mc"
+
+let impl = lam arg : { ident : String, ty : Type }.
+  {
+    ident = arg.ident,
+    ty = arg.ty,
+    libraries = ["ipoptml"],
+    cLibraries = ["ipopt"]
+  }
+
+let tyvec = otybaarrayclayoutfloat_ 1
+let tyevalf = tyarrow_ tyvec tyfloat_
+let tyevalgradf = tyarrows_ [tyvec, tyvec, otyunit_]
+let tyevalg = tyarrows_ [tyvec, tyvec, otyunit_]
+let tystructure = otyarray_ (otytuple_ [tyint_, tyint_])
+let tyevaljacg = tyarrows_ [tyvec, tyvec, otyunit_]
+let tyevalh = tyarrows_ [
+  otylabel_ "sigma" tyfloat_,
+  otylabel_ "x" tyvec,
+  otylabel_ "lambda" tyvec,
+  otylabel_ "h" tyvec,
+  otyunit_
+]
+
+let ipoptExtMap =
+  mapFromSeq cmpString
+  [
+    ("externalIpoptApplicationReturnStatusRetcode", [
+      impl {
+        ident = "Ipoptml.application_return_status_retcode",
+        ty = tyarrow_ otyopaque_ tyint_
+      }
+    ]),
+    ("externalIpoptCreateNLP", [
+      impl {
+        ident = "Ipoptml.create_nlp",
+        ty = tyarrows_ [
+          otylabel_ "eval_f" tyevalf,
+          otylabel_ "eval_grad_f" tyevalgradf,
+          otylabel_ "eval_g" tyevalg,
+          otylabel_ "jac_g_structure" tystructure,
+          otylabel_ "eval_jac_g" tyevaljacg,
+          otylabel_ "h_structure" tystructure,
+          otylabel_ "eval_h" tyevalh,
+          otylabel_ "lb" tyvec,
+          otylabel_ "ub" tyvec,
+          otylabel_ "constraints_lb" tyvec,
+          otylabel_ "constraints_ub" tyvec,
+          otyopaque_
+        ]
+      }
+    ]),
+    ("externalIpoptAddStrOption", [
+      impl {
+        ident = "Ipoptml.add_str_option",
+        ty = tyarrows_ [otyopaque_, otystring_, otystring_, otyunit_]
+      }
+    ]),
+    ("externalIpoptAddNumOption", [
+      impl {
+        ident = "Ipoptml.add_num_option",
+        ty = tyarrows_ [otyopaque_, otystring_, tyfloat_, otyunit_]
+      }
+    ]),
+    ("externalIpoptAddIntOption", [
+      impl {
+        ident = "Ipoptml.add_int_option",
+        ty = tyarrows_ [otyopaque_, otystring_, tyint_, otyunit_]
+      }
+    ]),
+    ("externalIpoptSolve", [
+      impl {
+        ident = "Ipoptml.solve",
+        ty = tyarrows_ [otyopaque_, tyvec, otyopaque_]
+      }
+    ])
+  ]

--- a/stdlib/ipopt/ipopt.mc
+++ b/stdlib/ipopt/ipopt.mc
@@ -1,0 +1,358 @@
+/-
+  Miking interface to the IPOPT constrained Non-Linear Program (NLP) solver.
+  @see <https://coin-or.github.io/Ipopt/index.html> for the IPOPT documentation.
+-/
+
+include "math.mc"
+include "tensor.mc"
+
+type IpoptNLP                     -- Constrained Non-Linear Program
+type IpoptApplicationReturnStatus -- Internal representation of return status
+
+type Vector = Tensor[Float]
+
+-- Callback function to evaluate the objective function f(x). The function
+-- argument `x` is the values of the variables.
+type IpoptEvalF = Vector -> Float
+
+-- Callback function to evaluate the gradient 𝛁f(x) of the objective
+-- function. The function arguments are:
+--   - `x`, the values of the variables,
+--   - `grad_f`, a vector for storing the values of 𝛁f(x), in the same order
+--               as `x`. I.e. `grad_f[i]` should hold the value of the gradient
+--               of f(x) with respect to `x[i]`.
+type IpoptEvalGradF = Vector -> Vector -> ()
+
+-- Callback function to evaluate the constraints g(x). The function arguments
+-- are:
+--   - [x], the values of the variables,
+--   - [g], a vector for storing the value of g(x).
+type IpoptEvalG = Vector -> Vector -> ()
+
+-- Encodes the structure of a sparse matrix. The tuple `(i, j)` in position `k`
+-- associates the matrix element `m[i, j]` with the sequence element `a[k]`. If
+-- `(i, j)` appears multiple times in the structure sequence, `m[i, j]` is
+-- associated with the sum of these elements in `a`. Matrix elements missing
+-- from the structure sequence are assumed to be zero.
+-- @see <https://coin-or.github.io/Ipopt/IMPL.html#TRIPLET> for documentation on
+-- the triplet format.
+type IpoptStructure = [(Int, Int)]
+
+-- Callback function to evaluate the Jacobian 𝛁g(x)^T of the constraints. The
+-- function arguments are:
+-- - `x`, the values of the variables,
+-- - `jac_g`, a vector for storing the non-zero values of 𝛁g(x)^T, where
+--            `jac_g` assumes some pre-defined structure.
+type IpoptEvalJacG = Vector -> Vector -> ()
+
+
+-- Callback function to evaluate the Hessian
+-- σ𝛁^2f(x_k) + Σ_i[λ_i𝛁^2g_i(x_k)]
+-- of the Lagrangian. The function arguments are:
+-- - `sigma`, the factor σ in front of the objective term,
+-- - `x`, the values of the variables,
+-- - `lambda`, the values of the constraint multiplier λ,
+-- - `h`, a vector for storing the non-zero values of the Hessian, where `h`
+--        assumes some pre-defined structure. This matrix is symmetric and
+--        only the lower diagonal entries must be specified.
+type IpoptEvalH = Float -> Vector -> Vector -> Vector -> ()
+
+
+type IpoptReturnStatus
+con SolveSucceeded : () -> IpoptReturnStatus
+con SolvedToAcceptableLevel : () -> IpoptReturnStatus
+con InfeasibleProblemDetected : () -> IpoptReturnStatus
+con SearchDirectionBecomesTooSmall : () -> IpoptReturnStatus
+con DivergingIterates : () -> IpoptReturnStatus
+con UserRequestedStop : () -> IpoptReturnStatus
+con FeasiblePointFound : () -> IpoptReturnStatus
+con MaximumIterationsExceeded : () -> IpoptReturnStatus
+con RestorationFailed : () -> IpoptReturnStatus
+con ErrorInStepComputation : () -> IpoptReturnStatus
+con MaximumCpuTimeExceeded : () -> IpoptReturnStatus
+con NotEnoughDegreesOfFreedom : () -> IpoptReturnStatus
+con InvalidProblemDefinition : () -> IpoptReturnStatus
+con InvalidOption : () -> IpoptReturnStatus
+con InvalidNumberDetected : () -> IpoptReturnStatus
+con UnrecoverableException : () -> IpoptReturnStatus
+con NonIpoptExceptionThrown : () -> IpoptReturnStatus
+con InsufficientMemory : () -> IpoptReturnStatus
+con InternalError : () -> IpoptReturnStatus
+
+
+external externalIpoptApplicationReturnStatusRetcode
+  : IpoptApplicationReturnStatus -> Int
+
+let _rctoreturnstatus = lam rc : Int.
+  if eqi rc 0 then SolveSucceeded ()
+  else if eqi rc 1 then SolvedToAcceptableLevel ()
+  else if eqi rc 2 then InfeasibleProblemDetected ()
+  else if eqi rc 3 then SearchDirectionBecomesTooSmall ()
+  else if eqi rc 4 then DivergingIterates ()
+  else if eqi rc 5 then UserRequestedStop ()
+  else if eqi rc 6 then FeasiblePointFound ()
+  else if eqi rc (negi 1) then MaximumIterationsExceeded ()
+  else if eqi rc (negi 2) then RestorationFailed ()
+  else if eqi rc (negi 3) then ErrorInStepComputation ()
+  else if eqi rc (negi 4) then MaximumCpuTimeExceeded ()
+  else if eqi rc (negi 10) then NotEnoughDegreesOfFreedom ()
+  else if eqi rc (negi 11) then InvalidProblemDefinition ()
+  else if eqi rc (negi 12) then InvalidOption ()
+  else if eqi rc (negi 13) then InvalidNumberDetected ()
+  else if eqi rc (negi 100) then UnrecoverableException ()
+  else if eqi rc (negi 101) then NonIpoptExceptionThrown ()
+  else if eqi rc (negi 102) then InsufficientMemory ()
+  else if eqi rc (negi 199) then InternalError ()
+  else error "Ipopt._rctoreturnstatus: Unknown return code"
+
+
+external externalIpoptCreateNLP
+  : IpoptEvalF ->
+    IpoptEvalGradF ->
+    IpoptEvalG ->
+    IpoptStructure ->
+    IpoptEvalJacG ->
+    IpoptStructure ->
+    IpoptEvalH ->
+    Vector ->
+    Vector ->
+    Vector ->
+    Vector ->
+    IpoptNLP
+
+type IpoptCreateNLPArg = {
+  -- Callback function to evaluate objective function.
+  evalF : IpoptEvalF,
+
+  -- Callback function to evaluate the gradient of the objective function.
+  evalGradF : IpoptEvalGradF,
+
+  -- Callback function to evaluate the constraint function.
+  evalG : IpoptEvalG,
+
+  -- Structure of the constraint Jacobian.
+  jacGStructure : IpoptStructure,
+
+  -- Callback function to evalute the Jacobian of the constraint function
+  evalJacG : IpoptEvalJacG,
+
+  -- Structure of the Hessian of the Lagrangian.
+  hStructure : IpoptStructure,
+
+  -- Callback function to evaluate the Hessian of the Lagrangian.
+  evalH : IpoptEvalH,
+
+  -- Lower bounds on the variables xL_k.
+  lb : Vector,
+
+  -- Upper bounds on the variables xU_k.
+  ub : Vector,
+
+  -- Lower bounds on the constraints gL_i.
+  constraintsLb : Vector,
+
+  -- Upper bounds on the constraints gU_i.
+  constraintsUb : Vector
+}
+
+-- Creates a constrained NLP:
+-- min_x[f(x)] s.t. xL_k ≤ x_k ≤ xU_k and gL_i ≤ g_i(x) ≤ gU_i.
+let ipoptCreateNLP : IpoptCreateNLPArg -> IpoptNLP = lam arg.
+  externalIpoptCreateNLP
+    arg.evalF
+    arg.evalGradF
+    arg.evalG
+    arg.jacGStructure
+    arg.evalJacG
+    arg.hStructure
+    arg.evalH
+    arg.lb
+    arg.ub
+    arg.constraintsLb
+    arg.constraintsUb
+
+
+external externalIpoptAddStrOption ! : IpoptNLP -> String -> String -> ()
+
+-- `ipoptAddStrOption p key val` sets the option `key` to the `String` value
+-- `val` in the NLP `p`. @see <https://coin-or.github.io/Ipopt/OPTIONS.html> for
+-- a summary of options.
+let ipoptAddStrOption : IpoptNLP -> String -> String -> ()
+= lam p. lam key. lam val. externalIpoptAddStrOption p key val
+
+
+external externalIpoptAddNumOption ! : IpoptNLP -> String -> Float -> ()
+
+-- As `ipoptAddStrOption`, but for `Float` values.
+let ipoptAddNumOption : IpoptNLP -> String -> Float -> ()
+= lam p. lam key. lam val. externalIpoptAddNumOption p key val
+
+
+external externalIpoptAddIntOption ! : IpoptNLP -> String -> Int -> ()
+
+-- As `ipoptAddStrOption`, but for `Int` values.
+let ipoptAddIntOption : IpoptNLP -> String -> Int -> ()
+= lam p. lam key. lam val. externalIpoptAddIntOption p key val
+
+
+external externalIpoptSolve !
+  : IpoptNLP -> Vector -> (IpoptApplicationReturnStatus, Float)
+
+-- `solve p x` tries to solve the constrained NLP `p` with initial values `x`.
+-- The function arguments are:
+-- - `p`, the constrained NLP,
+-- - `x`, Initial values of the variables. Will hold the optimal solution after
+--        calling `solve`.
+-- Returns: The tuple tuple `(rs, f)`, where `rs` is the return status and `f`
+--          is the final value of the objective function.
+let ipoptSolve : IpoptNLP -> Vector  -> (IpoptReturnStatus, Float)
+= lam p. lam x.
+  match externalIpoptSolve p x with (r, f) then
+    (_rctoreturnstatus (externalIpoptApplicationReturnStatusRetcode r), f)
+  else never
+
+mexpr
+
+let tget = tensorGetExn in
+let tset = tensorSetExn in
+let tcreate = tensorCreateCArrayFloat in
+
+-- Example problem from https://coin-or.github.io/Ipopt/
+-- min_x f(x), where f(x) = x[0]x[3](x[0] + x[1] + x[2]) + x[2],
+-- s.t.
+--  x[0]x[1]x[2]x[3] ≥ 25,
+--  x[0]^2 + x[1]^2 + x[2]^2 + x[3]^2 = 40,
+--  1 ≤ x[0], x[1], x[2], x[3] ≤ 5.
+
+let evalF = lam x.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  addf (mulf x0 (mulf x3 (addf x0 (addf x1 x2)))) x2
+in
+
+let evalGradF = lam x. lam gradF.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  tset gradF [0] (addf (mulf x0 x3) (mulf x3 (addf x0 (addf x1 x2))));
+  tset gradF [1] (mulf x0 x3);
+  tset gradF [2] (addf (mulf x0 x3) 1.);
+  tset gradF [3] (mulf x0 (addf x0 (addf x1 x2)));
+  ()
+in
+
+let evalG = lam x. lam g.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  tset g [0] (mulf x0 (mulf x1 (mulf x2 x3)));
+  tset g [1] (addf (mulf x0 x0) (addf (mulf x1 x1)
+                                      (addf (mulf x2 x2) (mulf x3 x3))));
+  ()
+in
+
+let jacGStructure =
+  [ (0, 0)
+  , (0, 1)
+  , (0, 2)
+  , (0, 3)
+  , (1, 0)
+  , (1, 1)
+  , (1, 2)
+  , (1, 3) ]
+in
+
+let evalJacG = lam x. lam jacG.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  tset jacG [0] (mulf x1 (mulf x2 x3));
+  tset jacG [1] (mulf x0 (mulf x2 x3));
+  tset jacG [2] (mulf x0 (mulf x1 x3));
+  tset jacG [3] (mulf x0 (mulf x1 x2));
+  tset jacG [4] (mulf 2. x0);
+  tset jacG [5] (mulf 2. x1);
+  tset jacG [6] (mulf 2. x2);
+  tset jacG [7] (mulf 2. x3);
+  ()
+in
+
+let hStructure =
+  [ (0, 0)
+  , (1, 0)
+  , (1, 1)
+  , (2, 0)
+  , (2, 1)
+  , (2, 2)
+  , (3, 0)
+  , (3, 1)
+  , (3, 2)
+  , (3, 3) ]
+in
+
+let evalH = lam sigma. lam x. lam lambda. lam h.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  let l0 = tget lambda [0] in
+  let l1 = tget lambda [1] in
+  tset h [0] (mulf sigma (mulf 2. x3));
+  tset h [1] (mulf sigma x3);
+  tset h [2] 0.;
+  tset h [3] (mulf sigma x3);
+  tset h [4] 0.;
+  tset h [5] 0.;
+  tset h [6] (mulf sigma (addf (mulf 2. x0) (addf x1 x2)));
+  tset h [7] (mulf sigma x0);
+  tset h [8] (mulf sigma x0);
+  tset h [9] 0.;
+  tset h [1] (addf (tget h [1]) (mulf l0 (mulf x2 x3)));
+  tset h [3] (addf (tget h [3]) (mulf l0 (mulf x1 x3)));
+  tset h [4] (addf (tget h [4]) (mulf l0 (mulf x0 x3)));
+  tset h [6] (addf (tget h [6]) (mulf l0 (mulf x1 x2)));
+  tset h [7] (addf (tget h [7]) (mulf l0 (mulf x0 x2)));
+  tset h [8] (addf (tget h [8]) (mulf l0 (mulf x0 x1)));
+  tset h [0] (addf (tget h [0]) (mulf l1 2.));
+  tset h [2] (addf (tget h [2]) (mulf l1 2.));
+  tset h [5] (addf (tget h [5]) (mulf l1 2.));
+  tset h [9] (addf (tget h [9]) (mulf l1 2.));
+  ()
+in
+
+let lb = tensorOfSeqExn tcreate [4] [1., 1., 1., 1.] in
+let ub = tensorOfSeqExn tcreate [4] [5., 5., 5., 5.] in
+let constraintsLb = tensorOfSeqExn tcreate [2] [25., 40.] in
+let constraintsUb = tensorOfSeqExn tcreate [2] [inf, 40.] in
+
+let p = ipoptCreateNLP {
+  evalF = evalF,
+  evalGradF = evalGradF,
+  evalG = evalG,
+  jacGStructure = jacGStructure,
+  evalJacG = evalJacG,
+  hStructure = hStructure,
+  evalH = evalH,
+  lb = lb,
+  ub = ub,
+  constraintsLb = constraintsLb,
+  constraintsUb = constraintsUb
+} in
+
+ipoptAddNumOption p "tol" 3.82e-6;
+ipoptAddStrOption p "mu_strategy" "adaptive";
+
+let x = tensorOfSeqExn tcreate [4] [1., 5., 5., 1.] in
+
+utest
+  match ipoptSolve p x with (SolveSucceeded _, _) then true
+  else false
+with true
+in
+
+()

--- a/stdlib/multicore/atomic.ext-ocaml.mc
+++ b/stdlib/multicore/atomic.ext-ocaml.mc
@@ -1,6 +1,9 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let impl = lam arg : { ident : String, ty : Type }.
+  { ident = arg.ident, ty = arg.ty, libraries = [], cLibraries = [] }
+
 let tyaref_ = lam. tyunknown_
 let tygeneric_ = lam. tyunknown_
 
@@ -8,36 +11,36 @@ let atomicExtMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
   [ ("externalAtomicMake", [
+      impl
       { ident = "Atomic.make"
       , ty = tyarrow_ (tygeneric_ "a") (tyaref_ "a")
-      , libraries = []
       }]),
 
     ("externalAtomicGet", [
+      impl
       { ident = "Atomic.get"
       , ty = tyarrow_ (tyaref_ "a") (tygeneric_ "a")
-      , libraries = []
       }]),
 
     ("externalAtomicExchange", [
+      impl
       { ident = "Atomic.exchange"
       , ty = tyarrows_ [tyaref_ "a", tygeneric_ "a", tygeneric_ "a"]
-      , libraries = []
       }]),
 
     ("externalAtomicCAS", [
+      impl
       { ident = "Atomic.compare_and_set"
       , ty = tyarrows_ [ tyaref_ "a"
                        , tygeneric_ "a"
                        , tygeneric_ "a"
                        , tybool_
                        ]
-      , libraries = []
       }]),
 
     ("externalAtomicFetchAndAdd", [
+      impl
       { ident = "Atomic.fetch_and_add"
       , ty = tyarrows_ [tyaref_ "Int", tyint_, tyint_]
-      , libraries = []
       }])
   ]

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -137,6 +137,17 @@ lang OCamlLabel
   | OTmLabel t -> OTmLabel { t with arg = f t.arg }
 end
 
+lang OCamlLam
+  syn Expr =
+  | OTmLam {label : Option String, ident : Name, body : Expr}
+
+  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
+  | OTmLam t -> f acc t.body
+
+  sem smap_Expr_Expr (f : Expr -> a) =
+  | OTmLam t -> OTmLam { t with body = f t.body }
+end
+
 lang OCamlTypeAst =
   BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst + RecordTypeAst +
   FunTypeAst + OCamlLabel
@@ -154,6 +165,7 @@ lang OCamlTypeAst =
   | OTyVarExt {info : Info, ident : String, args : [Type]}
   | OTyParam {info : Info, ident : String}
   | OTyRecord {info : Info, fields : [(String, Type)], tyident : Type}
+  | OTyString {info: Info}
 
   sem infoTy =
   | OTyList r -> r.info
@@ -168,12 +180,14 @@ lang OCamlTypeAst =
   | OTyVarExt r -> r.info
   | OTyParam r -> r.info
   | OTyRecord r -> r.info
+  | OTyString r -> r.info
 end
 
 lang OCamlAst =
   -- Terms
   LamAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
   OCamlArray + OCamlData + OCamlTypeDeclAst + OCamlRecord + OCamlLabel +
+  OCamlLam +
 
   -- Constants
   ArithIntAst + ShiftIntAst + ArithFloatAst + BoolAst + FloatIntConversionAst +
@@ -240,6 +254,9 @@ let otylabel_ = use OCamlAst in
 let otyrecord_ = use OCamlAst in
   lam tyident. lam fields.
     OTyRecord {info = NoInfo (), tyident = tyident, fields = fields}
+
+let otystring_ = use OCamlAst in
+  OTyString {info = NoInfo ()}
 
 let otyopaque_ = otyvarext_ "opaque" []
 

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -4,6 +4,7 @@ include "ext/math-ext.ext-ocaml.mc"
 include "sundials/sundials.ext-ocaml.mc"
 include "multicore/atomic.ext-ocaml.mc"
 include "multicore/thread.ext-ocaml.mc"
+include "ipopt/ipopt.ext-ocaml.mc"
 
 type ExternalImpl = {
   ident : String,
@@ -22,5 +23,6 @@ let globalExternalImplsMap : Map String [ExternalImpl] =
       mathExtMap,
       sundialsExtMap,
       atomicExtMap,
-      threadExtMap
+      threadExtMap,
+      ipoptExtMap
     ]

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -5,7 +5,12 @@ include "sundials/sundials.ext-ocaml.mc"
 include "multicore/atomic.ext-ocaml.mc"
 include "multicore/thread.ext-ocaml.mc"
 
-type ExternalImpl = { ident : String, ty : Type, libraries : [String] }
+type ExternalImpl = {
+  ident : String,
+  ty : Type,
+  libraries : [String],
+  cLibraries : [String]
+}
 
 -- NOTE(oerikss, 2021-04-30) Add your external maps here. This is a temporary
 -- solution. In the end we want to provide these definitions outside the

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -161,6 +161,7 @@ lang OCamlPrettyPrint =
   | OTmLabel _ -> true
   | OTmRecord _ -> true
   | OTmProject _ -> true
+  | OTmLam _ -> false
 
   sem patIsAtomic =
   | OPatRecord _ -> false
@@ -346,6 +347,17 @@ lang OCamlPrettyPrint =
     else never
   | TmLam {ident = id, body = b} ->
     match pprintVarName env id with (env,str) then
+      match pprintCode (pprintIncr indent) env b with (env,body) then
+        (env,join ["fun ", str, " ->", pprintNewline (pprintIncr indent), body])
+      else never
+    else never
+  | OTmLam {label = label, ident = id, body = b} ->
+    match pprintVarName env id with (env,str) then
+      let str =
+        match label with Some label then join ["~", label, ":", str]
+        else match label with None _ then str
+        else never
+      in
       match pprintCode (pprintIncr indent) env b with (env,body) then
         (env,join ["fun ", str, " ->", pprintNewline (pprintIncr indent), body])
       else never

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -1,6 +1,9 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
+let impl = lam arg : { ident : String, ty : Type }.
+  { ident = arg.ident, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
+
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []
 let tyidatriple = otyvarext_ "Ida.triple"
 let tyidajacobianargra =
@@ -41,76 +44,80 @@ let sundialsExtMap =
   mapFromSeq cmpString
   [
     ("externalSundialsRealArrayCreate", [
-      { ident = "Sundials.RealArray.create",
-        ty = tyarrow_ tyint_ otyopaque_,
-        libraries = ["sundialsml"] }
+      impl { ident = "Sundials.RealArray.create", ty = tyarrow_ tyint_ otyopaque_}
     ]),
     ("externalNvectorSerialWrap", [
-      { ident = "Nvector_serial.wrap",
-        ty = tyarrow_ (otybaarrayclayoutfloat_ 1) otyopaque_,
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Nvector_serial.wrap",
+        ty = tyarrow_ (otybaarrayclayoutfloat_ 1) otyopaque_
+      }
     ]),
     ("externalNvectorSerialUnwrap", [
-      { ident = "Nvector_serial.unwrap",
-        ty = tyarrow_ otyopaque_ (otybaarrayclayoutfloat_ 1),
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Nvector_serial.unwrap",
+        ty = tyarrow_ otyopaque_ (otybaarrayclayoutfloat_ 1)
+      }
     ]),
     ("externalSundialsMatrixDense", [
-      { ident = "Sundials.Matrix.dense",
-        ty = tyarrows_ [tyint_, otyopaque_],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Sundials.Matrix.dense",
+        ty = tyarrows_ [tyint_, otyopaque_]
+      }
     ]),
     ("externalSundialsMatrixDenseUnwrap", [
-      { ident = "Sundials.Matrix.Dense.unwrap",
-        ty = tyarrows_ [otyopaque_, (otybaarrayclayoutfloat_ 2)],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Sundials.Matrix.Dense.unwrap",
+        ty = tyarrows_ [otyopaque_, (otybaarrayclayoutfloat_ 2)]
+      }
     ]),
     ("externalIdaDlsDense", [
-      { ident = "Ida.Dls.dense",
-        ty = tyarrows_ [otyopaque_, otyopaque_, otyopaque_],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Ida.Dls.dense",
+        ty = tyarrows_ [otyopaque_, otyopaque_, otyopaque_]
+      }
     ]),
     ("externalIdaDlsSolverJacf", [
-      { ident = "Ida.Dls.solver",
+      impl {
+        ident = "Ida.Dls.solver",
         ty =
           tyarrows_ [
             otylabel_ "jac" tyidajacf,
             otyopaque_,
             otyopaque_
-          ],
-        libraries = ["sundialsml"] }
+          ]
+      }
     ]),
     ("externalIdaDlsSolver", [
-      { ident = "Ida.Dls.solver",
+      impl {
+        ident = "Ida.Dls.solver",
         ty =
           tyarrows_ [
             otyopaque_,
             otyopaque_
-          ],
-        libraries = ["sundialsml"] }
+          ]
+      }
     ]),
     ("idaVarIdAlgebraic", [
-      { ident = "Ida.VarId.algebraic",
-        ty = tyfloat_,
-        libraries = ["sundialsml"] }
+      impl { ident = "Ida.VarId.algebraic", ty = tyfloat_ }
     ]),
     ("idaVarIdDifferential", [
-      { ident = "Ida.VarId.differential",
-        ty = tyfloat_,
-        libraries = ["sundialsml"] }
+      impl { ident = "Ida.VarId.differential", ty = tyfloat_ }
     ]),
     ("externalIdaSSTolerances", [
-      { ident = "Boot.Sundials_wrapper.ida_ss_tolerances",
-        ty = tyarrows_ [tyfloat_, tyfloat_, otyopaque_],
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Boot.Sundials_wrapper.ida_ss_tolerances",
+        ty = tyarrows_ [tyfloat_, tyfloat_, otyopaque_]
+      }
     ]),
     ("externalIdaRetcode", [
-      { ident = "Boot.Sundials_wrapper.ida_retcode",
-        ty = tyarrow_ otyopaque_ tyint_,
-        libraries = ["sundialsml"] }
+      impl {
+        ident = "Boot.Sundials_wrapper.ida_retcode",
+        ty = tyarrow_ otyopaque_ tyint_
+      }
     ]),
     ("externalIdaInit", [
-      { ident = "Ida.init",
+      impl {
+        ident = "Ida.init",
         ty = tyarrows_ [
           otyopaque_,
           otyopaque_,
@@ -121,33 +128,36 @@ let sundialsExtMap =
           otyopaque_,
           otyopaque_,
           otyopaque_
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ]),
     ("externalIdaCalcICYaYd", [
-      { ident = "Ida.calc_ic_ya_yd'",
+      impl {
+        ident = "Ida.calc_ic_ya_yd'",
         ty = tyarrows_ [
                otyopaque_,
                tyfloat_,
                otylabel_ "y" otyopaque_,
                otylabel_ "y'" otyopaque_,
                otyunit_
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ]),
     ("externalIdaSolveNormal", [
-      { ident = "Ida.solve_normal",
+      impl {
+        ident = "Ida.solve_normal",
         ty = tyarrows_ [
                otyopaque_,
                tyfloat_,
                otyopaque_,
                otyopaque_,
                otytuple_ [tyfloat_, otyopaque_]
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ]),
     ("externalIdaReinit", [
-      { ident = "Ida.reinit",
+      impl {
+        ident = "Ida.reinit",
         ty = tyarrows_ [
           otyopaque_,
           otylabel_ "roots" (otytuple_ [tyint_, tyidarootf]),
@@ -155,7 +165,7 @@ let sundialsExtMap =
           otyopaque_,
           otyopaque_,
           otyunit_
-        ],
-        libraries = ["sundialsml"] }
+        ]
+      }
     ])
   ]

--- a/test-ipopt.mk
+++ b/test-ipopt.mk
@@ -1,0 +1,8 @@
+
+compile_files =
+compile_files += stdlib/ipopt/ipopt.mc
+
+all: ${compile_files}
+
+${compile_files}::
+	-@./make compile-test $@ "build/mi compile --test --disable-optimizations"


### PR DESCRIPTION
This PR includes #449.

In addition this PR includes an interface to the constrained Non-Linear Program solver [IPOPT](https://coin-or.github.io/Ipopt/). It is implemented using externals via the OCaml bindings [ipoptml](https://github.com/br4sco/ipoptml). See the README for installation instructions. If the dependent libraries are installed, the interface can be tested with `make test-ipopt`.