### PR TITLE
Type signatures and type checking improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ test-all:\
   test-boot-all\
   test-compile\
   test-compile-type-checked\
+  test-type-check\
   test-run\
 	test-tune
 	@./make lint
@@ -113,6 +114,9 @@ test-compile-all: build
 
 test-compile-type-checked: build
 	@$(MAKE) -s -f test-compile-type-checked.mk selected
+
+test-type-check: build
+	@$(MAKE) -s -f test-type-check.mk selected
 
 test-boot-compile-prune-utests: boot
 	@$(MAKE) -s -f test-boot-compile-prune-utests.mk selected

--- a/make
+++ b/make
@@ -153,6 +153,21 @@ run_test_boot() {
   run_test_prototype "build/boot eval src/main/mi.mc -- run --test --disable-prune-warning" $1
 }
 
+type_check() {
+  set +e
+  msg="Type checking $1..."
+  output="$(build/mi --test --keep-dead-code --disable-prune-utests --typecheck --exit-before $1 2>&1)"
+  exit_code=$?
+  if [ $exit_code -eq 0 ]
+  then
+      echo "$msg Ok"
+  else
+      echo "$msg FAILED with output\n$output"
+      exit 1
+  fi
+  set -e
+}
+
 case $1 in
     boot)
         build_boot
@@ -174,6 +189,9 @@ case $1 in
         ;;
     compile-test)
         compile_test "$2" "$3"
+        ;;
+    type-check)
+        type_check "$2"
         ;;
     lint)
         lint

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -223,7 +223,7 @@ and const =
   | CbootParserTree of ptree
   | CbootParserParseMExprString of int Mseq.t Mseq.t option
   | CbootParserParseMCoreFile of
-      (bool * bool * int Mseq.t Mseq.t * bool) option
+      (bool * bool * int Mseq.t Mseq.t * bool * bool) option
       * int Mseq.t Mseq.t option
   | CbootParserGetId
   | CbootParserGetTerm of tm option

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -151,8 +151,11 @@ let parseMExprString keywords str =
     reportErrorAndExit e
 
 let parseMCoreFile
-    (keep_utests, prune_external_utests, externals_exclude, warn) keywords
-    filename =
+    ( keep_utests
+    , prune_external_utests
+    , externals_exclude
+    , warn
+    , eliminate_deadcode ) keywords filename =
   try
     let keywords = Mseq.map Mseq.Helpers.to_ustring keywords in
     let symKeywordsMap = symbolizeEnvWithKeywords keywords in
@@ -172,6 +175,11 @@ let parseMCoreFile
       Intrinsics.Mseq.Helpers.to_list
         (Mseq.map Intrinsics.Mseq.Helpers.to_ustring externals_exclude)
     in
+    let deadcode_elimination =
+      if eliminate_deadcode then
+        Deadcode.elimination builtin_sym2term name2sym symKeywords
+      else fun x -> x
+    in
     PTreeTm
       ( filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
       |> Utils.normalize_path |> Parserutils.parse_mcore_file |> Mlang.flatten
@@ -180,11 +188,11 @@ let parseMCoreFile
       |> Symbolize.symbolize name2sym
       |> Parserutils.raise_parse_error_on_partially_applied_external
       |> (fun t -> if keep_utests then t else Parserutils.remove_all_utests t)
-      |> Deadcode.elimination builtin_sym2term name2sym symKeywords
+      |> deadcode_elimination
       |> Parserutils.prune_external_utests
            ~enable:(keep_utests && prune_external_utests)
            ~externals_exclude ~warn
-      |> Deadcode.elimination builtin_sym2term name2sym symKeywords )
+      |> deadcode_elimination )
   with (Lexer.Lex_error _ | Msg.Error _ | Parsing.Parse_error) as e ->
     reportErrorAndExit e
 

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1532,12 +1532,14 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
         ( Record.find (us "0") r
         , Record.find (us "1") r
         , Record.find (us "2") r
-        , Record.find (us "3") r )
+        , Record.find (us "3") r
+        , Record.find (us "4") r )
       with
       | ( TmConst (_, CBool keep_utests)
         , TmConst (_, CBool prune_external_utests)
         , TmSeq (_, externals_exclude)
-        , TmConst (_, CBool warn) ) ->
+        , TmConst (_, CBool warn)
+        , TmConst (_, CBool eliminate_deadcode) ) ->
           let externals_exclude =
             Mseq.map
               (function
@@ -1552,7 +1554,8 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
                     ( keep_utests
                     , prune_external_utests
                     , externals_exclude
-                    , warn )
+                    , warn
+                    , eliminate_deadcode )
                 , None ) )
       | _ ->
           fail_constapp fi

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -939,7 +939,8 @@ let desugar_post_flatten_with_nss nss (Program (_, tops, t)) =
   let syntydecl =
     List.map
       (fun (syn, fi) tm' ->
-        TmType (fi, syn, Symb.Helpers.nosym, [], TyUnknown NoInfo, tm') )
+        TmType (fi, syn, Symb.Helpers.nosym, [], TyVariant (NoInfo, []), tm')
+        )
       (USMap.bindings syns)
   in
   let stack = stack @ syntydecl in

--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -366,6 +366,7 @@ let compileAccelerated : Options -> AccelerateHooks -> String -> Unit =
     pruneExternalUtests = false,
     pruneExternalUtestsWarning = false,
     findExternalsExclude = false,
+    eliminateDeadCode = true,
     keywords = parallelKeywords
   } file in
   let ast = makeKeywords [] ast in

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -107,6 +107,7 @@ let compile = lam files. lam options : Options. lam args.
       pruneExternalUtests = not options.disablePruneExternalUtests,
       pruneExternalUtestsWarning = not options.disablePruneExternalUtestsWarning,
       findExternalsExclude = true,
+      eliminateDeadCode = not options.keepDeadCode,
       keywords = concat holeKeywords parallelKeywords
     } file in
     let ast = makeKeywords [] ast in

--- a/src/main/eval.mc
+++ b/src/main/eval.mc
@@ -58,7 +58,8 @@ let eval = lam files. lam options : Options. lam args.
       keywords = [],
       pruneExternalUtests = not options.disablePruneExternalUtests,
       pruneExternalUtestsWarning = not options.disablePruneExternalUtestsWarning,
-      findExternalsExclude = false -- the interpreter does not support externals
+      findExternalsExclude = false, -- the interpreter does not support externals
+      eliminateDeadCode = not options.keepDeadCode
     } file in
 
     -- If option --debug-parse, then pretty print the AST

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -57,6 +57,7 @@ let compile : Options -> String -> Unit = lam options. lam file.
     pruneExternalUtests = not options.disablePruneExternalUtests,
     pruneExternalUtestsWarning = not options.disablePruneExternalUtestsWarning,
     findExternalsExclude = true,
+    eliminateDeadCode = not options.keepDeadCode,
     keywords = []
   } file in
   let ast = utestStrip ast in

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -50,7 +50,7 @@ let ocamlCompile : Options -> String -> [String] -> [String] -> String -> String
   p.cleanup ();
   destinationFile
 
-let compile : Options -> String -> Unit = lam options. lam file.
+let compile : Options -> String -> () = lam options. lam file.
   use MCoreLiteCompile in
   let ast = parseParseMCoreFile {
     keepUtests = options.runTests,
@@ -62,8 +62,9 @@ let compile : Options -> String -> Unit = lam options. lam file.
   } file in
   let ast = utestStrip ast in
   let ast = symbolize ast in
-  let hooks = {emptyHooks with compileOcaml = ocamlCompile options file} in
-  compileMCore ast hooks
+  let hooks = mkEmptyHooks (ocamlCompile options file) in
+  compileMCore ast hooks;
+  ()
 
 mexpr
 

--- a/src/main/mi.mc
+++ b/src/main/mi.mc
@@ -41,7 +41,7 @@ optionsHelpString optionsConfig,
 ]
 in
 
-let subMenu = lam sub : String. lam config : ParseConfig. join
+let subMenu = lam sub : String. lam config : ParseConfig Options. join
 [
 "Usage: mi ",
 sub,
@@ -63,7 +63,7 @@ in
 type SubConfig = {
   name : String,
   cmd : [String] -> Options -> [String] -> Unit,
-  config : ParseConfig
+  config : ParseConfig Options
 } in
 
 -- Commands map, maps command strings to functions.

--- a/src/main/options-config.mc
+++ b/src/main/options-config.mc
@@ -77,6 +77,10 @@ let optionsConfig : ParseConfig = [
     "Enables use of 32-bit floating-point numbers in the C compiler",
     lam p: ArgPart Options.
       let o: Options = p.options in {o with use32BitFloats = true}),
+  ([("--keep-dead-code", "", "")],
+    "Disable dead code elimination pass",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with keepDeadCode = true}),
   ([("--typecheck", "", "")],
     "Type check the program before evaluation or compilation",
     lam p: ArgPart Options.

--- a/src/main/options-config.mc
+++ b/src/main/options-config.mc
@@ -2,7 +2,7 @@ include "arg.mc"
 include "options-type.mc"
 
 -- Options configuration
-let optionsConfig : ParseConfig = [
+let optionsConfig : ParseConfig Options = [
   ([("--debug-parse", "", "")],
     "Print the AST after parsing",
     lam p: ArgPart Options.

--- a/src/main/options-type.mc
+++ b/src/main/options-type.mc
@@ -20,6 +20,7 @@ type Options = {
   cpuOnly : Bool,
   use32BitIntegers : Bool,
   use32BitFloats : Bool,
+  keepDeadCode : Bool,
   typeCheck : Bool,
   printHelp : Bool,
   output : Option String,

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -23,6 +23,7 @@ let optionsDefault : Options = {
   cpuOnly = false,
   use32BitIntegers = false,
   use32BitFloats = false,
+  keepDeadCode = false,
   typeCheck = false,
   printHelp = false,
   output = None (),

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -31,10 +31,10 @@ let optionsDefault : Options = {
 }
 
 -- Get the help string for options
-let optionsHelpString : ParseConfig -> String = lam config.
+let optionsHelpString : ParseConfig Options -> String = lam config.
   argHelpOptions config
 
-let parseOptions : [String] -> ParseConfig -> ArgResult Options = lam args. lam config.
+let parseOptions : [String] -> ParseConfig Options -> ArgResult Options = lam args. lam config.
   let result =
     argParse_general {args = args, optionsStartWith = ["--"]} optionsDefault config
   in

--- a/src/main/parse.mc
+++ b/src/main/parse.mc
@@ -15,6 +15,9 @@ type ParseOptions = {
   -- Warn if there are pruned utests
   pruneExternalUtestsWarning : Bool,
 
+  -- Run dead code elimination
+  eliminateDeadCode : Bool,
+
   -- Additional keywords
   keywords : [String]
 }
@@ -24,6 +27,7 @@ let defaultParseOptions = {
   pruneExternalUtests = false,
   pruneExternalUtestsWarning = true,
   findExternalsExclude = false,
+  eliminateDeadCode = true,
   keywords = []
 }
 
@@ -40,6 +44,7 @@ let parseParseMCoreFile : ParseOptions -> String -> Expr = lam opt. lam file.
       pruneExternalUtests = true,
       externalsExclude = externalsExclude,
       pruneExternalUtestsWarning = opt.pruneExternalUtestsWarning,
+      eliminateDeadCode = opt.eliminateDeadCode,
       keywords = opt.keywords
     } file
   else
@@ -48,5 +53,6 @@ let parseParseMCoreFile : ParseOptions -> String -> Expr = lam opt. lam file.
       pruneExternalUtests = false,
       externalsExclude = [],
       pruneExternalUtestsWarning = false,
+      eliminateDeadCode = opt.eliminateDeadCode,
       keywords = opt.keywords
   } file

--- a/src/main/tune-config.mc
+++ b/src/main/tune-config.mc
@@ -3,7 +3,7 @@ include "options-type.mc"
 include "assoc.mc"
 include "tuning/tune-options.mc"
 
-let tuneOptionsConfig : ParseConfig = concat optionsConfig [
+let tuneOptionsConfig : ParseConfig Options = concat optionsConfig [
   ([("--verbose", "", "")],
     "Print the search state during tuning",
     lam p: ArgPart Options.
@@ -91,7 +91,7 @@ let tuneOptionsConfig : ParseConfig = concat optionsConfig [
     lam p: ArgPart Options.
       let o: Options = p.options in
       let to : TuneOptions = o.tuneOptions in
-      {o with tuneOptions = {to with seed = argToInt p}}),
+      {o with tuneOptions = {to with seed = Some (argToInt p)}}),
   ([("--dependency-analysis", "", "")],
     "Perform dependency analysis",
     lam p: ArgPart Options.

--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -47,6 +47,7 @@ let tune = lam files. lam options : Options. lam args.
       pruneExternalUtests = not options.disablePruneExternalUtests,
       pruneExternalUtestsWarning = not options.disablePruneExternalUtestsWarning,
       findExternalsExclude = true,
+      eliminateDeadCode = not options.keepDeadCode,
       keywords = holeKeywords
     } file in
     let ast = makeKeywords [] ast in

--- a/stdlib/assoc-seq.mc
+++ b/stdlib/assoc-seq.mc
@@ -9,26 +9,27 @@ include "seq.mc"
 type AssocSeq k v = [(k, v)]
 type AssocTraits k = {eq: k -> k -> Bool}
 
-let assocSeqInsert : k -> v -> AssocSeq k v -> AssocSeq k v =
+let assocSeqInsert : all k. all v. k -> v -> AssocSeq k v -> AssocSeq k v =
   lam k. lam v. lam s.
     cons (k,v) s
 
-let assocSeqLookup : AssocTraits k -> k -> AssocSeq k v -> Option v =
+let assocSeqLookup : all k. all v. AssocTraits k -> k -> AssocSeq k v -> Option v =
   lam traits : {eq : k -> k -> Bool}. lam k. lam s.
     optionMapOr (None ())
                 (lam t : (k, v). Some t.1)
                 (find (lam t : (k, v). traits.eq k t.0) s)
 
-let assocSeqReverseLookup : AssocTraits k -> v -> AssocSeq k v -> Option k =
+let assocSeqReverseLookup : all k. all v. AssocTraits v -> v -> AssocSeq k v -> Option k =
   lam revTraits : {eq : v -> v -> Bool}. lam v. lam s.
     optionMapOr (None ())
                 (lam t : (k, v). Some t.0)
                 (find (lam t : (k, v). revTraits.eq v t.1) s)
 
-let assocSeqMap : (v1 -> v2) -> AssocSeq k v1 -> AssocSeq k v2 =
+let assocSeqMap : all k. all v1. all v2. (v1 -> v2) -> AssocSeq k v1 -> AssocSeq k v2 =
   lam f. lam s.
-    map (lam t : (k, v). (t.0, f t.1)) s
+    map (lam t : (k, v1). (t.0, f t.1)) s
 
-let assocSeqFold : (acc -> k -> v -> acc) -> acc -> AssocSeq k v -> acc =
+let assocSeqFold : all acc. all k. all v.
+  (acc -> k -> v -> acc) -> acc -> AssocSeq k v -> acc =
   lam f. lam acc. lam s.
     foldl (lam acc. lam kv : (k, v). f acc kv.0 kv.1) acc s

--- a/stdlib/common.mc
+++ b/stdlib/common.mc
@@ -7,7 +7,8 @@ let const = lam x. lam. x
 let apply = lam f. lam x. f x
 let compose = lam f. lam g. lam x. f (g x)
 let curry = lam f. lam x. lam y. f(x, y)
-let uncurry = lam f. lam t : (a, b). f t.0 t.1
+let uncurry : all a. all b. all c. (a -> b -> c) -> (a, b) -> c =
+  lam f. lam t : (a, b). f t.0 t.1
 let flip = lam f. lam x. lam y. f y x
 
 -- Printing stuff
@@ -17,15 +18,17 @@ let printSeqLn = lam s. printSeq s; print "\n"; flushStdout ()
 let dprintLn = lam x. dprint x; printLn ""
 
 recursive
-  let fix = lam f. lam e. f (fix f) e
+  let fix : all a. all b. ((a -> b) -> a -> b) -> a -> b =
+    lam f. lam e. f (fix f) e
 end
 
 -- Fixpoint computation for mutual recursion. Thanks Oleg Kiselyov!
 -- (http://okmij.org/ftp/Computation/fixed-point-combinators.html)
-let fixMutual =
+let fixMutual : all a. all b. [[a -> b] -> a -> b] -> [a -> b] =
   lam l.
     let l = map (lam li. (li,)) l in
-    fix (lam self. lam l. map (lam li : {#label"0": a -> b -> c}. lam x. li.0 (self l) x) l) l
+    fix (lam self. lam l.
+      map (lam li : {#label"0" : [a -> b] -> a -> b}. lam x. li.0 (self l) x) l) l
 
 
 mexpr

--- a/stdlib/digraph.mc
+++ b/stdlib/digraph.mc
@@ -26,65 +26,66 @@ type Digraph v l = { adj : Map v [(v,l)],
                      eql : l -> l -> Bool }
 
 -- Returns an empty graph. Input: equality functions for vertices and labels.
-let digraphEmpty : (v -> v -> Int) -> (l -> l -> Bool) -> Digraph v l =
-  lam cmpv : v -> v -> Int. lam eql : l -> l -> Bool.
-  {adj = mapEmpty cmpv, eql = eql}
+let digraphEmpty : all v. all l. (v -> v -> Int) -> (l -> l -> Bool) -> Digraph v l =
+  lam cmpv. lam eql. {adj = mapEmpty cmpv, eql = eql}
 
 -- Get comparison function for vertices.
-let digraphCmpv = lam g : Digraph v l.
-  mapGetCmpFun g.adj
+let digraphCmpv : all v. all l. Digraph v l -> v -> v -> Int =
+  lam g. mapGetCmpFun g.adj
 
 -- Get equivalence function for vertices.
-let digraphEqv = lam g : Digraph v l.
-  lam v1. lam v2. eqi (digraphCmpv g v1 v2) 0
+let digraphEqv : all v. all l. Digraph v l -> v -> v -> Bool =
+  lam g. lam v1. lam v2. eqi (digraphCmpv g v1 v2) 0
 
 -- Get equivalence function for labels.
-let digraphEql = lam g : Digraph v l.
-  g.eql
+let digraphEql : all v. all l. Digraph v l -> l -> l -> Bool =
+  lam g. g.eql
 
 -- Get the vertices of the graph g.
-let digraphVertices = lam g : Digraph v l.
-  mapKeys g.adj
+let digraphVertices : all v. all l. Digraph v l -> [v] =
+  lam g. mapKeys g.adj
 
 -- Get the number of vertices in graph g.
-let digraphCountVertices = lam g : Digraph v l.
-  mapSize g.adj
+let digraphCountVertices : all v. all l. Digraph v l -> Int =
+  lam g. mapSize g.adj
 
 -- Get the edges of the graph g.
-let digraphEdges : Digraph v l -> [DigraphEdge v l] = lam g : Digraph v l.
+let digraphEdges : all v. all l. Digraph v l -> [DigraphEdge v l] = lam g.
   foldl (lam acc. lam b : (v, [(v,l)]).
     concat acc (map (lam t : (v, l). (b.0, t.0, t.1)) b.1))
     [] (mapBindings g.adj)
 
 -- Get the edges of the graph g.
-let digraphCountEdges = lam g : Digraph v l.
+let digraphCountEdges : all v. all l. Digraph v l -> Int = lam g.
   foldl (lam acc. lam es. addi acc (length es)) 0 (mapValues g.adj)
 
 -- Get the outgoing edges from vertex v in graph g.
-let digraphEdgesFrom = lam v : v. lam g : Digraph v l.
+let digraphEdgesFrom : all v. all l. v -> Digraph v l -> [DigraphEdge v l] =
+  lam v. lam g.
   map (lam t : (v, l). (v, t.0, t.1))
     (mapLookupOrElse (lam. error "Lookup failed") v g.adj)
 
 -- Get the incoming edges to vertex v in graph g.
-let digraphEdgesTo = lam v : v. lam g : Digraph v l.
+let digraphEdgesTo : all v. all l. v -> Digraph v l -> [DigraphEdge v l] =
+  lam v. lam g.
   let allEdges = digraphEdges g in
   filter (lam tup : DigraphEdge v l. eqi (digraphCmpv g v tup.1) 0) allEdges
 
 -- Get all edges from v1 to v2 in graph g.
-let digraphEdgesBetween : v -> v -> Digraph v l -> [DigraphEdge v l] =
-  lam v1. lam v2. lam g : Digraph v l.
+let digraphEdgesBetween : all v. all l. v -> v -> Digraph v l -> [DigraphEdge v l] =
+  lam v1. lam v2. lam g.
   let fromV1 = digraphEdgesFrom v1 g in
   filter (lam t : DigraphEdge v l. eqi (digraphCmpv g v2 t.1) 0) fromV1
 
 -- Get all labels between v1 and v2 in graph g.
-let digraphLabels = lam v1 : v. lam v2 : v. lam g : Digraph v l.
+let digraphLabels : all v. all l. v -> v -> Digraph v l -> [l] = lam v1. lam v2. lam g.
   let from_v1_to_v2 =
     filter (lam tup : DigraphEdge v l. eqi (digraphCmpv g tup.1 v2) 0)
       (digraphEdgesFrom v1 g) in
   map (lam tup : DigraphEdge v l. tup.2) from_v1_to_v2
 
 -- Check whether g has vertex v.
-let digraphHasVertex = lam v. lam g : Digraph v l.
+let digraphHasVertex : all v. all l. v -> Digraph v l -> Bool = lam v. lam g.
   mapMem v g.adj
 
 -- Check whether g has all the vertices vs.
@@ -92,14 +93,16 @@ let digraphHasVertices = lam vs. lam g.
   forAll (lam v. digraphHasVertex v g) vs
 
 -- Check whether edges e1 and e2 are equal in graph g.
-let digraphEdgeEq =
-  lam g : Digraph v l. lam e1 : DigraphEdge v l. lam e2 : DigraphEdge v l.
+let digraphEdgeEq : all v. all l.
+  Digraph v l -> DigraphEdge v l -> DigraphEdge v l -> Bool =
+  lam g. lam e1. lam e2.
   and (and (eqi (digraphCmpv g e1.0 e2.0) 0)
            (eqi (digraphCmpv g e1.1 e2.1) 0))
       (g.eql e1.2 e2.2)
 
 -- Check whether g has edge e.
-let digraphHasEdge = lam e : DigraphEdge v l. lam g : Digraph v l.
+let digraphHasEdge : all v. all l. DigraphEdge v l -> Digraph v l -> Bool =
+  lam e. lam g.
   match e with (from, to, lbl) in
   match mapLookup from g.adj with Some edgesFrom then
     any (lam t : (v, l).
@@ -114,8 +117,8 @@ let digraphHasEdges = lam es. lam g.
   forAll (lam e. digraphHasEdge e g) es
 
 -- Check whether graph g1 is equal to graph g2.
-let digraphGraphEq =
-  lam g1: Digraph v l. lam g2: Digraph v l.
+let digraphGraphEq : all v. all l. Digraph v l -> Digraph v l -> Bool =
+  lam g1. lam g2.
     if eqi (digraphCountEdges g1) (digraphCountEdges g2) then
       if eqi (digraphCountVertices g1) (digraphCountVertices g2) then
         mapEq (lam ds1. lam ds2.
@@ -132,18 +135,19 @@ let digraphGraphEq =
     else false
 
 -- Get successor nodes of v.
-let digraphSuccessors = lam v. lam g : Digraph v l.
+let digraphSuccessors : all v. all l. v -> Digraph v l -> [v] = lam v. lam g.
   let outgoing = digraphEdgesFrom v g in
   let successors = map (lam t : DigraphEdge v l. t.1) outgoing in
   setToSeq (setOfSeq (digraphCmpv g) successors)
 
 -- Get predecessor nodes of v.
-let digraphPredeccessors = lam v. lam g : Digraph v l.
+let digraphPredeccessors : all v. all l. v -> Digraph v l -> [v] = lam v. lam g.
   distinct (lam v1. lam v2. eqi (digraphCmpv g v1 v2) 0)
     (map (lam tup : DigraphEdge v l. tup.0) (digraphEdgesTo v g))
 
 -- Check whether vertex v1 is a successor of vertex v2 in graph g.
-let digraphIsSuccessor = lam v1. lam v2. lam g : Digraph v l.
+let digraphIsSuccessor : all v. all l. v -> v -> Digraph v l -> Bool =
+  lam v1. lam v2. lam g.
   let outgoing = mapLookupOrElse (lam. error "Lookup failed") v2 g.adj in
   let successors = map (lam t : (v, l). t.0) outgoing in
   let successors = setOfSeq (digraphCmpv g) successors in
@@ -153,7 +157,8 @@ let digraphIsSuccessor = lam v1. lam v2. lam g : Digraph v l.
 -- Add vertex v to graph g if it doesn't already exist in g.
 -- If v exists in g and check is true, an error is thrown.
 -- If v exist in g and check is false, g stays unchanged.
-let digraphAddVertexCheck = lam v. lam g : Digraph v l. lam check.
+let digraphAddVertexCheck : all v. all l. v -> Digraph v l -> Bool -> Digraph v l =
+  lam v. lam g. lam check.
   if digraphHasVertex v g then
     if check then error "vertex already exists" else g
   else
@@ -168,7 +173,8 @@ let digraphMaybeAddVertex = lam v. lam g.
   digraphAddVertexCheck v g false
 
 -- Add a vertex v to g. Updates the vertex v in graph g if v already exists in g.
-let digraphAddUpdateVertex = lam v. lam g : Digraph v l.
+let digraphAddUpdateVertex : all v. all l. v -> Digraph v l -> Digraph v l =
+  lam v. lam g.
   if digraphHasVertex v g then
     let edgeList = mapLookupOrElse (lam. error "Lookup failed") v g.adj in
     let m = mapRemove v g.adj in
@@ -181,7 +187,8 @@ let digraphAddUpdateVertex = lam v. lam g : Digraph v l.
     {g with adj = mapInsert v [] g.adj}
 
 -- Add edge e=(v1,v2,l) to g. Checks invariants iff utests are enabled.
-let digraphAddEdge = lam v1. lam v2. lam l. lam g : Digraph v l.
+let digraphAddEdge : all v. all l. v -> v -> l -> Digraph v l -> Digraph v l =
+  lam v1. lam v2. lam l. lam g.
   utest digraphHasVertex v1 g with true in
   utest digraphHasVertex v2 g with true in
   utest
@@ -193,7 +200,8 @@ let digraphAddEdge = lam v1. lam v2. lam l. lam g : Digraph v l.
   {g with adj = mapInsert v1 (snoc oldEdgeList (v2, l)) g.adj}
 
 -- Add edge e=(v1,v2,l) to g. Graph stays unchanged if e already exists in g.
-let digraphMaybeAddEdge = lam v1. lam v2. lam l. lam g : Digraph v l.
+let digraphMaybeAddEdge : all v. all l. v -> v -> l -> Digraph v l -> Digraph v l =
+  lam v1. lam v2. lam l. lam g.
   if digraphHasEdge (v1,v2,l) g then g
   else
     let oldEdgeList =
@@ -202,7 +210,8 @@ let digraphMaybeAddEdge = lam v1. lam v2. lam l. lam g : Digraph v l.
     {g with adj = mapInsert v1 (snoc oldEdgeList (v2, l)) g.adj}
 
 -- Add a list of edges to a graph g using the digraphMaybeAddEdge.
-let digraphMaybeAddEdges = lam es. lam g.
+let digraphMaybeAddEdges : all v. all l. [DigraphEdge v l] -> Digraph v l -> Digraph v l =
+  lam es. lam g.
   foldl (lam g. lam e : DigraphEdge v l. digraphMaybeAddEdge e.0 e.1 e.2 g) g es
 
 -- Add a list of vertices to a graph g.
@@ -210,18 +219,20 @@ let digraphAddVertices = lam vs. lam g.
   foldl (lam g. lam v. digraphAddVertex v g) g vs
 
 -- Add a list of edges to a graph g.
-let digraphAddEdges = lam es. lam g.
+let digraphAddEdges : all v. all l. [DigraphEdge v l] -> Digraph v l -> Digraph v l =
+  lam es. lam g.
   foldl (lam g. lam e : DigraphEdge v l. digraphAddEdge e.0 e.1 e.2 g) g es
 
 -- Reverse the direction of graph g.
-let digraphReverse = lam g : Digraph v l.
+let digraphReverse : all v. all l. Digraph v l -> Digraph v l = lam g.
   let edgesReversed = map (lam e : DigraphEdge v l. (e.1, e.0, e.2)) (digraphEdges g) in
   let vs = digraphVertices g in
   digraphAddEdges edgesReversed
     (digraphAddVertices vs (digraphEmpty (digraphCmpv g) g.eql))
 
 -- Remove an edge from the graph g.
-let digraphRemoveEdge = lam from. lam to. lam l. lam g : Digraph v l.
+let digraphRemoveEdge : all v. all l. v -> v -> l -> Digraph v l -> Digraph v l =
+  lam from. lam to. lam l. lam g.
   utest (digraphHasEdge (from, to, l) g) with true in
   let outgoing = mapFindExn from g.adj in
   let newOutgoing = filter (lam o : (v, l). not (g.eql l o.1)) outgoing in
@@ -229,7 +240,7 @@ let digraphRemoveEdge = lam from. lam to. lam l. lam g : Digraph v l.
 
 -- Breadth-first search. Marks all reachable vertices from the source with the
 -- distance to the source.
-let digraphBFS : Digraph v l -> v -> Map v Int = lam source. lam g.
+let digraphBFS : all v. all l. v -> Digraph v l -> Map v Int = lam source. lam g.
   recursive let work = lam fs. lam level. lam dist : Map v Int.
     if null fs then dist else
     match
@@ -245,10 +256,10 @@ let digraphBFS : Digraph v l -> v -> Map v Int = lam source. lam g.
   in
   work [source] 1 (mapInsert source 0 (mapEmpty (digraphCmpv g)))
 
-type Successors v l = {
+type Successors v = {
   i : Int,
-  number : Map v l,
-  lowlink : Map v l,
+  number : Map v Int,
+  lowlink : Map v Int,
   stack : [v],
   comps : [[v]]
 }
@@ -256,17 +267,17 @@ type Successors v l = {
 -- Strongly connected components of g.
 -- From the paper: Depth-First Search and Linear Graph Algorithms, Tarjan 72.
 -- https://doi.org/10.1137/0201010
-let digraphTarjan : Digraph v l -> [[v]] =
+let digraphTarjan : all v. all l. Digraph v l -> [[v]] =
 lam g.
   let cmpv = digraphCmpv g in
   let eqv = lam x. lam y. eqi (cmpv x y) 0 in
   let mapFind = mapFindExn in
   let and = lam x. lam y. if not x then false else y in
 
-  recursive let strongConnect = lam s : Successors v l. lam v.
-    let traverseSuccessors = lam s : Successors v l. lam w.
+  recursive let strongConnect = lam s : Successors v. lam v.
+    let traverseSuccessors = lam s : Successors v. lam w.
       if not (mapMem w s.number) then
-        let s : Successors v l = strongConnect s w in
+        let s : Successors v = strongConnect s w in
         let n = mini (mapFind v s.lowlink) (mapFind w s.lowlink) in
         {s with lowlink = mapInsert v n s.lowlink}
       else if lti (mapFind w s.number) (mapFind v s.number) then
@@ -277,7 +288,7 @@ lam g.
       else s
     in
 
-    let popStackIntoComp = lam s : Successors v l.
+    let popStackIntoComp = lam s : Successors v.
       let vn = mapFind v s.number in
       recursive let work = lam comp. lam stack.
         match stack with [] then (comp, stack)
@@ -297,7 +308,7 @@ lam g.
                   with i = addi s.i 1}
     in
 
-    let s : Successors v l =
+    let s : Successors v =
       foldl traverseSuccessors s (digraphSuccessors v g)
     in
 
@@ -305,9 +316,9 @@ lam g.
     then popStackIntoComp s else s
   in
 
-  let s : Successors v l =
+  let s : Successors v =
     foldl
-      (lam s : Successors v l. lam v.
+      (lam s : Successors v. lam v.
         if not (mapMem v s.number) then strongConnect s v else s)
       {
         i = 0,
@@ -325,7 +336,7 @@ let digraphStrongConnects = lam g. digraphTarjan g
 -- Kahn's algorithm: Topological sorting of large networks
 -- https://dl.acm.org/doi/10.1145/368996.369025
 -- Returns a list of sorted vertices
-let digraphTopologicalOrder:Digraph v l -> [v] = lam g.
+let digraphTopologicalOrder : all v. all l. Digraph v l -> [v] = lam g.
   let indegrees = foldl (lam acc. lam v. mapInsert v (length (digraphEdgesTo v g)) acc) (mapEmpty (digraphCmpv g)) (digraphVertices g) in
   let rootnodes = filter (lam v. eqi (length (digraphEdgesTo v g)) 0) (digraphVertices g) in
   recursive
@@ -344,7 +355,9 @@ let digraphTopologicalOrder:Digraph v l -> [v] = lam g.
   else error "Cycle detected! Topological order only applies to DAG"
 
 -- Print as dot format
-let digraphPrintDot = lam g. lam v2str. lam l2str.
+let digraphPrintDot : all v. all l.
+  Digraph v l -> (v -> String) -> (l -> String) -> () =
+  lam g. lam v2str. lam l2str.
   print "digraph {";
   (map
     (lam e : DigraphEdge v l.
@@ -368,7 +381,7 @@ let l5 = gensym () in
 let empty = digraphEmpty subi eqsym in
 
 utest digraphVertices empty with [] using eqSeq eqi in
-utest digraphEdges empty with [] using eqSeq eqi in
+utest digraphEdges empty with [] in
 utest digraphCountVertices empty with 0 in
 utest digraphCountEdges empty with 0 in
 
@@ -376,7 +389,7 @@ let g = digraphAddVertex 1 empty in
 
 utest digraphCountVertices g with 1 in
 utest digraphVertices g with [1] in
-utest digraphEdges g with [] using eqSeq eqi in
+utest digraphEdges g with [] in
 utest digraphHasVertex 1 g with true in
 utest digraphHasVertex 2 g with false in
 
@@ -407,7 +420,7 @@ utest
   then true else false with true
 in
 
-let g : Digraph v l =
+let g : Digraph Int Symbol =
   digraphAddEdges [(2,3,l4),(1,3,l3),(1,2,l2),(1,2,l1)] (digraphAddVertices [1,2,3] empty)
 in
 

--- a/stdlib/ext/async-ext.ext-ocaml.mc
+++ b/stdlib/ext/async-ext.ext-ocaml.mc
@@ -8,36 +8,36 @@ let asyncExtMap =
   [
     ("asyncSleepSec", [
       { expr = "Lwt_unix.sleep",
-        ty = tyarrows_ [tyfloat_, otyvarext_ "'a Lwt.t"],
+        ty = tyarrows_ [tyfloat_, otyvarext_ "'a Lwt.t" []],
         libraries = ["lwt.unix"],
         cLibraries = []
       }
     ]),
     ("asyncRun", [
       { expr = "Lwt_main.run",
-        ty = tyarrows_ [otyvarext_ "'a Lwt.t", otyvarext_ "'a"],
+        ty = tyarrows_ [otyvarext_ "'a Lwt.t" [], otyvarext_ "'a" []],
         libraries = ["lwt.unix"],
         cLibraries = []
       }
     ]),
     ("asyncBind", [
       { expr = "Lwt.bind",
-        ty = tyarrows_ [otyvarext_ "'a Lwt.t",
-                (tyarrows_ [otyvarext_ "'a", otyvarext_ "'b Lwt.t"]), otyvarext_ "'b Lwt.t"],
+        ty = tyarrows_ [otyvarext_ "'a Lwt.t" [],
+                (tyarrows_ [otyvarext_ "'a" [], otyvarext_ "'b Lwt.t" []]), otyvarext_ "'b Lwt.t" []],
         libraries = ["lwt.unix"],
         cLibraries = []
       }
     ]),
     ("asyncPrint", [
       { expr = "Lwt_io.print",
-        ty = tyarrows_ [otystring_ , otyvarext_ "unit Lwt.t"],
+        ty = tyarrows_ [otystring_ , otyvarext_ "unit Lwt.t" []],
         libraries = ["lwt.unix"],
         cLibraries = []
       }
     ]),
     ("asyncReturn", [
       { expr = "Lwt.return",
-        ty = tyarrows_ [otyvarext_ "'a", otyvarext_ "'a Lwt.t"],
+        ty = tyarrows_ [otyvarext_ "'a" [], otyvarext_ "'a Lwt.t" []],
         libraries = ["lwt.unix"],
         cLibraries = []
       }

--- a/stdlib/ext/file-ext.ext-ocaml.mc
+++ b/stdlib/ext/file-ext.ext-ocaml.mc
@@ -29,77 +29,77 @@ let fileExtMap =
     ]),
     ("writeOpen", [
       { expr = "(fun s -> try (open_out_bin s, true) with _ -> (stdout, false))",
-        ty = tyarrows_ [otystring_, otytuple_ [otyvarext_ "out_channel", tybool_]],
+        ty = tyarrows_ [otystring_, otytuple_ [otyvarext_ "out_channel" [], tybool_]],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("writeString", [
       { expr = "output_string",
-        ty = tyarrows_ [otyvarext_ "out_channel", otystring_, otyunit_],
+        ty = tyarrows_ [otyvarext_ "out_channel" [], otystring_, otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("writeFlush", [
       { expr = "flush",
-        ty = tyarrows_ [otyvarext_ "out_channel", otyunit_],
+        ty = tyarrows_ [otyvarext_ "out_channel" [], otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("writeClose", [
       { expr = "close_out_noerr",
-        ty = tyarrows_ [otyvarext_ "out_channel", otyunit_],
+        ty = tyarrows_ [otyvarext_ "out_channel" [], otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("readOpen", [
       { expr = "(fun s -> try (open_in_bin s, true) with _ -> (stdin, false))",
-        ty = tyarrows_ [otystring_, otytuple_ [otyvarext_ "in_channel", tybool_]],
+        ty = tyarrows_ [otystring_, otytuple_ [otyvarext_ "in_channel" [], tybool_]],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("readLine", [
       { expr = "(fun rc -> try (input_line rc, false) with | End_of_file -> (\"\",true))",
-        ty = tyarrows_ [otyvarext_ "in_channel", otytuple_ [otystring_, tybool_]],
+        ty = tyarrows_ [otyvarext_ "in_channel" [], otytuple_ [otystring_, tybool_]],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("readString", [
       { expr = "(fun f -> try really_input_string f (in_channel_length f) with _ -> \"\")",
-        ty = tyarrows_ [otyvarext_ "in_channel", otystring_],
+        ty = tyarrows_ [otyvarext_ "in_channel" [], otystring_],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("readClose", [
       { expr = "close_in_noerr",
-        ty = tyarrows_ [otyvarext_ "in_channel", otyunit_],
+        ty = tyarrows_ [otyvarext_ "in_channel" [], otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("stdin", [
       { expr = "stdin",
-        ty = otyvarext_ "in_channel",
+        ty = otyvarext_ "in_channel" [],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("stdout", [
       { expr = "stdout",
-        ty = otyvarext_ "out_channel",
+        ty = otyvarext_ "out_channel" [],
         libraries = [],
         cLibraries = []
       }
     ]),
     ("stderr", [
       { expr = "stderr",
-        ty = otyvarext_ "out_channel",
+        ty = otyvarext_ "out_channel" [],
         libraries = [],
         cLibraries = []
       }

--- a/stdlib/ext/toml-ext.ext-ocaml.mc
+++ b/stdlib/ext/toml-ext.ext-ocaml.mc
@@ -1,8 +1,8 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let tyTomlTable_ = otyvarext_ "Toml.Types.table"
-let tyTomlValue_ = otyvarext_ "Toml.Types.value"
+let tyTomlTable_ = otyvarext_ "Toml.Types.table" []
+let tyTomlValue_ = otyvarext_ "Toml.Types.value" []
 
 let impl = lam arg : { expr : String, ty : Type }.
   { expr = arg.expr, ty = arg.ty, libraries = ["toml"], cLibraries = [] }

--- a/stdlib/graph.mc
+++ b/stdlib/graph.mc
@@ -26,11 +26,11 @@ let graphEmpty = digraphEmpty
 let graphVertices = digraphVertices
 
 -- Get comparison function for vertices.
-let graphCmpv = lam g : Graph v l.
-  mapGetCmpFun g.adj
+let graphCmpv : all v. all l. Graph v l -> v -> v -> Int =
+  lam g. mapGetCmpFun g.adj
 
-let graphEdgeEq =
-lam g : Graph v l. lam e1 : DigraphEdge v l. lam e2: DigraphEdge v l.
+let graphEdgeEq : all v. all l. Graph v l -> DigraphEdge v l -> DigraphEdge v l -> Bool =
+  lam g. lam e1. lam e2.
   let eqv = digraphEqv g in
   and (or (and (eqv e1.0 e2.0) (eqv e1.1 e2.1))
           (and (eqv e1.1 e2.0) (eqv e1.0 e2.1)))

--- a/stdlib/iterator.mc
+++ b/stdlib/iterator.mc
@@ -13,20 +13,21 @@ type Iterator a b =
 -- 'iteratorInit step get' returns an iterator with step function 'step' and get
 -- function 'get'.
 let iteratorInit
-  : (Option a -> Option a)
-  -> (Option a -> Option b)
+  : all a. all b.
+     (Option a -> Option a)
+  -> (a -> b)
   -> Iterator a b
   = lam step. lam getVal.
     {state = None (), step = step, getVal = getVal}
 
 -- 'iteratorStep' moves the iterator one step and returns the new iterator.
-let iteratorStep : Iterator a b -> Iterator a b = lam it.
+let iteratorStep : all a. all b. Iterator a b -> Iterator a b = lam it.
   match it with {state = state, step = step} then
     {it with state = step state}
   else never
 
 -- 'iteratorGet it' returns the current value of the iterator.
-let iteratorGet : Iterator a b -> Option b = lam it.
+let iteratorGet : all a. all b. Iterator a b -> Option b = lam it.
   match it with {state = state, getVal = getVal} then
     match state with Some v then Some (getVal v)
     else None ()
@@ -34,12 +35,12 @@ let iteratorGet : Iterator a b -> Option b = lam it.
 
 -- 'iteratorNext it' moves the iterator one step. Returns both the new iterator
 -- and the current value.
-let iteratorNext : Iterator a b -> (Iterator a b, Option b) = lam it.
+let iteratorNext : all a. all b. Iterator a b -> (Iterator a b, Option b) = lam it.
   let it = iteratorStep it in
   (it, iteratorGet it)
 
 -- 'iteratorFromSeq it' converts 'it' into a sequence.
-let iteratorToSeq : Iterator a b -> [b] = lam it.
+let iteratorToSeq : all a. all b. Iterator a b -> [b] = lam it.
   recursive let work = lam acc. lam it.
     let n = iteratorNext it in
     match n with (_, None ()) then acc
@@ -49,7 +50,7 @@ let iteratorToSeq : Iterator a b -> [b] = lam it.
   in reverse (work [] it)
 
 -- 'iteratorFromSeq seq' converts 'seq' into an iterator.
-let iteratorFromSeq : [a] -> Iterator [a] a = lam seq.
+let iteratorFromSeq : all a. [a] -> Iterator [a] a = lam seq.
   let step = lam state.
     match state with Some ([] | [_]) then None ()
     else match state with Some seq then Some (tail seq)
@@ -62,7 +63,7 @@ let iteratorFromSeq : [a] -> Iterator [a] a = lam seq.
 -- 'iteratorTake n it' returns at most the first 'n' elements in iterator 'it'.
 -- If 'n' is negative, or if 'n' is larger than the number of elements in 'it',
 -- then all elements in 'it' are returned.
-let iteratorTake : Int -> Iterator a b -> [b] = lam n. lam it.
+let iteratorTake : all a. all b. Int -> Iterator a b -> [b] = lam n. lam it.
   recursive let work = lam acc. lam n. lam it.
     if eqi n 0 then acc
     else
@@ -75,7 +76,7 @@ let iteratorTake : Int -> Iterator a b -> [b] = lam n. lam it.
 
 -- 'iteratorFilter p it' returns a new iterator containing those element in 'it'
 -- that satisfy 'p'.
-let iteratorFilter : (b -> Bool) -> Iterator a b -> Iterator a b =
+let iteratorFilter : all a. all b. (b -> Bool) -> Iterator a b -> Iterator a b =
   lam p. lam it.
     {it with step = lam state.
        recursive let step = lam state.

--- a/stdlib/log.mc
+++ b/stdlib/log.mc
@@ -7,7 +7,7 @@ include "seq.mc"
   is set to off.
 -/
 
-type Loglevel = Int
+type LogLevel = Int
 let logLevel = {
   off = 0,
   error = 1,
@@ -27,7 +27,7 @@ let _logLevelToString = lam lvl : LogLevel.
   else ""
 
 -- Sets the log level
-let logSetLogLevel = lam lvl : Loglevel. modref _logLevel lvl
+let logSetLogLevel = lam lvl : LogLevel. modref _logLevel lvl
 
 -- `log lvl msg` logs the message `msg` at the log level `lvl`.
 let logMsg = lam lvl : LogLevel. lam msg : String.

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -9,44 +9,47 @@ include "string.mc"
 
 
 -- Aliases
-let mapLength : Map k v -> Int = lam m. mapSize m
-let mapLookupOrElse : (Unit -> v) -> k -> Map k v -> v =
+let mapLength : all k. all v. Map k v -> Int = lam m. mapSize m
+let mapLookupOrElse : all k. all v. (() -> v) -> k -> Map k v -> v =
   lam f. lam k. lam m.
   mapFindOrElse f k m
-let mapLookupApplyOrElse : (v1 -> v2) -> (Unit -> v2) -> k -> Map k v1 -> v2 =
+let mapLookupApplyOrElse : all k. all v1. all v2.
+  (v1 -> v2) -> (() -> v2) -> k -> Map k v1 -> v2 =
   lam f1. lam f2. lam k. lam m.
   mapFindApplyOrElse f1 f2 k m
 
-let mapIsEmpty : Map k v -> Bool = lam m. eqi (mapSize m) 0
+let mapIsEmpty : all k. all v. Map k v -> Bool = lam m. eqi (mapSize m) 0
 
-let mapLookup : k -> Map k v -> Option v =
+let mapLookup : all k. all v. k -> Map k v -> Option v =
   lam k. lam m.
     mapFindApplyOrElse (lam v. Some v) (lam. None ()) k m
 
-let mapInsertWith : (v -> v -> v) -> k -> v -> Map k v -> Map k v =
+let mapInsertWith : all k. all v. (v -> v -> v) -> k -> v -> Map k v -> Map k v =
   lam f. lam k. lam v. lam m.
     match mapLookup k m with Some prev then
       mapInsert k (f prev v) m
     else mapInsert k v m
 
-let mapUnion : Map k v -> Map k v -> Map k v = lam l. lam r.
+let mapUnion : all k. all v. Map k v -> Map k v -> Map k v = lam l. lam r.
   foldl (lam acc. lam binding : (k, v). mapInsert binding.0 binding.1 acc)
         l (mapBindings r)
 
-let mapFromSeq : (k -> k -> Int) -> [(k, v)] -> Map k v = lam cmp. lam bindings.
+let mapFromSeq : all k. all v. (k -> k -> Int) -> [(k, v)] -> Map k v =
+  lam cmp. lam bindings.
   foldl (lam acc. lam binding : (k, v). mapInsert binding.0 binding.1 acc)
         (mapEmpty cmp) bindings
 
-let mapKeys : Map k v -> [k] = lam m.
+let mapKeys : all k. all v. Map k v -> [k] = lam m.
   mapFoldWithKey (lam ks. lam k. lam. snoc ks k) [] m
 
-let mapValues : Map k v -> [v] = lam m.
+let mapValues : all k. all v. Map k v -> [v] = lam m.
   mapFoldWithKey (lam vs. lam. lam v. snoc vs v) [] m
 
-let mapToSeq : Map k v -> [(k,v)] = lam m.
+let mapToSeq : all k. all v. Map k v -> [(k,v)] = lam m.
   mapBindings m
 
-let mapMapAccum : (acc -> k -> v1 -> (acc, v2)) -> acc -> Map k v1 -> (acc, Map k v2) =
+let mapMapAccum : all k. all v1. all v2. all acc.
+  (acc -> k -> v1 -> (acc, v2)) -> acc -> Map k v1 -> (acc, Map k v2) =
   lam f. lam acc. lam m.
     mapFoldWithKey
       (lam tacc : (acc, Map k v2). lam k. lam v1.
@@ -54,20 +57,21 @@ let mapMapAccum : (acc -> k -> v1 -> (acc, v2)) -> acc -> Map k v1 -> (acc, Map 
          match fval with (acc, v2) then (acc, mapInsert k v2 tacc.1) else never)
       (acc, mapEmpty (mapGetCmpFun m)) m
 
-let mapFoldlOption : (acc -> k -> v -> Option acc)
-                  -> acc -> Map k v -> Option acc =
+let mapFoldlOption : all k. all v. all acc.
+  (acc -> k -> v -> Option acc) -> acc -> Map k v -> Option acc =
   lam f. lam acc. lam m.
     optionFoldlM (lam acc. lam t : (k, v). f acc t.0 t.1) acc (mapBindings m)
 
-let mapAllWithKey : (k -> v -> Bool) -> Map k v -> Bool = lam f. lam m.
+let mapAllWithKey : all k. all v. (k -> v -> Bool) -> Map k v -> Bool =
+  lam f. lam m.
   mapFoldWithKey (lam acc. lam k. lam v. and acc (f k v)) true m
 
-let mapAll : (v -> Bool) -> Map k v -> Bool = lam f. lam m.
+let mapAll : all k. all v. (v -> Bool) -> Map k v -> Bool = lam f. lam m.
   mapFoldWithKey (lam acc. lam. lam v. and acc (f v)) true m
 
 -- `mapChoose m` chooses one binding from `m`, giving `None ()` if `m` is
 -- empty.
-let mapChoose : Map k v -> Option (k, v) = lam m.
+let mapChoose : all k. all v. Map k v -> Option (k, v) = lam m.
   if mapIsEmpty m then None () else Some (mapChooseExn m)
 
 mexpr
@@ -113,11 +117,11 @@ utest mapLookup 4 merged with Some "44" using optionEq eqString in
 utest mapLookup (negi 1) merged with Some "-1" using optionEq eqString in
 utest mapLookup 5 merged with None () using optionEq eqString in
 
-utest mapFoldlOption (lam acc. lam k. lam v. Some v) 0 m
+utest mapFoldlOption (lam acc. lam k. lam v. Some v) "0" m
 with Some "3" using optionEq eqString in
 utest mapFoldlOption
   (lam acc. lam k. lam v. if eqi k acc then None () else Some acc) 3 m
-with None () using optionEq eqString in
+with None () using optionEq eqi in
 
 let m = mapFromSeq subi
   [ (1, "1")

--- a/stdlib/maxmatch.mc
+++ b/stdlib/maxmatch.mc
@@ -53,7 +53,7 @@ lam w.
       preds = negv
     }
 
-let debugShowState = lam state.
+let debugShowState = lam state : State.
   printLn "===";
   print "\nlus: ";
   dprint state.lus;

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -54,12 +54,12 @@ let tyarrows_ = use FunTypeAst in
   lam tys.
   foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
 
-let tyrecord_ = use RecordTypeAst in
+let tyrecord_ : [(String, Type)] -> Type = use RecordTypeAst in
   lam fields.
-  let fieldMapFunc = lam b : (String, a). (stringToSid b.0, b.1) in
+  let fieldMapFunc = lam b : (String, Type). (stringToSid b.0, b.1) in
   TyRecord {
     fields = mapFromSeq cmpSID (map fieldMapFunc fields),
-    labels = map (lam b : (String, a). stringToSid b.0) fields,
+    labels = map (lam b : (String, Type). stringToSid b.0) fields,
     info = NoInfo ()
   }
 
@@ -257,10 +257,11 @@ let pcon_ = use MExprAst in
   lam cs. lam cp.
   npcon_ (nameNoSym cs) cp
 
-let patRecord = use MExprAst in
+let patRecord : [(String, Pat)] -> Info -> Pat =
+  use MExprAst in
   lam bindings : [(String, Pat)].
   lam info : Info.
-  let bindingMapFunc = lam b : (String, a). (stringToSid b.0, b.1) in
+  let bindingMapFunc = lam b : (String, Pat). (stringToSid b.0, b.1) in
   PatRecord {
     bindings = mapFromSeq cmpSID (map bindingMapFunc bindings),
     info = info,
@@ -566,8 +567,9 @@ let record_add = use MExprAst in
   else
       error "record is not a TmRecord construct"
 
-let record_add_bindings = lam bindings. lam record.
-  foldl (lam recacc. lam b : (k, v). record_add b.0 b.1 recacc) record bindings
+let record_add_bindings : [(String, Expr)] -> Expr -> Expr =
+  lam bindings. lam record.
+  foldl (lam recacc. lam b : (String, Expr). record_add b.0 b.1 recacc) record bindings
 
 let never_ = use MExprAst in
   TmNever {ty = tyunknown_, info = NoInfo ()}

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -88,7 +88,7 @@ let tycon_ = lam s.
 
 let ntyvar_ = use VarTypeAst in
   lam n.
-  TyVar {ident = n, info = NoInfo ()}
+  TyVar {ident = n, level = 0, info = NoInfo ()}
 
 let tyvar_ =
   lam s.
@@ -109,13 +109,16 @@ let tyalls_ =
   foldr tyall_ ty strs
 
 let tyFlexUnbound = use FlexTypeAst in
-  lam info. lam ident. lam level. lam sort.
+  lam info. lam ident. lam level. lam sort. lam allowGeneralize.
   TyFlex {info = info,
-          contents = ref (Unbound {ident = ident, level = level, sort = sort})}
+          contents = ref (Unbound {ident = ident,
+                                   level = level,
+                                   sort = sort,
+                                   allowGeneralize = allowGeneralize})}
 
 let tyflexunbound_ = use FlexTypeAst in
   lam s.
-  tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 (TypeVar ())
+  tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 (TypeVar ()) true
 
 let tyflexlink_ = use FlexTypeAst in
   lam ty.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -5,6 +5,7 @@ include "assoc.mc"
 include "info.mc"
 include "name.mc"
 include "string.mc"
+include "stringid.mc"
 include "map.mc"
 
 -----------
@@ -39,15 +40,18 @@ lang Ast
   -- Intentionally left blank
 
   -- TODO(vipa, 2021-05-27): Replace smap and sfold with smapAccumL for Expr and Type as well
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | p -> (acc, p)
 
-  sem smap_Expr_Expr (f : a -> b) =
+  sem smap_Expr_Expr : (Expr -> Expr) -> Expr -> Expr
+  sem smap_Expr_Expr f =
   | p ->
     let res: ((), Expr) = smapAccumL_Expr_Expr (lam. lam a. ((), f a)) () p in
     res.1
 
-  sem sfold_Expr_Expr (f : acc -> a -> acc) (acc : acc) =
+  sem sfold_Expr_Expr : all acc. (acc -> Expr -> acc) -> acc -> Expr -> acc
+  sem sfold_Expr_Expr f acc =
   | p ->
     let res: (acc, Expr) = smapAccumL_Expr_Expr (lam acc. lam a. (f acc a, a)) acc p in
     res.0
@@ -55,41 +59,50 @@ lang Ast
   -- NOTE(vipa, 2021-05-28): This function *does not* touch the `ty`
   -- field. It only covers nodes in the AST, so to speak, not
   -- annotations thereof.
-  sem smapAccumL_Expr_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Type f acc =
   | p -> (acc, p)
 
-  sem smap_Expr_Type (f : a -> b) =
+  sem smap_Expr_Type : (Type -> Type) -> Expr -> Expr
+  sem smap_Expr_Type f =
   | p ->
     let res: ((), Expr) = smapAccumL_Expr_Type (lam. lam a. ((), f a)) () p in
     res.1
 
-  sem sfold_Expr_Type (f : acc -> a -> acc) (acc : acc) =
+  sem sfold_Expr_Type : all acc. (acc -> Type -> acc) -> acc -> Expr -> acc
+  sem sfold_Expr_Type f acc =
   | p ->
     let res: (acc, Expr) = smapAccumL_Expr_Type (lam acc. lam a. (f acc a, a)) acc p in
     res.0
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Type -> (acc, Type)
+  sem smapAccumL_Type_Type f acc =
   | p -> (acc, p)
 
-  sem smap_Type_Type (f : a -> b) =
+  sem smap_Type_Type : (Type -> Type) -> Type -> Type
+  sem smap_Type_Type f =
   | p ->
     let res: ((), Type) = smapAccumL_Type_Type (lam. lam a. ((), f a)) () p in
     res.1
 
-  sem sfold_Type_Type (f : acc -> a -> acc) (acc : acc) =
+  sem sfold_Type_Type : all acc. (acc -> Type -> acc) -> acc -> Type -> acc
+  sem sfold_Type_Type f acc =
   | p ->
     let res: (acc, Type) = smapAccumL_Type_Type (lam acc. lam a. (f acc a, a)) acc p in
     res.0
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat f acc =
   | p -> (acc, p)
 
-  sem smap_Pat_Pat (f : a -> b) =
+  sem smap_Pat_Pat : (Pat -> Pat) -> Pat -> Pat
+  sem smap_Pat_Pat f =
   | p ->
     let res: ((), Pat) = smapAccumL_Pat_Pat (lam. lam a. ((), f a)) () p in
     res.1
 
-  sem sfold_Pat_Pat (f : acc -> a -> acc) (acc : acc) =
+  sem sfold_Pat_Pat : all acc. (acc -> Pat -> acc) -> acc -> Pat -> acc
+  sem sfold_Pat_Pat f acc =
   | p ->
     let res: (acc, Pat) = smapAccumL_Pat_Pat (lam acc. lam a. (f acc a, a)) acc p in
     res.0
@@ -137,7 +150,7 @@ lang AppAst = Ast
   sem withType (ty : Type) =
   | TmApp t -> TmApp {t with ty = ty}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmApp t ->
     match f acc t.lhs with (acc, lhs) then
       match f acc t.rhs with (acc, rhs) then
@@ -168,13 +181,13 @@ lang LamAst = Ast + VarAst + AppAst
   sem withType (ty : Type) =
   | TmLam t -> TmLam {t with ty = ty}
 
-  sem smapAccumL_Expr_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TmLam t ->
     match f acc t.tyIdent with (acc, tyIdent) then
       (acc, TmLam {t with tyIdent = tyIdent})
     else never
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmLam t ->
     match f acc t.body with (acc, body) then
       (acc, TmLam {t with body = body})
@@ -204,13 +217,13 @@ lang LetAst = Ast + VarAst
   sem withType (ty : Type) =
   | TmLet t -> TmLet {t with ty = ty}
 
-  sem smapAccumL_Expr_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TmLet t ->
     match f acc t.tyBody with (acc, tyBody) then
       (acc, TmLet {t with tyBody = tyBody})
     else never
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmLet t ->
     match f acc t.body with (acc, body) then
       match f acc t.inexpr with (acc, inexpr) then
@@ -245,7 +258,7 @@ lang RecLetsAst = Ast + VarAst
   sem withType (ty : Type) =
   | TmRecLets t -> TmRecLets {t with ty = ty}
 
-  sem smapAccumL_Expr_Type (f:  acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Type (f:  acc -> Type -> (acc, Type)) (acc : acc) =
   | TmRecLets t ->
     let bindingFunc = lam acc. lam b: RecLetBinding.
       match f acc b.tyBody with (acc, tyBody) in
@@ -253,7 +266,7 @@ lang RecLetsAst = Ast + VarAst
     match mapAccumL bindingFunc acc t.bindings with (acc, bindings) in
     (acc, TmRecLets {t with bindings = bindings})
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmRecLets t ->
     let bindingFunc = lam acc. lam b: RecLetBinding.
       match f acc b.body with (acc, body) then
@@ -308,7 +321,7 @@ lang SeqAst = Ast
   sem withType (ty : Type) =
   | TmSeq t -> TmSeq {t with ty = ty}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmSeq t ->
     match mapAccumL f acc t.tms with (acc, tms) then
       (acc, TmSeq {t with tms = tms})
@@ -344,7 +357,7 @@ lang RecordAst = Ast
   | TmRecord t -> TmRecord {t with ty = ty}
   | TmRecordUpdate t -> TmRecordUpdate {t with ty = ty}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmRecord t ->
     match mapMapAccum (lam acc. lam. lam e. f acc e) acc t.bindings with (acc, bindings) then
       (acc, TmRecord {t with bindings = bindings})
@@ -379,13 +392,13 @@ lang TypeAst = Ast
   sem withType (ty : Type) =
   | TmType t -> TmType {t with ty = ty}
 
-  sem smapAccumL_Expr_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TmType t ->
     match f acc t.tyIdent with (acc, tyIdent) then
       (acc, TmType {t with tyIdent = tyIdent})
     else never
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmType t ->
     match f acc t.inexpr with (acc, inexpr) then
       (acc, TmType {t with inexpr = inexpr})
@@ -421,13 +434,13 @@ lang DataAst = Ast
   | TmConDef t -> TmConDef {t with ty = ty}
   | TmConApp t -> TmConApp {t with ty = ty}
 
-  sem smapAccumL_Expr_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TmConDef t ->
     match f acc t.tyIdent with (acc, tyIdent) then
       (acc, TmConDef {t with tyIdent = tyIdent})
     else never
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmConDef t ->
     match f acc t.inexpr with (acc, inexpr) then
       (acc, TmConDef {t with inexpr = inexpr})
@@ -463,7 +476,7 @@ lang MatchAst = Ast
   sem withType (ty : Type) =
   | TmMatch t -> TmMatch {t with ty = ty}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmMatch t ->
     match f acc t.target with (acc, target) then
       match f acc t.thn with (acc, thn) then
@@ -497,7 +510,7 @@ lang UtestAst = Ast
   sem withType (ty : Type) =
   | TmUtest t -> TmUtest {t with ty = ty}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmUtest t ->
     match f acc t.test with (acc, test) then
       match f acc t.expected with (acc, expected) then
@@ -558,13 +571,13 @@ lang ExtAst = Ast + VarAst
   sem withType (ty : Type) =
   | TmExt t -> TmExt {t with ty = ty}
 
-  sem smapAccumL_Expr_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TmExt t ->
     match f acc t.tyIdent with (acc, tyIdent) then
       (acc, TmExt {t with tyIdent = tyIdent})
     else never
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmExt t ->
     match f acc t.inexpr with (acc, inexpr) then
       (acc, TmExt {t with inexpr = inexpr})
@@ -669,7 +682,7 @@ end
 
 lang SymbAst = ConstAst
   syn Const =
-  | CSymb {val : Symb}
+  | CSymb {val : Symbol}
   | CGensym {}
   | CSym2hash {}
 end
@@ -861,7 +874,7 @@ lang SeqTotPat = MatchAst
   sem withTypePat (ty : Type) =
   | PatSeqTot r -> PatSeqTot {r with ty = ty}
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat (f : acc -> Pat -> (acc, Pat)) (acc : acc) =
   | PatSeqTot r ->
     match mapAccumL f acc r.pats with (acc, pats) then
       (acc, PatSeqTot {r with pats = pats})
@@ -888,7 +901,7 @@ lang SeqEdgePat = MatchAst
   sem withTypePat (ty : Type) =
   | PatSeqEdge r -> PatSeqEdge {r with ty = ty}
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat (f : acc -> Pat -> (acc, Pat)) (acc : acc) =
   | PatSeqEdge p ->
     match mapAccumL f acc p.prefix with (acc, prefix) then
       match mapAccumL f acc p.postfix with (acc, postfix) then
@@ -915,7 +928,7 @@ lang RecordPat = MatchAst
   sem withTypePat (ty : Type) =
   | PatRecord r -> PatRecord {r with ty = ty}
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat (f : acc -> Pat -> (acc, Pat)) (acc : acc) =
   | PatRecord p ->
     match mapMapAccum (lam acc. lam. lam p. f acc p) acc p.bindings with (acc, bindings) then
       (acc, PatRecord {p with bindings = bindings})
@@ -941,7 +954,7 @@ lang DataPat = MatchAst + DataAst
   sem withTypePat (ty : Type) =
   | PatCon r -> PatCon {r with ty = ty}
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat (f : acc -> Pat -> (acc, Pat)) (acc : acc) =
   | PatCon c ->
     match f acc c.subpat with (acc, subpat) then
       (acc, PatCon {c with subpat = subpat})
@@ -1024,7 +1037,7 @@ lang AndPat = MatchAst
   sem withTypePat (ty : Type) =
   | PatAnd r -> PatAnd {r with ty = ty}
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat (f : acc -> Pat -> (acc, Pat)) (acc : acc) =
   | PatAnd p ->
     match f acc p.lpat with (acc, lpat) then
       match f acc p.rpat with (acc, rpat) then
@@ -1052,7 +1065,7 @@ lang OrPat = MatchAst
   sem withTypePat (ty : Type) =
   | PatOr r -> PatOr {r with ty = ty}
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat (f : acc -> Pat -> (acc, Pat)) (acc : acc) =
   | PatOr p ->
     match f acc p.lpat with (acc, lpat) then
       match f acc p.rpat with (acc, rpat) then
@@ -1079,7 +1092,7 @@ lang NotPat = MatchAst
   sem withTypePat (ty : Type) =
   | PatNot r -> PatNot {r with ty = ty}
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat (f : acc -> Pat -> (acc, Pat)) (acc : acc) =
   | PatNot p ->
     match f acc p.subpat with (acc, subpat) then
       (acc, PatNot {p with subpat = subpat})
@@ -1158,7 +1171,7 @@ lang FunTypeAst = Ast
   sem tyWithInfo (info : Info) =
   | TyArrow t -> TyArrow {t with info = info}
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyArrow t ->
     match f acc t.from with (acc, from) then
       match f acc t.to with (acc, to) then
@@ -1178,7 +1191,7 @@ lang SeqTypeAst = Ast
   sem tyWithInfo (info : Info) =
   | TySeq t -> TySeq {t with info = info}
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TySeq t ->
     match f acc t.ty with (acc, ty) then
       (acc, TySeq {t with ty = ty})
@@ -1196,7 +1209,7 @@ lang TensorTypeAst = Ast
   sem tyWithInfo (info : Info) =
   | TyTensor t -> TyTensor {t with info = info}
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyTensor t ->
     match f acc t.ty with (acc, ty) then
       (acc, TyTensor {t with ty = ty})
@@ -1215,7 +1228,7 @@ lang RecordTypeAst = Ast
   sem tyWithInfo (info : Info) =
   | TyRecord t -> TyRecord {t with info = info}
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyRecord t ->
     match mapMapAccum (lam acc. lam. lam e. f acc e) acc t.fields with (acc, fields) then
       (acc, TyRecord {t with fields = fields})
@@ -1233,7 +1246,7 @@ lang VariantTypeAst = Ast
   sem tyWithInfo (info : Info) =
   | TyVariant t -> TyVariant {t with info = info}
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyVariant t ->
     match mapMapAccum (lam acc. lam. lam e. f acc e) acc t.constrs with (acc, constrs) then
       (acc, TyVariant {t with constrs = constrs})
@@ -1281,18 +1294,21 @@ lang VarSortAst
   | WeakVar ()
   | RecordVar {fields : Map SID Type}
 
-  sem smapAccumL_VarSort_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_VarSort_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> VarSort -> (acc, VarSort)
+  sem smapAccumL_VarSort_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | RecordVar r ->
     match mapMapAccum (lam acc. lam. lam e. f acc e) acc r.fields with (acc, flds) in
     (acc, RecordVar {r with fields = flds})
   | s ->
     (acc, s)
 
-  sem smap_VarSort_Type (f : a -> b) =
+  sem smap_VarSort_Type : (Type -> Type) -> VarSort -> VarSort
+  sem smap_VarSort_Type (f : Type -> Type) =
   | s ->
     match smapAccumL_VarSort_Type (lam. lam x. ((), f x)) () s with (_, s) in s
 
-  sem sfold_VarSort_Type (f : acc -> a -> acc) (acc : acc) =
+  sem sfold_VarSort_Type : all acc. (acc -> Type -> acc) -> acc -> VarSort -> acc
+  sem sfold_VarSort_Type (f : acc -> Type -> acc) (acc : acc) =
   | s ->
     match smapAccumL_VarSort_Type (lam a. lam x. (f a x, x)) acc s with (a, _) in a
 end
@@ -1332,7 +1348,7 @@ lang FlexTypeAst = VarSortAst + Ast
   sem infoTy =
   | TyFlex {info = info} -> info
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyFlex t & ty ->
     match deref t.contents with Unbound r then
       match smapAccumL_VarSort_Type f acc r.sort with (acc, sort) in
@@ -1355,7 +1371,7 @@ lang AllTypeAst = VarSortAst + Ast
   sem infoTy =
   | TyAll t -> t.info
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyAll t ->
     match smapAccumL_VarSort_Type f acc t.sort with (acc, sort) in
     match f acc t.ty with (acc, ty) in
@@ -1379,7 +1395,7 @@ lang AppTypeAst = Ast
   sem tyWithInfo (info : Info) =
   | TyApp t -> TyApp {t with info = info}
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyApp t ->
     match f acc t.lhs with (acc, lhs) then
       match f acc t.rhs with (acc, rhs) then

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -75,6 +75,22 @@ lang Ast
     let res: (acc, Expr) = smapAccumL_Expr_Type (lam acc. lam a. (f acc a, a)) acc p in
     res.0
 
+  sem smapAccumL_Expr_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Pat f acc =
+  | p -> (acc, p)
+
+  sem smap_Expr_Pat : (Pat -> Pat) -> Expr -> Expr
+  sem smap_Expr_Pat f =
+  | p ->
+    match smapAccumL_Expr_Pat (lam. lam a. ((), f a)) () p with (_, p) in
+    p
+
+  sem sfold_Expr_Pat : all acc. (acc -> Pat -> acc) -> acc -> Expr -> acc
+  sem sfold_Expr_Pat f acc =
+  | p ->
+    match smapAccumL_Expr_Pat (lam acc. lam a. (f acc a, a)) acc p
+    with (acc, _) in acc
+
   sem smapAccumL_Type_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Type -> (acc, Type)
   sem smapAccumL_Type_Type f acc =
   | p -> (acc, p)
@@ -485,6 +501,11 @@ lang MatchAst = Ast
         else never
       else never
     else never
+
+  sem smapAccumL_Expr_Pat f acc =
+  | TmMatch t ->
+    match f acc t.pat with (acc, pat) in
+    (acc, TmMatch {t with pat = pat})
 end
 
 

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1255,11 +1255,15 @@ lang ConTypeAst = Ast
   | TyCon r -> r.info
 end
 
+-- A Level denotes the nesting level of the let that a type variable is introduced by
+type Level = Int
+
 lang VarTypeAst = Ast
   syn Type =
   -- Rigid type variable
   | TyVar  {info     : Info,
-            ident    : Name}
+            ident    : Name,
+            level    : Level}
 
   sem tyWithInfo (info : Info) =
   | TyVar t -> TyVar {t with info = info}
@@ -1293,10 +1297,10 @@ lang VarSortAst
     match smapAccumL_VarSort_Type (lam a. lam x. (f a x, x)) acc s with (a, _) in a
 end
 
-type Level = Int
 type FlexVarRec = {ident : Name,
                    level : Level,
-                   sort  : VarSort}
+                   sort  : VarSort,
+                   allowGeneralize : Bool}
 
 lang FlexTypeAst = VarSortAst + Ast
   syn FlexVar =

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -28,6 +28,9 @@ type BootParserParseMCoreFileArg = {
   -- Warn on pruned external dependent utests
   pruneExternalUtestsWarning : Bool,
 
+  -- Run dead code elimination
+  eliminateDeadCode : Bool,
+
   -- Exclude pruning of utest for externals with whose dependencies are met on
   -- this system.
   externalsExclude : [String],
@@ -40,6 +43,7 @@ let defaultBootParserParseMCoreFileArg = {
   keepUtests = true,
   pruneExternalUtests = false,
   pruneExternalUtestsWarning = true,
+  eliminateDeadCode = true,
   externalsExclude = [],
   keywords = []
 }
@@ -57,7 +61,8 @@ lang BootParser = MExprAst + ConstTransformer
           arg.keepUtests,
           arg.pruneExternalUtests,
           arg.externalsExclude,
-          arg.pruneExternalUtestsWarning
+          arg.pruneExternalUtestsWarning,
+          arg.eliminateDeadCode
         )
         arg.keywords
         filename

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -128,7 +128,7 @@ lang BootParser = MExprAst + ConstTransformer
     let lst = create (glistlen t 0) (lam n. (gstr t n, gterm t n)) in
     TmRecord {bindings =
                 mapFromSeq cmpSID
-                  (map (lam b : (a,b). (stringToSid b.0, b.1)) lst),
+                  (map (lam b : (String,Expr). (stringToSid b.0, b.1)) lst),
               ty = TyUnknown { info = ginfo t 0 },
               info = ginfo t 0}
   | 108 /-TmRecordUpdate-/ ->
@@ -209,8 +209,10 @@ lang BootParser = MExprAst + ConstTransformer
   | 207 /-TyRecord-/ ->
     let lst = create (glistlen t 0) (lam n. (gstr t n, gtype t n)) in
     TyRecord {info = ginfo t 0,
-              labels = map (lam b : (String, a). stringToSid b.0) lst,
-              fields = mapFromSeq cmpSID (map (lam b : (a,b). (stringToSid b.0, b.1)) lst)}
+              labels = map (lam b : (String, Type). stringToSid b.0) lst,
+              fields =
+                mapFromSeq cmpSID
+                  (map (lam b : (String,Type). (stringToSid b.0, b.1)) lst)}
   | 208 /-TyVariant-/ ->
     if eqi (glistlen t 0) 0 then
       TyVariant {info = ginfo t 0,
@@ -277,7 +279,7 @@ lang BootParser = MExprAst + ConstTransformer
     let lst = create (glistlen t 0) (lam n. (gstr t n, gpat t n)) in
     PatRecord {bindings =
                mapFromSeq cmpSID
-                 (map (lam b : (a,b). (stringToSid b.0, b.1)) lst),
+                 (map (lam b : (String,Pat). (stringToSid b.0, b.1)) lst),
                info = ginfo t 0,
                ty = tyunknown_}
   | 404 /-PatCon-/ ->
@@ -382,7 +384,7 @@ utest l_info ["_aas_12"] "  _aas_12 " with r_info 1 2 1 9 in
 let s = "let y = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest l_infoClosed "  \n lam x.x" with r_info 2 1 2 8 in
-utest infoTm (match parseMExprString [] s with TmLet r then r.body else ())
+utest match parseMExprString [] s with TmLet r then infoTm r.body else NoInfo ()
 with r_info 1 8 1 15 in
 utest l_info ["y"] "  let x = 4 in y  " with r_info 1 2 1 14 in
 let s = "(printLn x); 10" in
@@ -474,7 +476,7 @@ let s = "match foo with _ then 7 else 2" in
 utest lside ["foo"] s with rside s in
 utest l_infoClosed "match [4] with x then x else [] " with r_info 1 0 1 31 in
 let s = " match bar with Foo {a = x} then x else 2" in
-utest match parseMExprString ["Foo", "bar"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["Foo", "bar"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 16 1 27 in
 
 -- TmMatch, PatSeqTot, PatSeqEdge
@@ -482,70 +484,70 @@ let s = "match x with \"\" then x else 2" in
 utest lside ["x"] s with rside s in
 let s = "match x with [x,y,z] then x else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 20 in
 let s = " match x with [a] ++ v ++ [x,y,z] then x else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 14 1 33 in
 let s = "match x with \"\" ++ x ++ [y] then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 27 in
 let s = "match x with [z] ++ x ++ \"\" then z else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 27 in
 
 --TmMatch, PatRecord
 let s = "match x with {} then x else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 15 in
 let s = "match x with {bar=_, foo=x} then x else 2" in
 let t = match_ (var_ "x")
                (prec_ [("bar", pvarw_), ("foo", pvar_ "x")])
                (var_ "x") (int_ 2) in
 utest parseMExprString ["x"] s with t using eqExpr in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 27 in
 
 --TmMatch, PatCon
 let s = "match x with Foo {foo = x} then x else 100" in
 utest lside ["x", "Foo"] s with rside s in
-utest match parseMExprString ["x", "Foo"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x", "Foo"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 26 in
 
 --TmMatch, PatInt, PatBool, PatChar
 let s = "match x with [1,2,12] then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 21 in
 let s = "match x with 'A' then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 16 in
 let s = "match x with [true,false] then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 25 in
 
 -- TmMatch, PatAnd, PatOr, PatNot
 let s = "match x with 1 & x then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 18 in
 let s = "match x with 1 | x then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 18 in
 let s = "match x with !y then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 15 in
 let s = "match 1 with (a & b) | (!c) then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else ()
+utest match parseMExprString ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
 with r_info 1 14 1 26 in
 
 -- TmUtest
@@ -570,47 +572,47 @@ utest l_infoClosed "   \n  external y! : Int in 1" with r_info 2 2 2 24 in
 -- TyUnknown
 let s = "let y:Unknown = lam x.x in y" in
 utest lsideClosed s with rside "let y = lam x.x in y" in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 13 in
 let s = "lam x:Int. lam y:Char. x" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] " \n lam x:Int. lam y:Char. x" with TmLam l then infoTy l.tyIdent else ()
+utest match parseMExprString [] " \n lam x:Int. lam y:Char. x" with TmLam l then infoTy l.tyIdent else NoInfo ()
 with r_info 2 7 2 10 in
 
 -- TyInt
 let s = "let y:Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 9 in
 
 -- TyFloat
 let s = "let y:Float = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 11 in
 
 -- TyChar
 let s = "let y:Char = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 10 in
 
 -- TyArrow
 let s = "let y:(Int)->(Int) = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 7 1 17 in
 
 -- Nested TyArrow
 let s = "let y:([Float])->(Int) = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 7 1 21 in
 
 -- TySeq
 let s = "let y:[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 11 in
 
 -- Nested TySeq
@@ -626,13 +628,13 @@ let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
 utest parseMExprString [] s with typedLet recTy using eqExpr in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 56 in
 
 -- TyTensor
 let s = "let y:Tensor[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 17 in
 
 -- Nested TyTensor
@@ -646,14 +648,14 @@ let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
 utest parseMExprString [] s with typedLet recTy using eqExpr in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 30 in
 
 -- TyRecord
 let s = "let y:{a:Int,b:[Char]} = lam x.x in y" in
 let recTy = tyrecord_ [("a", tyint_), ("b", tystr_)] in
 utest parseMExprString [] s with typedLet recTy using eqExpr in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 22 in
 
 -- Nested TyRecord
@@ -666,49 +668,49 @@ let recTy = tyrecord_ [
     ("b_1", tystr_),
     ("b_2", tyfloat_)])] in
 utest parseMExprString [] s with typedLet recTy using eqExpr in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 54 in
 
 -- TyVariant
 let s = "let y:<> = lam x.x in y" in
 -- NOTE(caylak,2021-03-17): Parsing of TyVariant is not supported yet
 --utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 8 in
 
 -- TyVar
 let s = "let y:_asd = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 10 in
 
 -- TyAll
 let s = "let y:all x.x = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 13 in
 
 -- Nested TyAll
 let s = "let y:all x.(all y.all z.z)->(all w.w) = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 37 in
 
 -- TyCon
 let s = "let y:Foo = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 6 1 9 in
 
 -- TyApp
 let s = "let y:((Int)->(Int))(Int) = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 8 1 24 in
 
 -- Nested TyApp
 let s = "let y:((((Int)->(Int))(Int))->(Int))(Int) = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else ()
+utest match parseMExprString [] s with TmLet l then infoTy l.tyBody else NoInfo ()
 with r_info 1 10 1 40 in
 ()

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -221,7 +221,8 @@ lang BootParser = MExprAst + ConstTransformer
            ident = gname t 0}
   | 210 /-TyVar-/ ->
     TyVar {info = ginfo t 0,
-           ident = gname t 0}
+           ident = gname t 0,
+           level = 0}
   | 211 /-TyApp-/ ->
     TyApp {info = ginfo t 0,
            lhs = gtype t 0,

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -151,3 +151,10 @@ let builtin = use MExprAst in
   , ("bootParserGetPat", CBootParserGetPat ())
   , ("bootParserGetInfo", CBootParserGetInfo ())
   ]
+
+let builtinTypes : [(String, [String])] =
+  [ ("Symbol", [])
+  , ("Ref", ["a"])
+  , ("Map", ["k", "v"])
+  , ("BootParseTree", [])
+  ]

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -877,7 +877,7 @@ lang RecordPatCFA = MatchCFA + RecordCFA + RecordPat
     -- Check if record pattern is compatible with abstract value record
     let compatible = mapAllWithKey (lam k. lam. mapMem k abindings) pbindings in
     if compatible then
-      mapFoldWithKey (lam graph: CFAGraph. lam k. lam pb: Pattern.
+      mapFoldWithKey (lam graph: CFAGraph. lam k. lam pb: Pat.
         let ab: Name = mapFindExn k abindings in
         let cstrs = foldl (lam acc. lam f. concat (f id ab pb) acc)
           [] graph.mcgfs in
@@ -1002,7 +1002,7 @@ let _testBase: Option PprintEnv -> Expr -> (Option PprintEnv, CFAGraph) =
       match pprintCode 0 env tANF with (env,tANFStr) in
       printLn "\n--- ANF ---";
       printLn tANFStr;
-      match cfaDebug (Some env) tANF with (Some env,cfaRes) in
+      match cfaDebug (None ()) (Some env) tANF with (Some env,cfaRes) in
       match cfaGraphToString env cfaRes with (env, resStr) in
       printLn "\n--- FINAL CFA GRAPH ---";
       printLn resStr;

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -88,7 +88,7 @@ lang LetCmp = Cmp + LetAst
     else identDiff
 end
 
-lang RecLetBindingCmp = Cmp
+lang RecLetBindingCmp = Cmp + RecLetsAst
   sem cmpRecLetBinding (lhs : RecLetBinding) =
   | rhs ->
     let rhs : RecLetBinding = rhs in

--- a/stdlib/mexpr/const-transformer.mc
+++ b/stdlib/mexpr/const-transformer.mc
@@ -31,7 +31,7 @@ lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + Named
       --dprint t2;
       t2
 
-  sem ctWorker (env: Map String Expr) =
+  sem ctWorker (env: Map String (Option Expr)) =
   | TmLet r ->
     let env = mapInsert (nameGetStr r.ident) (None()) env in
     let t1 = ctWorker env r.body in

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -4,12 +4,10 @@
 include "ast.mc"
 include "ast-builder.mc"
 
--- The types defined below are only used for documentation purposes, as these
--- cannot be properly represented using the existing types.
-let tysym_ = tyunknown_
-let tyref_ = tyunknown_
-let tymap_ = tyunknown_
-let tybootparsetree_ = tyunknown_
+let tysym_ = tycon_ "Symbol"
+let tyref_ = lam a. tyapp_ (tycon_ "Ref") a
+let tymap_ = lam k. lam v. tyapp_ (tyapp_ (tycon_ "Map") k) v
+let tybootparsetree_ = tycon_ "BootParseTree"
 
 let tyvarseq_ = lam id. tyseq_ (tyvar_ id)
 
@@ -164,7 +162,7 @@ lang IOTypeAst = IOAst
   sem tyConst =
   | CPrint _ -> tyarrow_ tystr_ tyunit_
   | CPrintError _ -> tyarrow_ tystr_ tyunit_
-  | CDPrint _ -> tyarrow_ tystr_ tyunit_
+  | CDPrint _ -> tyall_ "a" (tyarrow_ (tyvar_ "a") tyunit_)
   | CFlushStdout _ -> tyarrow_ tyunit_ tyunit_
   | CFlushStderr _ -> tyarrow_ tyunit_ tyunit_
   | CReadLine _ -> tyarrow_ tyunit_ tystr_
@@ -179,8 +177,8 @@ end
 
 lang SysTypeAst = SysAst
   sem tyConst =
-  | CExit _ -> tyarrow_ tyint_ tyunknown_
-  | CError _ -> tyarrow_ tystr_ tyunknown_
+  | CExit _ -> tyall_ "a" (tyarrow_ tyint_ (tyvar_ "a"))
+  | CError _ -> tyall_ "a" (tyarrow_ tystr_ (tyvar_ "a"))
   | CArgv _ -> tyseq_ tystr_
   | CCommand _ -> tyarrow_ tystr_ tyint_
 end
@@ -193,9 +191,9 @@ end
 
 lang RefOpTypeAst = RefOpAst
   sem tyConst =
-  | CRef _ -> tyall_ "a" (tyarrow_ (tyvar_ "a") tyref_)
-  | CModRef _ -> tyall_ "a" (tyarrows_ [tyref_, tyvar_ "a", tyunit_])
-  | CDeRef _ -> tyall_ "a" (tyarrow_ tyref_ (tyvar_ "a"))
+  | CRef _ -> tyall_ "a" (tyarrow_ (tyvar_ "a") (tyref_ (tyvar_ "a")))
+  | CModRef _ -> tyall_ "a" (tyarrows_ [tyref_ (tyvar_ "a"), tyvar_ "a", tyunit_])
+  | CDeRef _ -> tyall_ "a" (tyarrow_ (tyref_ (tyvar_ "a")) (tyvar_ "a"))
 end
 
 lang ConTagTypeAst = ConTagAst
@@ -206,54 +204,142 @@ end
 lang MapTypeAst = MapAst
   sem tyConst =
   | CMapEmpty _ ->
-    tyall_ "a" (tyarrow_ (tyarrows_ [tyvar_ "a", tyvar_ "a", tyint_]) tymap_)
+    tyalls_ ["k", "v"] (
+      tyarrow_ (tyarrows_ [tyvar_ "k", tyvar_ "k", tyint_])
+               (tymap_ (tyvar_ "k") (tyvar_ "v"))
+    )
   | CMapInsert _ ->
-    tyalls_ ["a", "b"] (tyarrows_ [tyvar_ "a", tyvar_ "b", tymap_, tymap_])
-  | CMapRemove _ -> tyall_ "a" (tyarrows_ [tyvar_ "a", tymap_, tymap_])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyvar_ "k",
+        tyvar_ "v",
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tymap_ (tyvar_ "k") (tyvar_ "v")
+      ]
+    )
+  | CMapRemove _ ->
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyvar_ "k",
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tymap_ (tyvar_ "k") (tyvar_ "v")
+      ]
+    )
   | CMapFindExn _ ->
-    tyalls_ ["a", "b"] (tyarrows_ [tyvar_ "a", tymap_, tyvar_ "b"])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyvar_ "k", tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tyvar_ "v"
+      ]
+    )
   | CMapFindOrElse _ ->
-    tyalls_ ["a", "b"]
-            (tyarrows_ [tyarrow_ tyunit_ (tyvar_ "b"),
-                        tyvar_ "a", tymap_, tyvar_ "b"])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyarrow_ tyunit_ (tyvar_ "v"),
+        tyvar_ "k",
+        tymap_ (tyvar_ "k") (tyvar_ "v"), tyvar_ "v"
+      ]
+    )
   | CMapFindApplyOrElse _ ->
-    tyalls_ ["a", "b", "c"]
-            (tyarrows_ [tyarrow_ (tyvar_ "b") (tyvar_ "c"),
-                        tyarrow_ tyunit_ (tyvar_ "c"), tyvar_ "a",
-                        tymap_, tyvar_ "c"])
+    tyalls_ ["k", "v1", "v2"] (
+      tyarrows_ [
+        tyarrow_ (tyvar_ "v1") (tyvar_ "v2"),
+        tyarrow_ tyunit_ (tyvar_ "v2"), tyvar_ "k",
+        tymap_ (tyvar_ "k") (tyvar_ "v1"), tyvar_ "v2"
+      ]
+    )
   | CMapBindings _ ->
-    tyalls_ ["a", "b"]
-            (tyarrow_ tymap_ (tyseq_ (tytuple_ [tyvar_ "a", tyvar_ "b"])))
+    tyalls_ ["k", "v"] (
+      tyarrow_ (tymap_ (tyvar_ "k") (tyvar_ "v"))
+               (tyseq_ (tytuple_ [tyvar_ "k", tyvar_ "v"]))
+    )
   | CMapChooseExn _ ->
-    tyalls_ ["a", "b"]
-            (tyarrows_ [tymap_, (tytuple_ [tyvar_ "a", tyvar_ "b"])])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        (tytuple_ [tyvar_ "k", tyvar_ "v"])
+      ]
+    )
   | CMapChooseOrElse _ ->
-    tyalls_ ["a", "b"]
-            (tyarrows_ [tyarrow_ tyunit_ (tytuple_ [tyvar_ "a", tyvar_ "b"]),
-                        tymap_, (tytuple_ [tyvar_ "a", tyvar_ "b"])])
-  | CMapSize _ -> tyarrow_ tymap_ tyint_
-  | CMapMem _ -> tyall_ "a" (tyarrows_ [tyvar_ "a", tymap_, tybool_])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyarrow_ tyunit_ (tytuple_ [tyvar_ "k", tyvar_ "v"]),
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        (tytuple_ [tyvar_ "k", tyvar_ "v"])
+      ]
+    )
+  | CMapSize _ ->
+    tyalls_ ["k", "v"] (
+      tyarrow_ (tymap_ (tyvar_ "k") (tyvar_ "v"))
+      tyint_
+    )
+  | CMapMem _ ->
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyvar_ "k",
+        tymap_ (tyvar_ "k") (tyvar_ "v"), tybool_
+      ]
+    )
   | CMapAny _ ->
-    tyalls_ ["a", "b"]
-            (tyarrows_ [tyarrows_ [tyvar_ "a", tyvar_ "b", tybool_], tymap_, tybool_])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyarrows_ [tyvar_ "k", tyvar_ "v", tybool_],
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tybool_
+      ]
+    )
   | CMapMap _ ->
-    tyalls_ ["b", "c"]
-            (tyarrows_ [tyarrow_ (tyvar_ "b") (tyvar_ "c"), tymap_, tymap_])
+    tyalls_ ["k", "v1", "v2"] (
+      tyarrows_ [
+        tyarrow_ (tyvar_ "v1") (tyvar_ "v2"),
+        tymap_ (tyvar_ "k") (tyvar_ "v1"),
+        tymap_ (tyvar_ "k") (tyvar_ "v2")
+      ]
+    )
   | CMapMapWithKey _ ->
-    tyalls_ ["a", "b", "c"]
-            (tyarrows_ [tyarrows_ [tyvar_ "a", tyvar_ "b", tyvar_ "c"],
-                        tymap_, tymap_])
+    tyalls_ ["k", "v1", "v2"] (
+      tyarrows_ [
+        tyarrows_ [tyvar_ "k", tyvar_ "v1", tyvar_ "v2"],
+        tymap_ (tyvar_ "k") (tyvar_ "v1"),
+        tymap_ (tyvar_ "k") (tyvar_ "v2")
+      ]
+    )
   | CMapFoldWithKey _ ->
-    tyalls_ ["a", "b", "c"]
-            (tyarrows_ [tyarrows_ [tyvar_ "a", tyvar_ "b", tyvar_ "c", tyvar_ "c"],
-                        tyvar_ "c", tymap_, tyvar_ "c"])
+    tyalls_ ["k", "v", "acc"] (
+      tyarrows_ [
+        tyarrows_ [tyvar_ "acc", tyvar_ "k", tyvar_ "v", tyvar_ "acc"],
+        tyvar_ "acc",
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tyvar_ "acc"
+      ]
+    )
   | CMapEq _ ->
-    tyall_ "b" (tyarrows_ [tyarrows_ [tyvar_ "b", tyvar_ "b", tybool_],
-                           tymap_, tymap_, tybool_])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyarrows_ [tyvar_ "v", tyvar_ "v", tybool_],
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tybool_
+      ]
+    )
   | CMapCmp _ ->
-    tyall_ "b" (tyarrows_ [tyarrows_ [tyvar_ "b", tyvar_ "b", tyint_],
-                           tymap_, tymap_, tyint_])
-  | CMapGetCmpFun _ -> tyall_ "a" (tyarrows_ [tymap_, tyvar_ "a", tyvar_ "a", tyint_])
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tyarrows_ [tyvar_ "v", tyvar_ "v", tyint_],
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tyint_
+      ]
+    )
+  | CMapGetCmpFun _ ->
+    tyalls_ ["k", "v"] (
+      tyarrows_ [
+        tymap_ (tyvar_ "k") (tyvar_ "v"),
+        tyvar_ "k",
+        tyvar_ "k",
+        tyint_
+      ]
+    )
 end
 
 lang TensorOpTypeAst = TensorOpAst

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -359,15 +359,15 @@ lang TensorOpTypeAst = TensorOpAst
   | CTensorSliceExn _ -> tyall_ "a" (tytensorsliceexn_ (tyvar_ "a"))
   | CTensorSubExn _ -> tyall_ "a" (tytensorsubexn_ (tyvar_ "a"))
   | CTensorIterSlice _ -> tyall_ "a" (tytensoriteri_ (tyvar_ "a"))
-  | CTensorEq _ -> tyall_ "a" (tytensoreq_ (tyvar_ "a") (tyvar_ "a"))
+  | CTensorEq _ -> tyalls_ ["a", "b"] (tytensoreq_ (tyvar_ "a") (tyvar_ "b"))
   | CTensorToString _ -> tyall_ "a" (tytensortostring_ (tyvar_ "a"))
 end
 
 lang BootParserTypeAst = BootParserAst
   sem tyConst =
-  | CBootParserParseMExprString _ -> tyarrow_ tystr_ tybootparsetree_
+  | CBootParserParseMExprString _ -> tyarrows_ [tyseq_ tystr_, tystr_, tybootparsetree_]
   | CBootParserParseMCoreFile _ -> tyarrows_ [
-      tytuple_ [tybool_, tybool_ ,tyseq_ tystr_],
+      tytuple_ [tybool_, tybool_ ,tyseq_ tystr_, tybool_, tybool_],
       tyseq_ tystr_,
       tystr_,
       tybootparsetree_

--- a/stdlib/mexpr/cse.mc
+++ b/stdlib/mexpr/cse.mc
@@ -15,7 +15,7 @@ let programPosLCP : ProgramPos -> ProgramPos -> ProgramPos =
   lam t1. lam t2.
   -- We use binary search to find the longest common prefix for which both
   -- sequences have the same positional indices.
-  recursive let binarySearch : Int -> Int -> PosPreds = lam lo. lam hi.
+  recursive let binarySearch : Int -> Int -> ProgramPos = lam lo. lam hi.
     if geqi (addi lo 1) hi then subsequence t1 0 hi
     else
       let mid = addi (divi (subi hi lo) 2) lo in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -17,8 +17,6 @@ include "pprint.mc"
 -- EVALUATION ENVIRONMENT --
 ----------------------------
 
-type Symbol = Int
-
 type Env = [(Name, Expr)]
 
 let evalEnvEmpty = createList 0 (lam. (nameNoSym "", unit_))
@@ -152,10 +150,11 @@ lang RecLetsEval =
 
   sem eval (ctx : {env : Env}) =
   | TmRecLets t ->
-    let foldli = lam f. lam init. lam seq.
-      let foldres : (Int, b) = foldl (lam acc : (Int, b). lam x.
-                                       (addi acc.0 1, f acc.0 acc.1 x))
-                                     (0, init) seq in
+    let foldli : all a. all acc. (Int -> acc -> a -> acc) -> acc -> [a] -> acc =
+      lam f. lam init. lam seq.
+      let foldres : (Int, acc) = foldl (lam acc : (Int, acc). lam x.
+                                         (addi acc.0 1, f acc.0 acc.1 x))
+                                       (0, init) seq in
       foldres.1
     in
     utest foldli (lam i. lam acc. lam x. concat (concat acc (int2string i)) x)
@@ -241,7 +240,7 @@ lang MatchEval = Eval + MatchAst
   | _ -> None ()
 end
 
-lang UtestEval = Eval + Eq + UtestAst
+lang UtestEval = Eval + Eq + AppEval + UtestAst + BoolAst
   sem eq (e1 : Expr) =
   | _ -> error "Equality not defined for expression"
 
@@ -251,7 +250,9 @@ lang UtestEval = Eval + Eq + UtestAst
     let v2 = eval ctx t.expected in
     let tusing = optionMap (eval ctx) t.tusing in
     let result = match tusing with Some tusing then
-      tusing v1 v2
+      match apply ctx v2 (apply ctx v1 tusing)
+      with TmConst {val = CBool {val = b}} then b
+      else error "Invalid utest equivalence function"
     else
       eqExpr v1 v2 in
     (if result then print "Test passed\n" else print "Test failed\n");
@@ -272,7 +273,7 @@ end
 -- TODO (oerikss, 2020-03-26): Eventually, this should be a rank 0 tensor.
 lang RefEval = Eval
   syn Expr =
-  | TmRef {ref : Ref}
+  | TmRef {ref : Ref Expr}
 
   sem eval (ctx : {env : Env}) =
   | TmRef r -> TmRef r
@@ -682,7 +683,7 @@ end
 
 lang CmpSymbEval = CmpSymbAst + ConstEval
   syn Const =
-  | CEqsym2 Symb
+  | CEqsym2 Symbol
 
   sem constArity =
   | CEqsym2 _ -> 1
@@ -777,7 +778,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     TmConst {val = CIter2 arg, ty = tyunknown_, info = NoInfo ()}
   | CIter2 f ->
     match arg with TmSeq s then
-      let f = lam x. apply {env = evalEnvEmpty} x f in
+      let f = lam x. apply {env = evalEnvEmpty} x f; () in
       iter f s.tms;
       uunit_
     else error "Second argument to iter not a sequence"
@@ -787,7 +788,7 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval
     match arg with TmSeq s then
       let f = lam i. lam x.
         apply {env = evalEnvEmpty} x
-          (apply {env = evalEnvEmpty} (int_ i) f) in
+          (apply {env = evalEnvEmpty} (int_ i) f); () in
       iteri f s.tms;
       uunit_
     else error "Second argument to iteri not a sequence"
@@ -1069,7 +1070,7 @@ end
 
 lang RefOpEval = RefOpAst + RefEval + IntAst
   syn Const =
-  | CModRef2 Ref
+  | CModRef2 (Ref Expr)
 
   sem constArity =
   | CModRef2 _ -> 1
@@ -1109,27 +1110,27 @@ lang MapEval =
   SeqAst + SeqTypeAst + RecordAst + RecordTypeAst + ConstEval
 
   syn Const =
-  | CMapVal {cmp : Expr -> Expr -> Expr, val : Map K V}
+  | CMapVal {cmp : Expr, val : Map Expr Expr}
   | CMapInsert2 Expr
   | CMapInsert3 (Expr, Expr)
   | CMapRemove2 Expr
   | CMapFindExn2 Expr
-  | CMapFindOrElse2 (Expr -> Expr)
-  | CMapFindOrElse3 (Expr -> Expr, Expr)
-  | CMapFindApplyOrElse2 (Expr -> Expr)
-  | CMapFindApplyOrElse3 (Expr -> Expr, Expr -> Expr)
-  | CMapFindApplyOrElse4 (Expr -> Expr, Expr -> Expr, Expr)
+  | CMapFindOrElse2 Expr
+  | CMapFindOrElse3 (Expr, Expr)
+  | CMapFindApplyOrElse2 Expr
+  | CMapFindApplyOrElse3 (Expr, Expr)
+  | CMapFindApplyOrElse4 (Expr, Expr, Expr)
   | CMapMem2 Expr
-  | CMapAny2 (Expr -> Expr -> Expr)
-  | CMapMap2 (Expr -> Expr)
-  | CMapMapWithKey2 (Expr -> Expr -> Expr)
-  | CMapFoldWithKey2 (Expr -> Expr -> Expr -> Expr)
-  | CMapFoldWithKey3 (Expr -> Expr -> Expr -> Expr, Expr)
+  | CMapAny2 Expr
+  | CMapMap2 Expr
+  | CMapMapWithKey2 Expr
+  | CMapFoldWithKey2 Expr
+  | CMapFoldWithKey3 (Expr, Expr)
   | CMapChooseOrElse2 Expr
-  | CMapEq2 (Expr -> Expr -> Expr)
-  | CMapEq3 (Expr -> Expr -> Expr, Map K V)
-  | CMapCmp2 (Expr -> Expr -> Expr)
-  | CMapCmp3 (Expr -> Expr -> Expr, Map K V)
+  | CMapEq2 Expr
+  | CMapEq3 (Expr, Map Expr Expr)
+  | CMapCmp2 Expr
+  | CMapCmp3 (Expr, Map Expr Expr)
 
   sem constArity =
   | CMapVal _ -> 0
@@ -1449,35 +1450,34 @@ lang TensorOpEval =
     else error "Second argument to CTensorIterSlice not a tensor"
   | TmConst { val = CTensorEq3 (eq, t1) } ->
     match arg with TmTensor { val = t2 } then
-    let mkeq = lam wrapx. lam wrapy.
-      lam x. lam y.
+    let mkeq : all a. all b. (a -> Expr) -> (b -> Expr) -> Tensor[a] -> Tensor[b] -> Bool =
+      lam wrapx. lam wrapy. lam t1. lam t2.
+      let eq = lam x. lam y.
         match apply ctx (wrapy y) (apply ctx (wrapx x) eq) with
           TmConst { val = CBool { val = b } }
         then b else error "Invalid equality function"
+      in
+      tensorEq eq t1 t2
     in
-    let eq =
-      match t1 with TInt _ then
-        match t2 with TInt _ then mkeq int_ int_
-        else match t2 with TFloat _ then mkeq int_ float_
-        else match t2 with TExpr _ then mkeq int_ (lam x. x)
+    let result =
+      match t1 with TInt t1 then
+        match t2 with TInt t2 then mkeq int_ int_ t1 t2
+        else match t2 with TFloat t2 then mkeq int_ float_ t1 t2
+        else match t2 with TExpr t2 then mkeq int_ (lam x. x) t1 t2
         else never
-      else match t1 with TFloat _ then
-        match t2 with TInt _ then mkeq float_ int_
-        else match t2 with TFloat _ then mkeq float_ float_
-        else match t2 with TExpr _ then mkeq float_ (lam x. x)
+      else match t1 with TFloat t1 then
+        match t2 with TInt t2 then mkeq float_ int_ t1 t2
+        else match t2 with TFloat t2 then mkeq float_ float_ t1 t2
+        else match t2 with TExpr t2 then mkeq float_ (lam x. x) t1 t2
         else never
-      else match t1 with TExpr _ then
-        match t2 with TInt _ then mkeq (lam x. x) int_
-        else match t2 with TFloat _ then mkeq (lam x. x) float_
-        else match t2 with TExpr _ then mkeq (lam x. x) (lam x. x)
+      else match t1 with TExpr t1 then
+        match t2 with TInt t2 then mkeq (lam x. x) int_ t1 t2
+        else match t2 with TFloat t2 then mkeq (lam x. x) float_ t1 t2
+        else match t2 with TExpr t2 then mkeq (lam x. x) (lam x. x) t1 t2
         else never
       else never
     in
-    match (t1, t2) with
-      (TInt t1 | TFloat t1 | TExpr t1, TInt t2 | TFloat t2 | TExpr t2)
-    then
-      bool_ (tensorEq eq t1 t2)
-    else never
+    bool_ result
     else error "Third argument to CTensorEq not a tensor"
   | TmConst { val = CTensorToString2 el2str } ->
     match arg with TmTensor { val = t } then
@@ -1714,19 +1714,19 @@ lang BootParserEval =
   RecordAst
 
   syn Const =
-  | CBootParserTree {val : BootParserTree}
+  | CBootParserTree {val : BootParseTree}
   | CBootParserParseMExprString2 [String]
   | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool)
   | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool), [String])
-  | CBootParserGetTerm2 BootParserTree
-  | CBootParserGetType2 BootParserTree
-  | CBootParserGetString2 BootParserTree
-  | CBootParserGetInt2 BootParserTree
-  | CBootParserGetFloat2 BootParserTree
-  | CBootParserGetListLength2 BootParserTree
-  | CBootParserGetConst2 BootParserTree
-  | CBootParserGetPat2 BootParserTree
-  | CBootParserGetInfo2 BootParserTree
+  | CBootParserGetTerm2 BootParseTree
+  | CBootParserGetType2 BootParseTree
+  | CBootParserGetString2 BootParseTree
+  | CBootParserGetInt2 BootParseTree
+  | CBootParserGetFloat2 BootParseTree
+  | CBootParserGetListLength2 BootParseTree
+  | CBootParserGetConst2 BootParseTree
+  | CBootParserGetPat2 BootParseTree
+  | CBootParserGetInfo2 BootParseTree
 
   sem constArity =
   | CBootParserTree _ -> 0
@@ -1932,7 +1932,7 @@ lang SeqTotPatEval = SeqTotPat + SeqAst
   | PatSeqTot {pats = pats} ->
     match t with TmSeq {tms = tms} then
       if eqi (length tms) (length pats) then
-        optionFoldlM (lam env. lam pair : (a,b). tryMatch env pair.0 pair.1) env
+        optionFoldlM (lam env. lam pair : (Expr,Pat). tryMatch env pair.0 pair.1) env
           (zipWith (lam a. lam b. (a, b)) tms pats)
       else None ()
     else None ()
@@ -1947,7 +1947,7 @@ lang SeqEdgePatEval = SeqEdgePat + SeqAst
         match splitAt tms (subi (length tms) (length post)) with (tms, postTm) then
         let pair = lam a. lam b. (a, b) in
         let paired = zipWith pair (concat preTm postTm) (concat pre post) in
-        let env = optionFoldlM (lam env. lam pair : (a,b). tryMatch env pair.0 pair.1) env paired in
+        let env = optionFoldlM (lam env. lam pair : (Expr,Pat). tryMatch env pair.0 pair.1) env paired in
         match middle with PName name then
           optionMap (evalEnvInsert name (seq_ tms)) env
         else match middle with PWildcard () then
@@ -2806,7 +2806,7 @@ utest eval (mapCmp_ cmpf m3 m5) with int_ 0 using eqExpr in
 utest eval (mapGetCmpFun_ m1) with uconst_ (CSubi ()) using eqExpr in
 
 -- Tensors
-let testTensors = lam tcreate_. lam v : (a,a,a).
+let testTensors = lam tcreate_. lam v : (Expr, Expr, Expr).
   let t0 = eval (tcreate_ (seq_ []) (ulam_ "x" v.0)) in
   let t1 = eval (tcreate_ (seq_ [int_ 4]) (ulam_ "x" v.0)) in
   let t2 = eval (tcreate_ (seq_ [int_ 4]) (ulam_ "x" v.1)) in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1716,8 +1716,8 @@ lang BootParserEval =
   syn Const =
   | CBootParserTree {val : BootParserTree}
   | CBootParserParseMExprString2 [String]
-  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool)
-  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool), [String])
+  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool)
+  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool), [String])
   | CBootParserGetTerm2 BootParserTree
   | CBootParserGetType2 BootParserTree
   | CBootParserGetString2 BootParserTree
@@ -1766,11 +1766,12 @@ lang BootParserEval =
 
   | CBootParserParseMCoreFile _ ->
     match arg with TmRecord {bindings = bs} then
-      match map (lam b. mapLookup b bs) (map stringToSid ["0", "1", "2", "3"]) with [
+      match map (lam b. mapLookup b bs) (map stringToSid ["0", "1", "2", "3", "4"]) with [
         Some (TmConst { val = CBool { val = keepUtests } }),
         Some (TmConst { val = CBool { val = pruneExternalUtests } }),
         Some (TmSeq { tms = externalsExclude }),
-        Some (TmConst { val = CBool { val = warn } })
+        Some (TmConst { val = CBool { val = warn } }),
+        Some (TmConst { val = CBool { val = eliminateDeadCode } })
       ]
       then
         let externalsExclude =
@@ -1784,8 +1785,11 @@ lang BootParserEval =
             externalsExclude
         in
         TmConst {val = CBootParserParseMCoreFile2 (
-                  keepUtests, pruneExternalUtests, externalsExclude, warn
-                 ),
+                  keepUtests,
+                  pruneExternalUtests,
+                  externalsExclude,
+                  warn,
+                  eliminateDeadCode ),
                  ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}
       else error "First argument to bootParserParseMCoreFile incorrect record"
     else error "First argument to bootParserParseMCoreFile not a record"

--- a/stdlib/mexpr/keyword-maker.mc
+++ b/stdlib/mexpr/keyword-maker.mc
@@ -148,7 +148,7 @@ lang _testKeywordMaker = KeywordMaker + MExpr + MExprEq
                                                  arg3 = get lst 2, info = info})
 
   -- smap for the new terms
-  sem smap_Expr_Expr (f : Expr -> a) =
+  sem smap_Expr_Expr (f : Expr -> Expr) =
   | TmNoArgs t -> TmNoArgs t
   | TmOneArg t -> TmOneArg {t with arg1 = f t.arg1}
   | TmTwoArgs t -> TmTwoArgs {{t with arg1 = f t.arg1} with arg2 = f t.arg2}

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -9,7 +9,7 @@ include "ast-builder.mc"
 include "eq.mc"
 include "info.mc"
 
-type ParseResult = {val : Expr, pos : Pos, str: String}
+type ParseResult a = {val : a, pos : Pos, str: String}
 type StrPos = {str : String, pos : Pos}
 
 let tabSpace = 2
@@ -67,7 +67,7 @@ end
 lang ExprParser = WSACParser
   sem parseExpr (p: Pos) =
   | s ->
-    let r1 : ParseResult = parseExprMain p 0 s in
+    let r1 : ParseResult Expr = parseExprMain p 0 s in
     let r2 : StrPos = eatWSAC r1.pos r1.str in
     if eqi (length r2.str) 0 then r1.val
     else posErrorExit r2.pos "Parse error. Unknown characters."
@@ -75,11 +75,11 @@ lang ExprParser = WSACParser
   sem parseExprMain (p: Pos) (prec: Int) =
   | s ->
     let r1 : StrPos = eatWSAC p s in
-    let exp : ParseResult = parseExprImp r1.pos r1.str in
+    let exp : ParseResult Expr = parseExprImp r1.pos r1.str in
     let r2 : StrPos = eatWSAC exp.pos exp.str in
     parseInfix r2.pos prec exp r2.str
 
-  sem parseInfix (p: Pos) (prec: Int) (exp: ParseResult) =
+  sem parseInfix (p: Pos) (prec: Int) (exp: ParseResult Expr) =
 
   sem parseExprImp (p: Pos) =
   | _ -> posErrorExit p "Parse error. Unknown character sequence."
@@ -88,7 +88,7 @@ end
 
 -- Include this fragment if there are no infix operations
 lang ExprParserNoInfix = ExprParser
-  sem parseInfix (p: Pos) (prec: Int) (exp: ParseResult) =
+  sem parseInfix (p: Pos) (prec: Int) (exp: ParseResult Expr) =
   | _ -> exp
 end
 
@@ -135,7 +135,7 @@ lang IdentParser = ExprParser
   | (['_' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' |
       'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' |
       'x' | 'y' | 'z' ] ++ s) & xs ->
-    let r : ParseResult = parseIdent false p xs in
+    let r : ParseResult String = parseIdent false p xs in
     nextIdent p r.str r.val
 
   sem nextIdent (p: Pos) (xs: String) =
@@ -185,7 +185,7 @@ utest parseUInt (initPos "") "Not a number"
 let parseFloatExponent : Pos -> String -> {val: String, pos: Pos, str: String} =
   lam p. lam str.
     match str with ['+' | '-'] ++ xs & s then
-      let n : ParseResult = parseUInt (advanceCol p 1) xs in
+      let n : ParseResult String = parseUInt (advanceCol p 1) xs in
       match n.val with "" then n
       else {val = cons (head s) n.val, pos = n.pos, str = n.str}
     else
@@ -206,7 +206,7 @@ utest parseFloatExponent (initPos "") "Not an exponent"
 lang UNumParser = ExprParser
   sem parseExprImp (p : Pos) =
   | (['0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'] ++ s) & xs ->
-    let n : ParseResult = parseUInt p xs in
+    let n : ParseResult String = parseUInt p xs in
     let nextChar = if null n.str then None () else Some (head n.str) in
     nextNum p n.str n.val nextChar
 
@@ -229,7 +229,7 @@ lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst + UnknownTypeAst
   sem nextNum (p: Pos) (xs: String) (nval: String) =
   | Some (('.' | 'e' | 'E') & c) ->
     let exponentHelper = lam pos. lam pre. lam expChar. lam s. lam isFloat.
-      let exp : ParseResult = parseFloatExponent (advanceCol pos 1) s in
+      let exp : ParseResult String = parseFloatExponent (advanceCol pos 1) s in
       match exp.val with "" then
         let constVal =
           if isFloat then
@@ -253,7 +253,7 @@ lang UFloatParser = UNumParser + ConstAst + FloatAst + IntAst + UnknownTypeAst
       let s = tail xs in
       match s with ['0' | '1' | '2' | '3' | '4' |
                     '5' | '6' | '7' | '8' | '9'] ++ s2 then
-        let n2 : ParseResult = parseUInt p3 s in
+        let n2 : ParseResult String = parseUInt p3 s in
         let preExponentStr = join [nval, ".", n2.val] in
         match n2.str with ['e' | 'E'] ++ s3 then
           exponentHelper n2.pos preExponentStr (head n2.str) s3 true
@@ -294,11 +294,11 @@ lang IfParser =
 
   sem nextIdent (p: Pos) (xs: String) =
   | "if" ->
-     let e1 : ParseResult = parseExprMain (advanceCol p 2) 0 xs in
+     let e1 : ParseResult Expr = parseExprMain (advanceCol p 2) 0 xs in
      let r1 : StrPos = matchKeyword "then" e1.pos e1.str in
-     let e2 : ParseResult = parseExprMain r1.pos 0 r1.str in
+     let e2 : ParseResult Expr = parseExprMain r1.pos 0 r1.str in
      let r2 : StrPos = matchKeyword "else" e2.pos e2.str  in
-     let e3 : ParseResult = parseExprMain r2.pos 0 r2.str in
+     let e3 : ParseResult Expr = parseExprMain r2.pos 0 r2.str in
      {val = TmMatch {target = e1.val, pat = ptrue_,
                      thn = e2.val, els = e3.val, ty = tyunknown_,
                      info = makeInfo p e3.pos},
@@ -312,7 +312,7 @@ lang IfParser =
 lang ParenthesesParser = ExprParser + KeywordUtils
   sem parseExprImp (p: Pos) =
   | "(" ++ xs ->
-    let e : ParseResult = parseExprMain (advanceCol p 1) 0 xs in
+    let e : ParseResult Expr = parseExprMain (advanceCol p 1) 0 xs in
     let r : StrPos = matchKeyword ")" e.pos e.str in
     {val = e.val, pos = r.pos, str = r.str}
 end
@@ -329,7 +329,7 @@ lang SeqParser = ExprParser + KeywordUtils + SeqAst + UnknownTypeAst
       else
         let r2 : StrPos =
           if first then r else matchKeyword "," r.pos r.str in
-        let e : ParseResult = parseExprMain r2.pos 0 r2.str in
+        let e : ParseResult Expr = parseExprMain r2.pos 0 r2.str in
         work (snoc acc e.val) false e.pos e.str
     in work [] true (advanceCol p 1) xs
 end
@@ -361,7 +361,7 @@ lang StringParser = ExprParser + SeqAst + CharAst + UnknownTypeAst
                       info = makeInfo p (advanceCol p2 1)},
 	                    pos = advanceCol p2 1, str = xs}
       else
-        let r : ParseResult = matchChar p2 str in
+        let r : ParseResult Char = matchChar p2 str in
         let v = TmConst {val = CChar {val = r.val}, ty = tyunknown_,
                          info = makeInfo p2 r.pos} in
 	      work (snoc acc v) r.pos r.str
@@ -373,7 +373,7 @@ end
 lang CharParser = ExprParser + KeywordUtils + CharAst + UnknownTypeAst
   sem parseExprImp (p: Pos) =
   | "\'" ++ xs ->
-      let r : ParseResult = matchChar (advanceCol p 1) xs in
+      let r : ParseResult Char = matchChar (advanceCol p 1) xs in
       let r2 : StrPos = matchKeyword "\'" r.pos r.str in
       {val = TmConst {val = CChar {val = r.val}, ty = tyunknown_,
                       info = makeInfo p r2.pos},
@@ -399,9 +399,9 @@ lang FunParser =
   sem nextIdent (p: Pos) (xs: String) =
   | "lam" ->
     let r : StrPos = eatWSAC (advanceCol p 3) xs in
-    let r2 : ParseResult = parseIdent false r.pos r.str in
+    let r2 : ParseResult String = parseIdent false r.pos r.str in
     let r3 : StrPos = matchKeyword "." r2.pos r2.str in
-    let e : ParseResult = parseExprMain r3.pos 0 r3.str in
+    let e : ParseResult Expr = parseExprMain r3.pos 0 r3.str in
     {val = TmLam {ident = nameNoSym r2.val, ty = tyunknown_,
                   tyIdent = tyunknown_, body = e.val,
                   info = makeInfo p e.pos},
@@ -415,11 +415,11 @@ lang LetParser =
   sem nextIdent (p: Pos) (xs: String) =
   | "let" ->
     let r : StrPos = eatWSAC (advanceCol p 3) xs in
-    let r2 : ParseResult = parseIdent false r.pos r.str in
+    let r2 : ParseResult String = parseIdent false r.pos r.str in
     let r3 : StrPos = matchKeyword "=" r2.pos r2.str in
-    let e1 : ParseResult = parseExprMain r3.pos 0 r3.str in
+    let e1 : ParseResult Expr = parseExprMain r3.pos 0 r3.str in
     let r4 : StrPos = matchKeyword "in" e1.pos e1.str in
-    let e2 : ParseResult = parseExprMain r4.pos 0 r4.str in
+    let e2 : ParseResult Expr = parseExprMain r4.pos 0 r4.str in
     {val = TmLet {ident = nameNoSym r2.val, tyBody = tyunknown_,
                   body = e1.val, inexpr = e2.val, ty = tyunknown_,
                   info = makeInfo p e2.pos},
@@ -433,17 +433,17 @@ lang ExprInfixParser = ExprParser
   | LeftAssoc ()
   | RightAssoc ()
 
-  sem parseInfix (p: Pos) (prec: Int) (exp: ParseResult) =
+  sem parseInfix (p: Pos) (prec: Int) (exp: ParseResult Expr) =
   | str ->
     let r : StrPos = eatWSAC p str in
     match parseInfixImp r.pos r.str with Some op then
-      let op : {val : Expr, pos : Pos, str : String,
+      let op : {val : Expr -> Expr -> Expr, pos : Pos, str : String,
                 assoc : Associativity, prec : Int} = op in
       if geqi op.prec prec then
         let prec2 = match op.assoc with LeftAssoc ()
                     then addi op.prec 1
                     else op.prec in
-        let exp2 : ParseResult = parseExprMain op.pos prec2 op.str in
+        let exp2 : ParseResult Expr = parseExprMain op.pos prec2 op.str in
         let exp3 = {val = op.val exp.val exp2.val,
                     pos = exp2.pos, str = exp2.str} in
 	      parseInfix exp3.pos prec exp3 exp3.str
@@ -518,7 +518,7 @@ in
 let eqExpr = lam l : Expr. lam r : Expr.
   eqExpr l r
 in
-let eqParseResult = lam l : ParseResult. lam r : ParseResult.
+let eqParseResult = lam l : ParseResult Expr. lam r : ParseResult Expr.
   and (eqExpr l.val r.val)
       (and (eqPos l.pos r.pos) (eqString l.str r.str))
 in
@@ -603,7 +603,7 @@ utest parseExprMain (initPos "file") 0 " 3.1992e--2 " with
        pos = posVal "file" 1 7, str = "e--2 "} using eqParseResult in
 
 --If expression
-let ifexpr : ParseResult = parseExprMain (initPos "") 0 "  if 1 then 22 else 3" in
+let ifexpr : ParseResult Expr = parseExprMain (initPos "") 0 "  if 1 then 22 else 3" in
 utest ifexpr.pos
   with posVal "" 1 21 in
 -- Boolean literal 'true'
@@ -658,15 +658,15 @@ utest parseExpr (initPos "") " \'\\n\' " with
   TmConst {val = CChar {val = '\n'}, ty = tyunknown_,
            info = infoVal "" 1 1 1 5} using eqExpr in
 -- Var
-let var : ParseResult = parseExprMain (initPos "") 0 " _xs " in
+let var : ParseResult Expr = parseExprMain (initPos "") 0 " _xs " in
 utest var.pos with posVal "" 1 4 in
-let var : ParseResult = parseExprMain (initPos "") 0 " fOO_12a " in
+let var : ParseResult Expr = parseExprMain (initPos "") 0 " fOO_12a " in
 utest var.pos with posVal "" 1 8 in
 -- Lambda
-let lambda : ParseResult = parseExprMain (initPos "") 0 " lam x . x " in
+let lambda : ParseResult Expr = parseExprMain (initPos "") 0 " lam x . x " in
 utest lambda.pos with posVal "" 1 10 in
 -- Let
-let letexpr : ParseResult = parseExprMain (initPos "") 0 "  let x = 5 in 8 " in
+let letexpr : ParseResult Expr = parseExprMain (initPos "") 0 "  let x = 5 in 8 " in
 utest letexpr.pos with posVal "" 1 16 in
 
 

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -138,7 +138,7 @@ lang IdentParser = ExprParser
     let r : ParseResult = parseIdent false p xs in
     nextIdent p r.str r.val
 
-  sem nextIdent (p: Pos) (xs: string) =
+  sem nextIdent (p: Pos) (xs: String) =
 end
 
 
@@ -384,7 +384,7 @@ end
 
 -- Parse variable
 lang VarParser = ExprParser + IdentParser + VarAst + UnknownTypeAst
-  sem nextIdent (p: Pos) (xs: string) =
+  sem nextIdent (p: Pos) (xs: String) =
   | x ->
       let p2 = advanceCol p (length x) in
       {val = TmVar {ident = nameNoSym x, ty = tyunknown_, info = makeInfo p p2, frozen = false},

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -133,7 +133,7 @@ let pprintConString = lam str.
 -- Get an optional list of tuple expressions for a record. If the record does
 -- not represent a tuple, None () is returned.
 let record2tuple
-  : Map SID a
+  : all a. Map SID a
   -> Option [a]
   = lam bindings.
     let keys = map sidToString (mapKeys bindings) in
@@ -1075,16 +1075,16 @@ lang RecordTypePrettyPrint = RecordTypeAst
   | TyRecord t ->
     if mapIsEmpty t.fields then (env,"()") else
       let tuple =
-        let seq = map (lam b : (a,b). (sidToString b.0, b.1)) (mapBindings t.fields) in
-        if forAll (lam t : (a,b). stringIsInt t.0) seq then
-          let seq = map (lam t : (a,b). (string2int t.0, t.1)) seq in
-          let seq : [(a,b)] = sort (lam l : (a,b). lam r : (a,b). subi l.0 r.0) seq in
-          let fst = lam x: (a, b). x.0 in
+        let seq = map (lam b : (SID,Type). (sidToString b.0, b.1)) (mapBindings t.fields) in
+        if forAll (lam t : (String,Type). stringIsInt t.0) seq then
+          let seq = map (lam t : (String,Type). (string2int t.0, t.1)) seq in
+          let seq : [(Int,Type)] = sort (lam l : (Int,Type). lam r : (Int,Type). subi l.0 r.0) seq in
+          let fst = lam x: (Int, Type). x.0 in
           let first = fst (head seq) in
           let last = fst (last seq) in
           if eqi first 0 then
             if eqi last (subi (length seq) 1) then
-              Some (map (lam t : (a,b). t.1) seq)
+              Some (map (lam t : (Int,Type). t.1) seq)
             else None ()
           else None ()
         else None ()
@@ -1097,8 +1097,8 @@ lang RecordTypePrettyPrint = RecordTypeAst
         let f = lam env. lam. lam v. getTypeStringCode indent env v in
         match mapMapAccum f env t.fields with (env, fields) then
           let fields =
-            map (lam b : (a,b). (sidToString b.0, b.1)) (mapBindings fields) in
-          let conventry = lam entry : (a,b). join [entry.0, ": ", entry.1] in
+            map (lam b : (SID,String). (sidToString b.0, b.1)) (mapBindings fields) in
+          let conventry = lam entry : (String,String). join [entry.0, ": ", entry.1] in
           (env,join ["{", strJoin ", " (map conventry fields), "}"])
         else never
 end

--- a/stdlib/mexpr/runtime-check.mc
+++ b/stdlib/mexpr/runtime-check.mc
@@ -77,7 +77,7 @@ lang MExprRuntimeCheck = MExprAst + MExprArity + MExprCmp + MExprPrettyPrint
           unit_
           (app_ (nvar_ errId) (concat_ (var_ infoId) (str_ cond.0)))) in
     recursive let addParam = lam acc : Expr. lam paramId : Name.
-      ulam_ paramId acc in
+      nulam_ paramId acc in
     let conditions = intrinsicRuntimeConditions intrinsic in
     let arity = constArity intrinsic in
     let intrinsicArgs = create arity (lam i. int2string i) in

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -343,7 +343,7 @@ end
 -- PATTERNS --
 --------------
 
-let _symbolize_patname: SymEnv -> PatName -> (SymEnv, PatName) =
+let _symbolize_patname: Map String Name -> PatName -> (Map String Name, PatName) =
   lam varEnv. lam pname.
     match pname with PName name then
       if nameHasSym name then (varEnv, PName name)

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -13,6 +13,7 @@ include "ast.mc"
 include "ast-builder.mc"
 include "info.mc"
 include "pprint.mc"
+include "type.mc"
 
 ---------------------------
 -- SYMBOLIZE ENVIRONMENT --
@@ -32,7 +33,12 @@ let symEnvEmpty =
   {varEnv = mapEmpty cmpString,
    conEnv = mapEmpty cmpString,
    tyVarEnv = mapEmpty cmpString,
-   tyConEnv = mapEmpty cmpString,
+
+   -- Built-in type constructors
+   tyConEnv = mapFromSeq cmpString (
+     map (lam t: (String, [String]). (t.0, nameNoSym t.0)) builtinTypes
+   ),
+
    strictTypeVars = false}
 
 -----------

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -396,7 +396,7 @@ lang NotPatSym = NotPat
     -- error to bind a name inside a not-pattern, but we're not doing
     -- that kind of static checks yet.  Note that we still need to run
     -- symbolizeExpr though, constructors must refer to the right symbol.
-    let res : (SymEnv, Pat) = symbolizePat env patEnv p.subpat in
+    let res : (Map String Name, Pat) = symbolizePat env patEnv p.subpat in
     (patEnv, PatNot {p with subpat = res.1})
 end
 

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -11,9 +11,9 @@ include "string.mc"
 
 include "ast.mc"
 include "ast-builder.mc"
+include "builtin.mc"
 include "info.mc"
 include "pprint.mc"
-include "type.mc"
 
 ---------------------------
 -- SYMBOLIZE ENVIRONMENT --

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -14,7 +14,7 @@ include "const-types.mc"
 include "eq.mc"
 include "pprint.mc"
 include "builtin.mc"
-include "mexpr/type.mc"
+include "type.mc"
 
 type TypeEnv = {
   varEnv: Map Name Type,
@@ -25,7 +25,9 @@ type TypeEnv = {
 let _typeEnvEmpty = {
   varEnv = mapEmpty nameCmp,
   conEnv = mapEmpty nameCmp,
-  tyEnv  = mapEmpty nameCmp
+  tyEnv  = mapFromSeq nameCmp (
+    map (lam t : (String, [String]). (nameNoSym t.0, tyvariant_ [])) builtinTypes
+  )
 }
 
 let _pprintType = use MExprPrettyPrint in

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -13,13 +13,13 @@
 
 include "ast.mc"
 include "ast-builder.mc"
+include "builtin.mc"
 include "const-types.mc"
 include "eq.mc"
 include "info.mc"
 include "math.mc"
 include "pprint.mc"
 include "seq.mc"
-include "type.mc"
 
 type TCEnv = {
   varEnv: Map Name Type,

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -19,6 +19,7 @@ include "info.mc"
 include "math.mc"
 include "pprint.mc"
 include "seq.mc"
+include "type.mc"
 
 type TCEnv = {
   varEnv: Map Name Type,
@@ -32,7 +33,14 @@ type TCEnv = {
 let _tcEnvEmpty = {
   varEnv = mapEmpty nameCmp,
   conEnv = mapEmpty nameCmp,
-  tyConEnv = mapEmpty nameCmp,
+
+  -- Built-in type constructors
+  tyConEnv = mapFromSeq nameCmp (
+    map (lam t : (String, [String]).
+          (nameNoSym t.0, (map nameSym t.1, tyvariant_ [])))
+        builtinTypes
+  ),
+
   currentLvl = 1,
   disableRecordPolymorphism = true
 }

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -483,8 +483,9 @@ lang LamTypeCheck = TypeCheck + LamAst
     in
     let body = typeCheckExpr (_insertVar t.ident tyX env) t.body in
     let tyLam = ityarrow_ t.info tyX (tyTm body) in
-    TmLam {{t with body = body}
-              with ty = tyLam}
+    TmLam {{{t with body = body}
+               with tyIdent = tyX}
+               with ty = tyLam}
 end
 
 lang AppTypeCheck = TypeCheck + AppAst
@@ -515,9 +516,10 @@ lang LetTypeCheck = TypeCheck + LetAst
       (sremoveUnknown t.tyBody)
     in
     let inexpr = typeCheckExpr (_insertVar t.ident tyBody env) t.inexpr in
-    TmLet {{{t with body = body}
-               with inexpr = inexpr}
-               with ty = tyTm inexpr}
+    TmLet {{{{t with body = body}
+                with tyBody = tyBody}
+                with inexpr = inexpr}
+                with ty = tyTm inexpr}
 end
 
 lang RecLetsTypeCheck = TypeCheck + RecLetsAst
@@ -559,9 +561,9 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst
         (lam. gen lvl (tyTm b.body))
         (sremoveUnknown b.tyBody)
       in
-      _insertVar b.ident tyBody acc
+      (_insertVar b.ident tyBody acc, {b with tyBody = tyBody})
     in
-    let env = foldl envIteratee env bindings in
+    match mapAccumL envIteratee env bindings with (env, bindings) in
     let inexpr = typeCheckExpr env t.inexpr in
     TmRecLets {{{t with bindings = bindings}
                    with inexpr = inexpr}

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -56,7 +56,7 @@ let _insertTyCon = lam name. lam ty. lam env : TCEnv.
 
 type UnifyEnv = {
   names: BiNameMap,
-  tyConEnv: Map Name Type
+  tyConEnv: Map Name ([Name], Type)
 }
 
 let errInfo = ref (NoInfo ())
@@ -78,7 +78,9 @@ let _fields2str = use RecordTypeAst in
   _type2str (TyRecord {info = NoInfo (), fields = m, labels = mapKeys m})
 
 let _sort2str = use MExprPrettyPrint in
-  getVarSortStringCode 0 pprintEnvEmpty
+  lam ident. lam sort.
+  match getVarSortStringCode 0 pprintEnvEmpty (nameGetStr ident) sort
+  with (_, str) in str
 
 lang VarTypeSubstitute = VarTypeAst
   sem substituteVars (subst : Map Name Type) =
@@ -138,7 +140,7 @@ lang Unify = MExprAst + ResolveAlias
     unificationError (_type2str ty1) (_type2str ty2)
 
   -- checkBeforeUnify is called before a variable `tv' is unified with another type.
-  -- Performs three tasks in one traversal:
+  -- Performs multiple tasks in one traversal:
   -- - Occurs check
   -- - Update level fields of FlexVars
   -- - If `tv' is monomorphic, ensure it is not unified with a polymorphic type
@@ -856,7 +858,7 @@ let idbody_ = ulam_ "y" (var_ "y") in
 let tyid_ = tyall_ "a" (tyarrow_ a a) in
 let id_ = ("id", tyid_) in
 
-let idsbody_ = bind_ id_ (seq_ [freeze_ (var_ "id")]) in
+let idsbody_ = bind_ idbody_ (seq_ [freeze_ (var_ "id")]) in
 let tyids_ = tyseq_ tyid_ in
 let ids_ = ("ids", tyids_) in
 

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -428,7 +428,14 @@ lang ResolveLinks = FlexTypeAst + UnknownTypeAst
   sem resolveLinksExpr =
   | tm ->
     let tm = withType (resolveLinks (tyTm tm)) tm in
+    let tm = smap_Expr_Type resolveLinks tm in
+    let tm = smap_Expr_Pat resolveLinksPat tm in
     smap_Expr_Expr resolveLinksExpr tm
+
+  sem resolveLinksPat =
+  | pat ->
+    let pat = withTypePat (resolveLinks (tyPat pat)) pat in
+    smap_Pat_Pat resolveLinksPat pat
 end
 
 lang TypeCheck = Unify + Generalize + ResolveLinks

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -376,7 +376,7 @@ mexpr
 
 use TestLang in
 
-let fst = lam x: (a, b). x.0 in
+let fst : all a. all b. (a, b) -> a = lam x. x.0 in
 
 let eqEnv = lam lenv. lam renv.
   use MExprEq in
@@ -555,7 +555,7 @@ match typeLift typeAliases with (env, t) in
 -- Note that records and variants are added to the front of the environment
 -- as they are processed, so the last record in the given term will be first
 -- in the environment.
-let ids = map (lam p: (a, b). p.0) env in
+let ids = map fst env in
 let fstSeqId = get ids 7 in    -- type Seq1 = [Char]
 let fstRecordId = get ids 6 in -- type Rec1 = {0 : Seq1, 1 : Int}
 let sndSeqId = get ids 5 in    -- type Seq2 = [Rec1]

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -10,3 +10,10 @@ recursive let typeUnwrapAlias = use MExprAst in
     else ty
   else ty
 end
+
+let builtinTypes : [(String, [String])] =
+  [ ("Symbol", [])
+  , ("Ref", ["a"])
+  , ("Map", ["k", "v"])
+  , ("BootParseTree", [])
+  ]

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -10,10 +10,3 @@ recursive let typeUnwrapAlias = use MExprAst in
     else ty
   else ty
 end
-
-let builtinTypes : [(String, [String])] =
-  [ ("Symbol", [])
-  , ("Ref", ["a"])
-  , ("Map", ["k", "v"])
-  , ("BootParseTree", [])
-  ]

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -9,6 +9,7 @@ include "builtin.mc"
 include "eq.mc"
 include "type-annot.mc"
 include "type-lift.mc"
+include "type.mc"
 
 include "common.mc"
 
@@ -289,7 +290,9 @@ let collectKnownProgramTypes = use MExprAst in
   in
   let emptyUtestTypeEnv = {
     variants = mapEmpty nameCmp,      -- Map Name Type
-    aliases = mapEmpty nameCmp,       -- Map Name Type
+    aliases = mapFromSeq nameCmp (    -- Map Name Type
+      map (lam t : (String, [String]). (nameNoSym t.0, tyunknown_)) builtinTypes
+    ),
     typeFunctions = use MExprCmp in mapEmpty cmpType -- Map Type (Name, Name)
   } in
   collectTypes emptyUtestTypeEnv expr

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -739,9 +739,9 @@ let constructSymbolizeEnv = lam env : UtestTypeEnv.
           (mapKeys constructors)
   ) (mapEmpty cmpString) env.variants in
   let typeNames = mapFoldWithKey (lam acc. lam typeId. lam.
-    mapInsert (nameGetStr typeId) typeId) (mapEmpty cmpString) env.variants in
+    mapInsert (nameGetStr typeId) typeId acc) (mapEmpty cmpString) env.variants in
   let typeNames = mapFoldWithKey (lam acc. lam id. lam.
-    mapInsert (nameGetStr id) id) typeNames env.aliases in
+    mapInsert (nameGetStr id) id acc) typeNames env.aliases in
    {{symEnvEmpty with conEnv = constructorNames}
                  with tyConEnv = typeNames}
 

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -9,7 +9,6 @@ include "builtin.mc"
 include "eq.mc"
 include "type-annot.mc"
 include "type-lift.mc"
-include "type.mc"
 
 include "common.mc"
 

--- a/stdlib/multicore/thread.ext-ocaml.mc
+++ b/stdlib/multicore/thread.ext-ocaml.mc
@@ -14,7 +14,6 @@ let threadExtMap =
       impl
       { expr = "Domain.spawn"
       , ty = tyarrow_ (tyarrow_ otyunit_ (tygeneric_ "a")) (tyathread_ "a")
-      , libraries = []
       }]),
 
     ("externalThreadJoin", [

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -27,7 +27,8 @@ lang OCamlRecord
   syn Pat =
   | OPatRecord {bindings : Map SID Pat}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmRecord t ->
     let bindFunc = lam acc. lam bind : (String, Expr).
       match f acc bind.1 with (acc, expr) then
@@ -41,7 +42,8 @@ lang OCamlRecord
       (acc, OTmProject {t with tm = tm})
     else never
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat f acc =
   | OPatRecord t ->
     match mapMapAccum (lam acc. lam. lam p. f acc p) acc t.bindings
     with (acc, bindings) then
@@ -58,7 +60,8 @@ lang OCamlMatch
 
   syn Pat =
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmMatch t ->
     let armsFunc = lam acc. lam arm : (Pat, Expr).
       match f acc arm.1 with (acc, expr) then
@@ -76,7 +79,8 @@ lang OCamlArray
   syn Expr =
   | OTmArray {tms : [Expr]}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmArray t ->
     match mapAccumL f acc t.tms with (acc, tms) then
       (acc, OTmArray {t with tms = tms})
@@ -90,13 +94,15 @@ lang OCamlTuple
   syn Pat =
   | OPatTuple { pats : [Pat] }
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmTuple t ->
     match mapAccumL f acc t.values with (acc, values) then
       (acc, OTmTuple {t with values = values})
     else never
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat f acc =
   | OPatTuple t ->
     match mapAccumL f acc t.pats with (acc, pats) then
       (acc, OPatTuple {t with pats = pats})
@@ -110,13 +116,15 @@ lang OCamlData
   syn Pat =
   | OPatCon { ident : Name, args : [Pat] }
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmConApp t ->
     match mapAccumL f acc t.args with (acc, args) then
       (acc, OTmConApp {t with args = args})
     else never
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat f acc =
   | OPatCon t ->
     match mapAccumL f acc t.args with (acc, args) then
       (acc, OPatCon {t with args = args})
@@ -145,13 +153,15 @@ lang OCamlExternal
   syn Pat =
   | OPatConExt { ident : String, args : [Pat] }
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmConAppExt t ->
     match mapAccumL f acc t.args with (acc, args) then
       (acc, OTmConAppExt {t with args = args})
     else never
 
-  sem smapAccumL_Pat_Pat (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Pat_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Pat -> (acc, Pat)
+  sem smapAccumL_Pat_Pat f acc =
   | OPatConExt t ->
     match mapAccumL f acc t.args with (acc, args) then
       (acc, OPatConExt {t with args = args})
@@ -162,7 +172,8 @@ lang OCamlLabel
   syn Expr =
   | OTmLabel { label : String, arg : Expr }
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmLabel t ->
     match f acc t.arg with (acc, arg) then
       (acc, OTmLabel {t with arg = arg})
@@ -173,7 +184,8 @@ lang OCamlLam
   syn Expr =
   | OTmLam {label : Option String, ident : Name, body : Expr}
 
-  sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem smapAccumL_Expr_Expr f acc =
   | OTmLam t ->
     match f acc t.body with (acc, body) then
       (acc, OTmLam {t with body = body})
@@ -215,7 +227,8 @@ lang OCamlTypeAst =
   | OTyRecord r -> r.info
   | OTyString r -> r.info
 
-  sem smapAccumL_Type_Type (f : acc -> a -> (acc, b)) (acc : acc) =
+  sem smapAccumL_Type_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Type -> (acc, Type)
+  sem smapAccumL_Type_Type f acc =
   | OTyList t ->
     match f acc t.ty with (acc, ty) then
       (acc, OTyList {t with ty = ty})

--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -10,7 +10,7 @@ type CompileOptions = {
 type Program = String -> [String] -> ExecResult
 type CompileResult = {
   run : Program,
-  cleanup : Unit -> Unit,
+  cleanup : () -> (),
   binaryPath : String
 }
 
@@ -76,7 +76,7 @@ let ocamlCompileWithConfig : CompileOptions -> String -> CompileResult =
           concat ["dune", "exec", "./program.exe", "--"] args
         in
         sysRunCommand command stdin (tempfile ""),
-    cleanup = sysTempDirDelete td,
+    cleanup = lam. sysTempDirDelete td (); (),
     binaryPath = tempfile "_build/default/program.exe"
   }
 

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -93,7 +93,7 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
     (getTy1 : Type -> Type -> Type)
     (getTy2 : Type -> Type -> Type)
     (t : Expr)
-    (fields : [(String, Type)]) =
+    (fields : Map SID Type) =
   | tys ->
     let ns = create (length tys) (lam. nameSym "t") in
     let pvars =

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -24,7 +24,7 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
 
   sem _convertEls
     (approxsize : Int)
-    (mapop : String)
+    (mapop : Expr)
     (info : Info)
     (env : GenerateEnv)
     (t : Expr)
@@ -66,10 +66,10 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
     else never
 
   sem _convertContainer
-    (op : String)
+    (op : Expr)
     (opcost : Int)
     (approxsize : Int)
-    (mapop : String)
+    (mapop : Expr)
     (info : Info)
     (env : GenerateEnv)
     (t : Expr)

--- a/stdlib/ocaml/mcore.mc
+++ b/stdlib/ocaml/mcore.mc
@@ -21,12 +21,13 @@ type Hooks a =
   , compileOcaml : [String] -> [String] -> String -> a
   }
 
-let emptyHooks : Hooks ExecResult =
+let mkEmptyHooks : all a. ([String] -> [String] -> String -> a) -> Hooks a =
+  lam compileOcaml.
   { debugTypeAnnot = lam. ()
   , debugGenerate = lam. ()
   , exitBefore = lam. ()
   , postprocessOcamlTops = lam tops. tops
-  , compileOcaml = lam. lam. lam. {stdout = "", stderr = "", returncode = 0}
+  , compileOcaml = compileOcaml
   }
 
 let collectLibraries : Map Name [ExternalImpl] -> Set String -> ([String], [String])
@@ -98,4 +99,4 @@ let compileRunMCore : String -> [String] -> Expr -> ExecResult =
     cunit.cleanup ();
     res
   in
-  compileMCore ast {emptyHooks with compileOcaml = compileOcaml}
+  compileMCore ast (mkEmptyHooks compileOcaml)

--- a/stdlib/ocaml/mcore.mc
+++ b/stdlib/ocaml/mcore.mc
@@ -13,7 +13,7 @@ lang MCoreCompileLang =
   OCamlGenerateExternalNaive
 end
 
-type Hooks =
+type Hooks a =
   { debugTypeAnnot : Expr -> ()
   , debugGenerate : String -> ()
   , exitBefore : () -> ()
@@ -21,15 +21,15 @@ type Hooks =
   , compileOcaml : [String] -> [String] -> String -> a
   }
 
-let emptyHooks : Hooks =
+let emptyHooks : Hooks ExecResult =
   { debugTypeAnnot = lam. ()
   , debugGenerate = lam. ()
   , exitBefore = lam. ()
   , postprocessOcamlTops = lam tops. tops
-  , compileOcaml = lam. lam. lam. ""
+  , compileOcaml = lam. lam. lam. {stdout = "", stderr = "", returncode = 0}
   }
 
-let collectLibraries : ExternalNameMap -> Set String -> ([String], [String])
+let collectLibraries : Map Name [ExternalImpl] -> Set String -> ([String], [String])
 = lam extNameMap. lam syslibs.
   let f = lam s. lam str. setInsert str s in
   let g = lam acc : (Set String, Set String). lam impl :  ExternalImpl.
@@ -43,7 +43,7 @@ let collectLibraries : ExternalNameMap -> Set String -> ([String], [String])
     (setToSeq libs, setToSeq clibs)
   else never
 
-let compileMCore : Expr -> Hooks -> a =
+let compileMCore : all a. Expr -> Hooks a -> a =
   lam ast. lam hooks.
   use MCoreCompileLang in
   let ast = typeAnnot ast in

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -450,7 +450,7 @@ lang OCamlPrettyPrint =
     else never
   | OTmConAppExt {ident = ident, args = []} -> (env, ident)
   | OTmConAppExt {ident = ident, args = [arg]} ->
-    match printParen ident env arg with (env, arg) then
+    match printParen indent env arg with (env, arg) then
       (env, join [ident, " ", arg])
     else never
   | OTmConAppExt {ident = ident, args = args} ->

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -48,7 +48,7 @@ lang OCamlSym =
     OTmRecord {t with bindings = bindings}
   | OTmProject t -> OTmProject {t with tm = symbolizeExpr env t.tm}
 
-  sem symbolizePat (env : SymEnv) (patEnv : SymEnv) =
+  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
   | OPatTuple { pats = pats } ->
     match mapAccumL (symbolizePat env) patEnv pats with (patEnv, pats) then
       (patEnv, OPatTuple { pats = pats })

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -32,13 +32,15 @@ utest optionMap (addi 1) (None ()) with (None ()) using optionEq eqi
 utest optionMap (addi 1) (Some 1) with (Some 2) using optionEq eqi
 
 let optionMapAccum: all a. all b. all acc.
-  (a -> (acc, b)) -> acc -> Option a -> (acc, Option b) =
+  (acc -> a -> (acc, b)) -> acc -> Option a -> (acc, Option b) =
   lam f. lam acc. lam o.
     match o with Some a then
       match f acc a with (acc, b) then
         (acc, Some b)
       else never
-    else (acc, o)
+    else (acc, None ())
+
+utest optionMapAccum (lam acc. lam a. (acc, a)) () (Some 5) with ((), Some 5)
 
 -- TODO(vipa, 2021-05-28): Write tests for optionMapAccum
 

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -275,14 +275,14 @@ let _opIdxP
     never
 let _addedNodesLeftChildren
   : TentativeNode self ROpen
-  -> [TentativeNode self ROpen] -- NonEmpty
+  -> Ref (TimeStep, Ref [PermanentNode]) -- NonEmpty
   = lam node.
     match node with TentativeRoot{addedNodesLeftChildren = x} | TentativeMid{addedNodesLeftChildren = x}
     then x
     else never
 let _addedNodesRightChildren
   : TentativeNode self ROpen
-  -> [TentativeNode self ROpen] -- NonEmpty
+  -> Ref (TimeStep, [PermanentNode]) -- NonEmpty
   = lam node.
     match node with TentativeRoot{addedNodesRightChildren = x} | TentativeMid{addedNodesRightChildren = x}
     then x

--- a/stdlib/pmexpr/parallel-patterns.mc
+++ b/stdlib/pmexpr/parallel-patterns.mc
@@ -90,7 +90,7 @@ let getInnerPatterns : AtomicPattern -> Option [AtomicPattern] = lam p.
 -- This function is implemented with the assumption that every pattern has been
 -- given a unique index. If multiple patterns with the same index are found, an
 -- error will be reported.
-let getPatternDependencies : [AtomicPattern] -> Map Int (Set Int) =
+let getPatternDependencies : [AtomicPattern] -> ([AtomicPattern], Map Int (Set Int)) =
   lam atomicPatterns.
   recursive let atomicPatternDependencies = lam dependencies. lam p.
     let id = getPatternIndex p in

--- a/stdlib/pmexpr/parallel-patterns.mc
+++ b/stdlib/pmexpr/parallel-patterns.mc
@@ -127,7 +127,7 @@ let getPatternDependencies : [AtomicPattern] -> ([AtomicPattern], Map Int (Set I
 -- checked.
 let withDependencies :
      {atomicPatterns : [AtomicPattern],
-      replacement : (Map VarPattern (Name, Expr)) -> Expr} -> Pattern = lam pat.
+      replacement : Info -> Map VarPattern (Name, Expr) -> Expr} -> Pattern = lam pat.
   recursive let work = lam acc. lam pat.
     let idx = getPatternIndex pat in
     let acc = cons (idx, pat) acc in

--- a/stdlib/regex.mc
+++ b/stdlib/regex.mc
@@ -2,10 +2,10 @@ include "dfa.mc"
 include "eqset.mc"
 
 -- Represents basic regular expressions.
-type RegEx
+type RegEx a
   con Empty   : ()             -> RegEx
   con Epsilon : ()             -> RegEx
-  con Symbol  : (a)            -> RegEx
+  con Symbol  : all a. (a)     -> RegEx
   con Union   : (RegEx, RegEx) -> RegEx
   con Concat  : (RegEx, RegEx) -> RegEx
   con Kleene  : (RegEx)        -> RegEx
@@ -169,7 +169,7 @@ let regexFromDFA = lam dfa.
       let trans = nfaTransitionsBetween from to dfa in
       match trans with [] then Empty () else
       match trans with [t] then t.2 else
-      error (strJoin ["getSymOrEmpty expected 0 or 1 transitions, was ", length trans])
+      error (join ["getSymOrEmpty expected 0 or 1 transitions, was ", int2string (length trans)])
 
     in
     -- Handle 1-state DFA
@@ -177,7 +177,7 @@ let regexFromDFA = lam dfa.
       let trans = nfaTransitions dfa in
       match trans with [] then Epsilon () else
       match trans with [t] then Kleene(t.2) else
-      error (join ["Expected 0 or 1 transitions in 1-state DFA, not ", length trans])
+      error (join ["Expected 0 or 1 transitions in 1-state DFA, not ", int2string (length trans)])
     in
     -- Handle 2-state DFA
     let generic2State = lam dfa.
@@ -201,7 +201,7 @@ let regexFromDFA = lam dfa.
     let nStates = length (nfaStates dfa) in
     match nStates with 1 then generic1State dfa else
     match nStates with 2 then generic2State dfa else
-    error (join ["Expected DFA of size 1 or 2, not ", nStates, "."])
+    error (join ["Expected DFA of size 1 or 2, not ", int2string nStates, "."])
   in
 
   -- Get the regex from a DFA with one accept state

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -9,72 +9,72 @@ include "map.mc"
 type Set a = Map a {}
 
 -- `setEmpty cmp` creates an empty set ordered by `cmp`.
-let setEmpty : (a -> a -> Int) -> Set a = lam cmp. mapEmpty cmp
+let setEmpty : all a. (a -> a -> Int) -> Set a = lam cmp. mapEmpty cmp
 
 -- The size of a set.
-let setSize : Set a -> Int = mapSize
+let setSize : all a. Set a -> Int = mapSize
 
 -- Is the set empty?
-let setIsEmpty : Set a -> Bool = mapIsEmpty
+let setIsEmpty : all a. Set a -> Bool = mapIsEmpty
 
 -- `setInsert e s` inserts element `e` into set `s`.
-let setInsert : a -> Set a -> Set a = lam e. lam s. mapInsert e {} s
+let setInsert : all a. a -> Set a -> Set a = lam e. lam s. mapInsert e {} s
 
 -- `setRemove e s` removes element `e` from set `s`.
-let setRemove : a -> Set a -> Set a = lam e. lam s. mapRemove e s
+let setRemove : all a. a -> Set a -> Set a = lam e. lam s. mapRemove e s
 
 -- Is the element member of the set?
-let setMem : a -> Set a -> Bool = lam e. lam s. mapMem e s
+let setMem : all a. a -> Set a -> Bool = lam e. lam s. mapMem e s
 
 -- Is s1 a subset of s2?
-let setSubset : Set a -> Set a -> Bool = lam s1. lam s2.
+let setSubset : all a. Set a -> Set a -> Bool = lam s1. lam s2.
   mapAllWithKey (lam e. lam. mapMem e s2) s1
 
 -- `setUnion s1 s2` is the union of set `s1` and `s2`.
-let setUnion : Set a -> Set a -> Set a = lam s1. lam s2. mapUnion s1 s2
+let setUnion : all a. Set a -> Set a -> Set a = lam s1. lam s2. mapUnion s1 s2
 
 -- `setIntersect s1 s2` is the intersection of set `s1` and `s2`.
-let setIntersect : Set a -> Set a -> Set a = lam s1. lam s2.
+let setIntersect : all a. Set a -> Set a -> Set a = lam s1. lam s2.
   let cmp = mapGetCmpFun s1 in
   mapFoldWithKey (lam acc. lam key. lam.
     if setMem key s2 then setInsert key acc else acc
   ) (setEmpty cmp) s1
 
 -- `setOfSeq cmp seq` construct a set ordered by `cmp` from a sequence `seq`.
-let setOfSeq : (a -> a -> Int) -> [a] -> Set a =
+let setOfSeq : all a. (a -> a -> Int) -> [a] -> Set a =
 lam cmp. lam seq.
   foldr setInsert (setEmpty cmp) seq
 
 -- `setFold f acc s` folds over the values of s with the given function and
 -- initial accumulator
-let setFold : (acc -> a -> acc) -> acc -> Set a -> acc =
+let setFold : all a. all acc. (acc -> a -> acc) -> acc -> Set a -> acc =
   lam f. lam acc. lam s.
     mapFoldWithKey (lam acc. lam k. lam. f acc k) acc s
 
 -- Transform a set to a sequence.
-let setToSeq : Set a -> [a] = lam s. mapKeys s
+let setToSeq : all a. Set a -> [a] = lam s. mapKeys s
 
 -- Two sets are equal, where equality is determined by the compare function.
 -- Both sets are assumed to have the same equality function.
-let setEq : Set a -> Set a -> Bool = mapEq (lam. lam. true)
+let setEq : all a. Set a -> Set a -> Bool = mapEq (lam. lam. true)
 
 -- `setCmp` provides comparison over sets.
-let setCmp : Set a -> Set a -> Int = mapCmp (lam. lam. 0)
+let setCmp : all a. Set a -> Set a -> Int = mapCmp (lam. lam. 0)
 
 -- `setChoose s` chooses one element from the set `s`, giving `None ()` if `s`
 -- is empty.
-let setChoose : Set a -> Option a =
+let setChoose : all a. Set a -> Option a =
   lam s. match mapChoose s with Some (k, _) then Some k else None ()
 
 -- `setChooseExn s` chooses one element from the set `s`, giving `error` if `s`
 -- is empty.
-let setChooseExn : Set a -> a =
+let setChooseExn : all a. Set a -> a =
 lam s.
   match mapChooseExn s with (k, _) then k else never
 
 -- `setAny p s` returns true if the predicate p returns true for any element in
 -- s.
-let setAny: (a -> Bool) -> Set a -> Bool = lam p. lam s.
+let setAny: all a. (a -> Bool) -> Set a -> Bool = lam p. lam s.
   mapFoldWithKey (lam acc. lam v. lam. if acc then acc else p v) false s
 
 mexpr

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -7,7 +7,7 @@ let impl = lam arg : { expr : String, ty : Type }.
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []
 let tyidatriple = otyvarext_ "Ida.triple"
 let tyidajacobianargra =
-  otyvarext_ "Ida.jacobian_arg" [tyidatriple tyrealarray, tyrealarray]
+  otyvarext_ "Ida.jacobian_arg" [tyidatriple [tyrealarray], tyrealarray]
 
 let tyidajacf =
   tyarrows_ [

--- a/stdlib/symtable.mc
+++ b/stdlib/symtable.mc
@@ -62,7 +62,7 @@ utest symtableSize _r3.table with 2
 
 -- 'symtableRemove n t' returns a new table where names with strings
 -- equal to the string of 'n' are removed from 't'.
-let symtableRemove : Name -> Symtable -> Symtable =
+let symtableRemove : Name -> SymTable -> SymTable =
   lam n. lam t.
     filter (lam n2. not (nameEqStr n n2)) t
 

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -48,7 +48,7 @@ utest cartesianToLinearIndex [2, 3] [1, 0] with 3
 
 
 -- Folds `f` over the range `start` `stop` using accumulator `acc`
-let indexFoldu : (a -> Int -> a) -> a -> Int -> Int -> a =
+let indexFoldu : all a. (a -> Int -> a) -> a -> Int -> Int -> a =
 lam f. lam acc. lam start. lam stop.
   recursive let work = lam acc. lam i.
     if lti i stop then work (f acc i) (addi i 1) else acc
@@ -63,7 +63,7 @@ utest indexFoldu (lam seq. lam i. snoc seq i) [] 2 1 with [] using (eqSeq eqi)
 
 -- Folds `f` over the indexes up to `shape` in row-major order and accumulator
 -- `acc`
-let indexFoldRM : (a -> [Int] -> a) -> a -> [Int] -> a =
+let indexFoldRM : all a. (a -> [Int] -> a) -> a -> [Int] -> a =
 lam f. lam acc. lam shape.
   let size = _prod shape in
   recursive let work = lam acc. lam k.
@@ -83,7 +83,7 @@ with [[0, 0], [0, 1], [1, 0], [1, 1]] using eqSeq (eqSeq eqi)
 
 -- Folds `f` over the indexes of `shape` in row-major order with accumulator
 -- `acc`. If `f acc idx` is `None ()` then the result is `None ()`.
-let optionIndexFoldRMM : (a -> [Int] -> Option a) -> a -> [Int] -> Option a =
+let optionIndexFoldRMM : all a. (a -> [Int] -> Option a) -> a -> [Int] -> Option a =
 lam f. lam acc. lam shape.
   let size = _prod shape in
   recursive let work = lam acc. lam k.
@@ -125,7 +125,7 @@ with None () using optionEq (eqSeq (eqSeq eqi))
 -- SHAPE AND RANK CHECKS --
 ---------------------------
 
-let tensorHasRank : Tensor[a] -> Int -> Bool =
+let tensorHasRank : all a. Tensor[a] -> Int -> Bool =
   lam t. lam rank. eqi (tensorRank t) rank
 
 utest
@@ -138,7 +138,7 @@ utest
   tensorHasRank t 1
 with false
 
-let tensorHasShape : Tensor[a] -> [Int] -> Bool =
+let tensorHasShape : all a. Tensor[a] -> [Int] -> Bool =
   lam t. lam shape. eqSeq eqi (tensorShape t) shape
 
 utest
@@ -152,7 +152,7 @@ utest
 with false
 
 
-let tensorHasSameShape : Tensor[a] -> Tensor[b] -> Bool =
+let tensorHasSameShape : all a. all b.  Tensor[a] -> Tensor[b] -> Bool =
 lam t1. lam t2. eqSeq eqi (tensorShape t1) (tensorShape t2)
 
 utest
@@ -175,8 +175,8 @@ with false
 let tensorCreate = tensorCreateDense
 
 -- Construct a tensor of shape `shape` from a sequence `seq`.
-let tensorOfSeqOrElse :
-  (Unit -> Tensor[a]) ->
+let tensorOfSeqOrElse : all a.
+  (() -> Tensor[a]) ->
   ([Int] -> ([Int] -> a) -> Tensor[a]) ->
   [Int] ->
   [a] ->
@@ -189,12 +189,12 @@ lam f. lam tcreate. lam shape. lam seq.
     tensorReshapeExn t shape
 
 let tensorOfSeqExn
-  : ([Int] -> ([Int] -> a) -> Tensor[a]) -> [Int] -> [a] -> Tensor[a] =
+  : all a. ([Int] -> ([Int] -> a) -> Tensor[a]) -> [Int] -> [a] -> Tensor[a] =
   tensorOfSeqOrElse
     (lam. error "Empty seq in tensorOfSeqExn")
 
 -- Construct a sequence from a rank 1 tensor `t`.
-let tensorToSeqOrElse : (Unit -> [a]) -> Tensor[a] -> [a] =
+let tensorToSeqOrElse : all a. (() -> [a]) -> Tensor[a] -> [a] =
 lam f. lam t.
   if neqi (tensorRank t) 1 then f ()
   else
@@ -203,7 +203,7 @@ lam f. lam t.
                then Some (tensorGetExn t [i], addi i 1) else None ())
             0
 
-let tensorToSeqExn : Tensor[a] -> [a] =
+let tensorToSeqExn : all a. Tensor[a] -> [a] =
   tensorToSeqOrElse (lam. error "Not rank 1 tensor in tensorToSeqExn")
 
 utest tensorToSeqExn (tensorOfSeqExn tensorCreateCArrayInt [0] [])
@@ -221,7 +221,7 @@ utest tensorToSeqExn (tensorOfSeqExn tensorCreateDense [4] [1, 2, 3, 4])
 with [1, 2, 3, 4] using eqSeq eqi
 
 -- Create a tensor filled with values `v`.
-let tensorDenseRepeat : [Int] -> a -> Tensor[a] =
+let tensorDenseRepeat : all a. [Int] -> a -> Tensor[a] =
 lam shape. lam v.
   tensorCreateDense shape (lam. v)
 
@@ -232,7 +232,7 @@ with [0, 0, 0, 0] using eqSeq eqi
 
 
 -- The number of elements in a tensor `t`.
-let tensorSize : Tensor[a] -> Int =
+let tensorSize : all a. Tensor[a] -> Int =
 lam t. _prod (tensorShape t)
 
 utest tensorSize (tensorCreateDense [1, 2, 3] (lam. 0)) with 6
@@ -243,7 +243,7 @@ utest tensorSize (tensorCreateDense [0] (lam. 0)) with 0
 -- Map the elements of `t1` to the elements of `t2` via the function `f`,
 -- where `t1` and `t2` has to have the same shape.
 let tensorMapOrElse
-  : (Unit -> Unit) -> (a -> b -> b) -> Tensor[a] -> Tensor[b] -> Unit =
+  : all a. all b. (() -> ()) -> (a -> b -> b) -> Tensor[a] -> Tensor[b] -> () =
 lam f. lam g. lam t1. lam t2.
   if tensorHasSameShape t1 t2 then
     let n = tensorSize t1 in
@@ -293,7 +293,7 @@ with 2
 
 
 -- Applies function `f` to the elements of `t`.
-let tensorMapInplace : (a -> a) -> Tensor[a] -> Unit =
+let tensorMapInplace : all a. (a -> a) -> Tensor[a] -> () =
   lam f. lam t. tensorMapExn (lam. f) t t
 
 utest
@@ -304,7 +304,7 @@ with [2, 3, 4, 5]
 
 
 -- Applies function `f` to the elements of a copy of `t`.
-let tensorMapCopy : (a -> a) -> Tensor[a] -> Tensor[a] =
+let tensorMapCopy : all a. (a -> a) -> Tensor[a] -> Tensor[a] =
   lam f. lam t.
     let r = tensorCopy t in
     tensorMapExn (lam. f) t r; r
@@ -318,7 +318,7 @@ with [2, 3, 4, 5]
 -- Map the index and elements of `t1` to the elements of `t2` via the function
 -- `f`, where `t1` and `t2` has to have the same shape.
 let tensorMapiOrElse
-  : (Unit -> Unit) -> ([Int] -> a -> b -> b) -> Tensor[a] -> Tensor[b] -> Unit =
+  : all a. all b. (() -> ()) -> ([Int] -> a -> b -> b) -> Tensor[a] -> Tensor[b] -> () =
 lam f. lam g. lam t1. lam t2.
   let shape = tensorShape t1 in
   if tensorHasShape t2 shape then
@@ -343,15 +343,15 @@ utest
     [1, 2
     ,3, 4]
   in
-  let t2 = tensorCreateDense [2, 2] (lam. ([], 0)) in
-  tensorMapiExn (lam idx. lam x1. lam x2 : ([a], Int). (idx, cons x1 x2.0)) t1 t2;
+  let t2 = tensorCreateDense [2, 2] (lam. ([], [])) in
+  tensorMapiExn (lam idx. lam x1. lam x2 : ([Int], [Int]). (idx, cons x1 x2.0)) t1 t2;
   tensorToSeqExn (tensorReshapeExn t2 [tensorSize t2])
 with [([0, 0], [1]), ([0, 1], [2]), ([1, 0], [3]), ([1, 1], [4])]
 
-let tensorMapiInplace : ([Int] -> a -> a) -> Tensor[a] -> Unit =
+let tensorMapiInplace : all a. ([Int] -> a -> a) -> Tensor[a] -> () =
   lam f. lam t. tensorMapiExn (lam idx. lam x. lam. f idx x) t t
 
-let tensorMapiCopy : ([Int] -> a -> a) -> Tensor[a] -> Tensor[a] =
+let tensorMapiCopy : all a. ([Int] -> a -> a) -> Tensor[a] -> Tensor[a] =
   lam f. lam t.
     let r = tensorCopy t in
     tensorMapiExn (lam idx. lam x. lam. f idx x) t r; r
@@ -359,7 +359,7 @@ let tensorMapiCopy : ([Int] -> a -> a) -> Tensor[a] -> Tensor[a] =
 
 -- Copies the content of `t1` to `t2`. Gives an error if `t1` and `t2` does no
 -- have the same shape.
-let tensorBlitExn : Tensor[a] -> Tensor[a] -> () =
+let tensorBlitExn : all a. Tensor[a] -> Tensor[a] -> () =
 lam t1. lam t2.
   if tensorHasSameShape t1 t2 then tensorMapExn (lam x. lam. x) t1 t2
   else error "Invalid Argument: tensor.tensorBlitExn"
@@ -378,7 +378,7 @@ let test =
 -- the accumulator, `idx` is the index of the slice, and `t` is the i'th slice
 -- of `t1`.
 let tensorFoldliSlice
-  : (b -> Int -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
+  : all a. all b. (b -> Int -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
   lam f. lam acc. lam t1.
   let accr = ref acc in
   tensorIterSlice
@@ -397,7 +397,7 @@ with 9
 
 -- Left folds `f acc t` over the zero'th dimension of `t1`, where `acc` is the
 -- accumulator and `t` is the i'th slice of `t1`.
-let tensorFoldlSlice : (b -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
+let tensorFoldlSlice : all a. all b. (b -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
   lam f. tensorFoldliSlice (lam acc. lam. f acc)
 
 utest
@@ -409,7 +409,7 @@ with 6
 
 -- Folds `f acc el` over all elements `el` of `t` in row-major order, where
 -- `acc` is the accumulator.
-let tensorFold : (b -> a -> b) -> b -> Tensor[a] -> b =
+let tensorFold : all a. all b. (b -> a -> b) -> b -> Tensor[a] -> b =
   lam f. lam acc. lam t.
   let t = tensorReshapeExn t [tensorSize t] in
   tensorFoldlSlice (lam acc. lam t. f acc (tensorGetExn t [])) acc t
@@ -422,7 +422,7 @@ with 6
 
 -- Folds `f idx acc el` over all elements `el` of `t` in row-major order, where
 -- `acc` is the accumulator and `idx` is the index of the element.
-let tensorFoldi : (b -> [Int] -> a -> b) -> b -> Tensor[a] -> b =
+let tensorFoldi : all a. all b. (b -> [Int] -> a -> b) -> b -> Tensor[a] -> b =
   lam f. lam acc. lam t.
   let shape = tensorShape t in
   let t = tensorReshapeExn t [tensorSize t] in
@@ -450,7 +450,7 @@ with [([0, 0], 1), ([0, 1], 2), ([1, 0], 3), ([1, 1], 4)]
 
 -- Iterates through the elements of `t` in row-major order, applying the
 -- function `f` on each index and element.
-let tensorIteri : ([Int] -> a -> Unit) -> Tensor[a] -> Unit =
+let tensorIteri : all a. ([Int] -> a -> ()) -> Tensor[a] -> () =
   lam f. lam t.
   let shape = tensorShape t in
   let t = tensorReshapeExn t [tensorSize t] in
@@ -466,12 +466,12 @@ with [2, 4, 6]
 
 -- Iterates through the elements of `t` in row-major order, applying the
 -- function `f` on each element.
-let tensorIter : (a -> Unit) -> Tensor[a] -> Unit =
+let tensorIter : all a. (a -> ()) -> Tensor[a] -> () =
   lam f. tensorIteri (lam. lam x. f x)
 
 
 -- The maximum element in `t` as defined by `cmp`.
-let tensorMax : (a -> a -> Int) -> Tensor[a] -> Option a =
+let tensorMax : all a. (a -> a -> Int) -> Tensor[a] -> Option a =
   lam cmp. lam t.
     if eqi (tensorRank t) 0 then Some (tensorGetExn t [])
     else if eqi (tensorSize t) 0 then None ()
@@ -513,7 +513,7 @@ with Some 6
 
 
 -- The minimum element in `t` as defined by `cmp`.
-let tensorMin : (a -> a -> Int) -> Tensor[a] -> Option a =
+let tensorMin : all a. (a -> a -> Int) -> Tensor[a] -> Option a =
   lam cmp. lam t. tensorMax (lam x. lam y. cmp y x) t
 
 utest
@@ -532,7 +532,7 @@ with Some 1
 
 -- Finds element and index `Some (el, i)` in `t` satisfying predicate `p`. If
 -- no such element is found then `None` is returned.
-let tensorFindi : (a -> Bool) -> Tensor[a] -> Option (a, [Int]) =
+let tensorFindi : all a. (a -> Bool) -> Tensor[a] -> Option (a, [Int]) =
   lam p. lam t.
     let n = tensorSize t in
     let shape = tensorShape t in
@@ -562,7 +562,7 @@ with (3, [0, 2])
 
 -- Finds element `Some el` in `t` satisfying predicate `p`. If
 -- no such element is found then `None` is returned.
-let tensorFind : (a -> Bool) -> Tensor[a] -> Option a =
+let tensorFind : all a. (a -> Bool) -> Tensor[a] -> Option a =
   lam p. lam t.
     let x = tensorFindi p t in
     match x with Some (x, _) then Some x
@@ -585,7 +585,7 @@ with 3
 
 -- Finds index `Some i` in `t` of element satisfying predicate `p`. If no such
 -- element is found then `None` is returned.
-let tensorIndex : (a -> Bool) -> Tensor[a] -> Option [Int] =
+let tensorIndex : all a. (a -> Bool) -> Tensor[a] -> Option [Int] =
   lam p. lam t.
     let x = tensorFindi p t in
     match x with Some (_, idx) then Some idx
@@ -609,7 +609,7 @@ with [0, 2]
 
 
 -- `true` if `p x` for some `x` in `t`, else `false`.
-let tensorAny : (a -> Bool) -> Tensor[a] -> Bool =
+let tensorAny : all a. (a -> Bool) -> Tensor[a] -> Bool =
   lam p. lam t.
     let x = tensorFindi p t in
     match x with Some _ then true
@@ -634,7 +634,7 @@ with false
 
 
 -- `true` if `p x` for all `x` in `t`, else `false`.
-let tensorAll : (a -> Bool) -> Tensor[a] -> Bool =
+let tensorAll : all a. (a -> Bool) -> Tensor[a] -> Bool =
   lam p. lam t.
     let x = tensorFindi (lam x. not (p x)) t in
     match x with Some _ then false
@@ -679,7 +679,7 @@ with false
 
 
 -- Filter elements of `t` given predicate `p`.
-let tensorFilter : (a -> Bool) -> Tensor[a] -> [a] =
+let tensorFilter : all a. (a -> Bool) -> Tensor[a] -> [a] =
   lam p. lam t.
     let t = tensorReshapeExn t [tensorSize t] in
     tensorFold
@@ -696,7 +696,7 @@ with [4, 5, 6]
 
 
 -- Filter index of elements of `t` given predicate `p`.
-let tensorFilteri : ([Int] -> a -> Bool) -> Tensor[a] -> [[Int]] =
+let tensorFilteri : all a. ([Int] -> a -> Bool) -> Tensor[a] -> [[Int]] =
   lam p. lam t.
     tensorFoldi
       (lam a. lam idx. lam x. if p idx x then snoc a idx else a)
@@ -714,14 +714,14 @@ with [[1, 0], [1, 1], [1, 2]]
 -- INTEGER TENSOR FUNCTIONS --
 ------------------------------
 
-let tensorCumsumiExn : Tensor[Int] -> Tensor[Int] -> Unit =
+let tensorCumsumiExn : Tensor[Int] -> Tensor[Int] -> () =
   lam t. lam r.
     if tensorHasSameShape t r then
       tensorFoldi
         (lam acc. lam idx. lam x.
           let acc = addi acc x in
           tensorSetExn r idx acc; acc)
-        0 t
+        0 t; ()
     else error "Invalid Argument: tensor.tensorCumsumiExn"
 
 utest
@@ -730,7 +730,7 @@ utest
   tensorCumsumiExn t r; tensorToSeqExn r
 with [1, 3, 6]
 
-let tensorCumsumiInplace : Tensor[Int] -> Unit =
+let tensorCumsumiInplace : Tensor[Int] -> () =
   lam t. tensorCumsumiExn t t
 
 utest

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -302,7 +302,7 @@ let parse = lam str.
 in
 
 --let test : Bool -> Expr -> Map String (Map [String] Expr) -> Expr =
-let test : Bool -> Expr -> [( String, [( [String], Expr )] )] -> Expr =
+let test : Bool -> Expr -> Map String (Map [String] Expr) -> Expr =
   lam debug: Bool. lam ast: Expr. lam lookupMap: Map String (Map [String] Expr).
     (if debug then
        printLn "-------- BEFORE ANF --------";

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -357,7 +357,7 @@ let parse = lam str.
   let ast = makeKeywords [] ast in
   symbolize ast
 in
-let test: Bool -> Expr -> [String] -> [(String,[AbsVal],Map NameInfo (Map [NameInfo] Int))] =
+let test: Bool -> Expr -> [String] -> [(String,Set AbsVal,Map NameInfo (Map [NameInfo] Int))] =
   lam debug: Bool. lam t: Expr. lam vars: [String].
     -- Use small ANF first, needed for context expansion
     let tANFSmall = use MExprHoles in normalizeTerm t in

--- a/stdlib/tuning/tune-options.mc
+++ b/stdlib/tuning/tune-options.mc
@@ -1,12 +1,12 @@
 include "option.mc"
 
 type SearchMethod
-con SimulatedAnnealing : Unit -> SearchMethod
-con TabuSearch         : Unit -> SearchMethod
-con RandomWalk         : Unit -> SearchMethod
-con Exhaustive         : Unit -> SearchMethod
-con SemiExhaustive     : Unit -> SearchMethod
-con BinarySearch       : Unit -> SearchMethod
+con SimulatedAnnealing : () -> SearchMethod
+con TabuSearch         : () -> SearchMethod
+con RandomWalk         : () -> SearchMethod
+con Exhaustive         : () -> SearchMethod
+con SemiExhaustive     : () -> SearchMethod
+con BinarySearch       : () -> SearchMethod
 
 let tuneSearchMethodMap =
 [ ("simulated-annealing", SimulatedAnnealing {})
@@ -24,7 +24,7 @@ type TuneOptions =
 , timeoutMs : Option Float
 , warmups : Int
 , method : SearchMethod
-, input : [[String]]
+, input : [String]
 , saInitTemp : Float
 , saDecayFactor : Float
 , tabuSize : Int

--- a/test-compile-type-checked.mk
+++ b/test-compile-type-checked.mk
@@ -7,4 +7,4 @@ all: $(src_files_all)
 selected: $(compile_type_checked)
 
 $(src_files_all):
-	@./make compile-test $@ "build/mi compile --test --disable-optimizations --disable-prune-utests --typecheck"
+	@./make compile-test $@ "build/mi compile --test --keep-dead-code --disable-optimizations --disable-prune-utests --typecheck"

--- a/test-compile-type-checked.mk
+++ b/test-compile-type-checked.mk
@@ -4,7 +4,7 @@ include test-files.mk
 
 all: $(src_files_all)
 
-selected: $(compile_type_checked)
+selected: $(compile_files_typecheck)
 
 $(src_files_all):
 	@./make compile-test $@ "build/mi compile --test --keep-dead-code --disable-optimizations --disable-prune-utests --typecheck"

--- a/test-files.mk
+++ b/test-files.mk
@@ -32,6 +32,7 @@ python_files += $(wildcard test/py/*.mc)
 # can be enabled by default.
 typecheck_files += test/mlang/type-alias.mc
 typecheck_files += $(wildcard stdlib/*.mc)
+typecheck_files += $(wildcard stdlib/mexpr/*.mc)
 
 
 # Programs that we currently cannot compile/test. These are programs written

--- a/test-files.mk
+++ b/test-files.mk
@@ -28,15 +28,14 @@ python_files += $(wildcard test/py/*.mc)
 
 # Programs that should be compiled with type-checking enabled. These are
 # excluded from the default compile rules, so that we don't test them twice.
-compile_type_checked += test/mlang/type-alias.mc
+compile_files_typecheck_base += test/mlang/type-alias.mc
+compile_files_typecheck_base += $(wildcard stdlib/*.mc)
 
 
 # Programs that we currently cannot compile/test. These are programs written
 # before the compiler was implemented. It is forbidden to add to this list of
 # programs but removing from it is very welcome.
-compile_files_exclude += stdlib/dfa.mc
 compile_files_exclude += stdlib/json.mc
-compile_files_exclude += stdlib/nfa.mc
 compile_files_exclude += stdlib/parser-combinators.mc
 compile_files_exclude += stdlib/regex.mc
 compile_files_exclude += test/mexpr/nestedpatterns.mc
@@ -54,6 +53,9 @@ run_files_exclude += stdlib/parser-combinators.mc
 run_files_exclude += test/mlang/catchall.mc
 run_files_exclude += test/mlang/mlang.mc
 
+# Programs that we should be able to compile/test with type-checking enabled.
+compile_files_typecheck =\
+	$(filter-out $(compile_files_exclude), $(compile_files_typecheck_base))
 
 # Programs that we should be able to compile/test if we prune utests.
 compile_files_prune =\
@@ -63,7 +65,7 @@ compile_files_prune =\
 # if all, except the special, external dependencies are met. Excludes files
 # that are to be compiled with type checking enabled.
 compile_files =\
-	$(filter-out $(special_dependencies_files) $(compile_type_checked), $(compile_files_prune))
+	$(filter-out $(special_dependencies_files) $(compile_files_typecheck), $(compile_files_prune))
 
 
 # Programs the we should be able to interpret/test with the interpreter.

--- a/test-files.mk
+++ b/test-files.mk
@@ -33,6 +33,7 @@ python_files += $(wildcard test/py/*.mc)
 typecheck_files += test/mlang/type-alias.mc
 typecheck_files += $(wildcard stdlib/*.mc)
 typecheck_files += $(wildcard stdlib/mexpr/*.mc)
+typecheck_files += $(wildcard stdlib/ocaml/*.mc)
 
 
 # Programs that we currently cannot compile/test. These are programs written

--- a/test-files.mk
+++ b/test-files.mk
@@ -26,10 +26,12 @@ special_dependencies_files +=\
 python_files += stdlib/python/python.mc
 python_files += $(wildcard test/py/*.mc)
 
-# Programs that should be compiled with type-checking enabled. These are
-# excluded from the default compile rules, so that we don't test them twice.
-compile_files_typecheck_base += test/mlang/type-alias.mc
-compile_files_typecheck_base += $(wildcard stdlib/*.mc)
+
+# Programs that should pass the type checker. The goal is to make this list
+# contain all programs, at which point it can be removed and the type checker
+# can be enabled by default.
+typecheck_files += test/mlang/type-alias.mc
+typecheck_files += $(wildcard stdlib/*.mc)
 
 
 # Programs that we currently cannot compile/test. These are programs written
@@ -53,9 +55,10 @@ run_files_exclude += stdlib/parser-combinators.mc
 run_files_exclude += test/mlang/catchall.mc
 run_files_exclude += test/mlang/mlang.mc
 
-# Programs that we should be able to compile/test with type-checking enabled.
+# Programs that should be compiled with type-checking enabled. These are
+# excluded from the default compile rules, so that we don't test them twice.
 compile_files_typecheck =\
-	$(filter-out $(compile_files_exclude), $(compile_files_typecheck_base))
+	$(filter-out $(compile_files_exclude), $(typecheck_files))
 
 # Programs that we should be able to compile/test if we prune utests.
 compile_files_prune =\

--- a/test-type-check.mk
+++ b/test-type-check.mk
@@ -7,4 +7,4 @@ all: $(src_files_all)
 selected: $(compile_files_typecheck)
 
 $(src_files_all):
-	@./make compile-test $@ "build/mi compile --test --disable-optimizations --disable-prune-utests --typecheck"
+	@./make type-check $@


### PR DESCRIPTION
This PR includes the following changes:
- Add option `--keep-dead-code` to disable dead code elimination
- Add `Ref`, `Map`, `Symbol` and `BootParseTree` types into initial environments of `symbolize.mc`, `type-check.mc`, `type-annot.mc` and `utesttrans.mc`, making these available as builtins
- Update `const-types.mc` to use the above types (and fix some incorrect const types)
- Fix a bug in the type checker where forall-bound type variables could escape their scope
  Specifically, the type checker would accept examples like the following.
  ```
  let f = lam x.
    let g : all a. a = x
    in g
  ```
  The type of `x` was allowed to be unified with `a`, even though this makes `a` escape its scope.
- Update the files `stdlib/*.mc` to pass the type checker, and update `test-compile-type-checked` make target to include these
- Fix miscellaneous bugs discovered while doing the above

EDIT:
- Also update the files `stdlib/mexpr/*.mc` and `stdlib/ocaml/*.mc` to typecheck. `mi-lite.mc` now passes the type checker
- Add a new make target `test-type-check` which type checks files (including dead code) without compiling them
  For reference, the existing target `test-compile-type-checked` type checks and compiles files, but excludes dead code (compilation is too slow otherwise)

EDIT 2:
This PR now also makes the type checker update `tyIdent` and `tyBody` fields of lambdas/lets, for compatibility with `typeAnnot`. As discussed previously, this probably is not what we want in the long term.