### PR TITLE
Move TyFlex to its own AST fragment

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -106,7 +106,7 @@ let tyalls_ =
   lam strs. lam ty.
   foldr tyall_ ty strs
 
-let tyFlexUnbound = use VarTypeAst in
+let tyFlexUnbound = use FlexTypeAst in
   lam info. lam ident. lam level. lam weak.
   TyFlex {info = info,
           contents = ref (Unbound {ident = ident, level = level, weak = weak})}
@@ -115,7 +115,7 @@ let tyflexunbound_ =
   lam s.
   tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 false
 
-let tyflexlink_ = use VarTypeAst in
+let tyflexlink_ = use FlexTypeAst in
   lam ty.
   TyFlex {info = NoInfo (),
           contents = ref (Link ty)}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1209,14 +1209,25 @@ type TVarRec = {ident : Name,
                 level : Level}
 
 lang VarTypeAst = Ast
+  syn Type =
+  -- Rigid type variable
+  | TyVar  {info     : Info,
+            ident    : Name}
+
+  sem tyWithInfo (info : Info) =
+  | TyVar t -> TyVar {t with info = info}
+
+  sem infoTy =
+  | TyVar t -> t.info
+
+end
+
+lang FlexTypeAst = Ast
   syn TVar =
   | Unbound TVarRec
   | Link Type
 
   syn Type =
-  -- Rigid type variable
-  | TyVar  {info     : Info,
-            ident    : Name}
   -- Flexible type variable
   | TyFlex {info     : Info,
             contents : Ref TVar}
@@ -1232,7 +1243,6 @@ lang VarTypeAst = Ast
     ty
 
   sem tyWithInfo (info : Info) =
-  | TyVar t -> TyVar {t with info = info}
   | TyFlex t ->
     match deref t.contents with Link ty then
       tyWithInfo ty
@@ -1240,7 +1250,6 @@ lang VarTypeAst = Ast
       TyFlex {t with info = info}
 
   sem infoTy =
-  | TyVar t -> t.info
   | TyFlex t ->
     match deref t.contents with Link ty then
       infoTy ty
@@ -1327,4 +1336,4 @@ lang MExprAst =
   -- Types
   UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
   FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + ConTypeAst +
-  VarTypeAst + AppTypeAst + TensorTypeAst + AllTypeAst
+  VarTypeAst + FlexTypeAst + AppTypeAst + TensorTypeAst + AllTypeAst

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -400,6 +400,10 @@ end
 lang VarTypeCmp = Cmp + VarTypeAst
   sem cmpTypeH =
   | (TyVar t1, TyVar t2) -> nameCmp t1.ident t2.ident
+end
+
+lang FlexTypeCmp = Cmp + FlexTypeAst
+  sem cmpTypeH =
   | (TyFlex _ & ty1, ty2)
   | (ty1, TyFlex _ & ty2) ->
     match (resolveLink ty1, resolveLink ty2) with (ty1, ty2) then
@@ -448,7 +452,7 @@ lang MExprCmp =
   -- Types
   UnknownTypeCmp + BoolTypeCmp + IntTypeCmp + FloatTypeCmp + CharTypeCmp +
   FunTypeCmp + SeqTypeCmp + TensorTypeCmp + RecordTypeCmp + VariantTypeCmp +
-  ConTypeCmp + VarTypeCmp + AppTypeCmp + AllTypeCmp
+  ConTypeCmp + VarTypeCmp + FlexTypeCmp + AppTypeCmp + AllTypeCmp
 
 -----------
 -- TESTS --

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -613,6 +613,10 @@ lang VarTypeEq = Eq + VarTypeAst
         (lam freeTyVars. {free with freeTyVars = freeTyVars})
         (_eqCheck l.ident r.ident typeEnv.tyVarEnv free.freeTyVars)
     else None ()
+end
+
+lang FlexTypeEq = Eq + FlexTypeAst
+  sem eqTypeH (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) (lhs : Type) =
   | TyFlex _ & rhs ->
     match (resolveLink lhs, resolveLink rhs) with (lhs, rhs) then
       match (lhs, rhs) with (TyFlex l, TyFlex r) then
@@ -668,7 +672,7 @@ lang MExprEq =
   -- Types
   + UnknownTypeEq + BoolTypeEq + IntTypeEq + FloatTypeEq + CharTypeEq +
   FunTypeEq + SeqTypeEq + RecordTypeEq + VariantTypeEq + ConTypeEq + VarTypeEq +
-  AllTypeEq + AppTypeEq + TensorTypeEq
+  FlexTypeEq + AllTypeEq + AppTypeEq + TensorTypeEq
 end
 
 -----------

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1098,6 +1098,10 @@ lang VarTypePrettyPrint = VarTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyVar t ->
     pprintEnvGetStr env t.ident
+end
+
+lang FlexTypePrettyPrint = FlexTypeAst
+  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
   | TyFlex t ->
     match deref t.contents with Unbound t then
       match pprintEnvGetStr env t.ident with (env, str) then
@@ -1163,8 +1167,8 @@ lang MExprPrettyPrint =
   UnknownTypePrettyPrint + BoolTypePrettyPrint + IntTypePrettyPrint +
   FloatTypePrettyPrint + CharTypePrettyPrint + FunTypePrettyPrint +
   SeqTypePrettyPrint + RecordTypePrettyPrint + VariantTypePrettyPrint +
-  ConTypePrettyPrint + VarTypePrettyPrint + AppTypePrettyPrint +
-  TensorTypePrettyPrint + AllTypePrettyPrint
+  ConTypePrettyPrint + VarTypePrettyPrint + FlexTypePrettyPrint +
+  AppTypePrettyPrint + TensorTypePrettyPrint + AllTypePrettyPrint
 
   -- Identifiers
   + MExprIdentifierPrettyPrint


### PR DESCRIPTION
This PR separates out `TyFlex` to its own AST fragment. Previously, it was in the same fragment as `TyVar` for no good reason.