### PR TITLE
Syntax dsl prep

### DIFF
--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -616,7 +616,7 @@ lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatRecord t ->
     let expectedTy = typeUnwrapAlias env.tyEnv expectedTy in
-    let expectedTy = match expectedTy with TyUnknown _ then t.ty else expectedTy in
+    let expectedTy = match expectedTy with TyUnknown _ | TyApp {lhs = TyUnknown _} then t.ty else expectedTy in
     let expectedTy = match expectedTy with TyRecord _ then expectedTy else
       match (record2tuple t.bindings, mapLength t.bindings) with (Some _, length & !1) then
         -- NOTE(vipa, 2021-05-26): This looks like a tuple pattern, so

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -381,7 +381,7 @@ let _pprintRecord = use MExprAst in
       mapMapWithKey (lam id. lam. pvar_ (sidToString id)) fields
     in
     let recordPattern =
-      PatRecord {bindings = recordBindings, info = NoInfo (), ty = tyunknown_}
+      PatRecord {bindings = recordBindings, info = makeInfo (posVal "utest_pprint" 0 0) (posVal "utest_pprint" 0 0), ty = tyunknown_}
     in
     let pprintSeq =
       match record2tuple fields with Some types then
@@ -425,8 +425,8 @@ let _equalRecord = use MExprAst in
   let rhsPrefix = "rhs_" in
   let matchPattern =
     ptuple_ [
-      PatRecord {bindings = recordBindings lhsPrefix, info = NoInfo (), ty = tyunknown_},
-      PatRecord {bindings = recordBindings rhsPrefix, info = NoInfo (), ty = tyunknown_}] in
+      PatRecord {bindings = recordBindings lhsPrefix, info = makeInfo (posVal "utest_eq" 0 0) (posVal "utest_eq" 0 0), ty = tyunknown_},
+      PatRecord {bindings = recordBindings rhsPrefix, info = makeInfo (posVal "utest_eq" 0 0) (posVal "utest_eq" 0 0), ty = tyunknown_}] in
   let fieldEquals = lam seq. lam id. lam fieldTy.
     let fieldEqName = getEqualFuncName env fieldTy in
     let lhs = var_ (join [lhsPrefix, sidToString id]) in
@@ -646,7 +646,7 @@ lang UtestViaMatchRecord = UtestViaMatch + RecordAst + RecordTypeAst + RecordPat
     let res: ([Expr], Map SID Pat) = mapMapAccum f [] bindings in
     let pat = PatRecord
       { bindings = res.1
-      , info = NoInfo ()
+      , info = makeInfo (posVal "utest_via_match" 0 0) (posVal "utest_via_match" 0 0)
       , ty = TyRecord
         { info = NoInfo ()
         , fields = mapMap (lam. tyunknown_) res.1

--- a/stdlib/parser/breakable-helper.mc
+++ b/stdlib/parser/breakable-helper.mc
@@ -1,0 +1,1049 @@
+include "breakable.mc"
+
+type AllowSet id
+con AllowSet : Map id () -> AllowSet id
+con DisallowSet : Map id () -> AllowSet id
+
+let _isWhitelist
+  : AllowSet id -> Bool
+  = lam a. match a with AllowSet _ then true else false
+
+type BreakableProduction prodLabel
+con BreakableAtom :
+  { label : prodLabel
+  } -> BreakableProduction prodLabel
+con BreakableInfix :
+  { label : prodLabel
+  , leftAllow : AllowSet prodLabel
+  , rightAllow : AllowSet prodLabel
+  } -> BreakableProduction prodLabel
+con BreakablePrefix :
+  { label : prodLabel
+  , rightAllow : AllowSet prodLabel
+  } -> BreakableProduction prodLabel
+con BreakablePostfix :
+  { label : prodLabel
+  , leftAllow : AllowSet prodLabel
+  } -> BreakableProduction prodLabel
+
+type OpGrouping = {mayGroupLeft : Bool, mayGroupRight : Bool}
+
+type BreakableGrammar prodLabel =
+  { productions : [BreakableProduction prodLabel]
+  , precedences : [((prodLabel, prodLabel), OpGrouping)]
+  , topAllowed : AllowSet prodLabel
+  }
+
+-- Each operator is uniquely identifiable by its ID, which is used to
+-- look up precedence and the like
+type OpId = Int
+
+type BreakableInput lstyle rstyle
+con AtomI :
+  { id : OpId
+  , allowedTop : Bool
+  } -> BreakableInput LClosed RClosed
+con InfixI :
+  { id : OpId
+  , allowedTop : Bool
+  , leftAllow : AllowSet OpId
+  , rightAllow : AllowSet OpId
+  , precWhenThisIsRight : Map OpId OpGrouping
+  } -> BreakableInput LOpen ROpen
+con PrefixI :
+  { id : OpId
+  , allowedTop : Bool
+  , rightAllow : AllowSet OpId
+  } -> BreakableInput LClosed ROpen
+con PostfixI :
+  { id : OpId
+  , allowedTop : Bool
+  , leftAllow : AllowSet OpId
+  , precWhenThisIsRight : Map OpId OpGrouping
+  } -> BreakableInput LOpen RClosed
+
+-- This describes a generated breakable grammar that is ready for parsing with
+type BreakableGenGrammar prodLabel =
+  { atoms : Map prodLabel (BreakableInput LClosed RClosed)
+  , prefixes : Map prodLabel (BreakableInput LClosed ROpen)
+  , infixes : Map prodLabel (BreakableInput LOpen ROpen)
+  , postfixes : Map prodLabel (BreakableInput LOpen RClosed)
+  }
+
+let _eqOpId : OpId -> OpId -> Bool = eqi
+let _cmpOpId : OpId -> OpId -> Int = subi
+let _rootID : OpId = negi 1
+let _firstOpId : OpId = 0
+let _nextOpId : OpId -> OpId = addi 1
+
+let _opIdI
+  : BrekableInput lstyle rstyle
+  -> OpId
+  = lam input.
+    switch input
+    case AtomI x then x.id
+    case InfixI x then x.id
+    case PrefixI x then x.id
+    case PostfixI x then x.id
+    end
+let _allowedTopI
+  : BreakableInput lstyle rstyle
+  -> Bool
+  = lam input.
+    switch input
+    case AtomI x then x.allowedTop
+    case InfixI x then x.allowedTop
+    case PrefixI x then x.allowedTop
+    case PostfixI x then x.allowedTop
+    end
+let _allowedLeftI
+  : BreakableInput lstyle rstyle
+  -> AllowSet OpId
+  = lam input.
+    switch input
+    case InfixI x then x.leftAllow
+    case PostfixI x then x.leftAllow
+    case _ then AllowSet (mapEmpty _cmpOpId)
+    end
+let _allowedRightI
+  : BreakableInput lstyle rstyle
+  -> AllowSet OpId
+  = lam input.
+    switch input
+    case InfixI x then x.rightAllow
+    case PrefixI x then x.rightAllow
+    case _ then AllowSet (mapEmpty _cmpOpId)
+    end
+
+let breakableInAllowSet
+  : id
+  -> AllowSet id
+  -> Bool
+  = lam id. lam set.
+    match set with AllowSet s then mapMem id s else
+    match set with DisallowSet s then not (mapMem id s) else
+    never
+
+let breakableInsertAllowSet
+  : id
+  -> AllowSet id
+  -> AllowSet id
+  = lam id. lam set.
+    match set with AllowSet s then AllowSet (mapInsert id () s) else
+    match set with DisallowSet s then DisallowSet (mapRemove id s) else
+    never
+
+let breakableRemoveAllowSet
+  : id
+  -> AllowSet id
+  -> AllowSet id
+  = lam id. lam set.
+    match set with AllowSet s then AllowSet (mapRemove id s) else
+    match set with DisallowSet s then DisallowSet (mapInsert id () s) else
+    never
+
+let breakableMapAllowSet
+  : (a -> b)
+  -> (b -> b -> Int)
+  -> AllowSet a
+  -> AllowSet b
+  = lam f. lam newCmp. lam s.
+    let convert = lam s. mapFromSeq newCmp (map (lam x: (a, ()). (f x.0, ())) (mapBindings s)) in
+    match s with AllowSet s then AllowSet (convert s) else
+    match s with DisallowSet s then DisallowSet (convert s) else
+    never
+
+let breakableGenGrammar
+  : (prodLabel -> prodLabel -> Int)
+  -> BreakableGrammar prodLabel
+  -> BreakableGenGrammar prodLabel
+  = lam cmp. lam grammar.
+    let nOpId : Ref OpId = ref _firstOpId in
+    let newOpId : () -> OpId = lam.
+      let res = deref nOpId in
+      modref nOpId (_nextOpId res);
+      res in
+
+    let label
+      : BreakableProduction prodLabel
+      -> prodLabel
+      = lam prod.
+        match prod with BreakableAtom {label = label} then label else
+        match prod with BreakablePrefix {label = label} then label else
+        match prod with BreakableInfix {label = label} then label else
+        match prod with BreakablePostfix {label = label} then label else
+        never
+    in
+
+    let prodLabelToOpId : Map prodLabel OpId =
+      mapFromSeq cmp (map (lam prod. (label prod, newOpId ())) grammar.productions) in
+    let toOpId : prodLabel -> OpId = lam label. mapFindExn label prodLabelToOpId in
+
+    -- TODO(vipa, 2021-02-15): This map can contain more entries than
+    -- required; the inner map should only ever have entries where the
+    -- key represents a right-open operator, but we here retain all
+    -- operators from the outside, which could have more (redundant)
+    -- entries
+    let groupingByRightOp : Map OpId (Map OpId OpGrouping) =
+      foldl
+        (lam acc. lam grouping.
+          match grouping with ((lplab, rplab), grouping) then
+           let lid = toOpId lplab in
+           let rid = toOpId rplab in
+           let prev = match mapLookup rid acc
+             with Some prev then prev
+             else mapEmpty _cmpOpId in
+           mapInsert rid (mapInsert lid grouping prev) acc
+          else never)
+        (mapEmpty _cmpOpId)
+        grammar.precedences
+    in
+    let getGroupingByRight : OpId -> Map OpId OpGrouping = lam opid.
+      match mapLookup opid groupingByRightOp with Some res then res
+      else mapEmpty _cmpOpId
+    in
+
+    let atoms : Ref [(prodLabel, BreakableInput LClosed RClosed)] = ref [] in
+    let prefixes : Ref [(prodLabel, BreakableInput LClosed ROpen)] = ref [] in
+    let infixes : Ref [(prodLabel, BreakableInput LOpen ROpen)] = ref [] in
+    let postfixes : Ref [(prodLabel, BreakableInput LOpen RClosed)] = ref [] in
+    let updateRef : Ref a -> (a -> a) -> ()
+      = lam ref. lam f. modref ref (f (deref ref)) in
+
+    let isTopAllowed =
+      let topAllowed = breakableMapAllowSet toOpId _cmpOpId grammar.topAllowed in
+      lam id. breakableInAllowSet id topAllowed in
+
+    for_ grammar.productions
+      (lam prod.
+        let label = label prod in
+        let id = toOpId label in
+        match prod with BreakableAtom _ then
+          updateRef atoms (cons (label, AtomI {id = id, allowedTop = isTopAllowed id}))
+        else match prod with BreakablePrefix {rightAllow = r} then
+          let r = breakableMapAllowSet toOpId _cmpOpId r in
+          updateRef prefixes (cons (label, PrefixI {id = id, allowedTop = isTopAllowed id, rightAllow = r}))
+        else match prod with BreakableInfix {leftAllow = l, rightAllow = r} then
+          let l = breakableMapAllowSet toOpId _cmpOpId l in
+          let r = breakableMapAllowSet toOpId _cmpOpId r in
+          let p = getGroupingByRight id in
+          updateRef infixes (cons (label, InfixI {id = id, allowedTop = isTopAllowed id, leftAllow = l, rightAllow = r, precWhenThisIsRight = p}))
+        else match prod with BreakablePostfix {leftAllow = l} then
+          let l = breakableMapAllowSet toOpId _cmpOpId l in
+          let p = getGroupingByRight id in
+          updateRef postfixes (cons (label, PostfixI {id = id, allowedTop = isTopAllowed id, leftAllow = l, precWhenThisIsRight = p}))
+        else never);
+
+    { atoms = mapFromSeq cmp (deref atoms)
+    , prefixes = mapFromSeq cmp (deref prefixes)
+    , infixes = mapFromSeq cmp (deref infixes)
+    , postfixes = mapFromSeq cmp (deref postfixes)
+    }
+
+type PairedSelf self lstyle rstyle =
+  { self : self lstyle rstyle
+  , input : BreakableInput lstyle rstyle
+  }
+
+let breakableHelperInterface
+  : BreakableGenGrammar prodLabel
+  -> BreakableInput LClosed RClosed
+  -> { addAtom
+       : BreakableInput LClosed RClosed
+       -> self LClosed RClosed
+       -> State self ROpen
+       -> State self RClosed
+     , addPrefix
+       : BreakableInput LClosed ROpen
+       -> self LClosed ROpen
+       -> State self ROpen
+       -> State self ROpen
+     , addInfix
+       : BreakableInput LOpen ROpen
+       -> self LOpen ROpen
+       -> State self RClosed
+       -> Option (State self ROpen)
+     , addPostfix
+       : BreakableInput LOpen RClosed
+       -> self LOpen RClosed
+       -> State self RClosed
+       -> Option (State self RClosed)
+     , finalizeParse
+       : State self RClosed
+       -> Option [PermanentNode self]
+     , reportAmbiguities
+       : { toTok : all lstyle. all rstyle. Important -> self lstyle rstyle -> [tokish]
+         , leftPos : all rstyle. self LClosed rstyle -> pos
+         , rightPos : all lstyle. self lstyle RClosed -> pos
+         , lpar : tokish
+         , rpar : tokish }
+       -> [PermanentNode self] -- NonEmpty
+       -> [Ambiguity pos tokish]
+     , constructSimple
+       : { constructAtom : self LClosed RClosed -> res
+         , constructInfix : self LOpen ROpen -> res -> res -> res
+         , constructPrefix : self LClosed ROpen -> res -> res
+         , constructPostfix : self LOpen RClosed -> res -> res
+         }
+       -> [PermanentNode self] -- NonEmpty
+       -> res
+     }
+  = lam gen. lam parInput.
+    let parId = _opIdI parInput in
+    let config: Config (PairedSelf self) =
+      { topAllowed = lam ps: PairedSelf self lstyle rstyle. _allowedTopI ps.input
+      , leftAllowed = lam x: {parent: PairedSelf self LOpen rstyle, child: PairedSelf self lstyle rstyle2}. breakableInAllowSet (_opIdI x.child.input) (_allowedLeftI x.parent.input)
+      , rightAllowed = lam x: {parent: PairedSelf self lstyle ROpen, child: PairedSelf self lstyle2 rstyle}. breakableInAllowSet (_opIdI x.child.input) (_allowedRightI x.parent.input)
+      , parenAllowed = lam x: PairedSelf self lstyle rstyle.
+        let l = breakableInAllowSet parId (_allowedLeftI x.input) in
+        let r = breakableInAllowSet parId (_allowedRightI x.input) in
+        switch (l, r)
+        case (true, true) then GEither ()
+        case (true, false) then GLeft ()
+        case (false, true) then GRight ()
+        case (false, false) then GNeither ()
+        end
+      , groupingsAllowed = lam pair: (PairedSelf self lstyle ROpen, PairedSelf self LOpen rstyle).
+        let map = switch pair .1 .input
+          case InfixI x then x.precWhenThisIsRight
+          case PostfixI x then x.precWhenThisIsRight
+          end in
+        match mapLookup (_opIdI pair .0 .input) map with Some g then
+          let g: OpGrouping = g in
+          switch g
+          case {mayGroupLeft = true, mayGroupRight = true} then GEither ()
+          case {mayGroupLeft = true, mayGroupRight = false} then GLeft ()
+          case {mayGroupLeft = false, mayGroupRight = true} then GRight ()
+          case {mayGroupLeft = false, mayGroupRight = false} then GNeither ()
+          end
+        else GEither ()
+      } in
+    { addAtom = lam input. lam self. lam state. breakableAddAtom config {self = self, input = input} state
+    , addInfix = lam input. lam self. lam state. breakableAddInfix config {self = self, input = input} state
+    , addPrefix = lam input. lam self. lam state. breakableAddPrefix config {self = self, input = input} state
+    , addPostfix = lam input. lam self. lam state. breakableAddPostfix config {self = self, input = input} state
+    , finalizeParse = lam state. breakableFinalizeParse config state
+    , reportAmbiguities =
+      lam reportConfig
+        : { toTok : all lstyle. all rstyle. Important -> self lstyle rstyle -> [tokish]
+          , leftPos : all rstyle. self LClosed rstyle -> pos
+          , rightPos : all lstyle. self lstyle RClosed -> pos
+          , lpar : tokish
+          , rpar : tokish }.
+      let reportConfig =
+        { topAllowed = config.topAllowed
+        , parenAllowed = config.parenAllowed
+        , toTok = lam important. lam self: PairedSelf self lstyle rstyle. reportConfig.toTok important self.self
+        , leftPos = lam self: PairedSelf self LClosed rstyle. reportConfig.leftPos self.self
+        , rightPos = lam self: PairedSelf self lstyle RClosed. reportConfig.rightPos self.self
+        , lpar = reportConfig.lpar
+        , rpar = reportConfig.rpar
+        }
+      in breakableReportAmbiguities reportConfig
+    , constructSimple =
+      lam config
+        : { constructAtom : self LClosed RClosed -> res
+        , constructInfix : self LOpen ROpen -> res -> res -> res
+        , constructPrefix : self LClosed ROpen -> res -> res
+        , constructPostfix : self LOpen RClosed -> res -> res }.
+      let config =
+        { constructAtom = lam self: PairedSelf self LClosed RClosed. config.constructAtom self.self
+        , constructInfix = lam self: PairedSelf self LOpen ROpen. config.constructInfix self.self
+        , constructPrefix = lam self: PairedSelf self LClosed ROpen. config.constructPrefix self.self
+        , constructPostfix = lam self: PairedSelf self LOpen RClosed. config.constructPostfix self.self
+        }
+      in breakableConstructSimple config
+    }
+
+mexpr
+
+type Ast in
+con IntA : {pos: Int, val: Int} -> Ast in
+con PlusA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con TimesA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con DivideA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con NegateA : {pos: Int, r: Ast} -> Ast in
+con IfA : {pos: Int, r: Ast} -> Ast in
+con ElseA : {pos: Int, l: Ast, r: Ast} -> Ast in
+con NonZeroA : {pos: Int, l: Ast} -> Ast in
+con ParA : {pos: Int} -> Ast in
+
+type Self lopen ropen = {pos: Int, val: Int, str: String} in
+
+let allowAllBut = lam xs. DisallowSet (mapFromSeq cmpString (map (lam x. (x, ())) xs)) in
+let allowAll = allowAllBut [] in
+let allowOnly = lam xs. AllowSet (mapFromSeq cmpString (map (lam x. (x, ())) xs)) in
+
+let highLowPrec
+  : [prodLabel]
+  -> [prodLabel]
+  -> [((prodLabel, prodLabel), OpGrouping)]
+  =
+    let mkGrouping = lam high. lam low.
+      [ ((high, low), {mayGroupLeft = true, mayGroupRight = false})
+      , ((low, high), {mayGroupLeft = false, mayGroupRight = true})
+      ] in
+    lam high. lam low. join (seqLiftA2 mkGrouping high low)
+in
+
+recursive let precTableNoEq
+  : [[prodLabel]]
+  -> [((prodLabel, prodLabel), OpGrouping)]
+  = lam table.
+    match table with [high] ++ lows then
+      concat (highLowPrec high (join lows)) (precTableNoEq lows)
+    else []
+in
+
+type Self a b = {val : Int, pos : Int, str : String} in
+
+type TestToken in
+con TestAtom : { x : Self RClosed RClosed, input : BreakableInput RClosed RClosed } -> TestToken in
+con TestPrefix : { x : Self RClosed ROpen, input : BreakableInput RClosed ROpen } -> TestToken in
+con TestInfix : { x : Self ROpen ROpen, input : BreakableInput ROpen ROpen } -> TestToken in
+con TestPostfix : { x : Self ROpen RClosed, input : BreakableInput ROpen RClosed } -> TestToken in
+
+let selfToTok : Important -> Self a b -> [(Bool, String)] = lam important. lam x. [(match important with Important _ then true else false, x.str)] in
+
+type ParseResult in
+con PSuccess : Ast -> ParseResult in
+con PFail : () -> ParseResult in
+con PAmbiguities : [Ambiguity Self (Bool, String)] -> ParseResult in
+
+let constructAtom
+  : Self LClosed RClosed -> Ast
+  = lam self. IntA {pos = self.pos, val = self.val} in
+let constructInfix
+  : Self LOpen ROpen -> Ast -> Ast -> Ast
+  = lam self. lam l. lam r.
+    switch self.str
+    case "+" then PlusA {pos = self.pos, l = l, r = r}
+    case "*" then TimesA {pos = self.pos, l = l, r = r}
+    case "/" then DivideA {pos = self.pos, l = l, r = r}
+    case "else" then ElseA {pos = self.pos, l = l, r = r}
+    end in
+let constructPrefix
+  : Self LClosed ROpen -> Ast -> Ast
+  = lam self. lam r.
+    switch self.str
+    case "-" then NegateA {pos = self.pos, r = r}
+    case "if" then IfA {pos = self.pos, r = r}
+    end in
+let constructPostfix
+  : Self LOpen RClosed -> Ast -> Ast
+  = lam self. lam l.
+    switch self.str
+    case "?" then NonZeroA {pos = self.pos, l = l}
+    end in
+
+let testParse
+  : BreakableGenGrammar String
+  -> [Int -> TestToken]
+  -> ParseResult
+  = lam gen.
+    let parInput = mapFindExn "par" gen.atoms in
+    match breakableHelperInterface gen parInput
+    with {addAtom = addAtom, addPrefix = addPrefix, addInfix = addInfix, addPostfix = addPostfix, finalizeParse = finalizeParse, reportAmbiguities = reportAmbiguities, constructSimple = constructSimple} in
+    recursive
+      let workROpen = lam pos. lam st. lam tokens.
+        match tokens with [t] ++ tokens then
+          let t = t pos in
+          let pos = addi 1 pos in
+          match t with TestAtom {x = self, input = input} then
+            workRClosed pos (addAtom input self st) tokens
+          else match t with TestPrefix {x = self, input = input} then
+            workROpen pos (addPrefix input self st) tokens
+          else PFail ()
+        else PFail ()
+      let workRClosed = lam pos. lam st. lam tokens.
+        match tokens with [t] ++ tokens then
+          let t = t pos in
+          let pos = addi 1 pos in
+          match t with TestInfix {x = self, input = input} then
+            match addInfix input self st with Some st
+            then workROpen pos st tokens
+            else PFail ()
+          else match t with TestPostfix {x = self, input = input} then
+            match addPostfix input self st with Some st
+            then workRClosed pos st tokens
+            else PFail ()
+          else PFail ()
+        else match finalizeParse st with Some tops then
+          let reportConfig =
+            { toTok = selfToTok
+            , leftPos = lam s: Self LClosed rstyle. s.pos
+            , rightPos = lam s: Self lstyle RClosed. s.pos
+            , lpar = (true, "(")
+            , rpar = (true, ")")
+            } in
+          let constructConfig =
+            { constructAtom = constructAtom
+            , constructInfix = constructInfix
+            , constructPrefix = constructPrefix
+            , constructPostfix = constructPostfix
+            } in
+          match reportAmbiguities reportConfig tops with ambs & [_] ++ _ then
+            PAmbiguities ambs
+          else PSuccess (constructSimple constructConfig tops)
+        else PFail ()
+    in workROpen 0 (breakableInitState ())
+in
+
+-- TODO(vipa, 2022-02-14): Code generation doesn't see the need to
+-- generate a function that compares (Bool, String), even though
+-- they're used and known later in this file, thus this utest is here
+-- to make the requirement explicit until the bug is fixed.
+-- See: https://github.com/miking-lang/miking/issues/542
+utest (true, "foo") with (true, "foo") in
+
+let i : String -> (Bool, String) = lam x. (true, x) in
+let u : String -> (Bool, String) = lam x. (false, x) in
+
+let grammar =
+  { productions =
+    [ BreakableAtom {label = "int"}
+    , BreakableAtom {label = "par"}
+    , BreakableInfix
+      { label = "plus"
+      , leftAllow = allowAll
+      , rightAllow = allowAll
+      }
+    , BreakableInfix
+      { label = "times"
+      , leftAllow = allowAll
+      , rightAllow = allowAll
+      }
+    , BreakableInfix
+      { label = "divide"
+      , leftAllow = allowAll
+      , rightAllow = allowAll
+      }
+    , BreakablePrefix
+      { label = "negate"
+      , rightAllow = allowAll
+      }
+    , BreakablePrefix
+      { label = "if"
+      , rightAllow = allowAll
+      }
+    , BreakableInfix
+      { label = "else"
+      , leftAllow = allowOnly ["if"]
+      , rightAllow = allowAll
+      }
+    , BreakablePostfix
+      { label = "nonZero"
+      , leftAllow = allowAll
+      }
+    ]
+  , precedences = join
+    [ precTableNoEq
+      [ ["negate"]
+      , ["times", "divide"]
+      , ["plus"]
+      , ["if"]
+      ]
+    ]
+  , topAllowed = allowAll
+  }
+in
+let genned: BreakableGenGrammar a b c = breakableGenGrammar cmpString grammar in
+let atom = lam label. mapFindExn label genned.atoms in
+let prefix = lam label. mapFindExn label genned.prefixes in
+let infix = lam label. mapFindExn label genned.infixes in
+let postfix = lam label. mapFindExn label genned.postfixes in
+
+let _int =
+  let input = atom "int" in
+  lam val. lam pos. TestAtom {x = {val = val, pos = pos, str = int2string val}, input = input} in
+let _plus =
+  let input = infix "plus" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "+"}, input = input} in
+let _times =
+  let input = infix "times" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "*"}, input = input} in
+let _divide =
+  let input = infix "divide" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "/"}, input = input} in
+let _negate =
+  let input = prefix "negate" in
+  lam pos. TestPrefix {x = {val = 0, pos = pos, str = "-"}, input = input} in
+let _if =
+  let input = prefix "if" in
+  lam pos. TestPrefix {x = {val = 0, pos = pos, str = "if"}, input = input} in
+let _else =
+  let input = infix "else" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "else"}, input = input} in
+let _nonZero =
+  let input = postfix "nonZero" in
+  lam pos. TestPostfix {x = {val = 0, pos = pos, str = "?"}, input = input} in
+
+let test = testParse genned in
+
+utest test []
+with PFail ()
+in
+
+utest test [_int 4]
+with PSuccess (IntA {val = 4,pos = 0})
+in
+
+utest test [_int 4, _plus]
+with PFail ()
+in
+
+utest test [_int 4, _plus, _int 7]
+with PSuccess
+  (PlusA
+    { pos = 1
+    , l = (IntA {val = 4,pos = 0})
+    , r = (IntA {val = 7,pos = 2})
+    })
+in
+
+utest test [_negate, _int 8]
+with PSuccess
+  (NegateA
+    { pos = 0
+    , r = (IntA {val = 8,pos = 1})
+    })
+in
+
+utest test [_negate, _negate, _int 8]
+with PSuccess
+  (NegateA
+    { pos = 0
+    , r = (NegateA
+      { pos = 1
+      , r = (IntA {val = 8,pos = 2})
+      })
+    })
+in
+
+utest test [_int 9, _nonZero, _nonZero]
+with PSuccess
+  (NonZeroA
+    { pos = 2
+    , l = (NonZeroA
+      { pos = 1
+      , l = (IntA {val = 9,pos = 0})})
+    })
+in
+
+utest test [_negate, _nonZero]
+with PFail ()
+in
+
+utest test [_int 1, _plus, _int 2, _times, _int 3]
+with PSuccess
+  (PlusA
+    { pos = 1
+    , l = (IntA {val = 1,pos = 0})
+    , r = (TimesA
+      { pos = 3
+      , l = (IntA {val = 2,pos = 2})
+      , r = (IntA {val = 3,pos = 4})
+      })
+    })
+in
+
+utest test [_int 1, _times, _int 2, _plus, _int 3]
+with PSuccess
+  (PlusA
+    { pos = 3
+    , l = (TimesA
+      { pos = 1
+      , l = (IntA {val = 1,pos = 0})
+      , r = (IntA {val = 2,pos = 2})
+      })
+    , r = (IntA {val = 3,pos = 4})
+    })
+in
+
+utest test [_int 1, _times, _int 2, _divide, _int 3]
+with PAmbiguities (
+  [ { range =
+      { first = 0
+      , last = 4
+      }
+    , partialResolutions =
+      [ [u"1", i"*", i"(", u"2", i"/", u"3", i")"]
+      , [i"(", u"1", i"*", u"2", i")", i"/", u"3"]
+      ]
+    }
+  ])
+in
+
+utest test [_int 1, _times, _int 2, _divide, _int 3, _plus, _int 4]
+with PAmbiguities (
+  [ { range =
+      { first = 0
+      , last = 4
+      }
+    , partialResolutions =
+      [ [u"1",i"*",i"(",u"2",i"/",u"3",i")"]
+      , [i"(",u"1",i"*",u"2",i")",i"/",u"3"]
+      ]
+    }
+  ])
+in
+
+utest test [_int 0, _plus, _int 1, _times, _int 2, _divide, _int 3]
+with PAmbiguities (
+  [ { range =
+      { first = 2
+      , last = 6 }
+    , partialResolutions =
+      [ [u"1",i"*",i"(",u"2",i"/",u"3",i")"]
+      , [i"(",u"1",i"*",u"2",i")",i"/",u"3"]
+      ]
+    }
+  ])
+in
+
+-- TODO(vipa, 2021-02-15): When we compute elisons we can report two ambiguities here, the nested one is independent
+utest test [_int 0, _plus, _int 1, _times, _int 2, _divide, _int 3, _plus, _int 4]
+with PAmbiguities (
+  [ { range =
+      { first = 0
+      , last = 8
+      }
+    , partialResolutions =
+      [ [u"0",i"+",i"(",u"1",u"*",u"2",u"/",u"3",i"+",u"4",i")"]
+      , [i"(",u"0",i"+",u"1",u"*",u"2",u"/",u"3",i")",i"+",u"4"]
+      ]
+    }
+  ])
+in
+
+-- TODO(vipa, 2021-02-15): Do we want to specify the order of the returned ambiguities in some way?
+utest test [_int 1, _times, _int 2, _divide, _int 3, _plus, _int 4, _divide, _int 5, _times, _int 6]
+with PAmbiguities (
+  [ { range =
+      { first = 6
+      , last = 10
+      }
+    , partialResolutions =
+      [ [u"4",i"/",i"(",u"5",i"*",u"6",i")"]
+      , [i"(",u"4",i"/",u"5",i")",i"*",u"6"]
+      ]
+    }
+  , { range =
+      { first = 0
+      , last = 4
+      }
+    , partialResolutions =
+      [ [u"1",i"*",i"(",u"2",i"/",u"3",i")"]
+      , [i"(",u"1",i"*",u"2",i")",i"/",u"3"]
+      ]
+    }
+  ])
+in
+
+utest test [_if, _int 1]
+with PSuccess
+  (IfA
+    { pos = 0
+    , r = (IntA {val = 1,pos = 1})
+    })
+in
+
+utest test [_if, _int 1, _else, _int 2]
+with PSuccess
+  (ElseA
+    { pos = 2
+    , l = (IfA
+      { pos = 0
+      , r = (IntA {val = 1,pos = 1})
+      })
+    , r = (IntA {val = 2,pos = 3})
+    })
+
+in
+
+utest test [_if, _int 1, _else, _int 2, _else, _int 3]
+with PFail ()
+in
+
+utest test [_if, _if, _int 1, _else, _int 2]
+with PAmbiguities (
+  [ { range =
+      { first = 0
+      , last = 4
+      }
+    , partialResolutions =
+      [ [i"if",i"(",i"if",u"1",i"else",u"2",i")"]
+      , [i"if",i"(",i"if",u"1",i")",i"else",u"2"]
+      ]
+    }
+  ])
+in
+
+utest test [_negate, _if, _int 1, _else, _int 2]
+with PSuccess
+  (NegateA
+    { pos = 0
+    , r = (ElseA
+      { pos = 3
+      , l = (IfA
+        { pos = 1
+        , r = (IntA {val = 1,pos = 2})
+        })
+      , r = (IntA {val = 2,pos = 4})
+      })
+    })
+in
+
+utest test [_if, _negate, _if, _int 1, _else, _int 2]
+with PAmbiguities (
+  [ { range =
+      { first = 0
+      , last = 5
+      }
+    , partialResolutions =
+      [ [i"if",i"(",u"-",i"if",u"1",i"else",u"2",i")"]
+      , [i"if",i"(",u"-",i"if",u"1",i")",i"else",u"2"]
+      ]
+    }
+  ])
+in
+
+utest test [_int 1, _plus, _if, _negate, _if, _int 1, _else, _int 2]
+with PAmbiguities (
+  [ { range =
+      { first = 2
+      , last = 7
+      }
+    , partialResolutions =
+      [ [i"if",i"(",u"-",i"if",u"1",i"else",u"2",i")"]
+      , [i"if",i"(",u"-",i"if",u"1",i")",i"else",u"2"]
+      ]
+    }
+  ])
+in
+
+utest test [_int 1, _times, _if, _int 7, _else, _int 12]
+with PSuccess
+  (TimesA
+    { pos = 1
+    , l = (IntA {val = 1,pos = 0})
+    , r = (ElseA
+      { pos = 4
+      , l = (IfA
+        { pos = 2
+        , r = (IntA {val = 7,pos = 3})
+        })
+      , r = (IntA {val = 12,pos = 5})
+      })
+    })
+in
+
+utest test [_int 7, _else, _int 12]
+with PFail ()
+in
+
+utest test [_int 1, _plus, _plus, _int 2]
+with PFail ()
+in
+
+utest test [_int 1, _plus, _nonZero]
+with PFail ()
+in
+
+utest test [_int 1, _nonZero, _plus, _int 2]
+with PSuccess
+  (PlusA
+    { pos = 2
+    , l = (NonZeroA
+      { pos = 1
+      , l = (IntA {val = 1,pos = 0})
+      })
+    , r = (IntA {val = 2,pos = 3})
+    })
+in
+
+let grammar =
+  { productions =
+    [ BreakableAtom {label = "int"}
+    , BreakableAtom {label = "par"}
+    , BreakableInfix
+      { label = "plus"
+      , leftAllow = allowAllBut ["else"]
+      , rightAllow = allowAllBut ["else"]
+      }
+    , BreakableInfix
+      { label = "times"
+      , leftAllow = allowAllBut ["else"]
+      , rightAllow = allowAllBut ["else"]
+      }
+    , BreakableInfix
+      { label = "divide"
+      , leftAllow = allowAllBut ["else"]
+      , rightAllow = allowAllBut ["else"]
+      }
+    , BreakablePrefix
+      { label = "negate"
+      , rightAllow = allowAllBut ["else"]
+      }
+    , BreakablePrefix
+      { label = "if"
+      , rightAllow = allowAll
+      }
+    , BreakableInfix
+      { label = "else"
+      , leftAllow = allowAllBut ["else"]
+      , rightAllow = allowAllBut ["else"]
+      }
+    , BreakablePostfix
+      { label = "nonZero"
+      , leftAllow = allowAllBut ["else"]
+      }
+    ]
+  , precedences = join
+    [ precTableNoEq
+      [ ["negate"]
+      , ["times", "divide"]
+      , ["plus"]
+      , ["if"]
+      ]
+    ]
+  , topAllowed = allowAllBut ["else"]
+  }
+in
+
+let genned: BreakableGenGrammar a b c = breakableGenGrammar cmpString grammar in
+let atom = lam label. mapFindExn label genned.atoms in
+let prefix = lam label. mapFindExn label genned.prefixes in
+let infix = lam label. mapFindExn label genned.infixes in
+let postfix = lam label. mapFindExn label genned.postfixes in
+
+let _int =
+  let input = atom "int" in
+  lam val. lam pos. TestAtom {x = {val = val, pos = pos, str = int2string val}, input = input} in
+let _plus =
+  let input = infix "plus" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "+"}, input = input} in
+let _times =
+  let input = infix "times" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "*"}, input = input} in
+let _divide =
+  let input = infix "divide" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "/"}, input = input} in
+let _negate =
+  let input = prefix "negate" in
+  lam pos. TestPrefix {x = {val = 0, pos = pos, str = "-"}, input = input} in
+let _if =
+  let input = prefix "if" in
+  lam pos. TestPrefix {x = {val = 0, pos = pos, str = "if"}, input = input} in
+let _else =
+  let input = infix "else" in
+  lam pos. TestInfix {x = {val = 0, pos = pos, str = "else"}, input = input} in
+let _nonZero =
+  let input = postfix "nonZero" in
+  lam pos. TestPostfix {x = {val = 0, pos = pos, str = "?"}, input = input} in
+
+let test = testParse genned in
+
+utest test [_if, _int 1]
+with PSuccess
+  (IfA
+    { pos = 0
+    , r = (IntA {val = 1,pos = 1})
+    })
+in
+
+utest test [_if, _int 1, _else, _int 2]
+with PSuccess
+  (IfA
+    { pos = 0
+    , r = (ElseA
+      { pos = 2
+      , l = (IntA {val = 1,pos = 1})
+      , r = (IntA {val = 2,pos = 3})
+      })
+    })
+
+in
+
+utest test [_if, _int 1, _else, _int 2, _else, _int 3]
+with PFail ()
+in
+
+utest test [_if, _if, _int 1, _else, _int 2]
+with PAmbiguities (
+  [ { range =
+      { first = 0
+      , last = 4
+      }
+    , partialResolutions =
+      [ [i"if",i"(",i"if",u"1",i")",i"else",u"2"]
+      , [i"if",i"(",i"if",u"1",i"else",u"2",i")"]
+      ]
+    }
+  ])
+in
+
+utest test [_negate, _if, _int 1, _else, _int 2]
+with PSuccess
+  (NegateA
+    { pos = 0
+    , r = (IfA
+      { pos = 1
+      , r = (ElseA
+        { pos = 3
+        , l = (IntA {val = 1,pos = 2})
+        , r = (IntA {val = 2,pos = 4})
+        })
+      })
+    })
+in
+
+utest test [_if, _negate, _if, _int 1, _else, _int 2]
+with PAmbiguities (
+  [ { range =
+      { first = 0
+      , last = 5
+      }
+    , partialResolutions =
+      [ [i"if",i"(",u"-",i"if",u"1",i")",i"else",u"2"]
+      , [i"if",i"(",u"-",i"if",u"1",i"else",u"2",i")"]
+      ]
+    }
+  ])
+in
+
+utest test [_int 1, _plus, _if, _negate, _if, _int 1, _else, _int 2]
+with PAmbiguities (
+  [ { range =
+      { first = 2
+      , last = 7
+      }
+    , partialResolutions =
+      [ [i"if",i"(",u"-",i"if",u"1",i")",i"else",u"2"]
+      , [i"if",i"(",u"-",i"if",u"1",i"else",u"2",i")"]
+      ]
+    }
+  ])
+in
+
+utest test [_int 1, _times, _if, _int 7, _else, _int 12]
+with PSuccess
+  (TimesA
+    { pos = 1
+    , l = (IntA {val = 1,pos = 0})
+    , r = (IfA
+      { pos = 2
+      , r = (ElseA
+        { pos = 4
+        , l = (IntA {val = 7,pos = 3})
+        , r = (IntA {val = 12,pos = 5})
+        })
+      })
+    })
+in
+
+utest test [_int 7, _else, _int 12]
+with PFail ()
+in
+
+()

--- a/stdlib/parser/error-highlight.mc
+++ b/stdlib/parser/error-highlight.mc
@@ -1,0 +1,202 @@
+include "seq.mc"
+include "char.mc"
+include "mexpr/info.mc"
+
+type Highlight
+-- A section of the code inside the area to be highlighted, but that
+-- is itself irrelevant. Optional, sections between other highlighted
+-- sections are irrelevant by default.
+con Irrelevant : Info -> Highlight
+-- A section that is inside the highlighted area and is relevant,
+-- i.e., it should be highlighted in some way.
+con Relevant : Info -> Highlight
+-- Text to be added in the highlighted section, even though it is not
+-- present in the original input. If `ensureSurroundedBySpaces` is
+-- true then the added content will additionally be surrounded by a
+-- space on either side, from the original input if possible,
+-- otherwise added.
+con Added : {content : String, ensureSurroundedBySpaces : Bool} -> Highlight
+
+-- Highlighting can be configured using the functions in this config.
+type HighlightConfig =
+  { beforeSection : String -> String  -- Called for the part before the section *on the same line* as the beginning
+  , afterSection : String -> String   -- Called for the part after the section *on the same line* as the end
+  , irrelevant : String -> String
+  , relevant : String -> String
+  , added : String -> String
+  }
+
+type InnerHighlight
+con IBefore : () -> InnerHighlight
+con IAfter : () -> InnerHighlight
+con IRelevant : () -> InnerHighlight
+con IIrrelevant : () -> InnerHighlight
+con IAdded : {ensureSurroundedBySpaces : Bool} -> InnerHighlight
+
+type HPos = { row : Int, col : Int }
+type HInput = { pos : HPos, rest : String }
+
+let _advanceRow
+  : HPos -> HPos
+  = lam pos. {{ pos with row = addi pos.row 1 } with col = 0}
+let _advanceCol
+  : HPos -> HPos
+  = lam pos. { pos with col = addi pos.col 1 }
+let _hposLessThan
+  : HPos -> HPos -> Bool
+  = lam a. lam b. or (lti a.row b.row) (and (eqi a.row b.row) (lti a.col b.col))
+let _advanceInput
+  : HInput -> Option (Char, HInput)
+  = lam input.
+    switch input.rest
+    case "\n" ++ rest then Some ('\n', {pos = _advanceRow input.pos, rest = rest})
+    case [c] ++ rest then Some (c, {pos = _advanceCol input.pos, rest = rest})
+    case [] then None ()
+    end
+let _splitInput
+  : HPos -> HInput -> (String, HInput)
+  = lam target. lam input.
+    recursive let work = lam acc. lam input: HInput.
+      if _hposLessThan input.pos target then
+        match _advanceInput input with Some (c, input) then
+          work (snoc acc c) input
+        else (acc, input)
+      else (acc, input)
+    in work "" input
+
+let _getRange
+  : Highlight
+  -> Option (HPos, HPos)
+  = lam h.
+    switch h
+    case Irrelevant (Info x) then Some ({row = x.row1, col = x.col1}, {row = x.row2, col = x.col2})
+    case Relevant (Info x) then Some ({row = x.row1, col = x.col1}, {row = x.row2, col = x.col2})
+    case Added _ then None ()
+    end
+
+-- Take a sequence of sections to be highlighted (positioned through
+-- `Info` values) belonging to a single file, in order, then produce a
+-- highlighted version of that section of the input file.
+let formatHighlights
+  : HighlightConfig
+  -> String  -- File content
+  -> [Highlight]
+  -> String  -- Highlighted section after processing
+  = lam config. lam content. lam highlights.
+    let contentTooShort = lam. error "The file isn't long enough, some of the highlight is outside" in
+    let input: HInput = { rest = content, pos = { row = 1, col = 0} } in
+    let startPos: HPos =
+      match findMap _getRange highlights with Some (startPos, _)
+      then startPos
+      else error "This highlight list doesn't have any info fields in it" in
+    let endPos: HPos =
+      match findMap _getRange (reverse highlights) with Some (_, endPos)
+      then endPos
+      else error "This highlight list doesn't have any info fields in it" in
+
+    -- NOTE(vipa, 2022-03-04): Identify the sections and their content
+    match _splitInput { startPos with col = 0 } input with (_, input) in
+    match _splitInput startPos input with (before, input) in
+    let sections = [(before, IBefore ())] in
+    recursive let work = lam sections. lam input. lam highlights.
+      match highlights with [h] ++ highlights then
+        match _getRange h with Some (startPos, endPos) then
+          match _splitInput startPos input with (irr, input) in
+          match _splitInput endPos input with (sec, input) in
+          let label =
+            switch h
+            case Relevant _ then IRelevant ()
+            case Irrelevant _ then IIrrelevant ()
+            case _ then error "impossible"
+            end in
+          work (concat sections [(irr, IIrrelevant()), (sec, label)]) input highlights
+        else match h with Added x then
+          work (snoc sections (x.content, IAdded {ensureSurroundedBySpaces = x.ensureSurroundedBySpaces})) input highlights
+        else never
+      else (sections, input)
+    in
+    match work sections input highlights with (sections, input) in
+    match _splitInput (_advanceRow endPos) input with (after, _) in
+    let after = match after with after ++ "\n" then after else after in
+    let sections = snoc sections (after, IAfter ()) in
+
+    let sections = filter (lam x. match x with ([_] ++ _, _) then true else false) sections in
+
+    -- NOTE(vipa, 2022-03-04): Format and concatenate the
+    -- sections. This isn't just a concatMap because we need to fix
+    -- padding for `Added` sections.
+    recursive let work = lam acc. lam needsPreSpace. lam sections.
+      match sections with [(content, label)] ++ sections then
+        let needsPadding = match label with (IAdded {ensureSurroundedBySpaces = true}) then true else false in
+        let needsPostSpace =
+          match sections with [([c] ++ _, _)] ++ _
+          then if isWhitespace c then false else true
+          else false in
+        let pre = if and needsPadding needsPreSpace then config.irrelevant " " else "" in
+        let post = if and needsPadding needsPostSpace then config.irrelevant " " else "" in
+        let f = switch label
+          case IBefore _ then config.beforeSection
+          case IAfter _ then config.afterSection
+          case IRelevant _ then config.relevant
+          case IIrrelevant _ then config.irrelevant
+          case IAdded _ then config.added
+          end in
+        let nextNeedsPreSpace =
+          match concat content post with _ ++ [c] in
+          if isWhitespace c then false else true in
+        work (join [acc, pre, f content, post]) nextNeedsPreSpace sections
+      else acc
+    in
+    work "" false sections
+
+let terminalHighlightAddedConfig: HighlightConfig =
+  { beforeSection = lam str. concat "[0m" str
+  , afterSection = lam str. concat "[0m" str
+  , irrelevant = lam str. concat "[0m" str
+  , relevant = lam str. concat (concat "[37m" str) "[0m"
+  , added = lam str. concat (concat "[31m" str) "[0m"
+  }
+
+let terminalHighlightErrorConfig: HighlightConfig =
+  { beforeSection = lam str. concat "[0m" str
+  , afterSection = lam str. concat "[0m" str
+  , irrelevant = lam str. concat "[0m" str
+  , relevant = lam str. concat (concat "[31m" str) "[0m"
+  , added = lam str. concat (concat "[31m" str) "[0m"
+  }
+
+mexpr
+
+let content = join
+  [ "let a = 1 in\n"
+  , "let x = match a with\n"
+  , "  | 1 -> match x with\n"
+  , "    | \"blub\" -> 1\n"
+  , "  | 2 -> 2\n"
+  ] in
+
+let config =
+  { beforeSection = lam str. join ["<bef>", str, "</bef>"]
+  , afterSection = lam str. join ["<aft>", str, "</aft>"]
+  , irrelevant = lam str. join ["<irr>", str, "</irr>"]
+  , relevant = lam str. join ["<rel>", str, "</rel>"]
+  , added = lam str. join ["<new>", str, "</new>"]
+  } in
+
+let highlights =
+  [ Relevant (infoVal "test" 2 8 2 13)
+  , Relevant (infoVal "test" 2 16 2 20)
+  , Irrelevant (infoVal "test" 3 8 3 9)
+  , Added {content = "(", ensureSurroundedBySpaces = true}
+  , Relevant (infoVal "test" 3 9 3 14)
+  ] in
+
+utest formatHighlights config content highlights
+with
+  let content: String = join
+    [ "<bef>let x = </bef><rel>match</rel><irr> a </irr><rel>with</rel><irr>\n"
+    , "  | 1 -></irr><irr> </irr><new>(</new><irr> </irr><rel>match</rel><aft> x with</aft>"
+    ]
+  in content in
+
+()

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -12,6 +12,7 @@ let tabSpace = 2
 -- Base language for whitespace and comments (WSAC) parsing
 lang WSACParser
   sem eatWSAC (p : Pos) =
+  | x -> {str = x, pos = p}
 end
 
 type Stream = {pos : Pos, str : String}
@@ -20,6 +21,7 @@ type NextTokenResult = {token : Token, lit : String, info : Info, stream : Strea
 -- Base language for parsing tokens preceeded by WSAC
 lang TokenParser = WSACParser
   syn Token =
+  syn TokenRepr =
   sem nextToken /- : Stream -> NextTokenResult -/ =
   | stream ->
     let stream: Stream = stream in
@@ -27,9 +29,13 @@ lang TokenParser = WSACParser
     parseToken stream.pos stream.str
 
   sem parseToken (pos : Pos) /- : String -> NextTokenResult -/ =
-  sem tokKindEq (tok : Token) /- : Token -> Bool -/ =
+  sem tokKindEq (tokRepr : TokenRepr) /- : Token -> Bool -/ =
   sem tokInfo /- : Token -> Info -/ =
   sem tokToStr /- : Token -> String -/ =
+  sem tokReprCompare /- : (TokenRepr, TokenRepr) -> Int -/ =
+  | (l, r) -> subi (constructorTag l) (constructorTag r)
+  sem tokReprToStr /- : TokenRepr -> String -/ =
+  sem tokToRepr /- : Token -> TokenRepr -/ =
 end
 
 -- Eats whitespace
@@ -39,7 +45,6 @@ lang WhitespaceParser = WSACParser
   | "\t" ++ xs -> eatWSAC (advanceCol p tabSpace) xs
   | "\n" ++ xs -> eatWSAC (advanceRow p 1) xs
   | "\r" ++ xs -> eatWSAC p xs
-  | x -> {str = x, pos = p}
 end
 
 
@@ -78,20 +83,28 @@ end
 lang EOFTokenParser = TokenParser
   syn Token =
   | EOFTok {info : Info}
+  syn TokenRepr =
+  | EOFRepr ()
 
   sem parseToken (pos : Pos) =
   | [] ->
     let info = makeInfo pos pos in
     {token = EOFTok {info = info}, lit = "", info = info, stream = {pos = pos, str = []}}
 
-  sem tokKindEq (tok : Tok) =
-  | EOFTok _ -> match tok with EOFTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | EOFTok _ -> match tokRepr with EOFRepr _ then true else false
 
   sem tokInfo =
   | EOFTok {info = info} -> info
 
   sem tokToStr =
   | EOFTok _ -> "<EOF>"
+
+  sem tokReprToStr =
+  | EOFRepr _ -> "<EOF>"
+
+  sem tokToRepr =
+  | EOFTok _ -> EOFRepr ()
 end
 
 -- Parses the continuation of an identifier, i.e., upper and lower
@@ -120,6 +133,8 @@ with {val = "Asd12", str = " ", pos = posVal "" 1 5}
 lang LIdentTokenParser = TokenParser
   syn Token =
   | LIdentTok {info : Info, val : String}
+  syn TokenRepr =
+  | LIdentRepr ()
 
   sem parseToken (pos : Pos) =
   | [('_' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' |
@@ -136,19 +151,27 @@ lang LIdentTokenParser = TokenParser
       }
     else never
 
-  sem tokKindEq (tok : Tok) =
-  | LIdentTok _ -> match tok with LIdentTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | LIdentTok _ -> match tokRepr with LIdentRepr _ then true else false
 
   sem tokInfo =
   | LIdentTok {info = info} -> info
 
+  sem tokReprToStr =
+  | LIdentRepr _ -> "<LIdent>"
+
   sem tokToStr =
   | LIdentTok tok -> concat "<LIdent>" tok.val
+
+  sem tokToRepr =
+  | LIdentTok _ -> LIdentRepr ()
 end
 
 lang UIdentTokenParser = TokenParser
   syn Token =
   | UIdentTok {info : Info, val : String}
+  syn TokenRepr =
+  | UIdentRepr ()
 
   sem parseToken (pos : Pos) =
   | [('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' |
@@ -165,14 +188,20 @@ lang UIdentTokenParser = TokenParser
       }
     else never
 
-  sem tokKindEq (tok : Tok) =
-  | UIdentTok _ -> match tok with UIdentTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | UIdentTok _ -> match tokRepr with UIdentRepr _ then true else false
 
   sem tokInfo =
   | UIdentTok {info = info} -> info
 
+  sem tokReprToStr =
+  | UIdentRepr _ -> "<UIdent>"
+
   sem tokToStr =
   | UIdentTok tok -> concat "<UIdent>" tok.val
+
+  sem tokToRepr =
+  | UIdentTok _ -> UIdentRepr ()
 end
 
 let parseUInt : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -201,6 +230,8 @@ utest parseUInt (initPos "") "Not a number"
 lang UIntTokenParser = TokenParser
   syn Token =
   | IntTok {info : Info, val : Int}
+  syn TokenRepr =
+  | IntRepr ()
 
   sem parseToken (pos : Pos) =
   | (['0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ _) & str ->
@@ -217,14 +248,20 @@ lang UIntTokenParser = TokenParser
     , stream = {pos = pos2, str = str}
     }
 
-  sem tokKindEq (tok : Tok) =
-  | IntTok _ -> match tok with IntTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | IntTok _ -> match tokRepr with IntRepr _ then true else false
 
   sem tokInfo =
   | IntTok {info = info} -> info
 
+  sem tokReprToStr =
+  | IntRepr _ -> "<Int>"
+
   sem tokToStr =
   | IntTok tok -> concat "<Int>" (int2string tok.val)
+
+  sem tokToRepr =
+  | IntTok _ -> IntRepr ()
 end
 
 let parseFloatExponent : Pos -> String -> {val: String, pos: Pos, str: String} =
@@ -250,6 +287,8 @@ utest parseFloatExponent (initPos "") "Not an exponent"
 lang UFloatTokenParser = UIntTokenParser
   syn Token =
   | FloatTok {info : Info, val : Float}
+  syn TokenRepr =
+  | FloatRepr ()
 
   sem parseIntCont (acc : String) (pos1 : Pos) (pos2 : Pos) =
   | ['.'] ++ str ->
@@ -290,15 +329,20 @@ lang UFloatTokenParser = UIntTokenParser
     , stream = {pos = pos2, str = str}
     }
 
-  sem tokKindEq (tok : Tok) =
-  | FloatTok _ -> match tok with FloatTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | FloatTok _ -> match tokRepr with FloatRepr _ then true else false
 
   sem tokInfo =
   | FloatTok {info = info} -> info
 
+  sem tokReprToStr =
+  | FloatRepr _ -> "<Float>"
+
   sem tokToStr =
   | FloatTok tok -> concat "<Float>" (float2string tok.val)
 
+  sem tokToRepr =
+  | FloatTok _ -> FloatRepr ()
 end
 
 let parseOperatorCont : Pos -> String -> {val : String, stream : {pos : Pos, str : String}} = lam p. lam str.
@@ -324,6 +368,8 @@ with {val = "<&>", stream = {str = " ", pos = posVal "" 1 3}}
 lang OperatorTokenParser = TokenParser
   syn Token =
   | OperatorTok {info : Info, val : String}
+  syn TokenRepr =
+  | OperatorRepr ()
 
   sem parseToken (pos : Pos) =
   | [('%' | '<' | '>' | '!' | '?' | '~' | ':' | '.' | '$' | '&' | '*' |
@@ -338,14 +384,20 @@ lang OperatorTokenParser = TokenParser
       , stream = stream}
     else never
 
-  sem tokKindEq (tok : Tok) =
-  | OperatorTok _ -> match tok with OperatorTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | OperatorTok _ -> match tokRepr with OperatorRepr _ then true else false
 
   sem tokInfo =
   | OperatorTok {info = info} -> info
 
+  sem tokReprToStr =
+  | OperatorRepr _ -> "<Operator>"
+
   sem tokToStr =
   | OperatorTok tok -> concat "<Operator>" tok.val
+
+  sem tokToRepr =
+  | OperatorTok _ -> OperatorRepr ()
 end
 
 lang BracketTokenParser = TokenParser
@@ -356,6 +408,13 @@ lang BracketTokenParser = TokenParser
   | RBracketTok {info : Info}
   | LBraceTok {info : Info}
   | RBraceTok {info : Info}
+  syn TokenRepr =
+  | LParenRepr ()
+  | RParenRepr ()
+  | LBracketRepr ()
+  | RBracketRepr ()
+  | LBraceRepr ()
+  | RBraceRepr ()
 
   sem parseToken (pos : Pos) =
   | "(" ++ str ->
@@ -383,13 +442,13 @@ lang BracketTokenParser = TokenParser
     let info = makeInfo pos pos2 in
     {token = RBraceTok {info = info}, lit = "}", info = info, stream = {pos = pos2, str = str}}
 
-  sem tokKindEq (tok : Tok) =
-  | LParenTok _ -> match tok with LParenTok _ then true else false
-  | RParenTok _ -> match tok with RParenTok _ then true else false
-  | LBracketTok _ -> match tok with LBracketTok _ then true else false
-  | RBracketTok _ -> match tok with RBracketTok _ then true else false
-  | LBraceTok _ -> match tok with LBraceTok _ then true else false
-  | RBraceTok _ -> match tok with RBraceTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | LParenTok _ -> match tokRepr with LParenRepr _ then true else false
+  | RParenTok _ -> match tokRepr with RParenRepr _ then true else false
+  | LBracketTok _ -> match tokRepr with LBracketRepr _ then true else false
+  | RBracketTok _ -> match tokRepr with RBracketRepr _ then true else false
+  | LBraceTok _ -> match tokRepr with LBraceRepr _ then true else false
+  | RBraceTok _ -> match tokRepr with RBraceRepr _ then true else false
 
   sem tokInfo =
   | LParenTok {info = info} -> info
@@ -399,6 +458,14 @@ lang BracketTokenParser = TokenParser
   | LBraceTok {info = info} -> info
   | RBraceTok {info = info} -> info
 
+  sem tokReprToStr =
+  | LParenRepr _ -> "<LParen>"
+  | RParenRepr _ -> "<RParen>"
+  | LBracketRepr _ -> "<LBracket>"
+  | RBracketRepr _ -> "<RBracket>"
+  | LBraceRepr _ -> "<LBrace>"
+  | RBraceRepr _ -> "<RBrace>"
+
   sem tokToStr =
   | LParenTok _ -> "<LParen>"
   | RParenTok _ -> "<RParen>"
@@ -406,11 +473,21 @@ lang BracketTokenParser = TokenParser
   | RBracketTok _ -> "<RBracket>"
   | LBraceTok _ -> "<LBrace>"
   | RBraceTok _ -> "<RBrace>"
+
+  sem tokToRepr =
+  | LParenTok _ -> LParenRepr ()
+  | RParenTok _ -> RParenRepr ()
+  | LBracketTok _ -> LBracketRepr ()
+  | RBracketTok _ -> RBracketRepr ()
+  | LBraceTok _ -> LBraceRepr ()
+  | RBraceTok _ -> RBraceRepr ()
 end
 
 lang SemiTokenParser = TokenParser
   syn Token =
   | SemiTok {info : Info}
+  syn TokenRepr =
+  | SemiRepr ()
 
   sem parseToken (pos : Pos) =
   | ";" ++ str ->
@@ -418,19 +495,27 @@ lang SemiTokenParser = TokenParser
     let info = makeInfo pos pos2 in
     {token = SemiTok {info = info}, lit = ";", info = info, stream = {pos = pos2, str = str}}
 
-  sem tokKindEq (tok : Tok) =
-  | SemiTok _ -> match tok with SemiTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | SemiTok _ -> match tokRepr with SemiRepr _ then true else false
 
   sem tokInfo =
   | SemiTok {info = info} -> info
 
+  sem tokReprToStr =
+  | SemiRepr _ -> "<Semi>"
+
   sem tokToStr =
   | SemiTok _ -> "<Semi>"
+
+  sem tokToRepr =
+  | SemiTok _ -> SemiRepr ()
 end
 
 lang CommaTokenParser = TokenParser
   syn Token =
   | CommaTok {info : Info}
+  syn TokenRepr =
+  | CommaRepr ()
 
   sem parseToken (pos : Pos) =
   | "," ++ str ->
@@ -438,14 +523,20 @@ lang CommaTokenParser = TokenParser
     let info = makeInfo pos pos2 in
     {token = CommaTok {info = info}, lit = ",", info = info, stream = {pos = pos2, str = str}}
 
-  sem tokKindEq (tok : Tok) =
-  | CommaTok _ -> match tok with CommaTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | CommaTok _ -> match tokRepr with CommaRepr _ then true else false
 
   sem tokInfo =
   | CommaTok {info = info} -> info
 
+  sem tokReprToStr =
+  | CommaRepr _ -> "<Comma>"
+
   sem tokToStr =
   | CommaTok _ -> "<Comma>"
+
+  sem tokToRepr =
+  | CommaTok _ -> CommaRepr ()
 end
 
 -- Matches a character (including escape character).
@@ -469,6 +560,8 @@ let matchChar : Pos -> String -> {val: Char, pos: Pos, str: String} =
 lang StringTokenParser = TokenParser
   syn Token =
   | StringTok {info : Info, val : String}
+  syn TokenRepr =
+  | StringRepr ()
 
   sem parseToken (pos : Pos) =
   | "\"" ++ str ->
@@ -487,19 +580,27 @@ lang StringTokenParser = TokenParser
       }
     else never
 
-  sem tokKindEq (tok : Tok) =
-  | StringTok _ -> match tok with StringTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | StringTok _ -> match tokRepr with StringRepr _ then true else false
 
   sem tokInfo =
   | StringTok {info = info} -> info
 
+  sem tokReprToStr =
+  | StringRepr _ -> "<String>"
+
   sem tokToStr =
   | StringTok tok -> concat "<String>" tok.val
+
+  sem tokToRepr =
+  | StringTok _ -> StringRepr ()
 end
 
 lang CharTokenParser = TokenParser
   syn Token =
   | CharTok {info : Info, val : Char}
+  syn TokenRepr =
+  | CharRepr ()
 
   sem parseToken (pos : Pos) =
   | "'" ++ str ->
@@ -515,19 +616,27 @@ lang CharTokenParser = TokenParser
       else posErrorExit pos "Expected ' to close character literal."
     else never
 
-  sem tokKindEq (tok : Tok) =
-  | CharTok _ -> match tok with CharTok _ then true else false
+  sem tokKindEq (tokRepr : TokRepr) =
+  | CharTok _ -> match tokRepr with CharRepr _ then true else false
 
   sem tokInfo =
   | CharTok {info = info} -> info
 
+  sem tokReprToStr =
+  | CharRepr _ -> "<Char>"
+
   sem tokToStr =
   | CharTok tok -> snoc "<Char>" tok.val
+
+  sem tokToRepr =
+  | CharTok _ -> CharRepr ()
 end
 
 lang HashStringTokenParser = TokenParser
   syn Token =
   | HashStringTok {info : Info, hash : String, val : String}
+  syn TokenRepr=
+  | HashStringRepr {hash : String}
 
   sem parseToken (pos : Pos) =
   | "#" ++ str ->
@@ -550,16 +659,25 @@ lang HashStringTokenParser = TokenParser
       else posErrorExit pos2 "Expected \" to begin hash string"
     else never
 
-  sem tokKindEq (tok : Tok) =
-  | HashStringTok {hash = hash} -> match tok with HashStringTok {hash = hash2}
+  sem tokKindEq (tokRepr : TokRepr) =
+  | HashStringTok {hash = hash} -> match tokRepr with HashStringRepr {hash = hash2}
     then eqString hash hash2
     else false
 
   sem tokInfo =
   | HashStringTok {info = info} -> info
 
+  sem tokReprToStr =
+  | HashStringRepr {hash = hash} -> join ["<", hash, " HashString>"]
+
   sem tokToStr =
   | HashStringTok tok -> join ["<Hash:", tok.hash, ">", tok.val]
+
+  sem tokReprCompare =
+  | (HashStringRepr l, HashStringRepr r) -> cmpString l.hash r.hash
+
+  sem tokToRepr =
+  | HashStringTok x -> HashStringRepr {hash = x.hash}
 end
 
 lang Lexer
@@ -570,37 +688,6 @@ lang Lexer
   + StringTokenParser + CharTokenParser
   + HashStringTokenParser
 end
-
--- NOTE(vipa, 2021-02-05): This is not a semantic function in a
--- language fragment since the output for each case must be distinct
--- from the output for any other fragment, meaning that there would be
--- an invisible dependency between them
-let _tokKindInt = use Lexer in lam tok.
-  match tok with EOFTok _ then 1 else
-  match tok with LIdentTok _ then 2 else
-  match tok with UIdentTok _ then 3 else
-  match tok with IntTok _ then 4 else
-  match tok with FloatTok _ then 5 else
-  match tok with OperatorTok _ then 6 else
-  match tok with LParenTok _ then 7 else
-  match tok with RParenTok _ then 8 else
-  match tok with LBracketTok _ then 9 else
-  match tok with RBracketTok _ then 10 else
-  match tok with LBraceTok _ then 11 else
-  match tok with RBraceTok _ then 12 else
-  match tok with SemiTok _ then 13 else
-  match tok with CommaTok _ then 14 else
-  match tok with StringTok _ then 15 else
-  match tok with CharTok _ then 16 else
-  match tok with HashStringTok _ then 17 else
-  never
-
-let compareTokKind = use Lexer in lam ltok. lam rtok.
-  let pair = (ltok, rtok) in
-  match pair with (HashStringTok {hash = h1}, HashStringTok {hash = h2}) then cmpString h1 h2 else
-  match pair with (HashStringTok _, _) then negi 1 else
-  match pair with (_, HashStringTok _) then 1 else
-  subi (_tokKindInt ltok) (_tokKindInt rtok)
 
 mexpr
 


### PR DESCRIPTION
This PR is a bit of a mixed bag of changes, related to the syntax dsl in progress.

- There's a new error highlighting library in `stdlib/parser/error-highlight.mc`. Give a sequence of source code locations (`Info`), each annotated as "relevant" or "irrelevant", along with the content of the file they refer to, get back a string with the text from those locations with user configurable highlighting.
- The core `breakable.mc` library now takes functions (predicates) instead of sets for its shallow restrictions. The old interface, along with the old tests, are now implemented as a library on top of this in `breakable-helper.mc`.
- A semantic action in the `ll1.mc` parser now takes an extra argument, meant to keep extra state in.
- The lexer has a stronger split between tokens that have been parsed (`Token`) and tokens that are placeholders for things that can be parsed (`TokenRepr`). The latter typically carries no data, and has no `Info` attached.

There are two changes that have some wider impact:
- Minor change in `type-annot.mc`, to make it not discard type information in a particular case that was triggered by my code. This fix is very hacky, but a better solution seems like it's more work than it's worth given that we want to throw it out anyway.
- `utesttrans.mc` attaches some dummy `Info` to generated code, just to give _something_ to search for if something goes wrong in there. This one we should decide if we want to keep, and if so what `Info` should be attached more precisely.