### PR TITLE
Remove dependency on `timeout` command for tune tests

### DIFF
--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -58,7 +58,7 @@ let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> Strin
 
     let fullCmd =
     [ "cd", cwd, ";"
-    , "echo", "\"", stdin, "\"|"
+    , "echo", join ["\"", stdin, "\""], "|"
     , strJoin " " cmd
     , ">", tempStdout
     , "2>", tempStderr

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -58,7 +58,7 @@ let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> Strin
 
     let fullCmd =
     [ "cd", cwd, ";"
-    , "echo", stdin, "|"
+    , "echo", "\"", stdin, "\"|"
     , strJoin " " cmd
     , ">", tempStdout
     , "2>", tempStderr
@@ -72,8 +72,8 @@ let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> Strin
     match _commandListTime fullCmd with (ms, retCode) then
 
       -- NOTE(Linnea, 2021-04-14): Workaround for readFile bug #145
-      _commandList ["echo", "", ">>", tempStdout];
-      _commandList ["echo", "", ">>", tempStderr];
+      _commandList ["echo", "\"\"", ">>", tempStdout];
+      _commandList ["echo", "\"\"", ">>", tempStderr];
       let stdout = init (readFile tempStdout) in
       let stderr = init (readFile tempStderr) in
 

--- a/stdlib/tuning/tune-options.mc
+++ b/stdlib/tuning/tune-options.mc
@@ -49,7 +49,7 @@ let tuneOptionsDefault : TuneOptions =
 , epsilonMs = 10.0
 , stepSize = 1
 , ignoreErrors = false
-, exitEarly = true
+, exitEarly = false
 , seed = None ()
 }
 
@@ -80,7 +80,7 @@ Tune options (after -- ):
   --step-size <n>.          If exhaustive or semi-exhaustive is used, use this as step
                             size for integer ranges. TODO: should be number of steps
   --ignore-errors           Ignore errors during tuning.
-  --disable-exit-early      Always let the process run to completion during
+  --enable-exit-early       Always let the process run to completion during
                             tuning (default is to kill it when it has run for
                             longer than the current best runtime.)
   --seed <n>                Set the seed for random search.
@@ -107,8 +107,8 @@ recursive let parseTuneOptions = lam o : TuneOptions. lam args : [String].
   else match args with ["--ignore-errors"] ++ args then
     parseTuneOptions {o with ignoreErrors = true} args
 
-  else match args with ["--disable-exit-early"] ++ args then
-    parseTuneOptions {o with exitEarly = false} args
+  else match args with ["--enable-exit-early"] ++ args then
+    parseTuneOptions {o with exitEarly = true} args
 
   else match args with ["--iters"] ++ args then
     match args with [i] ++ args then

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -51,9 +51,10 @@ lang TuneBase = Holes
   -- Intentionally left blank
 
   sem time (table : LookupTable) (runner : Runner) (file : String)
-           (options : TuneOptions) (timeout : Float) =
+           (options : TuneOptions) (timeout : Option Float) =
   | args ->
     tuneFileDumpTable file (None ()) table;
+    let timeout = if options.exitEarly then timeout else None () in
     match runner args timeout with (ms, res) then
       let res : ExecResult = res in
       let rcode = res.returncode in


### PR DESCRIPTION
The tune tests depended on the command `timeout`, which caused the tests to fail if that command didn't exist.