### PR TITLE
Rename ident to expr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,7 +1156,7 @@ let mathExtMap =
   [
     ("externalExp", [
       { 
-        ident = "Float.exp", 
+        expr = "Float.exp", 
         ty = tyarrow_ tyfloat_ tyfloat_ , 
         libraries = [], 
         cLibraries = [] 
@@ -1165,18 +1165,19 @@ let mathExtMap =
   ]
 ```
 
-This map associates the `externalExp` external to a list of implementations,
-which here only has one element, namely the function `Float.exp` from OCaml's
-standard library. The field `ty` encode the OCaml type of this value (see
-[stdlib/ocaml/ast.mc](stdlib/ocaml/ast.mc)), which is needed to convert values
-between miking and OCaml. In the case where you have multiple implementations,
-the compiler will try to pick the implementation which gives the least amount of
-overhead when converting to and from OCaml values. The `libraries` field list
-OCaml libraries that are needed to call this function, and `cLibraries` lists c
-libraries that are needed during linking. In this case none are needed since it
-is part of the standard library. If let's say we wanted to use `Float.exp` from
-a library `foo`, then we should instead have the field `libraries =
-["foo"]`. Finally, we need to add `mathExtMap` to `globalExternalImplsMap` in
+This map associates the `externalExp` external to a list of expressions in the
+target language, which here only has one element, namely the function
+`Float.exp` from OCaml's standard library. The field `ty` encode the OCaml type
+of this value (see [stdlib/ocaml/ast.mc](stdlib/ocaml/ast.mc)), which is needed
+to convert values between miking and OCaml. In the case where you have multiple
+implementations, the compiler will try to pick the implementation which gives
+the least amount of overhead when converting to and from OCaml values. The
+`libraries` field list OCaml libraries that are needed to call this function,
+and `cLibraries` lists c libraries that are needed during linking. In this case
+none are needed since it is part of the standard library. If let's say we wanted
+to use `Float.exp` from a library `foo`, then we should instead have the field
+`libraries = ["foo"]`. Finally, we need to add `mathExtMap` to
+`globalExternalImplsMap` in
 [stdlib/ocaml/external-includes.mc](stdlib/ocaml/external-includes.mc).
 
 ### Conversion between values

--- a/src/boot/lib/dune
+++ b/src/boot/lib/dune
@@ -26,9 +26,4 @@
    pypprint.ml
    from
    (pyml -> pypprint.py.ml)
-   (-> pypprint.py-skel.ml))
-  (select
-   sundials_wrapper.ml
-   from
-   (sundialsml -> sundials_wrapper.sd.ml)
-   (-> sundials_wrapper.sd-skel.ml))))
+   (-> pypprint.py-skel.ml))))

--- a/src/boot/lib/sundials_wrapper.sd.ml
+++ b/src/boot/lib/sundials_wrapper.sd.ml
@@ -1,9 +1,0 @@
-let ida_ss_tolerances rtol atol = Ida.SStolerances (rtol, atol)
-
-let ida_retcode = function
-  | Ida.Success ->
-      0
-  | Ida.StopTimeReached ->
-      1
-  | Ida.RootsFound ->
-      2

--- a/stdlib/ext/dist-ext.ext-ocaml.mc
+++ b/stdlib/ext/dist-ext.ext-ocaml.mc
@@ -8,60 +8,59 @@ let distExtMap =
   mapFromSeq cmpString
   [
     ("externalBinomialLogPmf", [
-      { ident = "Owl_stats.binomial_logpdf",
+      { expr = "Owl_stats.binomial_logpdf",
         ty = tyarrows_ [tyint_, otylabel_ "p" tyfloat_, otylabel_ "n" tyint_, tyfloat_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
     ("externalBinomialSample", [
-      { ident = "Owl_stats.binomial_rvs",
+      { expr = "Owl_stats.binomial_rvs",
         ty = tyarrows_ [otylabel_ "p" tyfloat_, otylabel_ "n" tyint_, tyint_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
     ("externalBetaLogPdf", [
-      { ident = "Owl_stats.beta_logpdf",
+      { expr = "Owl_stats.beta_logpdf",
         ty = tyarrows_ [tyfloat_, otylabel_ "a" tyfloat_, otylabel_ "b" tyfloat_, tyfloat_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
     ("externalBetaSample", [
-      { ident = "Owl_stats.beta_rvs",
+      { expr = "Owl_stats.beta_rvs",
         ty = tyarrows_ [otylabel_ "a" tyfloat_, otylabel_ "b" tyfloat_, tyfloat_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
     ("externalGaussianLogPdf", [
-      { ident = "Owl_stats.gaussian_logpdf",
+      { expr = "Owl_stats.gaussian_logpdf",
         ty = tyarrows_ [tyfloat_, otylabel_ "mu" tyfloat_, otylabel_ "sigma" tyfloat_, tyfloat_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
     ("externalGaussianSample", [
-      { ident = "Owl_stats.gaussian_rvs",
+      { expr = "Owl_stats.gaussian_rvs",
         ty = tyarrows_ [otylabel_ "mu" tyfloat_, otylabel_ "sigma" tyfloat_, tyfloat_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
     ("uniformSample", [
-      { ident = "Owl_stats.std_uniform_rvs",
+      { expr = "Owl_stats.std_uniform_rvs",
         ty = tyarrows_ [tyunit_, tyfloat_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
     ("externalRandomSample", [
-      { ident = "Owl_stats.uniform_int_rvs",
+      { expr = "Owl_stats.uniform_int_rvs",
         ty = tyarrows_ [tyint_, tyint_, tyint_],
         libraries = ["owl"],
         cLibraries = []
       }
     ])
   ]
-

--- a/stdlib/ext/ext-test.ext-ocaml.mc
+++ b/stdlib/ext/ext-test.ext-ocaml.mc
@@ -1,11 +1,11 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let implWithLibs = lam arg : { ident : String, ty : Type, libraries : [String] }.
-  { ident = arg.ident, ty = arg.ty, libraries = arg.libraries, cLibraries = [] }
+let implWithLibs = lam arg : { expr : String, ty : Type, libraries : [String] }.
+  { expr = arg.expr, ty = arg.ty, libraries = arg.libraries, cLibraries = [] }
 
-let impl = lam arg : { ident : String, ty : Type }.
-  implWithLibs { ident = arg.ident, ty = arg.ty, libraries = [] }
+let impl = lam arg : { expr : String, ty : Type }.
+  implWithLibs { expr = arg.expr, ty = arg.ty, libraries = [] }
 
 let extTestMap =
   use OCamlTypeAst in
@@ -14,35 +14,35 @@ let extTestMap =
     ("extTestListOfLists", [
       impl
       {
-        ident = "Boot.Exttest.list_of_lists",
+        expr = "Boot.Exttest.list_of_lists",
         ty = otylist_ (otylist_ tyint_)
       }
     ]),
     ("extTestListHeadHead", [
       impl
       {
-        ident = "Boot.Exttest.list_hd_hd",
+        expr = "Boot.Exttest.list_hd_hd",
         ty = tyarrow_ (otylist_ (otylist_ (otyparam_ "a"))) (otyparam_ "a")
       }
     ]),
     ("extTestArrayOfArrays", [
       impl
       {
-        ident = "Boot.Exttest.array_of_arrays",
+        expr = "Boot.Exttest.array_of_arrays",
         ty = otyarray_ (otyarray_ tyint_)
       }
     ]),
     ("extTestArrayHeadHead", [
       impl
       {
-        ident = "Boot.Exttest.array_hd_hd",
+        expr = "Boot.Exttest.array_hd_hd",
         ty = tyarrow_ (otyarray_ (otyarray_ (otyparam_ "a"))) (otyparam_ "a")
       }
     ]),
     ("extTestFlip", [
       impl
       {
-        ident = "Fun.flip",
+        expr = "Fun.flip",
         ty = tyarrows_ [tyarrows_ [(otyparam_ "a"),
                                    (otyparam_ "b"),
                                    (otyparam_ "c")],
@@ -55,49 +55,49 @@ let extTestMap =
     ("extTestUnit1", [
       impl
       {
-        ident = "Boot.Exttest.unit1",
+        expr = "Boot.Exttest.unit1",
         ty = tyarrow_ tyint_ (otytuple_ [])
       }
     ]),
     ("extTestUnit2", [
       impl
       {
-        ident = "Boot.Exttest.unit2",
+        expr = "Boot.Exttest.unit2",
         ty = tyarrow_ (otytuple_ []) tyint_
       }
     ]),
     ("extTestTuple1", [
       impl
       {
-        ident = "Boot.Exttest.tuple1",
+        expr = "Boot.Exttest.tuple1",
         ty = otytuple_ [tyint_, tyfloat_]
       }
     ]),
     ("extTestTuple2", [
       impl
       {
-        ident = "Boot.Exttest.tuple2",
+        expr = "Boot.Exttest.tuple2",
         ty = otytuple_ [otylist_ tyint_, tyint_]
       }
     ]),
     ("extTestTuple10th", [
       impl
       {
-        ident = "Boot.Exttest.tuple1_0th",
+        expr = "Boot.Exttest.tuple1_0th",
         ty = tyarrow_ (otytuple_ [tyint_, tyfloat_]) tyint_
       }
     ]),
     ("extTestTuple20th", [
       impl
       {
-        ident = "Boot.Exttest.tuple2_0th",
+        expr = "Boot.Exttest.tuple2_0th",
         ty = tyarrow_ (otytuple_ [otylist_ tyint_, tyint_]) (otylist_ tyint_)
       }
     ]),
     ("extTestRecord1", [
       impl
       {
-        ident = "Boot.Exttest.myrec1",
+        expr = "Boot.Exttest.myrec1",
         ty = otyrecord_
               (otyvarext_ "Boot.Exttest.myrec1_t" [])
               [("a", tyint_), ("b", tyfloat_)]
@@ -106,7 +106,7 @@ let extTestMap =
     ("extTestRecord1A", [
       impl
       {
-        ident = "Boot.Exttest.myrec1_a",
+        expr = "Boot.Exttest.myrec1_a",
         ty = tyarrow_ (otyrecord_
                         (otyvarext_ "Boot.Exttest.myrec1_t" [])
                         [("a", tyint_), ("b", tyfloat_)])
@@ -116,7 +116,7 @@ let extTestMap =
     ("extTestRecord2", [
       impl
       {
-        ident = "Boot.Exttest.myrec2",
+        expr = "Boot.Exttest.myrec2",
         ty = otyrecord_
               (otyvarext_ "Boot.Exttest.myrec2_t" [])
               [("a", otylist_ tyint_), ("b", tyint_)]
@@ -125,7 +125,7 @@ let extTestMap =
     ("extTestRecord2A", [
       impl
       {
-        ident = "Boot.Exttest.myrec2_a",
+        expr = "Boot.Exttest.myrec2_a",
         ty = tyarrow_ (otyrecord_
                         (otyvarext_ "Boot.Exttest.myrec2_t" [])
                         [("a", otylist_ tyint_), ("b", tyint_)])
@@ -135,7 +135,7 @@ let extTestMap =
     ("extTestRecord3", [
       impl
       {
-        ident = "Boot.Exttest.myrec3",
+        expr = "Boot.Exttest.myrec3",
         ty = otyrecord_
               (otyvarext_ "Boot.Exttest.myrec3_t" [])
               [
@@ -153,7 +153,7 @@ let extTestMap =
     ("extTestRecord3BA", [
       impl
       {
-        ident = "Boot.Exttest.myrec3_b_a",
+        expr = "Boot.Exttest.myrec3_b_a",
         ty =
           tyarrow_
             (otyrecord_
@@ -174,28 +174,28 @@ let extTestMap =
     ("extTestArgLabel", [
       impl
       {
-        ident = "Boot.Exttest.arg_label",
+        expr = "Boot.Exttest.arg_label",
         ty = tyarrows_ [otylabel_ "b" tyint_, otylabel_ "a" tyint_, tyint_]
       }
     ]),
     ("extTestGenarrIntNumDims", [
       impl
       {
-        ident = "Bigarray.Genarray.num_dims",
+        expr = "Bigarray.Genarray.num_dims",
         ty = tyarrow_ otygenarrayclayoutint_ tyint_
       }
     ]),
     ("extTestGenarrFloatNumDims", [
       impl
       {
-        ident = "Bigarray.Genarray.num_dims",
+        expr = "Bigarray.Genarray.num_dims",
         ty = tyarrow_ otygenarrayclayoutfloat_ tyint_
       }
     ]),
     ("extTestGenarrIntSliceLeft", [
       impl
       {
-        ident = "Bigarray.Genarray.slice_left",
+        expr = "Bigarray.Genarray.slice_left",
         ty = tyarrows_ [otygenarrayclayoutint_,
                         otyarray_ tyint_,
                         otygenarrayclayoutint_]
@@ -204,7 +204,7 @@ let extTestMap =
     ("extTestGenarrFloatSliceLeft", [
       impl
       {
-        ident = "Bigarray.Genarray.slice_left",
+        expr = "Bigarray.Genarray.slice_left",
         ty = tyarrows_ [otygenarrayclayoutfloat_,
                         otyarray_ tyint_,
                         otygenarrayclayoutfloat_]
@@ -213,7 +213,7 @@ let extTestMap =
     ("extTestArray2IntSliceLeft", [
       impl
       {
-        ident = "Bigarray.Array2.slice_left",
+        expr = "Bigarray.Array2.slice_left",
         ty = tyarrows_ [otybaarrayclayoutint_ 2,
                          tyint_,
                          otybaarrayclayoutint_ 1]
@@ -222,7 +222,7 @@ let extTestMap =
     ("extTestArray2FloatSliceLeft", [
       impl
       {
-        ident = "Bigarray.Array2.slice_left",
+        expr = "Bigarray.Array2.slice_left",
         ty = tyarrows_ [otybaarrayclayoutfloat_ 2,
                         tyint_,
                         otybaarrayclayoutfloat_ 1]
@@ -231,27 +231,27 @@ let extTestMap =
     ("extTestArray2IntOfGenarr", [
       impl
       {
-        ident = "Bigarray.array2_of_genarray",
+        expr = "Bigarray.array2_of_genarray",
         ty = tyarrow_ otygenarrayclayoutint_ (otybaarrayclayoutint_ 2)
       }
     ]),
     ("extTestArray2FloatOfGenarr", [
       impl
       {
-        ident = "Bigarray.array2_of_genarray",
+        expr = "Bigarray.array2_of_genarray",
         ty = tyarrow_ otygenarrayclayoutfloat_ (otybaarrayclayoutfloat_ 2)
       }
     ]),
     ("extTestZero", [
-      impl { ident = "Float.zero", ty = tyfloat_ }
+      impl { expr = "Float.zero", ty = tyfloat_ }
     ]),
     ("extTestExp", [
-      impl { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
+      impl { expr = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("extTestListMap", [
       impl
       {
-        ident = "List.map",
+        expr = "List.map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (tyvar_ "b"),
                         otylist_ (tyvar_ "a"),
                         otylist_ (tyvar_ "b")]
@@ -260,13 +260,13 @@ let extTestMap =
     ("extTestListConcatMap", [
       impl
       {
-        ident = "List.concat_map",
+        expr = "List.concat_map",
         ty = tyarrows_ [tyarrow_ (tyvar_ "a") (otylist_ (tyvar_ "b")),
                         otylist_ (tyvar_ "a"),
                         otylist_ (tyvar_ "b")]
       }
     ]),
     ("extTestNonExistant", [
-      implWithLibs { ident = "none", ty = tyint_, libraries = ["no-lib"] }
+      implWithLibs { expr = "none", ty = tyint_, libraries = ["no-lib"] }
     ])
   ]

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -1,34 +1,34 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { ident : String, ty : Type }.
-  { ident = arg.ident, ty = arg.ty, libraries = [], cLibraries = [] }
+let impl = lam arg : { expr : String, ty : Type }.
+  { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let mathExtMap =
   use OCamlTypeAst in
   mapFromSeq cmpString [
     ("externalExp", [
-      impl { ident = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
+      impl { expr = "Float.exp", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalLog", [
-      impl { ident = "Float.log", ty = tyarrow_ tyfloat_ tyfloat_ }
+      impl { expr = "Float.log", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalAtan", [
-      impl { ident = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_ }
+      impl { expr = "Float.atan", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalSin", [
-      impl { ident = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_ }
+      impl { expr = "Float.sin", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalCos", [
-      impl { ident = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_ }
+      impl { expr = "Float.cos", ty = tyarrow_ tyfloat_ tyfloat_ }
     ]),
     ("externalAtan2", [
-      impl { ident = "Float.atan2", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
+      impl { expr = "Float.atan2", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
     ]),
     ("externalPow", [
-      impl { ident = "Float.pow", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
+      impl { expr = "Float.pow", ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_] }
     ]),
     ("externalSqrt", [
-      impl { ident = "Float.sqrt", ty = tyarrow_ tyfloat_ tyfloat_ }
+      impl { expr = "Float.sqrt", ty = tyarrow_ tyfloat_ tyfloat_ }
     ])
   ]

--- a/stdlib/ipopt/ipopt.ext-ocaml.mc
+++ b/stdlib/ipopt/ipopt.ext-ocaml.mc
@@ -1,9 +1,9 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { ident : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : Type }.
   {
-    ident = arg.ident,
+    expr = arg.expr,
     ty = arg.ty,
     libraries = ["ipoptml"],
     cLibraries = ["ipopt"]
@@ -28,13 +28,13 @@ let ipoptExtMap =
   [
     ("externalIpoptApplicationReturnStatusRetcode", [
       impl {
-        ident = "Ipoptml.application_return_status_retcode",
+        expr = "Ipoptml.application_return_status_retcode",
         ty = tyarrow_ otyopaque_ tyint_
       }
     ]),
     ("externalIpoptCreateNLP", [
       impl {
-        ident = "Ipoptml.create_nlp",
+        expr = "Ipoptml.create_nlp",
         ty = tyarrows_ [
           otylabel_ "eval_f" tyevalf,
           otylabel_ "eval_grad_f" tyevalgradf,
@@ -53,25 +53,25 @@ let ipoptExtMap =
     ]),
     ("externalIpoptAddStrOption", [
       impl {
-        ident = "Ipoptml.add_str_option",
+        expr = "Ipoptml.add_str_option",
         ty = tyarrows_ [otyopaque_, otystring_, otystring_, otyunit_]
       }
     ]),
     ("externalIpoptAddNumOption", [
       impl {
-        ident = "Ipoptml.add_num_option",
+        expr = "Ipoptml.add_num_option",
         ty = tyarrows_ [otyopaque_, otystring_, tyfloat_, otyunit_]
       }
     ]),
     ("externalIpoptAddIntOption", [
       impl {
-        ident = "Ipoptml.add_int_option",
+        expr = "Ipoptml.add_int_option",
         ty = tyarrows_ [otyopaque_, otystring_, tyint_, otyunit_]
       }
     ]),
     ("externalIpoptSolve", [
       impl {
-        ident = "Ipoptml.solve",
+        expr = "Ipoptml.solve",
         ty = tyarrows_ [otyopaque_, tyvec, otyopaque_]
       }
     ])

--- a/stdlib/multicore/atomic.ext-ocaml.mc
+++ b/stdlib/multicore/atomic.ext-ocaml.mc
@@ -1,8 +1,8 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { ident : String, ty : Type }.
-  { ident = arg.ident, ty = arg.ty, libraries = [], cLibraries = [] }
+let impl = lam arg : { expr : String, ty : Type }.
+  { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let tyaref_ = lam. tyunknown_
 let tygeneric_ = lam. tyunknown_
@@ -12,25 +12,25 @@ let atomicExtMap =
   mapFromSeq cmpString
   [ ("externalAtomicMake", [
       impl
-      { ident = "Atomic.make"
+      { expr = "Atomic.make"
       , ty = tyarrow_ (tygeneric_ "a") (tyaref_ "a")
       }]),
 
     ("externalAtomicGet", [
       impl
-      { ident = "Atomic.get"
+      { expr = "Atomic.get"
       , ty = tyarrow_ (tyaref_ "a") (tygeneric_ "a")
       }]),
 
     ("externalAtomicExchange", [
       impl
-      { ident = "Atomic.exchange"
+      { expr = "Atomic.exchange"
       , ty = tyarrows_ [tyaref_ "a", tygeneric_ "a", tygeneric_ "a"]
       }]),
 
     ("externalAtomicCAS", [
       impl
-      { ident = "Atomic.compare_and_set"
+      { expr = "Atomic.compare_and_set"
       , ty = tyarrows_ [ tyaref_ "a"
                        , tygeneric_ "a"
                        , tygeneric_ "a"
@@ -40,7 +40,7 @@ let atomicExtMap =
 
     ("externalAtomicFetchAndAdd", [
       impl
-      { ident = "Atomic.fetch_and_add"
+      { expr = "Atomic.fetch_and_add"
       , ty = tyarrows_ [tyaref_ "Int", tyint_, tyint_]
       }])
   ]

--- a/stdlib/multicore/thread.ext-ocaml.mc
+++ b/stdlib/multicore/thread.ext-ocaml.mc
@@ -1,8 +1,8 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { ident : String, ty : Type }.
-  { ident = arg.ident, ty = arg.ty, libraries = [], cLibraries = [] }
+let impl = lam arg : { expr : String, ty : Type }.
+  { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let tyathread_ = lam. tyunknown_
 let tygeneric_ = lam. tyunknown_
@@ -12,32 +12,32 @@ let threadExtMap =
   mapFromSeq cmpString
   [ ("externalThreadSpawn", [
       impl
-      { ident = "Domain.spawn"
+      { expr = "Domain.spawn"
       , ty = tyarrow_ (tyarrow_ otyunit_ (tygeneric_ "a")) (tyathread_ "a")
       , libraries = []
       }]),
 
     ("externalThreadJoin", [
       impl
-      { ident = "Domain.join"
+      { expr = "Domain.join"
       , ty = tyarrow_ (tyathread_ "a") (tygeneric_ "a")
       }]),
 
     ("externalThreadGetID", [
       impl
-      { ident = "Domain.get_id"
+      { expr = "Domain.get_id"
       , ty = tyarrow_ (tyathread_ "a") tyint_
       }]),
 
     ("externalThreadSelf", [
       impl
-      { ident = "Domain.self"
+      { expr = "Domain.self"
       , ty = tyarrow_ otyunit_ tyint_
       }]),
 
     ("externalThreadCPURelax", [
       impl
-      { ident = "Domain.Sync.cpu_relax"
+      { expr = "Domain.Sync.cpu_relax"
       , ty = tyarrow_ otyunit_ otyunit_
       }])
   ]

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -138,6 +138,7 @@ lang OCamlExternal
   syn Expr =
   | OTmVarExt { ident : String }
   | OTmConAppExt { ident : String, args : [Expr] }
+  | OTmExprExt { expr : String }
 
   syn Pat =
   | OPatConExt { ident : String, args : [Pat] }

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -8,7 +8,7 @@ include "multicore/thread.ext-ocaml.mc"
 include "ipopt/ipopt.ext-ocaml.mc"
 
 type ExternalImpl = {
-  ident : String,
+  expr : String,
   ty : Type,
   libraries : [String],
   cLibraries : [String]

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -398,7 +398,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlMatchGenerate + OCamlGenerateExt
   | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info} ->
     match mapLookup ident env.exts with Some r then
       let r : ExternalImpl = head r in
-      match convertData info env (OTmVarExt { ident = r.ident }) r.ty tyIdent
+      match convertData info env (OTmExprExt { expr = r.expr }) r.ty tyIdent
       with (_, body) then
         let inexpr = generate env inexpr in
         TmLet {

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -163,6 +163,7 @@ lang OCamlPrettyPrint =
   | OTmConApp {args = []} -> true
   | OTmConApp _ -> false
   | OTmVarExt _ -> true
+  | OTmExprExt _ -> false
   | OTmConAppExt _ -> false
   | OTmString _ -> true
   | OTmLabel _ -> true
@@ -401,6 +402,7 @@ lang OCamlPrettyPrint =
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | OTmVarExt {ident = ident} -> (env, ident)
+  | OTmExprExt {expr = expr} -> (env, expr)
   | OTmConApp {ident = ident, args = []} -> pprintConName env ident
   | OTmConApp {ident = ident, args = [arg]} ->
     match pprintConName env ident with (env, ident) then

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -105,13 +105,20 @@ let sundialsExtMap =
     ]),
     ("externalIdaSSTolerances", [
       impl {
-        expr = "Boot.Sundials_wrapper.ida_ss_tolerances",
+        expr = "fun rtol atol -> Ida.SStolerances (rtol, atol)",
         ty = tyarrows_ [tyfloat_, tyfloat_, otyopaque_]
       }
     ]),
     ("externalIdaRetcode", [
       impl {
-        expr = "Boot.Sundials_wrapper.ida_retcode",
+        expr =
+"function
+  | Ida.Success ->
+      0
+  | Ida.StopTimeReached ->
+      1
+  | Ida.RootsFound ->
+      2",
         ty = tyarrow_ otyopaque_ tyint_
       }
     ]),

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -1,8 +1,8 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { ident : String, ty : Type }.
-  { ident = arg.ident, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
+let impl = lam arg : { expr : String, ty : Type }.
+  { expr = arg.expr, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
 
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []
 let tyidatriple = otyvarext_ "Ida.triple"
@@ -44,41 +44,41 @@ let sundialsExtMap =
   mapFromSeq cmpString
   [
     ("externalSundialsRealArrayCreate", [
-      impl { ident = "Sundials.RealArray.create", ty = tyarrow_ tyint_ otyopaque_}
+      impl { expr = "Sundials.RealArray.create", ty = tyarrow_ tyint_ otyopaque_}
     ]),
     ("externalNvectorSerialWrap", [
       impl {
-        ident = "Nvector_serial.wrap",
+        expr = "Nvector_serial.wrap",
         ty = tyarrow_ (otybaarrayclayoutfloat_ 1) otyopaque_
       }
     ]),
     ("externalNvectorSerialUnwrap", [
       impl {
-        ident = "Nvector_serial.unwrap",
+        expr = "Nvector_serial.unwrap",
         ty = tyarrow_ otyopaque_ (otybaarrayclayoutfloat_ 1)
       }
     ]),
     ("externalSundialsMatrixDense", [
       impl {
-        ident = "Sundials.Matrix.dense",
+        expr = "Sundials.Matrix.dense",
         ty = tyarrows_ [tyint_, otyopaque_]
       }
     ]),
     ("externalSundialsMatrixDenseUnwrap", [
       impl {
-        ident = "Sundials.Matrix.Dense.unwrap",
+        expr = "Sundials.Matrix.Dense.unwrap",
         ty = tyarrows_ [otyopaque_, (otybaarrayclayoutfloat_ 2)]
       }
     ]),
     ("externalIdaDlsDense", [
       impl {
-        ident = "Ida.Dls.dense",
+        expr = "Ida.Dls.dense",
         ty = tyarrows_ [otyopaque_, otyopaque_, otyopaque_]
       }
     ]),
     ("externalIdaDlsSolverJacf", [
       impl {
-        ident = "Ida.Dls.solver",
+        expr = "Ida.Dls.solver",
         ty =
           tyarrows_ [
             otylabel_ "jac" tyidajacf,
@@ -89,7 +89,7 @@ let sundialsExtMap =
     ]),
     ("externalIdaDlsSolver", [
       impl {
-        ident = "Ida.Dls.solver",
+        expr = "Ida.Dls.solver",
         ty =
           tyarrows_ [
             otyopaque_,
@@ -98,26 +98,26 @@ let sundialsExtMap =
       }
     ]),
     ("idaVarIdAlgebraic", [
-      impl { ident = "Ida.VarId.algebraic", ty = tyfloat_ }
+      impl { expr = "Ida.VarId.algebraic", ty = tyfloat_ }
     ]),
     ("idaVarIdDifferential", [
-      impl { ident = "Ida.VarId.differential", ty = tyfloat_ }
+      impl { expr = "Ida.VarId.differential", ty = tyfloat_ }
     ]),
     ("externalIdaSSTolerances", [
       impl {
-        ident = "Boot.Sundials_wrapper.ida_ss_tolerances",
+        expr = "Boot.Sundials_wrapper.ida_ss_tolerances",
         ty = tyarrows_ [tyfloat_, tyfloat_, otyopaque_]
       }
     ]),
     ("externalIdaRetcode", [
       impl {
-        ident = "Boot.Sundials_wrapper.ida_retcode",
+        expr = "Boot.Sundials_wrapper.ida_retcode",
         ty = tyarrow_ otyopaque_ tyint_
       }
     ]),
     ("externalIdaInit", [
       impl {
-        ident = "Ida.init",
+        expr = "Ida.init",
         ty = tyarrows_ [
           otyopaque_,
           otyopaque_,
@@ -133,7 +133,7 @@ let sundialsExtMap =
     ]),
     ("externalIdaCalcICYaYd", [
       impl {
-        ident = "Ida.calc_ic_ya_yd'",
+        expr = "Ida.calc_ic_ya_yd'",
         ty = tyarrows_ [
                otyopaque_,
                tyfloat_,
@@ -145,7 +145,7 @@ let sundialsExtMap =
     ]),
     ("externalIdaSolveNormal", [
       impl {
-        ident = "Ida.solve_normal",
+        expr = "Ida.solve_normal",
         ty = tyarrows_ [
                otyopaque_,
                tyfloat_,
@@ -157,7 +157,7 @@ let sundialsExtMap =
     ]),
     ("externalIdaReinit", [
       impl {
-        ident = "Ida.reinit",
+        expr = "Ida.reinit",
         ty = tyarrows_ [
           otyopaque_,
           otylabel_ "roots" (otytuple_ [tyint_, tyidarootf]),


### PR DESCRIPTION
This PR renames the `ident` field to `expr` in the external implementation record to reflect that this field can hold an arbitrary Ocaml expression. It also introduces a new term in the Ocaml AST `OTmExprExt` to hold these expressions. Moreover it moves some wrapper code for the sundials library to the `expr` field and removes its hacky inclusion in boot. 