### PR TITLE
Fix compilation when using `dune` version >= 3

### DIFF
--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -49,6 +49,7 @@ let ocamlCompileWithConfig : CompileOptions -> String -> CompileResult =
 
   writeFile (tempfile "program.ml") p;
   writeFile (tempfile "program.mli") "";
+  writeFile (tempfile "dune-project") "(lang dune 2.0)";
   writeFile (tempfile "dune") dunefile;
 
   let command =


### PR DESCRIPTION
This PR fixes a compilation error in the generated dune project for recent versions of `dune` (3.0.0 and later), due to a change in its behaviour relative to earlier versions.

To solve this, I generated a minimal `dune-project` file in the temporary directory, as this is required in `dune` versions >= 3. The reason I used `2.0` in the `(lang dune 2.0)` stanza is because this is backwards-compatible, so it works independently of the installed `dune` version (nothing seemed to happen when I used `1.0`, but I don't think we want to support such old versions anyway).