### PR TITLE
Add eval implementation for never terms

### DIFF
--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -266,7 +266,11 @@ lang SeqEval = Eval + SeqAst
 end
 
 lang NeverEval = Eval + NeverAst
-  --TODO(?,?)
+  sem eval (ctx : {env : Env}) =
+  | TmNever t ->
+    infoErrorExit t.info
+      (join [ "Reached a never term, which should be "
+            , "impossible in a well-typed program."])
 end
 
 -- TODO (oerikss, 2020-03-26): Eventually, this should be a rank 0 tensor.


### PR DESCRIPTION
This PR adds a missing implementation for evaluation of `TmNever` in the `mi` evaluator.

Before this change, `mi eval` would do a `dprint` of the term (which is extremely unreadable for `mi` at the moment) and report that there were no matching case for the `eval` function. After the change, it reports that a `never` term was reached, using the same text as in `boot eval`. The behaviour is identical to that of `boot eval` with the exception of an extra newline before the text (added by `infoErrorExit`).