### PR TITLE
Add support for record polymorphism in the type checker

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -94,13 +94,15 @@ let tyvar_ =
   lam s.
   ntyvar_ (nameNoSym s)
 
-let ntyall_ = use AllTypeAst in
-  lam n. lam ty.
-  TyAll {ident = n, info = NoInfo (), ty = ty, sort = TypeVar ()}
+let nstyall_ = use AllTypeAst in
+  lam n. lam sort. lam ty.
+  TyAll {ident = n, info = NoInfo (), ty = ty, sort = sort}
 
-let tyall_ =
+let styall_ = lam s. nstyall_ (nameNoSym s)
+
+let tyall_ = use VarSortAst in
   lam s.
-  ntyall_ (nameNoSym s)
+  styall_ s (TypeVar ())
 
 let tyalls_ =
   lam strs. lam ty.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -96,7 +96,7 @@ let tyvar_ =
 
 let ntyall_ = use AllTypeAst in
   lam n. lam ty.
-  TyAll {ident = n, info = NoInfo (), ty = ty}
+  TyAll {ident = n, info = NoInfo (), ty = ty, sort = TypeVar ()}
 
 let tyall_ =
   lam s.

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -226,7 +226,8 @@ lang BootParser = MExprAst + ConstTransformer
   | 213 /-TyAll-/ ->
     TyAll {info = ginfo t 0,
            ident = gname t 0,
-           ty = gtype t 0}
+           ty = gtype t 0,
+           sort = TypeVar ()}
 
 
   -- Get constant help function

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -402,19 +402,21 @@ lang VarTypeCmp = Cmp + VarTypeAst
   | (TyVar t1, TyVar t2) -> nameCmp t1.ident t2.ident
 end
 
-lang FlexTypeCmp = Cmp + FlexTypeAst
+lang VarSortCmp = Cmp + VarSortAst
   sem cmpVarSort =
   | (RecordVar l, RecordVar r) ->
     mapCmp cmpType l.fields r.fields
   | (lhs, rhs) ->
     subi (constructorTag lhs) (constructorTag rhs)
+end
 
+lang FlexTypeCmp = VarSortCmp + FlexTypeAst
   sem cmpTypeH =
   | (TyFlex _ & lhs, rhs)
   | (lhs, TyFlex _ & rhs) ->
     match (resolveLink lhs, resolveLink rhs) with (lhs, rhs) in
     match (lhs, rhs) with (TyFlex t1, TyFlex t2) then
-    match (deref t1.contents, deref t2.contents) with (Unbound n1, Unbound n2) in
+      match (deref t1.contents, deref t2.contents) with (Unbound n1, Unbound n2) in
       let identDiff = nameCmp n1.ident n2.ident in
       if eqi identDiff 0 then
         cmpVarSort (n1.sort, n2.sort)

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -426,11 +426,15 @@ lang FlexTypeCmp = VarSortCmp + FlexTypeAst
     else subi (constructorTag lhs) (constructorTag rhs)
 end
 
-lang AllTypeCmp = Cmp + AllTypeAst
+lang AllTypeCmp = VarSortCmp + AllTypeAst
   sem cmpTypeH =
   | (TyAll t1, TyAll t2) ->
     let identDiff = nameCmp t1.ident t2.ident in
-    if eqi identDiff 0 then cmpType t1.ty t2.ty
+    if eqi identDiff 0 then
+      let sortDiff = cmpVarSort (t1.sort, t2.sort) in
+      if eqi sortDiff 0 then
+        cmpType t1.ty t2.ty
+      else sortDiff
     else identDiff
 end
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -654,12 +654,15 @@ lang FlexTypeEq = VarSortEq + FlexTypeAst
     else None ()
 end
 
-lang AllTypeEq = Eq + AllTypeAst
+lang AllTypeEq = VarSortEq + AllTypeAst
   sem eqTypeH (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) (lhs : Type) =
   | TyAll r ->
     match unwrapType typeEnv lhs with Some (TyAll l) then
-      let tyVarEnv = biInsert (l.ident, r.ident) typeEnv.tyVarEnv in
-      eqTypeH {typeEnv with tyVarEnv = tyVarEnv} free l.ty r.ty
+      optionBind (eqVarSort typeEnv free (l.sort, r.sort))
+        (lam free.
+          eqTypeH
+            {typeEnv with tyVarEnv = biInsert (l.ident, r.ident) typeEnv.tyVarEnv}
+            free l.ty r.ty)
     else None ()
 end
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -623,7 +623,7 @@ lang VarTypeEq = Eq + VarTypeAst
     else None ()
 end
 
-lang FlexTypeEq = Eq + FlexTypeAst
+lang VarSortEq = Eq + VarSortAst
   sem eqVarSort (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) =
   | (RecordVar l, RecordVar r) ->
       if eqi (mapSize l.fields) (mapSize r.fields) then
@@ -637,7 +637,9 @@ lang FlexTypeEq = Eq + FlexTypeAst
   | (lhs, rhs) ->
     if eqi (constructorTag lhs) (constructorTag rhs) then Some free
     else None ()
+end
 
+lang FlexTypeEq = VarSortEq + FlexTypeAst
   sem eqTypeH (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) (lhs : Type) =
   | TyFlex _ & rhs ->
     match (resolveLink lhs, resolveLink rhs) with (lhs, rhs) in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1118,7 +1118,7 @@ lang VarTypePrettyPrint = VarTypeAst
     pprintEnvGetStr env t.ident
 end
 
-lang FlexTypePrettyPrint = FlexTypeAst + RecordTypeAst
+lang VarSortPrettyPrint = VarSortAst + RecordTypePrettyPrint
   sem getVarSortStringCode (indent : Int) (env : PprintEnv) (idstr : String) =
   | TypeVar () -> (env, idstr)
   | WeakVar () -> (env, concat "_" idstr)
@@ -1127,7 +1127,9 @@ lang FlexTypePrettyPrint = FlexTypeAst + RecordTypeAst
       TyRecord {info = NoInfo (), fields = r.fields, labels = mapKeys r.fields} in
     match getTypeStringCode indent env recty with (env, recstr) in
     (env, join [idstr, "<:", recstr])
+end
 
+lang FlexTypePrettyPrint = FlexTypeAst + VarSortPrettyPrint
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
   | TyFlex t & ty ->
     match deref t.contents with Unbound t then

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1139,14 +1139,13 @@ lang FlexTypePrettyPrint = FlexTypeAst + VarSortPrettyPrint
       getTypeStringCode indent env (resolveLink ty)
 end
 
-lang AllTypePrettyPrint = AllTypeAst
+lang AllTypePrettyPrint = AllTypeAst + VarSortPrettyPrint
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyAll t ->
-    match pprintEnvGetStr env t.ident with (env, var) then
-      match getTypeStringCode indent env t.ty with (env, str) then
-        (env, join ["all ", var, ". ", str])
-      else never
-    else never
+    match pprintEnvGetStr env t.ident with (env, idstr) in
+    match getVarSortStringCode indent env idstr t.sort with (env, varstr) in
+    match getTypeStringCode indent env t.ty with (env, tystr) in
+    (env, join ["all ", varstr, ". ", tystr])
 end
 
 lang AppTypePrettyPrint = AppTypeAst

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -105,10 +105,11 @@ lang LetSym = Sym + LetAst + AllTypeAst
       let tyBody = symbolizeType env t.tyBody in
       let ty = symbolizeType env t.ty in
       let body =
-        match stripTyAll tyBody with (vars, _) then
-          let tyVarEnv = foldr (lam v. mapInsert (nameGetStr v) v) env.tyVarEnv vars in
-          symbolizeExpr {env with tyVarEnv = tyVarEnv} t.body
-        else never
+        match stripTyAll tyBody with (vars, _) in
+        let tyVarEnv =
+          foldr (lam v: (Name, VarSort). mapInsert (nameGetStr v.0) v.0)
+            env.tyVarEnv vars in
+        symbolizeExpr {env with tyVarEnv = tyVarEnv} t.body
       in
       if nameHasSym t.ident then
         TmLet {{{{t with tyBody = tyBody}
@@ -294,16 +295,18 @@ lang VarTypeSym = VarTypeAst + UnknownTypeAst
         TyUnknown {info = t.info}
 end
 
-lang AllTypeSym = AllTypeAst
+lang AllTypeSym = AllTypeAst + VarSortAst
   sem symbolizeType (env : SymEnv) =
   | TyAll t & ty ->
     if nameHasSym t.ident then ty
     else
+      let sort = smap_VarSort_Type (symbolizeType env) t.sort in
       let str = nameGetStr t.ident in
       let ident = nameSetNewSym t.ident in
       let env = {env with tyVarEnv = mapInsert str ident env.tyVarEnv} in
-      TyAll {{t with ident = ident}
-                with ty = symbolizeType env t.ty}
+      TyAll {{{t with ident = ident}
+                 with ty = symbolizeType env t.ty}
+                 with sort = sort}
 end
 
 --------------


### PR DESCRIPTION
This PR extends the typechecker to handle polymorphism in records. Specifically, it adds bounded polymorphism for record types, so that a function like
```ocaml
let mapPair =
  lam f. lam r.
  match r with (x, y) in (x, f y)
```
is assigned the type `all a. all b. all c. all r<:(c,a). (a -> b) -> r -> (c,b)`. This lets us express a subset of the things we would be able to with row polymorphism, and was relatively straightforward to add given the approach used to infer record types. Note that I have not yet added syntax for writing bounds like this in type annotations : they only exist in the type checker.

I know I promised to work on better error messages, but I couldn't resist adding this while I was at it. I will work on the error messages next though.

With this, the only thing remaining to be able to typecheck all of the current codebase should be handling type aliases with parameters.

EDIT: I have now updated this PR so that the record polymorphism is disabled by default but can be enabled using a parameter to the `typeCheck` function. When record polymorphism is disabled, the behaviour is as before, so that an unannotated record parameter to a function is assumed to be monomorphic. Note that using annotations it is still possible to write functions on polymorphic records (just not polymorphic over the fields of the record):
```ocaml
let mapPair : all a. all b. all c. (a -> b) -> (c, a) -> (c, b) =
  lam f. lam r.
  match r with (x, y) in (x, f y)
```
typechecks fine.

In addition, this PR improves the type checker code somewhat and fixes a bug.