### PR TITLE
External dependent utest removal

### DIFF
--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -76,6 +76,10 @@ let main =
       , Arg.Set enable_debug_after_symbolize
       , " Enables output of the mexpr program after symbolize transformations."
       )
+    ; ( "--debug-utest-removal"
+      , Arg.Set enable_debug_after_external_dependent_utest_removal
+      , " Enables output of the mexpr program after external dependent utests \
+         removal." )
     ; ( "--debug-dead-code-elim"
       , Arg.Set enable_debug_after_dead_code_elimination
       , " Enables output of the mexpr program after dead code elimination." )
@@ -111,6 +115,12 @@ let main =
       , Arg.Set Boot.Mlang.enable_subsumption_analysis
       , " Enables subsumption analysis of language fragments in mlang \
          transformations." )
+    ; ( "--disable-utest-removal"
+      , Arg.Set disable_external_dependent_utest_removal
+      , " Disables removal of external dependent utests." )
+    ; ( "--supress-utest-removal-summary"
+      , Arg.Set supress_external_dependent_utest_removal_summary
+      , " Supress removal of external dependent utests summary printing." )
     ; ( "--disable-dead-code-elim"
       , Arg.Set disable_dead_code_elimination
       , " Disables dead code elimination." )

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -366,7 +366,7 @@ and ident =
 
 let tm_unit = TmRecord (NoInfo, Record.empty)
 
-let tyUnit fi = TyRecord (fi, Record.empty, [])
+let ty_unit fi = TyRecord (fi, Record.empty, [])
 
 (* smap for terms *)
 let smap_tm_tm (f : tm -> tm) = function

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -459,77 +459,14 @@ let smap_accum_left_tm_tm (f : 'a -> tm -> 'a * tm) (acc : 'a) : tm -> 'a * tm
       (acc, t)
 
 (* smap for terms *)
-let smap_tm_tm (f : tm -> tm) = function
-  | TmApp (fi, t1, t2) ->
-      TmApp (fi, f t1, f t2)
-  | TmLam (fi, x, s, ty, t1) ->
-      TmLam (fi, x, s, ty, f t1)
-  | TmLet (fi, x, s, ty, t1, t2) ->
-      TmLet (fi, x, s, ty, f t1, f t2)
-  | TmRecLets (fi, lst, tm) ->
-      TmRecLets
-        (fi, List.map (fun (fi, x, s, ty, t) -> (fi, x, s, ty, f t)) lst, f tm)
-  | TmSeq (fi, tms) ->
-      TmSeq (fi, Mseq.map f tms)
-  | TmRecord (fi, r) ->
-      TmRecord (fi, Record.map f r)
-  | TmRecordUpdate (fi, r, l, t) ->
-      TmRecordUpdate (fi, f r, l, f t)
-  | TmType (fi, x, s, ty, t1) ->
-      TmType (fi, x, s, ty, f t1)
-  | TmConDef (fi, x, s, ty, t1) ->
-      TmConDef (fi, x, s, ty, f t1)
-  | TmConApp (fi, k, s, t) ->
-      TmConApp (fi, k, s, f t)
-  | TmMatch (fi, t1, p, t2, t3) ->
-      TmMatch (fi, f t1, p, f t2, f t3)
-  | TmUtest (fi, t1, t2, tusing, tnext) ->
-      let tusing_mapped = Option.map f tusing in
-      TmUtest (fi, f t1, f t2, tusing_mapped, f tnext)
-  | TmUse (fi, l, t1) ->
-      TmUse (fi, l, f t1)
-  | TmExt (fi, x, s, ty, e, t) ->
-      TmExt (fi, x, s, ty, e, f t)
-  | TmClos (fi, x, s, t1, env) ->
-      TmClos (fi, x, s, f t1, env)
-  | (TmVar _ | TmConst _ | TmNever _ | TmFix _ | TmRef _ | TmTensor _) as t ->
-      t
+let smap_tm_tm (f : tm -> tm) (t : tm) : tm =
+  let _, t' = smap_accum_left_tm_tm (fun _ t -> ((), f t)) () t in
+  t'
 
 (* sfold over terms *)
-let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) = function
-  | TmApp (_, t1, t2) ->
-      f (f acc t1) t2
-  | TmLam (_, _, _, _, t1) ->
-      f acc t1
-  | TmLet (_, _, _, _, t1, t2) ->
-      f (f acc t1) t2
-  | TmRecLets (_, lst, tm) ->
-      f (List.fold_left (fun acc (_, _, _, _, t) -> f acc t) acc lst) tm
-  | TmSeq (_, tms) ->
-      Mseq.Helpers.fold_left f acc tms
-  | TmRecord (_, r) ->
-      Record.fold (fun _ t acc -> f acc t) r acc
-  | TmRecordUpdate (_, r, _, t) ->
-      f (f acc r) t
-  | TmType (_, _, _, _, t1) ->
-      f acc t1
-  | TmConDef (_, _, _, _, t1) ->
-      f acc t1
-  | TmConApp (_, _, _, t) ->
-      f acc t
-  | TmMatch (_, t1, _, t2, t3) ->
-      f (f (f acc t1) t2) t3
-  | TmUtest (_, t1, t2, tusing, tnext) ->
-      let acc = f (f acc t1) t2 in
-      f (match tusing with None -> acc | Some t -> f acc t) tnext
-  | TmUse (_, _, t1) ->
-      f acc t1
-  | TmExt (_, _, _, _, _, t) ->
-      f acc t
-  | TmClos (_, _, _, t1, _) ->
-      f acc t1
-  | TmVar _ | TmConst _ | TmNever _ | TmFix _ | TmRef _ | TmTensor _ ->
-      acc
+let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) (t : tm) : 'a =
+  let acc', _ = smap_accum_left_tm_tm (fun acc t -> (f acc t, t)) acc t in
+  acc'
 
 (* Returns arity given an type *)
 let rec ty_arity = function TyArrow (_, _, ty) -> 1 + ty_arity ty | _ -> 0

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -21,6 +21,8 @@ let enable_debug_after_symbolize = ref false
 
 let enable_debug_after_dead_code_elimination = ref false
 
+let enable_debug_after_external_dependent_utest_removal = ref false
+
 let enable_debug_dead_code_info = ref false
 
 let enable_debug_after_mlang = ref false
@@ -34,6 +36,10 @@ let enable_debug_stack_trace = ref false
 let enable_debug_profiling = ref false
 
 let disable_dead_code_elimination = ref false
+
+let supress_external_dependent_utest_removal_summary = ref false
+
+let disable_external_dependent_utest_removal = ref false
 
 let utest = ref false (* Set to true if unit testing is enabled *)
 

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -23,7 +23,8 @@ let evalprog filename =
       |> Mlang.desugar_post_flatten |> debug_after_mlang
       |> raise_parse_error_on_non_unique_external_id
       |> Symbolize.symbolize builtin_name2sym
-      |> debug_after_symbolize
+      |> debug_after_symbolize |> remove_utests_referencing_externals
+      |> debug_after_external_dependent_utest_removal
       |> Deadcode.elimination builtin_sym2term builtin_name2sym []
       |> debug_after_dead_code_elimination
       |> raise_parse_error_on_partially_applied_external

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -214,6 +214,14 @@ module Mseq = struct
       | _ ->
           raise (Invalid_argument "Mseq.fold_right2")
 
+    let map_accum_left f a = function
+      | Rope s ->
+          let a', s' = Rope.map_accuml_array_array f a s in
+          (a', Rope s')
+      | List s ->
+          let a', s' = List.fold_left_map f a s in
+          (a', List s')
+
     let of_list = of_list_rope
 
     let of_array = of_array_rope

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -216,6 +216,15 @@ module Mseq : sig
      *)
     val fold_right2 :
       ('a -> 'b -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+
+    (* Complexity:
+     * rope (?): O(n*k), where n is the length of the sequence, k is the
+     *   complexity of the function (flattens)
+     * list (?): O(n*k), where n is the length of the sequence, k is the
+     *   complexity of the function
+     *)
+    val map_accum_left :
+      ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a t -> 'acc * 'b t
   end
 end
 

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -264,7 +264,7 @@ constr_params:
   | ty
     { fun _ -> $1 }
   |
-    { fun i -> tyUnit i }
+    { fun i -> ty_unit i }
 
 params:
   | LPAREN var_ident COLON ty RPAREN params
@@ -532,7 +532,7 @@ ty_left:
 
 ty_atom:
   | LPAREN RPAREN
-    { tyUnit (mkinfo $1.i $2.i) }
+    { ty_unit (mkinfo $1.i $2.i) }
   | LPAREN ty RPAREN
     { $2 }
   | LSQUARE ty RSQUARE
@@ -540,7 +540,7 @@ ty_atom:
   | LPAREN ty COMMA ty_list RPAREN
     { tuplety2recordty (mkinfo $1.i $5.i) ($2::$4) }
   | LBRACKET RBRACKET
-    { tyUnit (mkinfo $1.i $2.i) }
+    { ty_unit (mkinfo $1.i $2.i) }
   | LBRACKET label_tys RBRACKET
     { let r = $2 |> List.fold_left
                       (fun acc (k,v) -> Record.add k v acc)

--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -178,6 +178,21 @@ let foldl_array (f : 'a -> 'b -> 'a) (acc : 'a) (s : 'b t) : 'a =
   let a = _collapse_array s in
   Array.fold_left f acc a
 
+let map_accuml_array_array (f : 'a -> 'b -> 'a * 'c) (acc : 'a) (s : 'b t) :
+    'a * 'c t =
+  (* TODO(oerikss,2021-10-20): In OCaml version 4.13.0 we can use
+     [Array.fold_left_map] directly *)
+  let acc' = ref acc in
+  let s' =
+    map_array_array
+      (fun x ->
+        let acc'', x' = f !acc' x in
+        acc' := acc'' ;
+        x' )
+      s
+  in
+  (!acc', s')
+
 let reverse_array (s : 'a t) : 'a t =
   let a = _collapse_array s in
   let a' = Array.copy a in

--- a/src/boot/lib/rope.mli
+++ b/src/boot/lib/rope.mli
@@ -63,6 +63,11 @@ val foldl_array : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
     accumulated value, which is initially [acc] and the elements of [s],
     starting from the leftmost element. This function collapses [s]. *)
 
+val map_accuml_array_array : ('a -> 'b -> 'a * 'c) -> 'a -> 'b t -> 'a * 'c t
+(** [Rope.map_accuml_* f acc s] is a combination of [Rope.map_*_*] and
+   [Rope.foldl_* f acc s] that threads an accumulator through calls to [f]. This
+   function collapses [s]. *)
+
 val reverse_array : 'a t -> 'a t
 (** [Rope.reverse_* s] returns a new rope containing the elements of [s] in
     reversed order. This function collapses [s]. *)


### PR DESCRIPTION
This is a draft PR proposing a method for handling _utests_ of externals when the dependencies for the external is not met by the current system. This method removes all _utests_ that references an external or any lets that themself references an external that is not supported. This is done before the dead-code elimination phase so that lets referencing externals that are only used in tests are removed are removed during dead-code elimination. 

Right now this functionality is only implemented in `boot` where any _utest_ referencing an external is removed since externals are not supported at all in `boot`. This functionality could however be extended to remove all _utests_  referencing only a certain subsets of the externals. A straighforward way to implement this is to add an additional argument to `bootParserParseMCoreFile` and  friends that supplies a set of externals that are supported on the current system  (we can check which are supported using `ocamlfind` for example) and supply these externals when we know them in `compile.mc`.

There are a number of new command line options added to `boot` with this PR. They are summarized below.
```
  --debug-utest-removal            Enables output of the mexpr program after external dependent utests removal.
  --disable-utest-removal          Disables removal of external dependent utests.
  --supress-utest-removal-summary  Supress removal of external dependent utests summary printing.
```

Note that the number of removed _utests_ are printed to _stderr_ by default.

Additionally this PR adds `smap_accum_left` over terms in `boot` together with some additions to `rope.ml`.