### PR TITLE
Add execution time dependency analysis for holes

### DIFF
--- a/stdlib/tuning/const-dep.mc
+++ b/stdlib/tuning/const-dep.mc
@@ -1,0 +1,283 @@
+include "mexpr/ast.mc"
+
+-- Language fragment that describes how data- and execution time dependencies
+-- flow from input parameters to the result for constants.
+
+let _constDepData = (true,false)
+let _constDepExe = (false,true)
+let _constDepBoth = (true,true)
+let _constDepNone = (false,false)
+
+lang IntDep = IntAst
+  sem constDep =
+  | CInt _ -> []
+end
+
+lang ArithIntDep = ArithIntAst
+  sem constDep =
+  | CAddi _ -> [_constDepData, _constDepData]
+  | CSubi _ -> [_constDepData, _constDepData]
+  | CMuli _ -> [_constDepData, _constDepData]
+  | CDivi _ -> [_constDepData, _constDepData]
+  | CNegi _ -> [_constDepData]
+  | CModi _ -> [_constDepData]
+end
+
+lang ShiftIntDep = ShiftIntAst
+  sem constDep =
+  | CSlli _ -> [_constDepData]
+  | CSrli _ -> [_constDepData]
+  | CSrai _ -> [_constDepData]
+end
+
+lang FloatDep = FloatAst
+  sem constDep =
+  | CFloat _ -> []
+end
+
+lang ArithFloatDep = ArithFloatAst
+  sem constDep =
+  | CAddf _ -> [_constDepData, _constDepData]
+  | CSubf _ -> [_constDepData, _constDepData]
+  | CMulf _ -> [_constDepData, _constDepData]
+  | CDivf _ -> [_constDepData, _constDepData]
+  | CNegf _ -> [_constDepData]
+end
+
+lang FloatIntConversionDep = FloatIntConversionAst
+  sem constDep =
+  | CFloorfi _ -> [_constDepData]
+  | CCeilfi _ -> [_constDepData]
+  | CRoundfi _ -> [_constDepData]
+  | CInt2float _ -> [_constDepData]
+end
+
+lang BoolDep = BoolAst
+  sem constDep =
+  | CBool _ -> []
+end
+
+lang CmpIntDep = CmpIntAst
+  sem constDep =
+  | CEqi _ -> [_constDepData, _constDepData]
+  | CNeqi _ -> [_constDepData, _constDepData]
+  | CLti _ -> [_constDepData, _constDepData]
+  | CGti _ -> [_constDepData, _constDepData]
+  | CLeqi _ -> [_constDepData, _constDepData]
+  | CGeqi _ -> [_constDepData, _constDepData]
+end
+
+lang CmpFloatDep = CmpFloatAst
+  sem constDep =
+  | CEqf _ -> [_constDepData, _constDepData]
+  | CLtf _ -> [_constDepData, _constDepData]
+  | CLeqf _ -> [_constDepData, _constDepData]
+  | CGtf _ -> [_constDepData, _constDepData]
+  | CGeqf _ -> [_constDepData, _constDepData]
+  | CNeqf _ -> [_constDepData, _constDepData]
+end
+
+lang CharDep = CharAst
+  sem constDep =
+  | CChar _ -> []
+end
+
+lang CmpCharDep = CmpCharAst
+  sem constDep =
+  | CEqc _ -> [_constDepData, _constDepData]
+end
+
+lang IntCharConversionDep = IntCharConversionAst
+  sem constDep =
+  | CInt2Char _ -> [_constDepData]
+  | CChar2Int _ -> [_constDepData]
+end
+
+lang FloatStringConversionDep = FloatStringConversionAst
+  sem constDep =
+  -- NOTE(Linnea,2021-11-19): technically, the execution times of these
+  -- conversions depend on the length of the strings, but we ignore that for
+  -- now.
+  | CStringIsFloat _ -> [_constDepData]
+  | CString2float _ -> [_constDepData]
+  | CFloat2string _ -> [_constDepData]
+end
+
+lang SymbDep = SymbAst
+  sem constDep =
+  | CSymb _ -> []
+  | CGensym _ -> [_constDepNone]
+  | CSym2hash _ -> [_constDepData]
+end
+
+lang CmpSymbDep = CmpSymbAst
+  sem constDep =
+  | CEqsym _ -> [_constDepData, _constDepData]
+end
+
+lang SeqOpDep = SeqOpAst
+  -- TODO(Linnea,2021-11-22): Does not handle different behaviors for Rope and
+  -- List. E.g., concat is linear for list but not for Rope. Moreover,
+  -- operations that are O(1) for both might have different constants. E.g.,
+  -- perhaps 'cons' should have execution dep. and not just data.
+  sem constDep =
+  -- NOTE(Linnea,2021-11-19): Assumes that the execution time of set and get
+  -- depends on the index.
+  | CSet _ -> [_constDepBoth, _constDepData, _constDepBoth]
+  | CGet _ -> [_constDepBoth, _constDepBoth]
+  | CCons _ -> [_constDepData, _constDepData] -- NOTE(Linnea,2021-11-22): Assumes O(1)
+  | CSnoc _ -> [_constDepData, _constDepData] -- NOTE(Linnea,2021-11-22): Assumes O(1)
+  | CConcat _ -> [_constDepData, _constDepData] -- NOTE(Linnea,2021-11-22): Assumes O(1)
+  | CLength _ -> [_constDepData] -- NOTE(Linnea,2021-11-22): Assumes O(1)
+  | CReverse _ -> [_constDepBoth] -- NOTE(Linnea,2021-11-22): Assumes > O(1)
+  | CHead _ -> [_constDepData] -- NOTE(Linnea,2021-11-22): Assumes O(1)
+  | CTail _ -> [_constDepData] -- NOTE(Linnea,2021-11-22): Assumes O(1)
+  | CNull _ -> [_constDepData] -- NOTE(Linnea,2021-11-22): Assumes O(1)
+  | CMap _ -> [_constDepBoth, _constDepBoth]
+  | CMapi _ -> [_constDepBoth, _constDepBoth]
+  | CIter _ -> [_constDepExe, _constDepExe]
+  | CIteri _ -> [_constDepExe, _constDepExe]
+  | CFoldl _ -> [_constDepBoth, _constDepBoth, _constDepBoth]
+  | CFoldr _ -> [_constDepBoth, _constDepBoth, _constDepBoth]
+  | CCreate _ -> [_constDepBoth, _constDepBoth]
+  | CCreateList _ -> [_constDepBoth, _constDepBoth]
+  | CCreateRope _ -> [_constDepData, _constDepBoth]  -- NOTE(Linnea,2021-11-22): Assumes length does not affect creation time of Rope
+  | CSplitAt _ -> [_constDepBoth, _constDepBoth]
+  | CSubsequence _ -> [_constDepBoth, _constDepBoth, _constDepBoth]
+end
+
+lang FileOpDep = FileOpAst
+  sem constDep =
+  | CFileRead _ -> [_constDepBoth]
+  | CFileWrite _ -> [_constDepNone, _constDepExe]
+  | CFileExists _ -> [_constDepData]
+  | CFileDelete _ -> [_constDepNone]
+end
+
+lang IODep = IOAst
+  sem constDep =
+  | CPrint _ -> [_constDepNone]
+  | CPrintError _ -> [_constDepNone]
+  | CDPrint _ -> [_constDepNone]
+  | CFlushStdout _ -> [_constDepNone]
+  | CFlushStderr _ -> [_constDepNone]
+  | CReadLine _ -> [_constDepNone]
+  | CReadBytesAsString _ -> [_constDepData]
+end
+
+lang RandomNumberGeneratorDep = RandomNumberGeneratorAst
+  sem constDep =
+  | CRandIntU _ -> [_constDepData,_constDepData]
+  | CRandSetSeed _ -> [_constDepNone]
+end
+
+lang SysDep = SysAst
+  sem constDep =
+  | CExit _ -> [_constDepNone]
+  | CError _ -> [_constDepNone]
+  | CArgv _ -> []
+  | CCommand _ -> [_constDepBoth]
+end
+
+lang TimeDep = TimeAst
+  sem constDep =
+  | CWallTimeMs _ -> [_constDepNone]
+  | CSleepMs _ -> [_constDepExe]
+end
+
+lang ConTagDep = ConTagAst
+  sem constDep =
+  | CConstructorTag _ -> [_constDepData]
+end
+
+-- NOTE(Linnea, 2021-11-22): This is not sufficient for tracking data flow of
+-- references. For example:
+--   let r = ref <data1> in
+--   let r2 = r in
+--   modref r2 <data2> in
+--   let x = deref r in  <-- {data1} ⊆ x, {data2} ⊈ x
+lang RefOpDep = RefOpAst
+  sem constDep =
+  | CRef _ -> [_constDepData]
+  | CModRef _ -> [_constDepNone,_constDepNone]
+  | CDeRef _ -> [_constDepData]
+end
+
+-- NOTE(Linnea, 2021-11-22): Assumes that all elements take equal time to
+-- insert, delete, or find.
+lang MapDep = MapAst
+  sem constDep =
+  | CMapEmpty _ -> [_constDepData]
+  | CMapInsert _ -> [_constDepData,_constDepData,_constDepBoth]
+  | CMapRemove _ -> [_constDepData,_constDepBoth]
+  | CMapFindExn _ -> [_constDepData,_constDepBoth]
+  | CMapFindOrElse _ -> [_constDepBoth,_constDepData,_constDepBoth]
+  | CMapFindApplyOrElse _ -> [_constDepBoth,_constDepBoth,_constDepData,_constDepBoth]
+  | CMapBindings _ -> [_constDepBoth]
+  | CMapChooseExn _ -> [_constDepData] -- NOTE(Linnea, 2021-11-22): Assuming O(1).
+  | CMapChooseOrElse _ -> [_constDepBoth,_constDepData]
+  | CMapSize _ -> [_constDepBoth] -- NOTE(Linnea, 2021-11-22): Assuming O(n).
+  | CMapMem _ -> [_constDepData,_constDepBoth]
+  | CMapAny _ -> [_constDepBoth,_constDepBoth]
+  | CMapMap _ -> [_constDepBoth,_constDepBoth]
+  | CMapMapWithKey _ -> [_constDepBoth,_constDepBoth]
+  | CMapFoldWithKey _ -> [_constDepBoth,_constDepBoth,_constDepBoth] -- NOTE(Linnea, 2021-11-22): Assuming accumulator's start value affects execution time, which it does in the general case, but perhaps not so often in practice.
+  | CMapEq _ -> [_constDepBoth,_constDepBoth,_constDepBoth]
+  | CMapCmp _ -> [_constDepBoth,_constDepBoth,_constDepBoth]
+  | CMapGetCmpFun _ -> [_constDepData] -- NOTE(Linnea, 2021-11-22): Implies that
+                                       -- a data dependency that entered through
+                                       -- an element in the map may
+                                       -- "contaminate" the compare function.
+end
+
+lang TensorOpDep = TensorOpAst
+  sem constDep =
+  | CTensorCreateInt _ -> error "TensorOpDep not implemented yet"
+  | CTensorCreateFloat _ -> error "TensorOpDep not implemented yet"
+  | CTensorCreate _ -> error "TensorOpDep not implemented yet"
+  | CTensorGetExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorSetExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorRank _ -> error "TensorOpDep not implemented yet"
+  | CTensorShape _ -> error "TensorOpDep not implemented yet"
+  | CTensorReshapeExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorCopy _ -> error "TensorOpDep not implemented yet"
+  | CTensorTransposeExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorSliceExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorSubExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorIterSlice _ -> error "TensorOpDep not implemented yet"
+  | CTensorEq _ -> error "TensorOpDep not implemented yet"
+  | CTensorToString _ -> error "TensorOpDep not implemented yet"
+end
+
+lang BootParserDep = BootParserAst
+  sem constDep =
+  | CBootParserParseMExprString _ -> error "BootParserDep not implemented yet"
+  | CBootParserParseMCoreFile _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetId _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetTerm _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetType _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetString _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetInt _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetFloat _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetListLength _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetConst _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetPat _ -> error "BootParserDep not implemented yet"
+  | CBootParserGetInfo _ -> error "BootParserDep not implemented yet"
+end
+
+lang MExprConstDep =
+  IntDep + ArithIntDep + ShiftIntDep + FloatDep + ArithFloatDep +
+  FloatIntConversionDep + BoolDep + CmpIntDep + CmpFloatDep +
+  CharDep + CmpCharDep + IntCharConversionDep +
+  FloatStringConversionDep + SymbDep + CmpSymbDep + SeqOpDep +
+  FileOpDep + IODep + RandomNumberGeneratorDep + SysDep + TimeDep +
+  ConTagDep + RefOpDep + MapDep + TensorOpDep + BootParserDep
+
+mexpr
+
+use MExprConstDep in
+
+utest constDep (CInt {val = 0}) with [] in
+utest constDep (CAddi {}) with [_constDepData,_constDepData] in
+
+()

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -1,0 +1,530 @@
+-- Analysis of data- and execution time dependency for holes.
+
+include "name.mc"
+include "common.mc"
+
+include "decision-points.mc"
+include "const-dep.mc"
+
+include "mexpr/cfa.mc"
+include "mexpr/const-arity.mc"
+include "mexpr/symbolize.mc"
+
+lang MExprHoleCFA = Holes + MExprCFA + MExprArity
+
+  syn AbsVal =
+  | AVDHole { id : Name }
+  | AVEHole { id : Name }
+  | AVConst { const : Const, args : [Name] }
+
+  sem absValToString (env : PprintEnv) =
+  | AVDHole {id = id} -> (env, join ["dhole", "(", nameGetStr id, ")"])
+  | AVEHole {id = id} -> (env, join ["ehole", "(", nameGetStr id, ")"])
+  | AVConst { const = const, args = args } ->
+    let const = getConstStringCode 0 const in
+    let args = strJoin ", " (map nameGetStr args) in
+    (env, join [const, "(", args, ")"])
+
+  sem cmpAbsValH =
+  | (AVDHole {id = id1}, AVDHole {id = id2}) -> nameCmp id1 id2
+  | (AVEHole {id = id1}, AVEHole {id = id2}) -> nameCmp id1 id2
+  | (AVConst lhs, AVConst rhs) ->
+    use ConstCmp in
+    let cmp = cmpConst lhs.const rhs.const in
+    if eqi 0 cmp then subi (length lhs.args) (length rhs.args)
+    else cmp
+
+  syn Constraint =
+    -- {dhole} ⊆ lhs ⇒ {dhole} ⊆ rhs
+  | CstrHoleDirect { lhs: Name, rhs: Name }
+    -- {dhole} ⊆ lhs ⇒ ({dhole} ⊆ res) AND ({ehole} ⊆ res)
+  | CstrHoleApp { lhs: Name, res: Name }
+    -- ({const with args = args} ⊆ lhs AND |args| = arity(const)-1
+    --    ⇒ ∀(a,i): (a,i) in ({args} ∪ {rhs} ⨯ [1,...,arity(const)]):
+    --        if const is data dep on position i AND {dhole} ⊆ a ⇒ {dhole} ⊆ res
+    --        AND
+    --        if const is exe dep on position i AND {dhole} ⊆ a ⇒ {ehole} ⊆ res)
+    -- AND
+    -- ({const with args = args} ⊆ lhs AND |args| < arity(const)-1
+    --    ⇒ {const with args = snoc args rhs } ⊆ res)
+  | CstrConstApp { lhs: Name, rhs : Name, res: Name }
+    -- {dhole} ⊆ lhs ⇒ {ehole} ⊆ res
+  | CstrHoleMatch { lhs: Name, res: Name }
+
+  sem initConstraint (graph : CFAGraph) =
+  | CstrHoleApp r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrHoleDirect r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrConstApp r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrHoleMatch r & cstr -> initConstraintName r.lhs graph cstr
+
+  sem propagateConstraint (update : (Name, AbsVal)) (graph : CFAGraph) =
+  | CstrHoleDirect { lhs = lhs, rhs = rhs } ->
+    match update.1 with AVDHole _ & av then addData graph av rhs else graph
+  | CstrHoleApp { lhs = lhs, res = res } ->
+    match update.1 with AVDHole {id = id} & av then
+      let graph = addData graph av res in
+      addData graph (AVEHole {id = id}) res
+    else graph
+  | CstrHoleMatch { lhs = lhs, res = res } ->
+    match update.1 with AVDHole {id = id} then addData graph (AVEHole {id = id}) res else graph
+  | CstrConstApp { lhs = lhs, rhs = rhs, res = res } ->
+    use MExprConstDep in
+    match update.1 with AVConst ({ const = const, args = args } & avc) then
+      let arity = constArity const in
+      let args = snoc args rhs in
+      if eqi arity (length args) then
+        -- Last application, analyse data and execution time
+        let cdeps = constDep const in
+        let graph = foldl (lam graph. lam argDep : (Name, (Bool, Bool)).
+          let arg = argDep.0 in
+          let dep = argDep.1 in
+          let isDataDep = dep.0 in
+          let isExeDep = dep.1 in
+          let s = dataLookup arg graph in
+          let avHoles : [Name] = setFold (lam acc. lam e.
+            match e with AVDHole {id = id} then cons id acc
+            else acc) [] s
+          in
+          -- Add data dependencies to the result
+          let graph =
+            if isDataDep then
+              foldl (lam acc. lam id. addData acc (AVDHole {id=id}) res)
+                graph avHoles
+            else graph
+          in
+          -- Add execution time dependencies the result
+          if isExeDep then
+            foldl (lam acc. lam id. addData acc (AVEHole {id = id}) res)
+              graph avHoles
+          else graph) graph (zip args cdeps) in
+        graph
+      else
+        -- Curried application, just add the new argument
+        addData graph (AVConst { avc with args = args }) res
+    else graph
+
+  sem generateHoleConstraints =
+  | _ -> []
+    -- Holes
+  | TmLet { ident = ident, body = TmHole _} ->
+    [ CstrInit {lhs = AVDHole {id = ident}, rhs = ident } ]
+  | TmLet { ident = ident, body = TmConst { val = c } } ->
+    let arity = constArity c in
+    if eqi arity 0 then []
+    else [ CstrInit { lhs = AVConst { const = c, args = [] }, rhs = ident }
+         ]
+  | TmLet { ident = ident, body = TmApp app} ->
+    match app.lhs with TmVar l then
+      match app.rhs with TmVar r then [
+        CstrHoleApp { lhs = l.ident, res = ident},
+        CstrConstApp { lhs = l.ident, rhs = r.ident, res = ident }
+      ]
+      else infoErrorExit (infoTm app.rhs) "Not a TmVar in application"
+    else infoErrorExit (infoTm app.lhs) "Not a TmVar in application"
+
+  sem constraintToString (env: PprintEnv) =
+  | CstrHoleDirect { lhs = lhs, rhs = rhs } ->
+    match pprintVarName env rhs with (env,rhs) in
+    match pprintVarName env lhs with (env,lhs) in
+    (env, join [ "{dhole} ⊆ ", lhs, " ⇒ {dhole} ⊆ ", rhs ])
+  | CstrHoleApp { lhs = lhs, res = res } ->
+    match pprintVarName env lhs with (env,lhs) in
+    match pprintVarName env res with (env,res) in
+    (env, join [
+      "{dhole} ⊆ ", lhs, " ⇒ {dhole} ⊆ ", res ])
+  | CstrHoleMatch { lhs = lhs, res = res } ->
+    match pprintVarName env lhs with (env,lhs) in
+    match pprintVarName env res with (env,res) in
+    (env, join [
+      "{dhole} ⊆ ", lhs, " ⇒ {ehole} ⊆ ", res ])
+  | CstrConstApp { lhs = lhs, rhs = rhs, res = res } ->
+    match pprintVarName env lhs with (env,lhs) in
+    match pprintVarName env rhs with (env,rhs) in
+    match pprintVarName env res with (env,res) in
+    (env, join [
+      "({const with args = args} ⊆ ", lhs, " AND |args| = arity(const)-1\n",
+      "  ⇒ ∀(a,i): (a,i) in ({args} ∪ {", rhs, "} ⨯ [1,...,arity(const)]):\n",
+      "    if const is data dep. on position i AND {dhole} ⊆ a ⇒ {dhole} ⊆ ", res, "\n",
+      "    AND\n",
+      "    if const is exe. dep. on position i AND {dhole} ⊆ a ⇒ {ehole} ⊆ ", res, ")\n",
+      "AND\n",
+      "({const with args = args} ⊆ ", lhs, " AND |args| < arity(const)-1\n",
+      "  ⇒ {const with args = snoc args ", rhs, "} ⊆ ", res, ")"
+    ])
+
+  sem generateHoleMatchResConstraints (id: Name) (target: Name) =
+  | ( PatSeqTot _
+    | PatSeqEdge _
+    | PatCon _
+    | PatInt _
+    | PatChar _
+    | PatBool _
+    ) & pat -> [
+      CstrHoleDirect { lhs = target, rhs = id },
+      CstrHoleMatch { lhs = target, res = id }
+    ]
+  | ( PatAnd p
+    | PatOr p
+    | PatNot p
+    ) -> infoErrorExit p.info "Pattern currently not supported"
+  | _ -> []
+
+  sem generateHoleMatchConstraints (id: Name) (target: Name) =
+  | pat ->
+    recursive let f = lam acc. lam pat.
+      let acc = match pat with PatNamed { ident = PName name }
+                             | PatSeqEdge { middle = PName name }
+                then cons name acc else acc in
+      sfold_Pat_Pat f acc pat
+    in
+    let pnames = f [] pat in
+    foldl (lam acc. lam name.
+      cons (CstrHoleDirect { lhs = target, rhs = name }) acc
+    ) [] pnames
+
+  -- Type: Expr -> CFAGraph
+  sem initGraph =
+  | t ->
+
+    -- Initial graph
+    let graph = emptyCFAGraph in
+
+    -- Initialize match constraint generating functions
+    let graph = { graph with mcgfs = [ generateMatchConstraints
+                                     , generateHoleMatchConstraints
+                                     , generateHoleMatchResConstraints
+                                     ] } in
+
+    -- Initialize constraint generating functions
+    let cgfs = [ generateConstraints
+               , generateConstraintsMatch graph.mcgfs
+               , generateHoleConstraints
+               ] in
+
+    -- Recurse over program and generate constraints
+    let cstrs: [Constraint] = collectConstraints cgfs [] t in
+
+    -- Initialize all collected constraints
+    let graph = foldl initConstraint graph cstrs in
+
+    -- Return graph
+    graph
+
+end
+
+lang Test = MExprHoleCFA + BootParser + MExprANFAll + MExprSym
+
+mexpr
+use Test in
+
+-- Test functions --
+let debug = false in
+let parse = lam str.
+  let ast = parseMExprString decisionPointsKeywords str in
+  let ast = makeKeywords [] ast in
+  symbolize ast
+in
+let test: Bool -> Expr -> [String] -> [[AbsVal]] =
+  lam debug: Bool. lam t: Expr. lam vars: [String].
+    if debug then
+      -- Version with debug printouts
+      let tANF = normalizeTerm t in
+      match pprintCode 0 pprintEnvEmpty t with (_,tStr) in
+      printLn "\n--- ORIGINAL PROGRAM ---";
+      printLn tStr;
+      match pprintCode 0 pprintEnvEmpty tANF with (env,tANFStr) in
+      printLn "\n--- ANF ---";
+      printLn tANFStr;
+      match cfaDebug (Some env) tANF with (Some env,cfaRes) in
+      match cfaGraphToString env cfaRes with (_, resStr) in
+      printLn "\n--- FINAL CFA GRAPH ---";
+      printLn resStr;
+      let cfaRes : CFAGraph = cfaRes in
+      map (lam var: String.
+        let binds = mapBindings cfaRes.data in
+        let res = foldl (lam acc. lam b : (Name, Set AbsVal).
+          if eqString var (nameGetStr b.0) then b.1 else acc
+        ) (setEmpty cmpAbsVal) binds in
+        (var, res)
+      ) vars
+
+    else
+      -- Version without debug printouts
+      let tANF = normalizeTerm t in
+      let cfaRes : CFAGraph = cfa tANF in
+      map (lam var: String.
+        let binds = mapBindings cfaRes.data in
+        let res = foldl (lam acc. lam b : (Name, Set AbsVal).
+          if eqString var (nameGetStr b.0) then b.1 else acc
+        ) (setEmpty cmpAbsVal) binds in
+        (var, res)
+      ) vars
+in
+
+-- Custom equality function for testing lambda control flow only
+type Dep = {d: [String], e: [String]} in
+let eqTestHole = eqSeq (lam t1:(String,Set AbsVal). lam t2:(String,Dep).
+  if eqString t1.0 t2.0 then
+    let data = setFold (lam acc. lam av.
+      match av with AVDHole {id = id} then cons (nameGetStr id) acc else acc)
+      [] t1.1
+    in
+    let exe = setFold (lam acc. lam av.
+      match av with AVEHole {id = id} then cons (nameGetStr id) acc else acc)
+      [] t1.1
+    in
+    let deps : Dep = t2.1 in
+    if setEq (setOfSeq cmpString data) (setOfSeq cmpString deps.d) then
+      setEq (setOfSeq cmpString exe) (setOfSeq cmpString deps.e)
+    else false
+  else false
+) in
+--------------------
+
+let t = parse
+"
+let h1 = hole (Boolean {default = true}) in
+let h2 = hole (Boolean {default = true}) in
+let x = h1 in
+let y = h2 in
+x
+"
+in
+
+utest test debug t ["h1", "h2", "x", "y"]
+with [("h1", {d = ["h1"], e = []}),("h2", {d = ["h2"], e = []}),("x", {d = ["h1"], e = []}),("y", {d = ["h2"], e = []})]
+using eqTestHole in
+
+
+let t = parse
+"
+let foo = lam.
+  let h = hole (Boolean {default = true}) in
+  h
+in
+let x = foo () in x
+"
+in
+
+utest test debug t ["x"]
+with [("x", {d = ["h"], e = []})]
+using eqTestHole in
+
+
+let t = parse
+"
+let foo = lam x.
+  x
+in
+let h = hole (Boolean {default = true}) in
+let y = foo h in y
+"
+in
+
+utest test debug t ["x", "y"]
+with [("x", {d = ["h"], e = []}), ("y", {d = ["h"], e = []})]
+using eqTestHole in
+
+
+let t = parse
+"
+let foo = lam x.
+  let h = hole (Boolean {default = true}) in
+  2
+in
+let h1 = hole (Boolean {default = true}) in
+let y = foo 3 in
+let z = foo h1 in
+y
+"
+in
+
+utest test debug t ["y", "z"]
+with [("y", {d = [], e = []}), ("z", {d = [], e = []})]
+using eqTestHole in
+
+
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+let x = if h then 1 else 2 in
+let y = if true then 1 else 2 in
+let z = if true then h else 2 in
+let a = match h with h1 then true else false in
+let b = match h with h1 then h1 else false in
+x
+"
+in
+
+utest test debug t ["x", "y", "z", "a", "b", "h"]
+with [ ("x", {d=["h"],e=["h"]})
+     , ("y", {d=[],e=[]})
+     , ("z", {d=["h"],e=[]})
+     , ("a", {d = [], e = []})
+     , ("b", {d=["h"],e=[]})
+     , ("h", {d=["h"],e=[]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+let f = if h then lam x. x else lam x. x in
+let a = f 1 in
+a
+"
+in
+
+utest test debug t ["f", "a"]
+with [ ("f", {d=["h"],e=["h"]})
+     , ("a", {d=["h"],e=["h"]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+let h1 = hole (IntRange {default = 1, min = 0, max = 1}) in
+let h2 = hole (IntRange {default = 1, min = 0, max = 1}) in
+let x = negi h1 in
+let y = addi 3 x in
+let y2 = addi h1 h2 in
+let z = sleepMs y in
+x
+"
+in
+
+utest test false t ["x", "y", "z", "y2"]
+with [ ("x", {d=["h1"],e=[]})
+     , ("y", {d=["h1"],e=[]})
+     , ("z", {d=[],e=["h1"]})
+     , ("y2",{d=["h1", "h2"],e=[]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+let r = {x = h, y = 2} in
+let a = r.x in
+let b = if r.x then true else false in
+let c = match r with {x = x, y = 2} then 2 else 42 in
+let d = match r with {x = true} then 2 else 42 in
+let e = r.y in
+()
+"
+in
+
+utest test debug t ["a", "b", "c", "d", "e"]
+with [ ("a", {d=["h"],e=[]})
+     , ("b", {d=["h"],e=["h"]})
+     , ("c", {d=[],e=[]})
+     , ("d", {d=["h"],e=["h"]})
+     , ("e", {d=[],e=[]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+let f = lam y. if y then 1 else 2 in
+let h = hole (Boolean {default = true}) in
+let x = f h in
+x
+"
+in
+
+utest test debug t ["x"]
+with [ ("x", {d=["h"],e=["h"]}) ]
+using eqTestHole in
+
+
+let t = parse
+"
+let h1 = hole (IntRange {default = 1, min = 1, max = 2}) in
+let h2 = hole (IntRange {default = 1, min = 1, max = 2}) in
+let h3 = hole (IntRange {default = 1, min = 1, max = 2}) in
+
+let f = lam x. lam y.
+  addi x y
+in
+let a = f h1 1 in
+let b = f 1 h2 in
+let c = f h1 h2 in
+let d = f h2 h3 in
+()
+" in
+
+utest test debug t ["a", "b", "c", "d"]
+with [ ("a",{d=["h1","h2","h3"],e=[]})
+     , ("b",{d=["h1","h2","h3"],e=[]})
+     , ("c",{d=["h1","h2","h3"],e=[]})
+     , ("d",{d=["h1","h2","h3"],e=[]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+-- Direct data-flow --
+let h = hole (Boolean {default = true}) in
+let x1 = h in -- { d(h) } ⊆ x1
+
+-- Applications --
+let f1 = lam x. x in
+let x2 = f1 h in -- { d(h) } ⊆ x2
+-- Limitation of 0-CFA: x22 gets d(h) because of above application
+let x22 = f1 3 in -- { d(h) } ⊆ x22
+
+let f2 = lam x. 3 in
+let x3 = f2 h in -- { } ⊆ x3
+
+-- Matches --
+let r = {a = h, b = false} in
+-- x4 is both data and execution time dependent. In a more exact analysis,
+-- it should only be data dependent since the two branches have equal execution time.
+let x4 = match r with {a = true} then 1 else 2 in -- { d(h), e(h) ⊆ x4 }
+-- x5 is not dependent on h since the match can never fail
+let x5 = match r with {a = a, b = false} then 1 else 2 in -- { } ⊆ x5
+
+let f = lam x. if x then 1 else 2 in
+let g = lam f. f h in
+let x6 = g f in -- { d(h), e(h) } ⊆ x6
+
+let f = if h then lam x. x else lam y. y in
+-- Similar for x4, x0 should not have e(h).
+-- Possibly, we could detect that it shouldn't have d(h) either.
+let x0 = f 1 in  -- { d(h), e(h) } ⊆ x0
+
+-- Constants --
+let h1 = hole (IntRange {default = 1, min = 1, max = 2}) in
+let h2 = hole (IntRange {default = 1, min = 1, max = 2}) in
+
+let x7 = addi 1 h1 in  -- { d(h1) } ⊆ x7
+let x8 = addi 1 h2 in -- { d(h2) } ⊆ x8
+let x9 = addi h1 h2 in  -- { d(h1), d(h2) } ⊆ x9
+
+()
+" in
+utest test true t ["x1", "x2", "x22", "x3", "x4", "x5", "x6", "x0", "x7", "x8", "x9"]
+with [ ("x1", {d=["h"],e=[]})
+     , ("x2", {d=["h"],e=[]})
+     , ("x22", {d=["h"],e=[]})
+     , ("x3", {d=[],e=[]})
+     , ("x4", {d=["h"],e=["h"]})
+     , ("x5", {d=[],e=[]})
+     , ("x6", {d=["h"],e=["h"]})
+     , ("x0", {d=["h"],e=["h"]})
+     , ("x7", {d=["h1"],e=[]})
+     , ("x8", {d=["h2"],e=[]})
+     , ("x9", {d=["h1", "h2"],e=[]})
+     ]
+using eqTestHole
+in
+
+
+-- TODO(Linnea,2021-11-22): test sequences, maps
+
+()


### PR DESCRIPTION
Uses 0-CFA to analyze execution time dependencies of holes in MExpr programs. See the top of the file `hole-cfa.mc` for more information.

Example:
```
-- Matches --
let h = hole (Boolean {default = true}) in
let r = {a = h, b = false} in
let x4 = match r with {a = true} then 1 else 2 in -- { d(h), e(h) ⊆ x4 }
-- x5 is not dependent on h since the match can never fail
let x5 = match r with {a = a, b = false} then 1 else 2 in -- { } ⊆ x5

let f = lam x. if x then 1 else 2 in
let g = lam f. f h in
let x6 = g f in -- { d(h), e(h) } ⊆ x6

-- Constants --
let h1 = hole (IntRange {default = 1, min = 1, max = 2}) in
let h2 = hole (IntRange {default = 1, min = 1, max = 2}) in

let x7 = addi 1 h1 in  -- { d(h1) } ⊆ x7
let x8 = addi 1 h2 in -- { d(h2) } ⊆ x8
let x9 = addi h1 h2 in  -- { d(h1), d(h2) } ⊆ x9

()
```