### PR TITLE
Update breakable

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -558,11 +558,22 @@ module IO = struct
           List.init (Obj.size v) (fun i ->
               istr ^ ", " ^ work (indent + 2) (Obj.field v i) )
         in
+        let mstring =
+          try
+            let ints =
+              Array.init (Obj.size v) (fun i ->
+                  let c = Obj.field v i in
+                  if Obj.is_int c then Obj.obj c else raise Not_found )
+            in
+            let str = Ustring.from_uchars ints in
+            us " (as a string: " ^. str ^. us ")" |> Ustring.to_utf8
+          with _ -> ""
+        in
         "{ tag: "
         ^ string_of_tag (Obj.tag v)
         ^ ", size: "
         ^ string_of_int (Obj.size v)
-        ^ "\n" ^ String.concat "" children ^ istr ^ "}\n"
+        ^ mstring ^ "\n" ^ String.concat "" children ^ istr ^ "}\n"
     in
     print_string (work 0 v)
 

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -295,9 +295,10 @@ let _getParents
   : TentativeNode res self rstyle
   -> Option [TentativeNode res self ROpen] -- NonEmpty
   = lam n.
-    match n with TentativeLeaf{parents = ps} | TentativeMid{parents = ps} then Some ps else
-    match n with TentativeRoot _ then None () else
-    never
+    switch n
+    case TentativeLeaf{parents = ps} | TentativeMid{parents = ps} then Some ps
+    case TentativeRoot _ then None ()
+    end
 let _opIdI
   : BreakableInput res self lstyle rstyle
   -> OpId
@@ -560,11 +561,12 @@ recursive let _maxDistanceFromRoot
   : TentativeNode res self rstyle
   -> Int
   = lam n.
-    match n with TentativeMid {maxDistanceFromRoot = r} then r else
-    match n with TentativeRoot _ then 0 else
-    match n with TentativeLeaf {parents = parents} then maxOrElse (lam. 0) subi (map _maxDistanceFromRoot parents) else
-    dprintLn n;
-    never
+    switch n
+    case TentativeMid {maxDistanceFromRoot = r} then r
+    case TentativeRoot _ then 0
+    case TentativeLeaf {parents = ps} then
+      maxOrElse (lam. 0) subi (map _maxDistanceFromRoot ps)
+    end
 end
 
 let _shallowAllowedLeft

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -784,7 +784,7 @@ let _addLOpen
             -- it isn't there already. It will later be made into a
             -- new permanent node, once all its children have been
             -- processed.
-            (match config with (Some child, None _, _, _) | (Some child, _, true, _) then
+            (match (parent, config) with (!TentativeRoot _, _) & ((_, (Some child, None _, _, _)) | (_, (Some child, _, true, _))) then
                match _addRightChildToParent time child parent with Some parent then
                  _addToQueue parent queue
                else ()

--- a/stdlib/parser/generator.mc
+++ b/stdlib/parser/generator.mc
@@ -1,901 +1,901 @@
-include "mexpr/ast-builder.mc"
-include "semantic.mc"
-include "gen-ast.mc"
-include "common.mc"
+-- include "mexpr/ast-builder.mc"
+-- include "semantic.mc"
+-- include "gen-ast.mc"
+-- include "common.mc"
 
-/-
+-- /-
 
-This file implements a small DSL for writing grammars and then
-auto-generating language fragments for the AST as well as a parser
-using `semantic.mc`. The main interface consists of the record
-`generatorNamespace` which contains a field for every exported
-function.
+-- This file implements a small DSL for writing grammars and then
+-- auto-generating language fragments for the AST as well as a parser
+-- using `semantic.mc`. The main interface consists of the record
+-- `generatorNamespace` which contains a field for every exported
+-- function.
 
-The main working function is `grammar`, which takes a grammar and
-produces a string containing the generated code.
+-- The main working function is `grammar`, which takes a grammar and
+-- produces a string containing the generated code.
 
--- TODO(vipa, 2021-03-16): Once we have proper AST types for language
-fragments we should probably return those instead, maybe have a
-convenience function that produces the string.
+-- -- TODO(vipa, 2021-03-16): Once we have proper AST types for language
+-- fragments we should probably return those instead, maybe have a
+-- convenience function that produces the string.
 
-The generated AST types will be in broken form and will typically
-require a post-processing step to unbreak. This post-processing can
-typically be expressed fairly concisely with `smap`, for example:
+-- The generated AST types will be in broken form and will typically
+-- require a post-processing step to unbreak. This post-processing can
+-- typically be expressed fairly concisely with `smap`, for example:
 
-```
-let g = generatorNamespace in
+-- ```
+-- let g = generatorNamespace in
 
--- Broken "if"
-let ifP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmIfBroken"
-  , prodType = g.defPrefix "thenExpr"
-  , syntax = [g.lit_ "if", g.nt "condition" "Expr", g.lit_ "then", tyField]
-  } in
+-- -- Broken "if"
+-- let ifP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmIfBroken"
+--   , prodType = g.defPrefix "thenExpr"
+--   , syntax = [g.lit_ "if", g.nt "condition" "Expr", g.lit_ "then", tyField]
+--   } in
 
-let elseP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmElseBroken"
-  , prodType = GeneratorInfix
-    { self = DefaultIn ()
-    , left = DefaultNotIn ()
-    , right = DefaultIn ()
-    , leftField = Some "ifExpr"
-    , rightField = Some "elseExpr"
-    }
-  , syntax = [g.lit_ "else", tyField]
-  } in
+-- let elseP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmElseBroken"
+--   , prodType = GeneratorInfix
+--     { self = DefaultIn ()
+--     , left = DefaultNotIn ()
+--     , right = DefaultIn ()
+--     , leftField = Some "ifExpr"
+--     , rightField = Some "elseExpr"
+--     }
+--   , syntax = [g.lit_ "else", tyField]
+--   } in
 
--- Broken "match"
-let matchP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmMatch"
-  , prodType = GeneratorAtom {self = DefaultNotIn ()}
-  , syntax =
-    [ g.lit_ "match", g.nt "target" "Expr", g.lit_ "with"
-    , g.nonsyntax "arms"
-      (seqType
-        (tupleType
-          [ targetableType (tycon_ "Pat")
-          , targetableType (tycon_ "Expr")
-          ]))
-      (seq_ [])
-    , tyField]
-  } in
+-- -- Broken "match"
+-- let matchP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmMatch"
+--   , prodType = GeneratorAtom {self = DefaultNotIn ()}
+--   , syntax =
+--     [ g.lit_ "match", g.nt "target" "Expr", g.lit_ "with"
+--     , g.nonsyntax "arms"
+--       (seqType
+--         (tupleType
+--           [ targetableType (tycon_ "Pat")
+--           , targetableType (tycon_ "Expr")
+--           ]))
+--       (seq_ [])
+--     , tyField]
+--   } in
 
-let matchArmP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmMatchArmBroken"
-  , prodType = GeneratorInfix
-    { self = DefaultIn ()
-    , left = DefaultNotIn ()
-    , right = DefaultIn ()
-    , leftField = Some "prev"
-    , rightField = Some "armExpr"
-    }
-  , syntax = [g.lit_ "|", g.nt "pat" "Pat", g.lit_ "->", tyField]
-  } in
+-- let matchArmP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmMatchArmBroken"
+--   , prodType = GeneratorInfix
+--     { self = DefaultIn ()
+--     , left = DefaultNotIn ()
+--     , right = DefaultIn ()
+--     , leftField = Some "prev"
+--     , rightField = Some "armExpr"
+--     }
+--   , syntax = [g.lit_ "|", g.nt "pat" "Pat", g.lit_ "->", tyField]
+--   } in
 
--- After grammar generation we (manually) write the following language
-fragments:
-lang MExprpostProcess = MExprComposed
-  sem postProcessExpr =
-  | t -> postProcessExprUp (smap_Expr_Expr postProcessExpr (postProcessExprDown t))
+-- -- After grammar generation we (manually) write the following language
+-- fragments:
+-- lang MExprpostProcess = MExprComposed
+--   sem postProcessExpr =
+--   | t -> postProcessExprUp (smap_Expr_Expr postProcessExpr (postProcessExprDown t))
 
-  sem postProcessExprDown =
-  | t -> t
-  sem postProcessExprUp =
-  | t -> t
-end
+--   sem postProcessExprDown =
+--   | t -> t
+--   sem postProcessExprUp =
+--   | t -> t
+-- end
 
-lang MExprTmIf = MExprBase
-  syn Expr =
-  | TmIf {info : Info, condition : Expr, thenExpr : Expr, elseExpr : Option Expr, ty : Type}
+-- lang MExprTmIf = MExprBase
+--   syn Expr =
+--   | TmIf {info : Info, condition : Expr, thenExpr : Expr, elseExpr : Option Expr, ty : Type}
 
-  -- omitted smapAccumL_Expr_Expr
-end
+--   -- omitted smapAccumL_Expr_Expr
+-- end
 
-lang MExprUnbreakIf = MExprpostProcess + MExprTmIf
-  sem postProcessExprDown =
-  | TmElseBroken
-    { info = info
-    , ifExpr = TmIfBroken
-      { condition = condition
-      , thenExpr = thenExpr
-      }
-    , elseExpr = elseExpr
-    } ->
-    TmIf
-      { info = info
-      , condition = condition
-      , thenExpr = thenExpr
-      , elseExpr = Some elseExpr
-      , ty = TyUnknown ()
-      }
-  | TmIfBroken
-    { info = info
-    , condition = condition
-    , thenExpr = thenExpr
-    } ->
-    TmIf
-      { info = info
-      , condition = condition
-      , thenExpr = thenExpr
-      , elseExpr = None ()
-      }
-end
+-- lang MExprUnbreakIf = MExprpostProcess + MExprTmIf
+--   sem postProcessExprDown =
+--   | TmElseBroken
+--     { info = info
+--     , ifExpr = TmIfBroken
+--       { condition = condition
+--       , thenExpr = thenExpr
+--       }
+--     , elseExpr = elseExpr
+--     } ->
+--     TmIf
+--       { info = info
+--       , condition = condition
+--       , thenExpr = thenExpr
+--       , elseExpr = Some elseExpr
+--       , ty = TyUnknown ()
+--       }
+--   | TmIfBroken
+--     { info = info
+--     , condition = condition
+--     , thenExpr = thenExpr
+--     } ->
+--     TmIf
+--       { info = info
+--       , condition = condition
+--       , thenExpr = thenExpr
+--       , elseExpr = None ()
+--       }
+-- end
 
-lang MExprUnbreakMatch = MExprpostProcess
-  sem postProcessExprUp =
-  | TmMatchArmBroken
-    { info = info
-    , prev = TmMatch r
-    , pat = pat
-    , armExpr = armExpr
-    } ->
-    TmMatch {{r with arms = snoc r.arms (pat, armExpr) } with info = info}
-end
+-- lang MExprUnbreakMatch = MExprpostProcess
+--   sem postProcessExprUp =
+--   | TmMatchArmBroken
+--     { info = info
+--     , prev = TmMatch r
+--     , pat = pat
+--     , armExpr = armExpr
+--     } ->
+--     TmMatch {{r with arms = snoc r.arms (pat, armExpr) } with info = info}
+-- end
 
-lang Unbreaking = MExprUnbreakIf + MExprUnbreakMatch
+-- lang Unbreaking = MExprUnbreakIf + MExprUnbreakMatch
 
--- We can then "unbreak" a value "tm" of type "Expr" like so:
+-- -- We can then "unbreak" a value "tm" of type "Expr" like so:
 
-use Unbreaking in postprocessExpr tm
+-- use Unbreaking in postprocessExpr tm
 
-```
+-- ```
 
--/
+-- -/
 
-type GeneratorSymbol
--- TODO(vipa, 2021-03-12): We want to support alternatives as well, or
--- at least optional elements, but to make that easy we probably want
--- to add support for that in `semantic.mc`
-con GeneratorInt : {field : Option String} -> GeneratorSymbol
-con GeneratorFloat : {field : Option String} -> GeneratorSymbol
-con GeneratorOperator : {field : Option String} -> GeneratorSymbol
-con GeneratorString : {field : Option String} -> GeneratorSymbol
-con GeneratorChar : {field : Option String} -> GeneratorSymbol
-con GeneratorHashString : {field : Option String, tag : String} -> GeneratorSymbol
-con GeneratorLit : {lit : String} -> GeneratorSymbol
-con GeneratorLIdent : {field : Option String} -> GeneratorSymbol
-con GeneratorUIdent : {field : Option String} -> GeneratorSymbol
-con GeneratorNonSyntax : {field : String, fieldType : CarriedType, fieldValue : Expr} -> GeneratorSymbol
-con GeneratorNt : {field : Option String, nt : NonTerminal} -> GeneratorSymbol
+-- type GeneratorSymbol
+-- -- TODO(vipa, 2021-03-12): We want to support alternatives as well, or
+-- -- at least optional elements, but to make that easy we probably want
+-- -- to add support for that in `semantic.mc`
+-- con GeneratorInt : {field : Option String} -> GeneratorSymbol
+-- con GeneratorFloat : {field : Option String} -> GeneratorSymbol
+-- con GeneratorOperator : {field : Option String} -> GeneratorSymbol
+-- con GeneratorString : {field : Option String} -> GeneratorSymbol
+-- con GeneratorChar : {field : Option String} -> GeneratorSymbol
+-- con GeneratorHashString : {field : Option String, tag : String} -> GeneratorSymbol
+-- con GeneratorLit : {lit : String} -> GeneratorSymbol
+-- con GeneratorLIdent : {field : Option String} -> GeneratorSymbol
+-- con GeneratorUIdent : {field : Option String} -> GeneratorSymbol
+-- con GeneratorNonSyntax : {field : String, fieldType : CarriedType, fieldValue : Expr} -> GeneratorSymbol
+-- con GeneratorNt : {field : Option String, nt : NonTerminal} -> GeneratorSymbol
 
-type GeneratorProdType
-con GeneratorAtom :
-  { self : DefaultInclude
-  } -> GeneratorProdType
-con GeneratorPrefix :
-  { self : DefaultInclude
-  , right : DefaultInclude
-  , rightField : Option String
-  } -> GeneratorProdType
-con GeneratorInfix :
-  { self : DefaultInclude
-  , left : DefaultInclude
-  , leftField : Option String
-  , right : DefaultInclude
-  , rightField : Option String
-  } -> GeneratorProdType
-con GeneratorPostfix :
-  { self : DefaultInclude
-  , left : DefaultInclude
-  , leftField : Option String
-  } -> GeneratorProdType
+-- type GeneratorProdType
+-- con GeneratorAtom :
+--   { self : DefaultInclude
+--   } -> GeneratorProdType
+-- con GeneratorPrefix :
+--   { self : DefaultInclude
+--   , right : DefaultInclude
+--   , rightField : Option String
+--   } -> GeneratorProdType
+-- con GeneratorInfix :
+--   { self : DefaultInclude
+--   , left : DefaultInclude
+--   , leftField : Option String
+--   , right : DefaultInclude
+--   , rightField : Option String
+--   } -> GeneratorProdType
+-- con GeneratorPostfix :
+--   { self : DefaultInclude
+--   , left : DefaultInclude
+--   , leftField : Option String
+--   } -> GeneratorProdType
 
--- A `GeneratorStaged t` is an expression of type `t`.
-type GeneratorStaged t = Expr
+-- -- A `GeneratorStaged t` is an expression of type `t`.
+-- type GeneratorStaged t = Expr
 
-type GeneratorProduction =
-  { stagedSpec : GeneratorStaged ProductionSpec
-  , constructor : Option Constructor
-  , sym : Symbol
-  , nonTerminal : NonTerminal
-  }
+-- type GeneratorProduction =
+--   { stagedSpec : GeneratorStaged ProductionSpec
+--   , constructor : Option Constructor
+--   , sym : Symbol
+--   , nonTerminal : NonTerminal
+--   }
 
-type GeneratorOverride
-con GeneratorLeftChild : { child : GeneratorProduction, parent : GeneratorProduction } -> GeneratorOverride
-con GeneratorRightChild : { child : GeneratorProduction, parent : GeneratorProduction } -> GeneratorOverride
+-- type GeneratorOverride
+-- con GeneratorLeftChild : { child : GeneratorProduction, parent : GeneratorProduction } -> GeneratorOverride
+-- con GeneratorRightChild : { child : GeneratorProduction, parent : GeneratorProduction } -> GeneratorOverride
 
-let _semanticProductionName = nameSym "semanticProduction"
-let _semanticGrammarName = nameSym "semanticGrammar"
-let _semanticNonTerminalName = nameSym "semanticNonTerminal"
-let _semanticParseFileName = nameSym "semanticParseFile"
-let _semanticLeftChildName = nameSym "LeftChild"
-let _semanticRightChildName = nameSym "RightChild"
-let _semanticAtomName = nameSym "Atom"
-let _semanticPrefixName = nameSym "Prefix"
-let _semanticInfixName = nameSym "Infix"
-let _semanticPostfixName = nameSym "Postfix"
-let _semanticDefaultInName = nameSym "DefaultIn"
-let _semanticDefaultNotInName = nameSym "DefaultNotIn"
-let _semanticIntName = nameSym "semanticInt"
-let _semanticFloatName = nameSym "semanticFloat"
-let _semanticOperatorName = nameSym "semanticOperator"
-let _semanticStringName = nameSym "semanticString"
-let _semanticCharName = nameSym "semanticChar"
-let _semanticHashStringName = nameSym "semanticHashString"
-let _semanticLitName = nameSym "semanticLit"
-let _semanticLIdentName = nameSym "semanticLIdent"
-let _semanticUIdentName = nameSym "semanticUIdent"
-let _semanticNtName = nameSym "semanticNt"
-let _semanticShortenErrorsName = nameSym "semanticShortenErrors"
-let _rightConName = nameSym "Right"
-let _leftConName = nameSym "Left"
-let _eitherMapRightName = nameSym "eitherMapRight"
-let _infoTypeName = nameSym "Info"
-let _symSeqInfoName = nameSym "_symSeqInfo"
-let _headName = nameSym "head"
-let _lastName = nameSym "last"
-let _ll1TokName = nameSym "Tok"
-let _ll1UserSymName = nameSym "UserSym"
-let _lexerIntName = nameSym "IntTok"
-let _lexerFloatName = nameSym "FloatTok"
-let _lexerOperatorName = nameSym "OperatorTok"
-let _lexerStringName = nameSym "StringTok"
-let _lexerCharName = nameSym "CharTok"
-let _lexerHashStringName = nameSym "HashStringTok"
-let _lexerLIdentName = nameSym "LIdentTok"
-let _lexerUIdentName = nameSym "UIdentTok"
-let _dprintLnName = nameSym "dprintLn"
+-- let _semanticProductionName = nameSym "semanticProduction"
+-- let _semanticGrammarName = nameSym "semanticGrammar"
+-- let _semanticNonTerminalName = nameSym "semanticNonTerminal"
+-- let _semanticParseFileName = nameSym "semanticParseFile"
+-- let _semanticLeftChildName = nameSym "LeftChild"
+-- let _semanticRightChildName = nameSym "RightChild"
+-- let _semanticAtomName = nameSym "Atom"
+-- let _semanticPrefixName = nameSym "Prefix"
+-- let _semanticInfixName = nameSym "Infix"
+-- let _semanticPostfixName = nameSym "Postfix"
+-- let _semanticDefaultInName = nameSym "DefaultIn"
+-- let _semanticDefaultNotInName = nameSym "DefaultNotIn"
+-- let _semanticIntName = nameSym "semanticInt"
+-- let _semanticFloatName = nameSym "semanticFloat"
+-- let _semanticOperatorName = nameSym "semanticOperator"
+-- let _semanticStringName = nameSym "semanticString"
+-- let _semanticCharName = nameSym "semanticChar"
+-- let _semanticHashStringName = nameSym "semanticHashString"
+-- let _semanticLitName = nameSym "semanticLit"
+-- let _semanticLIdentName = nameSym "semanticLIdent"
+-- let _semanticUIdentName = nameSym "semanticUIdent"
+-- let _semanticNtName = nameSym "semanticNt"
+-- let _semanticShortenErrorsName = nameSym "semanticShortenErrors"
+-- let _rightConName = nameSym "Right"
+-- let _leftConName = nameSym "Left"
+-- let _eitherMapRightName = nameSym "eitherMapRight"
+-- let _infoTypeName = nameSym "Info"
+-- let _symSeqInfoName = nameSym "_symSeqInfo"
+-- let _headName = nameSym "head"
+-- let _lastName = nameSym "last"
+-- let _ll1TokName = nameSym "Tok"
+-- let _ll1UserSymName = nameSym "UserSym"
+-- let _lexerIntName = nameSym "IntTok"
+-- let _lexerFloatName = nameSym "FloatTok"
+-- let _lexerOperatorName = nameSym "OperatorTok"
+-- let _lexerStringName = nameSym "StringTok"
+-- let _lexerCharName = nameSym "CharTok"
+-- let _lexerHashStringName = nameSym "HashStringTok"
+-- let _lexerLIdentName = nameSym "LIdentTok"
+-- let _lexerUIdentName = nameSym "UIdentTok"
+-- let _dprintLnName = nameSym "dprintLn"
 
-let _env =
-  match optionFoldlM pprintAddStr pprintEnvEmpty
-    [ _semanticProductionName
-    , _semanticGrammarName
-    , _semanticNonTerminalName
-    , _semanticParseFileName
-    , _semanticLeftChildName
-    , _semanticRightChildName
-    , _semanticAtomName
-    , _semanticPrefixName
-    , _semanticInfixName
-    , _semanticPostfixName
-    , _semanticDefaultInName
-    , _semanticDefaultNotInName
-    , _semanticIntName
-    , _semanticFloatName
-    , _semanticOperatorName
-    , _semanticStringName
-    , _semanticCharName
-    , _semanticHashStringName
-    , _semanticLitName
-    , _semanticLIdentName
-    , _semanticUIdentName
-    , _semanticNtName
-    , _semanticShortenErrorsName
-    , _rightConName
-    , _leftConName
-    , _eitherMapRightName
-    , _infoTypeName
-    , _symSeqInfoName
-    , _headName
-    , _lastName
-    , _ll1TokName
-    , _ll1UserSymName
-    , _lexerIntName
-    , _lexerFloatName
-    , _lexerOperatorName
-    , _lexerStringName
-    , _lexerCharName
-    , _lexerHashStringName
-    , _lexerLIdentName
-    , _lexerUIdentName
-    , _dprintLnName
-    ]
-  with Some env then env
-  else never
+-- let _env =
+--   match optionFoldlM pprintAddStr pprintEnvEmpty
+--     [ _semanticProductionName
+--     , _semanticGrammarName
+--     , _semanticNonTerminalName
+--     , _semanticParseFileName
+--     , _semanticLeftChildName
+--     , _semanticRightChildName
+--     , _semanticAtomName
+--     , _semanticPrefixName
+--     , _semanticInfixName
+--     , _semanticPostfixName
+--     , _semanticDefaultInName
+--     , _semanticDefaultNotInName
+--     , _semanticIntName
+--     , _semanticFloatName
+--     , _semanticOperatorName
+--     , _semanticStringName
+--     , _semanticCharName
+--     , _semanticHashStringName
+--     , _semanticLitName
+--     , _semanticLIdentName
+--     , _semanticUIdentName
+--     , _semanticNtName
+--     , _semanticShortenErrorsName
+--     , _rightConName
+--     , _leftConName
+--     , _eitherMapRightName
+--     , _infoTypeName
+--     , _symSeqInfoName
+--     , _headName
+--     , _lastName
+--     , _ll1TokName
+--     , _ll1UserSymName
+--     , _lexerIntName
+--     , _lexerFloatName
+--     , _lexerOperatorName
+--     , _lexerStringName
+--     , _lexerCharName
+--     , _lexerHashStringName
+--     , _lexerLIdentName
+--     , _lexerUIdentName
+--     , _dprintLnName
+--     ]
+--   with Some env then env
+--   else never
 
-let _semanticProduction_ = app_ (nvar_ _semanticProductionName)
-let _semanticGrammar_ = app_ (nvar_ _semanticGrammarName)
-let _semanticNonTerminal_ = app_ (nvar_ _semanticNonTerminalName)
-let _semanticParseFile_ = appf3_ (nvar_ _semanticParseFileName)
-let _semanticLeftChild_ = nconapp_ _semanticLeftChildName
-let _semanticRightChild_ = nconapp_ _semanticRightChildName
-let _semanticAtom_ = nconapp_ _semanticAtomName
-let _semanticPrefix_ = nconapp_ _semanticPrefixName
-let _semanticInfix_ = nconapp_ _semanticInfixName
-let _semanticPostfix_ = nconapp_ _semanticPostfixName
-let _semanticDefaultIn_ = nconapp_ _semanticDefaultInName uunit_
-let _semanticDefaultNotIn_ = nconapp_ _semanticDefaultNotInName uunit_
-let _semanticInt_ = nvar_ _semanticIntName
-let _semanticFloat_ = nvar_ _semanticFloatName
-let _semanticOperator_ = nvar_ _semanticOperatorName
-let _semanticString_ = nvar_ _semanticStringName
-let _semanticChar_ = nvar_ _semanticCharName
-let _semanticHashString_ = app_ (nvar_ _semanticHashStringName)
-let _semanticLit_ = app_ (nvar_ _semanticLitName)
-let _semanticLIdent_ = nvar_ _semanticLIdentName
-let _semanticUIdent_ = nvar_ _semanticUIdentName
-let _semanticNt_ = app_ (nvar_ _semanticNtName)
-let _semanticShortenErrors_ = app_ (nvar_ _semanticShortenErrorsName)
-let _symSeqInfo_ = app_ (nvar_ _symSeqInfoName)
-let _head_ = app_ (nvar_ _headName)
-let _last_ = app_ (nvar_ _lastName)
-let _dprintLn_ = app_ (nvar_ _dprintLnName)
-let _eitherMapRight_ = appf2_ (nvar_ _eitherMapRightName)
+-- let _semanticProduction_ = app_ (nvar_ _semanticProductionName)
+-- let _semanticGrammar_ = app_ (nvar_ _semanticGrammarName)
+-- let _semanticNonTerminal_ = app_ (nvar_ _semanticNonTerminalName)
+-- let _semanticParseFile_ = appf3_ (nvar_ _semanticParseFileName)
+-- let _semanticLeftChild_ = nconapp_ _semanticLeftChildName
+-- let _semanticRightChild_ = nconapp_ _semanticRightChildName
+-- let _semanticAtom_ = nconapp_ _semanticAtomName
+-- let _semanticPrefix_ = nconapp_ _semanticPrefixName
+-- let _semanticInfix_ = nconapp_ _semanticInfixName
+-- let _semanticPostfix_ = nconapp_ _semanticPostfixName
+-- let _semanticDefaultIn_ = nconapp_ _semanticDefaultInName uunit_
+-- let _semanticDefaultNotIn_ = nconapp_ _semanticDefaultNotInName uunit_
+-- let _semanticInt_ = nvar_ _semanticIntName
+-- let _semanticFloat_ = nvar_ _semanticFloatName
+-- let _semanticOperator_ = nvar_ _semanticOperatorName
+-- let _semanticString_ = nvar_ _semanticStringName
+-- let _semanticChar_ = nvar_ _semanticCharName
+-- let _semanticHashString_ = app_ (nvar_ _semanticHashStringName)
+-- let _semanticLit_ = app_ (nvar_ _semanticLitName)
+-- let _semanticLIdent_ = nvar_ _semanticLIdentName
+-- let _semanticUIdent_ = nvar_ _semanticUIdentName
+-- let _semanticNt_ = app_ (nvar_ _semanticNtName)
+-- let _semanticShortenErrors_ = app_ (nvar_ _semanticShortenErrorsName)
+-- let _symSeqInfo_ = app_ (nvar_ _symSeqInfoName)
+-- let _head_ = app_ (nvar_ _headName)
+-- let _last_ = app_ (nvar_ _lastName)
+-- let _dprintLn_ = app_ (nvar_ _dprintLnName)
+-- let _eitherMapRight_ = appf2_ (nvar_ _eitherMapRightName)
 
-let _sequentialComposition_ = lam a. lam b. use LetAst in TmLet
-  { ident = nameSym ""
-  , body = a
-  , tyBody = tyunknown_
-  , inexpr = b
-  , info = NoInfo ()
-  , ty = tyunknown_
-  }
+-- let _sequentialComposition_ = lam a. lam b. use LetAst in TmLet
+--   { ident = nameSym ""
+--   , body = a
+--   , tyBody = tyunknown_
+--   , inexpr = b
+--   , info = NoInfo ()
+--   , ty = tyunknown_
+--   }
 
-let _stageSymbol = lam sym.
-  match sym with GeneratorInt _ then
-    Some _semanticInt_
-  else match sym with GeneratorFloat _ then
-    Some _semanticFloat_
-  else match sym with GeneratorOperator _ then
-    Some _semanticOperator_
-  else match sym with GeneratorString _ then
-    Some _semanticString_
-  else match sym with GeneratorChar _ then
-    Some _semanticChar_
-  else match sym with GeneratorHashString {tag = tag} then
-    Some (_semanticHashString_ (str_ tag))
-  else match sym with GeneratorLit {lit = lit} then
-    Some (_semanticLit_ (str_ lit))
-  else match sym with GeneratorLIdent _ then
-    Some _semanticLIdent_
-  else match sym with GeneratorUIdent _ then
-    Some _semanticUIdent_
-  else match sym with GeneratorNonSyntax _ then
-    None ()
-  else match sym with GeneratorNt {nt = nt} then
-    Some (_semanticNt_ (var_ nt))
-  else dprintLn sym; never
+-- let _stageSymbol = lam sym.
+--   match sym with GeneratorInt _ then
+--     Some _semanticInt_
+--   else match sym with GeneratorFloat _ then
+--     Some _semanticFloat_
+--   else match sym with GeneratorOperator _ then
+--     Some _semanticOperator_
+--   else match sym with GeneratorString _ then
+--     Some _semanticString_
+--   else match sym with GeneratorChar _ then
+--     Some _semanticChar_
+--   else match sym with GeneratorHashString {tag = tag} then
+--     Some (_semanticHashString_ (str_ tag))
+--   else match sym with GeneratorLit {lit = lit} then
+--     Some (_semanticLit_ (str_ lit))
+--   else match sym with GeneratorLIdent _ then
+--     Some _semanticLIdent_
+--   else match sym with GeneratorUIdent _ then
+--     Some _semanticUIdent_
+--   else match sym with GeneratorNonSyntax _ then
+--     None ()
+--   else match sym with GeneratorNt {nt = nt} then
+--     Some (_semanticNt_ (var_ nt))
+--   else dprintLn sym; never
 
-let _stageInclude = lam inc.
-  match inc with DefaultIn _ then _semanticDefaultIn_ else
-  match inc with DefaultNotIn _ then _semanticDefaultNotIn_ else
-  never
+-- let _stageInclude = lam inc.
+--   match inc with DefaultIn _ then _semanticDefaultIn_ else
+--   match inc with DefaultNotIn _ then _semanticDefaultNotIn_ else
+--   never
 
-let generatorProd
-  : { constructorName : String
-    , nonTerminal : NonTerminal
-    , prodType : GeneratorProdType
-    , syntax : [GeneratorSymbol]
-    }
-  -> GeneratorProduction
-  = lam spec.
-    match spec with
-      { constructorName = constructorStr
-      , nonTerminal = nonTerminal
-      , prodType = prodType
-      , syntax = syntax
-      }
-    then
-      let sym = gensym () in
+-- let generatorProd
+--   : { constructorName : String
+--     , nonTerminal : NonTerminal
+--     , prodType : GeneratorProdType
+--     , syntax : [GeneratorSymbol]
+--     }
+--   -> GeneratorProduction
+--   = lam spec.
+--     match spec with
+--       { constructorName = constructorStr
+--       , nonTerminal = nonTerminal
+--       , prodType = prodType
+--       , syntax = syntax
+--       }
+--     then
+--       let sym = gensym () in
 
-      -- Constructor, i.e., input for ast-gen.mc
-      recursive let symbolToConstructorField
-        : GeneratorSymbol
-        -> Option (String, CarriedType)
-        = lam sym.
-          match sym with GeneratorInt {field = Some name} then
-            Some (name, untargetableType tyint_) else
-          match sym with GeneratorFloat {field = Some name} then
-            Some (name, untargetableType tyfloat_) else
-          match sym with GeneratorOperator {field = Some name} then
-            Some (name, untargetableType tystr_) else
-          match sym with GeneratorString {field = Some name} then
-            Some (name, untargetableType tystr_) else
-          match sym with GeneratorChar {field = Some name} then
-            Some (name, untargetableType tychar_) else
-          match sym with GeneratorHashString {field = Some name} then
-            Some (name, untargetableType tystr_) else
-          match sym with GeneratorLit _ then
-            None () else
-          match sym with GeneratorLIdent {field = Some name} then
-            Some (name, untargetableType tystr_) else
-          match sym with GeneratorUIdent {field = Some name} then
-            Some (name, untargetableType tystr_) else
-          match sym with GeneratorNonSyntax {field = name, fieldType = ty} then
-            Some (name, ty) else
-          match sym with GeneratorNt {field = Some name, nt = nt} then
-            Some (name, targetableType (tycon_ nt))
-          else None ()
-      in
-      let constructorName = nameSym constructorStr in
-      let wrappedSyntax =
-        match prodType with GeneratorAtom _ then syntax
-        else match prodType with GeneratorPrefix {rightField = rName} then
-          snoc
-            syntax
-            (GeneratorNt {field = rName, nt = nonTerminal})
-        else match prodType with GeneratorInfix {leftField = lName, rightField = rName} then
-          cons
-            (GeneratorNt {field = lName, nt = nonTerminal})
-            (snoc
-              syntax
-              (GeneratorNt {field = rName, nt = nonTerminal}))
-        else match prodType with GeneratorPostfix {leftField = lName} then
-          cons
-            (GeneratorNt {field = lName, nt = nonTerminal})
-            syntax
-        else never in
-      let constructor =
-        { name = constructorName
-        , synType = stringToSynType nonTerminal
-        , carried = recordType
-          (cons ("info", untargetableType (ntycon_ _infoTypeName))
-            (mapOption symbolToConstructorField wrappedSyntax))
-        } in
+--       -- Constructor, i.e., input for ast-gen.mc
+--       recursive let symbolToConstructorField
+--         : GeneratorSymbol
+--         -> Option (String, CarriedType)
+--         = lam sym.
+--           match sym with GeneratorInt {field = Some name} then
+--             Some (name, untargetableType tyint_) else
+--           match sym with GeneratorFloat {field = Some name} then
+--             Some (name, untargetableType tyfloat_) else
+--           match sym with GeneratorOperator {field = Some name} then
+--             Some (name, untargetableType tystr_) else
+--           match sym with GeneratorString {field = Some name} then
+--             Some (name, untargetableType tystr_) else
+--           match sym with GeneratorChar {field = Some name} then
+--             Some (name, untargetableType tychar_) else
+--           match sym with GeneratorHashString {field = Some name} then
+--             Some (name, untargetableType tystr_) else
+--           match sym with GeneratorLit _ then
+--             None () else
+--           match sym with GeneratorLIdent {field = Some name} then
+--             Some (name, untargetableType tystr_) else
+--           match sym with GeneratorUIdent {field = Some name} then
+--             Some (name, untargetableType tystr_) else
+--           match sym with GeneratorNonSyntax {field = name, fieldType = ty} then
+--             Some (name, ty) else
+--           match sym with GeneratorNt {field = Some name, nt = nt} then
+--             Some (name, targetableType (tycon_ nt))
+--           else None ()
+--       in
+--       let constructorName = nameSym constructorStr in
+--       let wrappedSyntax =
+--         match prodType with GeneratorAtom _ then syntax
+--         else match prodType with GeneratorPrefix {rightField = rName} then
+--           snoc
+--             syntax
+--             (GeneratorNt {field = rName, nt = nonTerminal})
+--         else match prodType with GeneratorInfix {leftField = lName, rightField = rName} then
+--           cons
+--             (GeneratorNt {field = lName, nt = nonTerminal})
+--             (snoc
+--               syntax
+--               (GeneratorNt {field = rName, nt = nonTerminal}))
+--         else match prodType with GeneratorPostfix {leftField = lName} then
+--           cons
+--             (GeneratorNt {field = lName, nt = nonTerminal})
+--             syntax
+--         else never in
+--       let constructor =
+--         { name = constructorName
+--         , synType = stringToSynType nonTerminal
+--         , carried = recordType
+--           (cons ("info", untargetableType (ntycon_ _infoTypeName))
+--             (mapOption symbolToConstructorField wrappedSyntax))
+--         } in
 
-      -- Staged production spec, i.e., input for semantic.mc
-      let stagedSpec =
-        let stagedProdType =
-          match prodType with GeneratorAtom {self = self} then
-            _semanticAtom_ (urecord_ [("self", _stageInclude self)])
-          else match prodType with GeneratorPrefix {self = self, right = right} then
-            _semanticPrefix_ (urecord_ [("self", _stageInclude self), ("right", _stageInclude right)])
-          else match prodType with GeneratorInfix {self = self, left = left, right = right} then
-            _semanticInfix_ (urecord_ [("self", _stageInclude self), ("left", _stageInclude left), ("right", _stageInclude right)])
-          else match prodType with GeneratorPostfix {self = self, left = left} then
-            _semanticPostfix_ (urecord_ [("self", _stageInclude self), ("left", _stageInclude left)])
-          else never in
-        let stageField = lam sym.
-          let simpleResult = lam field. lam conName.
-            let valName = nameSym field in
-            ( Some (npcon_ _ll1TokName (npcon_ conName (prec_ [("val", npvar_ valName)])))
-            , Some (field, nvar_ valName)
-            ) in
-          match sym with GeneratorInt {field = Some field} then
-            simpleResult field _lexerIntName
-          else match sym with GeneratorFloat {field = Some field} then
-            simpleResult field _lexerFloatName
-          else match sym with GeneratorOperator {field = Some field} then
-            simpleResult field _lexerOperatorName
-          else match sym with GeneratorString {field = Some field} then
-            simpleResult field _lexerStringName
-          else match sym with GeneratorChar {field = Some field} then
-            simpleResult field _lexerCharName
-          else match sym with GeneratorHashString {field = Some field} then
-            simpleResult field _lexerHashStringName
-          else match sym with GeneratorLIdent {field = Some field} then
-            simpleResult field _lexerLIdentName
-          else match sym with GeneratorUIdent {field = Some field} then
-            simpleResult field _lexerUIdentName
-          else match sym with GeneratorNonSyntax {field = field, fieldValue = val} then
-            ( None ()
-            , Some (field, val)
-            )
-          else match sym with GeneratorNt {field = Some field} then
-            let valName = nameSym field in
-            ( Some (npcon_ _ll1UserSymName (ptuple_ [pvarw_, npvar_ valName]))
-            , Some (field, nvar_ valName)
-            )
-          else (Some pvarw_, None ()) in
-        let stagedAction =
-          let infoName = nameSym "info" in
-          let paramName = nameSym "syms" in
-          nulam_ paramName
-            (_nulet_ infoName (_symSeqInfo_ (nvar_ paramName))
-              (utuple_
-                [ nvar_ infoName
-                , match unzip (map stageField wrappedSyntax) with (pats, fields) then
-                    match_ (nvar_ paramName) (pseqtot_ (mapOption identity pats))
-                      (nconapp_ constructorName
-                        (urecord_
-                          (cons ("info", nvar_ infoName)
-                            (mapOption identity fields))))
-                      never_
-                  else never
-                ]))
-        in
-        urecord_
-          [ ("name", str_ constructorStr)
-          , ("nt", var_ nonTerminal)
-          , ("ptype", stagedProdType)
-          , ("rhs" , seq_ (mapOption _stageSymbol syntax))
-          , ("action", stagedAction)
-          ]
-      in
+--       -- Staged production spec, i.e., input for semantic.mc
+--       let stagedSpec =
+--         let stagedProdType =
+--           match prodType with GeneratorAtom {self = self} then
+--             _semanticAtom_ (urecord_ [("self", _stageInclude self)])
+--           else match prodType with GeneratorPrefix {self = self, right = right} then
+--             _semanticPrefix_ (urecord_ [("self", _stageInclude self), ("right", _stageInclude right)])
+--           else match prodType with GeneratorInfix {self = self, left = left, right = right} then
+--             _semanticInfix_ (urecord_ [("self", _stageInclude self), ("left", _stageInclude left), ("right", _stageInclude right)])
+--           else match prodType with GeneratorPostfix {self = self, left = left} then
+--             _semanticPostfix_ (urecord_ [("self", _stageInclude self), ("left", _stageInclude left)])
+--           else never in
+--         let stageField = lam sym.
+--           let simpleResult = lam field. lam conName.
+--             let valName = nameSym field in
+--             ( Some (npcon_ _ll1TokName (npcon_ conName (prec_ [("val", npvar_ valName)])))
+--             , Some (field, nvar_ valName)
+--             ) in
+--           match sym with GeneratorInt {field = Some field} then
+--             simpleResult field _lexerIntName
+--           else match sym with GeneratorFloat {field = Some field} then
+--             simpleResult field _lexerFloatName
+--           else match sym with GeneratorOperator {field = Some field} then
+--             simpleResult field _lexerOperatorName
+--           else match sym with GeneratorString {field = Some field} then
+--             simpleResult field _lexerStringName
+--           else match sym with GeneratorChar {field = Some field} then
+--             simpleResult field _lexerCharName
+--           else match sym with GeneratorHashString {field = Some field} then
+--             simpleResult field _lexerHashStringName
+--           else match sym with GeneratorLIdent {field = Some field} then
+--             simpleResult field _lexerLIdentName
+--           else match sym with GeneratorUIdent {field = Some field} then
+--             simpleResult field _lexerUIdentName
+--           else match sym with GeneratorNonSyntax {field = field, fieldValue = val} then
+--             ( None ()
+--             , Some (field, val)
+--             )
+--           else match sym with GeneratorNt {field = Some field} then
+--             let valName = nameSym field in
+--             ( Some (npcon_ _ll1UserSymName (ptuple_ [pvarw_, npvar_ valName]))
+--             , Some (field, nvar_ valName)
+--             )
+--           else (Some pvarw_, None ()) in
+--         let stagedAction =
+--           let infoName = nameSym "info" in
+--           let paramName = nameSym "syms" in
+--           nulam_ paramName
+--             (_nulet_ infoName (_symSeqInfo_ (nvar_ paramName))
+--               (utuple_
+--                 [ nvar_ infoName
+--                 , match unzip (map stageField wrappedSyntax) with (pats, fields) then
+--                     match_ (nvar_ paramName) (pseqtot_ (mapOption identity pats))
+--                       (nconapp_ constructorName
+--                         (urecord_
+--                           (cons ("info", nvar_ infoName)
+--                             (mapOption identity fields))))
+--                       never_
+--                   else never
+--                 ]))
+--         in
+--         urecord_
+--           [ ("name", str_ constructorStr)
+--           , ("nt", var_ nonTerminal)
+--           , ("ptype", stagedProdType)
+--           , ("rhs" , seq_ (mapOption _stageSymbol syntax))
+--           , ("action", stagedAction)
+--           ]
+--       in
 
-      -- Putting it together
-      { constructor = Some constructor
-      , sym = sym
-      , stagedSpec = stagedSpec
-      , nonTerminal = nonTerminal
-      }
-    else never
+--       -- Putting it together
+--       { constructor = Some constructor
+--       , sym = sym
+--       , stagedSpec = stagedSpec
+--       , nonTerminal = nonTerminal
+--       }
+--     else never
 
-let generatorBracket
-  : { nonTerminal : NonTerminal
-    , leftBracket : [GeneratorSymbol]
-    , rightBracket : [GeneratorSymbol]
-    }
-  -> GeneratorProduction
-  = lam spec.
-    match spec with
-      { nonTerminal = nonTerminal
-      , leftBracket = leftBracket
-      , rightBracket = rightBracket
-      }
-    then
-      let sym = gensym () in
+-- let generatorBracket
+--   : { nonTerminal : NonTerminal
+--     , leftBracket : [GeneratorSymbol]
+--     , rightBracket : [GeneratorSymbol]
+--     }
+--   -> GeneratorProduction
+--   = lam spec.
+--     match spec with
+--       { nonTerminal = nonTerminal
+--       , leftBracket = leftBracket
+--       , rightBracket = rightBracket
+--       }
+--     then
+--       let sym = gensym () in
 
-      let stagedSpec =
-        let allSymbols = join
-          [ leftBracket
-          , [GeneratorNt {field = None (), nt = nonTerminal}]
-          , rightBracket
-          ] in
-        let stagedAction =
-          let infoName = nameSym "info" in
-          let paramName = nameSym "syms" in
-          let valName = nameSym "val" in
-          nulam_ paramName
-            (_nulet_ infoName (_symSeqInfo_ (nvar_ paramName))
-              (utuple_
-                [ nvar_ infoName
-                , match_ (get_ (nvar_ paramName) (int_ (length leftBracket)))
-                  (npcon_ _ll1UserSymName (ptuple_ [pvarw_, npvar_ valName]))
-                  (nvar_ valName)
-                  never_
-                ]))
-        in
-        urecord_
-          [ ("name", str_ (concat "grouping " nonTerminal))
-          , ("nt", var_ nonTerminal)
-          , ("ptype", _semanticAtom_ (urecord_ [("self", _stageInclude (DefaultIn ()))]))
-          , ("rhs", seq_ (mapOption _stageSymbol allSymbols))
-          , ("action", stagedAction)
-          ]
-      in
+--       let stagedSpec =
+--         let allSymbols = join
+--           [ leftBracket
+--           , [GeneratorNt {field = None (), nt = nonTerminal}]
+--           , rightBracket
+--           ] in
+--         let stagedAction =
+--           let infoName = nameSym "info" in
+--           let paramName = nameSym "syms" in
+--           let valName = nameSym "val" in
+--           nulam_ paramName
+--             (_nulet_ infoName (_symSeqInfo_ (nvar_ paramName))
+--               (utuple_
+--                 [ nvar_ infoName
+--                 , match_ (get_ (nvar_ paramName) (int_ (length leftBracket)))
+--                   (npcon_ _ll1UserSymName (ptuple_ [pvarw_, npvar_ valName]))
+--                   (nvar_ valName)
+--                   never_
+--                 ]))
+--         in
+--         urecord_
+--           [ ("name", str_ (concat "grouping " nonTerminal))
+--           , ("nt", var_ nonTerminal)
+--           , ("ptype", _semanticAtom_ (urecord_ [("self", _stageInclude (DefaultIn ()))]))
+--           , ("rhs", seq_ (mapOption _stageSymbol allSymbols))
+--           , ("action", stagedAction)
+--           ]
+--       in
 
-      { constructor = None ()
-      , sym = sym
-      , stagedSpec = stagedSpec
-      , nonTerminal = nonTerminal
-      }
-    else never
+--       { constructor = None ()
+--       , sym = sym
+--       , stagedSpec = stagedSpec
+--       , nonTerminal = nonTerminal
+--       }
+--     else never
 
--- TODO(vipa, 2021-03-10): We should run `semanticGrammar` once before
--- we generate the code and report errors there, then we know that the
--- grammar we generate won't produce any errors, so we don't have to
--- deal with it at that point.
-let generatorGrammar
-  : { langName : String
-    , start : NonTerminal
-    , productions : [GeneratorProduction]
-    , overrideAllow : [GeneratorOverride]
-    , overrideDisallow : [GeneratorOverride]
-    , precedences : [((GeneratorProduction, GeneratorProduction), Precedence)]
-    , sfunctions : [(NonTerminal, NonTerminal)]
-    }
-  -> String
-  = lam grammar.
-    match grammar with
-      { langName = langName
-      , start = start
-      , productions = productions
-      , overrideAllow = overrideAllow
-      , overrideDisallow = overrideDisallow
-      , precedences = precedences
-      , sfunctions = sfunctions
-      }
-    then
-      let composedName = concat langName "Composed" in
-      let astGenInput =
-        { namePrefix = langName
-        , constructors = mapOption (lam x: GeneratorProduction. x.constructor) productions
-        , requestedSFunctions = map
-          (lam x: (String, String). (stringToSynType x.0, tycon_ x.1))
-          sfunctions
-        , composedName = Some composedName
-        } in
-      let prodSymToName = lam sym. nameSetSym (nameNoSym "prod") sym in
-      let stageOverride = lam o.
-        match o
-        with GeneratorLeftChild {child = child, parent = parent}
-           | GeneratorRightChild {child = child, parent = parent}
-        then
-          let construct =
-            match o with GeneratorLeftChild _ then _semanticLeftChild_ else _semanticRightChild_ in
-          construct
-            (urecord_
-              [ ("child", nvar_ (prodSymToName child.sym))
-              , ("parent", nvar_ (prodSymToName parent.sym))
-              ])
-        else never in
-      let stagePrecedence = lam prec: ((GeneratorProduction, GeneratorProduction), Precedence).
-        match prec with ((l, r), {mayGroupLeft = mayGroupLeft, mayGroupRight = mayGroupRight}) then
-          utuple_
-            [ utuple_
-              [ nvar_ (prodSymToName l.sym)
-              , nvar_ (prodSymToName r.sym)
-              ]
-            , urecord_
-              [ ("mayGroupLeft", bool_ mayGroupLeft)
-              , ("mayGroupRight", bool_ mayGroupRight)
-              ]
-            ]
-        else never in
-      let nts = foldl
-        (lam acc. lam prod: GeneratorProduction. mapInsert prod.nonTerminal () acc)
-        (mapEmpty cmpString)
-        productions in
-      let ntLets = map
-        (lam pair: (NonTerminal, ()).
-          let nt = pair.0 in
-          ulet_ nt (_semanticNonTerminal_ (str_ nt)))
-        (mapBindings nts) in
-      let productions = map
-        (lam prod: GeneratorProduction.
-          let name = prodSymToName prod.sym in
-          (name, nulet_ name (_semanticProduction_ prod.stagedSpec)))
-        productions in
-      match unzip productions with (prodNames, prodLets) then
-        let semanticGrammar = urecord_
-          [ ("start", var_ start)
-          , ("productions", seq_ (map nvar_ prodNames))
-          , ("overrideAllow", seq_ (map stageOverride overrideAllow))
-          , ("overrideDisallow", seq_ (map stageOverride overrideDisallow))
-          , ("precedences", seq_ (map stagePrecedence precedences))
-          ] in
-        let grammarName = nameSym "grammar" in
-        use MExprPrettyPrint in
-        let resName = nameSym "res" in
-        let errsName = nameSym "errs" in
-        let fileNameName = nameSym "filename" in
-        let sourceName = nameSym "source" in
-        let parseFuncStr = join
-          [ "let parse", langName, "File = use ", composedName, " in use ParserConcrete in \n  "
-          , let res =
-              (_nulet_ resName
-                (_semanticGrammar_ (bindall_ (snoc (concat ntLets prodLets) semanticGrammar)))
-                (match_ (nvar_ resName)
-                  (npcon_ _rightConName (npvar_ grammarName))
-                  (nulam_ fileNameName
-                    (nulam_ sourceName
-                      (_eitherMapRight_ (lam_ "x" (tytuple_ [tyunknown_, tyunknown_]) (tupleproj_ 1 (var_ "x")))
-                        (_semanticParseFile_ (nvar_ grammarName) (nvar_ fileNameName) (nvar_ sourceName)))))
-                  (match_ (nvar_ resName)
-                    (npcon_ _leftConName (npvar_ errsName))
-                    (_sequentialComposition_
-                      (_dprintLn_ (_semanticShortenErrors_ (nvar_ errsName)))
-                      (error_ (str_ "Invalid grammar")))
-                    never_)))
-            in (pprintCode 2 _env res).1
-          , "\n"
-          ] in
-        use CarriedBasic in
-        join
-          [ "include \"parser/generator.mc\"\n"
-          , "include \"parser/semantic.mc\"\n"
-          , "\n"
-          , mkLanguages astGenInput, "\n\n"
-          , parseFuncStr]
-      else never
-    else never
+-- -- TODO(vipa, 2021-03-10): We should run `semanticGrammar` once before
+-- -- we generate the code and report errors there, then we know that the
+-- -- grammar we generate won't produce any errors, so we don't have to
+-- -- deal with it at that point.
+-- let generatorGrammar
+--   : { langName : String
+--     , start : NonTerminal
+--     , productions : [GeneratorProduction]
+--     , overrideAllow : [GeneratorOverride]
+--     , overrideDisallow : [GeneratorOverride]
+--     , precedences : [((GeneratorProduction, GeneratorProduction), Precedence)]
+--     , sfunctions : [(NonTerminal, NonTerminal)]
+--     }
+--   -> String
+--   = lam grammar.
+--     match grammar with
+--       { langName = langName
+--       , start = start
+--       , productions = productions
+--       , overrideAllow = overrideAllow
+--       , overrideDisallow = overrideDisallow
+--       , precedences = precedences
+--       , sfunctions = sfunctions
+--       }
+--     then
+--       let composedName = concat langName "Composed" in
+--       let astGenInput =
+--         { namePrefix = langName
+--         , constructors = mapOption (lam x: GeneratorProduction. x.constructor) productions
+--         , requestedSFunctions = map
+--           (lam x: (String, String). (stringToSynType x.0, tycon_ x.1))
+--           sfunctions
+--         , composedName = Some composedName
+--         } in
+--       let prodSymToName = lam sym. nameSetSym (nameNoSym "prod") sym in
+--       let stageOverride = lam o.
+--         match o
+--         with GeneratorLeftChild {child = child, parent = parent}
+--            | GeneratorRightChild {child = child, parent = parent}
+--         then
+--           let construct =
+--             match o with GeneratorLeftChild _ then _semanticLeftChild_ else _semanticRightChild_ in
+--           construct
+--             (urecord_
+--               [ ("child", nvar_ (prodSymToName child.sym))
+--               , ("parent", nvar_ (prodSymToName parent.sym))
+--               ])
+--         else never in
+--       let stagePrecedence = lam prec: ((GeneratorProduction, GeneratorProduction), Precedence).
+--         match prec with ((l, r), {mayGroupLeft = mayGroupLeft, mayGroupRight = mayGroupRight}) then
+--           utuple_
+--             [ utuple_
+--               [ nvar_ (prodSymToName l.sym)
+--               , nvar_ (prodSymToName r.sym)
+--               ]
+--             , urecord_
+--               [ ("mayGroupLeft", bool_ mayGroupLeft)
+--               , ("mayGroupRight", bool_ mayGroupRight)
+--               ]
+--             ]
+--         else never in
+--       let nts = foldl
+--         (lam acc. lam prod: GeneratorProduction. mapInsert prod.nonTerminal () acc)
+--         (mapEmpty cmpString)
+--         productions in
+--       let ntLets = map
+--         (lam pair: (NonTerminal, ()).
+--           let nt = pair.0 in
+--           ulet_ nt (_semanticNonTerminal_ (str_ nt)))
+--         (mapBindings nts) in
+--       let productions = map
+--         (lam prod: GeneratorProduction.
+--           let name = prodSymToName prod.sym in
+--           (name, nulet_ name (_semanticProduction_ prod.stagedSpec)))
+--         productions in
+--       match unzip productions with (prodNames, prodLets) then
+--         let semanticGrammar = urecord_
+--           [ ("start", var_ start)
+--           , ("productions", seq_ (map nvar_ prodNames))
+--           , ("overrideAllow", seq_ (map stageOverride overrideAllow))
+--           , ("overrideDisallow", seq_ (map stageOverride overrideDisallow))
+--           , ("precedences", seq_ (map stagePrecedence precedences))
+--           ] in
+--         let grammarName = nameSym "grammar" in
+--         use MExprPrettyPrint in
+--         let resName = nameSym "res" in
+--         let errsName = nameSym "errs" in
+--         let fileNameName = nameSym "filename" in
+--         let sourceName = nameSym "source" in
+--         let parseFuncStr = join
+--           [ "let parse", langName, "File = use ", composedName, " in use ParserConcrete in \n  "
+--           , let res =
+--               (_nulet_ resName
+--                 (_semanticGrammar_ (bindall_ (snoc (concat ntLets prodLets) semanticGrammar)))
+--                 (match_ (nvar_ resName)
+--                   (npcon_ _rightConName (npvar_ grammarName))
+--                   (nulam_ fileNameName
+--                     (nulam_ sourceName
+--                       (_eitherMapRight_ (lam_ "x" (tytuple_ [tyunknown_, tyunknown_]) (tupleproj_ 1 (var_ "x")))
+--                         (_semanticParseFile_ (nvar_ grammarName) (nvar_ fileNameName) (nvar_ sourceName)))))
+--                   (match_ (nvar_ resName)
+--                     (npcon_ _leftConName (npvar_ errsName))
+--                     (_sequentialComposition_
+--                       (_dprintLn_ (_semanticShortenErrors_ (nvar_ errsName)))
+--                       (error_ (str_ "Invalid grammar")))
+--                     never_)))
+--             in (pprintCode 2 _env res).1
+--           , "\n"
+--           ] in
+--         use CarriedBasic in
+--         join
+--           [ "include \"parser/generator.mc\"\n"
+--           , "include \"parser/semantic.mc\"\n"
+--           , "\n"
+--           , mkLanguages astGenInput, "\n\n"
+--           , parseFuncStr]
+--       else never
+--     else never
 
-let _symSeqInfo
-  : [Symbol]
-  -> Info
-  = lam syms.
-    let getInfo = lam sym. use ParserConcrete in
-      match sym with Tok tok then tokInfo tok else
-      match sym with Lit {info = info} then info else
-      match sym with UserSym (info, _) then info else
-      never in
-    match syms with [] then NoInfo () else
-    match syms with [sym] then getInfo sym else
-    match syms with [first] ++ _ ++ [last] then mergeInfo (getInfo first) (getInfo last) else
-    never
+-- let _symSeqInfo
+--   : [Symbol]
+--   -> Info
+--   = lam syms.
+--     let getInfo = lam sym. use ParserConcrete in
+--       match sym with Tok tok then tokInfo tok else
+--       match sym with Lit {info = info} then info else
+--       match sym with UserSym (info, _) then info else
+--       never in
+--     match syms with [] then NoInfo () else
+--     match syms with [sym] then getInfo sym else
+--     match syms with [first] ++ _ ++ [last] then mergeInfo (getInfo first) (getInfo last) else
+--     never
 
-let generatorNamespace =
-  -- Grammar construction and code generation
-  let prod = generatorProd in
-  let bracket = generatorBracket in
-  let grammar = generatorGrammar in
+-- let generatorNamespace =
+--   -- Grammar construction and code generation
+--   let prod = generatorProd in
+--   let bracket = generatorBracket in
+--   let grammar = generatorGrammar in
 
-  -- Production types
-  let defAtom = GeneratorAtom
-    { self = DefaultIn ()
-    } in
-  let defPrefix = lam rname. GeneratorPrefix
-    { self = DefaultIn (), right = DefaultIn ()
-    , rightField = Some rname
-    } in
-  let defInfix = lam lname. lam rname. GeneratorInfix
-    { self = DefaultIn (), left = DefaultIn (), right = DefaultIn ()
-    , leftField = Some lname, rightField = Some rname
-    } in
-  let defPostfix = lam lname. GeneratorPostfix
-    { self = DefaultIn (), left = DefaultIn ()
-    , leftField = Some lname
-    } in
+--   -- Production types
+--   let defAtom = GeneratorAtom
+--     { self = DefaultIn ()
+--     } in
+--   let defPrefix = lam rname. GeneratorPrefix
+--     { self = DefaultIn (), right = DefaultIn ()
+--     , rightField = Some rname
+--     } in
+--   let defInfix = lam lname. lam rname. GeneratorInfix
+--     { self = DefaultIn (), left = DefaultIn (), right = DefaultIn ()
+--     , leftField = Some lname, rightField = Some rname
+--     } in
+--   let defPostfix = lam lname. GeneratorPostfix
+--     { self = DefaultIn (), left = DefaultIn ()
+--     , leftField = Some lname
+--     } in
 
-  -- Precedence helpers
-  let groupLeft = semanticGroupLeft in
-  let groupRight = semanticGroupRight in
-  let groupEither = semanticGroupEither in
-  let groupNeither = semanticGroupNeither in
-  let highLowPrec = semanticHighLowPrec in
-  let precTableNoEq = semanticPrecTableNoEq in
-  let leftAssoc = semanticLeftAssoc in
-  let rightAssoc = semanticRightAssoc in
-  let nonAssoc = semanticNonAssoc in
-  let ambAssoc = semanticAmbAssoc in
-  let pairwiseGroup = semanticPairwiseGroup in
+--   -- Precedence helpers
+--   let groupLeft = semanticGroupLeft in
+--   let groupRight = semanticGroupRight in
+--   let groupEither = semanticGroupEither in
+--   let groupNeither = semanticGroupNeither in
+--   let highLowPrec = semanticHighLowPrec in
+--   let precTableNoEq = semanticPrecTableNoEq in
+--   let leftAssoc = semanticLeftAssoc in
+--   let rightAssoc = semanticRightAssoc in
+--   let nonAssoc = semanticNonAssoc in
+--   let ambAssoc = semanticAmbAssoc in
+--   let pairwiseGroup = semanticPairwiseGroup in
 
-  -- Token symbols
-  let int = lam field. GeneratorInt {field = Some field} in
-  let int_ = GeneratorInt {field = None ()} in
-  let float = lam field. GeneratorFloat {field = Some field} in
-  let float_ = GeneratorFloat {field = None ()} in
-  let operator = lam field. GeneratorOperator {field = Some field} in
-  let operator_ = GeneratorOperator {field = None ()} in
-  let string = lam field. GeneratorString {field = Some field} in
-  let string_ = GeneratorString {field = None ()} in
-  let char = lam field. GeneratorChar {field = Some field} in
-  let char_ = GeneratorChar {field = None ()} in
-  let hashString = lam field. lam tag. GeneratorHashString {field = Some field, tag = tag} in
-  let hashString_ = lam tag. GeneratorHashString {field = None (), tag = tag} in
-  let lit_ = lam lit. GeneratorLit {lit = lit} in
-  let lident = lam field. GeneratorLIdent {field = Some field} in
-  let lident_ = GeneratorLIdent {field = None ()} in
-  let uident = lam field. GeneratorUIdent {field = Some field} in
-  let uident_ = GeneratorUIdent {field = None ()} in
-  let nonsyntax = lam field. lam fieldType. lam fieldValue. GeneratorNonSyntax {field = field, fieldType = fieldType, fieldValue = fieldValue} in
-  let nt = lam field. lam nt. GeneratorNt {field = Some field, nt = nt} in
-  let nt_ = lam nt. GeneratorNt {field = None (), nt = nt} in
+--   -- Token symbols
+--   let int = lam field. GeneratorInt {field = Some field} in
+--   let int_ = GeneratorInt {field = None ()} in
+--   let float = lam field. GeneratorFloat {field = Some field} in
+--   let float_ = GeneratorFloat {field = None ()} in
+--   let operator = lam field. GeneratorOperator {field = Some field} in
+--   let operator_ = GeneratorOperator {field = None ()} in
+--   let string = lam field. GeneratorString {field = Some field} in
+--   let string_ = GeneratorString {field = None ()} in
+--   let char = lam field. GeneratorChar {field = Some field} in
+--   let char_ = GeneratorChar {field = None ()} in
+--   let hashString = lam field. lam tag. GeneratorHashString {field = Some field, tag = tag} in
+--   let hashString_ = lam tag. GeneratorHashString {field = None (), tag = tag} in
+--   let lit_ = lam lit. GeneratorLit {lit = lit} in
+--   let lident = lam field. GeneratorLIdent {field = Some field} in
+--   let lident_ = GeneratorLIdent {field = None ()} in
+--   let uident = lam field. GeneratorUIdent {field = Some field} in
+--   let uident_ = GeneratorUIdent {field = None ()} in
+--   let nonsyntax = lam field. lam fieldType. lam fieldValue. GeneratorNonSyntax {field = field, fieldType = fieldType, fieldValue = fieldValue} in
+--   let nt = lam field. lam nt. GeneratorNt {field = Some field, nt = nt} in
+--   let nt_ = lam nt. GeneratorNt {field = None (), nt = nt} in
 
-  -- Namespace as a record
-  { prod = prod, bracket = bracket, grammar = grammar
-  , defAtom = defAtom, defPrefix = defPrefix, defInfix = defInfix, defPostfix = defPostfix
-  , groupLeft = groupLeft, groupRight = groupRight, groupEither = groupEither
-  , groupNeither = groupNeither, highLowPrec = highLowPrec, precTableNoEq = precTableNoEq
-  , leftAssoc = leftAssoc, rightAssoc = rightAssoc, nonAssoc = nonAssoc, ambAssoc = ambAssoc
-  , pairwiseGroup = pairwiseGroup
-  , int = int, int_ = int_, float = float, float_ = float_
-  , operator = operator , operator_ = operator_, string = string, string_ = string_
-  , char = char, char_ = char_ , hashString = hashString, hashString_ = hashString_
-  , lit_ = lit_, lident = lident , lident_ = lident_, uident = uident, uident_ = uident_
-  , nonsyntax = nonsyntax , nt = nt, nt_ = nt_
-  }
+--   -- Namespace as a record
+--   { prod = prod, bracket = bracket, grammar = grammar
+--   , defAtom = defAtom, defPrefix = defPrefix, defInfix = defInfix, defPostfix = defPostfix
+--   , groupLeft = groupLeft, groupRight = groupRight, groupEither = groupEither
+--   , groupNeither = groupNeither, highLowPrec = highLowPrec, precTableNoEq = precTableNoEq
+--   , leftAssoc = leftAssoc, rightAssoc = rightAssoc, nonAssoc = nonAssoc, ambAssoc = ambAssoc
+--   , pairwiseGroup = pairwiseGroup
+--   , int = int, int_ = int_, float = float, float_ = float_
+--   , operator = operator , operator_ = operator_, string = string, string_ = string_
+--   , char = char, char_ = char_ , hashString = hashString, hashString_ = hashString_
+--   , lit_ = lit_, lident = lident , lident_ = lident_, uident = uident, uident_ = uident_
+--   , nonsyntax = nonsyntax , nt = nt, nt_ = nt_
+--   }
 
-mexpr
+-- mexpr
 
-let g = generatorNamespace in
+-- let g = generatorNamespace in
 
-let unknownTyP: GeneratorProduction = g.prod
-  { nonTerminal = "Type"
-  , constructorName = "TyUnknown"
-  , prodType = g.defAtom
-  , syntax = [g.lit_ "Unknown"]
-  } in
+-- let unknownTyP: GeneratorProduction = g.prod
+--   { nonTerminal = "Type"
+--   , constructorName = "TyUnknown"
+--   , prodType = g.defAtom
+--   , syntax = [g.lit_ "Unknown"]
+--   } in
 
--- TODO(vipa, 2021-03-16): This is ugly, the result from g.prod should
--- be opaque, but we need the precise name the constructor will use to
--- get it to pretty print correctly. There should be a better way to
--- solve it later (more or less running symbolize before printing),
--- but not at present.
-match unknownTyP with {constructor = Some x} then
-let unknownTyConstructorName = let x: Constructor = x in x.name in
-let tyField = g.nonsyntax "ty" (untargetableType (tycon_ "Type")) (var_ "tyunknown_") in
+-- -- TODO(vipa, 2021-03-16): This is ugly, the result from g.prod should
+-- -- be opaque, but we need the precise name the constructor will use to
+-- -- get it to pretty print correctly. There should be a better way to
+-- -- solve it later (more or less running symbolize before printing),
+-- -- but not at present.
+-- match unknownTyP with {constructor = Some x} then
+-- let unknownTyConstructorName = let x: Constructor = x in x.name in
+-- let tyField = g.nonsyntax "ty" (untargetableType (tycon_ "Type")) (var_ "tyunknown_") in
 
-let varP = g.prod
-  { constructorName = "TmVar"
-  , nonTerminal = "Expr"
-  , prodType = g.defAtom
-  , syntax = [g.lident "ident", tyField]
-  } in
+-- let varP = g.prod
+--   { constructorName = "TmVar"
+--   , nonTerminal = "Expr"
+--   , prodType = g.defAtom
+--   , syntax = [g.lident "ident", tyField]
+--   } in
 
-let appP = g.prod
-  { constructorName = "TmApp"
-  , nonTerminal = "Expr"
-  , prodType = g.defInfix "f" "a"
-  , syntax = [tyField]
-  } in
+-- let appP = g.prod
+--   { constructorName = "TmApp"
+--   , nonTerminal = "Expr"
+--   , prodType = g.defInfix "f" "a"
+--   , syntax = [tyField]
+--   } in
 
-let groupingP = g.bracket
-  { nonTerminal = "Expr"
-  , leftBracket = [g.lit_ "("]
-  , rightBracket = [g.lit_ ")"]
-  } in
+-- let groupingP = g.bracket
+--   { nonTerminal = "Expr"
+--   , leftBracket = [g.lit_ "("]
+--   , rightBracket = [g.lit_ ")"]
+--   } in
 
-let ifP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmIfBroken"
-  , prodType = g.defPrefix "thenExpr"
-  , syntax = [g.lit_ "if", g.nt "condition" "Expr", g.lit_ "then", tyField]
-  } in
+-- let ifP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmIfBroken"
+--   , prodType = g.defPrefix "thenExpr"
+--   , syntax = [g.lit_ "if", g.nt "condition" "Expr", g.lit_ "then", tyField]
+--   } in
 
-let elseP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmElseBroken"
-  , prodType = GeneratorInfix
-    { self = DefaultIn ()
-    , left = DefaultNotIn ()
-    , right = DefaultIn ()
-    , leftField = Some "ifExpr"
-    , rightField = Some "elseExpr"
-    }
-  , syntax = [g.lit_ "else", tyField]
-  } in
+-- let elseP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmElseBroken"
+--   , prodType = GeneratorInfix
+--     { self = DefaultIn ()
+--     , left = DefaultNotIn ()
+--     , right = DefaultIn ()
+--     , leftField = Some "ifExpr"
+--     , rightField = Some "elseExpr"
+--     }
+--   , syntax = [g.lit_ "else", tyField]
+--   } in
 
-let matchP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmMatch"
-  , prodType = GeneratorAtom {self = DefaultNotIn ()}
-  , syntax =
-    [ g.lit_ "match", g.nt "target" "Expr", g.lit_ "with"
-    , g.nonsyntax "arms"
-      (seqType
-        (tupleType
-          [ targetableType (tycon_ "Pat")
-          , targetableType (tycon_ "Expr")
-          ]))
-      (seq_ [])
-    , tyField]
-  } in
+-- let matchP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmMatch"
+--   , prodType = GeneratorAtom {self = DefaultNotIn ()}
+--   , syntax =
+--     [ g.lit_ "match", g.nt "target" "Expr", g.lit_ "with"
+--     , g.nonsyntax "arms"
+--       (seqType
+--         (tupleType
+--           [ targetableType (tycon_ "Pat")
+--           , targetableType (tycon_ "Expr")
+--           ]))
+--       (seq_ [])
+--     , tyField]
+--   } in
 
-let matchArmP = g.prod
-  { nonTerminal = "Expr"
-  , constructorName = "TmMatchArmBroken"
-  , prodType = GeneratorInfix
-    { self = DefaultIn ()
-    , left = DefaultNotIn ()
-    , right = DefaultIn ()
-    , leftField = Some "prev"
-    , rightField = Some "armExpr"
-    }
-  , syntax = [g.lit_ "|", g.nt "pat" "Pat", g.lit_ "->", tyField]
-  } in
+-- let matchArmP = g.prod
+--   { nonTerminal = "Expr"
+--   , constructorName = "TmMatchArmBroken"
+--   , prodType = GeneratorInfix
+--     { self = DefaultIn ()
+--     , left = DefaultNotIn ()
+--     , right = DefaultIn ()
+--     , leftField = Some "prev"
+--     , rightField = Some "armExpr"
+--     }
+--   , syntax = [g.lit_ "|", g.nt "pat" "Pat", g.lit_ "->", tyField]
+--   } in
 
-let intPatP = g.prod
-  { nonTerminal = "Pat"
-  , constructorName = "PatInt"
-  , prodType = g.defAtom
-  , syntax = [g.int "val", tyField]
-  } in
+-- let intPatP = g.prod
+--   { nonTerminal = "Pat"
+--   , constructorName = "PatInt"
+--   , prodType = g.defAtom
+--   , syntax = [g.int "val", tyField]
+--   } in
 
-let res = g.grammar
-  { langName = "MExpr"
-  , start = "Expr"
-  , productions = [varP, appP, groupingP, ifP, elseP, matchP, matchArmP, intPatP, unknownTyP]
-  , overrideAllow =
-    [ GeneratorLeftChild {parent = elseP, child = ifP}
-    , GeneratorLeftChild {parent = matchArmP, child = matchP}
-    , GeneratorLeftChild {parent = matchArmP, child = matchArmP}
-    ]
-  , overrideDisallow = []
-  , precedences = join
-    [ map g.leftAssoc [appP]
-    , g.precTableNoEq
-      [ [appP]
-      , [ifP]
-      ]
-    -- NOTE(vipa, 2021-03-16): These stem from if and match having
-    -- lower precedence than the things to the right, but they can't
-    -- be specified in the normal way because it should only apply to
-    -- their right children
-    , seqLiftA2 g.groupRight [elseP, matchArmP] [appP]
-    -- NOTE(vipa, 2021-03-16): Precedence with things to the left have
-    -- to be treated as ambiguous (groupEither) to allow them to float
-    -- to the appropriate thing they must attach to (ifP, matchP,
-    -- matchArmP)
-    , seqLiftA2 g.groupEither [appP, ifP, elseP, matchArmP] [elseP, matchArmP]
-    ]
-  , sfunctions =
-    [ ("Expr", "Expr")
-    , ("Expr", "Type")
-    , ("Expr", "Pat")
-    , ("Pat", "Pat")
-    , ("Pat", "Type")
-    , ("Type", "Type")
-    ]
-  } in
+-- let res = g.grammar
+--   { langName = "MExpr"
+--   , start = "Expr"
+--   , productions = [varP, appP, groupingP, ifP, elseP, matchP, matchArmP, intPatP, unknownTyP]
+--   , overrideAllow =
+--     [ GeneratorLeftChild {parent = elseP, child = ifP}
+--     , GeneratorLeftChild {parent = matchArmP, child = matchP}
+--     , GeneratorLeftChild {parent = matchArmP, child = matchArmP}
+--     ]
+--   , overrideDisallow = []
+--   , precedences = join
+--     [ map g.leftAssoc [appP]
+--     , g.precTableNoEq
+--       [ [appP]
+--       , [ifP]
+--       ]
+--     -- NOTE(vipa, 2021-03-16): These stem from if and match having
+--     -- lower precedence than the things to the right, but they can't
+--     -- be specified in the normal way because it should only apply to
+--     -- their right children
+--     , seqLiftA2 g.groupRight [elseP, matchArmP] [appP]
+--     -- NOTE(vipa, 2021-03-16): Precedence with things to the left have
+--     -- to be treated as ambiguous (groupEither) to allow them to float
+--     -- to the appropriate thing they must attach to (ifP, matchP,
+--     -- matchArmP)
+--     , seqLiftA2 g.groupEither [appP, ifP, elseP, matchArmP] [elseP, matchArmP]
+--     ]
+--   , sfunctions =
+--     [ ("Expr", "Expr")
+--     , ("Expr", "Type")
+--     , ("Expr", "Pat")
+--     , ("Pat", "Pat")
+--     , ("Pat", "Type")
+--     , ("Type", "Type")
+--     ]
+--   } in
 
--- printLn res;
+-- -- printLn res;
 
-()
+-- ()
 
-else never
+-- else never

--- a/stdlib/parser/semantic.mc
+++ b/stdlib/parser/semantic.mc
@@ -1,1354 +1,1354 @@
--- Miking is licensed under the MIT license.
--- Copyright (C) David Broman. See file LICENSE.txt
---
-
-/-
-
-This file implements breakable operators (`breakable.mc`) on top of a
-more normal parsing strategy, in this case LL(1) (`ll1.mc`).
-
-For more info on how precedence works, and basic ideas on how to break
-productions into operators, see `breakable.mc`.
-
-The primary entry-points to this module are `semanticGrammar` and
-`semanticParseFile`. All other exported values are used to help define
-a grammar, see the tests for examples on how to use them.
-
--/
-
-include "lexer.mc"
-include "ll1.mc"
-include "breakable.mc"
-include "common.mc"
-
-type NonTerminal = { sym: Symbol, name: String }
-
-type DefaultInclude
-con DefaultIn : () -> DefaultInclude
-con DefaultNotIn : () -> DefaultInclude
-
-let semanticDefIn = DefaultIn ()
-let semanticDefNotIn = DefaultNotIn ()
-
-type ProdType
-con Atom :
-  { self : DefaultInclude
-  } -> ProdType
-con Prefix :
-  { self : DefaultInclude
-  , right : DefaultInclude
-  } -> ProdType
-con Postfix :
-  { self : DefaultInclude
-  , left : DefaultInclude
-  } -> ProdType
-con Infix :
-  { self : DefaultInclude
-  , left : DefaultInclude
-  , right : DefaultInclude
-  } -> ProdType
-
-let _prodTypeSelf
-  : ProdType
-  -> DefaultInclude
-  = lam pt.
-    match pt
-    with Atom {self = self}
-       | Prefix {self = self}
-       | Postfix {self = self}
-       | Infix {self = self}
-    then self
-    else never
-
-let semanticDefInfix = Infix
-  { self = DefaultIn ()
-  , left = DefaultIn ()
-  , right = DefaultIn ()
-  }
-
-let semanticDefPrefix = Prefix
-  { self = DefaultIn ()
-  , right = DefaultIn ()
-  }
-
-let semanticDefPostfix = Postfix
-  { self = DefaultIn ()
-  , left = DefaultIn ()
-  }
-
-let semanticDefAtom = Atom
-  { self = DefaultIn ()
-  }
-
-let _lopenType = lam x.
-  match x with Postfix _ | Infix _ then true else false
-
-let _ropenType = lam x.
-  match x with Prefix _ | Infix _ then true else false
-
-type Precedence = { mayGroupLeft : Bool, mayGroupRight : Bool }
-
-let semanticGroupEither = lam l. lam r. ((l, r), { mayGroupLeft = true, mayGroupRight = true })
-let semanticGroupLeft = lam l. lam r. ((l, r), { mayGroupLeft = true, mayGroupRight = false })
-let semanticGroupRight = lam l. lam r. ((l, r), { mayGroupLeft = false, mayGroupRight = true })
-let semanticGroupNeither = lam l. lam r. ((l, r), { mayGroupLeft = false, mayGroupRight = false })
-
--- Take two lists of productions, make each production in the `high`
--- list have higher precedence than each production in the `low` list.
-let semanticHighLowPrec
-  : { high : [prod]
-    , low : [prod]
-    }
-  -> [((prod, prod), Precedence)]
-  = let mkGrouping = lam high. lam low.
-      [ semanticGroupLeft high low
-      , semanticGroupRight low high
-      ] in
-    lam spec. join (seqLiftA2 mkGrouping spec.high spec.low)
-
--- Take a precedence table, from high precedence to low precedence,
--- and impose the implied precedences. Note that no precedence is
--- applied between productions on the same precedence level.
-recursive let semanticPrecTableNoEq
-  : [[prod]]
-  -> [((prod, prod), Precedence)]
-  = lam table.
-    match table with [high] ++ lows then
-      concat (semanticHighLowPrec {high = high, low = join lows}) (semanticPrecTableNoEq lows)
-    else []
-end
-
-let semanticLeftAssoc
-  : prod
-  -> ((prod, prod), Precedence)
-  = lam prod. semanticGroupLeft prod prod
-
-let semanticRightAssoc
-  : prod
-  -> ((prod, prod), Precedence)
-  = lam prod. semanticGroupRight prod prod
-
-let semanticNonAssoc
-  : prod
-  -> ((prod, prod), Precedence)
-  = lam prod. semanticGroupNeither prod prod
-
-let semanticAmbAssoc
-  : prod
-  -> ((prod, prod), Precedence)
-  = lam prod. semanticGroupEither prod prod
-
-/-
-Apply the given grouping between all given operators, regardless of
-order. For example, `semanticPairwiseGroup semanticGroupLeft [a, b,
-c]` is equivalent with
-
-```
-[ semanticGroupLeft a b
-, semanticGroupLeft b a
-, semanticGroupLeft a c
-, semanticGroupLeft c a
-, semanticGroupLeft b c
-, semanticGroupLeft c b
-]
-```
--/
-recursive let semanticPairwiseGroup
-  : (prod -> prod -> Precedence)
-  -> [prod]
-  -> [((prod, prod), Precedence)]
-  = lam group.
-    recursive let work = lam prods.
-      match prods with [prod] ++ prods then
-        concat
-          (join (map (lam r. [group prod r, group r prod]) prods))
-          (work prods)
-      else []
-    in work
-end
-
--- Create a new non-terminal with the given name.
--- WARNING: not referentially transparent
-let semanticNonTerminal
-  : String
-  -> NonTerminal
-  = lam name.
-    { sym = gensym (), name = name }
-
-type ProductionSpec =
-  { name : String -- For use in error messages
-  , nt : NonTerminal
-  , ptype : ProdType
-  , rhs : [Symbol]
-  -- This is ll1.mc/Action. In case of an operator the rhs will have
-  -- a `UserSym` added on each open side (e.g., `ptype = defPrefix`,
-  -- `rhs = [lit "!"]` gives `action [lit "!", UserSym res]`
-  , action : Action
-  }
-
-type Production = { sym: Symbol, spec: ProductionSpec }
-
-type Override
-con LeftChild : { child : Production, parent : Production } -> Override
-con RightChild : { child : Production, parent : Production } -> Override
-
--- Create a new production.
--- WARNING: not referentially transparent
-let semanticProduction
-  : ProductionSpec
-  -> Production
-  = lam prod.
-    { sym = gensym (), spec = prod }
-
--- TODO(vipa, 2021-03-01): See the TODO at 2021-02-24 that also refers
--- to non-terminals.
-let semanticNt
-  : NonTerminal
-  -> Symbol
-  = lam nt. ll1Nt nt.name
-let semanticLit
-  : String
-  -> Symbol
-  = ll1Lit
-let semanticInt : Symbol = ll1Int
-let semanticFloat : Symbol = ll1Float
-let semanticOperator : Symbol = ll1Operator
-let semanticString : Symbol = ll1String
-let semanticChar : Symbol = ll1Char
-let semanticLIdent : Symbol = ll1LIdent
-let semanticUIdent : Symbol = ll1UIdent
-let semanticHashString : String -> Symbol = ll1HashString
-
-type Parser
-
-type SemanticGrammarError
-con DuplicatedPrecedence : [((ProductionSpec, ProductionSpec), Precedence)] -> SemanticGrammarError
-con UndefinedPrecedence : {left : ProductionSpec, right : ProductionSpec} -> SemanticGrammarError
-con SemanticGrammarLL1Error : GenError String -> SemanticGrammarError
-
-type SemanticParseError
-con SemanticParseBreakableError : {nt : String, info : Info} -> SemanticParseError
-con SemanticParseAmbiguityError : {info : Info, irrelevant : [Info]} -> SemanticParseError
-con SemanticParseError : ParseError String -> SemanticParseError
--- NOTE(vipa, 2021-02-25): All ll1 productions generated here will
--- follow the convention that we can always get the range of a
--- Symbol. In particular, each `UserSym` that goes between
--- non-terminals (i.e., once we've finished a breakable parse) will
--- carry an `Either [SemanticParseError] (Info, res)`.
-let _symInfo
-  : Symbol
-  -> Info
-  = lam sym.
-    use ParserConcrete in
-    match sym with Lit {info = info} then info else
-    match sym with UserSym (Right (info, _)) then info else
-    match sym with Tok t then use Lexer in tokInfo t else
-    never
-let _seqSymInfo
-  : [Symbol]
-  -> Info
-  = lam syms.
-    match syms with [s] then _symInfo s else
-    match syms with [s] ++ _ ++ [e] then mergeInfo (_symInfo s) (_symInfo e) else
-    match syms with [] then NoInfo () else
-    never
-
-let _breakableErrorToSemanticErrors
-  : BreakableError [Symbol]
-  -> [SemanticParseError]
-  = lam err.
-    match err with Ambiguities ambs then
-      map
-        (lam amb: Ambiguity [Symbol]. match amb with {first = f, last = l, irrelevant = irr} then
-           SemanticParseAmbiguityError
-             { info = mergeInfo (_seqSymInfo f) (_seqSymInfo l)
-             , irrelevant =
-               map
-                 (lam irr: Irrelevancy [Symbol].
-                   mergeInfo (_seqSymInfo irr.first) (_seqSymInfo irr.last))
-                 irr
-             }
-         else never)
-        ambs
-    else never
-
-let _buildSurroundedAtom
-  : [(BreakableInput res [Symbol] LClosed ROpen, [Symbol])]
-  -> (BreakableInput res [Symbol] LClosed RClosed, [Symbol])
-  -> [(BreakableInput res [Symbol] LOpen RClosed, [Symbol])]
-  -> (Info, State res [Symbol] RClosed -> Option (State res [Symbol] RClosed))
-  -> State res [Symbol] ROpen
-  -> Option (State res [Symbol] RClosed)
-  = lam pres. lam atom. lam posts. lam contFunc. lam st.
-    let st = foldl (lam st. lam pre: (BreakableInput res [Symbol] LClosed ROpen, [Symbol]). breakableAddPrefix pre.0 pre.1 st) st pres in
-    let st = breakableAddAtom atom.0 atom.1 st in
-    let mSt = optionFoldlM (lam st. lam post: (BreakableInput res [Symbol] LOpen RClosed, [Symbol]). breakableAddPostfix post.0 post.1 st) st posts in
-    optionBind mSt contFunc.1
-
-let _surroundedAtomInfo
-  : [(BreakableInput res [Symbol] LClosed ROpen, [Symbol])]
-  -> (BreakableInput res [Symbol] LClosed RClosed, [Symbol])
-  -> [(BreakableInput res [Symbol] LOpen RClosed, [Symbol])]
-  -> (Info, State res [Symbol] RClosed -> Option (State res [Symbol] RClosed))
-  -> Info
-  = lam pres. lam atom. lam posts. lam contFunc.
-    let snd: (a, b) -> b = lam x. x.1 in
-    let res = join (join [map snd pres, [atom.1], map snd posts]) in
-    match res with [first] ++ _ & _ ++ [last] then
-      mergeInfo (mergeInfo (_symInfo first) (_symInfo last)) contFunc.0
-    else never
-
--- NOTE(vipa, 2021-02-22): This assumes that we can impose a total
--- order on symbols via `sym2hash`, which is not guaranteed by its
--- interface
-let _cmpSym = lam a. lam b. subi (sym2hash a) (sym2hash b)
-let _cmpSymPair = lam a: (Symbol, Symbol). lam b: (Symbol, Symbol).
-  let aint1 = sym2hash a.0 in
-  let bint1 = sym2hash b.0 in
-  let res = subi aint1 bint1 in
-  if eqi res 0 then
-    subi (sym2hash a.1) (sym2hash b.1)
-  else res
-
--- Take a grammar and try to produce a parser.
-let semanticGrammar
-  : { start : NonTerminal
-    , productions : [Production]
-    , overrideAllow : [Override]
-    , overrideDisallow : [Override]
-    , precedences : [((Production, Production), Precedence)]
-    }
-  -> Either [SemanticGrammarError] Parser
-  = lam grammar.
-    let productions = grammar.productions in
-    let precedences = grammar.precedences in
-    let overrideAllow = grammar.overrideAllow in
-    let overrideDisallow = grammar.overrideDisallow in
-    let nonTerminals = foldl
-      (lam acc. lam prod: Production. mapInsert prod.spec.nt.sym prod.spec.nt.name acc)
-      (mapEmpty _cmpSym)
-      productions
-    in
-    let for = lam xs. lam f. map f xs in
-
-    -- TODO(vipa, 2021-02-24): It might be nice to report inconsistent
-    -- overrides, i.e., we're both overriding to allow *and* disallow
-    -- the same production in the same position, but I'm punting on
-    -- that for now, it should be a rare occurrence. Similarly, it
-    -- might be nice to report overrides that don't make sense, i.e.,
-    -- when the override is on left/right when the production isn't
-    -- left/right-open.
-    type SingleOverride = {allow: [Symbol], disallow: [Symbol]} in
-    type MultiOverride =
-      { left: SingleOverride
-      , right: SingleOverride
-      } in
-    let emptyMultiOverride = {left = {allow = [], disallow = []}, right = {allow = [], disallow = []}} in
-    let mergeMultiOverride =
-      let mergeSide = lam a: SingleOverride. lam b: SingleOverride.
-        { allow = concat a.allow b.allow
-        , disallow = concat a.disallow b.disallow
-        } in
-      lam a: MultiOverride. lam b: MultiOverride.
-      { left = mergeSide a.left b.left
-      , right = mergeSide a.right b.right
-      }
-    in
-    let overrides = foldl
-      (lam acc. lam override.
-        match override with LeftChild {child = {sym = child}, parent = {sym = parent}} then
-          mapInsertWith mergeMultiOverride parent
-            {emptyMultiOverride with left = {allow = [child], disallow = []}}
-            acc
-        else match override with RightChild {child = {sym = child}, parent = {sym = parent}} then
-          mapInsertWith mergeMultiOverride parent
-            {emptyMultiOverride with right = {allow = [child], disallow = []}}
-            acc
-        else never)
-      (mapEmpty _cmpSym)
-      overrideAllow in
-    let overrides = foldl
-      (lam acc. lam override.
-        match override with LeftChild {child = {sym = child}, parent = {sym = parent}} then
-          mapInsertWith mergeMultiOverride parent
-            {emptyMultiOverride with left = {disallow = [child], allow = []}}
-            acc
-        else match override with RightChild {child = {sym = child}, parent = {sym = parent}} then
-          mapInsertWith mergeMultiOverride parent
-            {emptyMultiOverride with right = {disallow = [child], allow = []}}
-            acc
-        else never)
-      overrides
-      overrideDisallow
-    in
-
-    -- Make each non-terminal separately, since they should generate a
-    -- breakable grammar each
-    let res = for (mapBindings nonTerminals)
-      (lam nt: (Symbol, String).
-        let ntsym = nt.0 in
-        let ntname = nt.1 in
-        let precedences = filter
-          (lam p: ((Production, Production), Precedence).
-            match p with (({spec = l}, {spec = r}), _) then
-              and
-               (and (eqsym l.nt.sym ntsym) (eqsym r.nt.sym ntsym))
-               (and (_ropenType l.ptype) (_lopenType r.ptype))
-            else false)
-          precedences in
-        let productions = filter
-          (lam prod: Production. eqsym prod.spec.nt.sym ntsym)
-          productions in
-
-        let getSyms = lam p: ((Production, Production), Precedence).
-          match p with (({sym = lsym}, {sym = rsym}), _)
-            then (lsym, rsym)
-            else never in
-        let groupedPrecs = foldl
-          (lam acc. lam p. mapInsertWith concat (getSyms p) [p] acc)
-          (mapEmpty _cmpSymPair)
-          precedences in
-
-        let dupPrecErrs =
-          let asSpecs = lam p: ((Production, Production), Precedence).
-            match p with (({spec = lspec}, {spec = rspec}), prec)
-              then ((lspec, rspec), prec)
-              else never in
-          let duplicatedPrecs = filter
-            (lam x. gti (length x) 1)
-            (map (lam x: (Unknown, Unknown). x.1) (mapBindings groupedPrecs)) in
-          let mkDupErr = lam ps. DuplicatedPrecedence (map asSpecs ps) in
-          map mkDupErr duplicatedPrecs
-        in
-
-        let undefPrecErrs =
-          let allLOpen = filter
-            (lam prod: Production. _lopenType prod.spec.ptype)
-            productions in
-          let allROpen = filter
-            (lam prod: Production. _ropenType prod.spec.ptype)
-            productions in
-          let paired = seqLiftA2 (lam a. lam b. (a, b)) allROpen allLOpen in
-          let undef = filter
-            (lam p: (Production, Production). match p with (l, r) then
-               not (mapMem (l.sym, r.sym) groupedPrecs)
-             else never)
-            paired in
-          map (lam x: (Production, Production). UndefinedPrecedence {left = (x.0).spec, right = (x.1).spec}) undef
-        in
-
-        let emptyAllowSet = AllowSet (mapEmpty _cmpSym) in
-        let defaultAllowSet =
-          let defaultDisallow = filter
-            (lam prod: Production. match _prodTypeSelf prod.spec.ptype with DefaultNotIn _ then true else false)
-            productions in
-          let syms = map (lam x: Production. (x.sym, ())) defaultDisallow in
-          DisallowSet (mapFromSeq _cmpSym syms)
-        in
-
-        let baseAllowSet
-          : DefaultInclude
-          -> AllowSet Symbol
-          = lam d.
-            match d with DefaultIn _ then defaultAllowSet else
-            match d with DefaultNotIn _ then emptyAllowSet else
-            never
-        in
-
-        let makeProductionBreakable = lam prod: Production.
-          use ParserConcrete in
-          match prod with {sym = sym, spec = {name = name, nt = nt, ptype = ptype, rhs = rhs, action = action}} then
-            let unwrapChildren = map
-              (lam sym. match sym with UserSym (Right (_, x))
-                then UserSym x
-                else sym) in
-            match ptype with Atom _ then
-              BreakableAtom {label = sym, construct = lam mid. action (unwrapChildren mid)}
-            else match ptype with Prefix {right = right} then
-              let overrides = match mapLookup sym overrides
-                with Some x then let x: MultiOverride = x in x.right
-                else {allow = [], disallow = []} in
-              let rightAllow = baseAllowSet right in
-              let rightAllow = foldl
-                (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
-                rightAllow
-                overrides.allow in
-              let rightAllow = foldl
-                (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
-                rightAllow
-                overrides.disallow in
-              let construct = lam mid. lam r. action (snoc (unwrapChildren mid) (UserSym r)) in
-              BreakablePrefix {label = sym, construct = construct, rightAllow = rightAllow}
-            else match ptype with Postfix {left = left} then
-              let overrides = match mapLookup sym overrides
-                with Some x then let x: MultiOverride = x in x.left
-                else {allow = [], disallow = []} in
-              let leftAllow = baseAllowSet left in
-              let leftAllow = foldl
-                (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
-                leftAllow
-                overrides.allow in
-              let leftAllow = foldl
-                (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
-                leftAllow
-                overrides.disallow in
-              let construct = lam mid. lam l. action (cons (UserSym l) (unwrapChildren mid)) in
-              BreakablePostfix {label = sym, construct = construct, leftAllow = leftAllow}
-            else match ptype with Infix {left = left, right = right} then
-              let overrides = match mapLookup sym overrides
-                with Some overrides then overrides
-                else emptyMultiOverride in
-              let leftAllow = baseAllowSet left in
-              let leftAllow = foldl
-                (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
-                leftAllow
-                overrides.left.allow in
-              let leftAllow = foldl
-                (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
-                leftAllow
-                overrides.left.disallow in
-              let rightAllow = baseAllowSet right in
-              let rightAllow = foldl
-                (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
-                rightAllow
-                overrides.right.allow in
-              let rightAllow = foldl
-                (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
-                rightAllow
-                overrides.right.disallow in
-              let construct = lam mid. lam l. lam r. action (cons (UserSym l) (snoc (unwrapChildren mid) (UserSym r))) in
-              BreakableInfix {label = sym, construct = construct, leftAllow = leftAllow, rightAllow = rightAllow}
-            else never
-          else never
-        in
-
-        let fst: (a, b) -> a = lam x. x.0 in
-        let snd: (a, b) -> b = lam x. x.1 in
-        let breakablePrecomputed = breakableGenGrammar _cmpSym
-          { productions = map makeProductionBreakable productions
-          , precedences = map
-            (lam pair. (fst pair, snd (head (snd pair))))
-            (mapBindings groupedPrecs)
-          } in
-        let atom = lam sym. mapFindExn sym breakablePrecomputed.atoms in
-        let prefix = lam sym. mapFindExn sym breakablePrecomputed.prefixes in
-        let postfix = lam sym. mapFindExn sym breakablePrecomputed.postfixes in
-        let infix = lam sym. mapFindExn sym breakablePrecomputed.infixes in
-
-        -- TODO(vipa, 2021-02-24): There will be a bug if multiple
-        -- non-terminals have the same name, they will be merged, even
-        -- though the interface (not referentially transparent) suggests
-        -- this is not the case. See also the TODO at 2021-03-01.
-        let topNt = ntname in
-        let contNt = concat ntname " continuation" in
-        let atomNt = concat "atomic " ntname in
-        let prefixNt = concat "prefix " ntname in
-        let prefixesNt = concat ntname " prefixes" in
-        let infixNt = concat "infix " ntname in
-        let postfixNt = concat "postfix " ntname in
-        let postfixesNt = concat ntname " postfixes" in
-
-        let makeProductionLL1 = lam prod: Production.
-          match prod with {sym = sym, spec = {name = name, nt = nt, ptype = ptype, rhs = rhs, action = action}} then
-            match ptype with Atom _ then
-              let input = atom sym in
-              {nt = atomNt, label = name, rhs = rhs, action = lam x. (input, x)}
-            else match ptype with Prefix {right = right} then
-              let input = prefix sym in
-              {nt = prefixNt, label = name, rhs = rhs, action = lam x. (input, x)}
-            else match ptype with Postfix {left = left} then
-              let input = postfix sym in
-              {nt = postfixNt, label = name, rhs = rhs, action = lam x. (input, x)}
-            else match ptype with Infix {left = left, right = right} then
-              let input = infix sym in
-              {nt = infixNt, label = name, rhs = rhs, action = lam x. (input, x)}
-            else never
-          else never
-        in
-        use ParserConcrete in
-        match concat dupPrecErrs undefPrecErrs with errs & [_] ++ _ then
-          Left errs
-        else Right (concat
-          (map makeProductionLL1 productions)
-          [ { nt = topNt
-            , label = ntname
-            , rhs = [ll1Nt prefixesNt, ll1Nt atomNt, ll1Nt postfixesNt, ll1Nt contNt]
-            , action = lam xs.
-              match xs with [UserSym pres, UserSym atom, UserSym posts, UserSym contFunc] then
-                let contFunc: (Unknown, Unknown, Unknown) = contFunc in
-                let syms = join
-                  [ join (map snd pres)
-                  , snd atom
-                  , join (map snd posts)
-                  , contFunc.2
-                  ] in
-                let errs = join
-                  (map
-                    (lam sym. match sym with UserSym (Left es) then es else [])
-                    syms) in
-                let st = breakableInitState () in
-                let mSt = _buildSurroundedAtom pres atom posts contFunc st in
-                let info = _surroundedAtomInfo pres atom posts contFunc in
-                match optionBind mSt breakableFinalizeParse with Some st then
-                  match errs with [] then
-                    eitherBiMap
-                      _breakableErrorToSemanticErrors
-                      (lam x. (info, x))
-                      (breakableConstructResult st)
-                  else
-                    Left errs
-                else
-                  Left (cons (SemanticParseBreakableError {nt = ntname, info = info}) errs)
-              else never
-            }
-          , { nt = contNt
-            , label = concat "empty " contNt
-            , rhs = []
-            , action = lam. (NoInfo (), lam x. Some x, [])
-            }
-          , { nt = contNt
-            , label = contNt
-            , rhs = [ll1Nt infixNt, ll1Nt prefixesNt, ll1Nt atomNt, ll1Nt postfixesNt, ll1Nt contNt]
-            , action = lam xs.
-              match xs with [UserSym infix, UserSym pres, UserSym atom, UserSym posts, UserSym contFunc] then
-                let contFunc: (Unknown, Unknown, Unknown) = contFunc in
-                let syms = join
-                  [ snd infix
-                  , join (map snd pres)
-                  , snd atom
-                  , join (map snd posts)
-                  , contFunc.2
-                  ] in
-                let newContFunc = lam st.
-                  optionBind
-                    (breakableAddInfix (fst infix) (snd infix) st)
-                    (_buildSurroundedAtom pres atom posts contFunc) in
-                let contInfo = _surroundedAtomInfo pres atom posts contFunc in
-                (contInfo, newContFunc, syms)
-              else never
-            }
-          , { nt = prefixesNt
-            , label = concat "empty " prefixesNt
-            , rhs = []
-            , action = lam. []
-            }
-          , { nt = prefixesNt
-            , label = prefixesNt
-            , rhs = [ll1Nt prefixNt, ll1Nt prefixesNt]
-            , action = lam xs.
-              match xs with [UserSym pre, UserSym pres] then
-                cons pre pres
-              else never
-            }
-          , { nt = postfixesNt
-            , label = concat "empty " postfixesNt
-            , rhs = []
-            , action = lam. []
-            }
-          , { nt = postfixesNt
-            , label = postfixesNt
-            , rhs = [ll1Nt postfixNt, ll1Nt postfixesNt]
-            , action = lam xs.
-              match xs with [UserSym post, UserSym posts] then
-                cons post posts
-              else never
-            }
-          ])
-        )
-    in
-
-    let res = eitherPartition res in
-    match res with ([], productions) then
-      eitherMapLeft
-        (lam x. [SemanticGrammarLL1Error x])
-        (ll1GenParser {productions = join productions, start = grammar.start.name})
-    else Left (join res.0)
-
-let semanticParseFile
-  : Parser
-  -> String -- Filename
-  -> String -- Content
-  -> Either [SemanticParseError] Dyn
-  = lam ll1table. lam filename. lam content.
-    let res = ll1ParseWithTable ll1table filename content in
-    match res with Left err then Left [SemanticParseError err] else
-    match res with Right (Left err) then Left err else
-    match res with Right (Right (_, res)) then Right res else
-    never
-
-let semanticUnwrapOrPrintErrors
-  : Either [SemanticParseError] Dyn -> Dyn
-  = lam x.
-    match x with Right x then x else
-    match x with Left errs then
-      for_ errs
-        (lam err.
-          match err with SemanticParseBreakableError r then
-            printLn (infoErrorString r.info (join ["This ", r.nt, " is not syntactically valid"]))
-          else match err with SemanticParseAmbiguityError err then
-            printLn (infoErrorString err.info "Ambiguity error");
-            for_ err.irrelevant
-              (lam irr: Info. printLn (infoErrorString irr "Irrelevant region"))
-          else match err with SemanticParseError err then
-            use ParserSpec in
-            use ParserConcrete in
-            match err with UnexpectedFirst err then
-              printLn (infoErrorString (symInfo err.found) "Unexpected first token");
-              printLn (concat "Expected one of: " (strJoin ", " (map symToStr err.expected)));
-              printLn (concat "Found: " (symToStr err.found))
-            else match err with UnexpectedToken err then
-              printLn (infoErrorString (symInfo err.found) "Unexpected token");
-              printLn (concat "Expected: " (symToStr err.expected));
-              printLn (concat "Found: " (symToStr err.found))
-            else never
-          else dprintLn err; never
-        );
-      exit 1
-    else never
-
--- Small helper to make smaller errors by discarding information that
--- is typically not interesting
-let semanticShortenErrors
-  : [SemanticGrammarError]
-  -> [(String, String)]
-  = let shortenOne = lam err.
-      match err with UndefinedPrecedence {left = {name = lname}, right = {name = rname}} then
-        ("undefPrec", join [lname, " -?- ", rname])
-      else match err with DuplicatedPrecedence ([(({name = lname}, {name = rname}), _)] ++ _ & precs) then
-        let precs = map (lam x: (Unknown, Precedence). x.1) precs in
-        let precs = map
-          (lam x: Precedence. join ["'", if x.mayGroupLeft then "<" else "", "-", if x.mayGroupRight then ">" else "", "'"])
-          precs in
-        ("dupPrec", join [lname, " -?- ", rname, " in {", strJoin ", " precs, "}"])
-      else match err with SemanticGrammarLL1Error err then
-        dprintLn (map (lam x: (Unknown, Map Unknown Unknown). {x with #label"1" = mapBindings x.1}) (mapBindings err)); ("ll1error", "dprinted above")
-      else dprintLn err; never
-    in map shortenOne
-
-mexpr
-
-let wrap = lam label. lam x. (label, x) in
-
-let exprNT = semanticNonTerminal "expression" in
-let declNT = semanticNonTerminal "declaration" in
-
-let intP = semanticProduction
-  { name = "int"
-  , nt = exprNT
-  , ptype = semanticDefAtom
-  , rhs = [semanticInt]
-  , action = wrap "int"
-  } in
-
-let addP = semanticProduction
-  { name = "add"
-  , nt = exprNT
-  , ptype = semanticDefInfix
-  , rhs = [semanticLit "+"]
-  , action = wrap "add"
-  } in
-
-let minusP = semanticProduction
-  { name = "minus"
-  , nt = exprNT
-  , ptype = semanticDefInfix
-  , rhs = [semanticLit "-"]
-  , action = wrap "minus"
-  } in
-
-let mulP = semanticProduction
-  { name = "mul"
-  , nt = exprNT
-  , ptype = semanticDefInfix
-  , rhs = [semanticLit "*"]
-  , action = wrap "mul"
-  } in
-
-let negP = semanticProduction
-  { name = "neg"
-  , nt = exprNT
-  , ptype = semanticDefPrefix
-  , rhs = [semanticLit "-"]
-  , action = wrap "neg"
-  } in
-
-let parP = semanticProduction
-  { name = "par"
-  , nt = exprNT
-  , ptype = semanticDefAtom
-  , rhs = [semanticLit "(", semanticNt exprNT, semanticLit ")"]
-  , action = wrap "par"
-  } in
-
-let fieldAccessP = semanticProduction
-  { name = "fieldAccess"
-  , nt = exprNT
-  , ptype = semanticDefPostfix
-  , rhs = [semanticLit ".", semanticLIdent]
-  , action = wrap "fieldAccess"
-  } in
-
-let ifP = semanticProduction
-  { name = "if"
-  , nt = exprNT
-  , ptype = semanticDefPrefix
-  , rhs = [semanticLit "if", semanticNt exprNT, semanticLit "then"]
-  , action = wrap "if"
-  } in
-
-let elseP = semanticProduction
-  { name = "else"
-  , nt = exprNT
-  , ptype = Infix
-    { self = semanticDefIn
-    , left = semanticDefNotIn
-    , right = semanticDefIn
-    }
-  , rhs = [semanticLit "else"]
-  , action = wrap "else"
-  } in
-
-let defP = semanticProduction
-  { name = "def"
-  , nt = declNT
-  , ptype = semanticDefAtom
-  , rhs = [semanticLit "def", semanticLIdent, semanticLit "=", semanticNt exprNT]
-  , action = wrap "def"
-  } in
-
-let twoDefP = semanticProduction
-  { name = "twoDef"
-  , nt = declNT
-  , ptype = semanticDefInfix
-  , rhs = []
-  , action = wrap "twoDef"
-  } in
-
--- NOTE(vipa, 2021-02-25): The tests in this file are mostly written
--- to only check some parts of the produced value, through pattern
--- matching, which gives somewhat strange formatting, but works pretty
--- nicely
-utest semanticGrammar
-  { start = exprNT
-  , productions = [intP, addP]
-  , overrideAllow = []
-  , overrideDisallow = []
-  , precedences = []
-  } with () using lam x. lam. match x
-with Left
-  [ UndefinedPrecedence
-    { left = {name = "add"}
-    , right = {name = "add"}
-    }
-  ]
-then true else false in
-
-let g =
-  let res = semanticGrammar
-    { start = exprNT
-    , productions = [intP, addP]
-    , overrideAllow = []
-    , overrideDisallow = []
-    , precedences = join
-      [ [semanticAmbAssoc addP]
-      ]
-    } in
-  utest res with () using lam x. lam. match x
-  with Right _
-  then true else false in
-  match res with Right x then x else never
-in
-
-utest semanticParseFile g "file" ""
-with () using lam x. lam. use ParserConcrete in match x
-with Left [SemanticParseError (UnexpectedFirst
-  { expected = [Tok (IntTok _)]
-  , found = Tok (EOFTok _)
-  })]
-then true else false in
-
-utest semanticParseFile g "file" "7"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("int",
-  [ Tok (IntTok {val = 7})
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "7 +"
-with () using lam x. lam. use ParserConcrete in match x
-with Left [SemanticParseError (UnexpectedFirst
-  { expected = [Tok (IntTok _)]
-  , stack = [{label = "expression"}] ++ _
-  , nt = "expression prefixes"
-  , found = Tok (EOFTok _)
-  })]
-then true else false in
-
-utest semanticParseFile g "file" "7 + 43"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("add",
-  [ UserSym ("int", [Tok (IntTok {val = 7})])
-  , Lit {lit = "+"}
-  , UserSym ("int", [Tok (IntTok {val = 43})])
-  ])
-then true else false in
-
--- TODO(vipa, 2021-02-26): The tests with ambiguities will presently
--- check that nothing is marked as irrelevant, even though some parts
--- should be considered irrelevant. They will then blow up once that
--- code is implemented, at which point we'll update the tests
--- properly.
-utest semanticParseFile g "file" "7 + 43 + 9"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 10}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-let g =
-  let res = semanticGrammar
-    { start = exprNT
-    , productions = [intP, addP, negP, mulP, minusP]
-    , overrideAllow = []
-    , overrideDisallow = []
-    , precedences = join
-      [ map semanticLeftAssoc [addP, minusP]
-      , map semanticAmbAssoc [mulP]
-      , semanticPrecTableNoEq
-        [ [negP]
-        , [mulP]
-        , [addP, minusP]
-        ]
-      , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
-      ]
-    } in
-  utest res with () using lam x. lam. match x
-  with Right _
-  then true else false in
-  match res with Right x then x else never
-in
-
-utest semanticParseFile g "file" "7 + 43 + 9"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("add",
-  [ UserSym ("add",
-    [ UserSym ("int", [Tok (IntTok {val = 7})])
-    , Lit {lit = "+"}
-    , UserSym ("int", [Tok (IntTok {val = 43})])
-    ])
-  , Lit {lit = "+"}
-  , UserSym ("int", [Tok (IntTok {val = 9})])
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "7 + 43 * 8 * 9"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 4, row2 = 1, col2 = 14}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "-1"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("neg",
-  [ Lit {lit = "-"}
-  , UserSym ("int", [Tok (IntTok {val = 1})])
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "-1 + 8 * -2"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("add",
-  [ UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 1})])])
-  , Lit {lit = "+"}
-  , UserSym ("mul",
-    [ UserSym ("int", [Tok (IntTok {val = 8})])
-    , Lit {lit = "*"}
-    , UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 2})])])
-    ])
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "-1 - - 8"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("minus",
-  [ UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 1})])])
-  , Lit {lit = "-"}
-  , UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 8})])])
-  ])
-then true else false in
-
-let g =
-  let res = semanticGrammar
-    { start = exprNT
-    , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP]
-    , overrideAllow = []
-    , overrideDisallow = []
-    , precedences = join
-      [ map semanticLeftAssoc [addP, minusP]
-      , map semanticAmbAssoc [mulP]
-      , semanticPrecTableNoEq
-        [ [negP, fieldAccessP]
-        , [mulP]
-        , [addP, minusP]
-        ]
-      , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
-      , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
-      ]
-    } in
-  utest res with () using lam x. lam. match x
-  with Right _
-  then true else false in
-  match res with Right x then x else never
-in
-
-utest semanticParseFile g "file" "1 .foo"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("fieldAccess",
-  [ UserSym ("int", [Tok (IntTok {val = 1})])
-  , Lit {lit = "."}
-  , Tok (LIdentTok {val = "foo"})
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "-1 .foo"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 7}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "-1 .foo + 32"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 7}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "(-1).foo"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("fieldAccess",
-  [ UserSym ("par",
-    [ Lit {lit = "("}
-    , UserSym ("neg",
-      [ Lit {lit = "-"}
-      , UserSym ("int", [Tok (IntTok {val = 1})])
-      ])
-    , Lit {lit = ")"}
-    ])
-  , Lit {lit = "."}
-  , Tok (LIdentTok {val = "foo"})
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "(1 * 2 * 3) * 8 * 9"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 1, row2 = 1, col2 = 10}
-    , irrelevant = []
-    }
-  ]
-  -- NOTE(vipa, 2021-03-01): This should actually be two ambiguity
-  -- errors, but we presently can't get an ambiguity error out without
-  -- trying to construct the final result. The latter can't be done if
-  -- there is an error in a descendant, which is the case when there
-  -- is a nested ambiguity error.
-then true else false in
-
-utest semanticGrammar
-  { start = exprNT
-  , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP, ifP, elseP]
-  , overrideAllow = [LeftChild{parent = elseP, child = ifP}]
-  , overrideDisallow = []
-  , precedences = join
-    [ map semanticLeftAssoc [addP, minusP]
-    , map semanticAmbAssoc [mulP]
-    , semanticPrecTableNoEq
-      [ [negP, fieldAccessP]
-      , [mulP]
-      , [addP, minusP]
-      , [ifP]
-      ]
-    , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
-    , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
-    , map semanticLeftAssoc [elseP]
-    , seqLiftA2 semanticGroupRight [elseP] [fieldAccessP]
-    , seqLiftA2 semanticGroupEither [elseP] [addP, mulP, minusP, ifP, fieldAccessP]
-    , seqLiftA2 semanticGroupEither [addP, negP, mulP, minusP, ifP] [elseP]
-    ]
-  }
-with () using lam x. lam. match x
-with Left
-  [ DuplicatedPrecedence
-    [ (({name = "else"}, {name = "fieldAccess"}), {mayGroupLeft = false, mayGroupRight = true})
-    , (({name = "else"}, {name = "fieldAccess"}), {mayGroupLeft = true, mayGroupRight = true})
-    ]
-  ]
-then true else false in
-
-let g =
-  let res = semanticGrammar
-    { start = exprNT
-    , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP, ifP, elseP]
-    , overrideAllow = [LeftChild{parent = elseP, child = ifP}]
-    , overrideDisallow = []
-    , precedences = join
-      [ map semanticLeftAssoc [addP, minusP]
-      , map semanticAmbAssoc [mulP]
-      , semanticPrecTableNoEq
-        [ [negP, fieldAccessP]
-        , [mulP]
-        , [addP, minusP]
-        , [ifP]
-        ]
-      , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
-      , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
-      , map semanticLeftAssoc [elseP]
-      , seqLiftA2 semanticGroupRight [elseP] [fieldAccessP, addP, mulP, minusP]
-      , seqLiftA2 semanticGroupEither [addP, negP, mulP, minusP, ifP] [elseP]
-      ]
-    } in
-  utest eitherMapLeft semanticShortenErrors res with () using lam x. lam. match x
-  with Right _
-  then true else false in
-  match res with Right x then x else never
-in
-
-utest semanticParseFile g "file" "2 else 3"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseBreakableError
-    { info = Info {filename = "file", row1 = 1, row2 = 1, col1 = 0, col2 = 8}
-    , nt = "expression"
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "if 1 then 2 else 3"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("else",
-  [ UserSym ("if",
-    [ Lit {lit = "if"}
-    , UserSym ("int", [Tok (IntTok {val = 1})])
-    , Lit {lit = "then"}
-    , UserSym ("int", [Tok (IntTok {val = 2})])
-    ])
-  , Lit {lit = "else"}
-  , UserSym ("int", [Tok (IntTok {val = 3})])
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "if 1 + 11 then 2 * 22 else 3 - 33"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("else",
-  [ UserSym ("if",
-    [ Lit {lit = "if"}
-    , UserSym ("add",
-      [ UserSym ("int", [Tok (IntTok {val = 1})])
-      , Lit {lit = "+"}
-      , UserSym ("int", [Tok (IntTok {val = 11})])
-      ])
-    , Lit {lit = "then"}
-    , UserSym ("mul",
-      [ UserSym ("int", [Tok (IntTok {val = 2})])
-      , Lit {lit = "*"}
-      , UserSym ("int", [Tok (IntTok {val = 22})])
-      ])
-    ])
-  , Lit {lit = "else"}
-  , UserSym ("minus",
-    [ UserSym ("int", [Tok (IntTok {val = 3})])
-    , Lit {lit = "-"}
-    , UserSym ("int", [Tok (IntTok {val = 33})])
-    ])
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "if 0 then if 1 then 2 else 3"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 28}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "if 0 then -if 1 then 2 else 3"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 29}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "if 0 then 1 + if 1 then 2 else 3"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 32}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "if 0 then if 1 then 2 else 3 .foo"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseAmbiguityError
-    { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 33}
-    , irrelevant = []
-    }
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "if 1 then 2 else 3 .foo"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("else",
-  [ UserSym ("if",
-    [ Lit {lit = "if"}
-    , UserSym ("int", [Tok (IntTok {val = 1})])
-    , Lit {lit = "then"}
-    , UserSym ("int", [Tok (IntTok {val = 2})])
-    ])
-  , Lit {lit = "else"}
-  , UserSym ("fieldAccess",
-    [ UserSym ("int", [Tok (IntTok {val = 3})])
-    , Lit {lit = "."}
-    , Tok (LIdentTok {val = "foo"})
-    ])
-  ])
-then true else false in
-
-let g =
-  let res = semanticGrammar
-    { start = declNT
-    , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP, ifP, elseP, defP, twoDefP]
-    , overrideAllow = [LeftChild{parent = elseP, child = ifP}]
-    , overrideDisallow = []
-    , precedences = join
-      [ map semanticLeftAssoc [twoDefP]
-
-      , map semanticLeftAssoc [addP, minusP]
-      , map semanticAmbAssoc [mulP]
-      , semanticPrecTableNoEq
-        [ [negP, fieldAccessP]
-        , [mulP]
-        , [addP, minusP]
-        , [ifP]
-        ]
-      , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
-      , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
-      , map semanticLeftAssoc [elseP]
-      , seqLiftA2 semanticGroupRight [elseP] [fieldAccessP, addP, mulP, minusP]
-      , seqLiftA2 semanticGroupEither [addP, negP, mulP, minusP, ifP] [elseP]
-      ]
-    } in
-  utest eitherMapLeft semanticShortenErrors res with () using lam x. lam. match x
-  with Right _
-  then true else false in
-  match res with Right x then x else never
-in
-
-utest semanticParseFile g "file" ""
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseError
-    (UnexpectedFirst
-      { expected = [Lit {lit = "def"}]
-      , stack = []
-      , found = Tok (EOFTok _)
-      , nt = "declaration"
-      }
-    )
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "7"
-with () using lam x. lam. use ParserConcrete in match x
-with Left
-  [ SemanticParseError
-    (UnexpectedFirst
-      { expected = [Lit {lit = "def"}]
-      , stack = []
-      , found = Tok (IntTok {val = 7})
-      , nt = "declaration"
-      }
-    )
-  ]
-then true else false in
-
-utest semanticParseFile g "file" "def x = 7"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("def",
-  [ Lit {lit = "def"}
-  , Tok (LIdentTok {val = "x"})
-  , Lit {lit = "="}
-  , UserSym ("int", [Tok (IntTok {val = 7})])
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "def x = 7 def y = 8"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("twoDef",
-  [ UserSym ("def",
-    [ Lit {lit = "def"}
-    , Tok (LIdentTok {val = "x"})
-    , Lit {lit = "="}
-    , UserSym ("int", [Tok (IntTok {val = 7})])
-    ])
-  , UserSym ("def",
-    [ Lit {lit = "def"}
-    , Tok (LIdentTok {val = "y"})
-    , Lit {lit = "="}
-    , UserSym ("int", [Tok (IntTok {val = 8})])
-    ])
-  ])
-then true else false in
-
-utest semanticParseFile g "file" "def x = 7\ndef y = 8\ndef z = 1 + 2"
-with () using lam x. lam. use ParserConcrete in match x
-with Right ("twoDef",
-  [ UserSym ("twoDef",
-    [ UserSym ("def",
-      [ Lit {lit = "def"}
-      , Tok (LIdentTok {val = "x"})
-      , Lit {lit = "="}
-      , UserSym ("int", [Tok (IntTok {val = 7})])
-      ])
-    , UserSym ("def",
-      [ Lit {lit = "def"}
-      , Tok (LIdentTok {val = "y"})
-      , Lit {lit = "="}
-      , UserSym ("int", [Tok (IntTok {val = 8})])
-      ])
-    ])
-  , UserSym ("def",
-    [ Lit {lit = "def"}
-    , Tok (LIdentTok {val = "z"})
-    , Lit {lit = "="}
-    , UserSym ("add",
-      [ UserSym ("int", [Tok (IntTok {val = 1})])
-      , Lit {lit = "+"}
-      , UserSym ("int", [Tok (IntTok {val = 2})])
-      ])
-    ])
-  ])
-then true else false in
-
-()
+-- -- Miking is licensed under the MIT license.
+-- -- Copyright (C) David Broman. See file LICENSE.txt
+-- --
+
+-- /-
+
+-- This file implements breakable operators (`breakable.mc`) on top of a
+-- more normal parsing strategy, in this case LL(1) (`ll1.mc`).
+
+-- For more info on how precedence works, and basic ideas on how to break
+-- productions into operators, see `breakable.mc`.
+
+-- The primary entry-points to this module are `semanticGrammar` and
+-- `semanticParseFile`. All other exported values are used to help define
+-- a grammar, see the tests for examples on how to use them.
+
+-- -/
+
+-- include "lexer.mc"
+-- include "ll1.mc"
+-- include "breakable.mc"
+-- include "common.mc"
+
+-- type NonTerminal = { sym: Symbol, name: String }
+
+-- type DefaultInclude
+-- con DefaultIn : () -> DefaultInclude
+-- con DefaultNotIn : () -> DefaultInclude
+
+-- let semanticDefIn = DefaultIn ()
+-- let semanticDefNotIn = DefaultNotIn ()
+
+-- type ProdType
+-- con Atom :
+--   { self : DefaultInclude
+--   } -> ProdType
+-- con Prefix :
+--   { self : DefaultInclude
+--   , right : DefaultInclude
+--   } -> ProdType
+-- con Postfix :
+--   { self : DefaultInclude
+--   , left : DefaultInclude
+--   } -> ProdType
+-- con Infix :
+--   { self : DefaultInclude
+--   , left : DefaultInclude
+--   , right : DefaultInclude
+--   } -> ProdType
+
+-- let _prodTypeSelf
+--   : ProdType
+--   -> DefaultInclude
+--   = lam pt.
+--     match pt
+--     with Atom {self = self}
+--        | Prefix {self = self}
+--        | Postfix {self = self}
+--        | Infix {self = self}
+--     then self
+--     else never
+
+-- let semanticDefInfix = Infix
+--   { self = DefaultIn ()
+--   , left = DefaultIn ()
+--   , right = DefaultIn ()
+--   }
+
+-- let semanticDefPrefix = Prefix
+--   { self = DefaultIn ()
+--   , right = DefaultIn ()
+--   }
+
+-- let semanticDefPostfix = Postfix
+--   { self = DefaultIn ()
+--   , left = DefaultIn ()
+--   }
+
+-- let semanticDefAtom = Atom
+--   { self = DefaultIn ()
+--   }
+
+-- let _lopenType = lam x.
+--   match x with Postfix _ | Infix _ then true else false
+
+-- let _ropenType = lam x.
+--   match x with Prefix _ | Infix _ then true else false
+
+-- type Precedence = { mayGroupLeft : Bool, mayGroupRight : Bool }
+
+-- let semanticGroupEither = lam l. lam r. ((l, r), { mayGroupLeft = true, mayGroupRight = true })
+-- let semanticGroupLeft = lam l. lam r. ((l, r), { mayGroupLeft = true, mayGroupRight = false })
+-- let semanticGroupRight = lam l. lam r. ((l, r), { mayGroupLeft = false, mayGroupRight = true })
+-- let semanticGroupNeither = lam l. lam r. ((l, r), { mayGroupLeft = false, mayGroupRight = false })
+
+-- -- Take two lists of productions, make each production in the `high`
+-- -- list have higher precedence than each production in the `low` list.
+-- let semanticHighLowPrec
+--   : { high : [prod]
+--     , low : [prod]
+--     }
+--   -> [((prod, prod), Precedence)]
+--   = let mkGrouping = lam high. lam low.
+--       [ semanticGroupLeft high low
+--       , semanticGroupRight low high
+--       ] in
+--     lam spec. join (seqLiftA2 mkGrouping spec.high spec.low)
+
+-- -- Take a precedence table, from high precedence to low precedence,
+-- -- and impose the implied precedences. Note that no precedence is
+-- -- applied between productions on the same precedence level.
+-- recursive let semanticPrecTableNoEq
+--   : [[prod]]
+--   -> [((prod, prod), Precedence)]
+--   = lam table.
+--     match table with [high] ++ lows then
+--       concat (semanticHighLowPrec {high = high, low = join lows}) (semanticPrecTableNoEq lows)
+--     else []
+-- end
+
+-- let semanticLeftAssoc
+--   : prod
+--   -> ((prod, prod), Precedence)
+--   = lam prod. semanticGroupLeft prod prod
+
+-- let semanticRightAssoc
+--   : prod
+--   -> ((prod, prod), Precedence)
+--   = lam prod. semanticGroupRight prod prod
+
+-- let semanticNonAssoc
+--   : prod
+--   -> ((prod, prod), Precedence)
+--   = lam prod. semanticGroupNeither prod prod
+
+-- let semanticAmbAssoc
+--   : prod
+--   -> ((prod, prod), Precedence)
+--   = lam prod. semanticGroupEither prod prod
+
+-- /-
+-- Apply the given grouping between all given operators, regardless of
+-- order. For example, `semanticPairwiseGroup semanticGroupLeft [a, b,
+-- c]` is equivalent with
+
+-- ```
+-- [ semanticGroupLeft a b
+-- , semanticGroupLeft b a
+-- , semanticGroupLeft a c
+-- , semanticGroupLeft c a
+-- , semanticGroupLeft b c
+-- , semanticGroupLeft c b
+-- ]
+-- ```
+-- -/
+-- recursive let semanticPairwiseGroup
+--   : (prod -> prod -> Precedence)
+--   -> [prod]
+--   -> [((prod, prod), Precedence)]
+--   = lam group.
+--     recursive let work = lam prods.
+--       match prods with [prod] ++ prods then
+--         concat
+--           (join (map (lam r. [group prod r, group r prod]) prods))
+--           (work prods)
+--       else []
+--     in work
+-- end
+
+-- -- Create a new non-terminal with the given name.
+-- -- WARNING: not referentially transparent
+-- let semanticNonTerminal
+--   : String
+--   -> NonTerminal
+--   = lam name.
+--     { sym = gensym (), name = name }
+
+-- type ProductionSpec =
+--   { name : String -- For use in error messages
+--   , nt : NonTerminal
+--   , ptype : ProdType
+--   , rhs : [Symbol]
+--   -- This is ll1.mc/Action. In case of an operator the rhs will have
+--   -- a `UserSym` added on each open side (e.g., `ptype = defPrefix`,
+--   -- `rhs = [lit "!"]` gives `action [lit "!", UserSym res]`
+--   , action : Action
+--   }
+
+-- type Production = { sym: Symbol, spec: ProductionSpec }
+
+-- type Override
+-- con LeftChild : { child : Production, parent : Production } -> Override
+-- con RightChild : { child : Production, parent : Production } -> Override
+
+-- -- Create a new production.
+-- -- WARNING: not referentially transparent
+-- let semanticProduction
+--   : ProductionSpec
+--   -> Production
+--   = lam prod.
+--     { sym = gensym (), spec = prod }
+
+-- -- TODO(vipa, 2021-03-01): See the TODO at 2021-02-24 that also refers
+-- -- to non-terminals.
+-- let semanticNt
+--   : NonTerminal
+--   -> Symbol
+--   = lam nt. ll1Nt nt.name
+-- let semanticLit
+--   : String
+--   -> Symbol
+--   = ll1Lit
+-- let semanticInt : Symbol = ll1Int
+-- let semanticFloat : Symbol = ll1Float
+-- let semanticOperator : Symbol = ll1Operator
+-- let semanticString : Symbol = ll1String
+-- let semanticChar : Symbol = ll1Char
+-- let semanticLIdent : Symbol = ll1LIdent
+-- let semanticUIdent : Symbol = ll1UIdent
+-- let semanticHashString : String -> Symbol = ll1HashString
+
+-- type Parser
+
+-- type SemanticGrammarError
+-- con DuplicatedPrecedence : [((ProductionSpec, ProductionSpec), Precedence)] -> SemanticGrammarError
+-- con UndefinedPrecedence : {left : ProductionSpec, right : ProductionSpec} -> SemanticGrammarError
+-- con SemanticGrammarLL1Error : GenError String -> SemanticGrammarError
+
+-- type SemanticParseError
+-- con SemanticParseBreakableError : {nt : String, info : Info} -> SemanticParseError
+-- con SemanticParseAmbiguityError : {info : Info, irrelevant : [Info]} -> SemanticParseError
+-- con SemanticParseError : ParseError String -> SemanticParseError
+-- -- NOTE(vipa, 2021-02-25): All ll1 productions generated here will
+-- -- follow the convention that we can always get the range of a
+-- -- Symbol. In particular, each `UserSym` that goes between
+-- -- non-terminals (i.e., once we've finished a breakable parse) will
+-- -- carry an `Either [SemanticParseError] (Info, res)`.
+-- let _symInfo
+--   : Symbol
+--   -> Info
+--   = lam sym.
+--     use ParserConcrete in
+--     match sym with Lit {info = info} then info else
+--     match sym with UserSym (Right (info, _)) then info else
+--     match sym with Tok t then use Lexer in tokInfo t else
+--     never
+-- let _seqSymInfo
+--   : [Symbol]
+--   -> Info
+--   = lam syms.
+--     match syms with [s] then _symInfo s else
+--     match syms with [s] ++ _ ++ [e] then mergeInfo (_symInfo s) (_symInfo e) else
+--     match syms with [] then NoInfo () else
+--     never
+
+-- let _breakableErrorToSemanticErrors
+--   : BreakableError [Symbol]
+--   -> [SemanticParseError]
+--   = lam err.
+--     match err with Ambiguities ambs then
+--       map
+--         (lam amb: Ambiguity [Symbol]. match amb with {first = f, last = l, irrelevant = irr} then
+--            SemanticParseAmbiguityError
+--              { info = mergeInfo (_seqSymInfo f) (_seqSymInfo l)
+--              , irrelevant =
+--                map
+--                  (lam irr: Irrelevancy [Symbol].
+--                    mergeInfo (_seqSymInfo irr.first) (_seqSymInfo irr.last))
+--                  irr
+--              }
+--          else never)
+--         ambs
+--     else never
+
+-- let _buildSurroundedAtom
+--   : [(BreakableInput res [Symbol] LClosed ROpen, [Symbol])]
+--   -> (BreakableInput res [Symbol] LClosed RClosed, [Symbol])
+--   -> [(BreakableInput res [Symbol] LOpen RClosed, [Symbol])]
+--   -> (Info, State res [Symbol] RClosed -> Option (State res [Symbol] RClosed))
+--   -> State res [Symbol] ROpen
+--   -> Option (State res [Symbol] RClosed)
+--   = lam pres. lam atom. lam posts. lam contFunc. lam st.
+--     let st = foldl (lam st. lam pre: (BreakableInput res [Symbol] LClosed ROpen, [Symbol]). breakableAddPrefix pre.0 pre.1 st) st pres in
+--     let st = breakableAddAtom atom.0 atom.1 st in
+--     let mSt = optionFoldlM (lam st. lam post: (BreakableInput res [Symbol] LOpen RClosed, [Symbol]). breakableAddPostfix post.0 post.1 st) st posts in
+--     optionBind mSt contFunc.1
+
+-- let _surroundedAtomInfo
+--   : [(BreakableInput res [Symbol] LClosed ROpen, [Symbol])]
+--   -> (BreakableInput res [Symbol] LClosed RClosed, [Symbol])
+--   -> [(BreakableInput res [Symbol] LOpen RClosed, [Symbol])]
+--   -> (Info, State res [Symbol] RClosed -> Option (State res [Symbol] RClosed))
+--   -> Info
+--   = lam pres. lam atom. lam posts. lam contFunc.
+--     let snd: (a, b) -> b = lam x. x.1 in
+--     let res = join (join [map snd pres, [atom.1], map snd posts]) in
+--     match res with [first] ++ _ & _ ++ [last] then
+--       mergeInfo (mergeInfo (_symInfo first) (_symInfo last)) contFunc.0
+--     else never
+
+-- -- NOTE(vipa, 2021-02-22): This assumes that we can impose a total
+-- -- order on symbols via `sym2hash`, which is not guaranteed by its
+-- -- interface
+-- let _cmpSym = lam a. lam b. subi (sym2hash a) (sym2hash b)
+-- let _cmpSymPair = lam a: (Symbol, Symbol). lam b: (Symbol, Symbol).
+--   let aint1 = sym2hash a.0 in
+--   let bint1 = sym2hash b.0 in
+--   let res = subi aint1 bint1 in
+--   if eqi res 0 then
+--     subi (sym2hash a.1) (sym2hash b.1)
+--   else res
+
+-- -- Take a grammar and try to produce a parser.
+-- let semanticGrammar
+--   : { start : NonTerminal
+--     , productions : [Production]
+--     , overrideAllow : [Override]
+--     , overrideDisallow : [Override]
+--     , precedences : [((Production, Production), Precedence)]
+--     }
+--   -> Either [SemanticGrammarError] Parser
+--   = lam grammar.
+--     let productions = grammar.productions in
+--     let precedences = grammar.precedences in
+--     let overrideAllow = grammar.overrideAllow in
+--     let overrideDisallow = grammar.overrideDisallow in
+--     let nonTerminals = foldl
+--       (lam acc. lam prod: Production. mapInsert prod.spec.nt.sym prod.spec.nt.name acc)
+--       (mapEmpty _cmpSym)
+--       productions
+--     in
+--     let for = lam xs. lam f. map f xs in
+
+--     -- TODO(vipa, 2021-02-24): It might be nice to report inconsistent
+--     -- overrides, i.e., we're both overriding to allow *and* disallow
+--     -- the same production in the same position, but I'm punting on
+--     -- that for now, it should be a rare occurrence. Similarly, it
+--     -- might be nice to report overrides that don't make sense, i.e.,
+--     -- when the override is on left/right when the production isn't
+--     -- left/right-open.
+--     type SingleOverride = {allow: [Symbol], disallow: [Symbol]} in
+--     type MultiOverride =
+--       { left: SingleOverride
+--       , right: SingleOverride
+--       } in
+--     let emptyMultiOverride = {left = {allow = [], disallow = []}, right = {allow = [], disallow = []}} in
+--     let mergeMultiOverride =
+--       let mergeSide = lam a: SingleOverride. lam b: SingleOverride.
+--         { allow = concat a.allow b.allow
+--         , disallow = concat a.disallow b.disallow
+--         } in
+--       lam a: MultiOverride. lam b: MultiOverride.
+--       { left = mergeSide a.left b.left
+--       , right = mergeSide a.right b.right
+--       }
+--     in
+--     let overrides = foldl
+--       (lam acc. lam override.
+--         match override with LeftChild {child = {sym = child}, parent = {sym = parent}} then
+--           mapInsertWith mergeMultiOverride parent
+--             {emptyMultiOverride with left = {allow = [child], disallow = []}}
+--             acc
+--         else match override with RightChild {child = {sym = child}, parent = {sym = parent}} then
+--           mapInsertWith mergeMultiOverride parent
+--             {emptyMultiOverride with right = {allow = [child], disallow = []}}
+--             acc
+--         else never)
+--       (mapEmpty _cmpSym)
+--       overrideAllow in
+--     let overrides = foldl
+--       (lam acc. lam override.
+--         match override with LeftChild {child = {sym = child}, parent = {sym = parent}} then
+--           mapInsertWith mergeMultiOverride parent
+--             {emptyMultiOverride with left = {disallow = [child], allow = []}}
+--             acc
+--         else match override with RightChild {child = {sym = child}, parent = {sym = parent}} then
+--           mapInsertWith mergeMultiOverride parent
+--             {emptyMultiOverride with right = {disallow = [child], allow = []}}
+--             acc
+--         else never)
+--       overrides
+--       overrideDisallow
+--     in
+
+--     -- Make each non-terminal separately, since they should generate a
+--     -- breakable grammar each
+--     let res = for (mapBindings nonTerminals)
+--       (lam nt: (Symbol, String).
+--         let ntsym = nt.0 in
+--         let ntname = nt.1 in
+--         let precedences = filter
+--           (lam p: ((Production, Production), Precedence).
+--             match p with (({spec = l}, {spec = r}), _) then
+--               and
+--                (and (eqsym l.nt.sym ntsym) (eqsym r.nt.sym ntsym))
+--                (and (_ropenType l.ptype) (_lopenType r.ptype))
+--             else false)
+--           precedences in
+--         let productions = filter
+--           (lam prod: Production. eqsym prod.spec.nt.sym ntsym)
+--           productions in
+
+--         let getSyms = lam p: ((Production, Production), Precedence).
+--           match p with (({sym = lsym}, {sym = rsym}), _)
+--             then (lsym, rsym)
+--             else never in
+--         let groupedPrecs = foldl
+--           (lam acc. lam p. mapInsertWith concat (getSyms p) [p] acc)
+--           (mapEmpty _cmpSymPair)
+--           precedences in
+
+--         let dupPrecErrs =
+--           let asSpecs = lam p: ((Production, Production), Precedence).
+--             match p with (({spec = lspec}, {spec = rspec}), prec)
+--               then ((lspec, rspec), prec)
+--               else never in
+--           let duplicatedPrecs = filter
+--             (lam x. gti (length x) 1)
+--             (map (lam x: (Unknown, Unknown). x.1) (mapBindings groupedPrecs)) in
+--           let mkDupErr = lam ps. DuplicatedPrecedence (map asSpecs ps) in
+--           map mkDupErr duplicatedPrecs
+--         in
+
+--         let undefPrecErrs =
+--           let allLOpen = filter
+--             (lam prod: Production. _lopenType prod.spec.ptype)
+--             productions in
+--           let allROpen = filter
+--             (lam prod: Production. _ropenType prod.spec.ptype)
+--             productions in
+--           let paired = seqLiftA2 (lam a. lam b. (a, b)) allROpen allLOpen in
+--           let undef = filter
+--             (lam p: (Production, Production). match p with (l, r) then
+--                not (mapMem (l.sym, r.sym) groupedPrecs)
+--              else never)
+--             paired in
+--           map (lam x: (Production, Production). UndefinedPrecedence {left = (x.0).spec, right = (x.1).spec}) undef
+--         in
+
+--         let emptyAllowSet = AllowSet (mapEmpty _cmpSym) in
+--         let defaultAllowSet =
+--           let defaultDisallow = filter
+--             (lam prod: Production. match _prodTypeSelf prod.spec.ptype with DefaultNotIn _ then true else false)
+--             productions in
+--           let syms = map (lam x: Production. (x.sym, ())) defaultDisallow in
+--           DisallowSet (mapFromSeq _cmpSym syms)
+--         in
+
+--         let baseAllowSet
+--           : DefaultInclude
+--           -> AllowSet Symbol
+--           = lam d.
+--             match d with DefaultIn _ then defaultAllowSet else
+--             match d with DefaultNotIn _ then emptyAllowSet else
+--             never
+--         in
+
+--         let makeProductionBreakable = lam prod: Production.
+--           use ParserConcrete in
+--           match prod with {sym = sym, spec = {name = name, nt = nt, ptype = ptype, rhs = rhs, action = action}} then
+--             let unwrapChildren = map
+--               (lam sym. match sym with UserSym (Right (_, x))
+--                 then UserSym x
+--                 else sym) in
+--             match ptype with Atom _ then
+--               BreakableAtom {label = sym, construct = lam mid. action (unwrapChildren mid)}
+--             else match ptype with Prefix {right = right} then
+--               let overrides = match mapLookup sym overrides
+--                 with Some x then let x: MultiOverride = x in x.right
+--                 else {allow = [], disallow = []} in
+--               let rightAllow = baseAllowSet right in
+--               let rightAllow = foldl
+--                 (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
+--                 rightAllow
+--                 overrides.allow in
+--               let rightAllow = foldl
+--                 (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
+--                 rightAllow
+--                 overrides.disallow in
+--               let construct = lam mid. lam r. action (snoc (unwrapChildren mid) (UserSym r)) in
+--               BreakablePrefix {label = sym, construct = construct, rightAllow = rightAllow}
+--             else match ptype with Postfix {left = left} then
+--               let overrides = match mapLookup sym overrides
+--                 with Some x then let x: MultiOverride = x in x.left
+--                 else {allow = [], disallow = []} in
+--               let leftAllow = baseAllowSet left in
+--               let leftAllow = foldl
+--                 (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
+--                 leftAllow
+--                 overrides.allow in
+--               let leftAllow = foldl
+--                 (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
+--                 leftAllow
+--                 overrides.disallow in
+--               let construct = lam mid. lam l. action (cons (UserSym l) (unwrapChildren mid)) in
+--               BreakablePostfix {label = sym, construct = construct, leftAllow = leftAllow}
+--             else match ptype with Infix {left = left, right = right} then
+--               let overrides = match mapLookup sym overrides
+--                 with Some overrides then overrides
+--                 else emptyMultiOverride in
+--               let leftAllow = baseAllowSet left in
+--               let leftAllow = foldl
+--                 (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
+--                 leftAllow
+--                 overrides.left.allow in
+--               let leftAllow = foldl
+--                 (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
+--                 leftAllow
+--                 overrides.left.disallow in
+--               let rightAllow = baseAllowSet right in
+--               let rightAllow = foldl
+--                 (lam acc. lam toAdd. breakableInsertAllowSet toAdd acc)
+--                 rightAllow
+--                 overrides.right.allow in
+--               let rightAllow = foldl
+--                 (lam acc. lam toRem. breakableRemoveAllowSet toRem acc)
+--                 rightAllow
+--                 overrides.right.disallow in
+--               let construct = lam mid. lam l. lam r. action (cons (UserSym l) (snoc (unwrapChildren mid) (UserSym r))) in
+--               BreakableInfix {label = sym, construct = construct, leftAllow = leftAllow, rightAllow = rightAllow}
+--             else never
+--           else never
+--         in
+
+--         let fst: (a, b) -> a = lam x. x.0 in
+--         let snd: (a, b) -> b = lam x. x.1 in
+--         let breakablePrecomputed = breakableGenGrammar _cmpSym
+--           { productions = map makeProductionBreakable productions
+--           , precedences = map
+--             (lam pair. (fst pair, snd (head (snd pair))))
+--             (mapBindings groupedPrecs)
+--           } in
+--         let atom = lam sym. mapFindExn sym breakablePrecomputed.atoms in
+--         let prefix = lam sym. mapFindExn sym breakablePrecomputed.prefixes in
+--         let postfix = lam sym. mapFindExn sym breakablePrecomputed.postfixes in
+--         let infix = lam sym. mapFindExn sym breakablePrecomputed.infixes in
+
+--         -- TODO(vipa, 2021-02-24): There will be a bug if multiple
+--         -- non-terminals have the same name, they will be merged, even
+--         -- though the interface (not referentially transparent) suggests
+--         -- this is not the case. See also the TODO at 2021-03-01.
+--         let topNt = ntname in
+--         let contNt = concat ntname " continuation" in
+--         let atomNt = concat "atomic " ntname in
+--         let prefixNt = concat "prefix " ntname in
+--         let prefixesNt = concat ntname " prefixes" in
+--         let infixNt = concat "infix " ntname in
+--         let postfixNt = concat "postfix " ntname in
+--         let postfixesNt = concat ntname " postfixes" in
+
+--         let makeProductionLL1 = lam prod: Production.
+--           match prod with {sym = sym, spec = {name = name, nt = nt, ptype = ptype, rhs = rhs, action = action}} then
+--             match ptype with Atom _ then
+--               let input = atom sym in
+--               {nt = atomNt, label = name, rhs = rhs, action = lam x. (input, x)}
+--             else match ptype with Prefix {right = right} then
+--               let input = prefix sym in
+--               {nt = prefixNt, label = name, rhs = rhs, action = lam x. (input, x)}
+--             else match ptype with Postfix {left = left} then
+--               let input = postfix sym in
+--               {nt = postfixNt, label = name, rhs = rhs, action = lam x. (input, x)}
+--             else match ptype with Infix {left = left, right = right} then
+--               let input = infix sym in
+--               {nt = infixNt, label = name, rhs = rhs, action = lam x. (input, x)}
+--             else never
+--           else never
+--         in
+--         use ParserConcrete in
+--         match concat dupPrecErrs undefPrecErrs with errs & [_] ++ _ then
+--           Left errs
+--         else Right (concat
+--           (map makeProductionLL1 productions)
+--           [ { nt = topNt
+--             , label = ntname
+--             , rhs = [ll1Nt prefixesNt, ll1Nt atomNt, ll1Nt postfixesNt, ll1Nt contNt]
+--             , action = lam xs.
+--               match xs with [UserSym pres, UserSym atom, UserSym posts, UserSym contFunc] then
+--                 let contFunc: (Unknown, Unknown, Unknown) = contFunc in
+--                 let syms = join
+--                   [ join (map snd pres)
+--                   , snd atom
+--                   , join (map snd posts)
+--                   , contFunc.2
+--                   ] in
+--                 let errs = join
+--                   (map
+--                     (lam sym. match sym with UserSym (Left es) then es else [])
+--                     syms) in
+--                 let st = breakableInitState () in
+--                 let mSt = _buildSurroundedAtom pres atom posts contFunc st in
+--                 let info = _surroundedAtomInfo pres atom posts contFunc in
+--                 match optionBind mSt breakableFinalizeParse with Some st then
+--                   match errs with [] then
+--                     eitherBiMap
+--                       _breakableErrorToSemanticErrors
+--                       (lam x. (info, x))
+--                       (breakableConstructResult st)
+--                   else
+--                     Left errs
+--                 else
+--                   Left (cons (SemanticParseBreakableError {nt = ntname, info = info}) errs)
+--               else never
+--             }
+--           , { nt = contNt
+--             , label = concat "empty " contNt
+--             , rhs = []
+--             , action = lam. (NoInfo (), lam x. Some x, [])
+--             }
+--           , { nt = contNt
+--             , label = contNt
+--             , rhs = [ll1Nt infixNt, ll1Nt prefixesNt, ll1Nt atomNt, ll1Nt postfixesNt, ll1Nt contNt]
+--             , action = lam xs.
+--               match xs with [UserSym infix, UserSym pres, UserSym atom, UserSym posts, UserSym contFunc] then
+--                 let contFunc: (Unknown, Unknown, Unknown) = contFunc in
+--                 let syms = join
+--                   [ snd infix
+--                   , join (map snd pres)
+--                   , snd atom
+--                   , join (map snd posts)
+--                   , contFunc.2
+--                   ] in
+--                 let newContFunc = lam st.
+--                   optionBind
+--                     (breakableAddInfix (fst infix) (snd infix) st)
+--                     (_buildSurroundedAtom pres atom posts contFunc) in
+--                 let contInfo = _surroundedAtomInfo pres atom posts contFunc in
+--                 (contInfo, newContFunc, syms)
+--               else never
+--             }
+--           , { nt = prefixesNt
+--             , label = concat "empty " prefixesNt
+--             , rhs = []
+--             , action = lam. []
+--             }
+--           , { nt = prefixesNt
+--             , label = prefixesNt
+--             , rhs = [ll1Nt prefixNt, ll1Nt prefixesNt]
+--             , action = lam xs.
+--               match xs with [UserSym pre, UserSym pres] then
+--                 cons pre pres
+--               else never
+--             }
+--           , { nt = postfixesNt
+--             , label = concat "empty " postfixesNt
+--             , rhs = []
+--             , action = lam. []
+--             }
+--           , { nt = postfixesNt
+--             , label = postfixesNt
+--             , rhs = [ll1Nt postfixNt, ll1Nt postfixesNt]
+--             , action = lam xs.
+--               match xs with [UserSym post, UserSym posts] then
+--                 cons post posts
+--               else never
+--             }
+--           ])
+--         )
+--     in
+
+--     let res = eitherPartition res in
+--     match res with ([], productions) then
+--       eitherMapLeft
+--         (lam x. [SemanticGrammarLL1Error x])
+--         (ll1GenParser {productions = join productions, start = grammar.start.name})
+--     else Left (join res.0)
+
+-- let semanticParseFile
+--   : Parser
+--   -> String -- Filename
+--   -> String -- Content
+--   -> Either [SemanticParseError] Dyn
+--   = lam ll1table. lam filename. lam content.
+--     let res = ll1ParseWithTable ll1table filename content in
+--     match res with Left err then Left [SemanticParseError err] else
+--     match res with Right (Left err) then Left err else
+--     match res with Right (Right (_, res)) then Right res else
+--     never
+
+-- let semanticUnwrapOrPrintErrors
+--   : Either [SemanticParseError] Dyn -> Dyn
+--   = lam x.
+--     match x with Right x then x else
+--     match x with Left errs then
+--       for_ errs
+--         (lam err.
+--           match err with SemanticParseBreakableError r then
+--             printLn (infoErrorString r.info (join ["This ", r.nt, " is not syntactically valid"]))
+--           else match err with SemanticParseAmbiguityError err then
+--             printLn (infoErrorString err.info "Ambiguity error");
+--             for_ err.irrelevant
+--               (lam irr: Info. printLn (infoErrorString irr "Irrelevant region"))
+--           else match err with SemanticParseError err then
+--             use ParserSpec in
+--             use ParserConcrete in
+--             match err with UnexpectedFirst err then
+--               printLn (infoErrorString (symInfo err.found) "Unexpected first token");
+--               printLn (concat "Expected one of: " (strJoin ", " (map symToStr err.expected)));
+--               printLn (concat "Found: " (symToStr err.found))
+--             else match err with UnexpectedToken err then
+--               printLn (infoErrorString (symInfo err.found) "Unexpected token");
+--               printLn (concat "Expected: " (symToStr err.expected));
+--               printLn (concat "Found: " (symToStr err.found))
+--             else never
+--           else dprintLn err; never
+--         );
+--       exit 1
+--     else never
+
+-- -- Small helper to make smaller errors by discarding information that
+-- -- is typically not interesting
+-- let semanticShortenErrors
+--   : [SemanticGrammarError]
+--   -> [(String, String)]
+--   = let shortenOne = lam err.
+--       match err with UndefinedPrecedence {left = {name = lname}, right = {name = rname}} then
+--         ("undefPrec", join [lname, " -?- ", rname])
+--       else match err with DuplicatedPrecedence ([(({name = lname}, {name = rname}), _)] ++ _ & precs) then
+--         let precs = map (lam x: (Unknown, Precedence). x.1) precs in
+--         let precs = map
+--           (lam x: Precedence. join ["'", if x.mayGroupLeft then "<" else "", "-", if x.mayGroupRight then ">" else "", "'"])
+--           precs in
+--         ("dupPrec", join [lname, " -?- ", rname, " in {", strJoin ", " precs, "}"])
+--       else match err with SemanticGrammarLL1Error err then
+--         dprintLn (map (lam x: (Unknown, Map Unknown Unknown). {x with #label"1" = mapBindings x.1}) (mapBindings err)); ("ll1error", "dprinted above")
+--       else dprintLn err; never
+--     in map shortenOne
+
+-- mexpr
+
+-- let wrap = lam label. lam x. (label, x) in
+
+-- let exprNT = semanticNonTerminal "expression" in
+-- let declNT = semanticNonTerminal "declaration" in
+
+-- let intP = semanticProduction
+--   { name = "int"
+--   , nt = exprNT
+--   , ptype = semanticDefAtom
+--   , rhs = [semanticInt]
+--   , action = wrap "int"
+--   } in
+
+-- let addP = semanticProduction
+--   { name = "add"
+--   , nt = exprNT
+--   , ptype = semanticDefInfix
+--   , rhs = [semanticLit "+"]
+--   , action = wrap "add"
+--   } in
+
+-- let minusP = semanticProduction
+--   { name = "minus"
+--   , nt = exprNT
+--   , ptype = semanticDefInfix
+--   , rhs = [semanticLit "-"]
+--   , action = wrap "minus"
+--   } in
+
+-- let mulP = semanticProduction
+--   { name = "mul"
+--   , nt = exprNT
+--   , ptype = semanticDefInfix
+--   , rhs = [semanticLit "*"]
+--   , action = wrap "mul"
+--   } in
+
+-- let negP = semanticProduction
+--   { name = "neg"
+--   , nt = exprNT
+--   , ptype = semanticDefPrefix
+--   , rhs = [semanticLit "-"]
+--   , action = wrap "neg"
+--   } in
+
+-- let parP = semanticProduction
+--   { name = "par"
+--   , nt = exprNT
+--   , ptype = semanticDefAtom
+--   , rhs = [semanticLit "(", semanticNt exprNT, semanticLit ")"]
+--   , action = wrap "par"
+--   } in
+
+-- let fieldAccessP = semanticProduction
+--   { name = "fieldAccess"
+--   , nt = exprNT
+--   , ptype = semanticDefPostfix
+--   , rhs = [semanticLit ".", semanticLIdent]
+--   , action = wrap "fieldAccess"
+--   } in
+
+-- let ifP = semanticProduction
+--   { name = "if"
+--   , nt = exprNT
+--   , ptype = semanticDefPrefix
+--   , rhs = [semanticLit "if", semanticNt exprNT, semanticLit "then"]
+--   , action = wrap "if"
+--   } in
+
+-- let elseP = semanticProduction
+--   { name = "else"
+--   , nt = exprNT
+--   , ptype = Infix
+--     { self = semanticDefIn
+--     , left = semanticDefNotIn
+--     , right = semanticDefIn
+--     }
+--   , rhs = [semanticLit "else"]
+--   , action = wrap "else"
+--   } in
+
+-- let defP = semanticProduction
+--   { name = "def"
+--   , nt = declNT
+--   , ptype = semanticDefAtom
+--   , rhs = [semanticLit "def", semanticLIdent, semanticLit "=", semanticNt exprNT]
+--   , action = wrap "def"
+--   } in
+
+-- let twoDefP = semanticProduction
+--   { name = "twoDef"
+--   , nt = declNT
+--   , ptype = semanticDefInfix
+--   , rhs = []
+--   , action = wrap "twoDef"
+--   } in
+
+-- -- NOTE(vipa, 2021-02-25): The tests in this file are mostly written
+-- -- to only check some parts of the produced value, through pattern
+-- -- matching, which gives somewhat strange formatting, but works pretty
+-- -- nicely
+-- utest semanticGrammar
+--   { start = exprNT
+--   , productions = [intP, addP]
+--   , overrideAllow = []
+--   , overrideDisallow = []
+--   , precedences = []
+--   } with () using lam x. lam. match x
+-- with Left
+--   [ UndefinedPrecedence
+--     { left = {name = "add"}
+--     , right = {name = "add"}
+--     }
+--   ]
+-- then true else false in
+
+-- let g =
+--   let res = semanticGrammar
+--     { start = exprNT
+--     , productions = [intP, addP]
+--     , overrideAllow = []
+--     , overrideDisallow = []
+--     , precedences = join
+--       [ [semanticAmbAssoc addP]
+--       ]
+--     } in
+--   utest res with () using lam x. lam. match x
+--   with Right _
+--   then true else false in
+--   match res with Right x then x else never
+-- in
+
+-- utest semanticParseFile g "file" ""
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left [SemanticParseError (UnexpectedFirst
+--   { expected = [Tok (IntTok _)]
+--   , found = Tok (EOFTok _)
+--   })]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "7"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("int",
+--   [ Tok (IntTok {val = 7})
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "7 +"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left [SemanticParseError (UnexpectedFirst
+--   { expected = [Tok (IntTok _)]
+--   , stack = [{label = "expression"}] ++ _
+--   , nt = "expression prefixes"
+--   , found = Tok (EOFTok _)
+--   })]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "7 + 43"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("add",
+--   [ UserSym ("int", [Tok (IntTok {val = 7})])
+--   , Lit {lit = "+"}
+--   , UserSym ("int", [Tok (IntTok {val = 43})])
+--   ])
+-- then true else false in
+
+-- -- TODO(vipa, 2021-02-26): The tests with ambiguities will presently
+-- -- check that nothing is marked as irrelevant, even though some parts
+-- -- should be considered irrelevant. They will then blow up once that
+-- -- code is implemented, at which point we'll update the tests
+-- -- properly.
+-- utest semanticParseFile g "file" "7 + 43 + 9"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 10}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- let g =
+--   let res = semanticGrammar
+--     { start = exprNT
+--     , productions = [intP, addP, negP, mulP, minusP]
+--     , overrideAllow = []
+--     , overrideDisallow = []
+--     , precedences = join
+--       [ map semanticLeftAssoc [addP, minusP]
+--       , map semanticAmbAssoc [mulP]
+--       , semanticPrecTableNoEq
+--         [ [negP]
+--         , [mulP]
+--         , [addP, minusP]
+--         ]
+--       , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
+--       ]
+--     } in
+--   utest res with () using lam x. lam. match x
+--   with Right _
+--   then true else false in
+--   match res with Right x then x else never
+-- in
+
+-- utest semanticParseFile g "file" "7 + 43 + 9"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("add",
+--   [ UserSym ("add",
+--     [ UserSym ("int", [Tok (IntTok {val = 7})])
+--     , Lit {lit = "+"}
+--     , UserSym ("int", [Tok (IntTok {val = 43})])
+--     ])
+--   , Lit {lit = "+"}
+--   , UserSym ("int", [Tok (IntTok {val = 9})])
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "7 + 43 * 8 * 9"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 4, row2 = 1, col2 = 14}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "-1"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("neg",
+--   [ Lit {lit = "-"}
+--   , UserSym ("int", [Tok (IntTok {val = 1})])
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "-1 + 8 * -2"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("add",
+--   [ UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 1})])])
+--   , Lit {lit = "+"}
+--   , UserSym ("mul",
+--     [ UserSym ("int", [Tok (IntTok {val = 8})])
+--     , Lit {lit = "*"}
+--     , UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 2})])])
+--     ])
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "-1 - - 8"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("minus",
+--   [ UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 1})])])
+--   , Lit {lit = "-"}
+--   , UserSym ("neg", [Lit {lit = "-"}, UserSym ("int", [Tok (IntTok {val = 8})])])
+--   ])
+-- then true else false in
+
+-- let g =
+--   let res = semanticGrammar
+--     { start = exprNT
+--     , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP]
+--     , overrideAllow = []
+--     , overrideDisallow = []
+--     , precedences = join
+--       [ map semanticLeftAssoc [addP, minusP]
+--       , map semanticAmbAssoc [mulP]
+--       , semanticPrecTableNoEq
+--         [ [negP, fieldAccessP]
+--         , [mulP]
+--         , [addP, minusP]
+--         ]
+--       , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
+--       , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
+--       ]
+--     } in
+--   utest res with () using lam x. lam. match x
+--   with Right _
+--   then true else false in
+--   match res with Right x then x else never
+-- in
+
+-- utest semanticParseFile g "file" "1 .foo"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("fieldAccess",
+--   [ UserSym ("int", [Tok (IntTok {val = 1})])
+--   , Lit {lit = "."}
+--   , Tok (LIdentTok {val = "foo"})
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "-1 .foo"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 7}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "-1 .foo + 32"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 7}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "(-1).foo"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("fieldAccess",
+--   [ UserSym ("par",
+--     [ Lit {lit = "("}
+--     , UserSym ("neg",
+--       [ Lit {lit = "-"}
+--       , UserSym ("int", [Tok (IntTok {val = 1})])
+--       ])
+--     , Lit {lit = ")"}
+--     ])
+--   , Lit {lit = "."}
+--   , Tok (LIdentTok {val = "foo"})
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "(1 * 2 * 3) * 8 * 9"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 1, row2 = 1, col2 = 10}
+--     , irrelevant = []
+--     }
+--   ]
+--   -- NOTE(vipa, 2021-03-01): This should actually be two ambiguity
+--   -- errors, but we presently can't get an ambiguity error out without
+--   -- trying to construct the final result. The latter can't be done if
+--   -- there is an error in a descendant, which is the case when there
+--   -- is a nested ambiguity error.
+-- then true else false in
+
+-- utest semanticGrammar
+--   { start = exprNT
+--   , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP, ifP, elseP]
+--   , overrideAllow = [LeftChild{parent = elseP, child = ifP}]
+--   , overrideDisallow = []
+--   , precedences = join
+--     [ map semanticLeftAssoc [addP, minusP]
+--     , map semanticAmbAssoc [mulP]
+--     , semanticPrecTableNoEq
+--       [ [negP, fieldAccessP]
+--       , [mulP]
+--       , [addP, minusP]
+--       , [ifP]
+--       ]
+--     , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
+--     , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
+--     , map semanticLeftAssoc [elseP]
+--     , seqLiftA2 semanticGroupRight [elseP] [fieldAccessP]
+--     , seqLiftA2 semanticGroupEither [elseP] [addP, mulP, minusP, ifP, fieldAccessP]
+--     , seqLiftA2 semanticGroupEither [addP, negP, mulP, minusP, ifP] [elseP]
+--     ]
+--   }
+-- with () using lam x. lam. match x
+-- with Left
+--   [ DuplicatedPrecedence
+--     [ (({name = "else"}, {name = "fieldAccess"}), {mayGroupLeft = false, mayGroupRight = true})
+--     , (({name = "else"}, {name = "fieldAccess"}), {mayGroupLeft = true, mayGroupRight = true})
+--     ]
+--   ]
+-- then true else false in
+
+-- let g =
+--   let res = semanticGrammar
+--     { start = exprNT
+--     , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP, ifP, elseP]
+--     , overrideAllow = [LeftChild{parent = elseP, child = ifP}]
+--     , overrideDisallow = []
+--     , precedences = join
+--       [ map semanticLeftAssoc [addP, minusP]
+--       , map semanticAmbAssoc [mulP]
+--       , semanticPrecTableNoEq
+--         [ [negP, fieldAccessP]
+--         , [mulP]
+--         , [addP, minusP]
+--         , [ifP]
+--         ]
+--       , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
+--       , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
+--       , map semanticLeftAssoc [elseP]
+--       , seqLiftA2 semanticGroupRight [elseP] [fieldAccessP, addP, mulP, minusP]
+--       , seqLiftA2 semanticGroupEither [addP, negP, mulP, minusP, ifP] [elseP]
+--       ]
+--     } in
+--   utest eitherMapLeft semanticShortenErrors res with () using lam x. lam. match x
+--   with Right _
+--   then true else false in
+--   match res with Right x then x else never
+-- in
+
+-- utest semanticParseFile g "file" "2 else 3"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseBreakableError
+--     { info = Info {filename = "file", row1 = 1, row2 = 1, col1 = 0, col2 = 8}
+--     , nt = "expression"
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "if 1 then 2 else 3"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("else",
+--   [ UserSym ("if",
+--     [ Lit {lit = "if"}
+--     , UserSym ("int", [Tok (IntTok {val = 1})])
+--     , Lit {lit = "then"}
+--     , UserSym ("int", [Tok (IntTok {val = 2})])
+--     ])
+--   , Lit {lit = "else"}
+--   , UserSym ("int", [Tok (IntTok {val = 3})])
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "if 1 + 11 then 2 * 22 else 3 - 33"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("else",
+--   [ UserSym ("if",
+--     [ Lit {lit = "if"}
+--     , UserSym ("add",
+--       [ UserSym ("int", [Tok (IntTok {val = 1})])
+--       , Lit {lit = "+"}
+--       , UserSym ("int", [Tok (IntTok {val = 11})])
+--       ])
+--     , Lit {lit = "then"}
+--     , UserSym ("mul",
+--       [ UserSym ("int", [Tok (IntTok {val = 2})])
+--       , Lit {lit = "*"}
+--       , UserSym ("int", [Tok (IntTok {val = 22})])
+--       ])
+--     ])
+--   , Lit {lit = "else"}
+--   , UserSym ("minus",
+--     [ UserSym ("int", [Tok (IntTok {val = 3})])
+--     , Lit {lit = "-"}
+--     , UserSym ("int", [Tok (IntTok {val = 33})])
+--     ])
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "if 0 then if 1 then 2 else 3"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 28}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "if 0 then -if 1 then 2 else 3"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 29}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "if 0 then 1 + if 1 then 2 else 3"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 32}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "if 0 then if 1 then 2 else 3 .foo"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseAmbiguityError
+--     { info = Info {filename = "file", row1 = 1, col1 = 0, row2 = 1, col2 = 33}
+--     , irrelevant = []
+--     }
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "if 1 then 2 else 3 .foo"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("else",
+--   [ UserSym ("if",
+--     [ Lit {lit = "if"}
+--     , UserSym ("int", [Tok (IntTok {val = 1})])
+--     , Lit {lit = "then"}
+--     , UserSym ("int", [Tok (IntTok {val = 2})])
+--     ])
+--   , Lit {lit = "else"}
+--   , UserSym ("fieldAccess",
+--     [ UserSym ("int", [Tok (IntTok {val = 3})])
+--     , Lit {lit = "."}
+--     , Tok (LIdentTok {val = "foo"})
+--     ])
+--   ])
+-- then true else false in
+
+-- let g =
+--   let res = semanticGrammar
+--     { start = declNT
+--     , productions = [intP, addP, negP, mulP, minusP, parP, fieldAccessP, ifP, elseP, defP, twoDefP]
+--     , overrideAllow = [LeftChild{parent = elseP, child = ifP}]
+--     , overrideDisallow = []
+--     , precedences = join
+--       [ map semanticLeftAssoc [twoDefP]
+
+--       , map semanticLeftAssoc [addP, minusP]
+--       , map semanticAmbAssoc [mulP]
+--       , semanticPrecTableNoEq
+--         [ [negP, fieldAccessP]
+--         , [mulP]
+--         , [addP, minusP]
+--         , [ifP]
+--         ]
+--       , semanticPairwiseGroup semanticGroupLeft [addP, minusP]
+--       , semanticPairwiseGroup semanticGroupEither [negP, fieldAccessP]
+--       , map semanticLeftAssoc [elseP]
+--       , seqLiftA2 semanticGroupRight [elseP] [fieldAccessP, addP, mulP, minusP]
+--       , seqLiftA2 semanticGroupEither [addP, negP, mulP, minusP, ifP] [elseP]
+--       ]
+--     } in
+--   utest eitherMapLeft semanticShortenErrors res with () using lam x. lam. match x
+--   with Right _
+--   then true else false in
+--   match res with Right x then x else never
+-- in
+
+-- utest semanticParseFile g "file" ""
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseError
+--     (UnexpectedFirst
+--       { expected = [Lit {lit = "def"}]
+--       , stack = []
+--       , found = Tok (EOFTok _)
+--       , nt = "declaration"
+--       }
+--     )
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "7"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Left
+--   [ SemanticParseError
+--     (UnexpectedFirst
+--       { expected = [Lit {lit = "def"}]
+--       , stack = []
+--       , found = Tok (IntTok {val = 7})
+--       , nt = "declaration"
+--       }
+--     )
+--   ]
+-- then true else false in
+
+-- utest semanticParseFile g "file" "def x = 7"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("def",
+--   [ Lit {lit = "def"}
+--   , Tok (LIdentTok {val = "x"})
+--   , Lit {lit = "="}
+--   , UserSym ("int", [Tok (IntTok {val = 7})])
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "def x = 7 def y = 8"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("twoDef",
+--   [ UserSym ("def",
+--     [ Lit {lit = "def"}
+--     , Tok (LIdentTok {val = "x"})
+--     , Lit {lit = "="}
+--     , UserSym ("int", [Tok (IntTok {val = 7})])
+--     ])
+--   , UserSym ("def",
+--     [ Lit {lit = "def"}
+--     , Tok (LIdentTok {val = "y"})
+--     , Lit {lit = "="}
+--     , UserSym ("int", [Tok (IntTok {val = 8})])
+--     ])
+--   ])
+-- then true else false in
+
+-- utest semanticParseFile g "file" "def x = 7\ndef y = 8\ndef z = 1 + 2"
+-- with () using lam x. lam. use ParserConcrete in match x
+-- with Right ("twoDef",
+--   [ UserSym ("twoDef",
+--     [ UserSym ("def",
+--       [ Lit {lit = "def"}
+--       , Tok (LIdentTok {val = "x"})
+--       , Lit {lit = "="}
+--       , UserSym ("int", [Tok (IntTok {val = 7})])
+--       ])
+--     , UserSym ("def",
+--       [ Lit {lit = "def"}
+--       , Tok (LIdentTok {val = "y"})
+--       , Lit {lit = "="}
+--       , UserSym ("int", [Tok (IntTok {val = 8})])
+--       ])
+--     ])
+--   , UserSym ("def",
+--     [ Lit {lit = "def"}
+--     , Tok (LIdentTok {val = "z"})
+--     , Lit {lit = "="}
+--     , UserSym ("add",
+--       [ UserSym ("int", [Tok (IntTok {val = 1})])
+--       , Lit {lit = "+"}
+--       , UserSym ("int", [Tok (IntTok {val = 2})])
+--       ])
+--     ])
+--   ])
+-- then true else false in
+
+-- ()


### PR DESCRIPTION
This PR applies some of the improvements I've made during the evaluation of the current paper. Here are some highlights:
- A slightly better formulation of shallow restrictions that let us express longest match disambiguation properly.
- A much stricter definition of which part of the input that is "relevant" to an ambiguity (and support for computing this in the resolution algorithm.
- A resolution algorithm at all :)
- An api that is slightly more flexible in how the AST is constructed, making it easier to omit an intermediate AST-like thing when unbreaking is relatively complicated, which should be a win for efficiency.

Unfortunately I haven't yet had time to update the other modules in the parsing directory accordingly, so in the interest of not making this PR huge I'm commenting them out presently, so they don't fail the build. This obviously is only OK if no one else is using these, which I think is the case, but we should confirm that before merging.

I also made one minor change to the intrinsics: `dprint` in the compiler will now attempt to print things that could be strings as such:

```
-- This program:
mexpr dprint "test"

-- ...gives this output (note "as a string"):
{ tag: 1, size: 1
, { tag: 0, size: 1
  , { tag: 0, size: 1
    , { tag: 0, size: 4 (as a string: test)
      , 116
      , 101
      , 115
      , 116
      }
    }
  }
}
```