### PR TITLE
`cfa.mc` and `pprint.mc` updates

### DIFF
--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -43,10 +43,13 @@ type CFAGraph = {
   -- Contains a list of functions used for generating match constraints
   -- TODO(dlunde,2021-11-17): Should be added as a product extension
   -- in the MatchCFA fragment instead, when possible.
-  mcgfs: [MatchGenFun]
+  mcgfs: [MatchGenFun],
 
   -- NOTE(dlunde,2021-11-18): Data needed for analyses based on this framework
-  -- must be put here directly, since we do not yet have product extensions.
+  -- must be put below directly, since we do not yet have product extensions.
+
+  -- Used for alignment analysis in miking-dppl
+  stochMatches: Set Name
 
 }
 
@@ -54,7 +57,8 @@ let emptyCFAGraph = {
   worklist = [],
   data = mapEmpty nameCmp,
   edges = mapEmpty nameCmp,
-  mcgfs = []
+  mcgfs = [],
+  stochMatches = setEmpty nameCmp
 }
 
 -------------------


### PR DESCRIPTION
- `mexpr/cfa.mc`
  - Add entry in `CFAGraph` needed for analysis in `miking-dppl` (should optimally be added directly in `miking-dppl` with product extensions).
  - Refactor tests to produce readable error messages.
- `mexpr/pprint.mc`
  - Add correct handling for variables with keyword names in MExpr through the new function `mexprToString`. For example, a variable with the name `#var"lam"` is printed as `lam1` so it does not clash with the keyword `lam`. Note that the old `expr2str` does _not_ handle MExpr keywords correctly. I did not want to add this, since (I think) `expr2str` is currently reused across different languages (which would probably like to include further keywords, like in CorePPL for example).
