### PR TITLE
Syntax DSL tool skeleton + documentation

### DIFF
--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -50,7 +50,9 @@ let infoVal : String -> Int -> Int -> Int -> Int -> Info =
 -- Generate a string from an info
 let info2str : Info -> String = lam fi.
   match fi with NoInfo () then "[No file info] " else
-  match fi with Info r then
+  match fi with Info (r & {row1 = 0}) then
+    join ["FILE \"", r.filename, "\" "]
+  else match fi with Info r then
     join ["FILE \"", r.filename, "\" ", int2string r.row1, ":", int2string r.col1,
     "-", int2string r.row2, ":", int2string r.col2, " "]
   else never

--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -95,6 +95,9 @@ with Info { filename = "path/to/file.mc",
 let infoErrorString : Info -> String -> String = lam fi. lam str.
     join [info2str fi, "ERROR: ", str]
 
+let infoWarningString : Info -> String -> String = lam fi. lam str.
+    join [info2str fi, "WARNING: ", str]
+
 -- Print an error with info struct info and exit (error code 1)
 let infoErrorExit : Info -> String -> Unknown = lam fi. lam str.
   print (join ["\n", (infoErrorString fi str), "\n"]);

--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -57,40 +57,6 @@ let info2str : Info -> String = lam fi.
     "-", int2string r.row2, ":", int2string r.col2, " "]
   else never
 
--- Parse an info string into an info
-let str2info : String -> Info = lam str.
-  let errorNotAnInfo = lam.
-    error (join ["Not an info string: '", str, "'"])
-  in
-  let str = strTrim str in
-  match str with "[No file info]" then NoInfo ()
-  else
-    match strSplit " " str with ["FILE", filename, rowcols] then
-      let filename =
-        match filename with ['\"'] ++ filename ++ ['\"'] then filename
-        else errorNotAnInfo ()
-      in
-      let parseRowCol : String -> (Int, Int) = lam rowcol.
-        match strSplit ":" rowcol with [row, col] then
-          (string2int row, string2int col)
-        else errorNotAnInfo ()
-      in
-      match strSplit "-" rowcols with [rowcols1, rowcols2] then
-        match (parseRowCol rowcols1, parseRowCol rowcols2)
-        with ((row1, col1), (row2, col2)) then
-          Info { filename = filename
-               , row1 = row1, col1 = col1
-               , row2 = row2, col2 = col2
-               }
-        else never
-      else errorNotAnInfo ()
-    else errorNotAnInfo ()
-
-utest str2info "   [No file info] " with NoInfo ()
-utest str2info "FILE \"path/to/file.mc\" 123:3-124:4"
-with Info { filename = "path/to/file.mc",
-            row1 = 123, col1 = 3, row2 = 124, col2 = 4 }
-
 -- Generate an info error string
 let infoErrorString : Info -> String -> String = lam fi. lam str.
     join [info2str fi, "ERROR: ", str]

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -1009,6 +1009,7 @@ let breakableToErrorHighlightSpec
       } in
     let res = breakableReportAmbiguities reportConfig tops in
     let fixup = lam amb: Ambiguity Info Highlight.
+      let amb: Ambiguity Info Highlight = amb in
       {info = mergeInfo amb.range.first amb.range.last, partialResolutions = amb.partialResolutions}
     in map fixup res
 

--- a/stdlib/parser/dsl.md
+++ b/stdlib/parser/dsl.md
@@ -3,7 +3,7 @@
 This file gives a basic runthrough of the in-progress design of a DSL
 for syntax and AST specification.
 
-## Basics
+## Basic syntax and AST structure
 
 ```
 -- Line comments
@@ -13,8 +13,8 @@ Multiline comments
 -/
 ```
 
-We declare new types in the AST and non-terminals in
-the grammar with `type`.
+We declare new types in the AST and non-terminals in the grammar with
+`type`:
 
 ```
 type Expr
@@ -24,226 +24,357 @@ A constructor in the AST and production in the grammar is introduced
 with `prod`.
 
 ```
-prod TmInt: Expr = value:Int
+prod Int: Expr = value:Integer
 ```
 
 Each constructor gets its own language fragment in the generated code,
 thus the above yields the following fragment:
 
 ```
-lang TmInt
+lang IntExprAst
   syn Expr =
-  | TmInt { value : Int }
+  | IntExpr { value : Int, info : Info }
+
+  sem get_Expr_info =
+  | IntExpr x -> x.info
 end
 ```
 
-The syntax of a single production can contain regex style repetition
-operators:
+At this point a few things bear mention:
+- The `info` field is automatically added and contains the source code
+  location of the parsed node. An accessor function is automatically
+  generated for this field: `get_Expr_info`.
+- By default we append the name of the type to the constructor name,
+  i.e., `IntExpr` instead of merely `Int`. If desired this can be
+  disabled, see more detailed information on the `type` construct.
+- `Integer` on the right-hand side of the production refers to the
+  builtin token type `Integer`. These are described in more detail
+  later, but here are some commonly used token types:
+  - `Integer`, `Float`, `Char`, and `String` for literals.
+  - `LIdent` and `UIdent` for lower-case and upper-case identifiers,
+    respectively.
+
+Operators can be defined explicitly or with some syntactic short-hand:
+
+```
+prod Add: Expr = left:Expr "+" right:Expr
+infix Mul: Expr = "*"
+```
+
+Note the use of `"+"` and `"*"`; these introduce "keywords" (in this
+case operators) that should appear verbatim in the source code.
+
+```
+lang AddExprAst
+  syn Expr =
+  | AddExpr { left : Expr, right : Expr, info : Info }
+
+  /- Some content omitted here -/
+end
+
+lang MulExprAst
+  syn Expr =
+  | MulExpr { left : Expr, right : Expr, info : Info }
+
+  /- Some content omitted here -/
+end
+```
+
+Note that `AddExpr` and `MulExpr` are largely identical. Similarly,
+you can use `prefix` and `postfix` as shorthand for unary operators:
+
+```
+prefix Negate: Expr = "-"
+-- ...is the same as:
+prod Negate: Expr = "-" right:Expr
+
+postfix FieldAccess: Expr = "." label:LIdent
+-- ...is the same as:
+prod FieldAccess: Expr = left:Expr "." label:LIdent
+```
+
+The omitted content in the above fragments define a number of helper
+functions. First is `get_Expr_info : Expr -> Info`, as mentioned
+earlier, but then there are some additional functions meant to assist
+in traversing an AST:
+
+- `smap_Expr_Expr : (Expr -> Expr) -> Expr -> Expr`, for mapping over
+  the direct children of the given `Expr`. A version of this function
+  is given for every relevant pair of non-terminals used, e.g.,
+  `smap_Expr_Type : (Type -> Type) -> Expr -> Expr` also exists
+  (assuming `Type` is declared as a non-terminal, i.e., there is a
+  `type Type` somewhere). In general, we can read `smap_X_Y` as a
+  _shallow mapping_ over every `Y` that is a direct child of the given
+  `X`.
+- `sfold_Expr_Expr : all acc. (acc -> Expr -> acc) -> acc -> Expr ->
+  acc` is the (left-) folding equivalent of `smap_Expr_Expr`.
+- `smapAccumL : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr
+  -> (acc, Expr)` both maps and folds at the same time, and is thus
+  more general than `smap` and `sfold`.
+
+These helpers make it easier to write generic code that traverses an
+AST. For example, we could count the number of sub-expressions in an
+expression with the following function:
+
+```
+recursive let countExprs
+  : Expr -> Int
+  = lam expr.
+    sfold_Expr_Expr (lam count. lam e. addi count (countExprs e)) 1 expr
+```
+
+This function will work for any expression and does not need any code
+that is specific to a particular kind of AST-node. See the Recursion
+Cookbook for more on this style of tree traversal.
+
+Returning to the syntax of productions, the right-hand side of a
+production can use regex-style `+` (one or more), `*` (zero or more),
+`?` (zero or one), and `|` (left or right):
 
 ```
 -- Repeated field names are collected into a sequence in the
--- order they appear in the source.
-prod TmTuple: Expr = "(" fields:Expr ("," fields:Expr)+ ")"
+-- order they appear in the source, i.e., left-most first.
+prod Tuple: Expr = "(" fields:Expr ("," fields:Expr)+ ")"
+
 -- Zero-or-more is expressed with `?` and produce an Option
-prod TmLet: Expr = "let" ident:LIdent (":" tyIdent:Type)? "=" value:Expr "in" body:Expr
+prod Let: Expr = "let" ident:LIdent (":" tyIdent:Type)? "=" value:Expr "in" body:Expr
 ```
 We thus get the following language fragments:
 
 ```
-lang TmTuple
+lang TupleExprAst
   syn Expr =
-  | TmTuple { fields : [Expr] }
+  | TupleExpr { fields : [Expr], info : Info }
+
+  /- Some content omitted here -/
 end
 
-lang TmLet
+lang LetExprAst
   syn Expr =
-  | TmLet { ident: String, tyIdent: Option Type, value: Expr, body: Expr }
-end
-```
+  | LetExpr { ident: String, tyIdent: Option Type, value: Expr, body: Expr, info : Info }
 
-We can also give the constructor nested records:
-
-```
-prod TmMatch: Expr = "match" target:Expr "with" arms:{"|" pat:Pat "->" body:Expr}+
-```
-
-```
-lang TmMatch
-  syn Expr =
-  | TmMatch { target : Expr, arms : [{pat : Pat, body : Expr}]}
+  /- Some content omitted here -/
 end
 ```
 
-Explicit grouping (i.e. parentheses) should not be specified as a
+Note that `fields` is a sequence in `TupleExpr` and `tyIdent` is an
+`Option Type` in `LetExpr`. More generally, if a field has type `X` in
+the right-hand side of the production its type in the AST will depend
+on how many types it _could_ appear in the production:
+
+- If it must appear precisely once, then its type is merely `X`.
+- If it can be absent or occur precisely once, then its type is
+  `Option X`.
+- Otherwise its type is `[X]`.
+
+We can also give the constructor nested records using `{}`:
+
+```
+prod Match: Expr = "match" target:Expr "with" arms:{"|" pat:Pat "->" body:Expr}+
+```
+
+```
+lang MatchExprAst
+  syn Expr =
+  | MatchExpr { target : Expr, arms : [{pat : Pat, body : Expr}], info : Info }
+end
+```
+
+Explicit grouping (typically parentheses) should not be specified as a
 production but rather explicitly as grouping:
 
 ```
 grouping "(" Expr ")"
 ```
 
-It should have the form `grouping` `<token>` `<type>` `<token>`. These
-do not produce a node in the final AST.
+`grouping` declarations differ from normal productions in that they do
+not affect the final AST; there is no node corresponding to
+parentheses once parsing is complete.
 
-### Tokens
+### Precedence and Associativity
 
-Tokens can be either a literal (e.g. `"let"`) or a named token
-(e.g. `LIdent`). In the current system new token types cannot be
-defined, rather there is a number of builtin token types, shown
-below. Each token carries a value that will end up in the AST if the
-token has a name attached. For example, `x:EOF` will put a field `x :
-()` in the AST node, while `value:Integer` gives a field `value: Int`.
+Precedence and associativity can disambiguate some expressions that
+would otherwise be ambiguous, by dictating how expressions should
+group in the absence of explicit grouping. This works largely as one
+might expect from prior experience from math and most programming
+languages; higher precedence operators "bind tighter", i.e., their AST
+nodes are further from the root of the AST, and associativity
+determines how expressions group between operators that have the same
+precedence. However, there is one important difference: neither
+precedence nor associativity is _mandatory_, you may leave some of
+them undefined, which yields an ambiguous language. If this seems
+perfectly reasonable to you, feel free to skip to the next heading,
+which describes how to define precedence and associativity concretely.
 
-- `EOF : ()`
-- `LIdent : String` Identifier starting with a lowercase letter.
-- `UIdent : String` Identifier starting with an uppercase letter.
-- `Integer : Int`
-- `Float : Float`
-- `String : String`
-- `Char : Char`
-- `Operator : String` A sequence of one or more of these characters: `%<>!?~:.$&*+-/=@^|`.
-- `LParen : ()`
-- `RParen : ()`
-- `LBracket : ()`
-- `RBracket : ()`
-- `LBrace : ()`
-- `RBrace : ()`
-- `Semicolon : ()`
-- `Comma : ()`
+Ambiguities arise almost immediately in most intuitively formulated
+languages. In most programming languages these are resolved through
+some mechanism in the parser that disambiguates according to some
+convention, e.g., precedence and associativity. Other examples of
+disambiguation mechanisms include longest match and various more
+ad-hoc approaches.
 
-Note that for many of these it's likely nicer to use a literal than
-the token type, e.g., `"("` instead of `LParen`, though the latter is
-available if you want it.
+A key term in the above paragraph is _convention_, these
+disambiguations provide a good user interface if the programmer knows
+the convention these disambiguations encode.
 
-Finally: in the current implementation all literals have to lex as a
-single token. This means that, e.g., `"set="` is not a valid token
-since it would normally lex as a `LIdent` followed by an `Operator`.
+For precedence this implies a that, as a general rule of thumb, you
+should give a defined precedence between two operators if _and only
+if_ a typical user of your programming language can be expected to
+know the precedence by heart. For example:
 
-## Operators
+- Most people know the precedence of most arithmetic operators, `*`
+  binds stronger than `+`, etc. Leaving precedence undefined would be
+  tedious, since it would require a lot of parentheses.
+- Most people know that comparators bind stronger than boolean and/or,
+  i.e., that `a == b && c` means `(a == b) && c`, not `a == (b && c)`.
+- Most mathematicians know that `a && b || c` is `(a && b) || c`, but
+  it's not as obvious for many programmers. Relatively few expressions
+  use both of these operators, thus we could leave precedence
+  undefined (which ends up making the parentheses required) without
+  introducing too much tedium.
+  - However, it makes no sense to require parentheses for, e.g., `a &&
+    b && c` since `&&` is associative (in the mathematical sense),
+    thus its still useful to define an associativity here.
+- Relatively few know the precedence of bitwise operators, e.g., what
+  should `a & b == c` be? In C and its descendants it's `a & (b ==
+  c)`, in Python its `(a & b) == c`.
+- Set union and intersection do not have a precedence convention at
+  all, thus no typical user of your language can be expected to know
+  the precedence.
 
-Operators can be written either explicitly:
-```
-prod TmAdd: Expr = left:Expr "+" right:Expr
-```
-
-...or with syntactic sugar:
-```
-infix TmMul: Expr = "*"
-
--- Similarly for prefix and postfix
-prefix TmNot: Expr = "!"
-postfix TmFieldAccess: Expr = "." field:LIdent
-```
-
-Note that if you want to give the operands other names than `left` and
-`right` you need to use the explicit form.
-
-Each production will be one of these things:
-- Simple/atomic if it has no direct recursion on either edge
-- Prefix if it only has direct recursion on the right edge
-- Postfix if it only has direct recursion on the left edge
-- Infix if it has direct recursion on both edges
-
-I suspect that productions that sometimes have direct recursion on the
-edge and sometimes not are a bad idea. Please let me know if such
-cases come up, so we can see if that is correct or not.
-
-## Implicit and Explicit Grouping of Operators
-
-<!-- TODO(vipa, 2021-10-29): Rewrite all of the stuff on grouping in
-general, probably include ambiguity here -->
-
-Infix productions can specify their associativity:
+To show the effect of leaving precedence undefined, consider the case
+where `&&` and `||` do not have a defined relative precedence. In this
+case we find that the code `a || b && c` is ambiguous, at which point
+our generated parser will present the following error message:
 
 ```
-prod left TmSub: Expr = left:Expr "-" right:Expr
-infix left TmDiv: Expr = "/"
+example:1:1: Parse error, this code is ambiguous:
+  ( a || b ) && c
+  a || ( b && c )
 ```
 
-## Precedence
+It is worth noting also that adding precedence between two operators
+that previously didn't have precedence is a backwards-compatible
+change: all previously valid programs are still valid and parse the
+same. This means that it is safe try out a language with more
+ambiguity, see how programmers end up wanting to use the language
+constructs in practice, and then removing the ambiguity when it's
+clear how it should be done.
 
-Precedence is primarily specified with a precedence table:
+#### Defining Precedence and Associativity
+
+Associativity is defined on a production:
+
+```
+prod left Add: Expr = left:Expr "+" right:Expr
+infix right And: Expr = "&&"
+```
+
+Note that an associativity declaration is only valid on an infix
+production, i.e., one that is both left and right-recursive.
+
+Precedence is defined with the `precedence` construct:
 
 ```
 precedence {
-  TmFieldAccess;
-  TmNot;
-  TmMul TmDiv;
-  TmAdd TmSub;
+  Negate;
+  Mul Div;
+  Add Sub;
 }
 ```
-Note that only non-simple productions can appear in a precedence list,
-i.e., operators; those that are prefix, postfix, or infix.
 
-Operators appearing earlier in the list (i.e. higher) have higher
-precedence than operators appearing later. Operators on the same
-level have the same precedence.
+Each line, terminated with `;`, defines a precedence level; all
+operators on the same level have equal precedence, and all operators
+on earlier (higher) levels have higher precedence than those on later
+(lower) levels.
 
-### Same Precedence
-
-To see what happens when two operators have the same precedence we
-first need to look at their associativity. Note that prefix operators
-associate to the right by definition, and postfix operators associate
-left.
-
-- If the operators have the same associativity then grouping will
-  follow that associativity. For example, given left-associative
-  addition and subtraction on the same precedence, `a - b + c` is
-  `(a - b) + c`.
-- If the operators do not have the same associativity grouping becomes
-  ambiguous.
-
-### Exceptions
-
-It is also possible to write a precedence table that is not total by
-specifying which relations should *not* be defined through this table:
+A language definition can have any number of precedence tables, as
+long as no two tables disagree on any pair of operators. As a trivial
+example, these two precedence tables conflict:
 
 ```
 precedence {
-  mul div;
-  add sub;
-  equal notEqual less greater;
+  Add Sub;  -- Equal precedence
+}
+precedence {
+  Add; -- Add has higher precedence
+  Sub;
+}
+```
+
+To make it easier to write tables that don't conflict we thus provide
+two features to remove precedences from a table. The most direct and
+flexible method is to provide an `except` list:
+
+```
+precedence {
+  Mul Div;
+  Add Sub;
+  Modulus;
+  Equal NotEqual LessThan GreaterThan;
 } except {
-  equal notEqual less greater;
+  Modulus ? Mul Div Add Sub;
+  Equal NotEqual LessThan GreaterThan ? Equal NotEqual LessThan GreaterThan;
 }
 ```
 
-Each line in the `except` block makes precedence undefined between
-each possible pair of operators on the line. In this case, e.g.,
-`equal` and `notEqual` do not have defined relative precedence, nor
-does `notEqual` and `greater`.
+A precedence table with an except list behaves like a normal table
+except for the operators appearing on opposite sides of a `?` in the
+`except` list. The table above does not define precedence between
+`Modulus` and any of the other arithmetic operators (though `Modulus`
+still has higher precedence than the comparators, and the other
+arithmetic operators have their normal precedence relative each
+other), nor does it define precedence between any of the comparators.
 
-## Broken Productions
-
-Productions that use the regex repetition operators can be broken
-apart into multiple operators for the parsing stage, then
-automatically reassembled when the AST is constructed. This makes it
-possible to perform disambiguation through precedence and
-associativity, and also to produce ambiguity error messages.
-
-Ideally this should happen entirely automatically with no need for
-additional annotations, thus this section should not be required
-reading in most cases.
-
-However, it will affect error messages for bad grammars. I believe it
-should not introduce new cases where grammars are bad, rather make
-some grammars accepted that otherwise wouldn't be and change the
-errors for others, but I'm not sure yet.
-
-The specifics of this are not yet known to me, but I suspect the
-following will be true:
-
-A repetition will be broken out to a new operator if it can end up
-adjacent to a direct recursion. For example:
+As a slightly less verbose option, you can also remove precedence
+between all operators appearing on the same level by starting the
+level with `~`, i.e., the above table could be written a bit more
+succinctly as:
 
 ```
--- Note that `?` is a repetition, just a very simple one
-prod if: Expr = "if" cond:Expr "then" then:Expr ("else" else:Expr)?
+precedence {
+  Mul Div;
+  Add Sub;
+  Modulus;
+  ~ Equal NotEqual LessThan GreaterThan;
+} except {
+  Modulus ? Mul Div Add Sub;
+}
 ```
 
-Note that a `*` or `+` repetition that has direct recursion at the
-edge will trivially be adjacent to direct recursion:
+### Lexing; custom tokens and whitespace
 
+The lexing phase uses language fragments written in the style of
+`WSACParser` and `TokenParser` in `stdlib/parser/lexer.mc`. The syntax
+for specifying which such fragments should be included in the lexer is
+not yet stable, but presently looks as follows:
 
 ```
-prod match: Expr = "match" target:Expr "with" arms:{"|" p:Pat "->" body:Expr}+
+--    v-- What's the name of the token when included in a regex?
+token String {
+  -- Which file should be included, i.e., where is the fragment defined?
+  include: "parser/lexer.mc",
+  -- Which language fragment contains the token?
+  lang: StringTokenParser,
+  -- What should the type be in the generated AST?
+  type: String,
+  -- How do we construct the token representation, to be put in the grammar?
+  unitConstructor: StringRepr (),
+  -- How do we construct the token representation if it is given an argument?
+  constructor: lam str. error "The string token doesn't take an argument",
+}
 ```
+
+All of the fields are optional except `include` and `lang`. For
+example, to include MExpr style line comments:
+
+```
+token {
+  include: "lexer.mc";
+  lang: LineCommentParser;
+}
+```
+
+Note that there is no name between `token` and `{`, since we're not
+actually defining a token, merely including a language fragment that
+parses line tokens.

--- a/stdlib/parser/dsl.md
+++ b/stdlib/parser/dsl.md
@@ -3,6 +3,22 @@
 This file gives a basic runthrough of the in-progress design of a DSL
 for syntax and AST specification.
 
+## Running the tool
+
+The tool is currently not sufficiently annotated to be compilable
+(it's not yet possible to annotate the final argument of a `sem`
+function, I'll fix that once we're a bit further along), thus it can
+presently only be interpreted. Assuming we're currently at the root of
+the `miking` repository:
+
+```bash
+MCORE_STDLIB=`pwd`/stdlib mi eval stdlib/parser/tool.mc -- test/examples/expr.syn
+```
+
+The tool presently only supports a subset of what's described in this
+document, and gives either errors or the generated output on standard
+out.
+
 ## Basic syntax and AST structure
 
 ```

--- a/stdlib/parser/dsl.md
+++ b/stdlib/parser/dsl.md
@@ -1,0 +1,197 @@
+# Introduction
+
+This file gives a basic runthrough of the in-progress design of a DSL
+for syntax and AST specification.
+
+## Basics
+
+```
+-- Line comments
+
+/-
+Multiline comments
+-/
+```
+
+We declare new types in the AST and non-terminals in
+the grammar with `type`.
+
+```
+type Expr
+```
+
+A constructor in the AST and production in the grammar is introduced
+with `prod`.
+
+```
+prod TmInt: Expr = value:Int
+```
+
+Each constructor gets its own language fragment in the generated code,
+thus the above yields the following fragment:
+
+```
+lang TmInt
+  syn Expr =
+  | TmInt { value : Int }
+```
+
+The syntax of a single production can contain regex style repetition
+operators:
+
+```
+-- Repeated field names are collected into a sequence in the
+-- order they appear in the source.
+prod TmTuple: Expr = "(" fields:Expr ("," fields:Expr)+ ")"
+-- Zero-or-more is expressed with `?` and produce an Option
+prod TmLet: Expr = "let" ident:LIdent (":" tyIdent:Type)? "=" value:Expr "in" body:Expr
+```
+We can also give the constructor nested records:
+
+```
+prod TmMatch: Expr = "match" target:Expr "with" arms:{"|" pat:Pat "->" body:Expr}+
+```
+
+```
+lang TmMatch
+  syn Expr =
+  | TmMatch { target : Expr, arms : [{pat : Pat, body : Expr}]}
+end
+```
+
+Explicit grouping (i.e. parentheses) should not be specified as a
+production but rather explicitly as grouping:
+
+```
+grouping "(" Expr ")"
+```
+
+It should have the form `grouping` `<token>` `<type>` `<token>`.
+
+### Tokens
+
+Tokens can be either a literal (e.g. `"let"`) or a named token
+(e.g. `LIdent`). In the current system there is a number of builtin
+token types, currently specified in `lexer.mc`.
+
+## Operators
+
+Operators can be written either explicitly:
+```
+prod TmAdd: Expr = left:Expr "+" right:Expr
+```
+
+...or with syntactic sugar:
+```
+infix TmMul: Expr = "*"
+
+-- Similarly for prefix and postfix
+prefix TmNot: Expr = "!"
+postfix TmFieldAccess: Expr = "." field:LIdent
+```
+
+Each production will be one of these things:
+- Simple/atomic if it has no direct recursion on either edge
+- Prefix if it only has direct recursion on the right edge
+- Postfix if it only has direct recursion on the left edge
+- Infix if it has direct recursion on both edges
+
+I suspect that productions that sometimes have direct recursion on the
+edge and sometimes not are a bad idea. Please let me know if such
+cases come up, so we can see if that is correct or not.
+
+Infix productions can specify their associativity:
+
+```
+prod left TmSub: Expr = left:Expr "-" right:Expr
+infix left TmDiv: Expr = "/"
+```
+
+## Precedence
+
+Precedence is primarily specified with a precedence table:
+
+```
+precedence {
+  TmFieldAccess;
+  TmNot;
+  TmMul TmDiv;
+  TmAdd TmSub;
+}
+```
+Note that only non-simple productions can appear in a precedence list,
+i.e., operators; those that are prefix, postfix, or infix.
+
+Operators appearing earlier in the list (i.e. higher) have higher
+precedence than operators appearing later. Operators on the same
+level have the same precedence.
+
+### Same Precedence
+
+To see what happens when two operators have the same precedence we
+first need to look at their associativity. Note that prefix operators
+associate to the right by definition, and postfix operators associate
+left.
+
+- If the operators have the same associativity then grouping will
+  follow that associativity. For example, given left-associative
+  addition and subtraction on the same precedence, `a - b + c` is
+  `(a - b) + c`.
+- If the operators do not have the same associativity grouping becomes
+  ambiguous.
+
+### Exceptions
+
+It is also possible to write a precedence table that is not total by
+specifying which relations should *not* be defined through this table:
+
+```
+precedence {
+  mul div;
+  add sub;
+  equal notEqual less greater;
+} except {
+  equal notEqual less greater;
+}
+```
+
+Each line in the `except` block makes precedence undefined between
+each possible pair of operators on the line. In this case, e.g.,
+`equal` and `notEqual` do not have defined relative precedence, nor
+does `notEqual` and `greater`.
+
+## Broken Productions
+
+Productions that use the regex repetition operators can be broken
+apart into multiple operators for the parsing stage, then
+automatically reassembled when the AST is constructed. This makes it
+possible to perform disambiguation through precedence and
+associativity, and also to produce ambiguity error messages.
+
+Ideally this should happen entirely automatically with no need for
+additional annotations, thus this section should not be required
+reading in most cases.
+
+However, it will affect error messages for bad grammars. I believe it
+should not introduce new cases where grammars are bad, rather make
+some grammars accepted that otherwise wouldn't be and change the
+errors for others, but I'm not sure yet.
+
+The specifics of this are not yet known to me, but I suspect the
+following will be true:
+
+A repetition will be broken out to a new operator if it can end up
+adjacent to a direct recursion. For example:
+
+```
+-- Note that `?` is a repetition, just a very simple one
+prod if: Expr = "if" cond:Expr "then" then:Expr ("else" else:Expr)?
+```
+
+Note that a `*` or `+` repetition that has direct recursion at the
+edge will trivially be adjacent to direct recursion:
+
+
+```
+prod match: Expr = "match" target:Expr "with" arms:{"|" p:Pat "->" body:Expr}+
+```

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -401,6 +401,30 @@ lang CarriedSeq = CarriedTypeBase
     else None ()
 end
 
+lang CarriedOption = CarriedTypeBase
+  syn CarriedType =
+  | OptionType CarriedType
+
+  sem carriedRepr =
+  | OptionType ty -> tyapp_ (tycon_ "Option") (carriedRepr ty)
+
+  sem carriedSMapAccumL f targetTy =
+  | OptionType ty ->
+    match carriedSMapAccumL f targetTy ty with Some mkNew then Some
+      (lam accName. lam valName.
+        let innerAcc = nameSym "acc" in
+        let innerVal = nameSym "x" in
+        appf3_
+          (var_ "optionMapAccum")
+          (nulam_ innerAcc
+            (nulam_ innerVal
+              (mkNew innerAcc innerVal)))
+          (nvar_ accName)
+          (nvar_ valName)
+      )
+    else None ()
+end
+
 lang CarriedRecord = CarriedTypeBase
   syn CarriedType =
   | RecordType [(String, CarriedType)]
@@ -467,6 +491,11 @@ let seqType
   -> CarriedType
   = lam ty. use CarriedSeq in SeqType ty
 
+let optionType
+  : CarriedType
+  -> CarriedType
+  = lam ty. use CarriedOption in OptionType ty
+
 let recordType
   : [(String, CarriedType)]
   -> CarriedType
@@ -519,7 +548,7 @@ lang CarriedTypeGenerate = CarriedTypeHelpers
     else never
 end
 
-lang CarriedBasic = CarriedTypeGenerate + CarriedTarget + CarriedSeq + CarriedRecord
+lang CarriedBasic = CarriedTypeGenerate + CarriedTarget + CarriedSeq + CarriedRecord + CarriedOption
 end
 
 mexpr

--- a/stdlib/parser/selfhost-sketch.mc
+++ b/stdlib/parser/selfhost-sketch.mc
@@ -203,8 +203,10 @@ lang FileOpBase
 
   sem topAllowed_FileOp =
   | _ -> true
+  sem leftAllowed_FileOp : {parent : FileOp LOpen rstyle1, child : FileOp lstyle rstyle2} -> Bool
   sem leftAllowed_FileOp =
   | {parent = _, child = c} -> topAllowed_FileOp c
+  sem rightAllowed_FileOp : {parent : FileOp lstyle1 ROpen, child : FileOp lstyle2 rstyle} -> Bool
   sem rightAllowed_FileOp =
   | {parent = _, child = c} -> topAllowed_FileOp c
   sem groupingsAllowed_FileOp =
@@ -221,8 +223,10 @@ lang DeclOpBase
 
   sem topAllowed_DeclOp =
   | _ -> true
+  sem leftAllowed_DeclOp : {parent : DeclOp LOpen rstyle1, child : DeclOp lstyle rstyle2} -> Bool
   sem leftAllowed_DeclOp =
   | {parent = _, child = c} -> topAllowed_DeclOp c
+  sem rightAllowed_DeclOp : {parent : DeclOp lstyle1 ROpen, child : DeclOp lstyle2 rstyle} -> Bool
   sem rightAllowed_DeclOp =
   | {parent = _, child = c} -> topAllowed_DeclOp c
   sem groupingsAllowed_DeclOp =
@@ -239,8 +243,10 @@ lang RegexOpBase
 
   sem topAllowed_RegexOp =
   | _ -> true
+  sem leftAllowed_RegexOp : {parent : RegexOp LOpen rstyle1, child : RegexOp lstyle rstyle2} -> Bool
   sem leftAllowed_RegexOp =
   | {parent = _, child = c} -> topAllowed_RegexOp c
+  sem rightAllowed_RegexOp : {parent : RegexOp lstyle1 ROpen, child : RegexOp lstyle2 rstyle} -> Bool
   sem rightAllowed_RegexOp =
   | {parent = _, child = c} -> topAllowed_RegexOp c
   sem groupingsAllowed_RegexOp =
@@ -257,8 +263,10 @@ lang ExprOpBase
 
   sem topAllowed_ExprOp =
   | _ -> true
+  sem leftAllowed_ExprOp : {parent : ExprOp LOpen rstyle1, child : ExprOp lstyle rstyle2} -> Bool
   sem leftAllowed_ExprOp =
   | {parent = _, child = c} -> topAllowed_ExprOp c
+  sem rightAllowed_ExprOp : {parent : ExprOp lstyle1 ROpen, child : ExprOp lstyle2 rstyle} -> Bool
   sem rightAllowed_ExprOp =
   | {parent = _, child = c} -> topAllowed_ExprOp c
   sem groupingsAllowed_ExprOp =
@@ -282,7 +290,7 @@ lang FileAst = SelfhostBaseAst
   sem get_File_info =
   | File x -> x.info
 
-  sem smapAccumL_File_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  sem smapAccumL_File_Decl f acc =
   | File x ->
     match mapAccumL f acc x.decls with (acc, decls) in
     (acc, File {x with decls = decls})
@@ -348,7 +356,7 @@ lang TypeDeclAst = SelfhostBaseAst
   sem get_Decl_info =
   | TypeDecl x -> x.info
 
-  sem smapAccumL_Decl_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smapAccumL_Decl_Expr f acc =
   | TypeDecl x ->
     match mapAccumL (lam acc. lam x. match f acc x.val with (acc, val) in {x with val = val}) acc x.properties with (acc, properties) in
     (acc, TypeDecl {x with properties = properties})
@@ -384,7 +392,7 @@ lang TokenDeclAst = SelfhostBaseAst
   sem get_Decl_info =
   | TokenDecl x -> x.info
 
-  sem smapAccumL_Decl_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smapAccumL_Decl_Expr f acc =
   | TokenDecl x ->
     match mapAccumL (lam acc. lam x. match f acc x.val with (acc, val) in {x with val = val}) acc x.properties with (acc, properties) in
     (acc, TokenDecl {x with properties = properties})
@@ -457,7 +465,7 @@ lang ProductionDeclAst = SelfhostBaseAst
   sem get_Decl_info =
   | ProductionDecl x -> x.info
 
-  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Decl_Regex f acc =
   | ProductionDecl x ->
     match f acc x.regex with (acc, regex) in
     (acc, ProductionDecl {x with regex = regex})
@@ -488,7 +496,7 @@ lang InfixDeclAst = SelfhostBaseAst
   sem get_Decl_info =
   | InfixDecl x -> x.info
 
-  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Decl_Regex f acc =
   | InfixDecl x ->
     match f acc x.regex with (acc, regex) in
     (acc, InfixDecl {x with regex = regex})
@@ -519,7 +527,7 @@ lang PrefixDeclAst = SelfhostBaseAst
   sem get_Decl_info =
   | PrefixDecl x -> x.info
 
-  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Decl_Regex f acc =
   | PrefixDecl x ->
     match f acc x.regex with (acc, regex) in
     (acc, PrefixDecl {x with regex = regex})
@@ -550,7 +558,7 @@ lang PostfixDeclAst = SelfhostBaseAst
   sem get_Decl_info =
   | PostfixDecl x -> x.info
 
-  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Decl_Regex f acc =
   | PostfixDecl x ->
     match f acc x.regex with (acc, regex) in
     (acc, PostfixDecl {x with regex = regex})
@@ -603,7 +611,7 @@ lang RecordRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | RecordRegex x -> x.info
 
-  sem smapAccumL_Regex_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smapAccumL_Regex_Expr f acc =
   | RecordRegex x ->
     match f acc x.regex with (acc, regex) in
     (acc, RecordRegex {x with regex = regex})
@@ -686,7 +694,7 @@ lang TokenRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | TokenRegex x -> x.info
 
-  sem smapAccumL_Regex_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smapAccumL_Regex_Expr f acc =
   | TokenRegex x ->
     match optionMapAccum f acc x.arg with (acc, arg) in
     (acc, TokenRegex {x with arg = arg })
@@ -717,7 +725,7 @@ lang RepeatPlusRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | RepeatPlusRegex x -> x.info
 
-  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Regex_Regex f acc =
   | RepeatPlusRegex x ->
     match f acc x.left with (acc, left) in
     (acc, RepeatPlusRegex {x with left = left})
@@ -751,7 +759,7 @@ lang RepeatStarRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | RepeatStarRegex x -> x.info
 
-  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Regex_Regex f acc =
   | RepeatStarRegex x ->
     match f acc x.left with (acc, left) in
     (acc, RepeatStarRegex {x with left = left})
@@ -785,7 +793,7 @@ lang RepeatQuestionRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | RepeatQuestionRegex x -> x.info
 
-  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Regex_Regex f acc =
   | RepeatQuestionRegex x ->
     match f acc x.left with (acc, left) in
     (acc, RepeatQuestionRegex {x with left = left})
@@ -819,7 +827,7 @@ lang NamedRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | NamedRegex x -> x.info
 
-  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Regex_Regex f acc =
   | NamedRegex x ->
     match f acc x.right with (acc, right) in
     (acc, NamedRegex {x with right = right})
@@ -853,7 +861,7 @@ lang AlternativeRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | AlternativeRegex x -> x.info
 
-  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Regex_Regex f acc =
   | AlternativeRegex x ->
     match f acc x.left with (acc, left) in
     match f acc x.right with (acc, right) in
@@ -892,7 +900,7 @@ lang ConcatRegexAst = SelfhostBaseAst
   sem get_Regex_info =
   | ConcatRegex x -> x.info
 
-  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Regex_Regex f acc =
   | ConcatRegex x ->
     match f acc x.left with (acc, left) in
     match f acc x.right with (acc, right) in

--- a/stdlib/parser/selfhost-sketch.mc
+++ b/stdlib/parser/selfhost-sketch.mc
@@ -106,9 +106,13 @@ lang SelfhostBaseAst
   sem get_Expr_info =
 
   sem smapAccumL_File_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_File_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_File_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_File_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | x -> (acc, x)
   sem smap_File_File (f : File -> File) =
   | x -> match smapAccumL_File_File (lam. lam x. ((), f x)) () x with (_, x) in x
   sem smap_File_Decl (f : Decl -> Decl) =
@@ -125,9 +129,13 @@ lang SelfhostBaseAst
   | x -> match smapAccumL_File_Expr (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
 
   sem smapAccumL_Decl_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Decl_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Decl_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | x -> (acc, x)
   sem smap_Decl_File (f : File -> File) =
   | x -> match smapAccumL_Decl_File (lam. lam x. ((), f x)) () x with (_, x) in x
   sem smap_Decl_Decl (f : Decl -> Decl) =
@@ -144,9 +152,13 @@ lang SelfhostBaseAst
   | x -> match smapAccumL_Decl_Expr (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
 
   sem smapAccumL_Regex_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Regex_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Regex_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | x -> (acc, x)
   sem smap_Regex_File (f : File -> File) =
   | x -> match smapAccumL_Regex_File (lam. lam x. ((), f x)) () x with (_, x) in x
   sem smap_Regex_Decl (f : Decl -> Decl) =
@@ -163,9 +175,13 @@ lang SelfhostBaseAst
   | x -> match smapAccumL_Regex_Expr (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
 
   sem smapAccumL_Expr_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Expr_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Expr_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | x -> (acc, x)
   sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | x -> (acc, x)
   sem smap_Expr_File (f : File -> File) =
   | x -> match smapAccumL_Expr_File (lam. lam x. ((), f x)) () x with (_, x) in x
   sem smap_Expr_Decl (f : Decl -> Decl) =

--- a/stdlib/parser/selfhost-sketch.mc
+++ b/stdlib/parser/selfhost-sketch.mc
@@ -1002,6 +1002,7 @@ lang ParseSelfhost = SelfhostAst + TokenParser
 end
 
 let _table =
+  type State = {errors : Ref [(Info, String)], content : String} in
   use ParseSelfhost in
   let brFile =
     let config =
@@ -1012,7 +1013,7 @@ let _table =
       , groupingsAllowed = groupingsAllowed_FileOp
       } in
     let mkOptInputFunction = lam addF.
-      lam p. lam x. lam st.
+      lam p : State. lam x. lam st.
       match st with Some st then
         let st = addF config x st in
         (match st with None _ then
@@ -1027,7 +1028,7 @@ let _table =
     , infix = mkOptInputFunction breakableAddInfix
     , prefix = mkInputFunction breakableAddPrefix
     , postfix = mkOptInputFunction breakableAddPostfix
-    , finalize = lam p. lam st.
+    , finalize = lam p : State. lam st.
       let res = optionBind st
         (lam st. match breakableFinalizeParse config st with Some [top] ++ _
           then Some (unsplit_FileOp top)
@@ -1045,7 +1046,7 @@ let _table =
       , groupingsAllowed = groupingsAllowed_DeclOp
       } in
     let mkOptInputFunction = lam addF.
-      lam p. lam x. lam st.
+      lam p : State. lam x. lam st.
       match st with Some st then
         let st = addF config x st in
         (match st with None _ then
@@ -1060,7 +1061,7 @@ let _table =
     , infix = mkOptInputFunction breakableAddInfix
     , prefix = mkInputFunction breakableAddPrefix
     , postfix = mkOptInputFunction breakableAddPostfix
-    , finalize = lam p. lam st.
+    , finalize = lam p : State. lam st.
       let res = optionBind st
         (lam st. match breakableFinalizeParse config st with Some [top] ++ _
           then Some (unsplit_DeclOp top)
@@ -1086,7 +1087,7 @@ let _table =
       , rpar = ")"
       } in
     let mkOptInputFunction = lam addF.
-      lam p. lam x. lam st.
+      lam p : State. lam x. lam st.
       match st with Some st then
         let st = addF config x st in
         (match st with None _ then
@@ -1101,7 +1102,7 @@ let _table =
     , infix = mkOptInputFunction breakableAddInfix
     , prefix = mkInputFunction breakableAddPrefix
     , postfix = mkOptInputFunction breakableAddPostfix
-    , finalize = lam p. lam st.
+    , finalize = lam p : State. lam st.
       let res = optionBind st
         (lam st. match breakableFinalizeParse config st with Some (tops & [top] ++ _)
           then
@@ -1133,7 +1134,7 @@ let _table =
       , rpar = ")"
       } in
     let mkOptInputFunction = lam addF.
-      lam p. lam x. lam st.
+      lam p : State. lam x. lam st.
       match st with Some st then
         let st = addF config x st in
         (match st with None _ then
@@ -1143,12 +1144,12 @@ let _table =
         st
       else st in
     let mkInputFunction =
-      lam addF. lam p. lam x. lam st. optionMap (addF config x) st in
+      lam addF. lam p : State. lam x. lam st. optionMap (addF config x) st in
     { atom = mkInputFunction breakableAddAtom
     , infix = mkOptInputFunction breakableAddInfix
     , prefix = mkInputFunction breakableAddPrefix
     , postfix = mkOptInputFunction breakableAddPostfix
-    , finalize = lam p. lam st.
+    , finalize = lam p : State. lam st.
       let res = optionBind st
         (lam st. match breakableFinalizeParse config st with Some (tops & [top] ++ _)
           then
@@ -1280,6 +1281,7 @@ let _table =
             , nt = match prev.nt with [x] ++ _ in x
             , regex = match prev.regex with [x] ++ _ in x
             , info = prev.info
+            , terms = prev.terms
             }
         }
       , { nt = decl_Production_1
@@ -1353,6 +1355,7 @@ let _table =
         , rhs = [litSym "{", ntSym decl_Type_2, litSym "}"]
         , action = lam p. lam seq.
           match seq with [LitParsed l, UserSym prev, LitParsed r] in
+          let prev : {properties : [{name : {v: Name, i: Info}, val : Expr}], terms : [Info]} = prev in
           { info = mergeInfo l.info r.info
           , name = []
           , properties = prev.properties

--- a/stdlib/parser/selfhost-sketch.mc
+++ b/stdlib/parser/selfhost-sketch.mc
@@ -301,7 +301,7 @@ prod Type: Decl =
 
 lang TypeDeclAst = SelfhostBaseAst
   syn Decl =
-  | TypeDecl { name : Name, properties : [{name : Name, val : Expr}], info : Info }
+  | TypeDecl { name : {v: Name, i: Info}, properties : [{name : {v: Name, i: Info}, val : Expr}], info : Info }
 
   sem get_Decl_info =
   | TypeDecl x -> x.info
@@ -314,7 +314,7 @@ end
 
 lang TypeDeclOp = DeclOpBase + TypeDeclAst
   syn DeclOp =
-  | TypeDeclOp { name : Name, properties : [{name : Name, val : Expr}], info : Info, terms : [Info] }
+  | TypeDeclOp { name : {v: Name, i: Info}, properties : [{name : {v: Name, i: Info}, val : Expr}], info : Info, terms : [Info] }
 
   sem get_DeclOp_terms =
   | TypeDeclOp x -> x.terms
@@ -340,8 +340,8 @@ prod PrecedenceTable: Decl =
 lang PrecedenceTableDeclAst = SelfhostBaseAst
   syn Decl =
   | PrecedenceTableDecl
-    { levels : [{noeq : Option (), operators : [Name]}]
-    , exceptions : [{lefts : [Name], rights : [Name]}]
+    { levels : [{noeq : Option {v: (), i: Info}, operators : [{v: Name, i: Info}]}]
+    , exceptions : [{lefts : [{v: Name, i: Info}], rights : [{v: Name, i: Info}]}]
     , info : Info
     }
 
@@ -352,8 +352,8 @@ end
 lang PrecedenceTableDeclOp = DeclOpBase + PrecedenceTableDeclAst
   syn DeclOp =
   | PrecedenceTableDeclOp
-    { levels : [{noeq : Option (), operators : [Name]}]
-    , exceptions : [{lefts : [Name], rights : [Name]}]
+    { levels : [{noeq : Option (), operators : [{v: Name, i: Info}]}]
+    , exceptions : [{lefts : [{v: Name, i: Info}], rights : [{v: Name, i: Info}]}]
     , info : Info
     , terms : [Info]
     }
@@ -374,7 +374,7 @@ prod Production: Decl = ("prod" | "infix" | "prefix" | "postfix") assoc:LIdent? 
 
 lang ProductionDeclAst = SelfhostBaseAst
   syn Decl =
-  | ProductionDecl { assoc : Option String, name : Name, nt : Name, regex : Regex, info : Info }
+  | ProductionDecl { assoc : Option {v: String, i: Info}, name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info }
 
   sem get_Decl_info =
   | ProductionDecl x -> x.info
@@ -387,7 +387,7 @@ end
 
 lang ProductionDeclOp = DeclOpBase + ProductionDeclAst
   syn DeclOp =
-  | ProductionDeclOp { assoc : Option Name, name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+  | ProductionDeclOp { assoc : Option {v: Name, i: Info}, name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info, terms : [Info] }
 
   sem get_DeclOp_terms =
   | ProductionDeclOp x -> x.terms
@@ -405,7 +405,7 @@ prod Infix: Decl = "infix" assoc:LIdent? name:UName ":" nt:UName "=" regex:Regex
 
 lang InfixDeclAst = SelfhostBaseAst
   syn Decl =
-  | InfixDecl { assoc : Option Name, name : Name, nt : Name, regex : Regex, info : Info }
+  | InfixDecl { assoc : Option {v: Name, i: Info}, name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info }
 
   sem get_Decl_info =
   | InfixDecl x -> x.info
@@ -418,7 +418,7 @@ end
 
 lang InfixDeclOp = DeclOpBase + InfixDeclAst
   syn DeclOp =
-  | InfixDeclOp { assoc : Option Name, name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+  | InfixDeclOp { assoc : Option {v: Name, i: Info}, name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info, terms : [Info] }
 
   sem get_DeclOp_terms =
   | InfixDeclOp x -> x.terms
@@ -436,7 +436,7 @@ prod Prefix: Decl = "prefix" name:UName ":" nt:UName "=" regex:Regex
 
 lang PrefixDeclAst = SelfhostBaseAst
   syn Decl =
-  | PrefixDecl { name : Name, nt : Name, regex : Regex, info : Info }
+  | PrefixDecl { name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info }
 
   sem get_Decl_info =
   | PrefixDecl x -> x.info
@@ -449,7 +449,7 @@ end
 
 lang PrefixDeclOp = DeclOpBase + PrefixDeclAst
   syn DeclOp =
-  | PrefixDeclOp { name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+  | PrefixDeclOp { name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info, terms : [Info] }
 
   sem get_DeclOp_terms =
   | PrefixDeclOp x -> x.terms
@@ -467,7 +467,7 @@ prod Postfix: Decl = "postfix" name:UName ":" nt:UName "=" regex:Regex
 
 lang PostfixDeclAst = SelfhostBaseAst
   syn Decl =
-  | PostfixDecl { name : Name, nt : Name, regex : Regex, info : Info }
+  | PostfixDecl { name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info }
 
   sem get_Decl_info =
   | PostfixDecl x -> x.info
@@ -480,7 +480,7 @@ end
 
 lang PostfixDeclOp = DeclOpBase + PostfixDeclAst
   syn DeclOp =
-  | PostfixDeclOp { name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+  | PostfixDeclOp { name : {v: Name, i: Info}, nt : {v: Name, i: Info}, regex : Regex, info : Info, terms : [Info] }
 
   sem get_DeclOp_terms =
   | PostfixDeclOp x -> x.terms
@@ -603,7 +603,7 @@ prod Token: Regex = name:UName ("[" arg:Expr "]")?
 
 lang TokenRegexAst = SelfhostBaseAst
   syn Regex =
-  | TokenRegex { name : Name, arg : Option Expr, info : Info }
+  | TokenRegex { name : {v: Name, i: Info}, arg : Option Expr, info : Info }
 
   sem get_Regex_info =
   | TokenRegex x -> x.info
@@ -616,7 +616,7 @@ end
 
 lang TokenRegexOp = RegexOpBase + TokenRegexAst
   syn RegexOp =
-  | TokenRegexOp { name : Name, arg : Option Expr, info : Info, terms : [Info] }
+  | TokenRegexOp { name : {v: Name, i: Info}, arg : Option Expr, info : Info, terms : [Info] }
 
   sem get_RegexOp_terms =
   | TokenRegexOp x -> x.terms
@@ -736,7 +736,7 @@ prefix Named: Regex = name:LName ":"
 
 lang NamedRegexAst = SelfhostBaseAst
   syn Regex =
-  | NamedRegex { name : Name, right : Regex, info : Info }
+  | NamedRegex { name : {v: Name, i: Info}, right : Regex, info : Info }
 
   sem get_Regex_info =
   | NamedRegex x -> x.info
@@ -749,7 +749,7 @@ end
 
 lang NamedRegexOp = RegexOpBase + NamedRegexAst
   syn RegexOp =
-  | NamedRegexOp { name : Name, info : Info, terms : [Info] }
+  | NamedRegexOp { name : {v: Name, i: Info}, info : Info, terms : [Info] }
 
   sem get_RegexOp_terms =
   | NamedRegexOp x -> x.terms
@@ -1186,7 +1186,7 @@ let _table =
         , rhs = [litSym "prod", ntSym decl_Production_1]
         , action = lam. lam seq.
           match seq with [LitParsed prod, UserSym prev] in
-          let prev: {info : Info, terms : [Info], assoc : [String], name : [Name], nt : [Name], regex : [Regex]} = prev in
+          let prev: {info : Info, terms : [Info], assoc : [{v: String, i: Info}], name : [{v: Name, i: Info}], nt : [{v: Name, i: Info}], regex : [Regex]} = prev in
           let prev = {{prev with info = mergeInfo prod.info prev.info} with terms = cons prod.info prev.terms} in
           ProductionDeclOp
             { assoc = match prev.assoc with [x] ++ _ then Some x else None ()
@@ -1207,8 +1207,8 @@ let _table =
         , rhs = [tokSym (LIdentRepr ()), ntSym decl_Production_2]
         , action = lam. lam seq.
           match seq with [TokParsed (LIdentTok tok), UserSym prev] in
-          let prev: {info : Info, terms : [Info], assoc : [String], name : [Name], nt : [Name], regex : [Regex]} = prev in
-          let prev = {{{prev with info = mergeInfo tok.info prev.info} with terms = cons tok.info prev.terms} with assoc = cons tok.val prev.assoc} in
+          let prev: {info : Info, terms : [Info], assoc : [{v: String, i: Info}], name : [{v: Name, i: Info}], nt : [{v: Name, i: Info}], regex : [Regex]} = prev in
+          let prev = {{{prev with info = mergeInfo tok.info prev.info} with terms = cons tok.info prev.terms} with assoc = cons {v = tok.val, i = tok.info} prev.assoc} in
           prev
         }
       , { nt = decl_Production_2
@@ -1219,8 +1219,8 @@ let _table =
           { info = mergeInfo name.info regexInfo
           , terms = [name.info, x1.info, nt.info, x2.info]
           , assoc = []
-          , name = [(nameNoSym) name.val]
-          , nt = [(nameNoSym) nt.val]
+          , name = [{v = (nameNoSym) name.val, i = name.info}]
+          , nt = [{v = (nameNoSym) nt.val, i = nt.info}]
           , regex = [regex]
           }
         }
@@ -1229,8 +1229,11 @@ let _table =
         , rhs = [litSym "type", tokSym (UIdentRepr ()), ntSym decl_Type_1]
         , action = lam p. lam seq.
           match seq with [LitParsed l, TokParsed (UIdentTok name), UserSym prev] in
-          let prev : {name : [Name], properties : [{name : Name, val : Expr}], info : Info, terms : [Info]} = prev in
-          let prev = {{{prev with name = cons (nameNoSym name.val) prev.name} with info = mergeInfo l.info (mergeInfo name.info prev.info)} with terms = concat [l.info, name.info] prev.terms} in
+          let prev : {name : [{v: Name, i: Info}], properties : [{name : {v: Name, i: Info}, val : Expr}], info : Info, terms : [Info]} = prev in
+          let prev = {{{prev
+            with name = cons {v = (nameNoSym name.val), i = name.info} prev.name}
+            with info = mergeInfo l.info (mergeInfo name.info prev.info)}
+            with terms = concat [l.info, name.info] prev.terms} in
           TypeDeclOp
             { name = match prev.name with [name] ++ _ in name
             , properties = prev.properties
@@ -1272,8 +1275,8 @@ let _table =
         , rhs = [tokSym (LIdentRepr ()), litSym "=", ntSym expr_top, litSym ",", ntSym decl_Type_2]
         , action = lam p. lam seq.
           match seq with [TokParsed (LIdentTok name), LitParsed eq, UserSym (_, expr), LitParsed comma, UserSym prev] in
-          let prev: {properties : [{name : Name, val : Expr}], terms : [Info]} = prev in
-          let prev = {{prev with properties = cons {name = nameNoSym name.val, val = expr} prev.properties} with terms = concat [name.info, eq.info, comma.info] prev.terms} in
+          let prev: {properties : [{name : {v: Name, i: Info}, val : Expr}], terms : [Info]} = prev in
+          let prev = {{prev with properties = cons {name = {v = nameNoSym name.val, i = name.info}, val = expr} prev.properties} with terms = concat [name.info, eq.info, comma.info] prev.terms} in
           prev
         }
       , { nt = decl_atom
@@ -1284,7 +1287,7 @@ let _table =
         , rhs = [litSym "precedence", litSym "{", ntSym decl_PrecedenceTable_1, litSym "}"]
         , action = lam p. lam seq.
           match seq with [LitParsed prec, LitParsed l, UserSym levels, LitParsed r] in
-          let levels: {levels : [{noeq : Option (), operators : [Name]}], terms : [Info]} = levels in
+          let levels: {levels : [{noeq : Option {v: (), i: Info}, operators : [{v: Name, i: Info}]}], terms : [Info]} = levels in
           PrecedenceTableDeclOp
             { info = mergeInfo prec.info r.info
             , terms = snoc (concat [prec.info, l.info] levels.terms) r.info
@@ -1297,11 +1300,11 @@ let _table =
         , rhs = [tokSym (UIdentRepr ()), ntSym decl_PrecedenceTable_2, litSym ";", ntSym decl_PrecedenceTable_1]
         , action = lam p. lam seq.
           match seq with [TokParsed (UIdentTok first), UserSym level, LitParsed semi, UserSym prev] in
-          let level: {terms : [Info], operators : [Name]} = level in
+          let level: {terms : [Info], operators : [{v: Name, i: Info}]} = level in
           let level = {{level
             with terms = snoc (cons first.info level.terms) semi.info}
-            with operators = cons (nameNoSym first.val) level.operators} in
-          let prev: {terms : [Info], levels : [{noeq : Option (), operators : [Name]}]} = prev in
+            with operators = cons {v = nameNoSym first.val, i = first.info} level.operators} in
+          let prev: {terms : [Info], levels : [{noeq : Option {v: (), i: Info}, operators : [{v: Name, i: Info}]}]} = prev in
           let prev = {{prev
             with terms = concat level.terms prev.terms}
             with levels = cons {noeq = None (), operators = level.operators} prev.levels} in
@@ -1318,10 +1321,10 @@ let _table =
         , rhs = [tokSym (UIdentRepr ()), ntSym (decl_PrecedenceTable_2)]
         , action = lam p. lam seq.
           match seq with [TokParsed (UIdentTok name), UserSym prev] in
-          let prev: {terms : [Info], operators : [Name]} = prev in
+          let prev: {terms : [Info], operators : [{v: Name, i: Info}]} = prev in
           let prev = {{prev
             with terms = cons name.info prev.terms}
-            with operators = cons (nameNoSym name.val) prev.operators} in
+            with operators = cons {v = nameNoSym name.val, i = name.info} prev.operators} in
           prev
         }
       , { nt = decl_PrecedenceTable_2
@@ -1406,8 +1409,8 @@ let _table =
         , rhs = [TokSpec (UIdentRepr ()), ntSym regex_Token_1]
         , action = lam p. lam seq.
           match seq with [TokParsed (UIdentTok x), UserSym prev] in
-          let prev: {info : Info, terms : [Info], name : [Name], arg : [Expr]} = prev in
-          let prev = {{{prev with info = mergeInfo x.info prev.info} with terms = cons x.info prev.terms} with name = cons (nameNoSym x.val) prev.name} in
+          let prev: {info : Info, terms : [Info], name : [{v: Name, i: Info}], arg : [Expr]} = prev in
+          let prev = {{{prev with info = mergeInfo x.info prev.info} with terms = cons x.info prev.terms} with name = cons {v = nameNoSym x.val, i = x.info} prev.name} in
           TokenRegexOp
             { info = prev.info
             , terms = prev.terms
@@ -1454,7 +1457,7 @@ let _table =
         , rhs = [TokSpec (LIdentRepr ()), litSym ":"]
         , action = lam p. lam seq.
           match seq with [TokParsed (LIdentTok name), LitParsed x] in
-          NamedRegexOp { name = nameNoSym name.val, info = mergeInfo name.info x.info, terms = [name.info, x.info] }
+          NamedRegexOp { name = {v = nameNoSym name.val, i = name.info}, info = mergeInfo name.info x.info, terms = [name.info, x.info] }
         }
       , { nt = regex_infix
         , label = "Regex_Alternative"
@@ -1501,12 +1504,6 @@ let parseSelfhostExn
     end
 
 mexpr
-
-let testParse = lam filename. lam content.
-  switch parseSelfhost filename content
-  case Right x then Some x
-  case Left errs then for_ errs (lam x. match x with (info, msg) in printLn (infoErrorString info msg)); None ()
-  end in
 
 let filename = "blub" in
 let content = join

--- a/stdlib/parser/selfhost-sketch.mc
+++ b/stdlib/parser/selfhost-sketch.mc
@@ -1,0 +1,1519 @@
+-- Basics, always present
+include "seq.mc"
+include "option.mc"
+include "parser/breakable.mc"
+include "parser/ll1.mc"
+
+/-
+token Integer {
+  include: "lexer.mc";
+  lang: UIntTokenParser;
+  type: "Int";
+  unitConstructor: "IntRepr ()";
+}
+token String {
+  include: "lexer.mc";
+  lang: StringTokenParser;
+  type: "String";
+  unitConstructor: "StringRepr ()";
+}
+token Operator {
+  include: "lexer.mc";
+  lang: OperatorTokenParser;
+  type: "String";
+  unitConstructor: "OperatorRepr ()";
+}
+token HashString {
+  include: "lexer.mc";
+  lang: HashStringTokenParser;
+  type: "String";
+  constructor: "lam str. HashStringRepr {hash = str}"
+}
+token UIdent {
+  include: "lexer.mc";
+  lang: UIdentTokenParser;
+  type: "String";
+  unitConstructor: "UIdentRepr ()"
+}
+token LIdent {
+  include: "lexer.mc";
+  lang: LIdentTokenParser;
+  type: "String";
+  unitConstructor: "LIdentRepr ()"
+}
+token {
+  include: "lexer.mc";
+  lang: WhitespaceParser;
+}
+token {
+  include: "lexer.mc";
+  lang: LineCommentParser;
+}
+token {
+  include: "lexer.mc";
+  lang: MultilineCommentParser;
+}
+token {
+  include: "lexer.mc";
+  lang: BracketTokenParser;
+}
+token {
+  include: "lexer.mc";
+  lang: CommaTokenParser;
+}
+token {
+  include: "lexer.mc";
+  lang: SemiTokenParser;
+}
+-/
+include "lexer.mc"
+
+/-
+token UName {
+  base: UIdent;
+  include: "name.mc";
+  type: "Name";
+  conversion: "nameNoSym";
+}
+token LName {
+  base: LIdent;
+  include: "name.mc";
+  type: "Name";
+  conversion: "nameNoSym";
+}
+-/
+include "name.mc"
+
+/-
+start File
+type File {
+  suffix: false
+}
+type Decl
+type Regex
+type Expr
+-/
+
+lang SelfhostBaseAst
+  syn File =
+  syn Decl =
+  syn Regex =
+  syn Expr =
+
+  sem get_File_info =
+  sem get_Decl_info =
+  sem get_Regex_info =
+  sem get_Expr_info =
+
+  sem smapAccumL_File_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  sem smapAccumL_File_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  sem smapAccumL_File_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_File_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smap_File_File (f : File -> File) =
+  | x -> match smapAccumL_File_File (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_File_Decl (f : Decl -> Decl) =
+  | x -> match smapAccumL_File_Decl (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_File_Regex (f : Regex -> Regex) =
+  | x -> match smapAccumL_File_Regex (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem sfold_File_File (f : acc -> File -> acc) (acc : acc) =
+  | x -> match smapAccumL_File_File (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_File_Decl (f : acc -> Decl -> acc) (acc : acc) =
+  | x -> match smapAccumL_File_Decl (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_File_Regex (f : acc -> Regex -> acc) (acc : acc) =
+  | x -> match smapAccumL_File_Regex (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_File_Expr (f : acc -> Expr -> acc) (acc : acc) =
+  | x -> match smapAccumL_File_Expr (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+
+  sem smapAccumL_Decl_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  sem smapAccumL_Decl_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Decl_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smap_Decl_File (f : File -> File) =
+  | x -> match smapAccumL_Decl_File (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_Decl_Decl (f : Decl -> Decl) =
+  | x -> match smapAccumL_Decl_Decl (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_Decl_Regex (f : Regex -> Regex) =
+  | x -> match smapAccumL_Decl_Regex (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem sfold_Decl_File (f : acc -> File -> acc) (acc : acc) =
+  | x -> match smapAccumL_Decl_File (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Decl_Decl (f : acc -> Decl -> acc) (acc : acc) =
+  | x -> match smapAccumL_Decl_Decl (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Decl_Regex (f : acc -> Regex -> acc) (acc : acc) =
+  | x -> match smapAccumL_Decl_Regex (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Decl_Expr (f : acc -> Expr -> acc) (acc : acc) =
+  | x -> match smapAccumL_Decl_Expr (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+
+  sem smapAccumL_Regex_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  sem smapAccumL_Regex_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Regex_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smap_Regex_File (f : File -> File) =
+  | x -> match smapAccumL_Regex_File (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_Regex_Decl (f : Decl -> Decl) =
+  | x -> match smapAccumL_Regex_Decl (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_Regex_Regex (f : Regex -> Regex) =
+  | x -> match smapAccumL_Regex_Regex (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem sfold_Regex_File (f : acc -> File -> acc) (acc : acc) =
+  | x -> match smapAccumL_Regex_File (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Regex_Decl (f : acc -> Decl -> acc) (acc : acc) =
+  | x -> match smapAccumL_Regex_Decl (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Regex_Regex (f : acc -> Regex -> acc) (acc : acc) =
+  | x -> match smapAccumL_Regex_Regex (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Regex_Expr (f : acc -> Expr -> acc) (acc : acc) =
+  | x -> match smapAccumL_Regex_Expr (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+
+  sem smapAccumL_Expr_File (f : acc -> File -> (acc, File)) (acc : acc) =
+  sem smapAccumL_Expr_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  sem smapAccumL_Expr_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  sem smap_Expr_File (f : File -> File) =
+  | x -> match smapAccumL_Expr_File (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_Expr_Decl (f : Decl -> Decl) =
+  | x -> match smapAccumL_Expr_Decl (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem smap_Expr_Regex (f : Regex -> Regex) =
+  | x -> match smapAccumL_Expr_Regex (lam. lam x. ((), f x)) () x with (_, x) in x
+  sem sfold_Expr_File (f : acc -> File -> acc) (acc : acc) =
+  | x -> match smapAccumL_Expr_File (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Expr_Decl (f : acc -> Decl -> acc) (acc : acc) =
+  | x -> match smapAccumL_Expr_Decl (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Expr_Regex (f : acc -> Regex -> acc) (acc : acc) =
+  | x -> match smapAccumL_Expr_Regex (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+  sem sfold_Expr_Expr (f : acc -> Expr -> acc) (acc : acc) =
+  | x -> match smapAccumL_Expr_Expr (lam acc. lam x. (f acc x, x)) acc x with (acc, _) in acc
+end
+
+lang FileOpBase
+  syn FileOp =
+
+  sem topAllowed_FileOp =
+  | _ -> true
+  sem leftAllowed_FileOp =
+  | {parent = _, child = c} -> topAllowed_FileOp c
+  sem rightAllowed_FileOp =
+  | {parent = _, child = c} -> topAllowed_FileOp c
+  sem groupingsAllowed_FileOp =
+  | _ -> GEither ()
+  sem parenAllowed_FileOp =
+  | _ -> GEither ()
+  sem get_FileOp_info =
+  sem get_FileOp_terms =
+  sem unsplit_FileOp =
+end
+
+lang DeclOpBase
+  syn DeclOp =
+
+  sem topAllowed_DeclOp =
+  | _ -> true
+  sem leftAllowed_DeclOp =
+  | {parent = _, child = c} -> topAllowed_DeclOp c
+  sem rightAllowed_DeclOp =
+  | {parent = _, child = c} -> topAllowed_DeclOp c
+  sem groupingsAllowed_DeclOp =
+  | _ -> GEither ()
+  sem parenAllowed_DeclOp =
+  | _ -> GEither ()
+  sem get_DeclOp_info =
+  sem get_DeclOp_terms =
+  sem unsplit_DeclOp =
+end
+
+lang RegexOpBase
+  syn RegexOp =
+
+  sem topAllowed_RegexOp =
+  | _ -> true
+  sem leftAllowed_RegexOp =
+  | {parent = _, child = c} -> topAllowed_RegexOp c
+  sem rightAllowed_RegexOp =
+  | {parent = _, child = c} -> topAllowed_RegexOp c
+  sem groupingsAllowed_RegexOp =
+  | _ -> GEither ()
+  sem parenAllowed_RegexOp =
+  | _ -> GEither ()
+  sem get_RegexOp_info =
+  sem get_RegexOp_terms =
+  sem unsplit_RegexOp =
+end
+
+lang ExprOpBase
+  syn ExprOp =
+
+  sem topAllowed_ExprOp =
+  | _ -> true
+  sem leftAllowed_ExprOp =
+  | {parent = _, child = c} -> topAllowed_ExprOp c
+  sem rightAllowed_ExprOp =
+  | {parent = _, child = c} -> topAllowed_ExprOp c
+  sem groupingsAllowed_ExprOp =
+  | _ -> GEither ()
+  sem parenAllowed_ExprOp =
+  | _ -> GEither ()
+  sem get_ExprOp_info =
+  sem get_ExprOp_terms =
+  sem unsplit_ExprOp =
+end
+
+/-
+-- # File
+prod File: File = decls:Decl+
+-/
+
+lang FileAst = SelfhostBaseAst
+  syn File =
+  | File { decls : [Decl], info : Info }
+
+  sem get_File_info =
+  | File x -> x.info
+
+  sem smapAccumL_File_Decl (f : acc -> Decl -> (acc, Decl)) (acc : acc) =
+  | File x ->
+    match mapAccumL f acc x.decls with (acc, decls) in
+    (acc, File {x with decls = decls})
+end
+
+lang FileOp = FileOpBase + FileAst
+  syn FileOp =
+  | FileOp { decls : [Decl], info : Info, terms : [Info] }
+
+  sem get_FileOp_terms =
+  | FileOp x -> x.terms
+
+  sem get_FileOp_info =
+  | FileOp x -> x.info
+
+  sem unsplit_FileOp =
+  | AtomP { self = FileOp x } -> (x.info, File {decls = x.decls, info = x.info})
+end
+
+/-
+-- # Decl
+-/
+
+/-
+prod Type: Decl =
+  "type" name:UName
+  ( "{"
+    properties:{name:LName "=" val:Expr ","}*
+  "}"
+  )?
+-/
+
+lang TypeDeclAst = SelfhostBaseAst
+  syn Decl =
+  | TypeDecl { name : Name, properties : [{name : Name, val : Expr}], info : Info }
+
+  sem get_Decl_info =
+  | TypeDecl x -> x.info
+
+  sem smapAccumL_Decl_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | TypeDecl x ->
+    match mapAccumL (lam acc. lam x. match f acc x.val with (acc, val) in {x with val = val}) acc x.properties with (acc, properties) in
+    (acc, TypeDecl {x with properties = properties})
+end
+
+lang TypeDeclOp = DeclOpBase + TypeDeclAst
+  syn DeclOp =
+  | TypeDeclOp { name : Name, properties : [{name : Name, val : Expr}], info : Info, terms : [Info] }
+
+  sem get_DeclOp_terms =
+  | TypeDeclOp x -> x.terms
+
+  sem get_DeclOp_info =
+  | TypeDeclOp x -> x.info
+
+  sem unsplit_DeclOp =
+  | AtomP { self = TypeDeclOp x } -> (x.info, TypeDecl {name = x.name, properties = x.properties, info = x.info})
+end
+
+/-
+prod PrecedenceTable: Decl =
+  "precedence" "{"
+    levels:{noeq:"~"? operators:UName+ ";"}*
+  "}"
+  ( "except" "{"
+    exceptions:{lefts:UName+ "?" rights:UName+ ";"}*
+  "}"
+  )?
+-/
+
+lang PrecedenceTableDeclAst = SelfhostBaseAst
+  syn Decl =
+  | PrecedenceTableDecl
+    { levels : [{noeq : Option (), operators : [Name]}]
+    , exceptions : [{lefts : [Name], rights : [Name]}]
+    , info : Info
+    }
+
+  sem get_Decl_info =
+  | PrecedenceTableDecl x -> x.info
+end
+
+lang PrecedenceTableDeclOp = DeclOpBase + PrecedenceTableDeclAst
+  syn DeclOp =
+  | PrecedenceTableDeclOp
+    { levels : [{noeq : Option (), operators : [Name]}]
+    , exceptions : [{lefts : [Name], rights : [Name]}]
+    , info : Info
+    , terms : [Info]
+    }
+
+  sem get_DeclOp_terms =
+  | PrecedenceTableDeclOp x -> x.terms
+
+  sem get_DeclOp_info =
+  | PrecedenceTableDeclOp x -> x.info
+
+  sem unsplit_DeclOp =
+  | AtomP { self = PrecedenceTableDeclOp x } -> (x.info, PrecedenceTableDecl {levels = x.levels, exceptions = x.exceptions, info = x.info})
+end
+
+/-
+prod Production: Decl = ("prod" | "infix" | "prefix" | "postfix") assoc:LIdent? name:UName ":" nt:UName "=" regex:Regex
+-/
+
+lang ProductionDeclAst = SelfhostBaseAst
+  syn Decl =
+  | ProductionDecl { assoc : Option String, name : Name, nt : Name, regex : Regex, info : Info }
+
+  sem get_Decl_info =
+  | ProductionDecl x -> x.info
+
+  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | ProductionDecl x ->
+    match f acc x.regex with (acc, regex) in
+    (acc, ProductionDecl {x with regex = regex})
+end
+
+lang ProductionDeclOp = DeclOpBase + ProductionDeclAst
+  syn DeclOp =
+  | ProductionDeclOp { assoc : Option Name, name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+
+  sem get_DeclOp_terms =
+  | ProductionDeclOp x -> x.terms
+
+  sem get_DeclOp_info =
+  | ProductionDeclOp x -> x.info
+
+  sem unsplit_DeclOp =
+  | AtomP { self = ProductionDeclOp x } -> (x.info, ProductionDecl {assoc = x.assoc, name = x.name, nt = x.nt, regex = x.regex, info = x.info})
+end
+
+/-
+prod Infix: Decl = "infix" assoc:LIdent? name:UName ":" nt:UName "=" regex:Regex
+-/
+
+lang InfixDeclAst = SelfhostBaseAst
+  syn Decl =
+  | InfixDecl { assoc : Option Name, name : Name, nt : Name, regex : Regex, info : Info }
+
+  sem get_Decl_info =
+  | InfixDecl x -> x.info
+
+  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | InfixDecl x ->
+    match f acc x.regex with (acc, regex) in
+    (acc, InfixDecl {x with regex = regex})
+end
+
+lang InfixDeclOp = DeclOpBase + InfixDeclAst
+  syn DeclOp =
+  | InfixDeclOp { assoc : Option Name, name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+
+  sem get_DeclOp_terms =
+  | InfixDeclOp x -> x.terms
+
+  sem get_DeclOp_info =
+  | InfixDeclOp x -> x.info
+
+  sem unsplit_DeclOp =
+  | AtomP { self = InfixDeclOp x } -> (x.info, InfixDecl {assoc = x.assoc, name = x.name, nt = x.nt, regex = x.regex, info = x.info})
+end
+
+/-
+prod Prefix: Decl = "prefix" name:UName ":" nt:UName "=" regex:Regex
+-/
+
+lang PrefixDeclAst = SelfhostBaseAst
+  syn Decl =
+  | PrefixDecl { name : Name, nt : Name, regex : Regex, info : Info }
+
+  sem get_Decl_info =
+  | PrefixDecl x -> x.info
+
+  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | PrefixDecl x ->
+    match f acc x.regex with (acc, regex) in
+    (acc, PrefixDecl {x with regex = regex})
+end
+
+lang PrefixDeclOp = DeclOpBase + PrefixDeclAst
+  syn DeclOp =
+  | PrefixDeclOp { name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+
+  sem get_DeclOp_terms =
+  | PrefixDeclOp x -> x.terms
+
+  sem get_DeclOp_info =
+  | PrefixDeclOp x -> x.info
+
+  sem unsplit_DeclOp =
+  | AtomP { self = PrefixDeclOp x } -> (x.info, PrefixDecl {name = x.name, nt = x.nt, regex = x.regex, info = x.info})
+end
+
+/-
+prod Postfix: Decl = "postfix" name:UName ":" nt:UName "=" regex:Regex
+-/
+
+lang PostfixDeclAst = SelfhostBaseAst
+  syn Decl =
+  | PostfixDecl { name : Name, nt : Name, regex : Regex, info : Info }
+
+  sem get_Decl_info =
+  | PostfixDecl x -> x.info
+
+  sem smapAccumL_Decl_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | PostfixDecl x ->
+    match f acc x.regex with (acc, regex) in
+    (acc, PostfixDecl {x with regex = regex})
+end
+
+lang PostfixDeclOp = DeclOpBase + PostfixDeclAst
+  syn DeclOp =
+  | PostfixDeclOp { name : Name, nt : Name, regex : Regex, info : Info, terms : [Info] }
+
+  sem get_DeclOp_terms =
+  | PostfixDeclOp x -> x.terms
+
+  sem get_DeclOp_info =
+  | PostfixDeclOp x -> x.info
+
+  sem unsplit_DeclOp =
+  | AtomP { self = PostfixDeclOp x } -> (x.info, PostfixDecl {name = x.name, nt = x.nt, regex = x.regex, info = x.info})
+end
+
+/-
+-- # Regex
+-/
+
+/-
+grouping "(" Regex ")"
+-/
+
+lang GroupingRegexOp = RegexOpBase
+  syn RegexOp =
+  | GroupingRegexOp { inner : Regex, info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | GroupingRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | GroupingRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | AtomP { self = GroupingRegexOp x } -> (x.info, x.inner)
+end
+
+/-
+prod Record: Regex = "{" regex:Regex "}"
+-/
+
+lang RecordRegexAst = SelfhostBaseAst
+  syn Regex =
+  | RecordRegex { regex : Regex, info : Info }
+
+  sem get_Regex_info =
+  | RecordRegex x -> x.info
+
+  sem smapAccumL_Regex_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | RecordRegex x ->
+    match f acc x.regex with (acc, regex) in
+    (acc, RecordRegex {x with regex = regex})
+end
+
+lang RecordRegexOp = RegexOpBase + RecordRegexAst
+  syn RegexOp =
+  | RecordRegexOp { regex : Regex, info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | RecordRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | RecordRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | AtomP { self = RecordRegexOp x } -> (x.info, RecordRegex {regex = x.regex, info = x.info})
+end
+
+/-
+prod Empty: Regex = "empty"
+-/
+
+lang EmptyRegexAst = SelfhostBaseAst
+  syn Regex =
+  | EmptyRegex { info : Info }
+
+  sem get_Regex_info =
+  | EmptyRegex x -> x.info
+end
+
+lang EmptyRegexOp = RegexOpBase + EmptyRegexAst
+  syn RegexOp =
+  | EmptyRegexOp { info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | EmptyRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | EmptyRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | AtomP { self = EmptyRegexOp x } -> (x.info, EmptyRegex {info = x.info})
+end
+
+/-
+prod Literal: Regex = val:String
+-/
+
+lang LiteralRegexAst = SelfhostBaseAst
+  syn Regex =
+  | LiteralRegex { val : String, info : Info }
+
+  sem get_Regex_info =
+  | LiteralRegex x -> x.info
+end
+
+lang LiteralRegexOp = RegexOpBase + LiteralRegexAst
+  syn RegexOp =
+  | LiteralRegexOp { val : String, info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | LiteralRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | LiteralRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | AtomP { self = LiteralRegexOp x } -> (x.info, LiteralRegex {val = x.val, info = x.info})
+end
+
+/-
+prod Token: Regex = name:UName ("[" arg:Expr "]")?
+-/
+
+lang TokenRegexAst = SelfhostBaseAst
+  syn Regex =
+  | TokenRegex { name : Name, arg : Option Expr, info : Info }
+
+  sem get_Regex_info =
+  | TokenRegex x -> x.info
+
+  sem smapAccumL_Regex_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | TokenRegex x ->
+    match optionMapAccum f acc x.arg with (acc, arg) in
+    (acc, TokenRegex {x with arg = arg })
+end
+
+lang TokenRegexOp = RegexOpBase + TokenRegexAst
+  syn RegexOp =
+  | TokenRegexOp { name : Name, arg : Option Expr, info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | TokenRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | TokenRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | AtomP { self = TokenRegexOp x } -> (x.info, TokenRegex {name = x.name, arg = x.arg, info = x.info})
+end
+
+/-
+postfix RepeatPlus: Regex = "+"
+-/
+
+lang RepeatPlusRegexAst = SelfhostBaseAst
+  syn Regex =
+  | RepeatPlusRegex { left : Regex, info : Info }
+
+  sem get_Regex_info =
+  | RepeatPlusRegex x -> x.info
+
+  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | RepeatPlusRegex x ->
+    match f acc x.left with (acc, left) in
+    (acc, RepeatPlusRegex {x with left = left})
+end
+
+lang RepeatPlusRegexOp = RegexOpBase + RepeatPlusRegexAst
+  syn RegexOp =
+  | RepeatPlusRegexOp { info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | RepeatPlusRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | RepeatPlusRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | PostfixP { self = RepeatPlusRegexOp x, leftChildAlts = [left] ++ _ } ->
+    match unsplit_RegexOp left with (linfo, left) in
+    let info = mergeInfo linfo x.info in
+    (info, RepeatPlusRegex { left = left, info = info })
+end
+
+/-
+postfix RepeatStar: Regex = "*"
+-/
+
+lang RepeatStarRegexAst = SelfhostBaseAst
+  syn Regex =
+  | RepeatStarRegex { left : Regex, info : Info }
+
+  sem get_Regex_info =
+  | RepeatStarRegex x -> x.info
+
+  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | RepeatStarRegex x ->
+    match f acc x.left with (acc, left) in
+    (acc, RepeatStarRegex {x with left = left})
+end
+
+lang RepeatStarRegexOp = RegexOpBase + RepeatStarRegexAst
+  syn RegexOp =
+  | RepeatStarRegexOp { info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | RepeatStarRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | RepeatStarRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | PostfixP { self = RepeatStarRegexOp x, leftChildAlts = [left] ++ _ } ->
+    match unsplit_RegexOp left with (linfo, left) in
+    let info = mergeInfo linfo x.info in
+    (info, RepeatStarRegex { left = left, info = info })
+end
+
+/-
+postfix RepeatQuestion: Regex = "?"
+-/
+
+lang RepeatQuestionRegexAst = SelfhostBaseAst
+  syn Regex =
+  | RepeatQuestionRegex { left : Regex, info : Info }
+
+  sem get_Regex_info =
+  | RepeatQuestionRegex x -> x.info
+
+  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | RepeatQuestionRegex x ->
+    match f acc x.left with (acc, left) in
+    (acc, RepeatQuestionRegex {x with left = left})
+end
+
+lang RepeatQuestionRegexOp = RegexOpBase + RepeatQuestionRegexAst
+  syn RegexOp =
+  | RepeatQuestionRegexOp { info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | RepeatQuestionRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | RepeatQuestionRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | PostfixP { self = RepeatQuestionRegexOp x, leftChildAlts = [left] ++ _ } ->
+    match unsplit_RegexOp left with (linfo, left) in
+    let info = mergeInfo linfo x.info in
+    (info, RepeatQuestionRegex { left = left, info = info })
+end
+
+/-
+prefix Named: Regex = name:LName ":"
+-/
+
+lang NamedRegexAst = SelfhostBaseAst
+  syn Regex =
+  | NamedRegex { name : Name, right : Regex, info : Info }
+
+  sem get_Regex_info =
+  | NamedRegex x -> x.info
+
+  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | NamedRegex x ->
+    match f acc x.right with (acc, right) in
+    (acc, NamedRegex {x with right = right})
+end
+
+lang NamedRegexOp = RegexOpBase + NamedRegexAst
+  syn RegexOp =
+  | NamedRegexOp { name : Name, info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | NamedRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | NamedRegexOp x -> x.info
+
+  sem unsplit_RegexOp =
+  | PrefixP { self = NamedRegexOp x, rightChildAlts = [right] ++ _ } ->
+    match unsplit_RegexOp right with (rinfo, right) in
+    let info = mergeInfo rinfo x.info in
+    (info, NamedRegex { right = right, info = info })
+end
+
+/-
+infix left Alternative: Regex = "|"
+-/
+
+lang AlternativeRegexAst = SelfhostBaseAst
+  syn Regex =
+  | AlternativeRegex { left : Regex, right : Regex, info : Info }
+
+  sem get_Regex_info =
+  | AlternativeRegex x -> x.info
+
+  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | AlternativeRegex x ->
+    match f acc x.left with (acc, left) in
+    match f acc x.right with (acc, right) in
+    (acc, AlternativeRegex {{x with left = left} with right = right})
+end
+
+lang AlternativeRegexOp = RegexOpBase + AlternativeRegexAst
+  syn RegexOp =
+  | AlternativeRegexOp { info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | AlternativeRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | AlternativeRegexOp x -> x.info
+
+  sem groupingsAllowed_RegexOp =
+  | (AlternativeRegexOp _, AlternativeRegexOp _) -> GLeft ()
+
+  sem unsplit_RegexOp =
+  | InfixP { self = AlternativeRegexOp x, leftChildAlts = [left] ++ _, rightChildAlts = [right] ++ _ } ->
+    match unsplit_RegexOp left with (linfo, left) in
+    match unsplit_RegexOp right with (rinfo, right) in
+    let info = mergeInfo linfo rinfo in
+    (info, AlternativeRegex { left = left, right = right, info = info })
+end
+
+/-
+infix left Concat: Regex = empty
+-/
+
+lang ConcatRegexAst = SelfhostBaseAst
+  syn Regex =
+  | ConcatRegex { left : Regex, right : Regex, info : Info }
+
+  sem get_Regex_info =
+  | ConcatRegex x -> x.info
+
+  sem smapAccumL_Regex_Regex (f : acc -> Regex -> (acc, Regex)) (acc : acc) =
+  | ConcatRegex x ->
+    match f acc x.left with (acc, left) in
+    match f acc x.right with (acc, right) in
+    (acc, ConcatRegex {{x with left = left} with right = right})
+end
+
+lang ConcatRegexOp = RegexOpBase + ConcatRegexAst
+  syn RegexOp =
+  | ConcatRegexOp { info : Info, terms : [Info] }
+
+  sem get_RegexOp_terms =
+  | ConcatRegexOp x -> x.terms
+
+  sem get_RegexOp_info =
+  | ConcatRegexOp x -> x.info
+
+  sem groupingsAllowed_RegexOp =
+  | (ConcatRegexOp _, ConcatRegexOp _) -> GLeft ()
+
+  sem unsplit_RegexOp =
+  | InfixP { self = ConcatRegexOp x, leftChildAlts = [left] ++ _, rightChildAlts = [right] ++ _ } ->
+    match unsplit_RegexOp left with (linfo, left) in
+    match unsplit_RegexOp right with (rinfo, right) in
+    let info = mergeInfo linfo rinfo in
+    (info, ConcatRegex { left = left, right = right, info = info })
+end
+
+/-
+precedence {
+  Named;
+  RepeatPlus RepeatStar RepeatQuestion;
+  Concat;
+  Alternative;
+}
+-/
+
+lang SelfhostPrecedence1
+  = NamedRegexOp + RepeatPlusRegexOp + RepeatStarRegexOp + RepeatQuestionRegexOp
+  + ConcatRegexOp + AlternativeRegexOp
+
+  sem groupingsAllowed_RegexOp =
+  | (NamedRegexOp _, RepeatPlusRegexOp _) -> GLeft ()
+  | (NamedRegexOp _, RepeatStarRegexOp _) -> GLeft ()
+  | (NamedRegexOp _, RepeatQuestionRegexOp _) -> GLeft ()
+  | (NamedRegexOp _, ConcatRegexOp _) -> GLeft ()
+  | (NamedRegexOp _, AlternativeRegexOp _) -> GLeft ()
+  | (ConcatRegexOp _, RepeatPlusRegexOp _) -> GRight ()
+  | (ConcatRegexOp _, RepeatStarRegexOp _) -> GRight ()
+  | (ConcatRegexOp _, RepeatQuestionRegexOp _) -> GRight ()
+  | (AlternativeRegexOp _, RepeatPlusRegexOp _) -> GRight ()
+  | (AlternativeRegexOp _, RepeatStarRegexOp _) -> GRight ()
+  | (AlternativeRegexOp _, RepeatQuestionRegexOp _) -> GRight ()
+  | (ConcatRegexOp _, AlternativeRegexOp _) -> GLeft ()
+  | (AlternativeRegexOp _, ConcatRegexOp _) -> GRight ()
+end
+
+lang SelfhostAst
+  = FileAst
+  + TypeDeclAst + PrecedenceTableDeclAst + ProductionDeclAst + InfixDeclAst
+  + PrefixDeclAst + PostfixDeclAst
+  + RecordRegexAst + EmptyRegexAst + LiteralRegexAst + TokenRegexAst
+  + RepeatPlusRegexAst + RepeatStarRegexAst + RepeatQuestionRegexAst
+  + NamedRegexAst + AlternativeRegexAst + ConcatRegexAst
+end
+
+lang ParseSelfhost = SelfhostAst + TokenParser
+  + UIntTokenParser + StringTokenParser + HashStringTokenParser + UIdentTokenParser + LIdentTokenParser + OperatorTokenParser
+  + WhitespaceParser + LineCommentParser + MultilineCommentParser + BracketTokenParser + CommaTokenParser + SemiTokenParser
+  + FileOpBase + DeclOpBase + RegexOpBase + ExprOpBase
+  + FileOp
+  + TypeDeclOp + PrecedenceTableDeclOp + ProductionDeclOp + InfixDeclOp + PrefixDeclOp + PostfixDeclOp
+  + GroupingRegexOp + RecordRegexOp + EmptyRegexOp + LiteralRegexOp + TokenRegexOp + RepeatPlusRegexOp + RepeatStarRegexOp + RepeatQuestionRegexOp + NamedRegexOp + AlternativeRegexOp + ConcatRegexOp
+  + SelfhostPrecedence1
+  + LL1Parser
+
+  syn File =
+  | BadFile { info : Info }
+
+  sem get_File_info =
+  | BadFile x -> x.info
+
+  syn Decl =
+  | BadDecl { info : Info }
+
+  sem get_Decl_info =
+  | BadDecl x -> x.info
+
+  syn Regex =
+  | BadRegex { info : Info }
+
+  sem get_Regex_info =
+  | BadRegex x -> x.info
+
+  syn Expr =
+  | BadExpr { info : Info }
+
+  sem get_Expr_info =
+  | BadExpr x -> x.info
+end
+
+let _table =
+  use ParseSelfhost in
+  let brFile =
+    let config =
+      { topAllowed = topAllowed_FileOp
+      , leftAllowed = leftAllowed_FileOp
+      , rightAllowed = rightAllowed_FileOp
+      , parenAllowed = parenAllowed_FileOp
+      , groupingsAllowed = groupingsAllowed_FileOp
+      } in
+    let mkOptInputFunction = lam addF.
+      lam p. lam x. lam st.
+      match st with Some st then
+        let st = addF config x st in
+        (match st with None _ then
+          let err = (get_FileOp_info x, "Invalid input") in
+          modref p.errors (snoc (deref p.errors) err)
+         else ());
+        st
+      else st in
+    let mkInputFunction =
+      lam addF. lam p. lam x. lam st. optionMap (addF config x) st in
+    { atom = mkInputFunction breakableAddAtom
+    , infix = mkOptInputFunction breakableAddInfix
+    , prefix = mkInputFunction breakableAddPrefix
+    , postfix = mkOptInputFunction breakableAddPostfix
+    , finalize = lam p. lam st.
+      let res = optionBind st
+        (lam st. match breakableFinalizeParse config st with Some [top] ++ _
+          then Some (unsplit_FileOp top)
+          else modref p.errors (snoc (deref p.errors) (NoInfo (), "Unfinished File"));-- TODO(vipa, 2022-03-11): Figure out how to get a good info field here
+            None ()) in
+      -- TODO(vipa, 2022-03-11): Also here
+      optionGetOr (NoInfo (), BadFile {info = NoInfo ()}) res
+    } in
+  let brDecl =
+    let config =
+      { topAllowed = topAllowed_DeclOp
+      , leftAllowed = leftAllowed_DeclOp
+      , rightAllowed = rightAllowed_DeclOp
+      , parenAllowed = parenAllowed_DeclOp
+      , groupingsAllowed = groupingsAllowed_DeclOp
+      } in
+    let mkOptInputFunction = lam addF.
+      lam p. lam x. lam st.
+      match st with Some st then
+        let st = addF config x st in
+        (match st with None _ then
+          let err = (get_DeclOp_info x, "Invalid input") in
+          modref p.errors (snoc (deref p.errors) err)
+         else ());
+        st
+      else st in
+    let mkInputFunction =
+      lam addF. lam p. lam x. lam st. optionMap (addF config x) st in
+    { atom = mkInputFunction breakableAddAtom
+    , infix = mkOptInputFunction breakableAddInfix
+    , prefix = mkInputFunction breakableAddPrefix
+    , postfix = mkOptInputFunction breakableAddPostfix
+    , finalize = lam p. lam st.
+      let res = optionBind st
+        (lam st. match breakableFinalizeParse config st with Some [top] ++ _
+          then Some (unsplit_DeclOp top)
+          else modref p.errors (snoc (deref p.errors) (NoInfo (), "Unfinished Decl"));-- TODO(vipa, 2022-03-11): Figure out how to get a good info field here
+            None ()) in
+      -- TODO(vipa, 2022-03-11): Also here
+      optionGetOr (NoInfo (), BadDecl {info = NoInfo ()}) res
+    } in
+  let brRegex =
+    let config =
+      { topAllowed = topAllowed_RegexOp
+      , leftAllowed = leftAllowed_RegexOp
+      , rightAllowed = rightAllowed_RegexOp
+      , parenAllowed = parenAllowed_RegexOp
+      , groupingsAllowed = groupingsAllowed_RegexOp
+      } in
+    let reportConfig =
+      { parenAllowed = parenAllowed_RegexOp
+      , topAllowed = topAllowed_RegexOp
+      , terminalInfos = get_RegexOp_terms
+      , getInfo = get_RegexOp_info
+      , lpar = "("
+      , rpar = ")"
+      } in
+    let mkOptInputFunction = lam addF.
+      lam p. lam x. lam st.
+      match st with Some st then
+        let st = addF config x st in
+        (match st with None _ then
+          let err = (get_RegexOp_info x, "Invalid input") in
+          modref p.errors (snoc (deref p.errors) err)
+         else ());
+        st
+      else st in
+    let mkInputFunction =
+      lam addF. lam p. lam x. lam st. optionMap (addF config x) st in
+    { atom = mkInputFunction breakableAddAtom
+    , infix = mkOptInputFunction breakableAddInfix
+    , prefix = mkInputFunction breakableAddPrefix
+    , postfix = mkOptInputFunction breakableAddPostfix
+    , finalize = lam p. lam st.
+      let res = optionBind st
+        (lam st. match breakableFinalizeParse config st with Some (tops & [top] ++ _)
+          then
+            let errs = breakableDefaultHighlight reportConfig p.content tops in
+            let res: (Info, Regex) = unsplit_RegexOp top in
+            if null errs then Some res else
+            modref p.errors (concat (deref p.errors) errs);
+            Some (res.0, BadRegex { info = res.0 })
+          else
+            modref p.errors (snoc (deref p.errors) (NoInfo (), "Unfinished Regex"));-- TODO(vipa, 2022-03-11): Figure out how to get a good info field here
+            None ()) in
+      -- TODO(vipa, 2022-03-11): Also here
+      optionGetOr (NoInfo (), BadRegex {info = NoInfo ()}) res
+    } in
+  let brExpr =
+    let config =
+      { topAllowed = topAllowed_ExprOp
+      , leftAllowed = leftAllowed_ExprOp
+      , rightAllowed = rightAllowed_ExprOp
+      , parenAllowed = parenAllowed_ExprOp
+      , groupingsAllowed = groupingsAllowed_ExprOp
+      } in
+    let reportConfig =
+      { parenAllowed = parenAllowed_ExprOp
+      , topAllowed = topAllowed_ExprOp
+      , terminalInfos = get_ExprOp_terms
+      , getInfo = get_ExprOp_info
+      , lpar = "("
+      , rpar = ")"
+      } in
+    let mkOptInputFunction = lam addF.
+      lam p. lam x. lam st.
+      match st with Some st then
+        let st = addF config x st in
+        (match st with None _ then
+          let err = (get_ExprOp_info x, "Invalid input") in
+          modref p.errors (snoc (deref p.errors) err)
+         else ());
+        st
+      else st in
+    let mkInputFunction =
+      lam addF. lam p. lam x. lam st. optionMap (addF config x) st in
+    { atom = mkInputFunction breakableAddAtom
+    , infix = mkOptInputFunction breakableAddInfix
+    , prefix = mkInputFunction breakableAddPrefix
+    , postfix = mkOptInputFunction breakableAddPostfix
+    , finalize = lam p. lam st.
+      let res = optionBind st
+        (lam st. match breakableFinalizeParse config st with Some (tops & [top] ++ _)
+          then
+            let errs = breakableDefaultHighlight reportConfig p.content tops in
+            let res: (Info, Expr) = unsplit_ExprOp top in
+            if null errs then Some res else
+            modref p.errors (concat (deref p.errors) errs);
+            Some (res.0, BadExpr { info = res.0 })
+          else
+            modref p.errors (snoc (deref p.errors) (NoInfo (), "Unfinished Expr"));-- TODO(vipa, 2022-03-11): Figure out how to get a good info field here
+            None ()) in
+      -- TODO(vipa, 2022-03-11): Also here
+      optionGetOr (NoInfo (), BadExpr {info = NoInfo ()}) res
+    } in
+  let brState = lam. Some (breakableInitState ()) in
+
+  let file_top = string2NonTerminal "File_Top" in
+  let file_lclosed = string2NonTerminal "File_LClosed" in
+  let file_lopen = string2NonTerminal "File_LOpen" in
+  let file_atom = string2NonTerminal "File_Atom" in
+  let file_File_cont = string2NonTerminal "File_File_Cont" in
+
+  let decl_top = string2NonTerminal "Decl_Top" in
+  let decl_lclosed = string2NonTerminal "Decl_LClosed" in
+  let decl_lopen = string2NonTerminal "Decl_LOpen" in
+  let decl_atom = string2NonTerminal "Decl_Atom" in
+  let decl_Production_1 = string2NonTerminal "Decl_Production_1" in
+  let decl_Production_2 = string2NonTerminal "Decl_Production_2" in
+  let decl_Type_1 = string2NonTerminal "Decl_Type_1" in
+  let decl_Type_2 = string2NonTerminal "Decl_Type_2" in
+  let decl_PrecedenceTable_1 = string2NonTerminal "Decl_PrecedenceTable_1" in
+  let decl_PrecedenceTable_2 = string2NonTerminal "Decl_PrecedenceTable_2" in
+
+  let regex_top = string2NonTerminal "Regex_Top" in
+  let regex_lclosed = string2NonTerminal "Regex_LClosed" in
+  let regex_lopen = string2NonTerminal "Regex_LOpen" in
+  let regex_atom = string2NonTerminal "Regex_Atom" in
+  let regex_prefix = string2NonTerminal "Regex_Prefix" in
+  let regex_postfix = string2NonTerminal "Regex_Postfix" in
+  let regex_infix = string2NonTerminal "Regex_Infix" in
+  let regex_Token_1 = string2NonTerminal "Regex_Token_1" in
+
+  let expr_top = string2NonTerminal "Expr_Top" in
+  let expr_lclosed = string2NonTerminal "Expr_LClosed" in
+  let expr_lopen = string2NonTerminal "Expr_LOpen" in
+  let expr_atom = string2NonTerminal "Expr_Atom" in
+  let expr_prefix = string2NonTerminal "Expr_Prefix" in
+  let expr_postfix = string2NonTerminal "Expr_Postfix" in
+  let expr_infix = string2NonTerminal "Expr_Infix" in
+
+  let grammar =
+    { start = file_top
+    , productions =
+      [ { nt = file_top
+        , label = "File_Top"
+        , rhs = [ntSym file_lclosed]
+        , action = lam p. lam seq.
+          match seq with [UserSym cont] in
+          cont (brState ())
+        }
+      , { nt = file_lclosed
+        , label = "File_LClosed"
+        , rhs = [ntSym file_atom, ntSym file_lopen]
+        , action = lam p. lam seq.
+          match seq with [UserSym atom, UserSym cont] in
+          lam st. cont (brFile.atom p atom st)
+        }
+      , { nt = file_lopen
+        , label = "File_End"
+        , rhs = []
+        , action = lam p. lam.
+          brFile.finalize p
+        }
+
+      , { nt = file_atom
+        , label = "File_File"
+        , rhs = [ntSym decl_top, ntSym file_File_cont]
+        , action = lam. lam seq.
+          match seq with [UserSym (info, decl), UserSym cont] in
+          cont {info = info, decls = [decl], terms = []}
+        }
+      , { nt = file_File_cont
+        , label = "File_File_Cont"
+        , rhs = [ntSym decl_top, ntSym file_File_cont]
+        , action = lam. lam seq.
+          match seq with [UserSym (info, decl), UserSym cont] in
+          lam x: {info : Info, decls : [Decl], terms : [Info]}.
+            cont {{x with info = mergeInfo x.info info} with decls = snoc x.decls decl}
+        }
+      , { nt = file_File_cont
+        , label = "File_File_End"
+        , rhs = []
+        , action = lam. lam.
+          lam x: {info : Info, decls : [Decl], terms : [Info]}.
+            FileOp {decls = x.decls, terms = x.terms, info = x.info}
+        }
+
+      , { nt = decl_top
+        , label = "Decl_Top"
+        , rhs = [ntSym decl_lclosed]
+        , action = lam p. lam seq.
+          match seq with [UserSym cont] in
+          cont (brState ())
+        }
+      , { nt = decl_lclosed
+        , label = "Decl_LClosed"
+        , rhs = [ntSym decl_atom, ntSym decl_lopen]
+        , action = lam p. lam seq.
+          match seq with [UserSym atom, UserSym cont] in
+          lam st. cont (brDecl.atom p atom st)
+        }
+      , { nt = decl_lopen
+        , label = "Decl_End"
+        , rhs = []
+        , action = lam p. lam.
+          brDecl.finalize p
+        }
+
+      , { nt = decl_atom
+        , label = "Decl_Production"
+        , rhs = [litSym "prod", ntSym decl_Production_1]
+        , action = lam. lam seq.
+          match seq with [LitParsed prod, UserSym prev] in
+          let prev: {info : Info, terms : [Info], assoc : [String], name : [Name], nt : [Name], regex : [Regex]} = prev in
+          let prev = {{prev with info = mergeInfo prod.info prev.info} with terms = cons prod.info prev.terms} in
+          ProductionDeclOp
+            { assoc = match prev.assoc with [x] ++ _ then Some x else None ()
+            , name = match prev.name with [x] ++ _ in x
+            , nt = match prev.nt with [x] ++ _ in x
+            , regex = match prev.regex with [x] ++ _ in x
+            , info = prev.info
+            }
+        }
+      , { nt = decl_Production_1
+        , label = "Decl_Production_1"
+        , rhs = [ntSym decl_Production_2]
+        , action = lam. lam seq.
+          match seq with [UserSym prev] in prev
+        }
+      , { nt = decl_Production_1
+        , label = "Decl_Production_2"
+        , rhs = [tokSym (LIdentRepr ()), ntSym decl_Production_2]
+        , action = lam. lam seq.
+          match seq with [TokParsed (LIdentTok tok), UserSym prev] in
+          let prev: {info : Info, terms : [Info], assoc : [String], name : [Name], nt : [Name], regex : [Regex]} = prev in
+          let prev = {{{prev with info = mergeInfo tok.info prev.info} with terms = cons tok.info prev.terms} with assoc = cons tok.val prev.assoc} in
+          prev
+        }
+      , { nt = decl_Production_2
+        , label = "Decl_Production_3"
+        , rhs = [tokSym (UIdentRepr ()), litSym ":", tokSym (UIdentRepr ()), litSym "=", ntSym regex_top]
+        , action = lam. lam seq.
+          match seq with [TokParsed (UIdentTok name), LitParsed x1, TokParsed (UIdentTok nt), LitParsed x2, UserSym (regexInfo, regex)] in
+          { info = mergeInfo name.info regexInfo
+          , terms = [name.info, x1.info, nt.info, x2.info]
+          , assoc = []
+          , name = [(nameNoSym) name.val]
+          , nt = [(nameNoSym) nt.val]
+          , regex = [regex]
+          }
+        }
+      , { nt = decl_atom
+        , label = "Decl_Type_1"
+        , rhs = [litSym "type", tokSym (UIdentRepr ()), ntSym decl_Type_1]
+        , action = lam p. lam seq.
+          match seq with [LitParsed l, TokParsed (UIdentTok name), UserSym prev] in
+          let prev : {name : [Name], properties : [{name : Name, val : Expr}], info : Info, terms : [Info]} = prev in
+          let prev = {{{prev with name = cons (nameNoSym name.val) prev.name} with info = mergeInfo l.info (mergeInfo name.info prev.info)} with terms = concat [l.info, name.info] prev.terms} in
+          TypeDeclOp
+            { name = match prev.name with [name] ++ _ in name
+            , properties = prev.properties
+            , info = prev.info
+            , terms = prev.terms
+            }
+        }
+      , { nt = decl_Type_1
+        , label = "Decl_Type_2"
+        , rhs = []
+        , action = lam p. lam seq.
+          { info = NoInfo ()
+          , name = []
+          , properties = []
+          , terms = []
+          }
+        }
+      , { nt = decl_Type_1
+        , label = "Decl_Type_3"
+        , rhs = [litSym "{", ntSym decl_Type_2, litSym "}"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed l, UserSym prev, LitParsed r] in
+          { info = mergeInfo l.info r.info
+          , name = []
+          , properties = prev.properties
+          , terms = cons l.info (snoc prev.terms r.info)
+          }
+        }
+      , { nt = decl_Type_2
+        , label = "Decl_Type_4"
+        , rhs = []
+        , action = lam p. lam seq.
+          { properties = []
+          , terms = []
+          }
+        }
+      , { nt = decl_Type_2
+        , label = "Decl_Type_5"
+        , rhs = [tokSym (LIdentRepr ()), litSym "=", ntSym expr_top, litSym ",", ntSym decl_Type_2]
+        , action = lam p. lam seq.
+          match seq with [TokParsed (LIdentTok name), LitParsed eq, UserSym (_, expr), LitParsed comma, UserSym prev] in
+          let prev: {properties : [{name : Name, val : Expr}], terms : [Info]} = prev in
+          let prev = {{prev with properties = cons {name = nameNoSym name.val, val = expr} prev.properties} with terms = concat [name.info, eq.info, comma.info] prev.terms} in
+          prev
+        }
+      , { nt = decl_atom
+        , label = "decl_PrecedenceTable"
+        -- NOTE(vipa, 2022-03-17): I'm not supporting the except list
+        -- here, since I won't use it in the early bootstrapping
+        -- process
+        , rhs = [litSym "precedence", litSym "{", ntSym decl_PrecedenceTable_1, litSym "}"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed prec, LitParsed l, UserSym levels, LitParsed r] in
+          let levels: {levels : [{noeq : Option (), operators : [Name]}], terms : [Info]} = levels in
+          PrecedenceTableDeclOp
+            { info = mergeInfo prec.info r.info
+            , terms = snoc (concat [prec.info, l.info] levels.terms) r.info
+            , levels = levels.levels
+            , exceptions = []
+            }
+        }
+      , { nt = decl_PrecedenceTable_1
+        , label = "decl_PrecedenceTable_1"
+        , rhs = [tokSym (UIdentRepr ()), ntSym decl_PrecedenceTable_2, litSym ";", ntSym decl_PrecedenceTable_1]
+        , action = lam p. lam seq.
+          match seq with [TokParsed (UIdentTok first), UserSym level, LitParsed semi, UserSym prev] in
+          let level: {terms : [Info], operators : [Name]} = level in
+          let level = {{level
+            with terms = snoc (cons first.info level.terms) semi.info}
+            with operators = cons (nameNoSym first.val) level.operators} in
+          let prev: {terms : [Info], levels : [{noeq : Option (), operators : [Name]}]} = prev in
+          let prev = {{prev
+            with terms = concat level.terms prev.terms}
+            with levels = cons {noeq = None (), operators = level.operators} prev.levels} in
+          prev
+        }
+      , { nt = decl_PrecedenceTable_1
+        , label = "decl_PrecedenceTable_2"
+        , rhs = []
+        , action = lam p. lam seq.
+          {terms = [], levels = []}
+        }
+      , { nt = decl_PrecedenceTable_2
+        , label = "decl_PrecedenceTable_3"
+        , rhs = [tokSym (UIdentRepr ()), ntSym (decl_PrecedenceTable_2)]
+        , action = lam p. lam seq.
+          match seq with [TokParsed (UIdentTok name), UserSym prev] in
+          let prev: {terms : [Info], operators : [Name]} = prev in
+          let prev = {{prev
+            with terms = cons name.info prev.terms}
+            with operators = cons (nameNoSym name.val) prev.operators} in
+          prev
+        }
+      , { nt = decl_PrecedenceTable_2
+        , label = "decl_PrecedenceTable_4"
+        , rhs = []
+        , action = lam p. lam seq.
+          {terms = [], operators = []}
+        }
+
+      , { nt = regex_top
+        , label = "Regex_Top"
+        , rhs = [ntSym regex_lclosed]
+        , action = lam. lam seq.
+          match seq with [UserSym cont] in
+          cont (brState ())
+        }
+      , { nt = regex_lclosed
+        , label = "Regex_LClosed_Atom"
+        , rhs = [ntSym regex_atom, ntSym regex_lopen]
+        , action = lam p. lam seq.
+          match seq with [UserSym atom, UserSym cont] in
+          lam st. cont (brRegex.atom p atom st)
+        }
+      , { nt = regex_lclosed
+        , label = "Regex_LClosed_Prefix"
+        , rhs = [ntSym regex_prefix, ntSym regex_lclosed]
+        , action = lam p. lam seq.
+          match seq with [UserSym prefix, UserSym cont] in
+          lam st. cont (brRegex.prefix p prefix st)
+        }
+      , { nt = regex_lopen
+        , label = "Regex_LOpen_Infix"
+        , rhs = [ntSym regex_infix, ntSym regex_lclosed]
+        , action = lam p. lam seq.
+          match seq with [UserSym infix, UserSym cont] in
+          lam st. cont (brRegex.infix p infix st)
+        }
+      , { nt = regex_lopen
+        , label = "Regex_LOpen_Postfix"
+        , rhs = [ntSym regex_postfix, ntSym regex_lopen]
+        , action = lam p. lam seq.
+          match seq with [UserSym postfix, UserSym cont] in
+          lam st. cont (brRegex.postfix p postfix st)
+        }
+      , { nt = regex_lopen
+        , label = "Regex_End"
+        , rhs = []
+        , action = lam p. lam.
+          brRegex.finalize p
+        }
+
+      , { nt = regex_atom
+        , label = "Regex_Grouping"
+        , rhs = [litSym "(", ntSym regex_top, litSym ")"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed l, UserSym (_, inner), LitParsed r] in
+          GroupingRegexOp { inner = inner, info = mergeInfo l.info r.info, terms = [l.info, r.info] }
+        }
+      , { nt = regex_atom
+        , label = "Regex_Record"
+        , rhs = [litSym "{", ntSym regex_top, litSym "}"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed l, UserSym (_, regex), LitParsed r] in
+          RecordRegexOp { regex = regex, info = mergeInfo l.info r.info, terms = [l.info, r.info] }
+        }
+      , { nt = regex_atom
+        , label = "Regex_Empty"
+        , rhs = [litSym "empty"]
+        , action = lam. lam seq.
+          match seq with [LitParsed x] in
+          EmptyRegexOp {info = x.info, terms = [x.info]}
+        }
+      , { nt = regex_atom
+        , label = "Regex_Literal"
+        , rhs = [TokSpec (StringRepr ())]
+        , action = lam. lam seq.
+          match seq with [TokParsed (StringTok x)] in
+          LiteralRegexOp {info = x.info, val = x.val, terms = [x.info]}
+        }
+      , { nt = regex_atom
+        , label = "Regex_Token"
+        , rhs = [TokSpec (UIdentRepr ()), ntSym regex_Token_1]
+        , action = lam p. lam seq.
+          match seq with [TokParsed (UIdentTok x), UserSym prev] in
+          let prev: {info : Info, terms : [Info], name : [Name], arg : [Expr]} = prev in
+          let prev = {{{prev with info = mergeInfo x.info prev.info} with terms = cons x.info prev.terms} with name = cons (nameNoSym x.val) prev.name} in
+          TokenRegexOp
+            { info = prev.info
+            , terms = prev.terms
+            , name = match prev.name with [name] ++ _ in name
+            , arg = match prev.arg with [arg] ++ _ then Some arg else None ()
+            }
+        }
+      , { nt = regex_Token_1
+        , label = "Regex_Token_1_1"
+        , rhs = []
+        , action = lam p. lam.
+          { info = NoInfo (), terms = [], name = [], arg = [] }
+        }
+      , { nt = regex_Token_1
+        , label = "Regex_Token_1_2"
+        , rhs = [litSym "[", ntSym expr_top, litSym "]"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed l, UserSym (_, expr), LitParsed r] in
+          { info = mergeInfo l.info r.info, terms = [l.info, r.info], name = [], arg = [expr] }
+        }
+      , { nt = regex_postfix
+        , label = "Regex_RepeatPlus"
+        , rhs = [litSym "+"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed x] in
+          RepeatPlusRegexOp { info = x.info, terms = [x.info] }
+        }
+      , { nt = regex_postfix
+        , label = "Regex_RepeatStar"
+        , rhs = [litSym "*"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed x] in
+          RepeatStarRegexOp { info = x.info, terms = [x.info] }
+        }
+      , { nt = regex_postfix
+        , label = "Regex_RepeatQuestion"
+        , rhs = [litSym "?"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed x] in
+          RepeatQuestionRegexOp { info = x.info, terms = [x.info] }
+        }
+      , { nt = regex_prefix
+        , label = "Regex_Named"
+        , rhs = [TokSpec (LIdentRepr ()), litSym ":"]
+        , action = lam p. lam seq.
+          match seq with [TokParsed (LIdentTok name), LitParsed x] in
+          NamedRegexOp { name = nameNoSym name.val, info = mergeInfo name.info x.info, terms = [name.info, x.info] }
+        }
+      , { nt = regex_infix
+        , label = "Regex_Alternative"
+        , rhs = [litSym "|"]
+        , action = lam p. lam seq.
+          match seq with [LitParsed x] in
+          AlternativeRegexOp { info = x.info, terms = [x.info] }
+        }
+      , { nt = regex_infix
+        , label = "Regex_Concat"
+        , rhs = []
+        , action = lam p. lam seq.
+          ConcatRegexOp { info = NoInfo (), terms = [] }
+        }
+      ]
+    } in
+  switch genParsingTable grammar
+  case Right table then table
+  case Left err then dprintLn err; never
+  end
+
+let parseSelfhost
+  : String -> String -> Either [(Info, String)] File
+  = lam filename. lam content.
+    use ParseSelfhost in
+    let config = {errors = ref [], content = content} in
+    let res = parseWithTable _table filename config content in
+    let errors = deref config.errors in
+    let errors =
+      match res with Left err then
+        let err = ll1DefaultHighlight content (ll1ToErrorHighlightSpec err) in
+        snoc errors err
+      else errors in
+    if null errors then eitherMapRight (lam x. match x with (_, x) in x) res else Left errors
+
+let parseSelfhostExn
+  : String -> String -> File
+  = lam filename. lam content.
+    switch parseSelfhost filename content
+    case Left errors then
+      for_ errors (lam x. match x with (info, msg) in printLn (infoErrorString info msg));
+      exit 1
+    case Right file then file
+    end
+
+mexpr
+
+let testParse = lam filename. lam content.
+  switch parseSelfhost filename content
+  case Right x then Some x
+  case Left errs then for_ errs (lam x. match x with (info, msg) in printLn (infoErrorString info msg)); None ()
+  end in
+
+let filename = "blub" in
+let content = join
+  [ "prod X: Y = A B | C*\n"
+  , "prod Z: Stuff = { empty } \n"
+  , "type Expr\n"
+  , "precedence { X Y; A; } \n"
+  ] in
+
+dprintLn (parseSelfhostExn filename content)

--- a/stdlib/parser/selfhost.syn
+++ b/stdlib/parser/selfhost.syn
@@ -1,0 +1,58 @@
+-- TODO(vipa, 2022-03-25): add grouping for Regex once we support it
+-- TODO(vipa, 2022-03-25): add grouping for Expr once we support it
+type File
+type Decl
+type Regex
+type Expr
+
+token String
+token UName
+token LName
+token LIdent
+
+start File
+
+prod File: File = decl:Decl?
+
+prod Start: Decl = "start" name:UName
+prod Type: Decl =
+  "type" name:UName
+  ( "{"
+    properties:{name:LName "=" val:Expr ","}*
+  "}"
+  )?
+prod TokenDecl: Decl =
+  "token" name:UName?
+  ( "{"
+    properties:{name:LName "=" val:Expr ","}*
+  "}"
+  )?
+prod PrecedenceTable: Decl =
+  "precedence" "{"
+    levels:{noeq:"~"? operators:UName+ ";"}*
+  "}"
+  ( "except" "{"
+    exceptions:{lefts:UName+ "?" rights:UName+ ";"}*
+  "}"
+  )?
+prod Production: Decl =
+  (kprod:"prod" | kinf:"infix" | kpref:"prefix" | kpostf:"postfix")
+  assoc:LIdent? name:UName ":" nt:UName "=" regex:Regex
+
+prod Record: Regex = "{" regex:Regex "}"
+prod Empty: Regex = "empty"
+prod Literal: Regex = val:String
+prod Token: Regex = name:UName ("[" arg:Expr "]")?
+prod RepeatPlus: Regex = left:Regex "+"
+prod RepeatStar: Regex = left:Regex "*"
+prod RepeatQuestion: Regex = left:Regex "?"
+prod Named: Regex = name:LIdent ":" right:Regex
+prod left Alternative: Regex = left:Regex "|" right:Regex
+prod left Concat: Regex = left:Regex right:Regex
+
+precedence {
+  Named;
+  RepeatPlus RepeatStar RepeatQuestion;
+  Concat;
+  Alternative;
+}

--- a/stdlib/parser/selfhost.syn
+++ b/stdlib/parser/selfhost.syn
@@ -12,7 +12,7 @@ token LIdent
 
 start File
 
-prod File: File = decl:Decl?
+prod File: File = decl:Decl+
 
 prod Start: Decl = "start" name:UName
 prod Type: Decl =

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -477,7 +477,7 @@ let generated: Res String = result.bind constructors -- TODO(vipa, 2022-03-22): 
       , constructors = map (lam x: ConstructorInfo. x.constructor) constructors
       , requestedSFunctions = requestedSFunctions
       }
-    in result.ok (mkLanguages genInput)
+    in result.ok (concat "include \"seq.mc\"\n\n" (mkLanguages genInput))
   ) in
 
 match result.consume (result.withAnnotations start (result.withAnnotations allResolved generated)) with (warnings, res) in
@@ -487,7 +487,7 @@ case Left errors then
   for_ errors (lam x. match x with (info, msg) in printLn (infoErrorString info msg));
   exit 1
 case Right res then
-  printLn res;
+  printLn res
   -- dprintLn temp;
-  printLn "Ok"
+  -- printLn "Ok"
 end

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -1,0 +1,154 @@
+include "selfhost-sketch.mc"
+include "gen-ast.mc"
+include "result.mc"
+include "seq.mc"
+
+mexpr
+
+use SelfhostAst in
+match argv with [_, filename] in
+let content = readFile filename in
+match parseSelfhostExn filename content with File {decls = decls} in
+
+let simpleHighlight
+  : Info -> String
+  = lam info.
+    formatHighlights terminalHighlightErrorConfig content [Relevant info]
+in
+
+type Res a = Result (Info, String) (Info, String) a in
+
+-- NOTE(vipa, 2022-03-18): Find all definitions in the file
+type PreNameEnv = {types : Map String [(Info, Name)], productions : Map String [(Info, Name)]} in
+let pullDefinition
+  : PreNameEnv -> Decl -> PreNameEnv
+  = lam env. lam decl.
+    switch decl
+    case TypeDecl x then
+      {env with types = mapInsertWith concat (nameGetStr x.name.v) [(x.name.i, nameSetNewSym x.name.v)] env.types}
+    case ProductionDecl x then
+      {env with productions = mapInsertWith concat (nameGetStr x.name.v) [(x.name.i, nameSetNewSym x.name.v)] env.productions}
+    case _ then
+      env
+    end
+in
+let nameEnv: PreNameEnv = foldl pullDefinition {types = mapEmpty cmpString, productions = mapEmpty cmpString} decls in
+
+-- NOTE(vipa, 2022-03-18): Create errors for things defined multiple times
+let mkMultiDefError
+  : [(Info, Name)] -> Res Name
+  = lam defs.
+    switch defs
+    case [(_, name)] then result.ok name
+    case everything & ([(info, name)] ++ _) then
+      let highlights = map
+        (lam x. match x with (info, _) in join ["  ", info2str info, simpleHighlight info, "\n"])
+        everything in
+      let msg = join
+        [ nameGetStr name, " has multiple definitions:\n"
+        , join highlights
+        ] in
+      result.err (info, msg)
+    end
+in
+type NameEnv = {types : Map String (Res Name), productions : Map String (Res Name)} in
+let nameEnv: NameEnv =
+  { types = mapMap mkMultiDefError nameEnv.types
+  , productions = mapMap mkMultiDefError nameEnv.productions
+  } in
+let lookupName
+  : {v: Name, i: Info} -> Map String (Res Name) -> Res {v: Name, i: Info}
+  = lam name. lam map.
+    let mkUnboundError = lam.
+      let msg = join
+        [ nameGetStr name.v, " is unbound.\n"
+        , "  ", simpleHighlight name.i, "\n"
+        ]
+      in result.err (name.i, msg) in
+    let res = mapFindOrElse mkUnboundError (nameGetStr name.v) map in
+    result.map (lam v. {name with v = v}) res
+in
+
+-- NOTE(vipa, 2022-03-18): Do name resolution in all declarations
+-- NOTE(vipa, 2022-03-21): This does not do name resolution inside
+-- expressions in regexes. Presumably I should call out to
+-- symbolize.mc, but I'll postpone that until later
+recursive let resolveRegex
+  : Regex -> Res Regex
+  = lam reg.
+    let smapM : (Regex -> Res Regex) -> Regex -> Res Regex = lam f. lam reg.
+      let inner = lam annot. lam here.
+        let res = f here in
+        let here = match result.consume res with (_, Right x) then x else here in
+        (result.withAnnotations res annot, here) in
+      match smapAccumL_Regex_Regex inner (result.ok ()) reg with (annot, res) in
+      result.withAnnotations annot (result.ok res)
+    in
+    switch reg
+    case TokenRegex x then
+      result.map
+        (lam name. TokenRegex {x with name = name})
+        (lookupName x.name nameEnv.types)
+    case other then
+      smapM resolveRegex other
+    end
+in
+let resolveDecl
+  : Decl -> Res Decl
+  = lam decl.
+    switch decl
+    case TypeDecl x then
+      result.map
+        (lam name. TypeDecl {x with name = name})
+        (lookupName x.name nameEnv.types)
+    case PrecedenceTableDecl x then
+      let resolveLevel = lam level: {noeq : Option {v: (), i: Info}, operators : [{v: Name, i: Info}]}.
+        result.map
+          (lam operators. {level with operators = operators})
+          (result.mapM (lam n. lookupName n nameEnv.productions) level.operators) in
+      let resolveException = lam exception: {lefts : [{v: Name, i: Info}], rights : [{v: Name, i: Info}]}.
+        result.map2
+          (lam lefts. lam rights. {{exception with lefts = lefts} with rights = rights})
+          (result.mapM (lam n. lookupName n nameEnv.productions) exception.lefts)
+          (result.mapM (lam n. lookupName n nameEnv.productions) exception.rights) in
+      result.map2
+        (lam levels. lam exceptions. PrecedenceTableDecl {{x with levels = levels} with exceptions = exceptions})
+        (result.mapM resolveLevel x.levels)
+        (result.mapM resolveException x.exceptions)
+    case ProductionDecl x then
+      result.map3
+        (lam name. lam nt. lam regex. ProductionDecl {{{x with name = name} with nt = nt} with regex = regex})
+        (lookupName x.name nameEnv.productions)
+        (lookupName x.nt nameEnv.types)
+        (resolveRegex x.regex)
+    case decl then result.ok decl
+    end
+in
+let decls: [Res Decl] = map resolveDecl decls in
+
+let nts: Res [Name] = result.mapM identity (mapValues nameEnv.types) in
+let requestedSFunctions: Res [(SynType, Type)] =
+  let mkPair = lam a. lam b. (stringToSynType (nameGetStr a), ntycon_ b) in
+  result.map (lam nts. seqLiftA2 mkPair nts nts) nts in
+let generated: Res String = result.bind requestedSFunctions
+  (lam requestedSFunctions.
+    let genInput =
+      { namePrefix = "Selfhost"
+      , constructors = []
+      , requestedSFunctions = requestedSFunctions
+      , composedName = None ()
+      }
+    in use CarriedTypeGenerate in result.ok (mkLanguages genInput)
+  ) in
+
+let currentlyUnused =
+  result.mapM identity decls in
+
+match result.consume (result.withAnnotations currentlyUnused generated) with (warnings, res) in
+switch res
+case Left errors then
+  for_ errors (lam x. match x with (info, msg) in printLn (infoErrorString info msg));
+  exit 1
+case Right res then
+  printLn res
+end

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -6,7 +6,10 @@ include "seq.mc"
 mexpr
 
 use SelfhostAst in
-match argv with [_, filename] in
+match argv with ![_, _] then
+  printLn "Please provide exactly one argument; a .syn file";
+  exit 0
+else match argv with [_, filename] in
 let content = readFile filename in
 match parseSelfhostExn filename content with File {decls = decls} in
 

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -167,8 +167,8 @@ let decls: [Decl] = mapOption result.toOption decls in
 let nts: [Name] =
   let inner = lam x. match x with TypeDecl x then Some x.name.v else None () in
   mapOption inner decls in
-let requestedSFunctions: [(SynType, Type)] =
-  let mkPair = lam a. lam b. (stringToSynType (nameGetStr a), ntycon_ b) in
+let requestedSFunctions: [(Name, Type)] =
+  let mkPair = lam a. lam b. (a, ntycon_ b) in
   seqLiftA2 mkPair nts nts in
 
 -- NOTE(vipa, 2022-03-22): Find the starting non-terminal
@@ -456,7 +456,7 @@ let constructors : Res [ConstructorInfo] =
       let mkRes = lam name. lam carried.
         { constructor =
           { name = name
-          , synType = stringToSynType (nameGetStr x.nt.v)
+          , synType = x.nt.v
           , carried = carried
           }
         } in

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -2,9 +2,13 @@ include "selfhost-sketch.mc"
 include "gen-ast.mc"
 include "result.mc"
 include "seq.mc"
+include "mexpr/cmp.mc"
 
 mexpr
 
+use MExprCmp in
+use MExprPrettyPrint in
+use CarriedBasic in
 use SelfhostAst in
 match argv with ![_, _] then
   printLn "Please provide exactly one argument; a .syn file";
@@ -174,65 +178,69 @@ let start: Res Name =
   end
 in
 
-type TypeInfo = {} in
-type TokenInfo = {} in
-let typeMap: Map Name (Either TypeInfo TokenInfo) =
+-- NOTE(vipa, 2022-03-28):  Compute type information
+type TypeInfo = {ty : Type} in
+type TokenInfo = {ty : Type, repr : Expr, tokConstructor : Name, getInfo : Expr -> Expr, getValue : Expr -> Expr} in
+let typeMap: Map Name (Either (Res TypeInfo) (Res TokenInfo)) =
   let addDecl = lam m. lam decl. switch decl
     case TypeDecl x then
-      mapInsert x.name.v (Left {}) m
+      let info: TypeInfo =
+        { ty = tycon_ (nameGetStr x.name.v)
+        } in
+      mapInsert x.name.v (Left (result.ok info)) m
     case TokenDecl (x & {name = Some n}) then
-      mapInsert n.v (Right {}) m
+      -- TODO(vipa, 2022-03-28): get this information in a more principled way
+      let info: TokenInfo =
+        { ty = tycon_ (nameGetStr n.v)
+        , repr = conapp_ (concat (nameGetStr n.v) "Repr") unit_
+        , tokConstructor = nameNoSym (concat (nameGetStr n.v) "Tok")
+        , getInfo = recordproj_ "info"
+        , getValue = recordproj_ "val"
+        } in
+      mapInsert n.v (Right (result.ok info)) m
     case _ then
       m
     end in
   foldl addDecl (mapEmpty nameCmp) decls
 in
 
+-- NOTE(vipa, 2022-03-28): Compute a canonicalized form of a regex, with embedded type information
+type Terminal in
+con NtTerm : Res TypeInfo -> Terminal in
+con TokenTerm : Res TokenInfo -> Terminal in
+con LitTerm : String -> Terminal in
 type SRegex in
-con NtReg : {name: {v: Name, i: Info}, field: Option String, info: Info} -> SRegex in
-con TokenReg : {name: {v: Name, i: Info}, field: Option String, info: Info} -> SRegex in
-con LiteralReg : {val: {v: String, i: Info}, field: Option String, info: Info} -> SRegex in
-con RecordReg : {content: {v: [SRegex], i: Info}, field: Option String, info: Info} -> SRegex in
+con TerminalReg : {term: Terminal, info: Info, field: Option (Info, String)} in
+con RecordReg : {content: [SRegex], info: Info, field: Option (Info, String)} -> SRegex in
 con KleeneReg : {content: {v: [SRegex], i: Info}, info: Info} -> SRegex in
 con AltReg : {alts: [[SRegex]]} -> SRegex in
 recursive
   let inner
-  : Option (String, Info) -> Regex -> Res [SRegex]
-  = lam name. lam reg.
-    let meta: Option String -> (Option String, Info) = lam msg. match name with Some (field, info)
-      then result.ok (Some field, info)
-      else
-        let info = get_Regex_info reg in
-        let res = result.ok (None (), info) in
-        match msg with Some msg
-        then result.withAnnotations (result.warn (simpleMsg info msg)) res
-        else res in
+  : Option (Info, String) -> Regex -> Res [SRegex]
+  = lam field. lam reg.
+    let suggestLabel: String -> Res () = lam msg.
+      match field with Some _ then result.ok () else
+      let info = get_Regex_info reg in
+      result.withAnnotations (result.warn (simpleMsg info msg)) (result.ok ()) in
     let res = switch reg
       case RecordRegex x then
-        let meta = meta (Some "You probably want to save this record to a field (otherwise you should use parentheses for grouping).\n") in
-        let mkReg = lam meta: (Option String, Info). lam content. [RecordReg
-          { content = {v = content, i = x.info}
-          , field = meta.0
-          , info = meta.1
+        let suggest = suggestLabel "You probably want to save this record to a field (otherwise you should use parentheses for grouping).\n" in
+        let mkReg = lam. lam content. [RecordReg
+          { content = content
+          , field = field
+          , info = x.info
           }] in
-        result.map2 mkReg meta (regexToSRegex x.regex)
+        result.map2 mkReg suggest (regexToSRegex x.regex)
       case LiteralRegex x then
-        let meta = meta (None ()) in
-        let mkReg = lam meta: (Option String, Info).
-          [LiteralReg {val = x.val, field = meta.0, info = meta.1}] in
-        result.map mkReg meta
+        result.ok [TerminalReg {term = LitTerm x.val, info = x.info, field = field}]
       case TokenRegex x then
         switch mapFindExn x.name.v typeMap
-        case Left _ then
-          let meta = meta (Some "You probably want to save this type to a field.\n") in
-          let mkReg = lam meta: (Option String, Info).
-            [NtReg {name = x.name, field = meta.0, info = meta.1}] in
-          result.map mkReg meta
-        case Right _ then
-          let meta = meta (None ()) in
-          let mkReg = lam meta: (Option String, Info).
-            [TokenReg {name = x.name, field = meta.0, info = meta.1}] in
-          result.map mkReg meta
+        case Left config then
+          let suggest = suggestLabel "You probably want to save this type to a field.\n" in
+          let res = result.ok [TerminalReg {term = NtTerm config, field = field, info = x.info}] in
+          result.withAnnotations suggest res
+        case Right config then
+          result.ok [TerminalReg {term = TokenTerm config, field = field, info = x.info}]
         end
       case ConcatRegex x then
         result.map2 concat (regexToSRegex x.left) (regexToSRegex x.right)
@@ -245,7 +253,7 @@ recursive
       case EmptyRegex _ then
         result.ok []
       case NamedRegex x then
-        inner (Some (x.name.v, x.info)) x.right
+        inner (Some (x.name.i, x.name.v)) x.right
       case RepeatPlusRegex x then
         let mkReg = lam regs. snoc regs (KleeneReg {content = {v = regs, i = get_Regex_info x.left}, info = x.info}) in
         result.map mkReg (regexToSRegex x.left)
@@ -257,8 +265,8 @@ recursive
         result.map mkReg (regexToSRegex x.left)
       end
     in
-    match (name, reg) with (Some _, !(RecordRegex _ | TokenRegex _ | LiteralRegex _)) then
-      let err = result.err (simpleMsg (get_Regex_info reg) "Only tokens, types, literals, and records can be saved in a field.\n") in
+    match (field, reg) with (Some (info, _), !(RecordRegex _ | TokenRegex _ | LiteralRegex _)) then
+      let err = result.err (simpleMsg info "Only tokens, types, literals, and records can be saved in a field.\n") in
       result.withAnnotations err res
     else res
   let regexToSRegex
@@ -266,12 +274,136 @@ recursive
   = lam reg. inner (None ()) reg
 in
 
+-- NOTE(vipa, 2022-03-28): `max` is `None` if there is no upper bound,
+-- i.e., if it's under a kleene star
+type FieldCount a = {min : Int, max : Option Int, ty : [(Info, a)]} in
+type ParseContent a = Map String (FieldCount a) in
+let emptyContent : ParseContent a = mapEmpty cmpString in
+let singleContent : String -> Info -> a -> ParseContent a = lam field. lam info. lam a.
+  mapInsert field {min = 1, max = Some 1, ty = [(info, a)]} emptyContent in
+let concatContent
+  : ParseContent a -> ParseContent a -> ParseContent a
+  = lam l. lam r.
+    let f : FieldCount a -> FieldCount a -> FieldCount a = lam l. lam r.
+      { min = addi l.min r.min
+      , max = match (l.max, r.max) with (Some l, Some r) then Some (addi l r) else None ()
+      , ty = concat l.ty r.ty
+      } in
+    foldl (lam acc. lam x. match x with (k, v) in mapInsertWith f k v acc) l (mapBindings r)
+in
+let altContent
+  : ParseContent a -> ParseContent a -> ParseContent a
+  = lam l. lam r.
+    let f : FieldCount a -> FieldCount a -> FieldCount a = lam l. lam r.
+      { min = mini l.min r.min
+      , max = match (l.max, r.max) with (Some l, Some r) then Some (maxi l r) else None ()
+      , ty = concat l.ty r.ty
+      } in
+    let minToZero : FieldCount a -> FieldCount a = lam c. {c with min = 0} in
+    -- OPT(vipa, 2022-03-28): Ideally this would use a generalized merging function, roughly:
+    -- `merge : (k -> a -> c) -> (k -> a -> b -> c) -> (k -> b -> c) -> Map k a -> Map k b -> Map k c`
+    let isIn : ParseContent a -> (String, FieldCount a) -> Bool = lam m. lam entry.
+      match mapLookup entry.0 m with Some _ then true else false in
+    match partition (isIn r) (mapBindings l) with (lInBoth, lOnly) in
+    match partition (isIn l) (mapBindings r) with (rInBoth, rOnly) in
+    let lOnly = map (lam pair. match pair with (k, v) in (k, minToZero v)) lOnly in
+    let rOnly = map (lam pair. match pair with (k, v) in (k, minToZero v)) rOnly in
+    let res = mapFromSeq (mapGetCmpFun l) lInBoth in
+    let res = foldl (lam acc. lam pair. match pair with (k, v) in mapInsertWith f k v acc) res rInBoth in
+    let res = foldl (lam acc. lam pair. match pair with (k, v) in mapInsert k v acc) res (concat lOnly rOnly) in
+    res
+in
+let kleeneContent
+  : ParseContent a -> ParseContent a
+  = lam c.
+    let f : FieldCount a -> FieldCount a = lam c. {{c with min = 0} with max = None ()} in
+    mapMap f c
+in
+
+recursive
+  let computeRecordType
+    : SRegex -> ParseContent (Res CarriedType)
+    = lam reg.
+      switch reg
+      case TerminalReg x then
+        match x.field with Some (info, field) then
+          switch x.term
+          case NtTerm config then
+            let ty = result.map (lam config: TypeInfo. targetableType config.ty) config in
+            singleContent field info ty
+          case TokenTerm config then
+            let ty = result.map
+              (lam config: TokenInfo. untargetableType (tyrecord_ [("v", config.ty), ("i", tycon_ "Info")]))
+              config in
+            singleContent field info ty
+          case LitTerm _ then
+            singleContent field info (result.ok (untargetableType (tycon_ "Info")))
+          end
+        else emptyContent
+      case RecordReg x then
+        -- NOTE(vipa, 2022-03-30): There's presently no way to pass on
+        -- errors discovered in an unlabelled record, which is a bit
+        -- annoying. It should be unlikely to matter in practice, but
+        -- it's a thing
+        match x.field with Some (info, field) then
+          let ty = reifyRecord x.info (concatted x.content) in
+          singleContent field info ty
+        else emptyContent
+      case KleeneReg x then
+        kleeneContent (concatted x.content.v)
+      case AltReg x then
+        match map concatted x.alts with [first] ++ rest in
+        foldl altContent first rest
+      end
+  let concatted
+    : [SRegex] -> ParseContent (Res CarriedType)
+    = lam regs. foldl concatContent emptyContent (map computeRecordType regs)
+  let reifyRecord
+    : Info -> ParseContent (Res CarriedType) -> Res CarriedType
+    = lam info. lam content.
+      let buryInfo : (Info, Res a) -> Res (Info, a) = lam x. result.map (lam a. (x.0, a)) x.1 in
+      let groupByTypeRepr : [(Info, CarriedType)] -> Map Type [(Info, CarriedType)] =
+        foldl
+          (lam m. lam pair : (Info, CarriedType). mapInsertWith concat (carriedRepr pair.1) [pair] m)
+          (mapEmpty cmpType) in
+      let extractUniqueType : String -> (Int, Option Int) -> Map Type [(Info, CarriedType)] -> Res (String, CarriedType) = lam field. lam counts. lam m.
+        switch mapBindings m
+        case [(_, [(_, ty)] ++ _)] then
+          let ty = switch counts
+            case (0, Some 1) then optionType ty
+            case (1, Some 1) then ty
+            case _ then seqType ty
+            end in
+          result.ok (field, ty)
+        case bindings then
+          let typeMsg : (Type, [(Info, CarriedType)]) -> String = lam pair.
+            let places = setOfSeq infoCmp (map (lam x. match x with (info, _) in info) pair.1) in
+            let placeToLine = lam info. join ["  ", info2str info, simpleHighlight info, "\n"] in
+            let places = join (map placeToLine (setToSeq places)) in
+            join ["\n  ", type2str pair.0, "\n", places]
+          in
+          let types = join (map typeMsg bindings) in
+          let msg = join ["The type of field '", field, "' is inconsistent:\n", types] in
+          result.err (info, msg)
+        end in
+      let fixField : (String, FieldCount (Res CarriedType)) -> Res (String, CarriedType) = lam pair.
+        match pair with (field, count) in
+        let tys : Res [(Info, CarriedType)] = result.mapM buryInfo count.ty in
+        let tys : Res (Map Type [(Info, CarriedType)]) = result.map groupByTypeRepr tys in
+        result.bind tys (extractUniqueType field (count.min, count.max))
+      in result.map recordType (result.mapM fixField (mapBindings content))
+in
+
 let temp =
   let check = lam decl. switch decl
     case ProductionDecl x then
-      regexToSRegex x.regex
+      let regInfo = get_Regex_info x.regex in
+      let reg = regexToSRegex x.regex in
+      let content = result.map concatted reg in
+      let carried = result.bind content (reifyRecord regInfo) in
+      result.map (lam x. Some (type2str (carriedRepr x))) carried
     case _ then
-      result.ok []
+      result.ok (None ())
     end in
   result.mapM check decls
 in
@@ -296,5 +428,6 @@ case Left errors then
   exit 1
 case Right res then
   -- printLn res;
-  dprintLn temp
+  dprintLn temp;
+  printLn "Ok"
 end

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -28,6 +28,8 @@ let pullDefinition
       {env with types = mapInsertWith concat (nameGetStr x.name.v) [(x.name.i, nameSetNewSym x.name.v)] env.types}
     case ProductionDecl x then
       {env with productions = mapInsertWith concat (nameGetStr x.name.v) [(x.name.i, nameSetNewSym x.name.v)] env.productions}
+    case TokenDecl {name = Some n} then
+      {env with types = mapInsertWith concat (nameGetStr n.v) [(n.i, nameSetNewSym n.v)] env.types}
     case _ then
       env
     end
@@ -101,6 +103,10 @@ let resolveDecl
       result.map
         (lam name. TypeDecl {x with name = name})
         (lookupName x.name nameEnv.types)
+    case TokenDecl x then
+      result.map
+        (lam name. TokenDecl {x with name = name})
+        (match x.name with Some name then lookupName name nameEnv.types else result.ok (None ()))
     case PrecedenceTableDecl x then
       let resolveLevel = lam level: {noeq : Option {v: (), i: Info}, operators : [{v: Name, i: Info}]}.
         result.map

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -18,6 +18,11 @@ let simpleHighlight
   = lam info.
     formatHighlights terminalHighlightErrorConfig content [Relevant info]
 in
+let simpleMsg
+  : Info -> String -> (Info, String)
+  = lam info. lam msg.
+    (info, join [msg, simpleHighlight info, "\n"])
+in
 
 type Res a = Result (Info, String) (Info, String) a in
 
@@ -65,11 +70,7 @@ let lookupName
   : {v: Name, i: Info} -> Map String (Res Name) -> Res {v: Name, i: Info}
   = lam name. lam map.
     let mkUnboundError = lam.
-      let msg = join
-        [ nameGetStr name.v, " is unbound.\n"
-        , "  ", simpleHighlight name.i, "\n"
-        ]
-      in result.err (name.i, msg) in
+      result.err (simpleMsg name.i (concat (nameGetStr name.v) " is unbound.\n")) in
     let res = mapFindOrElse mkUnboundError (nameGetStr name.v) map in
     result.map (lam v. {name with v = v}) res
 in
@@ -109,7 +110,7 @@ let resolveDecl
     case TokenDecl x then
       result.map
         (lam name. TokenDecl {x with name = name})
-        (match x.name with Some name then lookupName name nameEnv.types else result.ok (None ()))
+        (match x.name with Some name then result.map (lam x. Some x) (lookupName name nameEnv.types) else result.ok (None ()))
     case StartDecl x then
       result.map
         (lam name. StartDecl {x with name = name})
@@ -173,6 +174,108 @@ let start: Res Name =
   end
 in
 
+type TypeInfo = {} in
+type TokenInfo = {} in
+let typeMap: Map Name (Either TypeInfo TokenInfo) =
+  let addDecl = lam m. lam decl. switch decl
+    case TypeDecl x then
+      mapInsert x.name.v (Left {}) m
+    case TokenDecl (x & {name = Some n}) then
+      mapInsert n.v (Right {}) m
+    case _ then
+      m
+    end in
+  foldl addDecl (mapEmpty nameCmp) decls
+in
+
+type SRegex in
+con NtReg : {name: {v: Name, i: Info}, field: Option String, info: Info} -> SRegex in
+con TokenReg : {name: {v: Name, i: Info}, field: Option String, info: Info} -> SRegex in
+con LiteralReg : {val: {v: String, i: Info}, field: Option String, info: Info} -> SRegex in
+con RecordReg : {content: {v: [SRegex], i: Info}, field: Option String, info: Info} -> SRegex in
+con KleeneReg : {content: {v: [SRegex], i: Info}, info: Info} -> SRegex in
+con AltReg : {alts: [[SRegex]]} -> SRegex in
+recursive
+  let inner
+  : Option (String, Info) -> Regex -> Res [SRegex]
+  = lam name. lam reg.
+    let meta: Option String -> (Option String, Info) = lam msg. match name with Some (field, info)
+      then result.ok (Some field, info)
+      else
+        let info = get_Regex_info reg in
+        let res = result.ok (None (), info) in
+        match msg with Some msg
+        then result.withAnnotations (result.warn (simpleMsg info msg)) res
+        else res in
+    let res = switch reg
+      case RecordRegex x then
+        let meta = meta (Some "You probably want to save this record to a field (otherwise you should use parentheses for grouping).\n") in
+        let mkReg = lam meta: (Option String, Info). lam content. [RecordReg
+          { content = {v = content, i = x.info}
+          , field = meta.0
+          , info = meta.1
+          }] in
+        result.map2 mkReg meta (regexToSRegex x.regex)
+      case LiteralRegex x then
+        let meta = meta (None ()) in
+        let mkReg = lam meta: (Option String, Info).
+          [LiteralReg {val = x.val, field = meta.0, info = meta.1}] in
+        result.map mkReg meta
+      case TokenRegex x then
+        switch mapFindExn x.name.v typeMap
+        case Left _ then
+          let meta = meta (Some "You probably want to save this type to a field.\n") in
+          let mkReg = lam meta: (Option String, Info).
+            [NtReg {name = x.name, field = meta.0, info = meta.1}] in
+          result.map mkReg meta
+        case Right _ then
+          let meta = meta (None ()) in
+          let mkReg = lam meta: (Option String, Info).
+            [TokenReg {name = x.name, field = meta.0, info = meta.1}] in
+          result.map mkReg meta
+        end
+      case ConcatRegex x then
+        result.map2 concat (regexToSRegex x.left) (regexToSRegex x.right)
+      case AlternativeRegex x then
+        let sregAlts = lam regs. match regs with [AltReg x]
+          then x.alts
+          else [regs] in
+        let combine = lam ls. lam rs. [AltReg {alts = concat (sregAlts ls) (sregAlts rs)}] in
+        result.map2 combine (regexToSRegex x.left) (regexToSRegex x.right)
+      case EmptyRegex _ then
+        result.ok []
+      case NamedRegex x then
+        inner (Some (x.name.v, x.info)) x.right
+      case RepeatPlusRegex x then
+        let mkReg = lam regs. snoc regs (KleeneReg {content = {v = regs, i = get_Regex_info x.left}, info = x.info}) in
+        result.map mkReg (regexToSRegex x.left)
+      case RepeatStarRegex x then
+        let mkReg = lam regs. [KleeneReg {content = {v = regs, i = get_Regex_info x.left}, info = x.info}] in
+        result.map mkReg (regexToSRegex x.left)
+      case RepeatQuestionRegex x then
+        let mkReg = lam regs. [AltReg {alts = [[], regs]}] in
+        result.map mkReg (regexToSRegex x.left)
+      end
+    in
+    match (name, reg) with (Some _, !(RecordRegex _ | TokenRegex _ | LiteralRegex _)) then
+      let err = result.err (simpleMsg (get_Regex_info reg) "Only tokens, types, literals, and records can be saved in a field.\n") in
+      result.withAnnotations err res
+    else res
+  let regexToSRegex
+  : Regex -> Res [SRegex]
+  = lam reg. inner (None ()) reg
+in
+
+let temp =
+  let check = lam decl. switch decl
+    case ProductionDecl x then
+      regexToSRegex x.regex
+    case _ then
+      result.ok []
+    end in
+  result.mapM check decls
+in
+
 -- NOTE(vipa, 2022-03-21): Generate the actual language fragments
 let generated: Res String = result.bind (result.ok requestedSFunctions) -- TODO(vipa, 2022-03-22): Replace this with something appropriate once we're generating more stuff
   (lam requestedSFunctions.
@@ -185,11 +288,13 @@ let generated: Res String = result.bind (result.ok requestedSFunctions) -- TODO(
     in use CarriedTypeGenerate in result.ok (mkLanguages genInput)
   ) in
 
-match result.consume (result.withAnnotations start (result.withAnnotations allResolved generated)) with (warnings, res) in
+match result.consume (result.withAnnotations (result.withAnnotations temp start) (result.withAnnotations allResolved generated)) with (warnings, res) in
+for_ warnings (lam x. match x with (info, msg) in printLn (infoWarningString info msg));
 switch res
 case Left errors then
   for_ errors (lam x. match x with (info, msg) in printLn (infoErrorString info msg));
   exit 1
 case Right res then
-  printLn res
+  -- printLn res;
+  dprintLn temp
 end

--- a/stdlib/result.mc
+++ b/stdlib/result.mc
@@ -306,6 +306,13 @@ let #var"" =
   utest _prepTest (_mapM work [0, negi 1, negi 2]) with (['a'], Left [0, 0]) in
   ()
 
+-- Convert a Result to an Option, discarding any information present
+-- about warnings or a potential error.
+let _toOption
+  : all w. all e. all a. Result w e a -> Option b
+  = lam r.
+    match r with ResultOk x then Some x.value else None ()
+
 -- Perform a computation only if its input is error free. Preserves
 -- warnings and errors, but if the input is an error then the action
 -- won't run, thus any errors or warnings it would have been produced
@@ -421,6 +428,7 @@ let result =
   , warn = _warn
   -- Destructors
   , consume = _consume
+  , toOption = _toOption
   -- Mapping, action produces no new errors or warnings
   , map = _map
   , map2 = _map2

--- a/stdlib/result.mc
+++ b/stdlib/result.mc
@@ -433,4 +433,5 @@ let result =
   , bind2 = _bind2
   , bind3 = _bind3
   , bind4 = _bind4
+  , mapM = _mapM
   }

--- a/test/examples/expr.syn
+++ b/test/examples/expr.syn
@@ -1,0 +1,32 @@
+token String
+token LName
+token UName
+token Integer
+
+type File
+type Expr
+type Decl
+
+start File
+
+prod File: File = decl:Decl+
+
+prod Function: Decl =
+  "function" name:LName
+  "(" (args:LName ("," args:LName)*)? ")"
+  "=" body:Expr
+
+prod Int: Expr = val:Integer
+prod String: Expr = val:String
+prod Variable: Expr = ident:LName
+prod left Add: Expr = left:Expr "+" right:Expr
+prod left Sub: Expr = left:Expr "-" right:Expr
+prod left Mul: Expr = left:Expr "*" right:Expr
+prod left Div: Expr = left:Expr "/" right:Expr
+prod FunctionCall: Expr = f:Expr "(" (args:Expr ("," args:Expr)*)? ")"
+
+precedence {
+  FunctionCall;
+  Mul Div;
+  Add Sub;
+}


### PR DESCRIPTION
This PR adds the syntax dsl tool in a first version. Currently this means:

- It can parse `.syn` files (and there is documentation and an example of the format). Note that only a subset is parsed at the moment, I'll cover the entire format once I can bootstrap the `.syn` parser, since it's a lot of boilerplate.
- It can generate language fragments for the AST, including `smap` functions. Presently the only thing missing here is generating accessor functions for the `info` field.
- I have not yet made sure that it compiles (interpreting it works though), since most of it was written before #558 was merged, and that was needed for this.

There are some questions around the interface for this:
-  Should it be a new subcommand of `mi` or its own thing?
-  What things should be configurable, and where?
- Should the output be one file or two? Conceptually it could be split into AST definition and a parser that produces an AST. It's probably also relevant that the parser probably won't typecheck with the new typechecker since it uses GADTs, but the AST definition shouldn't have any issues with that (once it outputs `all`s properly, which isn't there right now).

---
The previous description of this PR, from when it only contained documentation, can be found below:

This PR contains the WIP documentation for the syntax specification DSL that we intend to develop, that will be based on the `breakable` idea. It can be found in rendered form [here](https://github.com/miking-lang/miking/blob/2ad5fcb1c9d96e148398c72343c84c72f7c451f6/stdlib/parser/dsl.md).

Edit: updated version is rendered [here](https://github.com/miking-lang/miking/blob/4d57c6802dbf498a46808e22c81aa02d58de5fed/stdlib/parser/dsl.md).

Edit 2: new version [here](https://github.com/miking-lang/miking/blob/ac43033185a9363b2ff237375048371e64420d29/stdlib/parser/dsl.md)