### PR TITLE
Lazy constraint generation in `mexpr/cfa.mc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ test-boot: boot
 test-boot-py: boot
 	@$(MAKE) -s -f test-boot.mk py
 
-test-boot-all:
+test-boot-all: boot
 	@$(MAKE) -s -f test-boot.mk all
 
 test-par: build

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -38,6 +38,12 @@ let setOfSeq : (a -> a -> Int) -> [a] -> Set a =
 lam cmp. lam seq.
   foldr setInsert (setEmpty cmp) seq
 
+-- `setFold f acc s` folds over the values of s with the given function and
+-- initial accumulator
+let setFold : (acc -> a -> acc) -> acc -> Set a -> acc =
+  lam f. lam acc. lam s.
+    mapFoldWithKey (lam acc. lam k. lam. f acc k) acc s
+
 -- Transform a set to a sequence.
 let setToSeq : Set a -> [a] = lam s. mapKeys s
 
@@ -100,5 +106,8 @@ let s7 = setOfSeq subi [1,2,6] in
 utest setSubset s5 s5 with true in
 utest setSubset s6 s5 with true in
 utest setSubset s7 s5 with false in
+
+let sFold = setOfSeq subi [1,2,3,4,5] in
+utest setFold (lam acc. lam v. addi v acc) 0 sFold with 15 in
 
 ()


### PR DESCRIPTION
This PR mainly changes the 0-CFA algorithm to use lazy constraint generation (mentioned briefly at p. 202 in Nielson et al.). Compared to the previous version, only O(n) constraints are generated initially (O(n^2) before), where n is the total number of subterms for a program. The worst-case time complexity is still O(n^3)

Minor fixes:
- Add missing dependency in `Makefile` causing occasional bugs when running `test-all` in parallel.
- Add `setFold : (acc -> a -> acc) -> acc -> Set a -> acc` to `set.mc`