### PR TITLE
Report error in compilation tests on non-zero exit code

### DIFF
--- a/make
+++ b/make
@@ -85,6 +85,7 @@ compile_test () {
         rm $binary
     else
         echo "ERROR: command ./$binary exited with $exit_code"
+        rm $binary
     fi
   else
       echo "ERROR: compilation of $1 exited with $exit_code"

--- a/make
+++ b/make
@@ -74,11 +74,20 @@ compile_test () {
   set +e
   output=$1
   output="$output\n$($2 $1 2>&1)"
-  if [ $? -eq 0 ]
+  exit_code=$?
+  if [ $exit_code -eq 0 ]
   then
     binary=$(basename "$1" .mc)
     output="$output$(./$binary)"
-    rm $binary
+    exit_code=$?
+    if [ $exit_code -eq 0 ]
+    then
+        rm $binary
+    else
+        echo "ERROR: command ./$binary exited with $exit_code"
+    fi
+  else
+      echo "ERROR: compilation of $1 exited with $exit_code"
   fi
   echo "$output\n"
   set -e


### PR DESCRIPTION
Before this PR, some errors such as segfaults were invisible when running the test suite. This PR makes the `make` script look at the exit code both of the compilation and of the running on the binary, and report in case they are non-zero.

Example (I introduced a bug in `atomic.mc`, the one in `thread.mc` is real but is fixed by #456)

Before this PR:
```
$ make test-par
Fatal error: exception Not_found
stdlib/multicore/atomic.mc
.....

stdlib/multicore/thread.mc
```

After this PR:
```
$ make test-par
Fatal error: exception Not_found
ERROR: command ./atomic exited with 2
stdlib/multicore/atomic.mc
.....

ERROR: compilation of stdlib/multicore/thread.mc exited with 139
stdlib/multicore/thread.mc
```
