### PR TITLE
Ocaml module export

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -74,9 +74,10 @@ let compile = lam files. lam options : Options. lam args.
       let ast = symbolizeExpr symEnv ast in
 
       ocamlCompileAst options file ast
-        (lam ast. if options.debugTypeAnnot then printLn (pprintMcore ast) else ())
-        (lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ())
-        (lam. if options.exitBefore then exit 0 else ())
+        { debugTypeAnnot = lam ast. if options.debugTypeAnnot then printLn (pprintMcore ast) else ()
+        , debugGenerate = lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ()
+        , exitBefore = lam. if options.exitBefore then exit 0 else ()
+        }
     else never
 
     -- Compile MExpr AST

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -75,15 +75,15 @@ let ocamlCompileAst =
 
   -- Translate the MExpr AST into an OCaml AST
   match typeLift ast with (env, ast) then
-    match generateTypeDecl env ast with (env, ast) then
+    match generateTypeDecls env with (env, typeTops) then
       let env : GenerateEnv =
         chooseExternalImpls globalExternalImplsMap env ast
       in
-      let ast = generate env ast in
+      let exprTops = generateTops env ast in
 
       -- Collect external library dependencies
       match collectlibraries env.exts with (libs, clibs) then
-        let ocamlProg = expr2str ast in
+        let ocamlProg = pprintOcamlTops (concat typeTops exprTops) in
 
         -- Print the AST after code generation
         debugGenerateHook ocamlProg;

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -63,15 +63,26 @@ let ocamlCompile : Options -> [String] -> [String] -> String -> String -> Unit =
   sysChmodWriteAccessFile destinationFile;
   p.cleanup ()
 
+type Hooks =
+  { debugTypeAnnot : Expr -> ()
+  , debugGenerate : String -> ()
+  , exitBefore : () -> ()
+  }
+
+let emptyHooks: Hooks =
+  { debugTypeAnnot = lam. ()
+  , debugGenerate = lam. ()
+  , exitBefore = lam. ()
+  }
+
 let ocamlCompileAst =
-  lam options : Options. lam sourcePath. lam ast. lam debugTypeAnnotHook.
-  lam debugGenerateHook. lam exitBeforeHook.
+  lam options : Options. lam sourcePath. lam ast. lam hooks: Hooks.
   use MCoreLiteCompile in
   let ast = typeAnnot ast in
   let ast = removeTypeAscription ast in
 
   -- If option --debug-type-annot, then pretty-print the AST
-  debugTypeAnnotHook ast;
+  hooks.debugTypeAnnot ast;
 
   -- Translate the MExpr AST into an OCaml AST
   match typeLift ast with (env, ast) then
@@ -86,10 +97,10 @@ let ocamlCompileAst =
         let ocamlProg = pprintOcamlTops (concat typeTops exprTops) in
 
         -- Print the AST after code generation
-        debugGenerateHook ocamlProg;
+        hooks.debugGenerate ocamlProg;
 
         -- If option --exit-before, exit the program here
-        exitBeforeHook ();
+        hooks.exitBefore ();
 
         -- Compile OCamlAst
         ocamlCompile options libs clibs sourcePath ocamlProg
@@ -102,7 +113,7 @@ let compile : Options -> String -> Unit = lam options. lam file.
   let ast = parseMCoreFile [] file in
   let ast = utestStrip ast in
   let ast = symbolize ast in
-  ocamlCompileAst options file ast (lam. ()) (lam. ()) (lam. ())
+  ocamlCompileAst options file ast emptyHooks
 
 mexpr
 

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -1,16 +1,18 @@
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 
-lang OCamlTypeDeclAst
-  syn Expr =
-  | OTmVariantTypeDecl { ident : Name, constrs : Map Name Type, inexpr : Expr }
+type OCamlTopBinding =
+  { ident : Name
+    , tyBody : Type
+    , body : Expr
+  }
 
-  sem smap_Expr_Expr (f : Expr -> a) =
-  | OTmVariantTypeDecl t ->
-    OTmVariantTypeDecl {t with inexpr = f t.inexpr}
-
-  sem sfold_Expr_Expr (f : a -> b -> a) (acc : a) =
-  | OTmVariantTypeDecl t -> f acc t.inexpr
+lang OCamlTopAst
+  syn Top =
+  | OTopVariantTypeDecl { ident : Name, constrs : Map Name Type }
+  | OTopLet { ident : Name, tyBody: Type, body : Expr }
+  | OTopRecLets { bindings : [OCamlTopBinding] }
+  | OTopExpr { expr : Expr }
 end
 
 lang OCamlRecord
@@ -184,9 +186,12 @@ lang OCamlTypeAst =
 end
 
 lang OCamlAst =
+  -- Tops
+  OCamlTopAst +
+
   -- Terms
   LamAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
-  OCamlArray + OCamlData + OCamlTypeDeclAst + OCamlRecord + OCamlLabel +
+  OCamlArray + OCamlData + OCamlRecord + OCamlLabel +
   OCamlLam +
 
   -- Constants

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -112,6 +112,13 @@ lang OCamlPrettyPrint =
   CharPatPrettyPrint + BoolPatPrettyPrint + OCamlTypePrettyPrint +
   AppPrettyPrint + MExprAst-- TODO(vipa, 2021-05-12): should MExprAst be here? It wasn't before, but some of the copied constants aren't in the others
 
+  sem pprintOcamlTops =
+  | tops ->
+    let env = collectTopNames tops in
+    match mapAccumL pprintTop env tops with (_, tops) then
+      strJoin "\n" tops
+    else never
+
   sem _nameSymString (esc : Name -> Name) =
   | name ->
     join [ nameGetStr (esc name)
@@ -135,7 +142,8 @@ lang OCamlPrettyPrint =
   sem pprintVarName (env : PprintEnv) =
   | name ->
     (env,
-     if nameHasSym name then
+     match mapLookup name env.nameMap with Some n then n
+     else if nameHasSym name then
        _nameSymString escapeName name
      else
        _nameNoSymString noSymVarPrefix escapeName name)
@@ -154,7 +162,6 @@ lang OCamlPrettyPrint =
   | OTmTuple _ -> true
   | OTmConApp {args = []} -> true
   | OTmConApp _ -> false
-  | OTmVariantTypeDecl _ -> false
   | OTmVarExt _ -> true
   | OTmConAppExt _ -> false
   | OTmString _ -> true
@@ -298,8 +305,32 @@ lang OCamlPrettyPrint =
   | CBootParserGetPat _ -> intrinsicOpBootparser "getPat"
   | CBootParserGetInfo _ -> intrinsicOpBootparser "getInfo"
 
-  sem pprintCode (indent : Int) (env: PprintEnv) =
-  | OTmVariantTypeDecl t ->
+  sem collectTopNames =
+  | tops ->
+    let maybeAdd = lam name. lam str. lam env: PprintEnv.
+      match mapLookup str env.strings with Some _ then
+        env
+      else
+        {{env with nameMap = mapInsert name str env.nameMap}
+              with strings = mapInsert str 1 env.strings}
+    in
+    let f = lam top. lam env.
+      switch top
+      case OTopLet t then
+        maybeAdd t.ident (escapeVarString t.ident.0) env
+      case OTopRecLets t then
+        let f = lam binding : OCamlTopBinding. lam env.
+          maybeAdd binding.ident (escapeVarString binding.ident.0) env
+        in foldr f env t.bindings
+      case top then
+        env
+      end
+    in
+    foldr f pprintEnvEmpty tops
+
+  sem pprintTop (env : PprintEnv) =
+  | OTopVariantTypeDecl t ->
+    let indent = 0 in
     let f = lam env. lam ident. lam ty.
       match pprintConName env ident with (env, ident) then
         let isUnit = match ty with TyRecord {fields = fields} then
@@ -313,15 +344,50 @@ lang OCamlPrettyPrint =
     in
     match pprintVarName env t.ident with (env, ident) then
       match mapMapAccum f env t.constrs with (env, constrs) then
-        match pprintCode indent env t.inexpr with (env, inexpr) then
-          let constrs = strJoin (pprintNewline (pprintIncr indent))
-                                (mapValues constrs) in
-          (env, join ["type ", ident, " =", pprintNewline (pprintIncr indent),
-                      constrs, ";;", pprintNewline indent,
-                      inexpr])
-        else never
+        let constrs = strJoin (pprintNewline (pprintIncr indent))
+                              (mapValues constrs) in
+        (env, join ["type ", ident, " =", pprintNewline (pprintIncr indent),
+                    constrs, ";;"])
       else never
     else never
+  | OTopLet t ->
+    let indent = 0 in
+    match pprintVarName env t.ident with (env, ident) then
+      match pprintCode (pprintIncr indent) env t.body with (env, body) then
+        (env, join ["let ", ident, " =", pprintNewline (pprintIncr indent),
+                    body, ";;"])
+      else never
+    else never
+  | OTopRecLets {bindings = bindings} ->
+    let indent = 0 in
+    let lname = lam env. lam bind : OCamlTopBinding.
+      match pprintVarName env bind.ident with (env,str) then
+        (env, str)
+      else never in
+    let lbody = lam env. lam bind : OCamlTopBinding.
+      match pprintCode (pprintIncr (pprintIncr indent)) env bind.body
+      with (env,str) then (env, str)
+      else never in
+    match mapAccumL lname env bindings with (env,idents) then
+      match mapAccumL lbody env bindings with (env,bodies) then
+        match bodies with [] then (env,"") else
+          let fzip = lam ident. lam body.
+            join [ident, " =",
+                  pprintNewline (pprintIncr (pprintIncr indent)),
+                  body]
+          in
+          (env,join ["let rec ",
+                     strJoin (join [pprintNewline indent, "and "])
+                     (zipWith fzip idents bodies), ";;"])
+      else never
+    else never
+  | OTopExpr {expr = expr} ->
+    let indent = 0 in
+    match pprintCode indent env expr with (env, code) then
+      (env, concat code ";;")
+    else never
+
+  sem pprintCode (indent : Int) (env: PprintEnv) =
   | OTmVarExt {ident = ident} -> (env, ident)
   | OTmConApp {ident = ident, args = []} -> pprintConName env ident
   | OTmConApp {ident = ident, args = [arg]} ->

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -15,28 +15,12 @@ let _symbolizeVarName = lam env : SymEnv. lam ident.
 lang OCamlSym =
   VarSym + AppAst + LamSym + LetSym + RecLetsSym + RecordAst + ConstAst
   + NamedPatSym + IntPat + CharPat + BoolPat + RecordAst
-  + OCamlTypeDeclAst + OCamlMatch + OCamlTuple + OCamlData
+  + OCamlMatch + OCamlTuple + OCamlData
   + UnknownTypeAst + IntTypeAst + BoolTypeAst + FloatTypeAst + CharTypeAst
   + RecordTypeAst + VarTypeSym + OCamlExternal
   + OCamlString + OCamlRecord + OCamlLabel
 
   sem symbolizeExpr (env : SymEnv) =
-  | OTmVariantTypeDecl t ->
-    let f = lam env. lam constr.
-      match constr with (ident, ty) then
-        match _symbolizeVarName env ident with (env, ident) then
-          (env, (ident, symbolizeType env ty))
-        else never
-      else never
-    in
-    match _symbolizeVarName env t.ident with (env, ident) then
-      let inexpr = symbolizeExpr env t.inexpr in
-      match mapAccumL f env t.constrs with (env, constrs) then
-        OTmVariantTypeDecl {{{t with ident = ident}
-                                with constrs = constrs}
-                                with inexpr = inexpr}
-      else never
-    else never
   | OTmMatch {target = target, arms = arms} ->
     let symbArm = lam arm. match arm with (pat, expr) then
       match symbolizePat env (mapEmpty cmpString) pat with (patEnv, pat) then


### PR DESCRIPTION
This PR changes the output of the compiler to be a sequence of top-level declarations (and expressions). This means that the output could be compiled as part of a larger OCaml program and used as a module therein.

The way you use this is still quite low-level and exposes at least one compiler implementation detail (name mangling), but should be stable enough for simple uses.

We definitely want to support something like this (exporting a module written in MCore as a module in another language), but the mechanism used here is not the form we want that in down the line. As such I'm not sure where we want the documentation on how this could be used, as documentation tends to imply support, but I'm not sure how much we want to support this very temporary workaround. As such, I put the steps to follow here, in lieu of a better place.

The most major long term consequence (that we actually want anyway) of this change is that our AST for OCaml is no longer rooted at `Expr`, but rather at `[Top]`, and that `OTmVariantTypeDecl _ : Expr` has become `OTopVariantTypeDecl _ : Top`.

The suggested approach goes as follows:

1. Produce a `.mc` file with one top-level definition per thing you intend to expose in the module. Make sure no two definitions have the same name. Example:
```
include "parser/breakable.mc"
include "seq.mc"

-- # Grammar construction

-- ## Allow sets
let allowAll : (label -> label -> Int) -> AllowSet label =
  lam cmp. DisallowSet (mapEmpty cmp)
let allowNone : (label -> label -> Int) -> AllowSet label =
  lam cmp. AllowSet (mapEmpty cmp)
let allowOneMore : label -> AllowSet label -> AllowSet label =
  lam label. lam set. breakableInsertAllowSet label set
let allowOneLess : label -> AllowSet label -> AllowSet label =
  lam label. lam set. breakableRemoveAllowSet label set

-- etc.
```
2. At the end of the file put a tuple containing all names you wish to expose, to trick dead-code elimination:
```
mexpr

-- dead-code elimination will remove everything if we don't mention these
( allowAll
, allowNone
, allowOneMore
, allowOneLess
-- etc.
)
```
3. Run `mi compile --debug-generate --exit-before module-file.mc > output.ml`
4. `output.ml` is now an OCaml module that has a top-level definition per top-level definition in `module-file.mc` (there are also more top-level definitions from included files, but they might not be mangled in a stable way, and should not be used). Your definitions should have names like `v_allowAll`, `v_allowNone`, etc. (following the example).
5. Presumably you want to create an `.mli` file stating that only those top-level definitions should be exposed.
6. Finally, the exposed module will reference the `Boot.Intrinsics` module, i.e., you need to include the `boot` library one way or another.