### PR TITLE
Unbreak `mi tune`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ test-all:\
   test-compile\
   test-run\
   test-par\
-  test-boot
+  test-boot\
+	test-tune
 
 test-boot-compile: boot
 	@$(MAKE) -s -f test-boot-compile.mk

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@
   test-boot-py\
   test-boot-ocaml\
   test-sundials\
-  test-par
+  test-par\
+	test-tune
 
 all: build
 
@@ -106,3 +107,6 @@ test-sundials: build
 
 test-par: build
 	@$(MAKE) -s -f test-par.mk
+
+test-tune: build
+	@$(MAKE) -s -f test-tune.mk

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,6 @@ test-all:\
   test-boot
 	@./make lint
 
-
 test-boot-compile: boot
 	@$(MAKE) -s -f test-boot-compile.mk
 

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -67,7 +67,7 @@ let ocamlCompileAstWithUtests = lam options : Options. lam sourcePath. lam ast.
       -- Re-symbolize the MExpr AST and re-annotate it with types
       let ast = symbolizeExpr symEnv ast in
 
-      ocamlCompileAst options file ast
+      ocamlCompileAst options sourcePath ast
         { debugTypeAnnot = lam ast. if options.debugTypeAnnot then printLn (pprintMcore ast) else ()
         , debugGenerate = lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ()
         , exitBefore = lam. if options.exitBefore then exit 0 else ()

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -45,7 +45,7 @@ let collectlibraries : ExternalNameMap -> ([String], [String])
   with (libs, clibs) then (setToSeq libs, setToSeq clibs)
   else never
 
-let ocamlCompile : Options -> [String] -> [String] -> String -> String -> Unit =
+let ocamlCompile : Options -> [String] -> [String] -> String -> String -> String =
   lam options. lam libs. lam clibs. lam sourcePath. lam ocamlProg.
   let compileOptions : CompileOptions =
     let opts = {{
@@ -61,7 +61,8 @@ let ocamlCompile : Options -> [String] -> [String] -> String -> String -> Unit =
   let destinationFile = filenameWithoutExtension (filename sourcePath) in
   sysMoveFile p.binaryPath destinationFile;
   sysChmodWriteAccessFile destinationFile;
-  p.cleanup ()
+  p.cleanup ();
+  destinationFile
 
 let ocamlCompileAst =
   lam options : Options. lam sourcePath. lam ast. lam debugTypeAnnotHook.

--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -31,7 +31,7 @@ let tune = lam files. lam options : Options. lam args.
         tempFile = tempFile, cleanup = cleanup }
     then
       -- Compile the program
-      let binary = ocamlCompileAst options file ast in
+      let binary = ocamlCompileAstWithUtests options file ast in
 
       -- Runs the program with a given input
       let run = lam args : String.

--- a/test-par.mk
+++ b/test-par.mk
@@ -2,7 +2,7 @@
 compile_files += stdlib/multicore/atomic.mc
 compile_files += stdlib/multicore/thread.mc
 
-.PHONY: all $(compile-files)
+.PHONY: all $(compile_files)
 
 all: $(compile_files)
 

--- a/test-tune.mk
+++ b/test-tune.mk
@@ -1,0 +1,10 @@
+
+tune_files += test/examples/tuning/tune-sleep.mc
+tune_files += test/examples/tuning/tune-context.mc
+
+.PHONY: all $(tune_files)
+
+all: $(tune_files)
+
+$(tune_files):
+	-@./make compile-test $@ "build/mi tune --test --disable-optimizations"

--- a/test/examples/tuning/tune-context.mc
+++ b/test/examples/tuning/tune-context.mc
@@ -4,9 +4,6 @@ include "common.mc"
 let foo = lam n.
   let h1 = hole (Boolean {default = true, depth = 1}) in
   let h2 = hole (Boolean {default = true, depth = 1}) in
-  printLn (join ["Value of h1 ", if h1 then "true" else "false", "\n"]);
-  printLn (join ["Value of h2 ", if h2 then "true" else "false", "\n"]);
-  printLn (join ["Value of n ", int2string n, "\n"]);
   if eqi n 0 then
     sleepMs (if and h1 h2 then 1000 else
              if and h1 (not h2) then 500 else


### PR DESCRIPTION
This PR unbreaks `mi tune` by refactoring `compile.mc` slightly, so that `src/main/tune.mc` can reuse the code for compilation. It also adds some rudimentary tests of `mi tune` to the Makefile, as target`make test-tune`. These tests are added to `make test-all`.