### PR TITLE
Fix iteri

### DIFF
--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -161,8 +161,9 @@ let iteri_array (f : int -> 'a -> unit) (s : 'a t) : unit =
         done ;
         len
     | Concat {lhs; rhs; _} ->
-        let n = iteri off lhs in
-        iteri (off + n) rhs
+        let n1 = iteri off lhs in
+        let n2 = iteri (off + n1) rhs in
+        n1 + n2
   in
   iteri 0 !s |> ignore
 

--- a/test/mexpr/seq-test.mc
+++ b/test/mexpr/seq-test.mc
@@ -166,6 +166,13 @@ utest
   deref r
 with 16 in
 
+utest
+ let r = ref [] in
+ let x = concat (concat (concat [] [0]) [1]) [2] in
+ iteri (lam i. lam x. modref r (snoc (deref r) (i, x))) x;
+ deref r
+with [(0, 0), (1, 1), (2, 2)] in
+
 -- The rest of the file contains various test computions with sequences
 
 -- map


### PR DESCRIPTION
This PR fixes a bug in `iteri` where the iteration variable were incorrect for some concatenated sequences.

Before the changes in this PR, this test
```
utest
 let r = ref [] in
 let x = concat (concat (concat [] [0]) [1]) [2] in
 iteri (lam i. lam x. modref r (snoc (deref r) (i, x))) x;
 deref r
with [(0, 0), (1, 1), (2, 2)] in
```
fails with the output
```
    LHS: [(0,0),(1,1),(1,2)]
    RHS: [(0,0),(1,1),(2,2)]
```