### PR TITLE
Fix bugs in lambda lifting

### DIFF
--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -710,6 +710,18 @@ let expected = preprocess (bindall_ [
   appf3_ (var_ "f") (var_ "a") (var_ "b") (int_ 7)]) in
 utest liftLambdas letMultiParam with expected using eqExpr in
 
+let nestedMap = preprocess (bindall_ [
+  ulet_ "s" (seq_ [int_ 1, int_ 2, int_ 3]),
+  map_
+    (ulam_ "s" (map_ (ulam_ "x" (addi_ (var_ "x") (int_ 1))) (var_ "s")))
+    (var_ "s")]) in
+let expected = preprocess (bindall_ [
+  ulet_ "s" (seq_ [int_ 1, int_ 2, int_ 3]),
+  ulet_ "t1" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
+  ulet_ "t2" (ulam_ "s" (map_ (var_ "t1") (var_ "s"))),
+  map_ (var_ "t2") (var_ "s")]) in
+utest liftLambdas nestedMap with expected using eqExpr in
+
 let nestedAnonymousLambdas = preprocess (bindall_ [
   ulet_ "s" (seq_ [int_ 1, int_ 2, int_ 3]),
   ulet_ "x" (int_ 0),


### PR DESCRIPTION
This PR fixes a bug in lambda lifting where the inner lambdas of nested anonymous lambdas would not be lifted. For example, if we add one to each element of a two-dimensional sequence as
```
map (lam s2 : [Int]. map (lam x. addi x 1) s2) s1
```
then both anonymous lambdas should be lifted. But prior to this PR, only the outermost lambda would be lifted because parts of the lambda lifting did not recurse into the body of an anonymous lambda.

After I opened this PR, I found and fixed two additional bugs in the lambda lifting:
1. The bodies of let-expressions inside recursive bindings would not remove lifted lambdas inside its body, leading to the same identifier being defined in multiple places in the program.
2. Lambda lifting of a recursive binding within a let-expression would not continue performing lambda lifting of the `inexpr` of the recursive binding.