### PR TITLE
Add file path to failed utest output

### DIFF
--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1652,7 +1652,7 @@ let shape_str = function
 let unittest_failed fi t1 t2 tusing =
   uprint_endline
     ( match fi with
-    | Info (_, l1, _, _, _) ->
+    | Info (file, l1, _, _, _) ->
         let using_str =
           match tusing with
           | Some t ->
@@ -1661,7 +1661,7 @@ let unittest_failed fi t1 t2 tusing =
               us ""
         in
         us "\n ** Unit test FAILED on line "
-        ^. us (string_of_int l1)
+        ^. us (string_of_int l1) ^. us " of file " ^. file
         ^. us " **\n    LHS: " ^. ustring_of_tm t1 ^. us "\n    RHS: "
         ^. ustring_of_tm t2 ^. using_str
     | NoInfo ->

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1651,21 +1651,16 @@ let shape_str = function
 (* Print out error message when a unit test fails *)
 let unittest_failed fi t1 t2 tusing =
   uprint_endline
-    ( match fi with
-    | Info (file, l1, _, _, _) ->
-        let using_str =
-          match tusing with
-          | Some t ->
-              us "\n    Using: " ^. ustring_of_tm t
-          | None ->
-              us ""
-        in
-        us "\n ** Unit test FAILED on line "
-        ^. us (string_of_int l1)
-        ^. us " of file " ^. file ^. us " **\n    LHS: " ^. ustring_of_tm t1
-        ^. us "\n    RHS: " ^. ustring_of_tm t2 ^. using_str
-    | NoInfo ->
-        us "Unit test FAILED " )
+    (let using_str =
+       match tusing with
+       | Some t ->
+           us "\n    Using: " ^. ustring_of_tm t
+       | None ->
+           us ""
+     in
+     us "\n ** Unit test FAILED: "
+     ^. info2str fi ^. us " **\n    LHS: " ^. ustring_of_tm t1
+     ^. us "\n    RHS: " ^. ustring_of_tm t2 ^. using_str )
 
 (* Check if two value terms are equal *)
 let rec val_equal v1 v2 =

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1661,9 +1661,9 @@ let unittest_failed fi t1 t2 tusing =
               us ""
         in
         us "\n ** Unit test FAILED on line "
-        ^. us (string_of_int l1) ^. us " of file " ^. file
-        ^. us " **\n    LHS: " ^. ustring_of_tm t1 ^. us "\n    RHS: "
-        ^. ustring_of_tm t2 ^. using_str
+        ^. us (string_of_int l1)
+        ^. us " of file " ^. file ^. us " **\n    LHS: " ^. ustring_of_tm t1
+        ^. us "\n    RHS: " ^. ustring_of_tm t2 ^. using_str
     | NoInfo ->
         us "Unit test FAILED " )
 

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -249,3 +249,5 @@ utest strJoin "--" ["water", "tea", "coffee"] with "water--tea--coffee"
 utest strJoin "--" [] with emptyStr
 utest strJoin "--" ["coffee"] with "coffee"
 utest strJoin "water" ["coffee", "tea"] with "coffeewatertea"
+
+utest true with false

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -249,5 +249,3 @@ utest strJoin "--" ["water", "tea", "coffee"] with "water--tea--coffee"
 utest strJoin "--" [] with emptyStr
 utest strJoin "--" ["coffee"] with "coffee"
 utest strJoin "water" ["coffee", "tea"] with "coffeewatertea"
-
-utest true with false


### PR DESCRIPTION
This PR updates the behaviour of failed utests in `boot` and `mi` so that the path to the file of the failed utest is printed, as discussed in #541. Prior to the changes in this PR, a failed utest would be reported as
```
 ** Unit test FAILED on line 252 **
```
while after this change it is reported as
```
 ** Unit test FAILED on line 252 of file <path>/<to>/<file>.mc **
```