### PR TITLE
StringIsFloat intrinsic and float and generic type arguments

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -116,6 +116,7 @@ and const =
   | Cceilfi
   | Croundfi
   | Cint2float
+  | CstringIsFloat
   | Cstring2float
   | Cfloat2string
   (* MCore intrinsics: Characters *)
@@ -575,6 +576,7 @@ let const_has_side_effect = function
   | Cceilfi
   | Croundfi
   | Cint2float
+  | CstringIsFloat
   | Cstring2float
   | Cfloat2string ->
       false

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -56,6 +56,7 @@ let builtin =
   ; ("ceilfi", f Cceilfi)
   ; ("roundfi", f Croundfi)
   ; ("int2float", f Cint2float)
+  ; ("stringIsFloat", f CstringIsFloat)
   ; ("string2float", f Cstring2float)
   ; ("float2string", f Cfloat2string) (* MCore intrinsics: Characters *)
   ; ("eqc", f (Ceqc None))

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -507,6 +507,10 @@ module FloatConversion = struct
 
   let roundfi f = f |> Float.round |> int_of_float
 
+  let string_is_float s =
+    s |> Mseq.Helpers.to_ustring |> Ustring.to_utf8 |> float_of_string_opt
+    |> function Some _ -> true | None -> false
+
   let string2float s = s |> Mseq.Helpers.to_ustring |> float_of_ustring
 
   let float2string r = r |> ustring_of_float |> Mseq.Helpers.of_ustring

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -353,6 +353,8 @@ module FloatConversion : sig
 
   val roundfi : float -> int
 
+  val string_is_float : int Mseq.t -> bool
+
   val string2float : int Mseq.t -> float
 
   val float2string : float -> int Mseq.t

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -136,6 +136,8 @@ let arity = function
       1
   | Cint2float ->
       1
+  | CstringIsFloat ->
+      1
   | Cstring2float ->
       1
   | Cfloat2string ->
@@ -703,6 +705,11 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
   | Cneqf (Some v1), TmConst (fi, CFloat v2) ->
       TmConst (fi, CBool (v1 <> v2))
   | Cneqf None, _ | Cneqf (Some _), _ ->
+      fail_constapp fi
+  | CstringIsFloat, TmSeq (_, s) ->
+      let s = tm_seq2int_seq fi s in
+      TmConst (fi, CBool (Intrinsics.FloatConversion.string_is_float s))
+  | CstringIsFloat, _ ->
       fail_constapp fi
   | Cstring2float, TmSeq (fi, s) ->
       let f = tm_seq2int_seq fi s in

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -339,6 +339,8 @@ let rec print_const fmt = function
       fprintf fmt "roundfi"
   | Cint2float ->
       fprintf fmt "int2float"
+  | CstringIsFloat ->
+      fprintf fmt "stringIsFloat"
   | Cstring2float ->
       fprintf fmt "string2float"
   | Cfloat2string ->

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -780,6 +780,10 @@ let char2int_ = use MExprAst in
   lam c.
   app_ (uconst_ (CChar2Int ())) c
 
+let stringIsfloat_ = use MExprAst in
+  lam s.
+  app_ (uconst_ (CStringIsFloat ())) s
+
 let string2float_ = use MExprAst in
   lam s.
   app_ (uconst_ (CString2float ())) s

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -654,6 +654,7 @@ end
 
 lang FloatStringConversionAst = SeqAst + FloatAst
   syn Const =
+  | CStringIsFloat {}
   | CString2float {}
   | CFloat2string {}
 end

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -37,6 +37,7 @@ let builtin = use MExprAst in
   , ("ceilfi", CCeilfi ())
   , ("roundfi", CRoundfi ())
   , ("int2float", CInt2float ())
+  , ("stringIsFloat", CStringIsFloat ())
   , ("string2float", CString2float ())
   , ("float2string", CFloat2string ())
   -- Characters

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -629,6 +629,7 @@ utest cmpConst (CEqc {}) (CEqc {}) with 0 in
 utest cmpConst (CInt2Char {}) (CInt2Char {}) with 0 in
 utest cmpConst (CChar2Int {}) (CChar2Int {}) with 0 in
 
+utest cmpConst (CStringIsFloat {}) (CStringIsFloat {}) with 0 in
 utest cmpConst (CString2float {}) (CString2float {}) with 0 in
 utest cmpConst (CFloat2string {}) (CFloat2string {}) with 0 in
 

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -88,6 +88,7 @@ end
 
 lang FloatStringConversionTypeAst = FloatStringConversionAst
   sem tyConst =
+  | CStringIsFloat _ -> tyarrow_ tystr_ tybool_
   | CString2float _ -> tyarrow_ tystr_ tyfloat_
   | CFloat2string _ -> tyarrow_ tyfloat_ tystr_
 end

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -834,8 +834,17 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     else error "Third argument to subsequence not a number"
 end
 
-lang FloatStringConversionEval = FloatStringConversionAst
+lang FloatStringConversionEval = FloatStringConversionAst + BoolAst
   sem delta (arg : Expr) =
+  | CStringIsFloat _ ->
+    match arg with TmSeq {tms = tms} then
+      let s = _seqOfCharsToString tms in
+      TmConst {
+        val = CBool { val = stringIsFloat s },
+        ty = tyunknown_,
+        info = NoInfo ()
+      }
+    else error "First argument not a sequence"
   | CString2float _ ->
     match arg with TmSeq {tms = tms} then
       let s = _seqOfCharsToString tms in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -677,6 +677,7 @@ end
 
 lang FloatStringConversionPrettyPrint = FloatStringConversionAst + ConstPrettyPrint
   sem getConstStringCode (indent : Int) =
+  | CStringIsFloat _ -> "stringIsFloat"
   | CString2float _ -> "string2float"
   | CFloat2string _ -> "float2string"
 end

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -220,6 +220,7 @@ lang OCamlPrettyPrint =
   | CFloorfi _ -> intrinsicOpFloat "floorfi"
   | CCeilfi _ -> intrinsicOpFloat "ceilfi"
   | CRoundfi _ -> intrinsicOpFloat "roundfi"
+  | CStringIsFloat _ -> intrinsicOpFloat "string_is_float"
   | CString2float _ -> intrinsicOpFloat "string2float"
   | CFloat2string _ -> intrinsicOpFloat "float2string"
   | CCreate _ -> intrinsicOpSeq "create"

--- a/test/mexpr/float-test.mc
+++ b/test/mexpr/float-test.mc
@@ -95,6 +95,12 @@ utest int2float 17 with 17.0 using eqf in
 utest int2float (negi 10) with negf 10.0 using eqf in
 
 -- Conversion from String to Float
+utest stringIsFloat "42" with true in
+utest stringIsFloat "3.14159" with true in
+utest stringIsFloat "3.2e-2" with true in
+utest stringIsFloat "3.2E-2" with true in
+utest stringIsFloat "-3.2e2" with true in
+utest stringIsFloat "a" with false in
 -- String -> Float
 utest string2float "42" with 42.0 using eqf in
 utest string2float "3.14159" with 3.14159 using eqf in


### PR DESCRIPTION
This PR adds a new intrinsic `stringIsFloat` that checks if a string represents a float and adds support for float type arguments to `arg.mc`. In addition this PR adds generic type arguments to the argument parser to allow extending it with special non-standards cases.