### PR TITLE
Wrap relevant intrinsics in try-with expressions

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -3,7 +3,7 @@ open Ustring.Op
 module Mseq = struct
   type 'a t = List of 'a List.t | Rope of 'a Rope.t
 
-  let _catchOutOfBounds (f : unit -> 'a) : 'a =
+  let _catch_out_of_bounds (f : unit -> 'a) : 'a =
     try f ()
     with _ ->
       Printf.eprintf
@@ -41,14 +41,14 @@ module Mseq = struct
   let get s i =
     match s with
     | Rope s ->
-        _catchOutOfBounds (fun _ -> Rope.get_array s i)
+        _catch_out_of_bounds (fun _ -> Rope.get_array s i)
     | List s ->
         List.nth s i
 
   let set s i v =
     match s with
     | Rope s ->
-        Rope (_catchOutOfBounds (fun _ -> Rope.set_array s i v))
+        Rope (_catch_out_of_bounds (fun _ -> Rope.set_array s i v))
     | List s ->
         let rec set i v s acc =
           match (i, s) with
@@ -82,14 +82,14 @@ module Mseq = struct
 
   let head = function
     | Rope s ->
-        _catchOutOfBounds (fun _ -> Rope.get_array s 0)
+        _catch_out_of_bounds (fun _ -> Rope.get_array s 0)
     | List s ->
         List.hd s
 
   let tail = function
     | Rope s ->
         Rope
-          (_catchOutOfBounds (fun _ ->
+          (_catch_out_of_bounds (fun _ ->
                Rope.sub_array s 1 (Rope.length_array s) ) )
     | List s ->
         List (List.tl s)
@@ -115,7 +115,7 @@ module Mseq = struct
   let split_at s i =
     match s with
     | Rope s ->
-        let s1, s2 = _catchOutOfBounds (fun _ -> Rope.split_at_array s i) in
+        let s1, s2 = _catch_out_of_bounds (fun _ -> Rope.split_at_array s i) in
         (Rope s1, Rope s2)
     | List s ->
         let rec split_at_rev l r = function
@@ -130,7 +130,7 @@ module Mseq = struct
   let subsequence s a n =
     match s with
     | Rope s ->
-        Rope (_catchOutOfBounds (fun _ -> Rope.sub_array s a n))
+        Rope (_catch_out_of_bounds (fun _ -> Rope.sub_array s a n))
     | List s ->
         let rec subsequence_rev acc s i j =
           match s with

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -3,14 +3,6 @@ open Ustring.Op
 module Mseq = struct
   type 'a t = List of 'a List.t | Rope of 'a Rope.t
 
-  let _catch_out_of_bounds (f : unit -> 'a) : 'a =
-    try f ()
-    with _ ->
-      Printf.eprintf
-        "Out of bounds access in sequence. Compile with flag --runtime-checks \
-         enabled for precise error information.\n" ;
-      exit 1
-
   let create_rope n f = Rope (Rope.create_array n f)
 
   let create_list n f = List (List.init n f)
@@ -38,17 +30,12 @@ module Mseq = struct
     | _ ->
         raise (Invalid_argument "Mseq.concat")
 
-  let get s i =
-    match s with
-    | Rope s ->
-        _catch_out_of_bounds (fun _ -> Rope.get_array s i)
-    | List s ->
-        List.nth s i
+  let get s = match s with Rope s -> Rope.get_array s | List s -> List.nth s
 
   let set s i v =
     match s with
     | Rope s ->
-        Rope (_catch_out_of_bounds (fun _ -> Rope.set_array s i v))
+        Rope (Rope.set_array s i v)
     | List s ->
         let rec set i v s acc =
           match (i, s) with
@@ -80,17 +67,11 @@ module Mseq = struct
     | List s ->
         List (List.rev s)
 
-  let head = function
-    | Rope s ->
-        _catch_out_of_bounds (fun _ -> Rope.get_array s 0)
-    | List s ->
-        List.hd s
+  let head = function Rope s -> Rope.get_array s 0 | List s -> List.hd s
 
   let tail = function
     | Rope s ->
-        Rope
-          (_catch_out_of_bounds (fun _ ->
-               Rope.sub_array s 1 (Rope.length_array s) ) )
+        Rope (Rope.sub_array s 1 (Rope.length_array s))
     | List s ->
         List (List.tl s)
 
@@ -115,7 +96,7 @@ module Mseq = struct
   let split_at s i =
     match s with
     | Rope s ->
-        let s1, s2 = _catch_out_of_bounds (fun _ -> Rope.split_at_array s i) in
+        let s1, s2 = Rope.split_at_array s i in
         (Rope s1, Rope s2)
     | List s ->
         let rec split_at_rev l r = function
@@ -130,7 +111,7 @@ module Mseq = struct
   let subsequence s a n =
     match s with
     | Rope s ->
-        Rope (_catch_out_of_bounds (fun _ -> Rope.sub_array s a n))
+        Rope (Rope.sub_array s a n)
     | List s ->
         let rec subsequence_rev acc s i j =
           match s with

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -3,6 +3,14 @@ open Ustring.Op
 module Mseq = struct
   type 'a t = List of 'a List.t | Rope of 'a Rope.t
 
+  let _catchOutOfBounds (f : unit -> 'a) : 'a =
+    try f ()
+    with _ ->
+      Printf.eprintf
+        "Out of bounds access in sequence. Compile with flag --runtime-checks \
+         enabled for precise error information.\n" ;
+      exit 1
+
   let create_rope n f = Rope (Rope.create_array n f)
 
   let create_list n f = List (List.init n f)
@@ -30,12 +38,17 @@ module Mseq = struct
     | _ ->
         raise (Invalid_argument "Mseq.concat")
 
-  let get = function Rope s -> Rope.get_array s | List s -> List.nth s
+  let get s i =
+    match s with
+    | Rope s ->
+        _catchOutOfBounds (fun _ -> Rope.get_array s i)
+    | List s ->
+        List.nth s i
 
   let set s i v =
     match s with
     | Rope s ->
-        Rope (Rope.set_array s i v)
+        Rope (_catchOutOfBounds (fun _ -> Rope.set_array s i v))
     | List s ->
         let rec set i v s acc =
           match (i, s) with
@@ -67,11 +80,17 @@ module Mseq = struct
     | List s ->
         List (List.rev s)
 
-  let head = function Rope s -> Rope.get_array s 0 | List s -> List.hd s
+  let head = function
+    | Rope s ->
+        _catchOutOfBounds (fun _ -> Rope.get_array s 0)
+    | List s ->
+        List.hd s
 
   let tail = function
     | Rope s ->
-        Rope (Rope.sub_array s 1 (Rope.length_array s))
+        Rope
+          (_catchOutOfBounds (fun _ ->
+               Rope.sub_array s 1 (Rope.length_array s) ) )
     | List s ->
         List (List.tl s)
 
@@ -96,7 +115,7 @@ module Mseq = struct
   let split_at s i =
     match s with
     | Rope s ->
-        let s1, s2 = Rope.split_at_array s i in
+        let s1, s2 = _catchOutOfBounds (fun _ -> Rope.split_at_array s i) in
         (Rope s1, Rope s2)
     | List s ->
         let rec split_at_rev l r = function
@@ -111,7 +130,7 @@ module Mseq = struct
   let subsequence s a n =
     match s with
     | Rope s ->
-        Rope (Rope.sub_array s a n)
+        Rope (_catchOutOfBounds (fun _ -> Rope.sub_array s a n))
     | List s ->
         let rec subsequence_rev acc s i j =
           match s with

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -17,6 +17,7 @@ include "tuning/tune-file.mc"
 include "ocaml/ast.mc"
 include "ocaml/mcore.mc"
 include "ocaml/external-includes.mc"
+include "ocaml/wrap-in-try-with.mc"
 include "pmexpr/demote.mc"
 
 lang MCoreCompile =
@@ -24,7 +25,8 @@ lang MCoreCompile =
   PMExprDemote +
   MExprHoles +
   MExprSym + MExprTypeAnnot + MExprTypeCheck + MExprUtestTrans +
-  MExprRuntimeCheck + MExprProfileInstrument
+  MExprRuntimeCheck + MExprProfileInstrument +
+  OCamlTryWithWrap
 end
 
 let pprintMcore = lam ast.
@@ -66,8 +68,9 @@ let ocamlCompileAstWithUtests = lam options : Options. lam sourcePath. lam ast.
     -- If option --typecheck, type check the AST
     let ast = if options.typeCheck then typeCheck (symbolize ast) else ast in
 
-    -- If --debug has been enabled, instrument runtime safety checks in AST.
-    -- This includes for example bounds checking on sequence operations.
+    -- If --runtime-checks is set, runtime safety checks are instrumented in
+    -- the AST. This includes for example bounds checking on sequence
+    -- operations.
     let ast = if options.runtimeChecks then injectRuntimeChecks ast else ast in
 
     -- If option --test, then generate utest runner calls. Otherwise strip away
@@ -81,6 +84,7 @@ let ocamlCompileAstWithUtests = lam options : Options. lam sourcePath. lam ast.
       { debugTypeAnnot = lam ast. if options.debugTypeAnnot then printLn (pprintMcore ast) else ()
       , debugGenerate = lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ()
       , exitBefore = lam. if options.exitBefore then exit 0 else ()
+      , postprocessOcamlTops = lam tops. if options.runtimeChecks then wrapInTryWith tops else tops
       , compileOcaml = ocamlCompile options sourcePath
       }
 

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -15,6 +15,7 @@ lang OCamlTopAst
   | OTopLet { ident : Name, tyBody: Type, body : Expr }
   | OTopRecLets { bindings : [OCamlTopBinding] }
   | OTopExpr { expr : Expr }
+  | OTopTryWith { try : Expr, arms : [(Pat, Expr)] }
 end
 
 lang OCamlRecord

--- a/stdlib/ocaml/mcore.mc
+++ b/stdlib/ocaml/mcore.mc
@@ -16,6 +16,7 @@ type Hooks =
   { debugTypeAnnot : Expr -> ()
   , debugGenerate : String -> ()
   , exitBefore : () -> ()
+  , postprocessOcamlTops : [Top] -> [Top]
   , compileOcaml : [String] -> [String] -> String -> a
   }
 
@@ -23,6 +24,7 @@ let emptyHooks : Hooks =
   { debugTypeAnnot = lam. ()
   , debugGenerate = lam. ()
   , exitBefore = lam. ()
+  , postprocessOcamlTops = lam tops. tops
   , compileOcaml = lam. lam. lam. ""
   }
 
@@ -55,6 +57,7 @@ let compileMCore : Expr -> Hooks -> a =
         chooseExternalImpls (externalGetSupportedExternalImpls ()) env ast
       in
       let exprTops = generateTops env ast in
+      let exprTops = hooks.postprocessOcamlTops exprTops in
 
       -- List OCaml packages availible on the system.
       let syslibs =

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -404,7 +404,7 @@ lang OCamlPrettyPrint =
       (env, concat code ";;")
     else never
   | OTopTryWith {try = try, arms = arms} ->
-    let i = 0 in
+    let i = pprintIncr 0 in
     let ii = pprintIncr i in
     let iii = pprintIncr ii in
     match pprintCode i env try with (env, try) in
@@ -416,7 +416,7 @@ lang OCamlPrettyPrint =
       else never
     else never in
     match mapAccumL pprintArm env arms with (env, arms) then
-      (env, join ["try", pprintNewline ii, try, pprintNewline i,
+      (env, join ["try", pprintNewline i, try, pprintNewline 0,
                   "with", join arms])
     else never
 

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -403,6 +403,23 @@ lang OCamlPrettyPrint =
     match pprintCode indent env expr with (env, code) then
       (env, concat code ";;")
     else never
+  | OTopTryWith {try = try, arms = arms} ->
+    let i = 0 in
+    let ii = pprintIncr i in
+    let iii = pprintIncr ii in
+    match pprintCode i env try with (env, try) in
+    let pprintArm = lam env. lam arm. match arm with (pat, expr) then
+      match getPatStringCode ii env pat with (env, pat) then
+        match printParen iii env expr with (env, expr) then
+          (env, join [pprintNewline i, "| ", pat, " ->", pprintNewline iii, expr])
+        else never
+      else never
+    else never in
+    match mapAccumL pprintArm env arms with (env, arms) then
+      (env, join ["try", pprintNewline ii, try, pprintNewline i,
+                  "with", join arms])
+    else never
+
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | OTmVarExt {ident = ident} -> (env, ident)

--- a/stdlib/ocaml/wrap-in-try-with.mc
+++ b/stdlib/ocaml/wrap-in-try-with.mc
@@ -1,0 +1,50 @@
+-- Defines a language fragment which wraps an OCaml AST in a try-with
+-- expression that captures exceptions thrown in the generated OCaml code and
+-- prints an MExpr-specific error message along with the OCaml exception and
+-- its backtrace. The backtraces are always enabled and printed for uncaught
+-- exceptions, so when this is applied the user does not need to use the
+-- OCAMLRUNPARAM=b to enable it.
+
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "ocaml/ast.mc"
+
+lang OCamlTryWithWrap = MExprAst + OCamlAst
+  sem wrapTopInTryWith (acc : (Expr, [Top])) =
+  | (OTopVariantTypeDecl _ | OTopCExternalDecl _) & t ->
+    (acc.0, snoc acc.1 t)
+  | OTopLet t ->
+    let letExpr = TmLet {
+      ident = t.ident, tyBody = t.tyBody, body = t.body, inexpr = unit_,
+      ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
+    (bind_ acc.0 letExpr, acc.1)
+  | OTopRecLets t ->
+    let toRecLetBinding = lam bind : OCamlTopBinding.
+      { ident = bind.ident, tyBody = bind.tyBody
+      ,  body = bind.body, info = NoInfo ()} in
+    let recLetExpr = TmRecLets {
+      bindings = map toRecLetBinding t.bindings, inexpr = unit_,
+      ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
+    (bind_ acc.0 recLetExpr, acc.1)
+  | OTopExpr t -> (bind_ acc.0 t.expr, acc.1)
+  | OTopTryWith t -> error "Nested try-with expressions currently not supported"
+
+  sem wrapInTryWith =
+  | tops /- [Top] -/ ->
+    match foldl wrapTopInTryWith (unit_, []) tops with (tryExpr, tops) in
+    let enableBacktracesTop = OTopLet {
+      ident = nameSym "",
+      tyBody = TyRecord {fields = mapEmpty cmpSID, labels = [], info = NoInfo ()},
+      body = OTmExprExt {expr = "Printexc.record_backtrace true"}} in
+    let excId = nameSym "exc" in
+    let withExpr = bindall_ [
+      ulet_ "" (appf2_ (OTmVarExt {ident = "Printf.printf"})
+        (OTmString {text = "MExpr runtime error: %s\\n"})
+        (app_ (OTmVarExt {ident = "Printexc.to_string"}) (nvar_ excId))),
+      ulet_ "" (OTmExprExt {expr = "Printexc.print_backtrace Stdlib.stdout"}),
+      OTmExprExt {expr = "Stdlib.exit 1"}] in
+    let tryWithTop = OTopTryWith {
+      try = tryExpr,
+      arms = [(npvar_ excId, withExpr)]} in
+    snoc (cons enableBacktracesTop tops) tryWithTop
+end


### PR DESCRIPTION
This PR wraps relevant intrinsics in the `boot` library in try-with expressions which provide a more helpful error message in case an exception is raised by the underlying `Rope` operation. The error message states that one should use the `--runtime-checks` flag for better error messages. This flag is not enabled by default because it has a non-negligible impact on performance, unlike the try-with expressions added here.