### PR TITLE
Add GitHub actions workflow file for installing Miking and running all tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,13 +22,9 @@ jobs:
 
     - name: Cache opam packages
       uses: actions/cache@v2
-      env:
-        cache-name: ocaml-packages
       with:
         path: ~/.opam
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
-        restore-keys: |
-          ${{ runner.os }}-build-
+        key: ${{ runner.os }}-opam-build
 
     - name: Install opam packages
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,12 +34,7 @@ jobs:
         # Install all opam packages used in make test-all
         opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.16.0
 
-    - name: Install Miking
-      run: |
-        eval $(opam env)
-        make install
-
-    - name: Run all tests
+    - name: Build Miking and run all tests
       run: |
         eval $(opam env)
         make -j$(nproc) test-all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.16.0
 
     - name: Build Miking and run all tests
+      timeout-minutes: 30
       run: |
         eval $(opam env)
         make -j$(nproc) test-all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,49 @@
+name: Miking CI
+
+on:
+  pull_request:
+    branches: [master, develop]
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build-and-test-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install OCaml and opam for Miking
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: ocaml-variants.4.12.0+domains
+        opam-repositories: |
+          default: https://github.com/ocaml/opam-repository.git
+          multicore: https://github.com/ocaml-multicore/multicore-opam.git
+
+    - name: Cache opam packages
+      uses: actions/cache@v2
+      env:
+        cache-name: ocaml-packages
+      with:
+        path: ~/.opam
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+
+    - name: Install opam packages
+      run: |
+        # Install dependencies of owl
+        sudo apt-get install -y liblapacke-dev libopenblas-dev
+
+        # Install all opam packages used in make test-all
+        opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.16.0
+
+    - name: Install Miking
+      run: |
+        eval $(opam env)
+        make install
+
+    - name: Run all tests
+      run: |
+        eval $(opam env)
+        make -j$(nproc) test-all


### PR DESCRIPTION
This PR adds a workflow file which starts a CI run every time a pull request to `master` or `develop` is opened, reopened, or an open PR is updated. The run:
1. Installs OCaml and opam, using the OCaml version expected by Miking.
2. Installs opam packages that are required in `make test-all`.
3. Bootstraps the compiler and runs tests in parallel (by running `make test-all` directly).