### PR TITLE
Type checker improvements

### DIFF
--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -75,7 +75,6 @@ let reserved_strings = [
   ("!",             fun(i) -> Parser.NOT{i=i;v=()});
   ("_",             fun(i) -> Parser.UNDERSCORE{i=i;v=()});
   ("->",            fun(i) -> Parser.ARROW{i=i;v=()});
-  ("`",             fun(i) -> Parser.BACKTICK{i=i;v=()});
 ]
 
 (* Info handling *)
@@ -169,7 +168,7 @@ let uident = ucase_letter (digit | '_' | us_letter)*
 
 let symtok =  "="  | "+" |  "-" | "*"  | "/" | "%"  | "<"  | "<=" | ">" | ">=" | "<<" | ">>" | ">>>" | "==" |
               "!=" | "!" | "&&" | "||" | "++"| "$" | "("  | ")"  | "["  | "]" | "{"  | "}"  |
-              "::" | ":" | ","  | ";"  | "."  | "&" | "|" | "->" | "=>" | "++" | "`"
+              "::" | ":" | ","  | ";"  | "."  | "&" | "|" | "->" | "=>" | "++"
 
 let line_comment = "--" [^ '\013' '\010']*
 let unsigned_integer = digit+
@@ -207,16 +206,17 @@ rule main = parse
       { let s = Ustring.from_utf8 c in
         let esc_s = Ustring.convert_escaped_chars s in
         Parser.CHAR{i=mkinfo_ustring (us"'" ^. s ^. us"'"); v=esc_s}}
-  | '#' (("con" | "type" | "var" | "label") as ident) '"'
+  | '#' (("con" | "type" | "var" | "label" | "frozen") as ident) '"'
        { Buffer.reset string_buf ;  parsestring lexbuf;
 	 let s = Ustring.from_utf8 (Buffer.contents string_buf) in
          let id = Ustring.convert_escaped_chars s  in
          let fi = mkinfo_ustring (s ^. us"  #" ^. us(ident)) in
 	 let rval = (match ident with
-            | "con"   -> Parser.CON_IDENT{i=fi; v=id}
-            | "type"  -> Parser.TYPE_IDENT{i=fi; v=id}
-            | "var"   -> Parser.VAR_IDENT{i=fi; v=id}
-            | "label" -> Parser.LABEL_IDENT{i=fi; v=id}
+            | "con"    -> Parser.CON_IDENT{i=fi; v=id}
+            | "type"   -> Parser.TYPE_IDENT{i=fi; v=id}
+            | "var"    -> Parser.VAR_IDENT{i=fi; v=id}
+            | "label"  -> Parser.LABEL_IDENT{i=fi; v=id}
+            | "frozen" -> Parser.FROZEN_IDENT{i=fi; v=id}
             | _ -> failwith "Cannot happen")
          in
 	 add_colno 3; colcount_fast ident; rval}

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -32,9 +32,10 @@
 /* Misc tokens */
 %token EOF
 
-/* Use the non-terminals 'con_ident', 'var_ident', 'type_ident', and 'ident' instead of the below */
+/* Use the non-terminals 'con_ident', 'var_ident', 'frozen_ident', 'type_ident', and 'ident' instead of the below */
 %token <Ustring.ustring Ast.tokendata> CON_IDENT
 %token <Ustring.ustring Ast.tokendata> VAR_IDENT
+%token <Ustring.ustring Ast.tokendata> FROZEN_IDENT
 %token <Ustring.ustring Ast.tokendata> TYPE_IDENT
 %token <Ustring.ustring Ast.tokendata> LABEL_IDENT
 %token <Ustring.ustring Ast.tokendata> UC_IDENT  /* An identifier that starts with an upper-case letter */
@@ -105,7 +106,6 @@
 %token <unit Ast.tokendata> NOT           /* "!"   */
 %token <unit Ast.tokendata> UNDERSCORE    /* "_"   */
 %token <unit Ast.tokendata> CONCAT        /* "++"  */
-%token <unit Ast.tokendata> BACKTICK      /* "`"   */
 
 %start main
 %start main_mexpr
@@ -389,7 +389,7 @@ atom:
       { TmRecord(mkinfo $1.i $4.i, Record.singleton (us "0") $2) }
   | LPAREN RPAREN        { TmRecord($1.i, Record.empty) }
   | var_ident            { TmVar($1.i,$1.v,Symb.Helpers.nosym, false) }
-  | BACKTICK var_ident   { TmVar($2.i,$2.v,Symb.Helpers.nosym, true) }
+  | frozen_ident         { TmVar($1.i,$1.v,Symb.Helpers.nosym, true) }
   | CHAR                 { TmConst($1.i, CChar(List.hd (ustring2list $1.v))) }
   | UINT                 { TmConst($1.i,CInt($1.v)) }
   | UFLOAT               { TmConst($1.i,CFloat($1.v)) }
@@ -596,6 +596,9 @@ ident:
 var_ident:
   | LC_IDENT {$1}
   | VAR_IDENT {$1}
+
+frozen_ident:
+  | FROZEN_IDENT {$1}
 
 con_ident:
   | UC_IDENT {$1}

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -606,10 +606,12 @@ and print_tm' fmt t =
   in
   match t with
   | TmVar (_, x, s, frozen) ->
-      let var_str = string_of_ustring (ustring_of_var x s) in
-      let print = if frozen then "`" ^ var_str else var_str in
+      let var_str =
+        if frozen then string_of_ustring (us "#frozen\"" ^. x ^. us "\"")
+        else string_of_ustring (ustring_of_var x s)
+      in
       (*  fprintf fmt "%s#%d" print s *)
-      fprintf fmt "%s" print
+      fprintf fmt "%s" var_str
   | TmLam (_, x, s, ty, t1) ->
       let x = string_of_ustring (ustring_of_var x s) in
       let ty = ty |> ustring_of_ty |> string_of_ustring in

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -8,6 +8,7 @@ include "mexpr/boot-parser.mc"
 include "mexpr/profiling.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/type-annot.mc"
+include "mexpr/type-check.mc"
 include "mexpr/remove-ascription.mc"
 include "mexpr/utesttrans.mc"
 include "mexpr/tuning/decision-points.mc"
@@ -20,7 +21,8 @@ include "ocaml/external-includes.mc"
 lang MCoreCompile =
   BootParser +
   MExprHoles +
-  MExprSym + MExprTypeAnnot + MExprUtestTrans + MExprProfileInstrument
+  MExprSym + MExprTypeAnnot + MExprTypeCheck + MExprUtestTrans +
+  MExprProfileInstrument
 end
 
 let pprintMcore = lam ast.
@@ -58,6 +60,9 @@ let ocamlCompileAstWithUtests = lam options : Options. lam sourcePath. lam ast.
       if options.debugProfile then instrumentProfiling (symbolize ast)
       else ast
     in
+
+    -- If option --typecheck, type check the AST
+    let ast = if options.typeCheck then typeCheck (symbolize ast) else ast in
 
     -- If option --test, then generate utest runner calls. Otherwise strip away
     -- all utest nodes from the AST.

--- a/src/main/eval.mc
+++ b/src/main/eval.mc
@@ -15,6 +15,7 @@ include "mexpr/mexpr.mc"
 include "mexpr/builtin.mc"
 include "mexpr/eval.mc"
 include "mexpr/type-annot.mc"
+include "mexpr/type-check.mc"
 include "mexpr/remove-ascription.mc"
 include "mexpr/type-lift.mc"
 include "mexpr/utesttrans.mc"
@@ -22,8 +23,8 @@ include "mexpr/utesttrans.mc"
 
 
 lang ExtMCore =
-  BootParser + MExpr + MExprTypeAnnot + MExprTypeLift + MExprUtestTrans +
-  MExprProfileInstrument + MExprEval
+  BootParser + MExpr + MExprTypeAnnot + MExprTypeCheck + MExprTypeLift +
+  MExprUtestTrans + MExprProfileInstrument + MExprEval
 
   sem updateArgv (args : [String]) =
   | TmConst r -> match r.val with CArgv () then seq_ (map str_ args) else TmConst r
@@ -59,6 +60,9 @@ let eval = lam files. lam options : Options. lam args.
         instrumentProfiling (symbolize ast)
       else ast
     in
+
+    -- If option --typecheck, type check the AST
+    let ast = if options.typeCheck then typeCheck (symbolize ast) else ast in
 
     -- If option --test, then generate utest runner calls. Otherwise strip away
     -- all utest nodes from the AST.

--- a/src/main/mi.mc
+++ b/src/main/mi.mc
@@ -38,6 +38,7 @@ Options:
   --exit-before           Exit before evaluation or compilation
   --test                  Generate utest code
   --disable-optimizations Disables optimizations to decrease compilation time
+  --typecheck             Type check the program before evaluation or compilation
   -- <args>               If the run or eval commands are used, then the texts
                           following -- are arguments to the executed program
   --help                  Display this list of options

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -14,6 +14,7 @@ type Options = {
   useTuned : Bool,
   compileAfterTune : Bool,
   cpuOnly : Bool,
+  typeCheck : Bool,
   printHelp : Bool
 }
 
@@ -29,6 +30,7 @@ let options = {
   useTuned = false,
   compileAfterTune = false,
   cpuOnly = false,
+  typeCheck = false,
   printHelp = false
 }
 
@@ -44,6 +46,7 @@ let optionsMap = [
 ("--tuned", lam o : Options. {o with useTuned = true}),
 ("--compile", lam o : Options. {o with compileAfterTune = true}),
 ("--cpu-only", lam o : Options. {o with cpuOnly = true}),
+("--typecheck", lam o : Options. {o with typeCheck = true}),
 ("--help", lam o: Options. {o with printHelp = true})
 ]
 

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1209,11 +1209,6 @@ lang ConTypeAst = Ast
   | TyCon r -> r.info
 end
 
-type Level = Int
-type TVarRec = {ident : Name,
-                weak  : Bool,
-                level : Level}
-
 lang VarTypeAst = Ast
   syn Type =
   -- Rigid type variable
@@ -1227,6 +1222,11 @@ lang VarTypeAst = Ast
   | TyVar t -> t.info
 
 end
+
+type Level = Int
+type TVarRec = {ident : Name,
+                weak  : Bool,
+                level : Level}
 
 lang FlexTypeAst = Ast
   syn TVar =

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1053,6 +1053,10 @@ lang UnknownTypeAst = Ast
 
   sem infoTy =
   | TyUnknown r -> r.info
+
+  sem sremoveUnknown =
+  | TyUnknown _ -> None ()
+  | ty -> Some ty
 end
 
 lang BoolTypeAst = Ast

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -10,8 +10,8 @@ let tysym_ = tyunknown_
 let tyref_ = tyunknown_
 let tymap_ = tyunknown_
 let tybootparsetree_ = tyunknown_
-let tygeneric_ = lam id. tyunknown_
-let tygenericseq_ = lam id. tyseq_ (tygeneric_ id)
+
+let tyvarseq_ = lam id. tyseq_ (tyvar_ id)
 
 lang LiteralTypeAst = IntAst + FloatAst + BoolAst + CharAst
   sem tyConst =
@@ -106,45 +106,47 @@ end
 
 lang SeqOpTypeAst = SeqOpAst
   sem tyConst =
-  | CSet _ -> tyarrows_ [tygenericseq_ "a", tyint_,
-                         tygeneric_ "a", tygenericseq_ "a"]
-  | CGet _ -> tyarrows_ [tygenericseq_ "a", tyint_, tygeneric_ "a"]
-  | CCons _ -> tyarrows_ [tygeneric_ "a", tygenericseq_ "a", tygenericseq_ "a"]
-  | CSnoc _ -> tyarrows_ [tygenericseq_ "a", tygeneric_ "a", tygenericseq_ "a"]
-  | CConcat _ -> tyarrows_ [tygenericseq_ "a", tygenericseq_ "a",
-                            tygenericseq_ "a"]
-  | CLength _ -> tyarrow_ (tygenericseq_ "a") tyint_
-  | CReverse _ -> tyarrow_ (tygenericseq_ "a") (tygenericseq_ "a")
-  | CHead _ -> tyarrow_ (tygenericseq_ "a") (tygeneric_ "a")
-  | CTail _ -> tyarrow_ (tygenericseq_ "a") (tygenericseq_ "a")
-  | CNull _ -> tyarrow_ (tygenericseq_ "a") tybool_
+  | CSet _ ->
+    tyall_ "a" (tyarrows_ [ tyvarseq_ "a", tyint_, tyvar_ "a", tyvarseq_ "a"])
+  | CGet _ -> tyall_ "a" (tyarrows_ [tyvarseq_ "a", tyint_, tyvar_ "a"])
+  | CCons _ -> tyall_ "a" (tyarrows_ [tyvar_ "a", tyvarseq_ "a", tyvarseq_ "a"])
+  | CSnoc _ -> tyall_ "a" (tyarrows_ [tyvarseq_ "a", tyvar_ "a", tyvarseq_ "a"])
+  | CConcat _ -> tyall_ "a" (tyarrows_ [tyvarseq_ "a", tyvarseq_ "a", tyvarseq_ "a"])
+  | CLength _ -> tyall_ "a" (tyarrow_ (tyvarseq_ "a") tyint_)
+  | CReverse _ -> tyall_ "a" (tyarrow_ (tyvarseq_ "a") (tyvarseq_ "a"))
+  | CHead _ -> tyall_ "a" (tyarrow_ (tyvarseq_ "a") (tyvar_ "a"))
+  | CTail _ -> tyall_ "a" (tyarrow_ (tyvarseq_ "a") (tyvarseq_ "a"))
+  | CNull _ -> tyall_ "a" (tyarrow_ (tyvarseq_ "a") tybool_)
   | CMap _ ->
-    tyarrows_ [ tyarrow_ (tygeneric_ "a") (tygeneric_ "a"),
-                tygenericseq_ "a", tygenericseq_ "a" ]
+    tyall_ "a" (tyarrows_ [ tyarrow_ (tyvar_ "a") (tyvar_ "a"),
+                            tyvarseq_ "a", tyvarseq_ "a" ])
   | CMapi _ ->
-    tyarrows_ [ tyarrows_ [tyint_, tygeneric_ "a", tygeneric_ "a"],
-                tygenericseq_ "a", tygenericseq_ "a" ]
+    tyall_ "a" (tyarrows_ [ tyarrows_ [tyint_, tyvar_ "a", tyvar_ "a"],
+                            tyvarseq_ "a", tyvarseq_ "a" ])
   | CIter _ ->
-    tyarrows_ [tyarrow_ (tygeneric_ "a") tyunit_, tygenericseq_ "a", tyunit_]
+    tyall_ "a" (tyarrows_ [tyarrow_ (tyvar_ "a") tyunit_, tyvarseq_ "a", tyunit_])
   | CIteri _ ->
-    tyarrows_ [ tyarrows_ [tyint_, tygeneric_ "a", tyunit_],
-                tygenericseq_ "a", tyunit_ ]
+    tyall_ "a" (tyarrows_ [ tyarrows_ [tyint_, tyvar_ "a", tyunit_],
+                            tyvarseq_ "a", tyunit_ ])
   | CFoldl _ ->
-    tyarrows_ [ tyarrows_ [tygeneric_ "a", tygeneric_ "b", tygeneric_ "a"],
-                tygeneric_ "a", tygenericseq_ "b", tygeneric_ "a" ]
+    tyalls_ ["a", "b"]
+            (tyarrows_ [ tyarrows_ [tyvar_ "a", tyvar_ "b", tyvar_ "a"],
+                         tyvar_ "a", tyvarseq_ "b", tyvar_ "a" ])
   | CFoldr _ ->
-    tyarrows_ [ tyarrows_ [tygeneric_ "b", tygeneric_ "a", tygeneric_ "a"],
-                tygeneric_ "a", tygenericseq_ "b", tygeneric_ "a" ]
-  | CCreate _ -> tyarrows_ [tyint_, tyarrow_ tyint_ (tygeneric_ "a"),
-                            tygenericseq_ "a"]
+    tyalls_ ["a", "b"]
+            (tyarrows_ [ tyarrows_ [tyvar_ "b", tyvar_ "a", tyvar_ "a"],
+                         tyvar_ "a", tyvarseq_ "b", tyvar_ "a" ])
+  | CCreate _ ->
+    tyall_ "a" (tyarrows_ [tyint_, tyarrow_ tyint_ (tyvar_ "a"), tyvarseq_ "a"])
   | CCreateList _ ->
-    tyarrows_ [tyint_, tyarrow_ tyint_ (tygeneric_ "a"), tygenericseq_ "a"]
+    tyall_ "a" (tyarrows_ [tyint_, tyarrow_ tyint_ (tyvar_ "a"), tyvarseq_ "a"])
   | CCreateRope _ ->
-    tyarrows_ [tyint_, tyarrow_ tyint_ (tygeneric_ "a"), tygenericseq_ "a"]
-  | CSplitAt _ -> tyarrows_ [tygenericseq_ "a", tyint_,
-                             tytuple_ [tygenericseq_ "a", tygenericseq_ "a"]]
-  | CSubsequence _ -> tyarrows_ [tygenericseq_ "a", tyint_, tyint_,
-                                 tygenericseq_ "a"]
+    tyall_ "a" (tyarrows_ [tyint_, tyarrow_ tyint_ (tyvar_ "a"), tyvarseq_ "a"])
+  | CSplitAt _ ->
+    tyall_ "a" (tyarrows_ [ tyvarseq_ "a", tyint_,
+                            tytuple_ [tyvarseq_ "a", tyvarseq_ "a"]])
+  | CSubsequence _ ->
+    tyall_ "a" (tyarrows_ [ tyvarseq_ "a", tyint_, tyint_, tyvarseq_ "a"])
 end
 
 lang FileOpTypeAst = FileOpAst
@@ -188,77 +190,86 @@ end
 
 lang RefOpTypeAst = RefOpAst
   sem tyConst =
-  | CRef _ -> tyarrow_ (tygeneric_ "a") tyref_
-  | CModRef _ -> tyarrows_ [tyref_, tygeneric_ "a", tyunit_]
-  | CDeRef _ -> tyarrow_ tyref_ (tygeneric_ "a")
+  | CRef _ -> tyall_ "a" (tyarrow_ (tyvar_ "a") tyref_)
+  | CModRef _ -> tyall_ "a" (tyarrows_ [tyref_, tyvar_ "a", tyunit_])
+  | CDeRef _ -> tyall_ "a" (tyarrow_ tyref_ (tyvar_ "a"))
 end
 
 lang ConTagTypeAst = ConTagAst
   sem tyConst =
-  | CConstructorTag _ -> tyarrow_ (tygeneric_ "a") tyint_
+  | CConstructorTag _ -> tyall_ "a" (tyarrow_ (tyvar_ "a") tyint_)
 end
 
 lang MapTypeAst = MapAst
   sem tyConst =
-  | CMapEmpty _ -> tyarrow_ (tyarrows_ [tygeneric_ "a", tygeneric_ "a", tyint_])
-                            tymap_
-  | CMapInsert _ -> tyarrows_ [tygeneric_ "a", tygeneric_ "b", tymap_, tymap_]
-  | CMapRemove _ -> tyarrows_ [tygeneric_ "a", tymap_, tymap_]
-  | CMapFindExn _ -> tyarrows_ [tygeneric_ "a", tymap_, tygeneric_ "b"]
-  | CMapFindOrElse _ -> tyarrows_ [tyarrow_ tyunit_ (tygeneric_ "b"),
-                                   tygeneric_ "a", tymap_, tygeneric_ "b"]
+  | CMapEmpty _ ->
+    tyall_ "a" (tyarrow_ (tyarrows_ [tyvar_ "a", tyvar_ "a", tyint_]) tymap_)
+  | CMapInsert _ ->
+    tyalls_ ["a", "b"] (tyarrows_ [tyvar_ "a", tyvar_ "b", tymap_, tymap_])
+  | CMapRemove _ -> tyall_ "a" (tyarrows_ [tyvar_ "a", tymap_, tymap_])
+  | CMapFindExn _ ->
+    tyalls_ ["a", "b"] (tyarrows_ [tyvar_ "a", tymap_, tyvar_ "b"])
+  | CMapFindOrElse _ ->
+    tyalls_ ["a", "b"]
+            (tyarrows_ [tyarrow_ tyunit_ (tyvar_ "b"),
+                        tyvar_ "a", tymap_, tyvar_ "b"])
   | CMapFindApplyOrElse _ ->
-    tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
-               tyarrow_ tyunit_ (tygeneric_ "c"), tygeneric_ "a",
-               tymap_, tygeneric_ "c"]
-  | CMapBindings _ -> tyarrow_ tymap_
-                               (tyseq_ (tytuple_ [tygeneric_ "a", tygeneric_ "b"]))
-  | CMapChooseExn _ -> tyarrows_ [
-      tymap_,
-      (tytuple_ [tygeneric_ "a", tygeneric_ "b"])
-    ]
-  | CMapChooseOrElse _ -> tyarrows_ [
-      tyarrow_ tyunit_ (tytuple_ [tygeneric_ "a", tygeneric_ "b"]),
-      tymap_,
-      (tytuple_ [tygeneric_ "a", tygeneric_ "b"])
-    ]
+    tyalls_ ["a", "b", "c"]
+            (tyarrows_ [tyarrow_ (tyvar_ "b") (tyvar_ "c"),
+                        tyarrow_ tyunit_ (tyvar_ "c"), tyvar_ "a",
+                        tymap_, tyvar_ "c"])
+  | CMapBindings _ ->
+    tyalls_ ["a", "b"]
+            (tyarrow_ tymap_ (tyseq_ (tytuple_ [tyvar_ "a", tyvar_ "b"])))
+  | CMapChooseExn _ ->
+    tyalls_ ["a", "b"]
+            (tyarrows_ [tymap_, (tytuple_ [tyvar_ "a", tyvar_ "b"])])
+  | CMapChooseOrElse _ ->
+    tyalls_ ["a", "b"]
+            (tyarrows_ [tyarrow_ tyunit_ (tytuple_ [tyvar_ "a", tyvar_ "b"]),
+                        tymap_, (tytuple_ [tyvar_ "a", tyvar_ "b"])])
   | CMapSize _ -> tyarrow_ tymap_ tyint_
-  | CMapMem _ -> tyarrows_ [tygeneric_ "a", tymap_, tybool_]
-  | CMapAny _ -> tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tybool_],
-                            tymap_, tybool_]
-  | CMapMap _ -> tyarrows_ [tyarrow_ (tygeneric_ "b") (tygeneric_ "c"),
-                            tymap_, tymap_]
+  | CMapMem _ -> tyall_ "a" (tyarrows_ [tyvar_ "a", tymap_, tybool_])
+  | CMapAny _ ->
+    tyalls_ ["a", "b"]
+            (tyarrows_ [tyarrows_ [tyvar_ "a", tyvar_ "b", tybool_], tymap_, tybool_])
+  | CMapMap _ ->
+    tyalls_ ["b", "c"]
+            (tyarrows_ [tyarrow_ (tyvar_ "b") (tyvar_ "c"), tymap_, tymap_])
   | CMapMapWithKey _ ->
-    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b", tygeneric_ "c"],
-               tymap_, tymap_]
+    tyalls_ ["a", "b", "c"]
+            (tyarrows_ [tyarrows_ [tyvar_ "a", tyvar_ "b", tyvar_ "c"],
+                        tymap_, tymap_])
   | CMapFoldWithKey _ ->
-    tyarrows_ [tyarrows_ [tygeneric_ "a", tygeneric_ "b",
-                          tygeneric_ "c", tygeneric_ "c"],
-               tygeneric_ "c", tymap_, tygeneric_ "c"]
-  | CMapEq _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tybool_],
-                           tymap_, tymap_, tybool_]
-  | CMapCmp _ -> tyarrows_ [tyarrows_ [tygeneric_ "b", tygeneric_ "b", tyint_],
-                            tymap_, tymap_, tyint_]
-  | CMapGetCmpFun _ -> tyarrows_ [tymap_, tygeneric_ "a", tygeneric_ "a", tyint_]
+    tyalls_ ["a", "b", "c"]
+            (tyarrows_ [tyarrows_ [tyvar_ "a", tyvar_ "b", tyvar_ "c", tyvar_ "c"],
+                        tyvar_ "c", tymap_, tyvar_ "c"])
+  | CMapEq _ ->
+    tyall_ "b" (tyarrows_ [tyarrows_ [tyvar_ "b", tyvar_ "b", tybool_],
+                           tymap_, tymap_, tybool_])
+  | CMapCmp _ ->
+    tyall_ "b" (tyarrows_ [tyarrows_ [tyvar_ "b", tyvar_ "b", tyint_],
+                           tymap_, tymap_, tyint_])
+  | CMapGetCmpFun _ -> tyall_ "a" (tyarrows_ [tymap_, tyvar_ "a", tyvar_ "a", tyint_])
 end
 
 lang TensorOpTypeAst = TensorOpAst
   sem tyConst =
   | CTensorCreateInt _ -> tytensorcreateint_
   | CTensorCreateFloat _ -> tytensorcreatefloat_
-  | CTensorCreate _ -> tytensorcreate_ (tygeneric_ "a")
-  | CTensorGetExn _ -> tytensorgetexn_ (tygeneric_ "a")
-  | CTensorSetExn _ -> tytensorsetexn_ (tygeneric_ "a")
-  | CTensorRank _ -> tytensorrank_ (tygeneric_ "a")
-  | CTensorShape _ -> tytensorshape_ (tygeneric_ "a")
-  | CTensorReshapeExn _ -> tytensorreshapeexn_ (tygeneric_ "a")
-  | CTensorCopy _ -> tytensorcopy_ (tygeneric_ "a")
-  | CTensorTransposeExn _ -> tytensortransposeexn_ (tygeneric_ "a")
-  | CTensorSliceExn _ -> tytensorsliceexn_ (tygeneric_ "a")
-  | CTensorSubExn _ -> tytensorsubexn_ (tygeneric_ "a")
-  | CTensorIterSlice _ -> tytensoriteri_ (tygeneric_ "a")
-  | CTensorEq _ -> tytensoreq_ (tygeneric_ "a") (tygeneric_ "a")
-  | CTensorToString _ -> tytensortostring_ (tygeneric_ "a")
+  | CTensorCreate _ -> tyall_ "a" (tytensorcreate_ (tyvar_ "a"))
+  | CTensorGetExn _ -> tyall_ "a" (tytensorgetexn_ (tyvar_ "a"))
+  | CTensorSetExn _ -> tyall_ "a" (tytensorsetexn_ (tyvar_ "a"))
+  | CTensorRank _ -> tyall_ "a" (tytensorrank_ (tyvar_ "a"))
+  | CTensorShape _ -> tyall_ "a" (tytensorshape_ (tyvar_ "a"))
+  | CTensorReshapeExn _ -> tyall_ "a" (tytensorreshapeexn_ (tyvar_ "a"))
+  | CTensorCopy _ -> tyall_ "a" (tytensorcopy_ (tyvar_ "a"))
+  | CTensorTransposeExn _ -> tyall_ "a" (tytensortransposeexn_ (tyvar_ "a"))
+  | CTensorSliceExn _ -> tyall_ "a" (tytensorsliceexn_ (tyvar_ "a"))
+  | CTensorSubExn _ -> tyall_ "a" (tytensorsubexn_ (tyvar_ "a"))
+  | CTensorIterSlice _ -> tyall_ "a" (tytensoriteri_ (tyvar_ "a"))
+  | CTensorEq _ -> tyall_ "a" (tytensoreq_ (tyvar_ "a") (tyvar_ "a"))
+  | CTensorToString _ -> tyall_ "a" (tytensortostring_ (tyvar_ "a"))
 end
 
 lang BootParserTypeAst = BootParserAst

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -240,9 +240,12 @@ lang VarPrettyPrint = PrettyPrint + VarAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmVar {ident = ident, frozen = frozen} ->
-    let freezeStr = if frozen then "`" else "" in
-    match pprintVarName env ident with (env, str)
-    then (env, concat freezeStr str) else never
+    if frozen then
+      match pprintEnvGetStr env ident with (env,str) then
+        (env, join ["#frozen\"", str, "\""])
+      else never
+    else
+      pprintVarName env ident
 end
 
 lang AppPrettyPrint = PrettyPrint + AppAst

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -378,12 +378,13 @@ lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsAst + LamAst + Unkn
     else never
 end
 
-lang ConstTypeAnnot = TypeAnnot + MExprConstType
+lang ConstTypeAnnot = TypeAnnot + MExprConstType + AllTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmConst t ->
     recursive let f = lam ty. smap_Type_Type f (tyWithInfo t.info ty) in
-    let ty = f (tyConst t.val) in
-    TmConst {t with ty = ty }
+    match stripTyAll (f (tyConst t.val)) with (_, ty) then
+      TmConst {t with ty = ty}
+    else never
 end
 
 lang SeqTypeAnnot = TypeAnnot + SeqAst + MExprEq

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -50,15 +50,16 @@ lang CompatibleType =
   -- be found, `None` is returned.
   sem compatibleType (tyEnv : TypeEnv) (ty1: Type) =
   | ty2 ->
-    let tys = (ty1, ty2) in
-    match compatibleTypeBase tyEnv tys with Some ty then Some ty
+    let ty1 = reduceTyVar ty1 in
+    let ty2 = reduceTyVar ty2 in
+    match compatibleTypeBase tyEnv (ty1, ty2) with Some ty then Some ty
 
     -- NOTE(dlunde,2021-05-05): Temporary hack to make sure that tyapps are
     -- reduced before tyvars. Not sure why this is needed, but it should not
     -- matter in the end when we have a proper type system.
-    else match tys with (TyApp t1, _) then
+    else match ty1 with TyApp t1 then
       compatibleType tyEnv t1.lhs ty2
-    else match tys with (_, TyApp t2) then
+    else match ty2 with TyApp t2 then
       compatibleType tyEnv ty1 t2.lhs
     --------
 
@@ -74,6 +75,11 @@ lang CompatibleType =
   sem reduceType (tyEnv: Env) =
   | _ -> None () -- Types cannot be reduced by default
 
+  -- NOTE(aathn,2021-10-27): We convert type variables to TyUnknown using this
+  -- semantic function as a temporary solution to enable typeCheck and typeAnnot
+  -- to be used in tandem.
+  sem reduceTyVar =
+  | ty -> ty
 end
 
 lang UnknownCompatibleType = CompatibleType + UnknownTypeAst
@@ -99,12 +105,17 @@ lang ConCompatibleType = CompatibleType + ConTypeAst
 end
 
 lang VarCompatibleType = CompatibleType + VarTypeAst + UnknownTypeAst
-  -- NOTE(aathn, 2021-09-26): As a temporary hack, type variables are made
-  -- compatible with everything.
-  sem compatibleTypeBase (tyEnv : TypeEnv) =
-  | (TyVar _ & ty, TyVar _) -> Some ty
-  | (TyVar _, ! (TyVar _ | TyUnknown _) & ty) -> Some ty
-  | (! (TyVar _ | TyUnknown _) & ty, TyVar _) -> Some ty
+  sem reduceTyVar =
+  | TyVar {info = i} -> TyUnknown {info = i}
+end
+
+lang FlexCompatibleType = CompatibleType + FlexTypeAst + UnknownTypeAst
+  sem reduceTyVar =
+  | TyFlex {info = i} & ty ->
+    match resolveLink ty with ! TyFlex _ & ty then
+      ty
+    else
+      TyUnknown {info = i}
 end
 
 lang AllCompatibleType = CompatibleType + AllTypeAst

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -441,9 +441,9 @@ lang UtestTypeCheck = TypeCheck + UtestAst
     let next = typeCheckBase env t.next in
     let tusing = optionMap (typeCheckBase env) t.tusing in
     (match tusing with Some tu then
-       unify (tyTm tu, tyarrows_ [tyTm test, tyTm expected, tybool_])
+       unify (tyTm tu) (tyarrows_ [tyTm test, tyTm expected, tybool_])
      else
-       unify (tyTm test, tyTm expected));
+       unify (tyTm test) (tyTm expected));
     TmUtest {{{{{t with test = test}
                    with expected = expected}
                    with next = next}

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -320,7 +320,7 @@ lang AppTypeCheck = TypeCheck + AppAst
     let lhs = typeCheckBase env t.lhs in
     let rhs = typeCheckBase env t.rhs in
     let tyRes = newvar env.currentLvl t.info in
-    unify (tyTm lhs, tyarrow_ (tyTm rhs) tyRes);
+    unify (tyTm lhs, ityarrow_ (infoTm lhs) (tyTm rhs) tyRes);
     TmApp {{{t with lhs = lhs}
                with rhs = rhs}
                with ty = tyRes}
@@ -479,7 +479,7 @@ lang SeqTotPatTypeCheck = PatTypeCheck + SeqTotPat
     match mapAccumL typeCheckPat env t.pats with (env, pats) then
       iter (lam pat. unify (elemTy, tyPat pat)) pats;
       (env, PatSeqTot {{t with pats = pats}
-                          with ty = tyseq_ elemTy})
+                          with ty = ityseq_ t.info elemTy})
     else never
 end
 
@@ -487,7 +487,7 @@ lang SeqEdgePatTypeCheck = PatTypeCheck + SeqEdgePat
   sem typeCheckPat (env : TCEnv) =
   | PatSeqEdge t ->
     let elemTy = newvar env.currentLvl t.info in
-    let seqTy = tyseq_ elemTy in
+    let seqTy = ityseq_ t.info elemTy in
     let unifyPat = lam pat. unify (elemTy, tyPat pat) in
     match mapAccumL typeCheckPat env t.prefix with (env, prefix) then
       iter unifyPat prefix;
@@ -506,17 +506,17 @@ end
 
 lang IntPatTypeCheck = PatTypeCheck + IntPat
   sem typeCheckPat (env : TCEnv) =
-  | PatInt t -> (env, PatInt {t with ty = tyint_})
+  | PatInt t -> (env, PatInt {t with ty = TyInt {info = t.info}})
 end
 
 lang CharPatTypeCheck = PatTypeCheck + CharPat
   sem typeCheckPat (env : TCEnv) =
-  | PatChar t -> (env, PatChar {t with ty = tychar_})
+  | PatChar t -> (env, PatChar {t with ty = TyChar {info = t.info}})
 end
 
 lang BoolPatTypeCheck = PatTypeCheck + BoolPat
   sem typeCheckPat (env : TCEnv) =
-  | PatBool t -> (env, PatBool {t with ty = tybool_})
+  | PatBool t -> (env, PatBool {t with ty = TyBool {info = t.info}})
 end
 
 lang AndPatTypeCheck = PatTypeCheck + AndPat

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -413,7 +413,7 @@ lang ConstTypeCheck = TypeCheck + MExprConstType
   sem typeCheckBase (env : TCEnv) =
   | TmConst t ->
     recursive let f = lam ty. smap_Type_Type f (tyWithInfo t.info ty) in
-    let ty = f (tyConst t.val) in
+    let ty = inst env.currentLvl (f (tyConst t.val)) in
     TmConst {t with ty = ty}
 end
 

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -355,7 +355,10 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst
 
     -- First: Generate a new environment containing the recursive bindings
     let recLetEnvIteratee = lam acc. lam b : RecLetBinding.
-      let tyBinding = optionGetOrElse (lam. newvar (addi 1 lvl) b.info) b.tyBody in
+      let tyBinding = optionGetOrElse
+        (lam. newvar (addi 1 lvl) b.info)
+        (sremoveUnknown b.tyBody)
+      in
       _insertVar b.ident tyBinding acc
     in
     let recLetEnv : TCEnv = foldl recLetEnvIteratee env t.bindings in
@@ -382,7 +385,10 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst
 
     -- Third: Produce a new environment with generalized types
     let envIteratee = lam acc. lam b : RecLetBinding.
-      let tyBody = optionGetOrElse (lam. gen lvl (tyTm b.body)) b.tyBody in
+      let tyBody = optionGetOrElse
+        (lam. gen lvl (tyTm b.body))
+        (sremoveUnknown b.tyBody)
+      in
       _insertVar b.ident tyBody acc
     in
     let env = foldl envIteratee env bindings in
@@ -751,11 +757,11 @@ let tests = [
        ("even", ulam_ "n"
          (if_ (eqi_ (var_ "n") (int_ 0))
            true_
-           (not_ (app_ (var_ "odd") (subi_ (var_ "n") (int_ 1)))))),
+           (app_ (var_ "odd") (subi_ (var_ "n") (int_ 1))))),
        ("odd", ulam_ "n"
-         (if_ (eqi_ (var_ "n") (int_ 1))
-           true_
-           (not_ (app_ (var_ "even") (subi_ (var_ "n") (int_ 1))))))
+         (if_ (eqi_ (var_ "n") (int_ 0))
+           false_
+           (app_ (var_ "even") (subi_ (var_ "n") (int_ 1)))))
      ],
      var_ "even"
    ],

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -175,6 +175,12 @@ lang SeqTypeUnify = Unify + SeqTypeAst
     unifyBase names (t1.ty, t2.ty)
 end
 
+lang TensorTypeUnify = Unify + TensorTypeAst
+  sem unifyBase (names : BiNameMap) =
+  | (TyTensor t1, TyTensor t2) ->
+    unifyBase names (t1.ty, t2.ty)
+end
+
 ------------------------------------
 -- INSTANTIATION / GENERALIZATION --
 ------------------------------------
@@ -388,7 +394,7 @@ lang MExprTypeCheck =
   -- Type unification
   VarTypeUnify + FlexTypeUnify + FunTypeUnify + AllTypeUnify + SeqTypeUnify +
   BoolTypeUnify + IntTypeUnify + FloatTypeUnify + CharTypeUnify +
-  UnknownTypeUnify +
+  UnknownTypeUnify + TensorTypeUnify +
 
   -- Type generalization
   VarTypeGeneralize + FlexTypeGeneralize +


### PR DESCRIPTION
This PR improves the type checker in several ways.

- Update the freeze syntax as discussed
- Add type checking for more terms:
  + Recursive lets
  + Pattern matching
  + Tensors
- Add correct types for primitive operations like `cons` (using type vars instead of `TyUnknown`)
- More tests
- Minor code improvements and bug fixes

Features still missing:
- Type checking of records and algebraic data types
- Improved error handling
- Value restriction

EDIT: I have also added a `--typecheck` flag to `mi` which can be used to run the typechecker on a program before evaluation / compilation. For instance, if `my_file.mc` contains
```
mexpr
let f = lam x. x in
[f true, 10]
```
then the output of `mi --typecheck my_file.mc` is
```
FILE "/path/to/miking/my_file.mc" 3:3-3:7 ERROR: Type check failed: unification failure
LHS: Bool
RHS: Int
```
Note that most practical programs still cannot be typechecked since unit and tuples are unsupported.