### PR TITLE
Make the intrinsics that take two sequences handle the case where their representation differ

### DIFF
--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -150,6 +150,8 @@ module Mseq : sig
   val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
 
   module Helpers : sig
+    val to_seq : 'a t -> 'a Seq.t
+
     val of_list : 'a list -> 'a t
 
     val of_list_list : 'a list -> 'a t

--- a/test/mexpr/seq-test.mc
+++ b/test/mexpr/seq-test.mc
@@ -72,6 +72,18 @@ utest concat [1] [3] with [1,3] in
 utest concat [] [3,10] with [3,10] in
 utest concat ['a','b'] [] with ['a','b'] in
 
+-- concat preserves the representation if the inputs agree, otherwise
+-- the result is a list
+utest isRope (concat (createRope 3 (lam i. i)) (createRope 3 (lam i. i))) with true in
+utest isRope (concat (createList 3 (lam i. i)) (createRope 3 (lam i. i))) with false in
+utest isList (concat (createList 3 (lam i. i)) (createRope 3 (lam i. i))) with true in
+utest isList (concat (createRope 3 (lam i. i)) (createList 3 (lam i. i))) with true in
+utest isList (concat (createList 3 (lam i. i)) (createList 3 (lam i. i))) with true in
+
+-- Lists and ropes are otherwise indistinguishable
+utest createList 3 (lam i. i) with [0, 1, 2] in
+utest createList 3 (lam i. i) with [0, 1, 2] using eqSeq eqi in
+
 -- 'get s n' returns element with index 'n' from sequence 's'
 -- [a] -> Int -> a
 utest get [1,3,9] 2 with 9 in


### PR DESCRIPTION
This PR makes the `MSeq` intrinsics that take two sequences (`concat`, `equal`, `combine`, and `fold_right2`) handle the case where one sequence is a `List` and one is a `Rope`. If the result is also a sequence then it will have a `List` representation, with the reasoning that you had to opt-in to get a `List`, thus you probably want to keep working with a list.

The implementation uses OCaml's `Seq.t` which are lazy sequences/iterators, which are implemented using anonymous functions. This means that we presumably allocate a lot of anonymous functions, but my hope is that this is cheaper than allocating a full list (since the functions can be discarded as soon as they've been run) without making the code any more annoying.