### PR TITLE
Fix free variable-lookup in lambda lifting for nested recursive lets

### DIFF
--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -6,7 +6,6 @@ include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/call-graph.mc"
 include "mexpr/eq.mc"
-include "mexpr/pprint.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/type-annot.mc"
 
@@ -100,7 +99,7 @@ lang LambdaLiftFindFreeVariables =
     let fv = findFreeVariablesInBody state fv t.body in
     findFreeVariablesInBody state fv t.inexpr
   | TmRecLets t ->
-    let fv = foldl (lam fv. lam bind.
+    let fv = foldl (lam fv: Map Name Type. lam bind : RecLetBinding.
       findFreeVariablesInBody state fv bind.body
     ) fv t.bindings in
     findFreeVariablesInBody state fv t.inexpr
@@ -376,7 +375,7 @@ lang MExprLambdaLift =
     (state.sols, liftGlobal t)
 end
 
-lang TestLang = MExprLambdaLift + MExprEq + MExprSym + MExprTypeAnnot + MExprPrettyPrint
+lang TestLang = MExprLambdaLift + MExprEq + MExprSym + MExprTypeAnnot
 end
 
 mexpr


### PR DESCRIPTION
Previously, nested recursive lets would not get their entire body checked for free variables, which meant that the following function could not be properly lifted:
```
let foo = lam x. lam y. lam mylist.
  if eqi x 10 then
    ()
  else
    recursive let inner_foo = lam z.
      if eqi y z then
        inner_foo (addi z 1)
      else
        recursive let deep_foo = lam i.
          if eqi i z then
            ()
          else
            -- mylist is not mentioned in the parent reclet's body
            get mylist i;
            deep_foo (addi i 1)
        in
        deep_foo 0
    in
    inner_foo 10
in
foo 11 12 [1,2,3]
```

Added the example above as a test case. It failed prior to applying the fix in `findFreeVariablesInBody` (now passes as expected).