### PR TITLE
Fix C compiler

### DIFF
--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -175,7 +175,7 @@ lang MExprCCompile = MExprAst + CAst
     let externals: Map Name Name = collectExternals (mapEmpty nameCmp) prog in
 
     -- Set up initial environment
-    let env = {{{ let e : CompileCOptions = compileCEnvEmpty compileOptions in e
+    let env = {{{ let e : CompileCEnv = compileCEnvEmpty compileOptions in e
       with ptrTypes = ptrTypes }
       with typeEnv = typeEnv }
       with externals = externals }

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -175,7 +175,7 @@ lang MExprCCompile = MExprAst + CAst
     let externals: Map Name Name = collectExternals (mapEmpty nameCmp) prog in
 
     -- Set up initial environment
-    let env = {{{ compileCEnvEmpty compileOptions
+    let env = {{{ let e : CompileCOptions = compileCEnvEmpty compileOptions in e
       with ptrTypes = ptrTypes }
       with typeEnv = typeEnv }
       with externals = externals }


### PR DESCRIPTION
Fixes a record type error in the C compiler file, which was only detected via DPPL, by adding an explicit type annotation.