### PR TITLE
Updates to CFA framework and ANF

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -237,7 +237,8 @@ lang MExprANF = MExprANFAll
 
 end
 
--- TODO
+-- TODO(dlunde,2021-11-16): This fragment should define a function for
+-- reversing ANF transformation for values.
 lang ValueReverseANF
 
 

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -570,8 +570,6 @@ end
 lang IntAst = ConstAst
   syn Const =
   | CInt {val : Int}
-  sem constArity =
-  | CInt _ -> 0
 end
 
 lang ArithIntAst = ConstAst + IntAst
@@ -582,14 +580,6 @@ lang ArithIntAst = ConstAst + IntAst
   | CDivi {}
   | CNegi {}
   | CModi {}
-
-  sem constArity =
-  | CAddi _ -> 2
-  | CSubi _ -> 2
-  | CMuli _ -> 2
-  | CDivi _ -> 2
-  | CNegi _ -> 1
-  | CModi _ -> 2
 end
 
 lang ShiftIntAst = ConstAst + IntAst
@@ -597,19 +587,11 @@ lang ShiftIntAst = ConstAst + IntAst
   | CSlli {}
   | CSrli {}
   | CSrai {}
-
-  sem constArity =
-  | CSlli _ -> 2
-  | CSrli _ -> 2
-  | CSrai _ -> 2
 end
 
 lang FloatAst = ConstAst
   syn Const =
   | CFloat {val : Float}
-
-  sem constArity =
-  | CFloat _ -> 0
 end
 
 lang ArithFloatAst = ConstAst + FloatAst
@@ -619,13 +601,6 @@ lang ArithFloatAst = ConstAst + FloatAst
   | CMulf {}
   | CDivf {}
   | CNegf {}
-
-  sem constArity =
-  | CAddf _ -> 2
-  | CSubf _ -> 2
-  | CMulf _ -> 2
-  | CDivf _ -> 2
-  | CNegf _ -> 1
 end
 
 lang FloatIntConversionAst = IntAst + FloatAst
@@ -634,20 +609,11 @@ lang FloatIntConversionAst = IntAst + FloatAst
   | CCeilfi {}
   | CRoundfi {}
   | CInt2float {}
-
-  sem constArity =
-  | CFloorfi _ -> 1
-  | CCeilfi _ -> 1
-  | CRoundfi _ -> 1
-  | CInt2float _ -> 1
 end
 
 lang BoolAst = ConstAst
   syn Const =
   | CBool {val : Bool}
-
-  sem constArity =
-  | CBool _ -> 0
 end
 
 lang CmpIntAst = IntAst + BoolAst
@@ -658,14 +624,6 @@ lang CmpIntAst = IntAst + BoolAst
   | CGti {}
   | CLeqi {}
   | CGeqi {}
-
-  sem constArity =
-  | CEqi _ -> 2
-  | CNeqi _ -> 2
-  | CLti _ -> 2
-  | CGti _ -> 2
-  | CLeqi _ -> 2
-  | CGeqi _ -> 2
 end
 
 lang CmpFloatAst = FloatAst + BoolAst
@@ -676,40 +634,22 @@ lang CmpFloatAst = FloatAst + BoolAst
   | CGtf {}
   | CGeqf {}
   | CNeqf {}
-
-  sem constArity =
-  | CEqf _ -> 2
-  | CLtf _ -> 2
-  | CLeqf _ -> 2
-  | CGtf _ -> 2
-  | CGeqf _ -> 2
-  | CNeqf _ -> 2
 end
 
 lang CharAst = ConstAst
   syn Const =
   | CChar {val : Char}
-
-  sem constArity =
-  | CChar _ -> 0
 end
 
 lang CmpCharAst = CharAst + BoolAst
   syn Const =
   | CEqc {}
-
-  sem constArity =
-  | CEqc _ -> 2
 end
 
 lang IntCharConversionAst = IntAst + CharAst
   syn Const =
   | CInt2Char {}
   | CChar2Int {}
-
-  sem constArity =
-  | CInt2Char _ -> 1
-  | CChar2Int _ -> 1
 end
 
 lang FloatStringConversionAst = SeqAst + FloatAst
@@ -717,11 +657,6 @@ lang FloatStringConversionAst = SeqAst + FloatAst
   | CStringIsFloat {}
   | CString2float {}
   | CFloat2string {}
-
-  sem constArity =
-  | CStringIsFloat _ -> 1
-  | CString2float _ -> 1
-  | CFloat2string _ -> 1
 end
 
 lang SymbAst = ConstAst
@@ -729,19 +664,11 @@ lang SymbAst = ConstAst
   | CSymb {val : Symb}
   | CGensym {}
   | CSym2hash {}
-
-  sem constArity =
-  | CSymb _ -> 0
-  | CGensym _ -> 1
-  | CSym2hash _ -> 1
 end
 
 lang CmpSymbAst = SymbAst + BoolAst
   syn Const =
   | CEqsym {}
-
-  sem constArity =
-  | CEqsym _ -> 2
 end
 
 lang SeqOpAst = SeqAst
@@ -767,29 +694,6 @@ lang SeqOpAst = SeqAst
   | CCreateRope {}
   | CSplitAt {}
   | CSubsequence {}
-
-  sem constArity =
-  | CSet _ -> 3
-  | CGet _ -> 2
-  | CCons _ -> 2
-  | CSnoc _ -> 2
-  | CConcat _ -> 2
-  | CLength _ -> 1
-  | CReverse _ -> 1
-  | CHead _ -> 1
-  | CTail _ -> 1
-  | CNull _ -> 1
-  | CMap _ -> 2
-  | CMapi _ -> 2
-  | CIter _ -> 2
-  | CIteri _ -> 2
-  | CFoldl _ -> 3
-  | CFoldr _ -> 3
-  | CCreate _ -> 2
-  | CCreateList _ -> 2
-  | CCreateRope _ -> 2
-  | CSplitAt _ -> 2
-  | CSubsequence _ -> 3
 end
 
 lang FileOpAst = ConstAst
@@ -798,12 +702,6 @@ lang FileOpAst = ConstAst
   | CFileWrite {}
   | CFileExists {}
   | CFileDelete {}
-
-  sem constArity =
-  | CFileRead _ -> 1
-  | CFileWrite _ -> 2
-  | CFileExists _ -> 1
-  | CFileDelete _ -> 1
 end
 
 lang IOAst = ConstAst
@@ -815,25 +713,12 @@ lang IOAst = ConstAst
   | CFlushStderr {}
   | CReadLine {}
   | CReadBytesAsString {}
-
-  sem constArity =
-  | CPrint _ -> 1
-  | CPrintError _ -> 1
-  | CDPrint _ -> 1
-  | CFlushStdout _ -> 1
-  | CFlushStderr _ -> 1
-  | CReadLine _ -> 1
-  | CReadBytesAsString _ -> 1
 end
 
 lang RandomNumberGeneratorAst = ConstAst
   syn Const =
   | CRandIntU {}
   | CRandSetSeed {}
-
-  sem constArity =
-  | CRandIntU _ -> 2
-  | CRandSetSeed _ -> 1
 end
 
 lang SysAst = ConstAst
@@ -842,30 +727,17 @@ lang SysAst = ConstAst
   | CError {}
   | CArgv {}
   | CCommand {}
-
-  sem constArity =
-  | CExit _ -> 1
-  | CError _ -> 1
-  | CArgv _ -> 0
-  | CCommand _ -> 1
 end
 
 lang TimeAst = ConstAst
   syn Const =
   | CWallTimeMs {}
   | CSleepMs {}
-
-  sem constArity =
-  | CWallTimeMs _ -> 1
-  | CSleepMs _ -> 1
 end
 
 lang ConTagAst = ConstAst
   syn Const =
   | CConstructorTag {}
-
-  sem constArity =
-  | CConstructorTag _ -> 1
 end
 
 lang RefOpAst = ConstAst
@@ -873,11 +745,6 @@ lang RefOpAst = ConstAst
   | CRef {}
   | CModRef {}
   | CDeRef {}
-
-  sem constArity =
-  | CRef _ -> 1
-  | CModRef _ -> 2
-  | CDeRef _ -> 1
 end
 
 lang MapAst = ConstAst
@@ -900,26 +767,6 @@ lang MapAst = ConstAst
   | CMapEq {}
   | CMapCmp {}
   | CMapGetCmpFun {}
-
-  sem constArity =
-  | CMapEmpty _ -> 1
-  | CMapInsert _ -> 3
-  | CMapRemove _ -> 2
-  | CMapFindExn _ -> 2
-  | CMapFindOrElse _ -> 3
-  | CMapFindApplyOrElse _ -> 4
-  | CMapBindings _ -> 1
-  | CMapChooseExn _ -> 1
-  | CMapChooseOrElse _ -> 2
-  | CMapSize _ -> 1
-  | CMapMem _ -> 2
-  | CMapAny _ -> 2
-  | CMapMap _ -> 2
-  | CMapMapWithKey _ -> 2
-  | CMapFoldWithKey _ -> 3
-  | CMapEq _ -> 3
-  | CMapCmp _ -> 3
-  | CMapGetCmpFun _ -> 1
 end
 
 lang TensorOpAst = ConstAst
@@ -939,23 +786,6 @@ lang TensorOpAst = ConstAst
   | CTensorIterSlice {}
   | CTensorEq {}
   | CTensorToString {}
-
-  sem constArity =
-  | CTensorCreateInt _ -> 2
-  | CTensorCreateFloat _ -> 2
-  | CTensorCreate _ -> 2
-  | CTensorGetExn _ -> 2
-  | CTensorSetExn _ -> 3
-  | CTensorRank _ -> 1
-  | CTensorShape _ -> 1
-  | CTensorReshapeExn _ -> 2
-  | CTensorCopy _ -> 1
-  | CTensorTransposeExn _ -> 3
-  | CTensorSliceExn _ -> 2
-  | CTensorSubExn _ -> 3
-  | CTensorIterSlice _ -> 2
-  | CTensorEq _ -> 3
-  | CTensorToString _ -> 2
 end
 
 lang BootParserAst = ConstAst
@@ -972,20 +802,6 @@ lang BootParserAst = ConstAst
   | CBootParserGetConst {}
   | CBootParserGetPat {}
   | CBootParserGetInfo {}
-
-  sem constArity =
-  | CBootParserParseMExprString _ -> 2
-  | CBootParserParseMCoreFile _ -> 3
-  | CBootParserGetId _ -> 1
-  | CBootParserGetTerm _ -> 2
-  | CBootParserGetType _ -> 2
-  | CBootParserGetString _ -> 2
-  | CBootParserGetInt _ -> 2
-  | CBootParserGetFloat _ -> 2
-  | CBootParserGetListLength _ -> 2
-  | CBootParserGetConst _ -> 2
-  | CBootParserGetPat _ -> 2
-  | CBootParserGetInfo _ -> 2
 end
 
 --------------

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -570,6 +570,8 @@ end
 lang IntAst = ConstAst
   syn Const =
   | CInt {val : Int}
+  sem constArity =
+  | CInt _ -> 0
 end
 
 lang ArithIntAst = ConstAst + IntAst
@@ -580,6 +582,14 @@ lang ArithIntAst = ConstAst + IntAst
   | CDivi {}
   | CNegi {}
   | CModi {}
+
+  sem constArity =
+  | CAddi _ -> 2
+  | CSubi _ -> 2
+  | CMuli _ -> 2
+  | CDivi _ -> 2
+  | CNegi _ -> 1
+  | CModi _ -> 2
 end
 
 lang ShiftIntAst = ConstAst + IntAst
@@ -587,11 +597,19 @@ lang ShiftIntAst = ConstAst + IntAst
   | CSlli {}
   | CSrli {}
   | CSrai {}
+
+  sem constArity =
+  | CSlli _ -> 2
+  | CSrli _ -> 2
+  | CSrai _ -> 2
 end
 
 lang FloatAst = ConstAst
   syn Const =
   | CFloat {val : Float}
+
+  sem constArity =
+  | CFloat _ -> 0
 end
 
 lang ArithFloatAst = ConstAst + FloatAst
@@ -601,6 +619,13 @@ lang ArithFloatAst = ConstAst + FloatAst
   | CMulf {}
   | CDivf {}
   | CNegf {}
+
+  sem constArity =
+  | CAddf _ -> 2
+  | CSubf _ -> 2
+  | CMulf _ -> 2
+  | CDivf _ -> 2
+  | CNegf _ -> 1
 end
 
 lang FloatIntConversionAst = IntAst + FloatAst
@@ -609,11 +634,20 @@ lang FloatIntConversionAst = IntAst + FloatAst
   | CCeilfi {}
   | CRoundfi {}
   | CInt2float {}
+
+  sem constArity =
+  | CFloorfi _ -> 1
+  | CCeilfi _ -> 1
+  | CRoundfi _ -> 1
+  | CInt2float _ -> 1
 end
 
 lang BoolAst = ConstAst
   syn Const =
   | CBool {val : Bool}
+
+  sem constArity =
+  | CBool _ -> 0
 end
 
 lang CmpIntAst = IntAst + BoolAst
@@ -624,6 +658,14 @@ lang CmpIntAst = IntAst + BoolAst
   | CGti {}
   | CLeqi {}
   | CGeqi {}
+
+  sem constArity =
+  | CEqi _ -> 2
+  | CNeqi _ -> 2
+  | CLti _ -> 2
+  | CGti _ -> 2
+  | CLeqi _ -> 2
+  | CGeqi _ -> 2
 end
 
 lang CmpFloatAst = FloatAst + BoolAst
@@ -634,22 +676,40 @@ lang CmpFloatAst = FloatAst + BoolAst
   | CGtf {}
   | CGeqf {}
   | CNeqf {}
+
+  sem constArity =
+  | CEqf _ -> 2
+  | CLtf _ -> 2
+  | CLeqf _ -> 2
+  | CGtf _ -> 2
+  | CGeqf _ -> 2
+  | CNeqf _ -> 2
 end
 
 lang CharAst = ConstAst
   syn Const =
   | CChar {val : Char}
+
+  sem constArity =
+  | CChar _ -> 0
 end
 
 lang CmpCharAst = CharAst + BoolAst
   syn Const =
   | CEqc {}
+
+  sem constArity =
+  | CEqc _ -> 2
 end
 
 lang IntCharConversionAst = IntAst + CharAst
   syn Const =
   | CInt2Char {}
   | CChar2Int {}
+
+  sem constArity =
+  | CInt2Char _ -> 1
+  | CChar2Int _ -> 1
 end
 
 lang FloatStringConversionAst = SeqAst + FloatAst
@@ -657,6 +717,11 @@ lang FloatStringConversionAst = SeqAst + FloatAst
   | CStringIsFloat {}
   | CString2float {}
   | CFloat2string {}
+
+  sem constArity =
+  | CStringIsFloat _ -> 1
+  | CString2float _ -> 1
+  | CFloat2string _ -> 1
 end
 
 lang SymbAst = ConstAst
@@ -664,11 +729,19 @@ lang SymbAst = ConstAst
   | CSymb {val : Symb}
   | CGensym {}
   | CSym2hash {}
+
+  sem constArity =
+  | CSymb _ -> 0
+  | CGensym _ -> 1
+  | CSym2hash _ -> 1
 end
 
 lang CmpSymbAst = SymbAst + BoolAst
   syn Const =
   | CEqsym {}
+
+  sem constArity =
+  | CEqsym _ -> 2
 end
 
 lang SeqOpAst = SeqAst
@@ -694,6 +767,29 @@ lang SeqOpAst = SeqAst
   | CCreateRope {}
   | CSplitAt {}
   | CSubsequence {}
+
+  sem constArity =
+  | CSet _ -> 3
+  | CGet _ -> 2
+  | CCons _ -> 2
+  | CSnoc _ -> 2
+  | CConcat _ -> 2
+  | CLength _ -> 1
+  | CReverse _ -> 1
+  | CHead _ -> 1
+  | CTail _ -> 1
+  | CNull _ -> 1
+  | CMap _ -> 2
+  | CMapi _ -> 2
+  | CIter _ -> 2
+  | CIteri _ -> 2
+  | CFoldl _ -> 3
+  | CFoldr _ -> 3
+  | CCreate _ -> 2
+  | CCreateList _ -> 2
+  | CCreateRope _ -> 2
+  | CSplitAt _ -> 2
+  | CSubsequence _ -> 3
 end
 
 lang FileOpAst = ConstAst
@@ -702,6 +798,12 @@ lang FileOpAst = ConstAst
   | CFileWrite {}
   | CFileExists {}
   | CFileDelete {}
+
+  sem constArity =
+  | CFileRead _ -> 1
+  | CFileWrite _ -> 2
+  | CFileExists _ -> 1
+  | CFileDelete _ -> 1
 end
 
 lang IOAst = ConstAst
@@ -713,12 +815,25 @@ lang IOAst = ConstAst
   | CFlushStderr {}
   | CReadLine {}
   | CReadBytesAsString {}
+
+  sem constArity =
+  | CPrint _ -> 1
+  | CPrintError _ -> 1
+  | CDPrint _ -> 1
+  | CFlushStdout _ -> 1
+  | CFlushStderr _ -> 1
+  | CReadLine _ -> 1
+  | CReadBytesAsString _ -> 1
 end
 
 lang RandomNumberGeneratorAst = ConstAst
   syn Const =
   | CRandIntU {}
   | CRandSetSeed {}
+
+  sem constArity =
+  | CRandIntU _ -> 2
+  | CRandSetSeed _ -> 1
 end
 
 lang SysAst = ConstAst
@@ -727,17 +842,30 @@ lang SysAst = ConstAst
   | CError {}
   | CArgv {}
   | CCommand {}
+
+  sem constArity =
+  | CExit _ -> 1
+  | CError _ -> 1
+  | CArgv _ -> 0
+  | CCommand _ -> 1
 end
 
 lang TimeAst = ConstAst
   syn Const =
   | CWallTimeMs {}
   | CSleepMs {}
+
+  sem constArity =
+  | CWallTimeMs _ -> 1
+  | CSleepMs _ -> 1
 end
 
 lang ConTagAst = ConstAst
   syn Const =
   | CConstructorTag {}
+
+  sem constArity =
+  | CConstructorTag _ -> 1
 end
 
 lang RefOpAst = ConstAst
@@ -745,6 +873,11 @@ lang RefOpAst = ConstAst
   | CRef {}
   | CModRef {}
   | CDeRef {}
+
+  sem constArity =
+  | CRef _ -> 1
+  | CModRef _ -> 2
+  | CDeRef _ -> 1
 end
 
 lang MapAst = ConstAst
@@ -767,6 +900,26 @@ lang MapAst = ConstAst
   | CMapEq {}
   | CMapCmp {}
   | CMapGetCmpFun {}
+
+  sem constArity =
+  | CMapEmpty _ -> 1
+  | CMapInsert _ -> 3
+  | CMapRemove _ -> 2
+  | CMapFindExn _ -> 2
+  | CMapFindOrElse _ -> 3
+  | CMapFindApplyOrElse _ -> 4
+  | CMapBindings _ -> 1
+  | CMapChooseExn _ -> 1
+  | CMapChooseOrElse _ -> 2
+  | CMapSize _ -> 1
+  | CMapMem _ -> 2
+  | CMapAny _ -> 2
+  | CMapMap _ -> 2
+  | CMapMapWithKey _ -> 2
+  | CMapFoldWithKey _ -> 3
+  | CMapEq _ -> 3
+  | CMapCmp _ -> 3
+  | CMapGetCmpFun _ -> 1
 end
 
 lang TensorOpAst = ConstAst
@@ -786,6 +939,23 @@ lang TensorOpAst = ConstAst
   | CTensorIterSlice {}
   | CTensorEq {}
   | CTensorToString {}
+
+  sem constArity =
+  | CTensorCreateInt _ -> 2
+  | CTensorCreateFloat _ -> 2
+  | CTensorCreate _ -> 2
+  | CTensorGetExn _ -> 2
+  | CTensorSetExn _ -> 3
+  | CTensorRank _ -> 1
+  | CTensorShape _ -> 1
+  | CTensorReshapeExn _ -> 2
+  | CTensorCopy _ -> 1
+  | CTensorTransposeExn _ -> 3
+  | CTensorSliceExn _ -> 2
+  | CTensorSubExn _ -> 3
+  | CTensorIterSlice _ -> 2
+  | CTensorEq _ -> 3
+  | CTensorToString _ -> 2
 end
 
 lang BootParserAst = ConstAst
@@ -794,7 +964,7 @@ lang BootParserAst = ConstAst
   | CBootParserParseMCoreFile {}
   | CBootParserGetId {}
   | CBootParserGetTerm {}
-  | CBootParserGetType ()
+  | CBootParserGetType {}
   | CBootParserGetString {}
   | CBootParserGetInt {}
   | CBootParserGetFloat {}
@@ -802,6 +972,20 @@ lang BootParserAst = ConstAst
   | CBootParserGetConst {}
   | CBootParserGetPat {}
   | CBootParserGetInfo {}
+
+  sem constArity =
+  | CBootParserParseMExprString _ -> 2
+  | CBootParserParseMCoreFile _ -> 3
+  | CBootParserGetId _ -> 1
+  | CBootParserGetTerm _ -> 2
+  | CBootParserGetType _ -> 2
+  | CBootParserGetString _ -> 2
+  | CBootParserGetInt _ -> 2
+  | CBootParserGetFloat _ -> 2
+  | CBootParserGetListLength _ -> 2
+  | CBootParserGetConst _ -> 2
+  | CBootParserGetPat _ -> 2
+  | CBootParserGetInfo _ -> 2
 end
 
 --------------

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -848,7 +848,7 @@ end
 
 lang SeqEdgePatCFA = MatchCFA + SeqCFA + SeqEdgePat
   sem propagateMatchConstraint (graph: CFAGraph) (id: Name) =
-  | (PatSeqEdge p, AVSeq { names = names }) ->
+  | (PatSeqEdge p, AVSeq { names = names } & av) ->
     let f = lam graph. lam pat: Pat. setFold (lam graph. lam name.
         let cstrs = foldl (lam acc. lam f. concat (f id name pat) acc)
           [] (matchConstraintGenFuns ()) in
@@ -856,11 +856,10 @@ lang SeqEdgePatCFA = MatchCFA + SeqCFA + SeqEdgePat
       ) graph names in
     let graph = foldl f graph p.prefix in
     let graph = foldl f graph p.postfix in
-    match p.middle with PName rhs then
-      foldl (lam graph. lam lhs: Name.
-        let cstr = CstrDirect { lhs = lhs, rhs = rhs } in
-        initConstraint graph cstr
-      ) graph names
+    match p.middle with PName rhs then addData graph av rhs
+    else graph
+  | (PatSeqEdge p, av) ->
+    match p.middle with PName rhs then addData graph av rhs
     else graph
 end
 

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -65,7 +65,6 @@ lang CFA = Ast + LetAst + MExprPrettyPrint
       else
         match head graph.worklist with (q,d) & h in
         let graph = { graph with worklist = tail graph.worklist } in
-        match dataLookup q graph with dq in
         match edgesLookup q graph with cc in
         let graph = foldl (propagateConstraint h) graph cc in
         iter graph
@@ -97,7 +96,6 @@ lang CFA = Ast + LetAst + MExprPrettyPrint
         match printGraph env graph "INTERMEDIATE CFA GRAPH" with env in
         match head graph.worklist with (q,d) & h in
         let graph = { graph with worklist = tail graph.worklist } in
-        match dataLookup q graph with dq in
         match edgesLookup q graph with cc in
         let graph = foldl (propagateConstraint h) graph cc in
         iter env graph

--- a/stdlib/mexpr/const-arity.mc
+++ b/stdlib/mexpr/const-arity.mc
@@ -1,0 +1,256 @@
+include "ast.mc"
+
+lang IntArity = IntAst
+  sem constArity =
+  | CInt _ -> 0
+end
+
+lang ArithIntArity = ArithIntAst
+  sem constArity =
+  | CAddi _ -> 2
+  | CSubi _ -> 2
+  | CMuli _ -> 2
+  | CDivi _ -> 2
+  | CNegi _ -> 1
+  | CModi _ -> 2
+end
+
+lang ShiftIntArity = ShiftIntAst
+  sem constArity =
+  | CSlli _ -> 2
+  | CSrli _ -> 2
+  | CSrai _ -> 2
+end
+
+lang FloatArity = FloatAst
+  sem constArity =
+  | CFloat _ -> 0
+end
+
+lang ArithFloatArity = ArithFloatAst
+  sem constArity =
+  | CAddf _ -> 2
+  | CSubf _ -> 2
+  | CMulf _ -> 2
+  | CDivf _ -> 2
+  | CNegf _ -> 1
+end
+
+lang FloatIntConversionArity = FloatIntConversionAst
+  sem constArity =
+  | CFloorfi _ -> 1
+  | CCeilfi _ -> 1
+  | CRoundfi _ -> 1
+  | CInt2float _ -> 1
+end
+
+lang BoolArity = BoolAst
+  sem constArity =
+  | CBool _ -> 0
+end
+
+lang CmpIntArity = CmpIntAst
+  sem constArity =
+  | CEqi _ -> 2
+  | CNeqi _ -> 2
+  | CLti _ -> 2
+  | CGti _ -> 2
+  | CLeqi _ -> 2
+  | CGeqi _ -> 2
+end
+
+lang CmpFloatArity = CmpFloatAst
+  sem constArity =
+  | CEqf _ -> 2
+  | CLtf _ -> 2
+  | CLeqf _ -> 2
+  | CGtf _ -> 2
+  | CGeqf _ -> 2
+  | CNeqf _ -> 2
+end
+
+lang CharArity = CharAst
+  sem constArity =
+  | CChar _ -> 0
+end
+
+lang CmpCharArity = CmpCharAst
+  sem constArity =
+  | CEqc _ -> 2
+end
+
+lang IntCharConversionArity = IntCharConversionAst
+  sem constArity =
+  | CInt2Char _ -> 1
+  | CChar2Int _ -> 1
+end
+
+lang FloatStringConversionArity = FloatStringConversionAst
+  sem constArity =
+  | CStringIsFloat _ -> 1
+  | CString2float _ -> 1
+  | CFloat2string _ -> 1
+end
+
+lang SymbArity = SymbAst
+  sem constArity =
+  | CSymb _ -> 0
+  | CGensym _ -> 1
+  | CSym2hash _ -> 1
+end
+
+lang CmpSymbArity = CmpSymbAst
+  sem constArity =
+  | CEqsym _ -> 2
+end
+
+lang SeqOpArity = SeqOpAst
+  sem constArity =
+  | CSet _ -> 3
+  | CGet _ -> 2
+  | CCons _ -> 2
+  | CSnoc _ -> 2
+  | CConcat _ -> 2
+  | CLength _ -> 1
+  | CReverse _ -> 1
+  | CHead _ -> 1
+  | CTail _ -> 1
+  | CNull _ -> 1
+  | CMap _ -> 2
+  | CMapi _ -> 2
+  | CIter _ -> 2
+  | CIteri _ -> 2
+  | CFoldl _ -> 3
+  | CFoldr _ -> 3
+  | CCreate _ -> 2
+  | CCreateList _ -> 2
+  | CCreateRope _ -> 2
+  | CSplitAt _ -> 2
+  | CSubsequence _ -> 3
+end
+
+lang FileOpArity = FileOpAst
+  sem constArity =
+  | CFileRead _ -> 1
+  | CFileWrite _ -> 2
+  | CFileExists _ -> 1
+  | CFileDelete _ -> 1
+end
+
+lang IOArity = IOAst
+  sem constArity =
+  | CPrint _ -> 1
+  | CPrintError _ -> 1
+  | CDPrint _ -> 1
+  | CFlushStdout _ -> 1
+  | CFlushStderr _ -> 1
+  | CReadLine _ -> 1
+  | CReadBytesAsString _ -> 1
+end
+
+lang RandomNumberGeneratorArity = RandomNumberGeneratorAst
+  sem constArity =
+  | CRandIntU _ -> 2
+  | CRandSetSeed _ -> 1
+end
+
+lang SysArity = SysAst
+  sem constArity =
+  | CExit _ -> 1
+  | CError _ -> 1
+  | CArgv _ -> 0
+  | CCommand _ -> 1
+end
+
+lang TimeArity = TimeAst
+  sem constArity =
+  | CWallTimeMs _ -> 1
+  | CSleepMs _ -> 1
+end
+
+lang ConTagArity = ConTagAst
+  sem constArity =
+  | CConstructorTag _ -> 1
+end
+
+lang RefOpArity = RefOpAst
+  sem constArity =
+  | CRef _ -> 1
+  | CModRef _ -> 2
+  | CDeRef _ -> 1
+end
+
+lang MapArity = MapAst
+  sem constArity =
+  | CMapEmpty _ -> 1
+  | CMapInsert _ -> 3
+  | CMapRemove _ -> 2
+  | CMapFindExn _ -> 2
+  | CMapFindOrElse _ -> 3
+  | CMapFindApplyOrElse _ -> 4
+  | CMapBindings _ -> 1
+  | CMapChooseExn _ -> 1
+  | CMapChooseOrElse _ -> 2
+  | CMapSize _ -> 1
+  | CMapMem _ -> 2
+  | CMapAny _ -> 2
+  | CMapMap _ -> 2
+  | CMapMapWithKey _ -> 2
+  | CMapFoldWithKey _ -> 3
+  | CMapEq _ -> 3
+  | CMapCmp _ -> 3
+  | CMapGetCmpFun _ -> 1
+end
+
+lang TensorOpArity = TensorOpAst
+  sem constArity =
+  | CTensorCreateInt _ -> 2
+  | CTensorCreateFloat _ -> 2
+  | CTensorCreate _ -> 2
+  | CTensorGetExn _ -> 2
+  | CTensorSetExn _ -> 3
+  | CTensorRank _ -> 1
+  | CTensorShape _ -> 1
+  | CTensorReshapeExn _ -> 2
+  | CTensorCopy _ -> 1
+  | CTensorTransposeExn _ -> 3
+  | CTensorSliceExn _ -> 2
+  | CTensorSubExn _ -> 3
+  | CTensorIterSlice _ -> 2
+  | CTensorEq _ -> 3
+  | CTensorToString _ -> 2
+end
+
+lang BootParserArity = BootParserAst
+  sem constArity =
+  | CBootParserParseMExprString _ -> 2
+  | CBootParserParseMCoreFile _ -> 3
+  | CBootParserGetId _ -> 1
+  | CBootParserGetTerm _ -> 2
+  | CBootParserGetType _ -> 2
+  | CBootParserGetString _ -> 2
+  | CBootParserGetInt _ -> 2
+  | CBootParserGetFloat _ -> 2
+  | CBootParserGetListLength _ -> 2
+  | CBootParserGetConst _ -> 2
+  | CBootParserGetPat _ -> 2
+  | CBootParserGetInfo _ -> 2
+end
+
+lang MExprArity =
+  IntArity + ArithIntArity + ShiftIntArity + FloatArity + ArithFloatArity +
+  FloatIntConversionArity + BoolArity + CmpIntArity + CmpFloatArity +
+  CharArity + CmpCharArity + IntCharConversionArity +
+  FloatStringConversionArity + SymbArity + CmpSymbArity + SeqOpArity +
+  FileOpArity + IOArity + RandomNumberGeneratorArity + SysArity + TimeArity +
+  ConTagArity + RefOpArity + MapArity + TensorOpArity + BootParserArity
+
+mexpr
+
+use MExprArity in
+
+utest constArity (CInt {val = 0}) with 0 in
+utest constArity (CAddi {}) with 2 in
+utest constArity (CLength {}) with 1 in
+
+()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -304,6 +304,13 @@ lang ArithIntEval = ArithIntAst + ConstEval
   | CDivi2 Int
   | CModi2 Int
 
+  sem constArity =
+  | CAddi2 _ -> 1
+  | CSubi2 _ -> 1
+  | CMuli2 _ -> 1
+  | CDivi2 _ -> 1
+  | CModi2 _ -> 1
+
   sem delta (arg : Expr) =
   | CAddi _ ->
     match arg with TmConst (t & {val = CInt {val = n}}) then
@@ -357,6 +364,11 @@ lang ShiftIntEval = ShiftIntAst + ConstEval
   | CSrli2 Int
   | CSrai2 Int
 
+  sem constArity =
+  | CSlli2 _ -> 1
+  | CSrli2 _ -> 1
+  | CSrai2 _ -> 1
+
   sem delta (arg : Expr) =
   | CSlli _ ->
     match arg with TmConst (t & {val = CInt {val = n}}) then
@@ -390,6 +402,12 @@ lang ArithFloatEval = ArithFloatAst + ConstEval
   | CSubf2 Float
   | CMulf2 Float
   | CDivf2 Float
+
+  sem constArity =
+  | CAddf2 _ -> 1
+  | CSubf2 _ -> 1
+  | CMulf2 _ -> 1
+  | CDivf2 _ -> 1
 
   sem delta (arg : Expr) =
   | CAddf _ ->
@@ -477,6 +495,14 @@ lang CmpIntEval = CmpIntAst + ConstEval
   | CLeqi2 Int
   | CGeqi2 Int
 
+  sem constArity =
+  | CEqi2 _ -> 1
+  | CNeqi2 _ -> 1
+  | CLti2 _ -> 1
+  | CGti2 _ -> 1
+  | CLeqi2 _ -> 1
+  | CGeqi2 _ -> 1
+
   sem delta (arg : Expr) =
   | CEqi _ ->
     match arg with TmConst (t & {val = CInt {val = n}}) then
@@ -532,6 +558,9 @@ lang CmpCharEval = CmpCharAst + ConstEval
   syn Const =
   | CEqc2 Char
 
+  sem constArity =
+  | CEqc2 _ -> 1
+
   sem delta (arg : Expr) =
   | CEqc _ ->
     match arg with TmConst (t & {val = CChar {val = c}}) then
@@ -563,6 +592,14 @@ lang CmpFloatEval = CmpFloatAst + ConstEval
   | CGtf2 Float
   | CGeqf2 Float
   | CNeqf2 Float
+
+  sem constArity =
+  | CEqf2 _ -> 1
+  | CLtf2 _ -> 1
+  | CLeqf2 _ -> 1
+  | CGtf2 _ -> 1
+  | CGeqf2 _ -> 1
+  | CNeqf2 _ -> 1
 
   sem delta (arg : Expr) =
   | CEqf _ ->
@@ -641,6 +678,9 @@ lang CmpSymbEval = CmpSymbAst + ConstEval
   syn Const =
   | CEqsym2 Symb
 
+  sem constArity =
+  | CEqsym2 _ -> 1
+
   sem delta (arg : Expr) =
   | CEqsym _ ->
     match arg with TmConst (t & {val = CSymb s}) then
@@ -653,6 +693,7 @@ lang CmpSymbEval = CmpSymbAst + ConstEval
 end
 
 lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
+
   syn Const =
   | CGet2 [Expr]
   | CSet2 [Expr]
@@ -674,6 +715,28 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
   | CFoldl3 (Expr, Expr)
   | CFoldr2 Expr
   | CFoldr3 (Expr, Expr)
+
+  sem constArity =
+  | CGet2 _ -> 1
+  | CSet2 _ -> 2
+  | CSet3 _ -> 3
+  | CCons2 _ -> 1
+  | CSnoc2 _ -> 1
+  | CConcat2 _ -> 1
+  | CSplitAt2 _ -> 1
+  | CCreate2 _ -> 1
+  | CCreateList2 _ -> 1
+  | CCreateRope2 _ -> 1
+  | CSubsequence2 _ -> 2
+  | CSubsequence3 _ -> 1
+  | CMap2 _ -> 1
+  | CMapi2 _ -> 1
+  | CIter2 _ -> 1
+  | CIteri2 _ -> 1
+  | CFoldl2 _ -> 2
+  | CFoldl3 _ -> 1
+  | CFoldr2 _ -> 2
+  | CFoldr3 _ -> 1
 
   sem delta (arg : Expr) =
   | CHead _ ->
@@ -859,7 +922,10 @@ end
 
 lang FileOpEval = FileOpAst + SeqAst + BoolAst + CharAst + UnknownTypeAst
   syn Const =
-  | CFileWrite2 string
+  | CFileWrite2 String
+
+  sem constArity =
+  | CFileWrite2 _ -> 1
 
   sem delta (arg : Expr) =
   | CFileRead _ ->
@@ -933,6 +999,9 @@ lang RandomNumberGeneratorEval = RandomNumberGeneratorAst + IntAst
   syn Const =
   | CRandIntU2 Int
 
+  sem constArity =
+  | CRandIntU2 _ -> 1
+
   sem delta (arg : Expr) =
   | CRandIntU _ ->
     match arg with TmConst c then
@@ -987,6 +1056,9 @@ end
 lang RefOpEval = RefOpAst + RefEval + IntAst
   syn Const =
   | CModRef2 Ref
+
+  sem constArity =
+  | CModRef2 _ -> 1
 
   sem delta (arg : Expr) =
   | CRef _ -> TmRef {ref = ref arg}
@@ -1044,6 +1116,29 @@ lang MapEval =
   | CMapEq3 (Expr -> Expr -> Expr, Map K V)
   | CMapCmp2 (Expr -> Expr -> Expr)
   | CMapCmp3 (Expr -> Expr -> Expr, Map K V)
+
+  sem constArity =
+  | CMapVal _ -> 0
+  | CMapInsert2 _ -> 2
+  | CMapInsert3 _ -> 1
+  | CMapRemove2 _ -> 1
+  | CMapFindExn2 _ -> 1
+  | CMapFindOrElse2 _ -> 2
+  | CMapFindOrElse3 _ -> 1
+  | CMapFindApplyOrElse2 _ -> 3
+  | CMapFindApplyOrElse3 _ -> 2
+  | CMapFindApplyOrElse4 _ -> 1
+  | CMapMem2 _ -> 1
+  | CMapAny2 _ -> 1
+  | CMapMap2 _ -> 1
+  | CMapMapWithKey2 _ -> 1
+  | CMapFoldWithKey2 _ -> 2
+  | CMapFoldWithKey3 _ -> 1
+  | CMapChooseOrElse2 _ -> 1
+  | CMapEq2 _ -> 2
+  | CMapEq3 _ -> 1
+  | CMapCmp2 _ -> 2
+  | CMapCmp3 _ -> 1
 
   sem _bindToRecord =
   | (k, v) ->
@@ -1262,6 +1357,24 @@ lang TensorOpEval =
   | CTensorEq2 Expr
   | CTensorEq3 (Expr, T)
   | CTensorToString2 Expr
+
+  sem constArity =
+  | CTensorCreateInt2 _ -> 1
+  | CTensorCreateFloat2 _ -> 1
+  | CTensorCreate2 _ -> 1
+  | CTensorGetExn2 _ -> 1
+  | CTensorSetExn2 _ -> 2
+  | CTensorSetExn3 _ -> 1
+  | CTensorReshapeExn2 _ -> 1
+  | CTensorTransposeExn2 _ -> 2
+  | CTensorTransposeExn3 _ -> 1
+  | CTensorSliceExn2 _ -> 1
+  | CTensorSubExn2 _ -> 2
+  | CTensorSubExn3 _ -> 1
+  | CTensorIterSlice2 _ -> 1
+  | CTensorEq2 _ -> 2
+  | CTensorEq3 _ -> 1
+  | CTensorToString2 _ -> 1
 
   sem _ofTmSeq =
   | TmSeq { tms = tms } ->
@@ -1556,6 +1669,21 @@ lang BootParserEval =
   | CBootParserGetConst2 BootParserTree
   | CBootParserGetPat2 BootParserTree
   | CBootParserGetInfo2 BootParserTree
+
+  sem constArity =
+  | CBootParserTree _ -> 0
+  | CBootParserParseMExprString2 _ -> 1
+  | CBootParserParseMCoreFile2 _ -> 2
+  | CBootParserParseMCoreFile3 _ -> 3
+  | CBootParserGetTerm2 _ -> 1
+  | CBootParserGetType2 _ -> 1
+  | CBootParserGetString2 _ -> 1
+  | CBootParserGetInt2 _ -> 1
+  | CBootParserGetFloat2 _ -> 1
+  | CBootParserGetListLength2 _ -> 1
+  | CBootParserGetConst2 _ -> 1
+  | CBootParserGetPat2 _ -> 1
+  | CBootParserGetInfo2 _ -> 1
 
   sem delta (arg : Expr) =
   | CBootParserParseMExprString _ ->

--- a/stdlib/pmexpr/ast.mc
+++ b/stdlib/pmexpr/ast.mc
@@ -175,13 +175,6 @@ lang PMExprAst = KeywordMaker + MExprAst + MExprEq + MExprANF + MExprTypeAnnot
       else None ()
     else None ()
 
-  sem isValue =
-  | TmAccelerate _ -> false
-  | TmParallelMap _ -> false
-  | TmParallelMap2 _ -> false
-  | TmParallelFlatMap _ -> false
-  | TmParallelReduce _ -> false
-
   sem normalize (k : Expr -> Expr) =
   | TmAccelerate t ->
     k (TmAccelerate {t with e = normalizeTerm t.e})

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -65,6 +65,11 @@ let setChooseExn : Set a -> a =
 lam s.
   match mapChooseExn s with (k, _) then k else never
 
+-- `setAny p s` returns true if the predicate p returns true for any element in
+-- s.
+let setAny: (a -> Bool) -> Set a -> Bool = lam p. lam s.
+  mapFoldWithKey (lam acc. lam v. lam. if acc then acc else p v) false s
+
 mexpr
 
 let s = setEmpty subi in
@@ -116,6 +121,9 @@ utest setCmp s6 s5 with negi 1 in
 utest setCmp s5 s7 with negi 3 in
 utest setCmp s7 s5 with 3 in
 utest setCmp s6 s7 with negi 3 in
+
+utest setAny (eqi 2) s5 with true in
+utest setAny (eqi 0) s5 with false in
 
 let sFold = setOfSeq subi [1,2,3,4,5] in
 utest setFold (lam acc. lam v. addi v acc) 0 sFold with 15 in

--- a/stdlib/tuning/decision-points.mc
+++ b/stdlib/tuning/decision-points.mc
@@ -222,9 +222,6 @@ lang HoleAst = IntAst + ANF + KeywordMaker
       else never
     else never
 
-  sem isValue =
-  | TmHole _ -> false
-
   sem next (last : Option Expr) (stepSize : Int) =
   | TmHole {inner = inner} ->
     hnext last stepSize inner


### PR DESCRIPTION
- Updates to CFA framework
  - Move init constraints to own fragment
  - Make constraint generation for TmApp and TmMatch modular.
- Change `isValue` to `liftANF` in `anf.mc`. There is now an ANF fragment  (`MExprANFAll`) that lifts *everything* (required for CFA labeling). For example,
   ```
   addi 1 1
   ```
   is transformed to
   ```
   let t = addi in
   let t2 = 1 in
   let t3 = 1 in
   let t4 = t t2 t3 in
   t4
   ```
   The fragment `MExprANF` still does *not* lift values (i.e., lambdas and constants) for backward compatibility.
- Clean up ANF tests a bit.
- Fixed inconsistency in `ast.mc` (`CBootParserGetType ()` -> `CBootParserGetType {}`)
- Add `constArity` function (in `mexpr/const-arity.mc` and `mexpr/eval.mc`)
- Add `setAny` function to `set.mc`.
