### PR TITLE
Typesafe map intrinsics

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -152,6 +152,7 @@ and const =
   | CMap of tm * (tm, tm) Mmap.t
   | CmapEmpty
   | CmapSize
+  | CmapIsEmpty
   | CmapGetCmpFun
   | CmapInsert of tm option * tm option
   | CmapRemove of tm option
@@ -601,6 +602,7 @@ let const_has_side_effect = function
   | CMap _
   | CmapEmpty
   | CmapSize
+  | CmapIsEmpty
   | CmapGetCmpFun
   | CmapInsert _
   | CmapRemove _

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -149,8 +149,7 @@ and const =
   | CmodRef of tm ref option
   | CdeRef
   (* MCore intrinsics: Maps *)
-  (* NOTE(Linnea, 2021-01-27): Obj.t denotes the type of the internal map (I was so far unable to express it properly) *)
-  | CMap of tm * Obj.t
+  | CMap of tm * (tm, tm) Mmap.t
   | CmapEmpty
   | CmapSize
   | CmapGetCmpFun
@@ -165,8 +164,8 @@ and const =
   | CmapMapWithKey of (tm -> tm -> tm) option
   | CmapFoldWithKey of (tm -> tm -> tm -> tm) option * tm option
   | CmapBindings
-  | CmapEq of (tm -> tm -> bool) option * (tm * Obj.t) option
-  | CmapCmp of (tm -> tm -> int) option * (tm * Obj.t) option
+  | CmapEq of (tm -> tm -> bool) option * (tm * (tm, tm) Mmap.t) option
+  | CmapCmp of (tm -> tm -> int) option * (tm * (tm, tm) Mmap.t) option
   (* MCore intrinsics: Tensors *)
   | CtensorCreateDense of int Mseq.t option
   | CtensorCreateCArrayInt of int Mseq.t option

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -117,6 +117,7 @@ let builtin =
   ; ("modref", f (CmodRef None)) (* MCore intrinsics: Maps *)
   ; ("mapEmpty", f CmapEmpty)
   ; ("mapSize", f CmapSize)
+  ; ("mapIsEmpty", f CmapIsEmpty)
   ; ("mapGetCmpFun", f CmapGetCmpFun)
   ; ("mapInsert", f (CmapInsert (None, None)))
   ; ("mapRemove", f (CmapRemove None))

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -378,35 +378,37 @@ module ConTag : sig
 end
 
 module Mmap : sig
-  val empty : ('a -> 'a -> int) -> Obj.t
+  type ('a, 'b) t
 
-  val insert : 'a -> 'b -> Obj.t -> Obj.t
+  val empty : ('a -> 'a -> int) -> ('a, 'b) t
 
-  val remove : 'a -> Obj.t -> Obj.t
+  val insert : 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
 
-  val find : 'a -> Obj.t -> 'b
+  val remove : 'a -> ('a, 'b) t -> ('a, 'b) t
 
-  val find_or_else : (unit -> 'b) -> 'a -> Obj.t -> 'b
+  val find : 'a -> ('a, 'b) t -> 'b
 
-  val find_apply_or_else : ('b -> 'c) -> (unit -> 'c) -> 'a -> Obj.t -> 'c
+  val find_or_else : (unit -> 'b) -> 'a -> ('a, 'b) t -> 'b
 
-  val bindings : Obj.t -> ('a * 'b) Mseq.t
+  val find_apply_or_else : ('b -> 'c) -> (unit -> 'c) -> 'a -> ('a, 'b) t -> 'c
 
-  val size : Obj.t -> int
+  val bindings : ('a, 'b) t -> ('a * 'b) Mseq.t
 
-  val mem : 'a -> Obj.t -> bool
+  val size : ('a, 'b) t -> int
 
-  val any : ('a -> 'b -> bool) -> Obj.t -> bool
+  val mem : 'a -> ('a, 'b) t -> bool
 
-  val map : ('b -> 'c) -> Obj.t -> Obj.t
+  val any : ('a -> 'b -> bool) -> ('a, 'b) t -> bool
 
-  val map_with_key : ('a -> 'b -> 'c) -> Obj.t -> Obj.t
+  val map : ('b -> 'c) -> ('a, 'b) t -> ('a, 'c) t
 
-  val fold_with_key : ('c -> 'a -> 'b -> 'c) -> 'c -> Obj.t -> 'c
+  val map_with_key : ('a -> 'b -> 'c) -> ('a, 'b) t -> ('a, 'c) t
 
-  val eq : ('b -> 'b -> bool) -> Obj.t -> Obj.t -> bool
+  val fold_with_key : ('c -> 'a -> 'b -> 'c) -> 'c -> ('a, 'b) t -> 'c
 
-  val cmp : ('b -> 'b -> int) -> Obj.t -> Obj.t -> int
+  val eq : ('b -> 'b -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool
 
-  val key_cmp : Obj.t -> 'a -> 'a -> int
+  val cmp : ('b -> 'b -> int) -> ('a, 'b) t -> ('a, 'b) t -> int
+
+  val key_cmp : ('a, 'b) t -> 'a -> 'a -> int
 end

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -396,6 +396,8 @@ module Mmap : sig
 
   val size : ('a, 'b) t -> int
 
+  val is_empty : ('a, 'b) t -> bool
+
   val mem : 'a -> ('a, 'b) t -> bool
 
   val any : ('a -> 'b -> bool) -> ('a, 'b) t -> bool

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -301,6 +301,8 @@ let arity = function
       1
   | CmapSize ->
       1
+  | CmapIsEmpty ->
+      1
   | CmapGetCmpFun ->
       1
   | CmapInsert (None, None) ->
@@ -1014,6 +1016,10 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
   | CmapSize, TmConst (_, CMap (_, m)) ->
       TmConst (fi, CInt (Mmap.size m))
   | CmapSize, _ ->
+      fail_constapp fi
+  | CmapIsEmpty, TmConst (_, CMap (_, m)) ->
+      TmConst (fi, CBool (Mmap.is_empty m))
+  | CmapIsEmpty, _ ->
       fail_constapp fi
   | CmapGetCmpFun, TmConst (_, CMap (cmp, _)) ->
       cmp

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -454,6 +454,8 @@ let rec print_const fmt = function
       fprintf fmt "mapEmpty"
   | CmapSize ->
       fprintf fmt "mapSize"
+  | CmapIsEmpty ->
+      fprintf fmt "mapIsEmpty"
   | CmapGetCmpFun ->
       fprintf fmt "mapGetCmpFun"
   | CmapInsert _ ->

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -17,8 +17,6 @@ let mapLookupApplyOrElse : (v1 -> v2) -> (Unit -> v2) -> k -> Map k v1 -> v2 =
   lam f1. lam f2. lam k. lam m.
   mapFindApplyOrElse f1 f2 k m
 
-let mapIsEmpty : Map k v -> Bool = lam m. eqi (mapSize m) 0
-
 let mapLookup : k -> Map k v -> Option v =
   lam k. lam m.
     mapFindApplyOrElse (lam v. Some v) (lam. None ()) k m
@@ -69,7 +67,6 @@ let m = mapEmpty subi in
 utest mapLookupOrElse (lam. 2) 1 m with 2 in
 utest mapLookupApplyOrElse (lam. 2) (lam. 3) 1 m with 3 in
 utest mapLength m with 0 in
-utest mapIsEmpty m with true in
 
 utest mapLookup 1 m with None () using optionEq eqString in
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -1118,6 +1118,10 @@ let mapSize_ = use MExprAst in
   lam m.
   appf1_ (uconst_ (CMapSize ())) m
 
+let mapIsEmpty_ = use MExprAst in
+  lam m.
+  appf1_ (uconst_ (CMapIsEmpty ())) m
+
 let mapMem_ = use MExprAst in
   lam k. lam m.
   appf2_ (uconst_ (CMapMem ())) k m

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -754,6 +754,7 @@ lang MapAst = ConstAst
   | CMapFindApplyOrElse {}
   | CMapBindings {}
   | CMapSize {}
+  | CMapIsEmpty {}
   | CMapMem {}
   | CMapAny {}
   | CMapMap {}

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -98,6 +98,7 @@ let builtin = use MExprAst in
   -- Maps
   , ("mapEmpty", CMapEmpty ())
   , ("mapSize", CMapSize ())
+  , ("mapIsEmpty", CMapIsEmpty ())
   , ("mapGetCmpFun", CMapGetCmpFun ())
   , ("mapInsert", CMapInsert ())
   , ("mapRemove", CMapRemove ())

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -421,6 +421,7 @@ lang MapCmp = Cmp + MapAst
   | (CMapFindApplyOrElse _, CMapFindApplyOrElse _) -> 0
   | (CMapBindings _, CMapBindings _) -> 0
   | (CMapSize _, CMapSize _) -> 0
+  | (CMapIsEmpty _, CMapIsEmpty _) -> 0
   | (CMapMem _, CMapMem _) -> 0
   | (CMapAny _, CMapAny _) -> 0
   | (CMapMap _, CMapMap _) -> 0
@@ -894,6 +895,7 @@ utest cmpConst (CMapFindOrElse {}) (CMapFindOrElse {}) with 0 in
 utest cmpConst (CMapFindApplyOrElse {}) (CMapFindApplyOrElse {}) with 0 in
 utest cmpConst (CMapBindings {}) (CMapBindings {}) with 0 in
 utest cmpConst (CMapSize {}) (CMapSize {}) with 0 in
+utest cmpConst (CMapIsEmpty {}) (CMapIsEmpty {}) with 0 in
 utest cmpConst (CMapMem {}) (CMapMem {}) with 0 in
 utest cmpConst (CMapAny {}) (CMapAny {}) with 0 in
 utest cmpConst (CMapMap {}) (CMapMap {}) with 0 in

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -212,6 +212,7 @@ lang MapTypeAst = MapAst
   | CMapBindings _ -> tyarrow_ tymap_
                                (tyseq_ (tytuple_ [tygeneric_ "a", tygeneric_ "b"]))
   | CMapSize _ -> tyarrow_ tymap_ tyint_
+  | CMapIsEmpty _ -> tyarrow_ tymap_ tybool_
   | CMapMem _ -> tyarrows_ [tygeneric_ "a", tymap_, tybool_]
   | CMapAny _ -> tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tybool_],
                             tymap_, tybool_]

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1101,6 +1101,11 @@ lang MapEval =
       TmConst {val = CInt {val = mapSize m}, ty = TyInt {info = NoInfo ()},
                info = NoInfo ()}
     else error "Argument of mapSize not a map"
+  | CMapIsEmpty _ ->
+    match arg with TmConst {val = CMapVal {val = m}} then
+      TmConst {val = CBool {val = mapIsEmpty m}, ty = TyInt {info = NoInfo ()},
+               info = NoInfo ()}
+    else error "Argument of mapIsEmpty not a map"
   | CMapMem _ ->
     TmConst {val = CMapMem2 arg, ty = TyUnknown {info = NoInfo ()},
              info = NoInfo ()}
@@ -2494,7 +2499,9 @@ utest eval (mapFindApplyOrElse_ applyf elsef (int_ 0) m1) with int_ 2 using eqEx
 utest eval (mapFindApplyOrElse_ applyf elsef (int_ 0) m2) with int_ 4 using eqExpr in
 
 utest eval (mapSize_ m1) with int_ 0 using eqExpr in
+utest eval (mapIsEmpty_ m1) with true_ using eqExpr in
 utest eval (mapSize_ m2) with int_ 1 using eqExpr in
+utest eval (mapIsEmpty_ m2) with false_ using eqExpr in
 utest eval (mapSize_ m3) with int_ 2 using eqExpr in
 utest eval (mapSize_ m4) with int_ 1 using eqExpr in
 utest eval (mapSize_ m5) with int_ 2 using eqExpr in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -778,6 +778,7 @@ lang MapPrettyPrint = MapAst + ConstPrettyPrint
   | CMapFindApplyOrElse _ -> "mapFindApplyOrElse"
   | CMapBindings _ -> "mapBindings"
   | CMapSize _ -> "mapSize"
+  | CMapIsEmpty _ -> "mapIsEmpty"
   | CMapMem _ -> "mapMem"
   | CMapAny _ -> "mapAny"
   | CMapMap _ -> "mapMap"

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -1676,6 +1676,21 @@ let mapSizeEmptyTest = bindall_
 utest ocamlEvalInt (generateEmptyEnv mapSizeEmptyTest)
 with int_ 0 using eqExpr in
 
+let mapIsEmptyEmptyTest = bindall_
+  [ ulet_ "m" (mapEmpty_ (uconst_ (CSubi ())))
+  , mapIsEmpty_ (var_ "m")
+  ] in
+utest ocamlEvalBool (generateEmptyEnv mapIsEmptyEmptyTest)
+with true_ using eqExpr in
+
+let mapIsEmptyNonEmptyTest = bindall_
+  [ ulet_ "m" (mapEmpty_ (uconst_ (CSubi ())))
+  , ulet_ "m" (mapInsert_ (int_ 42) (int_ 1) (var_ "m"))
+  , mapIsEmpty_ (var_ "m")
+  ] in
+utest ocamlEvalBool (generateEmptyEnv mapIsEmptyNonEmptyTest)
+with false_ using eqExpr in
+
 let mapSizeTest = bindall_
   [ ulet_ "m" (mapEmpty_ (uconst_ (CSubi ())))
   , ulet_ "m" (mapInsert_ (int_ 42) (int_ 1) (var_ "m"))

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -260,6 +260,7 @@ lang OCamlPrettyPrint =
   | CMapFindApplyOrElse _ -> intrinsicOpMap "find_apply_or_else"
   | CMapBindings _ -> intrinsicOpMap "bindings"
   | CMapSize _ -> intrinsicOpMap "size"
+  | CMapIsEmpty _ -> intrinsicOpMap "is_empty"
   | CMapMem _ -> intrinsicOpMap "mem"
   | CMapAny _ -> intrinsicOpMap "any"
   | CMapMap _ -> intrinsicOpMap "map"

--- a/test/mexpr/map.mc
+++ b/test/mexpr/map.mc
@@ -13,6 +13,7 @@ let m = mapEmpty subi in
 utest (mapGetCmpFun m) 2 1 with 1 in
 
 utest mapSize m with 0 in
+utest mapIsEmpty m with true in
 
 let m = mapInsert 1 '1' m in
 let m = mapInsert 2 '2' m in
@@ -21,6 +22,7 @@ let m = mapInsert 4 '4' m in
 let m = mapInsert 4 '5' m in
 
 utest mapSize m with 4 in
+utest mapIsEmpty m with false in
 
 utest mapFindWithExn 1 m with '1' in
 utest mapFindWithExn 2 m with '2' in


### PR DESCRIPTION
This PR re-implements the map intrinsics in a typesafe way (without `Obj`). It was done with help from @elegios.

Some preliminary benchmarks (run on my laptop while I didn't touch it).
*Before change:*
```
Bootstrapping the Miking compiler (1st round, might take a few minutes)

real	1m4.069s
user	1m2.929s
sys	0m0.887s
Bootstrapping the Miking compiler (2nd round, might take some more time)

real	0m12.359s
user	0m11.520s
sys	0m0.620s

$ for i in {1..20}; do time mi compile src/main/mi.mc; done                       lingmar@lingmar-mbp
mi compile src/main/mi.mc  11.54s user 0.61s system 99% cpu 12.248 total
mi compile src/main/mi.mc  11.53s user 0.63s system 99% cpu 12.171 total
mi compile src/main/mi.mc  11.51s user 0.61s system 99% cpu 12.149 total
mi compile src/main/mi.mc  11.51s user 0.61s system 99% cpu 12.156 total
mi compile src/main/mi.mc  11.51s user 0.62s system 99% cpu 12.155 total
mi compile src/main/mi.mc  11.60s user 0.62s system 99% cpu 12.255 total
mi compile src/main/mi.mc  11.53s user 0.62s system 99% cpu 12.218 total
mi compile src/main/mi.mc  11.55s user 0.62s system 99% cpu 12.198 total
mi compile src/main/mi.mc  11.57s user 0.62s system 99% cpu 12.210 total
mi compile src/main/mi.mc  11.52s user 0.62s system 99% cpu 12.173 total
mi compile src/main/mi.mc  11.54s user 0.63s system 99% cpu 12.193 total
mi compile src/main/mi.mc  11.55s user 0.62s system 99% cpu 12.222 total
mi compile src/main/mi.mc  11.49s user 0.62s system 99% cpu 12.150 total
mi compile src/main/mi.mc  11.55s user 0.62s system 99% cpu 12.196 total
mi compile src/main/mi.mc  11.51s user 0.62s system 99% cpu 12.156 total
mi compile src/main/mi.mc  11.61s user 0.62s system 99% cpu 12.247 total
mi compile src/main/mi.mc  11.51s user 0.62s system 99% cpu 12.154 total
mi compile src/main/mi.mc  11.52s user 0.62s system 99% cpu 12.166 total
mi compile src/main/mi.mc  11.57s user 0.63s system 99% cpu 12.235 total
mi compile src/main/mi.mc  11.51s user 0.61s system 99% cpu 12.145 total
```

*After change*
```
Bootstrapping the Miking compiler (1st round, might take a few minutes)


real	1m28.254s
user	1m26.571s
sys	0m1.105s
Bootstrapping the Miking compiler (2nd round, might take some more time)

real	0m12.991s
user	0m12.001s
sys	0m0.651s

for i in {1..20}; do time mi compile src/main/mi.mc; done                       lingmar@lingmar-mbp
mi compile src/main/mi.mc  11.90s user 0.63s system 99% cpu 12.643 total
mi compile src/main/mi.mc  11.90s user 0.64s system 99% cpu 12.583 total
mi compile src/main/mi.mc  11.89s user 0.64s system 99% cpu 12.578 total
mi compile src/main/mi.mc  11.90s user 0.64s system 99% cpu 12.572 total
mi compile src/main/mi.mc  11.93s user 0.64s system 99% cpu 12.608 total
mi compile src/main/mi.mc  11.89s user 0.64s system 99% cpu 12.574 total
mi compile src/main/mi.mc  11.85s user 0.63s system 99% cpu 12.514 total
mi compile src/main/mi.mc  11.78s user 0.63s system 99% cpu 12.450 total
mi compile src/main/mi.mc  11.87s user 0.63s system 99% cpu 12.529 total
mi compile src/main/mi.mc  11.86s user 0.64s system 99% cpu 12.522 total
mi compile src/main/mi.mc  11.89s user 0.65s system 99% cpu 12.572 total
mi compile src/main/mi.mc  11.86s user 0.64s system 99% cpu 12.530 total
mi compile src/main/mi.mc  12.13s user 0.68s system 98% cpu 12.947 total
mi compile src/main/mi.mc  11.85s user 0.64s system 99% cpu 12.531 total
mi compile src/main/mi.mc  11.88s user 0.65s system 99% cpu 12.547 total
mi compile src/main/mi.mc  11.82s user 0.64s system 99% cpu 12.489 total
mi compile src/main/mi.mc  11.87s user 0.64s system 99% cpu 12.534 total
mi compile src/main/mi.mc  11.85s user 0.64s system 99% cpu 12.510 total
mi compile src/main/mi.mc  11.92s user 0.64s system 99% cpu 12.584 total
mi compile src/main/mi.mc  11.88s user 0.63s system 99% cpu 12.540 total
```

So it seems the changes make things a bit slower, we might want to investigate why before merging.