### PR TITLE
First version of 0-CFA framework for MExpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,9 @@ output of the above program might be:
 However, the values and order of the thread IDs might be different over
 different runs.
 
+### Probability distributions
+Externals for probability distributions are defined in `stdlib/ext/dist-ext.mc`. To use these, you must install the `opam` package `owl` (i.e., `opam install owl`)
+
 ## Profiling
 
 Profiling of an MExpr program can be enabled using the `--debug-profile` flag

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -322,6 +322,9 @@ mexpr:
   | MATCH mexpr WITH pat THEN mexpr ELSE mexpr
       { let fi = mkinfo $1.i (tm_info $8) in
         TmMatch(fi,$2,$4,$6,$8) }
+  | MATCH mexpr WITH pat IN mexpr
+      { let fi = mkinfo $1.i (tm_info $6) in
+        TmMatch(fi,$2,$4,$6,TmNever(fi)) }
   | SWITCH mexpr swcases
       {
         let fi = mkinfo $1.i (tm_info $3) in

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -59,6 +59,9 @@ let mapFoldlOption : (acc -> k -> v -> Option acc)
   lam f. lam acc. lam m.
     optionFoldlM (lam acc. lam t : (k, v). f acc t.0 t.1) acc (mapBindings m)
 
+let mapAllWithKey : (k -> v -> Bool) -> Map k v -> Bool = lam f. lam m.
+  mapFoldWithKey (lam acc. lam k. lam v. and acc (f k v)) true m
+
 let mapAll : (v -> Bool) -> Map k v -> Bool = lam f. lam m.
   mapFoldWithKey (lam acc. lam. lam v. and acc (f v)) true m
 
@@ -145,6 +148,9 @@ let m = mapFromSeq subi
   , (2, "2")
   , (123, "123")
   ] in
+utest mapAllWithKey (lam i. lam. geqi i 1) m with true in
+utest mapAllWithKey (lam i. lam. leqi i 123) m with true in
+utest mapAllWithKey (lam i. lam. lti i 123) m with false in
 utest mapAll (lam str. geqi (length str) 1) m with true in
 utest mapAll (lam str. leqi (length str) 3) m with true in
 utest mapAll (lam str. lti (length str) 2) m with false in

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -424,6 +424,10 @@ utest _anf nestedreclet with
         (ulam_ "c" (int_ 1))))
 using eqExpr in
 
+let constant = int_ 1 in
+utest _anf constant with int_ 1
+using eqExpr in
+
 let debug = false in
 
 let debugPrint = lam t.

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -3,9 +3,15 @@
 -- Program Analysis" (Nielson et al.).
 
 include "set.mc"
+include "name.mc"
+include "ast.mc"
 
 -- OPT(dlunde,2021-10-29): Map all names in analyzed program to integers 0,1,...,#variables-1
 -- to speed up analysis? Or, use a hash table?
+
+-- NOTE:
+-- * We need to handle sequences of applications specially, (e.g., f a b c d)  since they are not labelled by ANF
+-- * AVLam should perhaps be adapted to also contain currying information.
 
 -- Extensible types (syn)
 -- * Abstract values. By default, this will only contain term names (for, e.g., functions).
@@ -22,14 +28,28 @@ include "set.mc"
 -- * Build the graph from constraints
 -- * Propagate constraints
 
+-- NOTE(dlunde,2021-11-01): It would be nice if CFAFunction type and the
+-- 'functions' component of CFAGraph could be defined/added in the fragment
+-- LamCFA, rather than here. I guess this is what product extensions will
+-- eventually allow?
+type CFAFunction = { fident: Name, idents: [Name], body: Name }
 type CFAGraph = {
+  functions: [CFAFunction],
   constraints: [Constraint],
   worklist: [Name],
   data: Map Name (Set AbsVal),
   edges: Map Name [Constraint]
 }
 
-lang CFA = ...
+emptyCFAGraph = {
+  functions = [],
+  constraints = [],
+  worklist = [],
+  data = mapEmpty nameCmp,
+  edges = mapEmpty nameCmp
+}
+
+lang CFA = Ast
 
   syn Constraint =
   -- Intentionally left blank
@@ -37,14 +57,194 @@ lang CFA = ...
   syn AbsVal =
   -- Intentionally left blank
 
-  sem generateConstraints =
-  -- Intentionally left blank
-  | -- sfold as default?
+  sem exprName =
+  | t -> infoErrorExit (infoTm t) "Unsupported in exprName for CFA"
 
-  sem initCFA (graph: CFAGraph) =
+  sem _collectConstraints (acc: CFAGraph) =
+  | t ->
+    let acc = {
+      acc with constraints =
+        concat (generateConstraints acc.functions t) acc.constraints } in
+    sfold_Expr_Expr _collectConstraints acc t
+
+  sem generateConstraints (functions: [CFAFunction]) =
+  -- Intentionally left blank
+
+  sem initConstraint (graph: CFAGraph) =
   -- Intentionally left blank
 
   sem propagateConstraint (graph: CFAGraph) =
   -- Intentionally left blank
 
+  -- CFAGraph -> Name -> Set AbsVal -> CFAGraph
+  sem _addData (graph: CFAGraph) (q: Name) =
+  | d ->
+    match mapLookup q graph.data with Some dq then
+    if subset d dq then graph else
+      {{ graph with
+           data = mapInsert q (setUnion dq d) graph.data } with
+           worklist = cons q worklist }
+    else never
+
+  sem _collectFunctions (acc: CFAGraph) =
+  -- Intentionally left blank. NOTE(dlunde,2021-11-01): It would be nice if
+  -- this and other possible functions could be defined in language fragments
+  -- below, and then somehow used abstractly here. For instance, fragments
+  -- could define various initialization functions and put them in a list, and
+  -- then all functions in this list would be called as part of initialization
+  -- here in this base fragment.
+
 end
+
+-- av ∈ rhs
+lang InitConstraint = CFA
+
+  syn Constraint =
+  | CstrInit { av: AbsVal, rhs: Name }
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrInit r -> _addData graph r.rhs (setInsert r.av setEmpty nameCmp)
+
+end
+
+-- lhs ⊆ rhs
+lang DirectConstraint = CFA
+
+  syn Constraint =
+  | CstrDirect { lhs: Name, rhs: Name }
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrDirect r & cstr ->
+    match mapLookup r.lhs graph.edges with Some elhs then
+      { graph with edges = mapInsert r.lhs (cons cstr elhs) graph.edges }
+    else never
+
+  sem propagateConstraint (graph: CFAGraph) =
+  | CstrDirect r ->
+    match mapLookup r.lhs graph.data with Some dlhs then
+      _addData graph r.rhs dlhs
+    else never
+
+end
+
+lang ConditionalConstraint = CFA
+
+  -- av ∈  lrhs ⇒ rlhs ⊆ rrhs
+  syn Constraint =
+  | CstrCond { av: AbsVal, lrhs: Name, rlhs: Name, rrhs: Name }
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrCond r & cstr ->
+    match mapLookup r.rlhs graph.edges with Some erlhs then
+    match mapLookup r.lrhs graph.edges with Some elrhs then
+      let es = mapInsert r.rlhs (cons cstr erlhs) graph.edges in
+      let es = mapInsert r.lrhs (cons cstr elrhs) es in
+      { graph with edges = es }
+    else never
+    else never
+
+  sem propagateConstraint (graph: CFAGraph) =
+  | CstrCond r ->
+    match mapLookup r.lrhs graph.data with Some dlrhs then
+      if setMem r.av dlrhs then _addData graph r.rrhs dlrhs
+      else graph
+    else never
+
+end
+
+lang VarCFA = CFA + VarAst
+
+  sem generateConstraints (functions: [CFAFunction]) =
+  | TmVar t -> []
+
+  sem exprName =
+  | TmVar t -> t.ident
+
+end
+
+lang LamCFA = CFA + DirectConstraint + LamAst
+
+  syn AbsVal =
+  | AVLam { fident: Name, paramIdent: Name }
+
+  sem _collectFunctions (acc: CFAGraph) =
+  | TmLet { ident = fident, body = TmLam t } ->
+    -- TODO Recurse here, collect all idents in sequence of lambda
+    let cf = { fident = fident, ident = ident, body = exprName t.body } in
+    { acc with functions = cons cf acc.functions }
+  | TmLam t -> infoErrorExit t.info
+      "Unbound TmLam. Did you run ANF transformation?"
+  | t -> sfold_Expr_Expr _collectFunctions acc t
+
+  sem generateConstraints (functions: [CFAFunction]) =
+  | TmLet { ident = ident, body = TmLam _ } ->
+    -- TODO The AVLam here will have a different form eventually
+    [
+      CstrInit { lhs = AVLam { ident = ident }, rhs = ident }
+    ]
+
+end
+
+lang AppCFA = CFA + ConditionalConstraint + LamCFA + AppAst -- TODO Also reclets
+
+  -- TODO Need to do something smart here... Actually, should be quite
+  -- straightforward? a, b, and c flows to three first args in f.
+  -- f a b c
+  -- OPT f can only consist of functions of three or more arguments
+
+  sem generateConstraints (functions: [CFAFunction]) =
+  | TmApp t ->
+    join (map (lam f: CFAFunction. [
+      CstrCond { av = AVLam { ident = f.fident }, lrhs =, rlhs =, rrhs = },
+      CstrCond { av =, lrhs =, rlhs =, rrhs = }
+    ] ) functions)
+
+end
+
+lang LetCFA = CFA + LetAst
+  sem exprName =
+  | TmLet t -> exprName t.inexpr
+end
+
+lang RecLetsCFA = CFA + RecLetsAst
+  sem exprName =
+  | TmRecLets t -> exprName t.inexpr
+end
+
+lang ConstCFA = CFA + ConstAst
+end
+
+lang SeqCFA = CFA + SeqAst
+end
+
+lang RecordCFA = CFA + RecordAst
+end
+
+lang TypeCFA = CFA + TypeAst
+  sem exprName =
+  | TmType t -> exprName t.inexpr
+end
+
+lang DataCFA = CFA + DataAst
+  sem exprName =
+  | TmConDef t -> exprName t.inexpr
+end
+
+-- NOTE We probably need more abstract values for records and variants to get
+-- this right
+lang MatchCFA = CFA + MatchAst
+end
+
+lang UtestCFA = CFA + UtestAst
+  sem exprName =
+  | TmUtest t -> exprName t.next
+end
+
+lang NeverCFA = CFA + NeverAst
+end
+
+lang ExtCFA = CFA + ExtAst
+  sem exprName
+  | TmExt t -> exprName t.inexpr
+end
+

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -354,7 +354,7 @@ lang RecLetsCFA = CFA + LamCFA + RecLetsAst
 
   sem generateConstraints (functions: [CFAFunction]) =
   | TmRecLets { bindings = bindings } ->
-    map (lam b.
+    map (lam b: RecLetBinding.
       match b.body with TmLam t then
         CstrDirectAv { lhs = AVLam { ident = t.ident}, rhs = b.ident }
       else infoErrorExit (infoTm b.body) "Not a lambda in recursive let body"

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -1,0 +1,50 @@
+-- CFA framework for MExpr. Currently, only 0-CFA (context insensitive) is
+-- supported. The algorithm is based on Table 3.7 in the book "Principles of
+-- Program Analysis" (Nielson et al.).
+
+include "set.mc"
+
+-- OPT(dlunde,2021-10-29): Map all names in analyzed program to integers 0,1,...,#variables-1
+-- to speed up analysis? Or, use a hash table?
+
+-- Extensible types (syn)
+-- * Abstract values. By default, this will only contain term names (for, e.g., functions).
+-- * Constraints. By default, we have direct constraints and implication constraints
+
+-- Required data structures for algorithm
+-- * A set of constraints (Could possibly just be a list?)
+-- * A sequence W containing nodes for which constraints must be propagated.
+-- * A data tensor D such that D[n] is a set of abstract values.
+-- * Edge tensor E encoding constraints for each node.
+
+-- Semantic functions (sem)
+-- * Generate constraints from a program
+-- * Build the graph from constraints
+-- * Propagate constraints
+
+type CFAGraph = {
+  constraints: [Constraint],
+  worklist: [Name],
+  data: Map Name (Set AbsVal),
+  edges: Map Name [Constraint]
+}
+
+lang CFA = ...
+
+  syn Constraint =
+  -- Intentionally left blank
+
+  syn AbsVal =
+  -- Intentionally left blank
+
+  sem generateConstraints =
+  -- Intentionally left blank
+  | -- sfold as default?
+
+  sem initCFA (graph: CFAGraph) =
+  -- Intentionally left blank
+
+  sem propagateConstraint (graph: CFAGraph) =
+  -- Intentionally left blank
+
+end

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -133,11 +133,10 @@ lang VarEq = Eq + VarAst
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmVar r ->
     match lhs with TmVar l then
-      match (env,free) with ({varEnv = varEnv},{varEnv = freeVarEnv}) then
-        match _eqCheck l.ident r.ident varEnv freeVarEnv with Some freeVarEnv then
-          Some {free with varEnv = freeVarEnv}
-        else None ()
-      else never
+      match (env,free) with ({varEnv = varEnv},{varEnv = freeVarEnv}) in
+      match _eqCheck l.ident r.ident varEnv freeVarEnv with Some freeVarEnv then
+        Some {free with varEnv = freeVarEnv}
+      else None ()
     else None ()
 end
 

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -465,7 +465,7 @@ lang DataTypeAnnot = TypeAnnot + DataAst + MExprEq
               tyvar to
             else
               let msg = join [
-                "Inconsistent types of constructor application",
+                "Inconsistent types of constructor application. ",
                 "Constructor expected argument of type ", _pprintType from,
                 ", but the actual type was ", _pprintType (tyTm body)
               ] in

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -13,7 +13,7 @@ let init = lam seq. subsequence seq 0 (subi (length seq) 1)
 utest init [2,3,5] with [2,3]
 utest last [2,4,8] with 8
 
-let eqSeq = lam eq : (a -> a -> Bool). lam s1. lam s2.
+let eqSeq = lam eq : (a -> b -> Bool). lam s1. lam s2.
   recursive let work = lam s1. lam s2.
     match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) then
       if eq h1 h2 then work t1 t2

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -26,6 +26,10 @@ let setRemove : a -> Set a -> Set a = lam e. lam s. mapRemove e s
 -- Is the element member of the set?
 let setMem : a -> Set a -> Bool = lam e. lam s. mapMem e s
 
+-- Is s1 a subset of s2?
+let setSubset : Set a -> Set a -> Bool = lam s1. lam s2.
+  mapAllWithKey (lam e. lam. mapMem e s2) s1
+
 -- `setUnion s1 s2` is the union of set `s1` and `s2`.
 let setUnion : Set a -> Set a -> Set a = lam s1. lam s2. mapUnion s1 s2
 
@@ -89,5 +93,12 @@ utest setMem 3 s4 with true in
 
 utest setEq s4 s4 with true in
 utest setEq s4 s3 with false in
+
+let s5 = setOfSeq subi [1,2,3,4,5] in
+let s6 = setOfSeq subi [1,2,3] in
+let s7 = setOfSeq subi [1,2,6] in
+utest setSubset s5 s5 with true in
+utest setSubset s6 s5 with true in
+utest setSubset s7 s5 with false in
 
 ()

--- a/stdlib/tuning/decision-points.mc
+++ b/stdlib/tuning/decision-points.mc
@@ -185,6 +185,9 @@ lang HoleAst = IntAst + ANF + KeywordMaker
             info : Info,
             inner : Hole}
 
+  sem infoTm =
+  | TmHole h -> h.info
+
   sem tyTm =
   | TmHole {ty = ty} -> ty
 


### PR DESCRIPTION
## Major changes
- Add a modular and extensible (hopefully) 0-CFA framework to Miking, based on chapter 3 in Nielson et al. ("Principles of Program Analysis"). Example: for the simple program `(lam x. x) (lam y. y)`, the analysis currently generates the following:
   ```
   --- ORIGINAL PROGRAM ---
   (lam x.
      x)
     (lam y.
        y)
   
   --- ANF ---
   let t =
     lam x.
       x
   in
   let t1 =
     lam y.
       y
   in
   let t2 =
     t
       t1
   in
   t2
   
   --- FINAL CFA GRAPH ---
   *** WORKLIST ***
     []
   *** DATA ***
     t =
       lam x
     t1 =
       lam y
     t2 =
       lam y
     x =
       lam y
   *** EDGES ***
     t =
       {lam x} ⊆ t ⇒ t1 ⊆ x
       {lam x} ⊆ t ⇒ x ⊆ t2
       {lam y} ⊆ t ⇒ t1 ⊆ y
       {lam y} ⊆ t ⇒ y ⊆ t2
     t1 =
       {lam x} ⊆ t ⇒ t1 ⊆ x
       {lam y} ⊆ t ⇒ t1 ⊆ y
     x =
       {lam x} ⊆ t ⇒ x ⊆ t2
     y =
       {lam y} ⊆ t ⇒ y ⊆ t2
   ```
   Data-flow components are not included, and should instead be added separately for the various analyses that we implement. Finally, some parts of MExpr are not yet supported. Most importantly, analysis of control flow within/through records and variants is still missing. 
- *Needs to be discussed*: Add support for the syntactic sugar `match t1 with p in t2` for `match t1 with p then t2 else never`.
- ANF updates
  - Propagate term info in `bind`.
  - Add default case for `isValue`.
  - Lift and bind lambdas to names (they were previously not lifted). Sequences of lambdas are still only bound to one name. That is, we translate `(lam x. (lam y. (lam z. b)))` to `let t = (lam x. (lam y. (lam z. b))) in t`, and *not* `
  let t1 = (lam x. let t2 = (lam y. let t3 = (lam z. b) in t3) in t2) in t1`. This is similar to sequences of applications, for which each intermediate closure is *not* assigned a name.
  - ANF transformation of recursive lets now halts on encountering non-lambda bodies.

## Minor changes
- Add note for installing `owl` to README.
- Add `mapAllWithKey` to `stdlib/map.mc`
- Fix typo in `type-annot.mc` error message.
- Generalize the first argument of `eqSeq` from `a -> a -> Bool` to `a -> b -> Bool`.
- Add `setSubset` to `set.mc`.
