### PR TITLE
Refactoring of `tuning` directory

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -12,7 +12,7 @@ include "mexpr/type-annot.mc"
 include "mexpr/type-check.mc"
 include "mexpr/remove-ascription.mc"
 include "mexpr/utesttrans.mc"
-include "tuning/decision-points.mc"
+include "tuning/context-expansion.mc"
 include "tuning/tune-file.mc"
 include "ocaml/ast.mc"
 include "ocaml/mcore.mc"
@@ -96,7 +96,7 @@ let compile = lam files. lam options : Options. lam args.
       pruneExternalUtests = not options.disablePruneExternalUtests,
       pruneExternalUtestsWarning = not options.disablePruneExternalUtestsWarning,
       findExternalsExclude = true,
-      keywords = concat decisionPointsKeywords parallelKeywords
+      keywords = concat holeKeywords parallelKeywords
     } file in
     let ast = makeKeywords [] ast in
 

--- a/src/main/mi.mc
+++ b/src/main/mi.mc
@@ -26,7 +26,7 @@ Commands:
   eval       Evaluates a .mc file using an internal interpreter
   compile    Compiles a .mc file into an executable with the same name
   run        Combines eval and compile, to run the program as fast as possible
-  tune       Tunes a program with decision points
+  tune       Tunes a program with holes
 
 If no command is given, the file will be executed using the run command
 and all arguments after the file are arguments to the .mc executed file.

--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -6,7 +6,7 @@ include "compile.mc"
 include "options.mc"
 include "sys.mc"
 include "parse.mc"
-include "tuning/decision-points.mc"
+include "tuning/context-expansion.mc"
 include "tuning/tune.mc"
 
 lang MCoreTune =
@@ -32,7 +32,7 @@ let tune = lam files. lam options : Options. lam args.
       pruneExternalUtests = not options.disablePruneExternalUtests,
       pruneExternalUtestsWarning = not options.disablePruneExternalUtestsWarning,
       findExternalsExclude = true,
-      keywords = decisionPointsKeywords
+      keywords = holeKeywords
     } file in
     let ast = makeKeywords [] ast in
 
@@ -42,8 +42,8 @@ let tune = lam files. lam options : Options. lam args.
     let ast = symbolize ast in
     let ast = normalizeTerm ast in
 
-    -- Flatten the decision points
-    match flatten [] ast with
+    -- Context expand the holes
+    match contextExpand [] ast with
       { ast = ast, table = table, tempFile = tempFile, cleanup = cleanup,
         env = env, tempDir = tempDir }
     then

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -1,0 +1,210 @@
+include "mexpr/ast.mc"
+include "mexpr/anf.mc"
+include "mexpr/keyword-maker.mc"
+include "mexpr/boot-parser.mc"
+
+-- Defines AST nodes for holes.
+
+let holeKeywords = ["hole", "Boolean", "IntRange"]
+
+let _lookupExit = lam info : Info. lam s : String. lam m : Map String a.
+  mapLookupOrElse (lam. infoErrorExit info (concat s " not found")) s m
+
+let _expectConstInt = lam info : Info. lam s. lam i.
+  use IntAst in
+  match i with TmConst {val = CInt {val = i}} then i
+  else infoErrorExit info (concat "Expected a constant integer: " s)
+
+lang HoleAstBase = IntAst + ANF + KeywordMaker
+  syn Hole =
+
+  syn Expr =
+  | TmHole {default : Expr,
+            depth : Int,
+            ty : Type,
+            info : Info,
+            inner : Hole}
+
+  sem infoTm =
+  | TmHole h -> h.info
+
+  sem tyTm =
+  | TmHole {ty = ty} -> ty
+
+  sem symbolizeExpr (env : SymEnv) =
+  | TmHole h -> TmHole h
+
+  sem default =
+  | TmHole {default = default} -> default
+  | t -> smap_Expr_Expr default t
+
+  sem isAtomic =
+  | TmHole _ -> false
+
+  sem pprintHole =
+
+  sem pprintCode (indent : Int) (env : SymEnv) =
+  | TmHole t ->
+    match pprintCode indent env t.default with (env, default) then
+      match pprintHole t.inner with (keyword, bindings) then
+        (env, join
+          [ "hole ("
+          , keyword
+          , " {"
+          , "depth = ", int2string t.depth, ", "
+          , "default = ", default, ", "
+          , strJoin ", "
+            (map (lam b : (String, String). join [b.0, " = ", b.1])
+               bindings)
+          ,  "}"
+          , ")"
+          ])
+      else never
+    else never
+
+  sem next (last : Option Expr) (stepSize : Int) =
+  | TmHole {inner = inner} ->
+    hnext last stepSize inner
+
+  sem hnext (last : Option Expr) (stepSize : Int) =
+
+  sem sample =
+  | TmHole {inner = inner} ->
+    hsample inner
+
+  sem hsample =
+
+  sem normalize (k : Expr -> Expr) =
+  | TmHole ({default = default} & t) ->
+    k (TmHole {t with default = normalizeTerm t.default})
+
+  sem isKeyword =
+  | TmHole _ -> true
+
+  sem matchKeywordString (info : Info) =
+  | "hole" -> Some (1, lam lst. head lst)
+
+  sem _mkHole (info : Info) (hty : Type) (holeMap : Map String Expr -> Hole)
+              (validate : Expr -> Expr) =
+  | arg ->
+    use RecordAst in
+    match arg with TmRecord {bindings = bindings} then
+      let bindings = mapFromSeq cmpString
+        (map (lam t : (SID, Expr). (sidToString t.0, t.1))
+           (mapBindings bindings)) in
+      let default = _lookupExit info "default" bindings in
+      let depth = mapLookupOrElse (lam. int_ 0) "depth" bindings in
+      validate
+        (TmHole { default = default
+                , depth = _expectConstInt info "depth" depth
+                , info = info
+                , ty = hty
+                , inner = holeMap bindings})
+    else error "impossible"
+end
+
+-- A Boolean hole.
+lang HoleBoolAst = BoolAst + HoleAstBase
+  syn Hole =
+  | BoolHole {}
+
+  sem hsample =
+  | BoolHole {} ->
+    get [true_, false_] (randIntU 0 2)
+
+  sem hnext (last : Option Expr) (stepSize : Int) =
+  | BoolHole {} ->
+    match last with None () then Some false_
+    else match last with Some (TmConst {val = CBool {val = false}}) then
+      Some true_
+    else match last with Some (TmConst {val = CBool {val = true}}) then
+      None ()
+    else never
+
+  sem fromString =
+  | "true" -> true
+  | "false" -> false
+
+  sem matchKeywordString (info : Info) =
+  | "Boolean" ->
+    Some (1,
+      let validate = lam expr.
+        match expr with TmHole {default = default} then
+          match default with TmConst {val = CBool _} then expr
+          else infoErrorExit info "Default value not a constant Boolean"
+        else infoErrorExit info "Not a hole" in
+
+      lam lst. _mkHole info tybool_ (lam. BoolHole {}) validate (get lst 0))
+
+  sem pprintHole =
+  | BoolHole {} ->
+    ("Boolean", [])
+end
+
+-- An integer hole (range of integers).
+lang HoleIntRangeAst = IntAst + HoleAstBase
+  syn Hole =
+  | HIntRange {min : Int,
+              max : Int}
+
+  sem hsample =
+  | HIntRange {min = min, max = max} ->
+    int_ (randIntU min (addi max 1))
+
+  sem hnext (last : Option Expr) (stepSize : Int) =
+  | HIntRange {min = min, max = max} ->
+    match last with None () then Some (int_ min)
+    else match last with Some (TmConst {val = CInt {val = i}}) then
+      if eqi i max then
+        None ()
+      else
+        let next = addi i stepSize in
+        utest geqi next min with true in
+        if leqi next max then Some (int_ next)
+        else None ()
+    else never
+
+  sem matchKeywordString (info : Info) =
+  | "IntRange" ->
+    Some (1,
+      let validate = lam expr.
+        match expr
+        with TmHole {default = TmConst {val = CInt {val = i}},
+                     inner = HIntRange {min = min, max = max}}
+        then
+          if and (leqi min i) (geqi max i) then expr
+          else infoErrorExit info "Default value is not within range"
+        else infoErrorExit info "Not a hole" in
+
+      lam lst. _mkHole info tyint_
+        (lam m.
+           let min = _expectConstInt info "min" (_lookupExit info "min" m) in
+           let max = _expectConstInt info "max" (_lookupExit info "max" m) in
+           if leqi min max then
+             HIntRange {min = min, max = max}
+           else infoErrorExit info
+             (join ["Empty domain: ", int2string min, "..", int2string max]))
+        validate (get lst 0))
+
+  sem pprintHole =
+  | HIntRange {min = min, max = max} ->
+    ("IntRange", [("min", int2string min), ("max", int2string max)])
+end
+
+let holeBool_ = use HoleBoolAst in
+  lam default. lam depth.
+  TmHole { default = default
+         , depth = depth
+         , ty = tybool_
+         , info = NoInfo ()
+         , inner = BoolHole {}}
+
+let holeIntRange_ = use HoleIntRangeAst in
+  lam default. lam depth. lam min. lam max.
+  TmHole { default = default
+         , depth = depth
+         , ty = tyint_
+         , info = NoInfo ()
+         , inner = HIntRange {min = min, max = max}}
+
+lang HoleAst = HoleAstBase + HoleBoolAst + HoleIntRangeAst

--- a/stdlib/tuning/call-graph.mc
+++ b/stdlib/tuning/call-graph.mc
@@ -1,0 +1,311 @@
+include "mexpr/ast.mc"
+include "mexpr/symbolize.mc"
+include "mexpr/anf.mc"
+include "mexpr/ast-builder.mc" -- for tests
+
+include "digraph.mc"
+
+include "name-info.mc"
+
+-- Call graph creation for programs with holes.
+
+-- Assumes that the AST is symbolized and in ANF.
+
+type CallGraph = DiGraph NameInfo NameInfo
+
+let callGraphNames = lam cg.
+  map (lam t : NameInfo. t.0) (digraphVertices cg)
+
+let _callGraphNameSeq = lam seq.
+  map (lam t : (NameInfo, NameInfo, NameInfo).
+    ((t.0).0, (t.1).0, (t.2).0)) seq
+
+let callGraphEdgeNames = lam cg.
+  _callGraphNameSeq (digraphEdges cg)
+
+-- The top of the call graph, has no incoming edges.
+let _callGraphTop = (nameSym "top", NoInfo ())
+
+type Binding = {ident : Name, body : Expr, info : Info}
+let _handleLetVertex = use LamAst in
+  lam f. lam letexpr : Binding.
+    match letexpr.body with TmLam lm then
+      cons (letexpr.ident, letexpr.info) (f lm.body)
+    else f letexpr.body
+
+let _handleApps = use AppAst in use VarAst in
+  lam id. lam f. lam prev. lam g. lam name2info. lam app.
+    recursive let appHelper = lam g. lam app.
+      match app with TmApp {lhs = TmVar v, rhs = rhs} then
+        let resLhs =
+          if digraphHasVertex (v.ident, v.info) g then
+            let correctInfo : Info = mapFindExn v.ident name2info in
+            [(prev, (v.ident, correctInfo), id)]
+          else []
+        in concat resLhs (f g prev name2info rhs)
+      else match app with TmApp {lhs = TmApp a, rhs = rhs} then
+        let resLhs = appHelper g (TmApp a) in
+        concat resLhs (f g prev name2info rhs)
+      else match app with TmApp a then
+        concat (f g prev name2info a.lhs) (f g prev name2info a.rhs)
+      else never
+  in appHelper g app
+
+-- Construct a call graph from an AST. The nodes are named functions, and the
+-- edges are calls to named functions. Complexity O(|V|*|F|), as we visit each
+-- node exactly once and each time potentially perform a graph union operation,
+-- which we assume has complexity O(|F|). V is the set of nodes in the AST and F
+-- is the set of nodes in the call graph (i.e. set of functions in the AST).
+lang HoleCallGraph = LetAst + LamAst + RecLetsAst
+  sem toCallGraph =
+  | arg ->
+    let gempty = digraphAddVertex _callGraphTop
+      (digraphEmpty nameInfoCmp nameInfoEq) in
+    let g = digraphAddVertices (_findVertices arg) gempty in
+    let infoMap = mapFromSeq nameCmp (digraphVertices g) in
+    let edges = _findEdges g _callGraphTop infoMap arg in
+    digraphAddEdges edges g
+
+  sem _findVertices =
+  | TmLet t ->
+    concat
+      (_handleLetVertex _findVertices
+        {ident = t.ident, body = t.body, info = t.info})
+      (_findVertices t.inexpr)
+
+  | TmRecLets t ->
+    let res =
+      foldl (lam acc. lam b : RecLetBinding.
+               concat acc
+                 (_handleLetVertex _findVertices
+                   {ident = b.ident, body = b.body, info = b.info}))
+            [] t.bindings
+    in concat res (_findVertices t.inexpr)
+
+  | tm ->
+    sfold_Expr_Expr concat [] (smap_Expr_Expr _findVertices tm)
+
+  sem _findEdges (cg : CallGraph) (prev : NameInfo) (name2info : Map Name Info) =
+  | TmLet ({body = TmApp a} & t) ->
+    let resBody = _handleApps (t.ident, t.info) _findEdges prev cg name2info t.body in
+    concat resBody (_findEdges cg prev name2info t.inexpr)
+
+  | TmLet ({body = TmLam lm} & t) ->
+    let resBody = _findEdges cg (t.ident, t.info) name2info lm.body in
+    concat resBody (_findEdges cg prev name2info t.inexpr)
+
+  | TmRecLets t ->
+    let res =
+      let handleBinding = lam g. lam b : RecLetBinding.
+        match b with { body = TmLam { body = lambody }, ident = ident, info = info } then
+          _findEdges g (ident, info) name2info lambody
+        else
+          _findEdges g prev name2info b.body
+      in foldl (lam acc. lam b. concat acc (handleBinding cg b)) [] t.bindings
+    in concat res (_findEdges cg prev name2info t.inexpr)
+
+  | tm ->
+    sfold_Expr_Expr concat [] (smap_Expr_Expr (_findEdges cg prev name2info) tm)
+
+end
+
+lang TestLang = HoleCallGraph + MExprSym + MExprANF
+
+mexpr
+
+use TestLang in
+
+let anf = compose normalizeTerm symbolize in
+
+type CallGraphTest = {ast : Expr, expected : Expr, vs : [String],
+                      calls : [(String, String)]} in
+
+let doCallGraphTests = lam r : CallGraphTest.
+  let tests = lam ast. lam strVs : [String]. lam strEdgs : [(String, String)].
+
+    let toStr = lam ng.
+      let edges = map (lam t : (NameInfo, NameInfo, NameInfo).
+        match t with (from, to, label) then
+          (nameGetStr from.0, nameGetStr to.0, label.0)
+        else never
+      ) (digraphEdges ng) in
+
+      let vertices = map nameInfoGetStr (digraphVertices ng) in
+
+      digraphAddEdges edges (digraphAddVertices vertices (digraphEmpty cmpString _eqn))
+    in
+    let sg = toStr (toCallGraph ast) in
+
+    utest eqsetEqual eqString strVs (digraphVertices sg) with true in
+
+    let es = digraphEdges sg in
+    utest length es with length strEdgs in
+    map (lam t : (String, String).
+      utest digraphIsSuccessor t.1 t.0 sg with true in ()) strEdgs
+  in
+  tests (anf r.ast) r.vs r.calls
+in
+
+-- 1
+let constant = {
+  ast = int_ 1,
+  expected = int_ 1,
+  vs = ["top"],
+  calls = []
+} in
+
+-- let foo = lam x. x in ()
+let identity = {
+  ast = ulet_ "foo" (ulam_ "x" (var_ "x")),
+  expected = uunit_,
+  vs = ["top", "foo"],
+  calls = []
+} in
+
+-- let foo = lam x. x in
+-- let bar = lam x. foo x in ()
+let funCall = {
+  ast = bind_ (ulet_ "foo" (ulam_ "x" (var_ "x")))
+              (ulet_ "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))),
+  expected = uunit_,
+  vs = ["top", "foo", "bar"],
+  calls = [("bar", "foo")]
+} in
+
+-- let foo = lam x. x in
+-- let bar = lam x. addi (foo x) (foo x) in
+-- bar 1
+let ast =
+  bindall_ [identity.ast,
+            ulet_ "bar" (ulam_ "x" (addi_ (app_ (var_ "foo") (var_ "x"))
+                                         (app_ (var_ "foo") (var_ "x")))),
+            (app_ (var_ "bar") (int_ 1))] in
+let callSameFunctionTwice = {
+  ast = ast,
+  expected = int_ 2,
+  vs = ["top", "foo", "bar"],
+  calls = [("top", "bar"), ("bar", "foo"), ("bar", "foo")]
+} in
+
+--let foo = lam x. lam y. addi x y in
+--foo 1 2
+let twoArgs = {
+  ast = bind_
+          (ulet_ "foo"
+            (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))))
+          (appf2_ (var_ "foo") (int_ 1) (int_ 2)),
+  expected = int_ 3,
+  vs = ["top", "foo"],
+  calls = [("top", "foo")]
+} in
+
+-- let foo = lam a. lam b.
+--     let bar = lam x. addi b x in
+--     let b = 3 in
+--     addi (bar b) a
+-- in ()
+let innerFun = {
+  ast = ulet_ "foo" (ulam_ "a" (ulam_ "b" (
+          let bar = ulet_ "bar" (ulam_ "x"
+                         (addi_ (var_ "b") (var_ "x"))) in
+          let babar = ulet_ "b" (int_ 3) in
+          bind_ bar (
+          bind_ babar (
+            addi_ (app_ (var_ "bar")
+                        (var_ "b"))
+                  (var_ "a")))))),
+  expected = uunit_,
+  vs = ["top", "foo", "bar"],
+  calls = [("foo", "bar")]
+} in
+
+-- let foo = lam x. x in
+-- let a = foo 1 in
+-- a
+let letWithFunCall = {
+  ast = let foo = ulet_ "foo" (ulam_ "x" (var_ "x")) in
+        let a = ulet_ "a" (app_ (var_ "foo") (int_ 1)) in
+        bind_ (bind_ foo a) (var_ "a"),
+  expected = int_ 1,
+  vs = ["top", "foo"],
+  calls = [("top", "foo")]
+} in
+
+-- recursive let factorial = lam n.
+--     if eqi n 0 then
+--       1
+--     else
+--       muli n (factorial (subi n 1))
+-- in
+-- factorial 4
+let factorial = {
+  ast = bind_
+    (ureclets_add "factorial"
+           (lam_ "n" (tyint_)
+                 (if_ (eqi_ (var_ "n") (int_ 0))
+                      (int_ 1)
+                      (muli_ (var_ "n")
+                             (app_ (var_ "factorial")
+                                   (subi_ (var_ "n")
+                                          (int_ 1))))))
+     reclets_empty)
+    (app_ (var_ "factorial") (int_ 2)),
+  expected = int_ 2,
+  vs = ["top", "factorial"],
+  calls = [("top", "factorial"), ("factorial", "factorial")]
+} in
+
+-- recursive
+--     let even = lam x.
+--         if eqi x 0
+--         then true
+--         else odd (subi x 1)
+--     let odd = lam x.
+--         if eqi x 1
+--         then true
+--         else even (subi x 1)
+-- in even 4
+let evenOdd ={
+  ast = bind_
+    (ureclets_add "even" (ulam_ "x" (if_ (eqi_ (var_ "x") (int_ 0))
+                                       (true_)
+                                       (app_ (var_ "odd") (subi_ (var_ "x") (int_ 1)))))
+    (ureclets_add "odd" (ulam_ "x" (if_ (eqi_ (var_ "x") (int_ 1))
+                                      (true_)
+                                      (app_ (var_ "even") (subi_ (var_ "x") (int_ 1)))))
+     reclets_empty))
+    (app_ (var_ "even") (int_ 2)),
+  expected = true_,
+  vs = ["top", "even", "odd"],
+  calls = [("top", "even"), ("even", "odd"), ("odd", "even")]
+} in
+
+-- let bar = lam y. y in
+-- let foo = lam f. lam x. f x in -- cannot see that foo calls bar
+-- foo bar 1
+let hiddenCall = {
+  ast = bindall_ [
+          ulet_ "bar" (ulam_ "y" (var_ "y")),
+          ulet_ "foo" (ulam_ "f" (ulam_ "x" (app_ (var_ "f") (var_ "x")))),
+          appf2_ (var_ "foo") (var_ "bar") (int_ 1)],
+  expected = int_ 1,
+  vs = ["top", "foo", "bar"],
+  calls = [("top", "foo")]
+} in
+
+
+let cgTests =
+[ constant
+, identity
+, funCall
+, callSameFunctionTwice
+, innerFun
+, letWithFunCall
+, factorial
+, evenOdd
+, hiddenCall
+] in
+
+map doCallGraphTests cgTests;
+
+()

--- a/stdlib/tuning/decision-points.mc
+++ b/stdlib/tuning/decision-points.mc
@@ -75,8 +75,8 @@ let _callGraphTop = (nameSym "top", NoInfo ())
 type Binding = {ident : Name, body : Expr, info : Info}
 let _handleLetVertex = use LamAst in
   lam f. lam letexpr : Binding.
-    match letexpr.body with TmLam lm
-    then cons (letexpr.ident, letexpr.info) (f lm.body)
+    match letexpr.body with TmLam lm then
+      cons (letexpr.ident, letexpr.info) (f lm.body)
     else f letexpr.body
 
 let _handleApps = use AppAst in use VarAst in
@@ -85,11 +85,7 @@ let _handleApps = use AppAst in use VarAst in
       match app with TmApp {lhs = TmVar v, rhs = rhs} then
         let resLhs =
           if digraphHasVertex (v.ident, v.info) g then
-            let correctInfo : Info = mapFindExn v.ident name2info
-              -- match
-              --   find (lam n : NameInfo. nameEq v.ident n.0) (digraphVertices g)
-              -- with Some v then v else error "impossible"
-            in
+            let correctInfo : Info = mapFindExn v.ident name2info in
             [(prev, (v.ident, correctInfo), id)]
           else []
         in concat resLhs (f g prev name2info rhs)
@@ -106,7 +102,7 @@ let _handleApps = use AppAst in use VarAst in
 -- node exactly once and each time potentially perform a graph union operation,
 -- which we assume has complexity O(|F|). V is the set of nodes in the AST and F
 -- is the set of nodes in the call graph (i.e. set of functions in the AST).
-lang Ast2CallGraph = LetAst + LamAst + RecLetsAst
+lang HoleCallGraph = LetAst + LamAst + RecLetsAst
   sem toCallGraph =
   | arg ->
     let gempty = digraphAddVertex _callGraphTop
@@ -799,7 +795,7 @@ type Flattened =
 }
 
 -- Fragment for transforming a program with decision points.
-lang FlattenHoles = Ast2CallGraph + HoleAst + IntAst
+lang FlattenHoles = HoleCallGraph + HoleAst + IntAst
   -- 'flatten public t' eliminates all decision points in the expression 't' and
   --  and replace them by lookups in a static table One reference per function
   --  tracks which function that latest called that function, thereby

--- a/stdlib/tuning/decision-points.mc
+++ b/stdlib/tuning/decision-points.mc
@@ -1012,7 +1012,7 @@ lang FlattenHoles = HoleCallGraph + HoleAst + IntAst
   | TmLet ({ body = TmLam lm } & t) ->
     let curBody = (t.ident, t.info) in
     match _maintainCallCtx lookup env eqPaths curBody t.body with (env, body) in
-    match _maintainCallCtx lookup env eqPaths curBody t.inexpr with (env, inexpr) in
+    match _maintainCallCtx lookup env eqPaths cur t.inexpr with (env, inexpr) in
     ( env,
       TmLet {{t with body = body}
                 with inexpr = inexpr})

--- a/stdlib/tuning/decision-points.mc
+++ b/stdlib/tuning/decision-points.mc
@@ -998,7 +998,8 @@ lang FlattenHoles = Ast2CallGraph + HoleAst + IntAst
   -- Decision point: lookup the value depending on call history.
   | TmLet ({ body = TmHole { depth = depth }, ident = ident} & t) ->
     let lookupCode =
-      if eqi depth 0 then
+      let isTop = nameInfoEq cur _callGraphTop in
+      if or (eqi depth 0) isTop then
         let env = callCtxAddHole t.body (ident, t.info) [[]] cur env in
         lookup (callCtxHole2Idx (ident, t.info) [] env)
       else

--- a/stdlib/tuning/eq-paths.mc
+++ b/stdlib/tuning/eq-paths.mc
@@ -2,13 +2,12 @@ include "digraph.mc"
 include "string.mc"
 include "eqset.mc"
 
--- This file implements eqPaths: computing equivalence paths for decision
--- points.
+-- Computes equivalence paths for holes.
 
 -- 'eqPaths g endNode depth startNodes' computes representative paths in the
 -- call graph 'g' for the equivalence classes used for classifying computation
--- contexts for decision points. The paths are suffixes of paths starting in
--- any of the 'startNodes' and end in 'endNode'.
+-- contexts for holes. The paths are suffixes of paths starting in any of the
+-- 'startNodes' and end in 'endNode'.
 let eqPaths : Digraph -> a -> Int -> [a] -> [[a]] =
   lam g. lam endNode. lam depth. lam startNodes.
     -- Reverse graph for forward search (more efficient for adjacency map)

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -24,17 +24,18 @@
 -- in
 -- ()
 
-include "name.mc"
-include "common.mc"
-
-include "decision-points.mc"
-include "const-dep.mc"
-
 include "mexpr/cfa.mc"
 include "mexpr/const-arity.mc"
 include "mexpr/symbolize.mc"
+include "mexpr/cmp.mc"
 
-lang MExprHoleCFA = Holes + MExprCFA + MExprArity
+include "name.mc"
+include "common.mc"
+
+include "ast.mc"
+include "const-dep.mc"
+
+lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
 
   syn AbsVal =
   | AVDHole { id : Name }
@@ -244,7 +245,7 @@ use Test in
 -- Test functions --
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprString decisionPointsKeywords str in
+  let ast = parseMExprString holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in

--- a/stdlib/tuning/name-info.mc
+++ b/stdlib/tuning/name-info.mc
@@ -1,0 +1,26 @@
+include "name.mc"
+
+-- Defines simple convenience functions for name-info tuples.
+
+let _eqn = lam n1. lam n2.
+  if and (nameHasSym n1) (nameHasSym n2) then
+    nameEqSym n1 n2
+  else
+    error "Name without symbol."
+
+type NameInfo = (Name, Info)
+
+let nameInfoCmp = lam v1 : NameInfo. lam v2 : NameInfo.
+  nameCmp v1.0 v2.0
+
+let nameInfoEq = lam l1 : NameInfo. lam l2 : NameInfo.
+  _eqn l1.0 l2.0
+
+let nameInfoGetStr = lam ni : NameInfo.
+  nameGetStr ni.0
+
+let nameInfoGetName = lam ni : NameInfo.
+  ni.0
+
+let nameInfoGetInfo = lam ni : NameInfo.
+  ni.1

--- a/stdlib/tuning/tune-file.mc
+++ b/stdlib/tuning/tune-file.mc
@@ -66,7 +66,7 @@ let _tuneTable2str = lam table : LookupTable.
   strJoin _delim rows
 
 let tuneFileDump = lam env : CallCtxEnv. lam table : LookupTable. lam format : TuneFileFormat.
-  let hole2idx = deref env.hole2idx in
+  let hole2idx = env.hole2idx in
   let hole2fun = deref env.hole2fun in
   let verbosePath = deref env.verbosePath in
   let callGraph = env.callGraph in

--- a/stdlib/tuning/tune-file.mc
+++ b/stdlib/tuning/tune-file.mc
@@ -49,9 +49,9 @@ in concat withoutExtension tuneFileExtension
 
 let _vertexPath : NameInfo -> Int -> Env -> [NameInfo] = lam h : NameInfo. lam i : Int. lam env : CallCtxEnv.
   match env with {verbosePath = verbosePath, hole2fun = hole2fun} then
-    let edgePath = mapFindExn i (deref verbosePath) in
+    let edgePath = mapFindExn i verbosePath in
     match edgePath with [] then
-      [mapFindExn h (deref hole2fun)]
+      [mapFindExn h hole2fun]
     else
       let lastEdge : (NameInfo, NameInfo, NameInfo) = last edgePath in
       let destination = lastEdge.1 in
@@ -67,8 +67,8 @@ let _tuneTable2str = lam table : LookupTable.
 
 let tuneFileDump = lam env : CallCtxEnv. lam table : LookupTable. lam format : TuneFileFormat.
   let hole2idx = env.hole2idx in
-  let hole2fun = deref env.hole2fun in
-  let verbosePath = deref env.verbosePath in
+  let hole2fun = env.hole2fun in
+  let verbosePath = env.verbosePath in
   let callGraph = env.callGraph in
 
   let entry2str = lam holeInfo : NameInfo. lam path : [NameInfo]. lam i : Int.

--- a/stdlib/tuning/tune-file.mc
+++ b/stdlib/tuning/tune-file.mc
@@ -1,5 +1,5 @@
 
-include "decision-points.mc"
+include "context-expansion.mc"
 include "string.mc"
 
 -- Defines helpers for writing to and reading from a tune file.

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -560,7 +560,7 @@ let tuneEntry =
     (match options.seed with Some seed then randSetSeed seed else ());
 
     let holes : [Expr] = deref env.idx2hole in
-    let hole2idx : Map NameInfo (Map [NameInfo] Int) = deref env.hole2idx in
+    let hole2idx : Map NameInfo (Map [NameInfo] Int) = env.hole2idx in
 
     -- Runs the program with a given command-line input and optional timeout
     let runner = lam input : String. lam timeoutMs : Option Float.

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -1,13 +1,15 @@
 include "ext/local-search.mc"
+
 include "sys.mc"
 include "string.mc"
 include "map.mc"
-include "decision-points.mc"
-include "tune-options.mc"
 include "common.mc"
+
+include "context-expansion.mc"
+include "tune-options.mc"
 include "tune-file.mc"
 
--- Performs tuning of a flattened program with decision points.
+-- Performs tuning of a context expanded program with holes.
 
 -- Start time of search.
 let tuneSearchStart = ref 0.
@@ -45,7 +47,7 @@ let _timingResult2str : TimingResult -> String = lam t.
   case Timeout {ms = ms} then join ["Timeout at ", float2string ms, " ms"]
   end
 
-lang TuneBase = Holes
+lang TuneBase = HoleAst
   sem tune (options : TuneOptions) (run : Runner) (holes : Expr)
            (file : String) (hole2idx : Map NameInfo (Map [NameInfo] Int)) =
   -- Intentionally left blank
@@ -65,7 +67,7 @@ lang TuneBase = Holes
       else
         let msg = strJoin " "
         [ "Program returned non-zero exit code during tuning\n"
-        , "decision point values:\n", _tuneTable2str table, "\n"
+        , "hole values:\n", _tuneTable2str table, "\n"
         , "command line arguments:", strJoin " " args, "\n"
         , "stdout:", res.stdout, "\n"
         , "stderr:", res.stderr
@@ -246,7 +248,7 @@ lang TuneLocalSearch = TuneBase + LocalSearchBase
 end
 
 -- Explore the search space exhaustively, i.e. try all combinations of all
--- decision points. The decision points are explored from left to right.
+-- holes. The holes are explored from left to right.
 lang TuneExhaustive = TuneLocalSearch
   syn MetaState =
   | Exhaustive {prev : [Option Expr], exhausted : Bool}
@@ -298,10 +300,10 @@ lang TuneExhaustive = TuneLocalSearch
     else never
 end
 
--- Explore the values of each decision point one by one, from left to right,
+-- Explore the values of each hole one by one, from left to right,
 -- while keeping the rest fixed (to their tuned values, or their defaults if
 -- they have note yet been tuned). Hence, it assumes a total independence of the
--- decision points.
+-- holes.
 lang TuneSemiExhaustive = TuneLocalSearch
   syn MetaState =
   | SemiExhaustive {curIdx : Int, lastImproved : Int, prev : Option Expr}

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -559,7 +559,7 @@ let tuneEntry =
     -- Set the random seed?
     (match options.seed with Some seed then randSetSeed seed else ());
 
-    let holes : [Expr] = deref env.idx2hole in
+    let holes : [Expr] = env.idx2hole in
     let hole2idx : Map NameInfo (Map [NameInfo] Int) = env.hole2idx in
 
     -- Runs the program with a given command-line input and optional timeout


### PR DESCRIPTION
* Renames decision points->holes
* Renames flattening->context expansion
* Breaks out `decision-points.mc` file into several smaller files.
* Uses `smapAccumL` instead of `smap` in transformation (removes unnecessary use of references)
* Fixes a bug with top-level context-dependent holes
* Updates the code generated from context expansion to use the most recent stdlib functions