### PR TITLE
Use full ANF for CFA (and CFA refactoring)

### DIFF
--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -839,7 +839,7 @@ end
 lang SeqTotPatCFA = MatchCFA + SeqCFA + SeqTotPat
   sem propagateMatchConstraint (graph: CFAGraph) (id: Name) =
   | (PatSeqTot p, AVSeq { names = names }) ->
-    let f = lam graph. lam pat: Pat. setFold (lam graph. lam name.
+    let f = lam graph. lam pat: Pat. setFold (lam graph: CFAGraph. lam name.
         let cstrs =
           foldl (lam acc. lam f. concat (f id name pat) acc) [] graph.mcgfs
         in
@@ -851,7 +851,7 @@ end
 lang SeqEdgePatCFA = MatchCFA + SeqCFA + SeqEdgePat
   sem propagateMatchConstraint (graph: CFAGraph) (id: Name) =
   | (PatSeqEdge p, AVSeq { names = names } & av) ->
-    let f = lam graph. lam pat: Pat. setFold (lam graph. lam name.
+    let f = lam graph. lam pat: Pat. setFold (lam graph: CFAGraph. lam name.
         let cstrs = foldl (lam acc. lam f. concat (f id name pat) acc)
           [] graph.mcgfs in
         foldl initConstraint graph cstrs
@@ -871,7 +871,7 @@ lang RecordPatCFA = MatchCFA + RecordCFA + RecordPat
     -- Check if record pattern is compatible with abstract value record
     let compatible = mapAllWithKey (lam k. lam. mapMem k abindings) pbindings in
     if compatible then
-      mapFoldWithKey (lam graph. lam k. lam pb: Pattern.
+      mapFoldWithKey (lam graph: CFAGraph. lam k. lam pb: Pattern.
         let ab: Name = mapFindExn k abindings in
         let cstrs = foldl (lam acc. lam f. concat (f id ab pb) acc)
           [] graph.mcgfs in

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -969,7 +969,7 @@ let test: Bool -> Expr -> [String] -> [[AbsVal]] =
       match pprintCode 0 pprintEnvEmpty tANF with (env,tANFStr) in
       printLn "\n--- ANF ---";
       printLn tANFStr;
-      match cfaDebug (Some env) tANF with (env,cfaRes) in
+      match cfaDebug (Some env) tANF with (Some env,cfaRes) in
       match cfaGraphToString env cfaRes with (_, resStr) in
       printLn "\n--- FINAL CFA GRAPH ---";
       printLn resStr;


### PR DESCRIPTION
Based on the discussion during the last Miking meeting, this PR changes the fragment `MExprANFAll` to lift *everything*, including individual applications and lambdas. In contrast to my original intuition, this actually simplifies the CFA framework a lot.

**Edit:** Also refactors some aspects of `cfa.mc`

### Illustration for `MExprANFAll`
```
--- BEFORE ANF ---
addi
  1
  2

--- AFTER ANF ---
let t =
  addi
in
let t1 =
  1
in
let t2 =
  t
    t1
in
let t3 =
  2
in
let t4 =
  t2
    t3
in
t4

--- BEFORE ANF ---
lam x.
  lam y.
    lam z.
      1

--- AFTER ANF ---
let t =
  lam x.
    let t1 =
      lam y.
        let t2 =
          lam z.
            let t3 =
              1
            in
            t3
        in
        t2
    in
    t1
in
t
```