### PR TITLE
AD based IPOPT interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@
   test-boot-py\
   test-boot-ocaml\
   test-sundials\
+	test-ipopt\
   test-par
 
 all: build
@@ -97,6 +98,9 @@ test-boot-ocaml: boot
 
 test-sundials: build
 	@$(MAKE) -s -f test-sundials.mk
+
+test-ipopt: build/mi
+	@$(MAKE) -s -f test-ipopt.mk all
 
 test-par: build
 	@$(MAKE) -s -f test-par.mk

--- a/README.md
+++ b/README.md
@@ -1241,7 +1241,6 @@ Please consult [stdlib/ext/ext-test.mc](stdlib/ext/ext-test.mc) and
 examples.
 
 ### Sundials
-
 A more involved example on the use of externals is an interface to the
 [Sundials](https://computing.llnl.gov/projects/sundials) numerical DAE solver.
 You find the implementation in
@@ -1291,6 +1290,39 @@ make test-sundials
 ```
 
 To install for the current user, run `make install` as usual.
+
+
+### Ipopt
+Another example use of externals is an interface to the constrained Non-Linear
+Program solver [Ipopt](https://coin-or.github.io/Ipopt/). This interface is
+defined in [stdlib/ipopt/ipopt.mc](stdlib/ipopt/ipopt.mc) and
+[stdlib/ipopt/ipopt.ext-ocaml.mc](stdlib/ipopt/ipopt.ext-ocaml.mc). This library
+depends on both the OCaml library [ipoptml](https://github.com/br4sco/ipoptml)
+and the ipopt c library.
+
+To use this library you need to do the following:
+
+Install the ipopt c library, which you can do on ubuntu 20.04 with
+```
+sudo apt-get install coinor-libipopt-dev
+```
+
+Install dependencies for [ipoptml](https://github.com/br4sco/ipoptml),
+```
+opam install ctypes ctypes-foreign
+```
+
+Clone the [ipoptml](https://github.com/br4sco/ipoptml) repo and in its root run
+```
+dune build
+dune install
+```
+
+You can then test the solver in Miking with
+
+```
+make test-ipopt
+```
 
 ### Parallel Programming
 Miking offers a set of externals for shared-memory parallelism using

--- a/src/boot/lib/tensor.ml
+++ b/src/boot/lib/tensor.ml
@@ -260,10 +260,11 @@ module Uop (T : TENSOR) : UOP with type ('a, 'b) t = ('a, 'b) T.t = struct
         done ;
         us "[" ^. !elems ^. us "]" )
       else
+        let n = (T.shape t).(0) in
         let newindent = indent ^. us "\t" in
         let elems = ref (us "") in
-        for i = 0 to rank - 1 do
-          let e = if i < rank - 1 then us ",\n" ^. newindent else us "" in
+        for i = 0 to n - 1 do
+          let e = if i < n - 1 then us ",\n" ^. newindent else us "" in
           elems := !elems ^. recur newindent (T.slice_exn t [|i|]) ^. e
         done ;
         us "\n[\n" ^. newindent ^. !elems ^. us "\n" ^. indent ^. us "]\n"

--- a/stdlib/ad/dualnum-lift.mc
+++ b/stdlib/ad/dualnum-lift.mc
@@ -14,6 +14,7 @@ include "dualnum-helpers.mc"
 include "bool.mc"
 include "math.mc"
 include "tensor.mc"
+include "common.mc"
 
 -------------
 -- ALIASES --
@@ -102,10 +103,10 @@ utest muln dnum012 dnum134 with dnum1 dnum036 dnum048 using dualnumEq eqf
 
 
 ----------------------------
--- DEEP PRIAMAL OPERATOR  --
+-- DEEP PRIMAL OPERATOR  --
 ----------------------------
 
--- Real part of arbritrary nested dual number p.
+-- Real part of arbitrary nested dual number p.
 recursive
 let dualnumPrimalDeep : DualNum -> DualNum =
 lam p.
@@ -137,7 +138,7 @@ lam cmp.
 let _liftBool = dualnumLiftBoolFun2
 
 
--- Real part of arbritrary nested dual number p as string.
+-- Real part of arbitrary nested dual number p as string.
 let dualnum2string : DualNum -> String =
 lam p. float2string (_unpack (dualnumPrimalDeep p))
 
@@ -197,7 +198,7 @@ utest nder 0 (lam x. muln x x) (num2) with num4
 utest nder 1 (lam x. muln x x) (num4) with num8
 utest nder 2 (lam x. muln x x) (num4) with num2
 
--- Inplace computation of the i'th component of df_j/dx_i.
+-- Inplace computation of the i'th component of the Jacobian df_j/dx_i.
 let jaci
   : (Tensor[DualNum] -> Tensor[DualNum] -> ())
   -> Int
@@ -233,10 +234,37 @@ utest
   jacT f x m;
   map _unpack (tensorToSeqExn (tensorReshapeExn m [4]))
 with
-[1., 24.
-,2., 12.]
+[
+  1., 24.,
+  2., 12.
+]
 
--- Inplace computation of gradient df/dx_i if `f` at `x` stored in `g`.
+utest
+  let f = lam x. lam r.
+    let x0 = tensorGetExn x [0] in
+    let x1 = tensorGetExn x [1] in
+    let x2 = tensorGetExn x [2] in
+    let x3 = tensorGetExn x [3] in
+    tensorSetExn r [0] (muln x0 (muln x1 (muln x2 x3)));
+    tensorSetExn r [1] (addn (muln x0 x0) (addn (muln x1 x1)
+                                          (addn (muln x2 x2) (muln x3 x3))));
+    ()
+  in
+  let x =
+    tensorOfSeqExn tensorCreateDense [4] [_num 1., _num 5., num 5., num 1.]
+  in
+  let m = tensorCreateDense [4, 2] (lam. _num 0.) in
+  jacT f x m;
+  map _unpack (tensorToSeqExn (tensorReshapeExn m [8]))
+with
+[
+  25., 2.,
+  5., 10.,
+  5., 10.,
+  25., 2.
+]
+
+-- Inplace computation of gradient df/dx_i of `f` at `x` stored in `g`.
 let grad
   : (Tensor[DualNum] -> DualNum)
   -> Tensor[DualNum]
@@ -263,6 +291,51 @@ utest
   map _unpack (tensorToSeqExn g)
 with [3., 2.]
 
+-- Computes the ij'th component of the Hessian d2f/(dx_i)(dx_j) of `f` at `x`,
+-- where `idxi` and `idxj` are tensor indices.
+let hessij
+  : (Tensor[DualNum] -> DualNum)
+  -> [Int]
+  -> [Int]
+  -> Tensor[DualNum]
+  -> DualNum =
+lam f. lam idxi. lam idxj. lam x.
+  let ei = genEpsilon () in
+  let ej = genEpsilon () in
+  let xi = tensorGetExn x idxi in
+  tensorSetExn x idxi (_dnum ei xi (_num 1.));
+  let xj = tensorGetExn x idxj in
+  tensorSetExn x idxj (_dnum ej xj (_num 1.));
+  let hij = _pertubation ei (_pertubation ej (f x)) in
+  tensorSetExn x idxj xj;
+  tensorSetExn x idxi xi;
+  hij
+
+-- Inplace computation of Hessian d2f/(dx_i)(dx_j) of `f` at `x` stored in `h`.
+let hess
+  : (Tensor[DualNum] -> DualNum)
+  -> Tensor[DualNum]
+  -> Tensor[DualNum]
+  -> () =
+lam f. lam x. lam h.
+  tensorIterSlice (lam i. lam hi. tensorMapiInplace (lam j. lam. hessij f [i] j x) hi) h
+
+utest
+  let f = lam x.
+    let x1 = tensorGetExn x [0] in
+    let x2 = tensorGetExn x [1] in
+    muln (muln x1 x1) (muln x2 x2)
+  in
+  let x = tensorOfSeqExn tensorCreateDense [2] [_num 2., _num 3.] in
+  let h = tensorCreateDense [2, 2] (lam. _num 0.) in
+  hess f x h;
+  map _unpack (tensorToSeqExn (tensorReshapeExn h [4]))
+with
+[
+  18., 24.,
+  24., 8.
+]
+
 ----------------
 -- CONSTANTS  --
 ----------------
@@ -271,7 +344,7 @@ let epsn = _num 1.e-15
 
 
 -----------------------
--- BOLEAN OPERATORS  --
+-- BOOLEAN OPERATORS  --
 -----------------------
 
 let eqn = _liftBool eqf -- lifted ==
@@ -344,7 +417,7 @@ using dualnumEq eqf
 
 utest der negn num1 with negn num1 using dualnumEq eqf
 
--- lifted substraction
+-- lifted subtraction
 let subn = lam p1. lam p2.
   _lift2
     (_float2num2 subf)
@@ -367,7 +440,7 @@ with dnum0 num1 (_num (negf 1.)) using dualnumEq eqf
 let absn = lam p. if ltn p num0 then negn p else p
 
 
--- lifted approximate comapre function
+-- lifted approximate compare function
 let eqnEps = lam l. lam r.
   ltn (absn (subn l r)) epsn
 

--- a/stdlib/ipopt/ipopt-ad.mc
+++ b/stdlib/ipopt/ipopt-ad.mc
@@ -1,0 +1,190 @@
+include "ad/dualnum.mc"
+include "ipopt.mc"
+
+-- for brevity
+let num = dualnumNum
+let unpack = compose dualnumPrimalDeep dualnumUnpackNum
+let tset = tensorSetExn
+let tget = tensorGetExn
+let tcreate = tensorCreateCArrayFloat
+
+type Vector = Tensor[Dualnum]
+
+type IpoptAdCreateNLPArg = {
+  -- Objective function f(x).
+  f : Vector -> Dualnum,
+
+  -- Constraint functions g_i(x).
+  gs : [Vector -> Dualnum],
+
+  -- Lower bounds on the variables xL_k.
+  lb : [Float],
+
+  -- Upper bounds on the variables xU_k.
+  ub : [Float],
+
+  -- Lower bounds on the constraints gL_i.
+  constraintsLb : [Float],
+
+  -- Upper bounds on the constraints gU_i.
+  constraintsUb : [Float]
+}
+
+-- Creates a constrained NLP:
+-- min_x[f(x)] s.t. xL_k ≤ x_k ≤ xU_k and gL_i ≤ g_i(x) ≤ gU_i.
+-- This functions wraps `ipoptCreateNLP` and calculates Jacobians and the
+-- Hessian using Automatic Differentation.
+let ipoptAdCreateNLP : IpoptAdCreateNLPArg -> IpoptNLP
+= lam arg.
+  let nx = length arg.lb in
+  let ng = length arg.constraintsLb in
+  if and (eqi (length arg.ub) nx) (eqi (length arg.constraintsUb) ng)
+  then
+  if eqi (length arg.gs) ng then
+      -- Pre-allocate some memory.
+      let xd = tensorCreate [nx] (lam. num 0.) in
+      let gradFd = tensorCreate [nx] (lam. num 0.) in
+      let jacGd = tensorCreate [nx, ng] (lam. num 0.) in
+      -- Computes f(x)
+      let evalF = lam x.
+        tensorMapExn num x xd;
+        unpack (arg.f xd)
+      in
+      -- Computes g(x)
+      let evalG = lam x. lam r.
+        tensorMapExn num x xd;
+        iteri (lam i. lam g. tset r [i] (unpack (g xd))) arg.gs;
+        ()
+      in
+      -- We use this function to compute the Jacobian.
+      let evalGd = lam x. lam r.
+        iteri (lam i. lam g. tset r [i] (g x)) arg.gs
+      in
+      -- Computes 𝛁f(x)
+      let evalGradF = lam x. lam gradF.
+        tensorMapExn num x xd;
+        grad arg.f xd gradFd;
+        tensorMapExn unpack gradFd gradF;
+        ()
+      in
+      -- jacT gives us the transpose of the Jacobian.
+      let jacGStructure = join (create nx (lam i. create ng (lam j. (j, i)))) in
+      let nJacG = muli ng nx in
+      -- Computes 𝛁g(x)
+      let evalJacG = lam x. lam jacG.
+        tensorMapExn num x xd;
+        jacT evalGd xd jacGd;
+        tensorMapExn unpack (tensorReshapeExn jacGd [nJacG]) jacG;
+        ()
+      in
+      -- The Hessian of the Lagrangian is symmetric so we only need the lower
+      -- triangular part.
+      let hStructure =
+        join
+          (create
+            nx
+            (lam i.
+              unfoldr
+                (lam j. if gti j i then None () else Some ((i, j), succ j))
+                0))
+      in
+      -- Computes σ𝛁^2f(x_k) + Σ_i[λ_i𝛁^2g_i(x_k)]
+      let evalH = lam sigma. lam x. lam lambda. lam h.
+        tensorMapExn num x xd;
+        iteri
+          (lam k : Int. lam ij : (Int, Int).
+            match ij with (i, j) then
+              tset h [k] (mulf sigma (unpack (hessij arg.f [i] [j] xd)));
+              iteri
+                (lam l. lam g.
+                  let hk = tget h [k] in
+                  let ll = tget lambda [l] in
+                  let gij = unpack (hessij g [i] [j] xd) in
+                  tset h [k] (addf hk (mulf ll gij)))
+                arg.gs
+            else never)
+          hStructure;
+        ()
+      in
+      let lb = tensorOfSeqExn tcreate [nx] arg.lb in
+      let ub = tensorOfSeqExn tcreate [nx] arg.ub in
+      let constraintsLb = tensorOfSeqExn tcreate [ng] arg.constraintsLb in
+      let constraintsUb = tensorOfSeqExn tcreate [ng] arg.constraintsUb in
+      ipoptCreateNLP {
+        evalF = evalF,
+        evalGradF = evalGradF,
+        evalG = evalG,
+        jacGStructure = jacGStructure,
+        evalJacG = evalJacG,
+        hStructure = hStructure,
+        evalH = evalH,
+        lb = lb,
+        ub = ub,
+        constraintsLb = constraintsLb,
+        constraintsUb = constraintsUb
+      }
+    else error "ipoptAdCreateNLP: Shape mismatch between constraints"
+  else error "ipoptAdCreateNLP: Shape mismatch between lower and upper bounds"
+
+mexpr
+
+-- Example problem from https://coin-or.github.io/Ipopt/
+-- min_x f(x), where f(x) = x[0]x[3](x[0] + x[1] + x[2]) + x[2],
+-- s.t.
+--  x[0]x[1]x[2]x[3] ≥ 25,
+--  x[0]^2 + x[1]^2 + x[2]^2 + x[3]^2 = 40,
+--  1 ≤ x[0], x[1], x[2], x[3] ≤ 5.
+
+let f = lam x.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  addn (muln x0 (muln x3 (addn x0 (addn x1 x2)))) x2
+in
+
+let g0 = lam x.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  muln x0 (muln x1 (muln x2 x3))
+in
+
+let g1 = lam x.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  addn (muln x0 x0) (addn (muln x1 x1)
+                    (addn (muln x2 x2) (muln x3 x3)))
+in
+
+let gs = [g0, g1] in
+
+let lb = [1., 1., 1., 1.] in
+let ub = [5., 5., 5., 5.] in
+let constraintsLb = [25., 40.] in
+let constraintsUb = [inf, 40.] in
+
+let p = ipoptAdCreateNLP {
+  f = f,
+  gs = gs,
+  lb = lb,
+  ub = ub,
+  constraintsLb = constraintsLb,
+  constraintsUb = constraintsUb
+} in
+
+ipoptAddNumOption p "tol" 3.82e-6;
+ipoptAddStrOption p "mu_strategy" "adaptive";
+
+let x = tensorOfSeqExn tcreate [4] [1., 5., 5., 1.] in
+
+utest
+  match ipoptSolve p x with (SolveSucceeded _, _) then true
+  else false
+with true
+in
+
+()

--- a/stdlib/ipopt/ipopt.ext-ocaml.mc
+++ b/stdlib/ipopt/ipopt.ext-ocaml.mc
@@ -1,0 +1,78 @@
+include "map.mc"
+include "ocaml/ast.mc"
+
+let impl = lam arg : { ident : String, ty : Type }.
+  {
+    ident = arg.ident,
+    ty = arg.ty,
+    libraries = ["ipoptml"],
+    cLibraries = ["ipopt"]
+  }
+
+let tyvec = otybaarrayclayoutfloat_ 1
+let tyevalf = tyarrow_ tyvec tyfloat_
+let tyevalgradf = tyarrows_ [tyvec, tyvec, otyunit_]
+let tyevalg = tyarrows_ [tyvec, tyvec, otyunit_]
+let tystructure = otyarray_ (otytuple_ [tyint_, tyint_])
+let tyevaljacg = tyarrows_ [tyvec, tyvec, otyunit_]
+let tyevalh = tyarrows_ [
+  otylabel_ "sigma" tyfloat_,
+  otylabel_ "x" tyvec,
+  otylabel_ "lambda" tyvec,
+  otylabel_ "h" tyvec,
+  otyunit_
+]
+
+let ipoptExtMap =
+  mapFromSeq cmpString
+  [
+    ("externalIpoptApplicationReturnStatusRetcode", [
+      impl {
+        ident = "Ipoptml.application_return_status_retcode",
+        ty = tyarrow_ otyopaque_ tyint_
+      }
+    ]),
+    ("externalIpoptCreateNLP", [
+      impl {
+        ident = "Ipoptml.create_nlp",
+        ty = tyarrows_ [
+          otylabel_ "eval_f" tyevalf,
+          otylabel_ "eval_grad_f" tyevalgradf,
+          otylabel_ "eval_g" tyevalg,
+          otylabel_ "jac_g_structure" tystructure,
+          otylabel_ "eval_jac_g" tyevaljacg,
+          otylabel_ "h_structure" tystructure,
+          otylabel_ "eval_h" tyevalh,
+          otylabel_ "lb" tyvec,
+          otylabel_ "ub" tyvec,
+          otylabel_ "constraints_lb" tyvec,
+          otylabel_ "constraints_ub" tyvec,
+          otyopaque_
+        ]
+      }
+    ]),
+    ("externalIpoptAddStrOption", [
+      impl {
+        ident = "Ipoptml.add_str_option",
+        ty = tyarrows_ [otyopaque_, otystring_, otystring_, otyunit_]
+      }
+    ]),
+    ("externalIpoptAddNumOption", [
+      impl {
+        ident = "Ipoptml.add_num_option",
+        ty = tyarrows_ [otyopaque_, otystring_, tyfloat_, otyunit_]
+      }
+    ]),
+    ("externalIpoptAddIntOption", [
+      impl {
+        ident = "Ipoptml.add_int_option",
+        ty = tyarrows_ [otyopaque_, otystring_, tyint_, otyunit_]
+      }
+    ]),
+    ("externalIpoptSolve", [
+      impl {
+        ident = "Ipoptml.solve",
+        ty = tyarrows_ [otyopaque_, tyvec, otyopaque_]
+      }
+    ])
+  ]

--- a/stdlib/ipopt/ipopt.mc
+++ b/stdlib/ipopt/ipopt.mc
@@ -5,6 +5,7 @@
 
 include "math.mc"
 include "tensor.mc"
+include "common.mc"
 
 type IpoptNLP                     -- Constrained Non-Linear Program
 type IpoptApplicationReturnStatus -- Internal representation of return status
@@ -53,7 +54,7 @@ type IpoptEvalJacG = Vector -> Vector -> ()
 -- - `x`, the values of the variables,
 -- - `lambda`, the values of the constraint multiplier λ,
 -- - `h`, a vector for storing the non-zero values of the Hessian, where `h`
---        assumes some pre-defined structure. This matrix is symmetric and
+--        assumes some pre-defined structure. This Hessian is symmetric and
 --        only the lower diagonal entries must be specified.
 type IpoptEvalH = Float -> Vector -> Vector -> Vector -> ()
 
@@ -205,7 +206,7 @@ external externalIpoptSolve !
 --        calling `solve`.
 -- Returns: The tuple tuple `(rs, f)`, where `rs` is the return status and `f`
 --          is the final value of the objective function.
-let ipoptSolve : IpoptNLP -> Vector  -> (IpoptReturnStatus, Float)
+let ipoptSolve : IpoptNLP -> Vector -> (IpoptReturnStatus, Float)
 = lam p. lam x.
   match externalIpoptSolve p x with (r, f) then
     (_rctoreturnstatus (externalIpoptApplicationReturnStatusRetcode r), f)

--- a/stdlib/ipopt/ipopt.mc
+++ b/stdlib/ipopt/ipopt.mc
@@ -1,0 +1,358 @@
+/-
+  Miking interface to the IPOPT constrained Non-Linear Program (NLP) solver.
+  @see <https://coin-or.github.io/Ipopt/index.html> for the IPOPT documentation.
+-/
+
+include "math.mc"
+include "tensor.mc"
+
+type IpoptNLP                     -- Constrained Non-Linear Program
+type IpoptApplicationReturnStatus -- Internal representation of return status
+
+type Vector = Tensor[Float]
+
+-- Callback function to evaluate the objective function f(x). The function
+-- argument `x` is the values of the variables.
+type IpoptEvalF = Vector -> Float
+
+-- Callback function to evaluate the gradient 𝛁f(x) of the objective
+-- function. The function arguments are:
+--   - `x`, the values of the variables,
+--   - `grad_f`, a vector for storing the values of 𝛁f(x), in the same order
+--               as `x`. I.e. `grad_f[i]` should hold the value of the gradient
+--               of f(x) with respect to `x[i]`.
+type IpoptEvalGradF = Vector -> Vector -> ()
+
+-- Callback function to evaluate the constraints g(x). The function arguments
+-- are:
+--   - `x`, the values of the variables,
+--   - `g`, a vector for storing the value of g(x).
+type IpoptEvalG = Vector -> Vector -> ()
+
+-- Encodes the structure of a sparse matrix. The tuple `(i, j)` in position `k`
+-- associates the matrix element `m[i, j]` with the sequence element `a[k]`. If
+-- `(i, j)` appears multiple times in the structure sequence, `m[i, j]` is
+-- associated with the sum of these elements in `a`. Matrix elements missing
+-- from the structure sequence are assumed to be zero.
+-- @see <https://coin-or.github.io/Ipopt/IMPL.html#TRIPLET> for documentation on
+-- the triplet format.
+type IpoptStructure = [(Int, Int)]
+
+-- Callback function to evaluate the Jacobian 𝛁g(x)^T of the constraints. The
+-- function arguments are:
+-- - `x`, the values of the variables,
+-- - `jac_g`, a vector for storing the non-zero values of 𝛁g(x)^T, where
+--            `jac_g` assumes some pre-defined structure.
+type IpoptEvalJacG = Vector -> Vector -> ()
+
+
+-- Callback function to evaluate the Hessian
+-- σ𝛁^2f(x_k) + Σ_i[λ_i𝛁^2g_i(x_k)]
+-- of the Lagrangian. The function arguments are:
+-- - `sigma`, the factor σ in front of the objective term,
+-- - `x`, the values of the variables,
+-- - `lambda`, the values of the constraint multiplier λ,
+-- - `h`, a vector for storing the non-zero values of the Hessian, where `h`
+--        assumes some pre-defined structure. This matrix is symmetric and
+--        only the lower diagonal entries must be specified.
+type IpoptEvalH = Float -> Vector -> Vector -> Vector -> ()
+
+
+type IpoptReturnStatus
+con SolveSucceeded : () -> IpoptReturnStatus
+con SolvedToAcceptableLevel : () -> IpoptReturnStatus
+con InfeasibleProblemDetected : () -> IpoptReturnStatus
+con SearchDirectionBecomesTooSmall : () -> IpoptReturnStatus
+con DivergingIterates : () -> IpoptReturnStatus
+con UserRequestedStop : () -> IpoptReturnStatus
+con FeasiblePointFound : () -> IpoptReturnStatus
+con MaximumIterationsExceeded : () -> IpoptReturnStatus
+con RestorationFailed : () -> IpoptReturnStatus
+con ErrorInStepComputation : () -> IpoptReturnStatus
+con MaximumCpuTimeExceeded : () -> IpoptReturnStatus
+con NotEnoughDegreesOfFreedom : () -> IpoptReturnStatus
+con InvalidProblemDefinition : () -> IpoptReturnStatus
+con InvalidOption : () -> IpoptReturnStatus
+con InvalidNumberDetected : () -> IpoptReturnStatus
+con UnrecoverableException : () -> IpoptReturnStatus
+con NonIpoptExceptionThrown : () -> IpoptReturnStatus
+con InsufficientMemory : () -> IpoptReturnStatus
+con InternalError : () -> IpoptReturnStatus
+
+
+external externalIpoptApplicationReturnStatusRetcode
+  : IpoptApplicationReturnStatus -> Int
+
+let _rctoreturnstatus = lam rc : Int.
+  if eqi rc 0 then SolveSucceeded ()
+  else if eqi rc 1 then SolvedToAcceptableLevel ()
+  else if eqi rc 2 then InfeasibleProblemDetected ()
+  else if eqi rc 3 then SearchDirectionBecomesTooSmall ()
+  else if eqi rc 4 then DivergingIterates ()
+  else if eqi rc 5 then UserRequestedStop ()
+  else if eqi rc 6 then FeasiblePointFound ()
+  else if eqi rc (negi 1) then MaximumIterationsExceeded ()
+  else if eqi rc (negi 2) then RestorationFailed ()
+  else if eqi rc (negi 3) then ErrorInStepComputation ()
+  else if eqi rc (negi 4) then MaximumCpuTimeExceeded ()
+  else if eqi rc (negi 10) then NotEnoughDegreesOfFreedom ()
+  else if eqi rc (negi 11) then InvalidProblemDefinition ()
+  else if eqi rc (negi 12) then InvalidOption ()
+  else if eqi rc (negi 13) then InvalidNumberDetected ()
+  else if eqi rc (negi 100) then UnrecoverableException ()
+  else if eqi rc (negi 101) then NonIpoptExceptionThrown ()
+  else if eqi rc (negi 102) then InsufficientMemory ()
+  else if eqi rc (negi 199) then InternalError ()
+  else error "Ipopt._rctoreturnstatus: Unknown return code"
+
+
+external externalIpoptCreateNLP
+  : IpoptEvalF ->
+    IpoptEvalGradF ->
+    IpoptEvalG ->
+    IpoptStructure ->
+    IpoptEvalJacG ->
+    IpoptStructure ->
+    IpoptEvalH ->
+    Vector ->
+    Vector ->
+    Vector ->
+    Vector ->
+    IpoptNLP
+
+type IpoptCreateNLPArg = {
+  -- Callback function to evaluate objective function.
+  evalF : IpoptEvalF,
+
+  -- Callback function to evaluate the gradient of the objective function.
+  evalGradF : IpoptEvalGradF,
+
+  -- Callback function to evaluate the constraint function.
+  evalG : IpoptEvalG,
+
+  -- Structure of the constraint Jacobian.
+  jacGStructure : IpoptStructure,
+
+  -- Callback function to evalute the Jacobian of the constraint function
+  evalJacG : IpoptEvalJacG,
+
+  -- Structure of the Hessian of the Lagrangian.
+  hStructure : IpoptStructure,
+
+  -- Callback function to evaluate the Hessian of the Lagrangian.
+  evalH : IpoptEvalH,
+
+  -- Lower bounds on the variables xL_k.
+  lb : Vector,
+
+  -- Upper bounds on the variables xU_k.
+  ub : Vector,
+
+  -- Lower bounds on the constraints gL_i.
+  constraintsLb : Vector,
+
+  -- Upper bounds on the constraints gU_i.
+  constraintsUb : Vector
+}
+
+-- Creates a constrained NLP:
+-- min_x[f(x)] s.t. xL_k ≤ x_k ≤ xU_k and gL_i ≤ g_i(x) ≤ gU_i.
+let ipoptCreateNLP : IpoptCreateNLPArg -> IpoptNLP = lam arg.
+  externalIpoptCreateNLP
+    arg.evalF
+    arg.evalGradF
+    arg.evalG
+    arg.jacGStructure
+    arg.evalJacG
+    arg.hStructure
+    arg.evalH
+    arg.lb
+    arg.ub
+    arg.constraintsLb
+    arg.constraintsUb
+
+
+external externalIpoptAddStrOption ! : IpoptNLP -> String -> String -> ()
+
+-- `ipoptAddStrOption p key val` sets the option `key` to the `String` value
+-- `val` in the NLP `p`. @see <https://coin-or.github.io/Ipopt/OPTIONS.html> for
+-- a summary of options.
+let ipoptAddStrOption : IpoptNLP -> String -> String -> ()
+= lam p. lam key. lam val. externalIpoptAddStrOption p key val
+
+
+external externalIpoptAddNumOption ! : IpoptNLP -> String -> Float -> ()
+
+-- As `ipoptAddStrOption`, but for `Float` values.
+let ipoptAddNumOption : IpoptNLP -> String -> Float -> ()
+= lam p. lam key. lam val. externalIpoptAddNumOption p key val
+
+
+external externalIpoptAddIntOption ! : IpoptNLP -> String -> Int -> ()
+
+-- As `ipoptAddStrOption`, but for `Int` values.
+let ipoptAddIntOption : IpoptNLP -> String -> Int -> ()
+= lam p. lam key. lam val. externalIpoptAddIntOption p key val
+
+
+external externalIpoptSolve !
+  : IpoptNLP -> Vector -> (IpoptApplicationReturnStatus, Float)
+
+-- `solve p x` tries to solve the constrained NLP `p` with initial values `x`.
+-- The function arguments are:
+-- - `p`, the constrained NLP,
+-- - `x`, Initial values of the variables. Will hold the optimal solution after
+--        calling `solve`.
+-- Returns: The tuple tuple `(rs, f)`, where `rs` is the return status and `f`
+--          is the final value of the objective function.
+let ipoptSolve : IpoptNLP -> Vector  -> (IpoptReturnStatus, Float)
+= lam p. lam x.
+  match externalIpoptSolve p x with (r, f) then
+    (_rctoreturnstatus (externalIpoptApplicationReturnStatusRetcode r), f)
+  else never
+
+mexpr
+
+let tget = tensorGetExn in
+let tset = tensorSetExn in
+let tcreate = tensorCreateCArrayFloat in
+
+-- Example problem from https://coin-or.github.io/Ipopt/
+-- min_x f(x), where f(x) = x[0]x[3](x[0] + x[1] + x[2]) + x[2],
+-- s.t.
+--  x[0]x[1]x[2]x[3] ≥ 25,
+--  x[0]^2 + x[1]^2 + x[2]^2 + x[3]^2 = 40,
+--  1 ≤ x[0], x[1], x[2], x[3] ≤ 5.
+
+let evalF = lam x.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  addf (mulf x0 (mulf x3 (addf x0 (addf x1 x2)))) x2
+in
+
+let evalGradF = lam x. lam gradF.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  tset gradF [0] (addf (mulf x0 x3) (mulf x3 (addf x0 (addf x1 x2))));
+  tset gradF [1] (mulf x0 x3);
+  tset gradF [2] (addf (mulf x0 x3) 1.);
+  tset gradF [3] (mulf x0 (addf x0 (addf x1 x2)));
+  ()
+in
+
+let evalG = lam x. lam g.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  tset g [0] (mulf x0 (mulf x1 (mulf x2 x3)));
+  tset g [1] (addf (mulf x0 x0) (addf (mulf x1 x1)
+                                      (addf (mulf x2 x2) (mulf x3 x3))));
+  ()
+in
+
+let jacGStructure =
+  [ (0, 0)
+  , (0, 1)
+  , (0, 2)
+  , (0, 3)
+  , (1, 0)
+  , (1, 1)
+  , (1, 2)
+  , (1, 3) ]
+in
+
+let evalJacG = lam x. lam jacG.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  tset jacG [0] (mulf x1 (mulf x2 x3));
+  tset jacG [1] (mulf x0 (mulf x2 x3));
+  tset jacG [2] (mulf x0 (mulf x1 x3));
+  tset jacG [3] (mulf x0 (mulf x1 x2));
+  tset jacG [4] (mulf 2. x0);
+  tset jacG [5] (mulf 2. x1);
+  tset jacG [6] (mulf 2. x2);
+  tset jacG [7] (mulf 2. x3);
+  ()
+in
+
+let hStructure =
+  [ (0, 0)
+  , (1, 0)
+  , (1, 1)
+  , (2, 0)
+  , (2, 1)
+  , (2, 2)
+  , (3, 0)
+  , (3, 1)
+  , (3, 2)
+  , (3, 3) ]
+in
+
+let evalH = lam sigma. lam x. lam lambda. lam h.
+  let x0 = tget x [0] in
+  let x1 = tget x [1] in
+  let x2 = tget x [2] in
+  let x3 = tget x [3] in
+  let l0 = tget lambda [0] in
+  let l1 = tget lambda [1] in
+  tset h [0] (mulf sigma (mulf 2. x3));
+  tset h [1] (mulf sigma x3);
+  tset h [2] 0.;
+  tset h [3] (mulf sigma x3);
+  tset h [4] 0.;
+  tset h [5] 0.;
+  tset h [6] (mulf sigma (addf (mulf 2. x0) (addf x1 x2)));
+  tset h [7] (mulf sigma x0);
+  tset h [8] (mulf sigma x0);
+  tset h [9] 0.;
+  tset h [1] (addf (tget h [1]) (mulf l0 (mulf x2 x3)));
+  tset h [3] (addf (tget h [3]) (mulf l0 (mulf x1 x3)));
+  tset h [4] (addf (tget h [4]) (mulf l0 (mulf x0 x3)));
+  tset h [6] (addf (tget h [6]) (mulf l0 (mulf x1 x2)));
+  tset h [7] (addf (tget h [7]) (mulf l0 (mulf x0 x2)));
+  tset h [8] (addf (tget h [8]) (mulf l0 (mulf x0 x1)));
+  tset h [0] (addf (tget h [0]) (mulf l1 2.));
+  tset h [2] (addf (tget h [2]) (mulf l1 2.));
+  tset h [5] (addf (tget h [5]) (mulf l1 2.));
+  tset h [9] (addf (tget h [9]) (mulf l1 2.));
+  ()
+in
+
+let lb = tensorOfSeqExn tcreate [4] [1., 1., 1., 1.] in
+let ub = tensorOfSeqExn tcreate [4] [5., 5., 5., 5.] in
+let constraintsLb = tensorOfSeqExn tcreate [2] [25., 40.] in
+let constraintsUb = tensorOfSeqExn tcreate [2] [inf, 40.] in
+
+let p = ipoptCreateNLP {
+  evalF = evalF,
+  evalGradF = evalGradF,
+  evalG = evalG,
+  jacGStructure = jacGStructure,
+  evalJacG = evalJacG,
+  hStructure = hStructure,
+  evalH = evalH,
+  lb = lb,
+  ub = ub,
+  constraintsLb = constraintsLb,
+  constraintsUb = constraintsUb
+} in
+
+ipoptAddNumOption p "tol" 3.82e-6;
+ipoptAddStrOption p "mu_strategy" "adaptive";
+
+let x = tensorOfSeqExn tcreate [4] [1., 5., 5., 1.] in
+
+utest
+  match ipoptSolve p x with (SolveSucceeded _, _) then true
+  else false
+with true
+in
+
+()

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -5,6 +5,7 @@ include "ext/dist-ext.ext-ocaml.mc"
 include "sundials/sundials.ext-ocaml.mc"
 include "multicore/atomic.ext-ocaml.mc"
 include "multicore/thread.ext-ocaml.mc"
+include "ipopt/ipopt.ext-ocaml.mc"
 
 type ExternalImpl = {
   ident : String,
@@ -24,5 +25,6 @@ let globalExternalImplsMap : Map String [ExternalImpl] =
       sundialsExtMap,
       atomicExtMap,
       threadExtMap,
-      distExtMap
+      distExtMap,
+      ipoptExtMap
     ]

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -358,7 +358,7 @@ with 9
 
 -- Left folds `f acc t` over the zero'th dimension of `t1`, where `acc` is the
 -- accumulator and `t` is the i'th slice of `t1`.
-let tensorFoldlSlice : (b -> Int -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
+let tensorFoldlSlice : (b -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
   lam f. tensorFoldliSlice (lam acc. lam. f acc)
 
 utest
@@ -383,7 +383,7 @@ with 6
 
 -- Folds `f idx acc el` over all elements `el` of `t` in row-major order, where
 -- `acc` is the accumulator and `idx` is the index of the element.
-let tensorFoldi : ([Int] -> a -> b) -> b -> Tensor[a] -> b =
+let tensorFoldi : (b -> [Int] -> a -> b) -> b -> Tensor[a] -> b =
   lam f. lam acc. lam t.
   let shape = tensorShape t in
   let t = tensorReshapeExn t [tensorSize t] in

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -708,6 +708,28 @@ utest
   tensorToSeqExn t
 with [1, 2, 3]
 
+
+---------------------------
+-- SHAPE AND RANK CHECKS --
+---------------------------
+
+let tensorHasRank : Tensor[a] -> Int -> Bool =
+  lam t. lam rank. eqi (tensorRank t) rank
+
+utest
+  let t = tensorOfSeqExn tensorCreateDense [2, 2] [1, 2, 3, 4] in
+  tensorHasRank t 2
+with true
+
+
+let tensorHasShape : Tensor[a] -> [Int] -> Bool =
+  lam t. lam shape. eqSeq eqi (tensorShape t) shape
+
+utest
+  let t = tensorOfSeqExn tensorCreateDense [4, 1] [1, 2, 3, 4] in
+  tensorHasShape t [4, 1]
+with true
+
 mexpr
 
 -- Tensors are mutable data structures and can be of up to rank 16. The index

--- a/test-ipopt.mk
+++ b/test-ipopt.mk
@@ -1,6 +1,7 @@
 
 compile_files =
 compile_files += stdlib/ipopt/ipopt.mc
+compile_files += stdlib/ipopt/ipopt-ad.mc
 
 all: ${compile_files}
 

--- a/test-ipopt.mk
+++ b/test-ipopt.mk
@@ -1,0 +1,8 @@
+
+compile_files =
+compile_files += stdlib/ipopt/ipopt.mc
+
+all: ${compile_files}
+
+${compile_files}::
+	-@./make compile-test $@ "build/mi compile --test --disable-optimizations"


### PR DESCRIPTION
This PR includes an interface to the constrained Non-Linear Program solver [IPOPT](https://coin-or.github.io/Ipopt/). It is implemented using externals via the OCaml bindings [ipoptml](https://github.com/br4sco/ipoptml). See the README for installation instructions. If the dependent libraries are installed, the interface can be tested with `make test-ipopt`. In addition, it includes:
- A Fix to a bug in `tensor2string`.
- A Fix to `tensorFoldi` and `tensorFoldlSlice` signatures.
- Utility functions for checking the shape and rank of tensors.
- Functions for computing the Hessian and gradient in `stdlib/ad/dualnum-lift.mc`. 
- A simplified interface to ipopt where Jacobians and the Hessian is computed using AD (in `stdlib/ipopt/ipopt-ad.mc`).

*Note: Since we compute the gradient of the objective function we would ideally want to have a reverse-mode AD implementation here in the future.*