### PR TITLE
Add limited typechecking of records and algebraic data types

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -107,13 +107,13 @@ let tyalls_ =
   foldr tyall_ ty strs
 
 let tyFlexUnbound = use FlexTypeAst in
-  lam info. lam ident. lam level. lam weak.
+  lam info. lam ident. lam level. lam sort.
   TyFlex {info = info,
-          contents = ref (Unbound {ident = ident, level = level, weak = weak})}
+          contents = ref (Unbound {ident = ident, level = level, sort = sort})}
 
-let tyflexunbound_ =
+let tyflexunbound_ = use FlexTypeAst in
   lam s.
-  tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 false
+  tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 (TypeVar ())
 
 let tyflexlink_ = use FlexTypeAst in
   lam ty.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1225,10 +1225,17 @@ end
 
 type Level = Int
 type TVarRec = {ident : Name,
-                weak  : Bool,
-                level : Level}
+                level : Level,
+                sort  : VarSort}
 
 lang FlexTypeAst = Ast
+  -- VarSort indicates the sort of type variable and contains related data
+  -- (such as regular type variable or row variable)
+  syn VarSort =
+  | TypeVar ()
+  | WeakVar ()
+  | RecordVar {fields : Map SID Type}
+
   syn TVar =
   | Unbound TVarRec
   | Link Type
@@ -1249,21 +1256,30 @@ lang FlexTypeAst = Ast
     ty
 
   sem tyWithInfo (info : Info) =
-  | TyFlex t ->
-    match deref t.contents with Link ty then
-      tyWithInfo info ty
-    else
+  | TyFlex t & ty ->
+    match deref t.contents with Unbound _ then
       TyFlex {t with info = info}
+    else
+      tyWithInfo info (resolveLink ty)
 
   sem infoTy =
   | TyFlex {info = info} -> info
 
+  sem smapAccumL_VarSort_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  | RecordVar r ->
+    match mapMapAccum (lam acc. lam. lam e. f acc e) acc r.fields with (acc, flds) in
+    (acc, RecordVar {r with fields = flds})
+  | s ->
+    (acc, s)
+
   sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
-  | TyFlex t & ty1 ->
-    match deref t.contents with Link ty2 then
-      smapAccumL_Type_Type f acc ty2
+  | TyFlex t & ty ->
+    match deref t.contents with Unbound r then
+      match smapAccumL_VarSort_Type f acc r.sort with (acc, sort) in
+      modref t.contents (Unbound {r with sort = sort});
+      (acc, ty)
     else
-      (acc, ty1)
+      smapAccumL_Type_Type f acc (resolveLink ty)
 end
 
 lang AllTypeAst = Ast

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1251,16 +1251,12 @@ lang FlexTypeAst = Ast
   sem tyWithInfo (info : Info) =
   | TyFlex t ->
     match deref t.contents with Link ty then
-      tyWithInfo ty
+      tyWithInfo info ty
     else
       TyFlex {t with info = info}
 
   sem infoTy =
-  | TyFlex t ->
-    match deref t.contents with Link ty then
-      infoTy ty
-    else
-      t.info
+  | TyFlex {info = info} -> info
 
   sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
   | TyFlex t & ty1 ->

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -403,17 +403,25 @@ lang VarTypeCmp = Cmp + VarTypeAst
 end
 
 lang FlexTypeCmp = Cmp + FlexTypeAst
+  sem cmpVarSort =
+  | (RecordVar l, RecordVar r) ->
+    mapCmp cmpType l.fields r.fields
+  | (lhs, rhs) ->
+    subi (constructorTag lhs) (constructorTag rhs)
+
   sem cmpTypeH =
-  | (TyFlex _ & ty1, ty2)
-  | (ty1, TyFlex _ & ty2) ->
-    match (resolveLink ty1, resolveLink ty2) with (ty1, ty2) then
-      match (ty1, ty2) with (TyFlex t1, TyFlex t2) then
-        match (deref t1.contents, deref t2.contents) with (Unbound n1, Unbound n2) then
-          nameCmp n1.ident n2.ident
-        else never
-      else match (ty1, ty2) with (! TyFlex _, ! TyFlex _) then cmpType ty1 ty2
-      else subi (constructorTag ty1) (constructorTag ty2)
-    else never
+  | (TyFlex _ & lhs, rhs)
+  | (lhs, TyFlex _ & rhs) ->
+    match (resolveLink lhs, resolveLink rhs) with (lhs, rhs) in
+    match (lhs, rhs) with (TyFlex t1, TyFlex t2) then
+    match (deref t1.contents, deref t2.contents) with (Unbound n1, Unbound n2) in
+      let identDiff = nameCmp n1.ident n2.ident in
+      if eqi identDiff 0 then
+        cmpVarSort (n1.sort, n2.sort)
+      else
+        identDiff
+    else match (lhs, rhs) with (! TyFlex _, ! TyFlex _) then cmpType lhs rhs
+    else subi (constructorTag lhs) (constructorTag rhs)
 end
 
 lang AllTypeCmp = Cmp + AllTypeAst

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -118,11 +118,11 @@ lang SeqOpTypeAst = SeqOpAst
   | CTail _ -> tyall_ "a" (tyarrow_ (tyvarseq_ "a") (tyvarseq_ "a"))
   | CNull _ -> tyall_ "a" (tyarrow_ (tyvarseq_ "a") tybool_)
   | CMap _ ->
-    tyall_ "a" (tyarrows_ [ tyarrow_ (tyvar_ "a") (tyvar_ "a"),
-                            tyvarseq_ "a", tyvarseq_ "a" ])
+    tyalls_ ["a", "b"] (tyarrows_ [ tyarrow_ (tyvar_ "a") (tyvar_ "b"),
+                                    tyvarseq_ "a", tyvarseq_ "b" ])
   | CMapi _ ->
-    tyall_ "a" (tyarrows_ [ tyarrows_ [tyint_, tyvar_ "a", tyvar_ "a"],
-                            tyvarseq_ "a", tyvarseq_ "a" ])
+    tyalls_ ["a", "b"] (tyarrows_ [ tyarrows_ [tyint_, tyvar_ "a", tyvar_ "b"],
+                                               tyvarseq_ "a", tyvarseq_ "b" ])
   | CIter _ ->
     tyall_ "a" (tyarrows_ [tyarrow_ (tyvar_ "a") tyunit_, tyvarseq_ "a", tyunit_])
   | CIteri _ ->

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -45,6 +45,15 @@ let biLookup : (Name,Name) -> BiNameMap -> Option (Name,Name) =
     in
     find pred bmap
 
+-- 'biMem (i1, i2) bmap' returns true if i1 <-> i2 in the bijective map,
+-- or false otherwise.
+let biMem : (Name, Name) -> BiNameMap -> Bool =
+  lam i : (Name, Name). lam bmap.
+  let pred = lam n : (Name, Name).
+    if nameEq i.0 n.0 then nameEq i.1 n.1 else false
+  in
+  optionIsSome (find pred bmap)
+
 type EqEnv = {
   varEnv : BiNameMap,
   conEnv : BiNameMap

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1100,17 +1100,23 @@ lang VarTypePrettyPrint = VarTypeAst
     pprintEnvGetStr env t.ident
 end
 
-lang FlexTypePrettyPrint = FlexTypeAst
+lang FlexTypePrettyPrint = FlexTypeAst + RecordTypeAst
+  sem getVarSortStringCode (indent : Int) (env : PprintEnv) (idstr : String) =
+  | TypeVar () -> (env, idstr)
+  | WeakVar () -> (env, concat "_" idstr)
+  | RecordVar r ->
+    let recty =
+      TyRecord {info = NoInfo (), fields = r.fields, labels = mapKeys r.fields} in
+    match getTypeStringCode indent env recty with (env, recstr) in
+    (env, join [idstr, "<:", recstr])
+
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
-  | TyFlex t ->
+  | TyFlex t & ty ->
     match deref t.contents with Unbound t then
-      match pprintEnvGetStr env t.ident with (env, str) then
-        let prefix = if t.weak then "_" else "" in
-        (env, concat prefix str)
-      else never
-    else match deref t.contents with Link ty then
-      getTypeStringCode indent env ty
-    else never
+      match pprintEnvGetStr env t.ident with (env, idstr) in
+      getVarSortStringCode indent env idstr t.sort
+    else
+      getTypeStringCode indent env (resolveLink ty)
 end
 
 lang AllTypePrettyPrint = AllTypeAst

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -15,7 +15,7 @@ include "eq.mc"
 include "pprint.mc"
 include "builtin.mc"
 include "mexpr/type.mc"
-include "type-check.mc" -- Used only to access TyFlexRecord
+include "type-check.mc" -- Used only to access TyRecordFlex
 
 type TypeEnv = {
   varEnv: Map Name Type,
@@ -119,10 +119,10 @@ lang FlexCompatibleType = CompatibleType + FlexTypeAst + UnknownTypeAst
       TyUnknown {info = i}
 end
 
-lang FlexRecordCompatibleType = CompatibleType + FlexRecordTypeAst + UnknownTypeAst
+lang RecordFlexCompatibleType = CompatibleType + RecordFlexTypeAst + UnknownTypeAst
   sem reduceTyVar =
-  | TyFlexRecord {info = i} & ty ->
-    match resolveRLink ty with ! TyFlexRecord _ & ty then
+  | TyRecordFlex {info = i} & ty ->
+    match resolveRLink ty with ! TyRecordFlex _ & ty then
       ty
     else
       TyUnknown {info = i}
@@ -673,7 +673,7 @@ lang MExprTypeAnnot =
   FunCompatibleType + SeqCompatibleType + TensorCompatibleType +
   RecordCompatibleType + VariantCompatibleType + AppCompatibleType +
   PropagateArrowLambda + PropagateLetType + VarCompatibleType +
-  FlexCompatibleType + FlexRecordCompatibleType + AllCompatibleType +
+  FlexCompatibleType + RecordFlexCompatibleType + AllCompatibleType +
 
   -- Terms
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -663,7 +663,7 @@ lang MExprTypeAnnot =
   FunCompatibleType + SeqCompatibleType + TensorCompatibleType +
   RecordCompatibleType + VariantCompatibleType + AppCompatibleType +
   PropagateArrowLambda + PropagateLetType + VarCompatibleType +
-  AllCompatibleType +
+  FlexCompatibleType + AllCompatibleType +
 
   -- Terms
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -15,6 +15,7 @@ include "eq.mc"
 include "pprint.mc"
 include "builtin.mc"
 include "mexpr/type.mc"
+include "type-check.mc" -- Used only to access TyFlexRecord
 
 type TypeEnv = {
   varEnv: Map Name Type,
@@ -113,6 +114,15 @@ lang FlexCompatibleType = CompatibleType + FlexTypeAst + UnknownTypeAst
   sem reduceTyVar =
   | TyFlex {info = i} & ty ->
     match resolveLink ty with ! TyFlex _ & ty then
+      ty
+    else
+      TyUnknown {info = i}
+end
+
+lang FlexRecordCompatibleType = CompatibleType + FlexRecordTypeAst + UnknownTypeAst
+  sem reduceTyVar =
+  | TyFlexRecord {info = i} & ty ->
+    match resolveRLink ty with ! TyFlexRecord _ & ty then
       ty
     else
       TyUnknown {info = i}
@@ -663,7 +673,7 @@ lang MExprTypeAnnot =
   FunCompatibleType + SeqCompatibleType + TensorCompatibleType +
   RecordCompatibleType + VariantCompatibleType + AppCompatibleType +
   PropagateArrowLambda + PropagateLetType + VarCompatibleType +
-  FlexCompatibleType + AllCompatibleType +
+  FlexCompatibleType + FlexRecordCompatibleType + AllCompatibleType +
 
   -- Terms
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -15,7 +15,6 @@ include "eq.mc"
 include "pprint.mc"
 include "builtin.mc"
 include "mexpr/type.mc"
-include "type-check.mc" -- Used only to access TyRecordFlex
 
 type TypeEnv = {
   varEnv: Map Name Type,
@@ -114,15 +113,6 @@ lang FlexCompatibleType = CompatibleType + FlexTypeAst + UnknownTypeAst
   sem reduceTyVar =
   | TyFlex {info = i} & ty ->
     match resolveLink ty with ! TyFlex _ & ty then
-      ty
-    else
-      TyUnknown {info = i}
-end
-
-lang RecordFlexCompatibleType = CompatibleType + RecordFlexTypeAst + UnknownTypeAst
-  sem reduceTyVar =
-  | TyRecordFlex {info = i} & ty ->
-    match resolveRLink ty with ! TyRecordFlex _ & ty then
       ty
     else
       TyUnknown {info = i}
@@ -673,7 +663,7 @@ lang MExprTypeAnnot =
   FunCompatibleType + SeqCompatibleType + TensorCompatibleType +
   RecordCompatibleType + VariantCompatibleType + AppCompatibleType +
   PropagateArrowLambda + PropagateLetType + VarCompatibleType +
-  FlexCompatibleType + RecordFlexCompatibleType + AllCompatibleType +
+  FlexCompatibleType + AllCompatibleType +
 
   -- Terms
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -955,6 +955,49 @@ let tests = [
    ty = tyseq_ (tyseq_ tyint_),
    env = []},
 
+  {name = "Record1",
+   tm = uunit_,
+   ty = tyunit_,
+   env = []},
+
+  {name = "Record2",
+   tm = utuple_ [int_ 0, true_],
+   ty = tytuple_ [tyint_, tybool_],
+   env = []},
+
+  {name = "Record3",
+   tm = urecord_ [
+     ("a", int_ 0), ("b", float_ 2.718), ("c", urecord_ []),
+     ("d", urecord_ [
+       ("e", seq_ [int_ 1, int_ 2]),
+       ("f", urecord_ [
+         ("x", var_ "x"), ("y", var_ "y"), ("z", var_ "z")
+       ])
+     ])
+   ],
+   ty = tyrecord_ [
+     ("a", tyint_), ("b", tyfloat_), ("c", tyunit_),
+     ("d", tyrecord_ [
+       ("e", tyseq_ tyint_),
+       ("f", tyrecord_ [
+         ("x", tyint_), ("y", tyfloat_), ("z", tybool_)
+       ])
+     ])
+   ],
+   env = [("x", tyint_), ("y", tyfloat_), ("z", tybool_)]},
+
+  {name = "Record4",
+   tm = recordupdate_ (urecord_ [
+     ("a", int_ 0),
+     ("b", float_ 2.718)
+   ]) "a" (int_ 1),
+   ty = tyrecord_ [
+     ("a", tyint_),
+     ("b", tyfloat_)
+   ],
+   env = []},
+
+
   {name = "Utest1",
    tm = utest_ (int_ 1) (addi_ (int_ 0) (int_ 1)) false_,
    ty = tybool_,

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -88,9 +88,14 @@ end
 lang FlexTypeUnify = Unify + FlexTypeAst + UnknownTypeAst
   sem unifyBase (names : BiNameMap) =
   | (TyFlex {contents = r1} & ty1, TyFlex {contents = r2} & ty2) ->
-    match (deref r1, deref r2) with (Unbound {ident = n}, Unbound {ident = m}) then
+    match (deref r1, deref r2) with
+      (Unbound {ident = n, weak = w1, level = l1},
+       Unbound {ident = m, weak = w2, level = l2})
+    then
       if not (nameEq n m) then
-        modref r1 (Link ty2)
+        let updated = Unbound {ident = n, weak = or w1 w2, level = mini l1 l2} in
+        modref r1 updated;
+        modref r2 (Link ty1)
       else ()
     else
       unifyBase names (resolveLink ty1, resolveLink ty2)

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -145,11 +145,9 @@ end
 lang VarTypeUnify = Unify + VarTypeAst
   sem unifyBase (env : UnifyEnv) =
   | (TyVar t1 & ty1, TyVar t2 & ty2) ->
-    if not (nameEq t1.ident t2.ident) then
-      match biLookup (t1.ident, t2.ident) env.names with None () then
-        unificationError (ty1, ty2)
-      else ()
-    else ()
+    if nameEq t1.ident t2.ident then ()
+    else if biMem (t1.ident, t2.ident) env.names then ()
+    else unificationError (ty1, ty2)
 end
 
 lang FlexTypeUnify = Unify + FlexTypeAst + UnknownTypeAst
@@ -296,7 +294,8 @@ lang RecordFlexTypeUnify = Unify + RecordFlexTypeAst + RecordTypeAst
           match b with (k, ty2) in
           match mapLookup k r1.fields with Some ty1 then
             -- TODO(aathn, 2021-11-06): Occurs check
-            unify ty1 ty2
+            unifyBase env (ty1, ty2);
+            acc
           else
             mapInsert k ty2 acc
         in
@@ -313,7 +312,7 @@ lang RecordFlexTypeUnify = Unify + RecordFlexTypeAst + RecordTypeAst
         match b with (k, ty1) in
         match mapLookup k t2.fields with Some ty2 then
           -- TODO(aathn, 2021-11-06): Occurs check
-          unify ty1 ty2
+          unifyBase env (ty1, ty2)
         else
           unificationError (tyrecflex, tyrec)
       in

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -13,7 +13,7 @@ let init = lam seq. subsequence seq 0 (subi (length seq) 1)
 utest init [2,3,5] with [2,3]
 utest last [2,4,8] with 8
 
-let eqSeq = lam eq : (a -> b -> Bool). lam s1. lam s2.
+let eqSeq = lam eq : (a -> b -> Bool). lam s1 : [a]. lam s2 : [b].
   recursive let work = lam s1. lam s2.
     match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) then
       if eq h1 h2 then work t1 t2
@@ -74,7 +74,7 @@ let foldr1 = lam f. lam seq. foldr f (last seq) (init seq)
 utest foldr (lam x. lam acc. x) 0 [1,2] with 1
 utest foldr (lam acc. lam x. x) 0 [] with 0
 utest foldr cons [] [1,2,3] with [1,2,3]
-utest foldr1 (lam x. lam acc. (x,acc)) [1,2] with (1,2)
+utest foldr1 addi [1,2] with 3
 
 recursive
 let unfoldr = lam f. lam b.
@@ -247,7 +247,7 @@ utest distinct eqi [1,1,5,1,2,3,4,5,0] with [1,5,2,3,4,0]
 
 -- Sorting
 recursive
-let quickSort = lam cmp. lam seq.
+let quickSort : all a. (a -> a -> Int) -> ([a] -> [a]) = lam cmp. lam seq.
   if null seq then seq else
     let h = head seq in
     let t = tail seq in


### PR DESCRIPTION
This PR adds limited forms of typechecking for records and algebraic data types.

The main limitations are:
- Record types are inferred, but polymorphism over record types is not allowed
- Algebraic data types are typechecked nominally (similar to Haskell or OCaml). In addition, I have not yet added proper support for ~type parameters in~ type aliases