### PR TITLE
Add tensor intrinsics for linear indexing

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -207,6 +207,8 @@ and const =
   | CtensorCreateCArrayFloat of int Mseq.t option
   | CtensorGetExn of tm T.t option
   | CtensorSetExn of tm T.t option * int Mseq.t option
+  | CtensorLinearGetExn of tm T.t option
+  | CtensorLinearSetExn of tm T.t option * int option
   | CtensorRank
   | CtensorShape
   | CtensorCopy
@@ -677,6 +679,8 @@ let const_has_side_effect = function
   | CtensorCreateCArrayFloat _
   | CtensorGetExn _
   | CtensorSetExn _
+  | CtensorLinearGetExn _
+  | CtensorLinearSetExn _
   | CtensorRank
   | CtensorShape
   | CtensorCopy

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -143,6 +143,8 @@ let builtin =
   ; ("tensorCreateDense", f (CtensorCreateDense None))
   ; ("tensorGetExn", f (CtensorGetExn None))
   ; ("tensorSetExn", f (CtensorSetExn (None, None)))
+  ; ("tensorLinearGetExn", f (CtensorLinearGetExn None))
+  ; ("tensorLinearSetExn", f (CtensorLinearSetExn (None, None)))
   ; ("tensorRank", f CtensorRank)
   ; ("tensorShape", f CtensorShape)
   ; ("tensorReshapeExn", f (CtensorReshapeExn None))

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -258,6 +258,10 @@ module T = struct
 
     val set_exn : ('a, 'b) t -> int Mseq.t -> 'a -> unit
 
+    val linear_get_exn : ('a, 'b) t -> int -> 'a
+
+    val linear_set_exn : ('a, 'b) t -> int -> 'a -> unit
+
     val shape : ('a, 'b) t -> int Mseq.t
 
     val reshape_exn : ('a, 'b) t -> int Mseq.t -> ('a, 'b) t
@@ -276,6 +280,10 @@ module T = struct
     let get_exn t idx = T.get_exn t (to_arr idx)
 
     let set_exn t idx = T.set_exn t (to_arr idx)
+
+    let linear_get_exn t idx = T.linear_get_exn t idx
+
+    let linear_set_exn t idx = T.linear_set_exn t idx
 
     let shape t = of_arr (T.shape t)
 
@@ -322,6 +330,24 @@ module T = struct
         Op_mseq_barray.set_exn t' idx v
     | TGen t' ->
         Op_mseq_generic.set_exn t' idx v
+
+  let linear_get_exn (type a b) (t : (a, b) u) idx : a =
+    match t with
+    | TInt t' ->
+        Op_mseq_barray.linear_get_exn t' idx
+    | TFloat t' ->
+        Op_mseq_barray.linear_get_exn t' idx
+    | TGen t' ->
+        Op_mseq_generic.linear_get_exn t' idx
+
+  let linear_set_exn (type a b) (t : (a, b) u) idx (v : a) : unit =
+    match t with
+    | TInt t' ->
+        Op_mseq_barray.linear_set_exn t' idx v
+    | TFloat t' ->
+        Op_mseq_barray.linear_set_exn t' idx v
+    | TGen t' ->
+        Op_mseq_generic.linear_set_exn t' idx v
 
   let shape (type a b) (t : (a, b) u) : int Mseq.t =
     match t with

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -254,6 +254,10 @@ module T : sig
 
     val set_exn : ('a, 'b) t -> int Mseq.t -> 'a -> unit
 
+    val linear_get_exn : ('a, 'b) t -> int -> 'a
+
+    val linear_set_exn : ('a, 'b) t -> int -> 'a -> unit
+
     val shape : ('a, 'b) t -> int Mseq.t
 
     val reshape_exn : ('a, 'b) t -> int Mseq.t -> ('a, 'b) t
@@ -286,6 +290,10 @@ module T : sig
   val get_exn : ('a, 'b) u -> int Mseq.t -> 'a
 
   val set_exn : ('a, 'b) u -> int Mseq.t -> 'a -> unit
+
+  val linear_get_exn : ('a, 'b) u -> int -> 'a
+
+  val linear_set_exn : ('a, 'b) u -> int -> 'a -> unit
 
   val shape : ('a, 'b) u -> int Mseq.t
 

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -406,6 +406,16 @@ let arity = function
       2
   | CtensorSetExn (_, Some _) ->
       1
+  | CtensorLinearGetExn None ->
+      2
+  | CtensorLinearGetExn (Some _) ->
+      1
+  | CtensorLinearSetExn (None, None) ->
+      3
+  | CtensorLinearSetExn (_, None) ->
+      2
+  | CtensorLinearSetExn (_, Some _) ->
+      1
   | CtensorRank ->
       1
   | CtensorShape ->
@@ -1268,6 +1278,42 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
       tm_unit
     with Invalid_argument msg -> raise_error fi msg )
   | CtensorSetExn _, _ ->
+      fail_constapp fi
+  | CtensorLinearGetExn None, TmTensor (_, t) ->
+      TmConst (fi, CtensorLinearGetExn (Some t))
+  | CtensorLinearGetExn (Some t), TmConst (_, CInt idx) -> (
+      try
+        t
+        |> function
+        | T.TBootInt t' ->
+            TmConst (fi, CInt (T.Op_mseq_barray.linear_get_exn t' idx))
+        | T.TBootFloat t' ->
+            TmConst (fi, CFloat (T.Op_mseq_barray.linear_get_exn t' idx))
+        | T.TBootGen t' ->
+            T.Op_mseq_generic.linear_get_exn t' idx
+      with Invalid_argument msg -> raise_error fi msg )
+  | CtensorLinearGetExn _, _ ->
+      fail_constapp fi
+  | CtensorLinearSetExn (None, None), TmTensor (_, t) ->
+      TmConst (fi, CtensorLinearSetExn (Some t, None))
+  | CtensorLinearSetExn (Some t, None), TmConst (_, CInt idx) ->
+      TmConst (fi, CtensorLinearSetExn (Some t, Some idx))
+  | CtensorLinearSetExn (Some (T.TBootInt t), Some idx), TmConst (_, CInt n) -> (
+    try
+      T.Op_mseq_barray.linear_set_exn t idx n ;
+      tm_unit
+    with Invalid_argument msg -> raise_error fi msg )
+  | CtensorLinearSetExn (Some (T.TBootFloat t), Some idx), TmConst (_, CFloat r) -> (
+    try
+      T.Op_mseq_barray.linear_set_exn t idx r ;
+      tm_unit
+    with Invalid_argument msg -> raise_error fi msg )
+  | CtensorLinearSetExn (Some (T.TBootGen t), Some idx), tm -> (
+    try
+      T.Op_mseq_generic.linear_set_exn t idx tm ;
+      tm_unit
+    with Invalid_argument msg -> raise_error fi msg )
+  | CtensorLinearSetExn _, _ ->
       fail_constapp fi
   | CtensorRank, TmTensor (_, t) ->
       let n =

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1282,28 +1282,30 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
   | CtensorLinearGetExn None, TmTensor (_, t) ->
       TmConst (fi, CtensorLinearGetExn (Some t))
   | CtensorLinearGetExn (Some t), TmConst (_, CInt idx) -> (
-      try
-        t
-        |> function
-        | T.TBootInt t' ->
-            TmConst (fi, CInt (T.Op_mseq_barray.linear_get_exn t' idx))
-        | T.TBootFloat t' ->
-            TmConst (fi, CFloat (T.Op_mseq_barray.linear_get_exn t' idx))
-        | T.TBootGen t' ->
-            T.Op_mseq_generic.linear_get_exn t' idx
-      with Invalid_argument msg -> raise_error fi msg )
+    try
+      t
+      |> function
+      | T.TBootInt t' ->
+          TmConst (fi, CInt (T.Op_mseq_barray.linear_get_exn t' idx))
+      | T.TBootFloat t' ->
+          TmConst (fi, CFloat (T.Op_mseq_barray.linear_get_exn t' idx))
+      | T.TBootGen t' ->
+          T.Op_mseq_generic.linear_get_exn t' idx
+    with Invalid_argument msg -> raise_error fi msg )
   | CtensorLinearGetExn _, _ ->
       fail_constapp fi
   | CtensorLinearSetExn (None, None), TmTensor (_, t) ->
       TmConst (fi, CtensorLinearSetExn (Some t, None))
   | CtensorLinearSetExn (Some t, None), TmConst (_, CInt idx) ->
       TmConst (fi, CtensorLinearSetExn (Some t, Some idx))
-  | CtensorLinearSetExn (Some (T.TBootInt t), Some idx), TmConst (_, CInt n) -> (
+  | CtensorLinearSetExn (Some (T.TBootInt t), Some idx), TmConst (_, CInt n)
+    -> (
     try
       T.Op_mseq_barray.linear_set_exn t idx n ;
       tm_unit
     with Invalid_argument msg -> raise_error fi msg )
-  | CtensorLinearSetExn (Some (T.TBootFloat t), Some idx), TmConst (_, CFloat r) -> (
+  | CtensorLinearSetExn (Some (T.TBootFloat t), Some idx), TmConst (_, CFloat r)
+    -> (
     try
       T.Op_mseq_barray.linear_set_exn t idx r ;
       tm_unit

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -511,6 +511,10 @@ let rec print_const fmt = function
       fprintf fmt "tensorGetExn"
   | CtensorSetExn _ ->
       fprintf fmt "tensorSetExn"
+  | CtensorLinearGetExn _ ->
+      fprintf fmt "tensorLinearGetExn"
+  | CtensorLinearSetExn _ ->
+      fprintf fmt "tensorLinearSetExn"
   | CtensorRank ->
       fprintf fmt "tensorRank"
   | CtensorShape ->

--- a/src/boot/lib/tensor.ml
+++ b/src/boot/lib/tensor.ml
@@ -89,7 +89,7 @@ let linear_to_cartesian_idx shape linear_idx =
   let tmp_k = ref linear_idx in
   for i = rank - 1 downto 0 do
     let d = shape.(i) in
-    idx.(i) <- (!tmp_k mod d) ;
+    idx.(i) <- !tmp_k mod d ;
     tmp_k := !tmp_k / d
   done ;
   idx

--- a/src/boot/lib/tensor.mli
+++ b/src/boot/lib/tensor.mli
@@ -7,6 +7,10 @@ module type TENSOR = sig
 
   val set_exn : ('a, 'b) t -> int array -> 'a -> unit
 
+  val linear_get_exn : ('a, 'b) t -> int -> 'a
+
+  val linear_set_exn : ('a, 'b) t -> int -> 'a -> unit
+
   val shape : ('a, 'b) t -> int array
 
   val rank : ('a, 'b) t -> int

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -148,6 +148,16 @@ let tytensorsetexn_ = lam ty.
             , tyseq_ tyint_
             , ty, tyunit_ ]
 
+let tytensorlineargetexn_ = lam ty.
+  tyarrows_ [ tytensor_ ty
+            , tyint_
+            , ty ]
+
+let tytensorlinearsetexn_ = lam ty.
+  tyarrows_ [ tytensor_ ty
+            , tyint_
+            , ty, tyunit_ ]
+
 let tytensorrank_ = lam ty.
   tyarrow_ (tytensor_ ty) tyint_
 
@@ -1047,6 +1057,18 @@ let tensorSetExn_ = use MExprAst in
   appf3_ (const_ (tytensorsetexn_ ty) (CTensorSetExn ())) t is v
 
 let utensorSetExn_ = tensorSetExn_ tyunknown_
+
+let tensorLinearGetExn_ = use MExprAst in
+  lam ty. lam t. lam i.
+  appf2_ (const_ (tytensorlineargetexn_ ty) (CTensorLinearGetExn ())) t i
+
+let utensorLinearGetExn_ = tensorLinearGetExn_ tyunknown_
+
+let tensorLinearSetExn_ = use MExprAst in
+  lam ty. lam t. lam i. lam v.
+  appf3_ (const_ (tytensorlinearsetexn_ ty) (CTensorLinearSetExn ())) t i v
+
+let utensorLinearSetExn_ = tensorLinearSetExn_ tyunknown_
 
 let tensorRank_ = use MExprAst in
   lam ty. lam t.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -786,6 +786,8 @@ lang TensorOpAst = ConstAst
   | CTensorCreate {}
   | CTensorGetExn {}
   | CTensorSetExn {}
+  | CTensorLinearGetExn {}
+  | CTensorLinearSetExn {}
   | CTensorRank {}
   | CTensorShape {}
   | CTensorReshapeExn {}

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -125,6 +125,8 @@ let builtin = use MExprAst in
   , ("tensorCreateDense", CTensorCreate ())
   , ("tensorGetExn", CTensorGetExn ())
   , ("tensorSetExn", CTensorSetExn ())
+  , ("tensorLinearGetExn", CTensorLinearGetExn ())
+  , ("tensorLinearSetExn", CTensorLinearSetExn ())
   , ("tensorRank", CTensorRank ())
   , ("tensorShape", CTensorShape ())
   , ("tensorReshapeExn", CTensorReshapeExn ())

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -802,6 +802,8 @@ lang TensorOpCFA = CFA + ConstCFA + TensorOpAst
   -- | CTensorCreate _ -> []
   -- | CTensorGetExn _ -> []
   -- | CTensorSetExn _ -> []
+  -- | CTensorLinearGetExn _ -> []
+  -- | CTensorLinearSetExn _ -> []
   -- | CTensorRank _ -> []
   -- | CTensorShape _ -> []
   -- | CTensorReshapeExn _ -> []

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -737,6 +737,8 @@ utest cmpConst (CTensorCreateFloat {}) (CTensorCreateFloat {}) with 0 in
 utest cmpConst (CTensorCreate {}) (CTensorCreate {}) with 0 in
 utest cmpConst (CTensorGetExn {}) (CTensorGetExn {}) with 0 in
 utest cmpConst (CTensorSetExn {}) (CTensorSetExn {}) with 0 in
+utest cmpConst (CTensorLinearGetExn {}) (CTensorLinearGetExn {}) with 0 in
+utest cmpConst (CTensorLinearSetExn {}) (CTensorLinearSetExn {}) with 0 in
 utest cmpConst (CTensorRank {}) (CTensorRank {}) with 0 in
 utest cmpConst (CTensorShape {}) (CTensorShape {}) with 0 in
 utest cmpConst (CTensorReshapeExn {}) (CTensorReshapeExn {}) with 0 in

--- a/stdlib/mexpr/const-arity.mc
+++ b/stdlib/mexpr/const-arity.mc
@@ -211,6 +211,8 @@ lang TensorOpArity = TensorOpAst
   | CTensorCreate _ -> 2
   | CTensorGetExn _ -> 2
   | CTensorSetExn _ -> 3
+  | CTensorLinearGetExn _ -> 2
+  | CTensorLinearSetExn _ -> 3
   | CTensorRank _ -> 1
   | CTensorShape _ -> 1
   | CTensorReshapeExn _ -> 2

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -263,6 +263,8 @@ lang TensorOpTypeAst = TensorOpAst
   | CTensorCreate _ -> tyall_ "a" (tytensorcreate_ (tyvar_ "a"))
   | CTensorGetExn _ -> tyall_ "a" (tytensorgetexn_ (tyvar_ "a"))
   | CTensorSetExn _ -> tyall_ "a" (tytensorsetexn_ (tyvar_ "a"))
+  | CTensorLinearGetExn _ -> tyall_ "a" (tytensorlineargetexn_ (tyvar_ "a"))
+  | CTensorLinearSetExn _ -> tyall_ "a" (tytensorlinearsetexn_ (tyvar_ "a"))
   | CTensorRank _ -> tyall_ "a" (tytensorrank_ (tyvar_ "a"))
   | CTensorShape _ -> tyall_ "a" (tytensorshape_ (tyvar_ "a"))
   | CTensorReshapeExn _ -> tyall_ "a" (tytensorreshapeexn_ (tyvar_ "a"))

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -824,6 +824,8 @@ lang TensorOpPrettyPrint = TensorOpAst + ConstPrettyPrint
   | CTensorCreate _ -> "tensorCreateDense"
   | CTensorGetExn _ -> "tensorGetExn"
   | CTensorSetExn _ -> "tensorSetExn"
+  | CTensorLinearGetExn _ -> "tensorLinearGetExn"
+  | CTensorLinearSetExn _ -> "tensorLinearSetExn"
   | CTensorRank _ -> "tensorRank"
   | CTensorShape _ -> "tensorShape"
   | CTensorReshapeExn _ -> "tensorReshapeExn"

--- a/stdlib/mexpr/side-effect.mc
+++ b/stdlib/mexpr/side-effect.mc
@@ -78,7 +78,9 @@ lang ConstSideEffect = MExprAst
   | CMapMapWithKey _ | CMapFoldWithKey _ | CMapEq _ | CMapCmp _
   | CMapGetCmpFun _ -> true
   | CTensorCreateInt _ | CTensorCreateFloat _ | CTensorCreate _
-  | CTensorGetExn _ | CTensorSetExn _ | CTensorRank _ | CTensorShape _
+  | CTensorGetExn _ | CTensorSetExn _
+  | CTensorLinearGetExn _ | CTensorLinearSetExn _
+  | CTensorRank _ | CTensorShape _
   | CTensorReshapeExn _ | CTensorCopy _ | CTensorTransposeExn _
   | CTensorSliceExn _ | CTensorSubExn _ | CTensorIterSlice _ |  CTensorEq _
   | CTensorToString _ -> true

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -293,6 +293,8 @@ lang OCamlPrettyPrint =
   | CTensorShape _ -> intrinsicOpTensor "shape"
   | CTensorGetExn _ -> intrinsicOpTensor "get_exn"
   | CTensorSetExn _ -> intrinsicOpTensor "set_exn"
+  | CTensorLinearGetExn _ -> intrinsicOpTensor "linear_get_exn"
+  | CTensorLinearSetExn _ -> intrinsicOpTensor "linear_set_exn"
   | CTensorReshapeExn _ -> intrinsicOpTensor "reshape_exn"
   | CTensorCopy _ -> intrinsicOpTensor "copy"
   | CTensorTransposeExn _ -> intrinsicOpTensor "transpose_exn"

--- a/stdlib/tuning/const-dep.mc
+++ b/stdlib/tuning/const-dep.mc
@@ -239,6 +239,8 @@ lang TensorOpDep = TensorOpAst
   | CTensorCreate _ -> error "TensorOpDep not implemented yet"
   | CTensorGetExn _ -> error "TensorOpDep not implemented yet"
   | CTensorSetExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorLinearGetExn _ -> error "TensorOpDep not implemented yet"
+  | CTensorLinearSetExn _ -> error "TensorOpDep not implemented yet"
   | CTensorRank _ -> error "TensorOpDep not implemented yet"
   | CTensorShape _ -> error "TensorOpDep not implemented yet"
   | CTensorReshapeExn _ -> error "TensorOpDep not implemented yet"

--- a/test/mexpr/tensor.mc
+++ b/test/mexpr/tensor.mc
@@ -68,6 +68,23 @@ let testTensors =
   utest tensorGetExn t [2, 2] with v11 using eq in
   utest tensorGetExn t [2, 3] with v12 using eq in
 
+  -- Linear Get
+  let t = mkRank2TestTensor () in
+  utest tensorRank t with 2 in
+  utest tensorShape t with [3, 4] in
+  utest tensorLinearGetExn t 0 with v1 using eq in
+  utest tensorLinearGetExn t 1 with v2 using eq in
+  utest tensorLinearGetExn t 2 with v3 using eq in
+  utest tensorLinearGetExn t 3 with v4 using eq in
+  utest tensorLinearGetExn t 4 with v5 using eq in
+  utest tensorLinearGetExn t 5 with v6 using eq in
+  utest tensorLinearGetExn t 6 with v7 using eq in
+  utest tensorLinearGetExn t 7 with v8 using eq in
+  utest tensorLinearGetExn t 8 with v9 using eq in
+  utest tensorLinearGetExn t 9 with v10 using eq in
+  utest tensorLinearGetExn t 10 with v11 using eq in
+  utest tensorLinearGetExn t 11 with v12 using eq in
+
   -- Copy
   let t1 = mkRank2TestTensor () in
   let t2 = tensorCopy t1 in
@@ -342,6 +359,52 @@ let testTensors =
   utest tensorGetExn t [1, 1, 0] with v10 using eq in
   utest tensorGetExn t [1, 1, 1] with v11 using eq in
   utest tensorGetExn t [1, 1, 2] with v12 using eq in
+
+  -- Linear Get
+  let t = mkRank3TestTensor () in
+  utest tensorRank t with 3 in
+  utest tensorShape t with [2, 2, 3] in
+  utest tensorLinearGetExn t 0 with v1 using eq in
+  utest tensorLinearGetExn t 1 with v2 using eq in
+  utest tensorLinearGetExn t 2 with v3 using eq in
+  utest tensorLinearGetExn t 3 with v4 using eq in
+  utest tensorLinearGetExn t 4 with v5 using eq in
+  utest tensorLinearGetExn t 5 with v6 using eq in
+  utest tensorLinearGetExn t 6 with v7 using eq in
+  utest tensorLinearGetExn t 7 with v8 using eq in
+  utest tensorLinearGetExn t 8 with v9 using eq in
+  utest tensorLinearGetExn t 9 with v10 using eq in
+  utest tensorLinearGetExn t 10 with v11 using eq in
+  utest tensorLinearGetExn t 11 with v12 using eq in
+
+  -- Linear Set
+  let t = mkRank3TestTensor () in
+  utest tensorRank t with 3 in
+  utest tensorShape t with [2, 2, 3] in
+  tensorLinearSetExn t 0 v12;
+  tensorLinearSetExn t 1 v11;
+  tensorLinearSetExn t 2 v10;
+  tensorLinearSetExn t 3 v9;
+  tensorLinearSetExn t 4 v8;
+  tensorLinearSetExn t 5 v7;
+  tensorLinearSetExn t 6 v6;
+  tensorLinearSetExn t 7 v5;
+  tensorLinearSetExn t 8 v4;
+  tensorLinearSetExn t 9 v3;
+  tensorLinearSetExn t 10 v2;
+  tensorLinearSetExn t 11 v1;
+  utest tensorGetExn t [0, 0, 0] with v12 using eq in
+  utest tensorGetExn t [0, 0, 1] with v11 using eq in
+  utest tensorGetExn t [0, 0, 2] with v10 using eq in
+  utest tensorGetExn t [0, 1, 0] with v9 using eq in
+  utest tensorGetExn t [0, 1, 1] with v8 using eq in
+  utest tensorGetExn t [0, 1, 2] with v7 using eq in
+  utest tensorGetExn t [1, 0, 0] with v6 using eq in
+  utest tensorGetExn t [1, 0, 1] with v5 using eq in
+  utest tensorGetExn t [1, 0, 2] with v4 using eq in
+  utest tensorGetExn t [1, 1, 0] with v3 using eq in
+  utest tensorGetExn t [1, 1, 1] with v2 using eq in
+  utest tensorGetExn t [1, 1, 2] with v1 using eq in
 
   -- Transpose
   let t1 = mkRank3TestTensor () in


### PR DESCRIPTION
Adds the intrinsics

* `tensorLinearGetExn: Tensor[a] -> Int -> a`
* `tensorLinearSetExn: Tensor[a] -> Int -> a -> ()`

which gets or sets elements based on a row-major linear index. I.e. the following statements (1) and (2) are equivalent:

```
let t = tensorCreateDense [3,3] (lam idx. ...) in
let #var"(1)" = tensorGetExn t [1,2] in
let #var"(2)" = tensorLinearGetExn t 5 in
...
```

The goal of this is allow for optimization in the CUDA backend, where there is currently a lot of computations just to work out indices for simple operations such as pair-wise addition of matrices.