### PR TITLE
Toml parser

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -535,6 +535,7 @@ module IO = struct
       else if Obj.tag v = Obj.double_tag then
         string_of_float (Obj.obj v) ^ "\n"
       else if Obj.tag v = Obj.closure_tag then "<closure>\n"
+      else if Obj.tag v = Obj.unaligned_tag then "<unaligned>\n"
       else
         let istr = String.make indent ' ' in
         let children =

--- a/stdlib/ext/toml-ext.ext-ocaml.mc
+++ b/stdlib/ext/toml-ext.ext-ocaml.mc
@@ -1,0 +1,39 @@
+include "map.mc"
+include "ocaml/ast.mc"
+
+let tyTomlTable_ = otyvarext_ "Toml.Types.table"
+let tyTomlValue_ = otyvarext_ "Toml.Types.value"
+
+let impl = lam arg : { expr : String, ty : Type }.
+  { expr = arg.expr, ty = arg.ty, libraries = ["toml"], cLibraries = [] }
+
+let tomlExtMap =
+  use OCamlAst in
+  mapFromSeq cmpString
+  [
+    ("externalTomlFromString", [
+      impl { expr = "fun s -> Toml.Parser.(from_string s |> unsafe)",
+      ty = tyarrows_ [otystring_, tyTomlTable_] }
+    ]),
+    ("externalTomlFindExn", [
+      impl { expr = "fun key table -> Toml.Types.Table.find (Toml.Min.key key) table",
+      ty = tyarrows_ [otystring_, tyTomlTable_, tyTomlValue_] }
+    ]),
+    ("externalTomlBindings", [
+      impl { expr = "fun table ->
+        List.map
+          (fun (k, v) -> (Toml.Types.Table.Key.to_string k, v))
+          (Toml.Types.Table.bindings table)
+      ",
+      ty = tyarrows_ [tyTomlTable_, otylist_ (otytuple_ [otystring_, tyTomlValue_])] }
+    ]),
+    ("externalTomlValueToInt", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TInt v -> v
+         | _ -> raise (Invalid_argument \"tomlValueToInt\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, tyint_] }
+    ])
+
+  ]

--- a/stdlib/ext/toml-ext.ext-ocaml.mc
+++ b/stdlib/ext/toml-ext.ext-ocaml.mc
@@ -52,7 +52,14 @@ let tomlExtMap =
       ",
       ty = tyarrows_ [tyTomlValue_, tyfloat_] }
     ]),
-
+    ("externalTomlValueToTableExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TTable v -> v
+         | _ -> raise (Invalid_argument \"tomlValueToTableExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, tyTomlTable_] }
+    ]),
     ("externalTomlValueToIntSeqExn", [
       impl { expr =
       "fun v -> match v with
@@ -76,6 +83,14 @@ let tomlExtMap =
          | _ -> raise (Invalid_argument \"tomlValueToFloatSeqExn\")
       ",
       ty = tyarrows_ [tyTomlValue_, otylist_ tyfloat_] }
+    ]),
+    ("externalTomlValueToTableSeqExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TArray (Toml.Types.NodeTable v) -> v
+         | _ -> raise (Invalid_argument \"tomlValueToTableSeqExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, otylist_ tyTomlTable_] }
     ]),
 
     -- Writing TOML
@@ -101,8 +116,25 @@ let tomlExtMap =
     ("externalTomlFloatToValue", [
       impl { expr = "fun x -> Toml.Types.TFloat x",
       ty = tyarrows_ [tyfloat_, tyTomlValue_] }
+    ]),
+    ("externalTomlTableToValue", [
+      impl { expr = "fun x -> Toml.Types.TTable x",
+      ty = tyarrows_ [tyTomlTable_, tyTomlValue_] }
+    ]),
+    ("externalTomlIntSeqToValue", [
+      impl { expr = "fun x -> Toml.Types.TArray (Toml.Types.NodeInt x)",
+      ty = tyarrows_ [otylist_ tyint_, tyTomlValue_] }
+    ]),
+    ("externalTomlStringSeqToValue", [
+      impl { expr = "fun x -> Toml.Types.TArray (Toml.Types.NodeString x)",
+      ty = tyarrows_ [otylist_ otystring_, tyTomlValue_] }
+    ]),
+    ("externalTomlFloatSeqToValue", [
+      impl { expr = "fun x -> Toml.Types.TArray (Toml.Types.NodeFloat x)",
+      ty = tyarrows_ [otylist_ tyfloat_, tyTomlValue_] }
+    ]),
+    ("externalTomlTableSeqToValue", [
+      impl { expr = "fun x -> Toml.Types.TArray (Toml.Types.NodeTable x)",
+      ty = tyarrows_ [otylist_ tyTomlTable_, tyTomlValue_] }
     ])
-
-
-
   ]

--- a/stdlib/ext/toml-ext.ext-ocaml.mc
+++ b/stdlib/ext/toml-ext.ext-ocaml.mc
@@ -11,7 +11,8 @@ let tomlExtMap =
   use OCamlAst in
   mapFromSeq cmpString
   [
-    ("externalTomlFromString", [
+    -- Reading TOML
+    ("externalTomlFromStringExn", [
       impl { expr = "fun s -> Toml.Parser.(from_string s |> unsafe)",
       ty = tyarrows_ [otystring_, tyTomlTable_] }
     ]),
@@ -27,13 +28,81 @@ let tomlExtMap =
       ",
       ty = tyarrows_ [tyTomlTable_, otylist_ (otytuple_ [otystring_, tyTomlValue_])] }
     ]),
-    ("externalTomlValueToInt", [
+    ("externalTomlValueToIntExn", [
       impl { expr =
       "fun v -> match v with
          | Toml.Types.TInt v -> v
-         | _ -> raise (Invalid_argument \"tomlValueToInt\")
+         | _ -> raise (Invalid_argument \"tomlValueToIntExn\")
       ",
       ty = tyarrows_ [tyTomlValue_, tyint_] }
+    ]),
+    ("externalTomlValueToStringExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TString v -> v
+         | _ -> raise (Invalid_argument \"tomlValueToStringExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, otystring_] }
+    ]),
+    ("externalTomlValueToFloatExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TFloat v -> v
+         | _ -> raise (Invalid_argument \"tomlValueToFloatExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, tyfloat_] }
+    ]),
+
+    ("externalTomlValueToIntSeqExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TArray (Toml.Types.NodeInt v) -> v
+         | _ -> raise (Invalid_argument \"tomlValueToIntSeqExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, otylist_ tyint_] }
+    ]),
+    ("externalTomlValueToStringSeqExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TArray (Toml.Types.NodeString v) -> v
+         | _ -> raise (Invalid_argument \"tomlValueToStringSeqExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, otylist_ otystring_] }
+    ]),
+    ("externalTomlValueToFloatSeqExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TArray (Toml.Types.NodeFloat v) -> v
+         | _ -> raise (Invalid_argument \"tomlValueToFloatSeqExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, otylist_ tyfloat_] }
+    ]),
+
+    -- Writing TOML
+    ("externalTomlToString", [
+      impl { expr = "Toml.Printer.string_of_table",
+      ty = tyarrows_ [tyTomlTable_, otystring_] }
+    ]),
+    ("externalTomlFromBindings", [
+      impl { expr =
+      "fun binds ->
+         Toml.Types.Table.of_key_values
+           (List.map (fun (k, v) -> (Toml.Types.Table.Key.of_string k, v)) binds)",
+      ty = tyarrows_ [otylist_ (otytuple_ [otystring_, tyTomlValue_]), tyTomlTable_] }
+    ]),
+    ("externalTomlIntToValue", [
+      impl { expr = "fun x -> Toml.Types.TInt x",
+      ty = tyarrows_ [tyint_, tyTomlValue_] }
+    ]),
+    ("externalTomlStringToValue", [
+      impl { expr = "fun x -> Toml.Types.TString x",
+      ty = tyarrows_ [otystring_, tyTomlValue_] }
+    ]),
+    ("externalTomlFloatToValue", [
+      impl { expr = "fun x -> Toml.Types.TFloat x",
+      ty = tyarrows_ [tyfloat_, tyTomlValue_] }
     ])
+
+
 
   ]

--- a/stdlib/ext/toml-ext.ext-ocaml.mc
+++ b/stdlib/ext/toml-ext.ext-ocaml.mc
@@ -64,6 +64,7 @@ let tomlExtMap =
       impl { expr =
       "fun v -> match v with
          | Toml.Types.TArray (Toml.Types.NodeInt v) -> v
+         | Toml.Types.TArray Toml.Types.NodeEmpty -> []
          | _ -> raise (Invalid_argument \"tomlValueToIntSeqExn\")
       ",
       ty = tyarrows_ [tyTomlValue_, otylist_ tyint_] }
@@ -72,6 +73,7 @@ let tomlExtMap =
       impl { expr =
       "fun v -> match v with
          | Toml.Types.TArray (Toml.Types.NodeString v) -> v
+         | Toml.Types.TArray Toml.Types.NodeEmpty -> []
          | _ -> raise (Invalid_argument \"tomlValueToStringSeqExn\")
       ",
       ty = tyarrows_ [tyTomlValue_, otylist_ otystring_] }
@@ -80,6 +82,7 @@ let tomlExtMap =
       impl { expr =
       "fun v -> match v with
          | Toml.Types.TArray (Toml.Types.NodeFloat v) -> v
+         | Toml.Types.TArray Toml.Types.NodeEmpty -> []
          | _ -> raise (Invalid_argument \"tomlValueToFloatSeqExn\")
       ",
       ty = tyarrows_ [tyTomlValue_, otylist_ tyfloat_] }
@@ -88,9 +91,23 @@ let tomlExtMap =
       impl { expr =
       "fun v -> match v with
          | Toml.Types.TArray (Toml.Types.NodeTable v) -> v
+         | Toml.Types.TArray Toml.Types.NodeEmpty -> []
          | _ -> raise (Invalid_argument \"tomlValueToTableSeqExn\")
       ",
       ty = tyarrows_ [tyTomlValue_, otylist_ tyTomlTable_] }
+    ]),
+    ("externalTomlValueToSeqSeqExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TArray (Toml.Types.NodeArray a) ->
+           List.map (fun e -> Toml.Types.TArray e) a
+         | _ -> raise (Invalid_argument \"tomlValueToSeqSeqExn\")
+      ",
+      ty = tyarrows_ [tyTomlValue_, otylist_ tyTomlValue_] }
+    ]),
+    ("externalTomlValueToString", [
+      impl { expr = "Toml.Printer.string_of_value",
+      ty = tyarrows_ [tyTomlValue_, otystring_] }
     ]),
 
     -- Writing TOML
@@ -136,5 +153,16 @@ let tomlExtMap =
     ("externalTomlTableSeqToValue", [
       impl { expr = "fun x -> Toml.Types.TArray (Toml.Types.NodeTable x)",
       ty = tyarrows_ [otylist_ tyTomlTable_, tyTomlValue_] }
+    ]),
+    ("externalTomlSeqSeqToValue", [
+      impl { expr =
+      "fun x ->
+         let a = List.map (fun e -> match e with
+           | Toml.Types.TArray a -> a
+           | _ -> raise (Invalid_argument \"tomlSeqSeqToValue\")) x in
+         Toml.Types.TArray (Toml.Types.NodeArray a)
+      ",
+      ty = tyarrows_ [otylist_ tyTomlValue_, tyTomlValue_] }
     ])
+
   ]

--- a/stdlib/ext/toml-ext.mc
+++ b/stdlib/ext/toml-ext.mc
@@ -1,0 +1,28 @@
+
+type TomlTable
+type TomlValue
+
+external externalTomlFromString ! : String -> TomlTable
+let tomlFromString = lam str. externalTomlFromString str
+
+utest tomlFromString "key=1"; () with ()
+
+external externalTomlFindExn ! : String -> TomlTable -> TomlValue
+let tomlFindExn = lam str. lam table. externalTomlFindExn str table
+
+utest tomlFindExn "key" (tomlFromString "key=1"); () with ()
+
+external externalTomlBindings ! : TomlTable -> [(String, TomlValue)]
+let tomlBindings = lam table. externalTomlBindings table
+
+utest
+  let binds = tomlBindings (tomlFromString "intval=1\nstringval=\"abc\"") in
+  let keys = map (lam b : (String, TomlValue). b.0) binds in
+  keys
+with ["intval", "stringval"]
+
+-- Parsing toml values
+external externalTomlValueToInt ! : TomlValue -> Int
+let tomlValueToInt = lam v. externalTomlValueToInt v
+
+utest tomlValueToInt (tomlFindExn "key" (tomlFromString "key=1")) with 1

--- a/stdlib/ext/toml-ext.mc
+++ b/stdlib/ext/toml-ext.mc
@@ -1,28 +1,113 @@
 
+include "map.mc"
+
 type TomlTable
 type TomlValue
 
-external externalTomlFromString ! : String -> TomlTable
-let tomlFromString = lam str. externalTomlFromString str
+------------------
+-- READING TOML --
+------------------
 
-utest tomlFromString "key=1"; () with ()
+-- 'tomlFromString str' parses 'str' into a toml table.
+external externalTomlFromStringExn ! : String -> TomlTable
+let tomlFromStringExn = lam str. externalTomlFromStringExn str
 
+utest tomlFromStringExn "key=1"; () with ()
+
+-- 'tomlFindExn key table' returns the value bound to 'key' in 'table'.
 external externalTomlFindExn ! : String -> TomlTable -> TomlValue
 let tomlFindExn = lam str. lam table. externalTomlFindExn str table
 
-utest tomlFindExn "key" (tomlFromString "key=1"); () with ()
+utest tomlFindExn "key" (tomlFromStringExn "key=1"); () with ()
 
+-- 'tomlBindings table' returns the bindings of 'table'.
 external externalTomlBindings ! : TomlTable -> [(String, TomlValue)]
 let tomlBindings = lam table. externalTomlBindings table
 
 utest
-  let binds = tomlBindings (tomlFromString "intval=1\nstringval=\"abc\"") in
+  let binds = tomlBindings (tomlFromStringExn "intval=1\nstringval=\"abc\"") in
   let keys = map (lam b : (String, TomlValue). b.0) binds in
   keys
 with ["intval", "stringval"]
 
--- Parsing toml values
-external externalTomlValueToInt ! : TomlValue -> Int
-let tomlValueToInt = lam v. externalTomlValueToInt v
+-- 'tomlBindings table' converts 'table' into a map.
+let tomlTableToMap : TomlTable -> Map String TomlValue = lam table.
+  mapFromSeq (tomlBindings table)
 
-utest tomlValueToInt (tomlFindExn "key" (tomlFromString "key=1")) with 1
+-- 'tomlValueToIntExn v' converts a toml value to an integer.
+external externalTomlValueToIntExn ! : TomlValue -> Int
+let tomlValueToIntExn = lam v. externalTomlValueToIntExn v
+
+utest tomlValueToIntExn (tomlFindExn "key" (tomlFromStringExn "key=1")) with 1
+
+-- 'tomlValueToStringExn v' converts a toml value to a string.
+external externalTomlValueToStringExn ! : TomlValue -> String
+let tomlValueToStringExn = lam v. externalTomlValueToStringExn v
+
+utest tomlValueToStringExn (tomlFindExn "key" (tomlFromStringExn "key=\"value\"")) with "value"
+
+-- 'tomlValueToFloatExn v' converts a toml value to a float.
+external externalTomlValueToFloatExn ! : TomlValue -> Float
+let tomlValueToFloatExn = lam v. externalTomlValueToFloatExn v
+
+utest tomlValueToFloatExn (tomlFindExn "key" (tomlFromStringExn "key=3.14")) with 3.14
+
+-- 'tomlValueToIntSeqExn v' converts a toml value to an integer sequence.
+external externalTomlValueToIntSeqExn ! : TomlValue -> [Int]
+let tomlValueToIntSeqExn = lam v. externalTomlValueToIntSeqExn v
+
+utest tomlValueToIntSeqExn (tomlFindExn "key" (tomlFromStringExn "key=[1,2,3]")) with [1,2,3]
+
+-- 'tomlValueToStringSeqExn v' converts a toml value to a string sequence.
+external externalTomlValueToStringSeqExn ! : TomlValue -> [String]
+let tomlValueToStringSeqExn = lam v. externalTomlValueToStringSeqExn v
+
+utest tomlValueToStringSeqExn (tomlFindExn "key" (tomlFromStringExn "key=[\"foo\", \"bar\"]")) with ["foo", "bar"]
+
+-- 'tomlValueToFloatSeqExn v' converts a toml value to a float sequence.
+external externalTomlValueToFloatSeqExn ! : TomlValue -> [Float]
+let tomlValueToFloatSeqExn = lam v. externalTomlValueToFloatSeqExn v
+
+utest tomlValueToFloatSeqExn (tomlFindExn "key" (tomlFromStringExn "key=[3.14,1e1]")) with [3.14,1e1]
+
+------------------
+-- WRITING TOML --
+------------------
+
+let _strEqNoWhitespace = lam s1. lam s2.
+  let s1 = filter (lam c. not (isWhitespace c)) s1 in
+  let s2 = filter (lam c. not (isWhitespace c)) s2 in
+  eqString s1 s2
+
+-- 'tomlToString table' converts 'table' into a string.
+external externalTomlToString ! : TomlTable -> String
+let tomlToString = lam table. externalTomlToString table
+
+utest tomlToString (tomlFromStringExn "key=1") with "key=1" using _strEqNoWhitespace
+
+-- 'tomlFromBindings binds' converts 'binds' to a table.
+external externalTomlFromBindings ! : [(String, TomlValue)] -> TomlTable
+let tomlFromBindings = lam binds. externalTomlFromBindings binds
+
+-- 'tomlIntToValue v' converts an integer to a toml value.
+external externalTomlIntToValue ! : Int -> TomlValue
+let tomlIntToValue = lam v. externalTomlIntToValue v
+
+utest tomlToString (tomlFromBindings [("key", tomlIntToValue 1)]) with "key=1" using _strEqNoWhitespace
+
+-- 'tomlStringToValue v' converts a string to a toml value.
+external externalTomlStringToValue ! : String -> TomlValue
+let tomlStringToValue = lam s. externalTomlStringToValue s
+
+utest tomlToString (tomlFromBindings [("key", tomlStringToValue "42")]) with "key=\"42\"" using _strEqNoWhitespace
+
+-- 'tomlFloatToValue v' converts a float to a toml value.
+external externalTomlFloatToValue ! : Float -> TomlValue
+let tomlFloatToValue = lam v. externalTomlFloatToValue v
+
+utest tomlToString (tomlFromBindings [("key", tomlFloatToValue 3.14)]) with "key=3.14" using _strEqNoWhitespace
+
+
+
+
+

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -2,6 +2,7 @@ include "ocaml/ast.mc"
 include "ext/ext-test.ext-ocaml.mc"           -- For testing
 include "ext/math-ext.ext-ocaml.mc"
 include "ext/dist-ext.ext-ocaml.mc"
+include "ext/toml-ext.ext-ocaml.mc"
 include "sundials/sundials.ext-ocaml.mc"
 include "multicore/atomic.ext-ocaml.mc"
 include "multicore/thread.ext-ocaml.mc"
@@ -26,5 +27,6 @@ let globalExternalImplsMap : Map String [ExternalImpl] =
       atomicExtMap,
       threadExtMap,
       distExtMap,
-      ipoptExtMap
+      ipoptExtMap,
+      tomlExtMap
     ]


### PR DESCRIPTION
This PR adds a TOML parser under `stdlib/ext/toml-ext.mc`. It uses the [ocaml-toml](https://github.com/ocaml-toml) parser via externals.