### PR TITLE
Support for singleton tuple matching

### DIFF
--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -486,6 +486,9 @@ pat_atom:
       { PatSeqEdge(mkinfo (fst $1) (fst $3), Mseq.empty, snd $1, $3 |> snd |> Mseq.Helpers.of_list) }
   | LPAREN pat RPAREN
       { $2 }
+  | LPAREN pat COMMA RPAREN
+      { let fi = mkinfo $1.i $4.i in
+        PatRecord(fi,Record.singleton (us"0") $2) }
   | LPAREN pat COMMA pat_list RPAREN
       { let fi = mkinfo $1.i $5.i in
         let r = List.fold_left (fun (i,a) x ->

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -184,6 +184,14 @@ utest match {blue = {red = true}} with {blue = {}} then true else false with tru
 utest match {blue = true, red = true} with {blue = _} & {red = _} then true else false with true in
 --utest match {blue = true} with {blue = _} & {red = _} then true else false with false in
 
+-- Matching with tuples
+utest match ("foo", "bar") with ("foo", "bar") then true else false with true in
+utest match ("foo", "bar") with ("foo", _) then true else false with true in
+utest match ("foo", "bar") with (_, "foo") then true else false with false in
+utest match ("foo",) with ("foo",) then true else false with true in
+utest match ("foo",) with (_,) then true else false with true in
+utest match ("foo",) with ("bar",) then true else false with false in
+
 -- Matching with "&", "|", "!"
 utest match true with !_ then true else false with false in
 utest match (1, 2) with (a, _) & (_, b) then (a, b) else (0, 0) with (1, 2) in

--- a/test/mexpr/tuples.mc
+++ b/test/mexpr/tuples.mc
@@ -15,4 +15,7 @@ utest ('a',8,"the").2 with "the" in
 
 utest ("foo",5) with {#label"0" = "foo", #label"1" = 5} in
 
+-- Singleton tuples
+utest ("foo",) with ("foo",) in
+
 ()


### PR DESCRIPTION
It is currently possible to define singleton tuples, but not to match on them in patterns. This adds support in the boot compiler for creating patterns on singleton tuples.