### PR TITLE
Restructure lambda lifting

### DIFF
--- a/stdlib/mexpr/call-graph.mc
+++ b/stdlib/mexpr/call-graph.mc
@@ -1,0 +1,109 @@
+-- Defines a language fragment for constructing a call-graph of the bindings in
+-- a recursive let-expression. The call graph contains an edge from a to b if
+-- the body of binding a contains a call to binding b.
+
+include "digraph.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/symbolize.mc"
+include "mexpr/type-annot.mc"
+
+lang MExprCallGraph = MExprAst
+  sem constructCallGraph =
+  | TmRecLets t ->
+    let g : Digraph Name Int = digraphEmpty nameCmp eqi in
+    let g = _addGraphVertices g (TmRecLets {t with inexpr = unit_}) in
+    _addGraphCallEdges g t.bindings
+  | t ->
+    infoErrorExit (infoTm t) (join ["A call graph can only be constructed ",
+                                    "from a recursive let-expression"])
+
+  sem _addGraphVertices (g : Digraph Name Int) =
+  | TmLet t ->
+    let g =
+      match t.tyBody with TyArrow _ then digraphAddVertex t.ident g
+      else g
+    in
+    let g = _addGraphVertices g t.body in
+    _addGraphVertices g t.inexpr
+  | TmRecLets t ->
+    let g =
+      foldl
+        (lam g. lam bind : RecLetBinding. digraphAddVertex bind.ident g)
+        g t.bindings in
+    let g =
+      foldl
+        (lam g. lam bind : RecLetBinding.
+          _addGraphVertices g bind.body)
+        g t.bindings in
+    _addGraphVertices g t.inexpr
+  | t -> sfold_Expr_Expr _addGraphVertices g t
+
+  sem _addGraphCallEdges (g : Digraph Name Int) =
+  | bindings /- : [RecLetBinding] -/ ->
+    let edges =
+      foldl
+        (lam edges. lam bind : RecLetBinding.
+          _findCallEdges bind.ident g edges bind.body)
+        (mapEmpty nameCmp) bindings in
+    mapFoldWithKey
+      (lam g : Digraph Name Int. lam edgeSrc : Name. lam edgeDsts : Set Name.
+        mapFoldWithKey
+          (lam g : Digraph Name Int. lam edgeDst : Name. lam.
+            digraphAddEdge edgeSrc edgeDst 0 g)
+          g edgeDsts)
+      g edges
+
+  sem _findCallEdges (src : Name) (g : Digraph Name Int)
+                            (edges : Map Name (Set Name)) =
+  | TmVar t ->
+    if digraphHasVertex t.ident g then
+      let outEdges =
+        match mapLookup t.ident edges with Some outEdges then
+          setInsert t.ident outEdges
+        else setOfSeq nameCmp [t.ident] in
+      mapInsert src outEdges edges
+    else edges
+  | TmLet t ->
+    let letSrc = match t.tyBody with TyArrow _ then t.ident else src in
+    let edges = _findCallEdges letSrc g edges t.body in
+    _findCallEdges src g edges t.inexpr
+  | TmRecLets t ->
+    let edges =
+      foldl
+        (lam edges : Map Name (Set Name). lam bind : RecLetBinding.
+          _findCallEdges bind.ident g edges bind.body)
+        (mapEmpty nameCmp) t.bindings in
+    _findCallEdges src g edges t.inexpr
+  | t -> sfold_Expr_Expr (_findCallEdges src g) edges t
+end
+
+lang TestLang = MExprCallGraph + MExprSym + MExprTypeAnnot
+
+mexpr
+
+use TestLang in
+
+let preprocess = lam t.
+  typeAnnot (symbolize t)
+in
+
+let a = nameSym "a" in
+let b = nameSym "b" in
+let c = nameSym "c" in
+let d = nameSym "d" in
+let t = preprocess (nureclets_ [
+  (a, ulam_ "x" (bindall_ [
+    nulet_ b (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
+    nulet_ c (ulam_ "x" (app_ (nvar_ b) (var_ "x"))),
+    nulet_ d (ulam_ "x" (app_ (nvar_ b) (var_ "x"))),
+    addi_ (addi_ (app_ (nvar_ b) (var_ "x"))
+                 (app_ (nvar_ c) (var_ "x")))
+          (app_ (nvar_ d) (int_ 2))]))]) in
+let g = constructCallGraph t in
+utest digraphSuccessors a g with [b, c, d] using eqSeq nameEq in
+utest digraphSuccessors b g with [] using eqSeq nameEq in
+utest digraphSuccessors c g with [b] using eqSeq nameEq in
+utest digraphSuccessors d g with [b] using eqSeq nameEq in
+
+()

--- a/stdlib/mexpr/call-graph.mc
+++ b/stdlib/mexpr/call-graph.mc
@@ -59,7 +59,7 @@ lang MExprCallGraph = MExprAst
   | TmVar t ->
     if digraphHasVertex t.ident g then
       let outEdges =
-        match mapLookup t.ident edges with Some outEdges then
+        match mapLookup src edges with Some outEdges then
           setInsert t.ident outEdges
         else setOfSeq nameCmp [t.ident] in
       mapInsert src outEdges edges
@@ -73,7 +73,7 @@ lang MExprCallGraph = MExprAst
       foldl
         (lam edges : Map Name (Set Name). lam bind : RecLetBinding.
           _findCallEdges bind.ident g edges bind.body)
-        (mapEmpty nameCmp) t.bindings in
+        edges t.bindings in
     _findCallEdges src g edges t.inexpr
   | t -> sfold_Expr_Expr (_findCallEdges src g) edges t
 end

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -4,6 +4,7 @@
 include "digraph.mc"
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
+include "mexpr/call-graph.mc"
 include "mexpr/eq.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/type-annot.mc"
@@ -75,7 +76,9 @@ end
 -- corresponding types. For recursive let-expressions, this requires solving a
 -- system of set equations (as the free variables within bindings may affect
 -- each other).
-lang LambdaLiftFindFreeVariables = MExprAst + LambdaLiftFindFreeVariablesPat
+lang LambdaLiftFindFreeVariables =
+  MExprAst + MExprCallGraph + LambdaLiftFindFreeVariablesPat
+
   sem findFreeVariablesInBody (state : LambdaLiftState) (fv : Map Name Type) =
   | TmVar t ->
     if setMem t.ident state.vars then
@@ -111,65 +114,6 @@ lang LambdaLiftFindFreeVariables = MExprAst + LambdaLiftFindFreeVariablesPat
     let state = foldl findBinding state t.bindings in
     findFreeVariablesReclet state t.inexpr
   | t -> sfold_Expr_Expr findFreeVariablesReclet state t
-
-  sem addGraphVertices (g : Digraph Name Int) =
-  | TmLet t ->
-    let g =
-      match t.tyBody with TyArrow _ then digraphAddVertex t.ident g
-      else g
-    in
-    let g = addGraphVertices g t.body in
-    addGraphVertices g t.inexpr
-  | TmRecLets t ->
-    let g =
-      foldl
-        (lam g. lam bind : RecLetBinding. digraphAddVertex bind.ident g)
-        g t.bindings in
-    let g =
-      foldl
-        (lam g. lam bind : RecLetBinding.
-          addGraphVertices g bind.body)
-        g t.bindings in
-    addGraphVertices g t.inexpr
-  | t -> sfold_Expr_Expr addGraphVertices g t
-
-  sem addGraphCallEdges (g : Digraph Name Int) =
-  | bindings /- : [RecLetBinding] -/ ->
-    let edges =
-      foldl
-        (lam edges. lam bind : RecLetBinding.
-          _lamliftFindCallEdges bind.ident g edges bind.body)
-        (mapEmpty nameCmp) bindings in
-    mapFoldWithKey
-      (lam g : Digraph Name Int. lam edgeSrc : Name. lam edgeDsts : Set Name.
-        mapFoldWithKey
-          (lam g : Digraph Name Int. lam edgeDst : Name. lam.
-            digraphAddEdge edgeSrc edgeDst 0 g)
-          g edgeDsts)
-      g edges
-
-  sem _lamliftFindCallEdges (src : Name) (g : Digraph Name Int)
-                            (edges : Map Name (Set Name)) =
-  | TmVar t ->
-    if digraphHasVertex t.ident g then
-      let outEdges =
-        match mapLookup t.ident edges with Some outEdges then
-          setInsert t.ident outEdges
-        else setOfSeq nameCmp [t.ident] in
-      mapInsert src outEdges edges
-    else edges
-  | TmLet t ->
-    let letSrc = match t.tyBody with TyArrow _ then t.ident else src in
-    let edges = _lamliftFindCallEdges letSrc g edges t.body in
-    _lamliftFindCallEdges src g edges t.inexpr
-  | TmRecLets t ->
-    let edges =
-      foldl
-        (lam edges : Map Name (Set Name). lam bind : RecLetBinding.
-          _lamliftFindCallEdges bind.ident g edges bind.body)
-        (mapEmpty nameCmp) t.bindings in
-    _lamliftFindCallEdges src g edges t.inexpr
-  | t -> sfold_Expr_Expr (_lamliftFindCallEdges src g) edges t
 
   sem findFreeVariables (state : LambdaLiftState) =
   | TmLam t ->
@@ -212,9 +156,7 @@ lang LambdaLiftFindFreeVariables = MExprAst + LambdaLiftFindFreeVariablesPat
       findFreeVariables state bind.body
     in
     let state = findFreeVariablesReclet state (TmRecLets t) in
-    let g : Digraph Name Int = digraphEmpty nameCmp eqi in
-    let g = addGraphVertices g (TmRecLets t) in
-    let g = addGraphCallEdges g t.bindings in
+    let g : Digraph Name Int = constructCallGraph (TmRecLets t) in
     let sccs = digraphTarjan g in
     let state = propagateFunNames state g (reverse sccs) in
     let state = foldl findFreeVariablesBinding state t.bindings in

--- a/stdlib/pmexpr/extract.mc
+++ b/stdlib/pmexpr/extract.mc
@@ -6,6 +6,7 @@ include "map.mc"
 include "name.mc"
 include "set.mc"
 include "mexpr/ast-builder.mc"
+include "mexpr/call-graph.mc"
 include "mexpr/cmp.mc"
 include "mexpr/eq.mc"
 include "mexpr/lamlift.mc"
@@ -36,7 +37,7 @@ let _randAlphanum : Unit -> Char = lam.
   else if lti r 36 then int2char (addi r 55)
   else int2char (addi r 61)
 
-lang PMExprExtractAccelerate = PMExprAst + MExprLambdaLift
+lang PMExprExtractAccelerate = PMExprAst + MExprCallGraph
   sem collectProgramIdentifiers (env : AddIdentifierAccelerateEnv) =
   | TmVar t ->
     let sid = stringToSid (nameGetStr t.ident) in

--- a/stdlib/pmexpr/extract.mc
+++ b/stdlib/pmexpr/extract.mc
@@ -159,11 +159,9 @@ lang PMExprExtractAccelerate = PMExprAst + MExprLambdaLift
       collectIdentifiersExpr used bind.body
     in
     match extractAccelerateTermsH used t.inexpr with (used, inexpr) then
-      -- Construct a call graph, reusing functions from lambda lifting. By
-      -- using DFS on this graph, we find the bindings that are used.
-      let g : Digraph Name Int = digraphEmpty nameCmp eqi in
-      let g = addGraphVertices g (TmRecLets t) in
-      let g = addGraphCallEdges g t.bindings in
+      -- NOTE(larshum, 2021-10-03): We find the bindings that are used by
+      -- applying DFS on the call graph.
+      let g : Digraph Name Int = constructCallGraph (TmRecLets t) in
       let visited = setEmpty nameCmp in
       let usedIdents =
         foldl


### PR DESCRIPTION
The lambda lifting implementation previously defined functions for constructing a call graph. These functions were however also used in another file (`stdlib/pmexpr/extract.mc`), and I later found a bug in the latter file which was caused by the call graph implementation. So in this PR the call graph functions are moved to a separate file, and the bugs are fixed.

In addition, I found a performance bug when adding the vertices to the call graph, which resulted in adding unnecessary amounts of vertices (the graph included the `inexpr` of a recursive binding). After this change, along with the latest performance improvements to the `digraph` library, lambda lifting on the `src/main/mi.mc` AST takes ≈2s on my computer (which is slightly faster than the boot parser on the same file).