### PR TITLE
More info prints on errors in stdlib

### DIFF
--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -244,7 +244,7 @@ decl:
       Data (fi, $2.v, $4) }
   | SEM var_ident params EQ cases
     { let fi = mkinfo $1.i $4.i in
-      Inter (fi, $2.v, TyUnknown NoInfo, Some $3, $5) }
+      Inter (fi, $2.v, TyUnknown fi, Some $3, $5) }
   | SEM var_ident COLON ty
     { let fi = mkinfo $1.i (ty_info $4) in
       Inter (fi, $2.v, $4, None, []) }

--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -159,7 +159,6 @@ let cudaTranslation : Options -> Map Name AccelerateData -> Expr -> (CuProg, CuP
   validatePMExprAst accelerateData ast;
   let ast = utestStrip ast in
   wellFormed ast;
-  printLn (pprintCudaPMExprAst ast);
   let ast = constantAppToExpr ast in
   let ast = toCudaPMExpr ast in
   match typeLift ast with (typeEnv, ast) in

--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -159,6 +159,7 @@ let cudaTranslation : Options -> Map Name AccelerateData -> Expr -> (CuProg, CuP
   validatePMExprAst accelerateData ast;
   let ast = utestStrip ast in
   wellFormed ast;
+  printLn (pprintCudaPMExprAst ast);
   let ast = constantAppToExpr ast in
   let ast = toCudaPMExpr ast in
   match typeLift ast with (typeEnv, ast) in

--- a/stdlib/cuda/compile.mc
+++ b/stdlib/cuda/compile.mc
@@ -222,7 +222,8 @@ lang CudaCompileFree = MExprCCompileAlloc + CudaPMExprAst + CudaAst
   | ty ->
     use MExprPrettyPrint in
     let tystr = type2str ty in
-    error (concat "Freeing CPU memory not implemented for type " tystr)
+    let infostr = info2str (infoTy ty) in
+    error (join [infostr, "Freeing CPU memory not implemented for type ", tystr])
 
   sem _compileFreeGpu (env : CompileCEnv) (arg : CExpr) =
   | ty & (TySeq {ty = elemType}) ->

--- a/stdlib/cuda/compile.mc
+++ b/stdlib/cuda/compile.mc
@@ -97,7 +97,7 @@ lang CudaCompileCopy = MExprCCompileAlloc + CudaPMExprAst + CudaAst
   | ty ->
     use MExprPrettyPrint in
     let tystr = type2str ty in
-    error (concat "Copying GPU -> CPU not implemented for type " tystr)
+    infoErrorExit (infoTy ty) (concat "Copying GPU -> CPU not implemented for type " tystr)
 
   sem _compileCopyToGpu (env : CompileCEnv) (dst : CExpr) (arg : CExpr) =
   | ty & (TySeq {ty = elemType}) ->
@@ -177,7 +177,7 @@ lang CudaCompileCopy = MExprCCompileAlloc + CudaPMExprAst + CudaAst
   | ty ->
     use MExprPrettyPrint in
     let tystr = type2str ty in
-    error (concat "Copying CPU -> GPU not implemented for type " tystr)
+    infoErrorExit (infoTy ty) (concat "Copying CPU -> GPU not implemented for type " tystr)
 end
 
 lang CudaCompileFree = MExprCCompileAlloc + CudaPMExprAst + CudaAst
@@ -222,8 +222,7 @@ lang CudaCompileFree = MExprCCompileAlloc + CudaPMExprAst + CudaAst
   | ty ->
     use MExprPrettyPrint in
     let tystr = type2str ty in
-    let infostr = info2str (infoTy ty) in
-    error (join [infostr, "Freeing CPU memory not implemented for type ", tystr])
+    infoErrorExit (infoTy ty) (join ["Freeing CPU memory not implemented for type ", tystr])
 
   sem _compileFreeGpu (env : CompileCEnv) (arg : CExpr) =
   | ty & (TySeq {ty = elemType}) ->
@@ -283,7 +282,7 @@ lang CudaCompileFree = MExprCCompileAlloc + CudaPMExprAst + CudaAst
   | ty ->
     use MExprPrettyPrint in
     let tystr = type2str ty in
-    error (concat "Freeing GPU memory not implemented for type " tystr)
+    infoErrorExit (infoTy ty) (concat "Freeing GPU memory not implemented for type " tystr)
 end
 
 lang CudaCompile = CudaCompileCopy + CudaCompileFree
@@ -317,7 +316,7 @@ lang CudaCompile = CudaCompileCopy + CudaCompileFree
       t = compileExpr env t.t, ofs = compileExpr env t.ofs,
       len = compileExpr env t.len, ty = compileType env t.ty}
   | TmMapKernel t -> infoErrorExit t.info "Maps are not supported"
-  | TmReduceKernel t -> error "not implemented yet"
+  | TmReduceKernel t -> infoErrorExit t.info "not implemented yet"
   | TmLoop t | TmParallelLoop t ->
     -- NOTE(larshum, 2022-03-08): Parallel loops that were not promoted to a
     -- kernel are compiled to sequential loops.

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -414,7 +414,7 @@ let nreclets_add = use MExprAst in
     let newbind = {ident = n, tyBody = ty, body = body, info = NoInfo ()} in
     TmRecLets {t with bindings = cons newbind t.bindings}
   else
-    error "reclets is not a TmRecLets construct"
+    infoErrorExit (infoTm reclets) "reclets is not a TmRecLets construct"
 
 let reclets_add = use MExprAst in
   lam s. lam ty. lam body. lam reclets.
@@ -456,7 +456,7 @@ let var_ = use MExprAst in
 let freeze_ = use MExprAst in
   lam var.
   match var with TmVar t then TmVar {t with frozen = true}
-  else error "var is not a TmVar construct"
+  else infoErrorExit (infoTm var) "var is not a TmVar construct"
 
 let nconapp_ = use MExprAst in
   lam n. lam b.
@@ -561,7 +561,7 @@ let record_add = use MExprAst in
   match record with TmRecord t then
       TmRecord {t with bindings = mapInsert (stringToSid key) value t.bindings}
   else
-      error "record is not a TmRecord construct"
+      infoErrorExit (infoTm record) "record is not a TmRecord construct"
 
 let record_add_bindings = lam bindings. lam record.
   foldl (lam recacc. lam b : (k, v). record_add b.0 b.1 recacc) record bindings
@@ -579,7 +579,7 @@ let matchall_ = use MExprAst in
     foldr1 (lam m. lam acc.
       match m with TmMatch t then
         TmMatch {t with els = acc}
-      else error "expected match expression")
+      else infoErrorExit (infoTm m) "expected match expression")
       matches
 
 let nrecordproj_ = use MExprAst in

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -23,20 +23,18 @@ lang Ast
   syn Pat =
   -- Intentionally left blank
 
-  sem infoTm =
-  -- Intentionally left blank
+  sem infoTm: Expr -> Info
+  sem tyTm: Expr -> Type
+  sem withInfo: Info -> Expr -> Expr
+  sem withType: Type -> Expr -> Expr
 
-  sem tyTm =
-  -- Intentionally left blank
+  sem infoPat: Pat -> Info
+  sem tyPat: Pat -> Type
+  sem withInfoPat: Info -> Pat -> Pat
+  sem withTypePat: Type -> Pat -> Pat
 
-  sem withType (ty : Type) =
-  -- Intentionally left blank
-
-  sem tyPat =
-  -- Intentionally left blank
-
-  sem withTypePat (ty : Type) =
-  -- Intentionally left blank
+  sem infoTy: Info -> Type
+  sem tyWithInfo: Info -> Type -> Type
 
   -- TODO(vipa, 2021-05-27): Replace smap and sfold with smapAccumL for Expr and Type as well
   sem smapAccumL_Expr_Expr (f : acc -> a -> (acc, b)) (acc : acc) =

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -17,7 +17,8 @@ lang Cmp = Ast
   | (lhs, rhs) /- (Expr, Expr) -/ ->
     let res = subi (constructorTag lhs) (constructorTag rhs) in
     if eqi res 0 then
-      error "Missing case in cmpExprH for expressions with equal indices."
+      infoErrorExit (mergeInfo (infoTm lhs) (infoTm rhs))
+                    "Missing case in cmpExprH for expressions with equal indices."
     else res
 
   sem cmpConst (lhs: Const) =
@@ -36,7 +37,8 @@ lang Cmp = Ast
   | (lhs, rhs) /- (Pat, Pat) -/ ->
     let res = subi (constructorTag lhs) (constructorTag rhs) in
     if eqi res 0 then
-      error "Missing case in cmpPatH for patterns with equal indices."
+      infoErrorExit (mergeInfo (infoPat lhs) (infoPat rhs))
+                    "Missing case in cmpPatH for patterns with equal indices."
     else res
 
   sem cmpType (lhs: Type) =
@@ -47,7 +49,8 @@ lang Cmp = Ast
   | (lhs, rhs) /- (Type, Type) -/ ->
     let res = subi (constructorTag lhs) (constructorTag rhs) in
     if eqi res 0 then
-      error "Missing case in cmpTypeH for types with equal indices."
+      infoErrorExit (mergeInfo (infoTy lhs) (infoTy rhs))
+                    "Missing case in cmpTypeH for types with equal indices."
     else res
 end
 

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -38,7 +38,7 @@ lang FunCPS = LamSym + LamEq + UnknownTypeAst + UnknownTypeEq
       t.lhs
 
   sem cpsM =
-  | TmApp t -> error "CPS: TmApp is not atomic"
+  | TmApp t -> infoErrorExit t.info "CPS: TmApp is not atomic"
   | TmVar t -> TmVar t
   | TmLam t ->
     let k = nameSym "k" in

--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -9,6 +9,8 @@ type Info
 con Info : {filename: String, row1: Int, col1: Int, row2: Int, col2: Int} -> Info
 con NoInfo : () -> Info
 
+let testinfo_: Info = Info {filename = "testinfo_", row1 = 1, col1 = 5, row2 = 1, col2 = 10}
+
 -- Data structure for a positon value
 type Pos = {filename: String, row: Int, col: Int}
 

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -217,8 +217,8 @@ lang LambdaLiftInsertFreeVariables = MExprAst
         (subMap, TmLet {{{t with tyBody = tyBody}
                             with body = body}
                             with inexpr = inexpr})
-    else error (join ["Found no free variable solution for ",
-                      nameGetStr t.ident])
+    else infoErrorExit t.info (join ["Found no free variable solution for ",
+                                     nameGetStr t.ident])
   | TmRecLets t ->
     let addBindingSubExpression =
       lam subMap : Map Name (Info -> Expr). lam bind : RecLetBinding.
@@ -242,8 +242,8 @@ lang LambdaLiftInsertFreeVariables = MExprAst
             (TmVar {ident = bind.ident, ty = bindType, info = info, frozen = false})
             (reverse (mapBindings freeVars)) in
         mapInsert bind.ident subExpr subMap
-      else error (join ["Lambda lifting error: No solution found for binding ",
-                        nameGetStr bind.ident])
+      else infoErrorExit bind.info (join ["Lambda lifting error: No solution found for binding ",
+                                          nameGetStr bind.ident])
     in
     let insertFreeVarsBinding =
       lam subMap : Map Name (Info -> Expr). lam bind : RecLetBinding.
@@ -261,8 +261,8 @@ lang LambdaLiftInsertFreeVariables = MExprAst
         let tyBody = tyTm body in
         match insertFreeVariablesH solutions subMap body with (subMap, body) in
         (subMap, {{bind with tyBody = tyBody} with body = body})
-      else error (join ["Lambda lifting error: No solution found for binding ",
-                        nameGetStr bind.ident])
+      else infoErrorExit bind.info (join ["Lambda lifting error: No solution found for binding ",
+                                          nameGetStr bind.ident])
     in
     let subMap = foldl addBindingSubExpression subMap t.bindings in
     match mapAccumL insertFreeVarsBinding subMap t.bindings with (subMap, bindings) in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1107,7 +1107,10 @@ lang VariantTypePrettyPrint = VariantTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyVariant t ->
     if eqi (mapLength t.constrs) 0 then (env,"<>")
-    else error "Printing of non-empty variant types not yet supported"
+    else (env, join ["Variant<", strJoin ", " (map nameGetStr (mapKeys t.constrs)), ">"])
+    -- NOTE(wikman, 2022-04-04): This pretty printing above is just temporary
+    -- as we do not have syntax for TyVariant. It is necessary however since we
+    -- still use TyVariant in the AST and might get compilation errors for it.
 end
 
 lang ConTypePrettyPrint = ConTypeAst

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -281,7 +281,7 @@ lang AppPrettyPrint = PrettyPrint + AppAst
       match printArgs aindent env (tail apps) with (env,args) then
         (env, join [fun, pprintNewline aindent, args])
       else never
-    else error "Impossible"
+    else infoErrorExit t.info "Impossible"
 end
 
 lang LamPrettyPrint = PrettyPrint + LamAst + UnknownTypeAst


### PR DESCRIPTION
Adds info to `error` expressions in stdlib to help with debugging during compilation. This is not exhaustive, but it adds information in important places during the CUDA compilation process.

Also adds a temporary pprint for TyVariant, since this is used in the CUDA backend.