### PR TITLE
Re-write OCaml data conversion into a more modular language fragment

### DIFF
--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -865,7 +865,7 @@ let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function
               | Some params ->
                   params
               | None ->
-                  [Param (NoInfo, us "", TyUnknown NoInfo)]
+                  []
             in
             Some
               ( fi

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -861,11 +861,7 @@ let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function
       let translate_inter = function
         | Inter (fi, name, ty, params, cases) ->
             let params =
-              match params with
-              | Some params ->
-                  params
-              | None ->
-                  []
+              match params with Some params -> params | None -> []
             in
             Some
               ( fi

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -34,7 +34,7 @@ lang Ast
   sem withInfoPat: Info -> Pat -> Pat
   sem withTypePat: Type -> Pat -> Pat
 
-  sem infoTy: Info -> Type
+  sem infoTy: Type -> Info
   sem tyWithInfo: Info -> Type -> Type
 
   -- TODO(vipa, 2021-05-27): Replace smap and sfold with smapAccumL for Expr and Type as well

--- a/stdlib/mexpr/remove-ascription.mc
+++ b/stdlib/mexpr/remove-ascription.mc
@@ -3,6 +3,7 @@ include "ast-builder.mc"
 include "eq.mc"
 
 lang MExprRemoveTypeAscription = MExprAst
+  sem removeTypeAscription : Expr -> Expr
   sem removeTypeAscription =
   | (TmLet {ident = idLet, body = body, inexpr = TmVar {ident = idExpr}}) & letexpr ->
     if nameEq idLet idExpr then

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -5,9 +5,6 @@ include "ocaml/ast.mc"
 include "ocaml/intrinsics-ops.mc"
 include "ocaml/generate-env.mc"
 
-lang OCamlDataConversion = OCamlAst + MExprAst
-end
-
 let _approxsize = 10
 let _listToSeqCost = 5
 let _arrayToSeqCost = 2
@@ -16,20 +13,121 @@ let _tupleConversionCost = 1
 let _recordConversionCost = 1
 let _seqtostringcost = 2
 
-lang OCamlGenerateExternal = OCamlAst + MExprAst
-  -- Popluates `env` by chosing external implementations.
+lang OCamlChooseExternalImpl
+  -- `chooseExternalImpls impls env t` chooses external definitions from
+  -- `impls` for each external in `t` and adds these to `env`.
   sem chooseExternalImpls
-        (implsMap : Map String [ExternalImpl])
-        (env : GenerateEnv) = /- : Expr -> GenerateEnv -/
+    : Map String [ExternalImpl] -> GenerateEnv -> Expr -> GenerateEnv
+end
 
-  sem _convertEls
-    (approxsize : Int)
-    (mapop : Expr)
-    (info : Info)
-    (env : GenerateEnv)
-    (t : Expr)
-    (ty1 : Type) =
-  | ty2 ->
+lang OCamlDataConversion
+  -- `convertDataInner info env tm2 (ty1, ty2)` converts the term `t` from
+  -- `ty1` to `ty2`, returning a tuple `(cost, t2)`, where `tm2` is the
+  -- converted term and `cost` which is the cost of the conversion. The cost is
+  -- 0 If, and only if, no conversion is necessary.
+  sem convertDataInner
+    : Info -> GenerateEnv -> Expr -> (Type, Type) -> (Int, Expr)
+
+  -- `convertData` wraps `convertDataInner`, performing common operations
+  -- on types before conversions such as unwrapping type aliases. I.e. recursive
+  -- calls to `convertDataInner` should in most cases go via this function.
+  sem convertData
+    : Info -> GenerateEnv -> Expr -> (Type, Type) -> (Int, Expr)
+  sem convertData info env t =
+  | (ty1, ty2) ->
+    let ty1 = typeUnwrapAlias env.aliases ty1 in
+    let ty2 = typeUnwrapAlias env.aliases ty2 in
+    convertDataInner info env t (ty1, ty2)
+end
+
+lang OCamlDataConversionBase = OCamlDataConversion + OCamlAst
+  + IntTypeAst + FloatTypeAst + BoolTypeAst
+
+  sem convertDataInner info env t =
+  | (TyInt _, TyInt _) | (TyFloat _, TyFloat _) | (TyBool _, TyBool _) -> (0, t)
+end
+
+lang OCamlDataConversionOpaque = OCamlDataConversion + OCamlAst
+  + ConTypeAst + AppTypeAst + UnknownTypeAst
+
+  sem convertDataInner info env t =
+  | (TyUnknown _, _) | (_, TyUnknown _)
+  | (TyCon {ident = ident}, _) | (_, TyCon {ident = ident})
+  | (TyApp {lhs = TyCon _}, _) | (_, TyApp {lhs = TyCon _})
+  -> (0, t)
+end
+
+lang OCamlDataConversionFun =
+  OCamlDataConversion + OCamlAst + FunTypeAst + UnknownTypeAst
+  sem convertDataInner info env t =
+  | (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22}) ->
+     let ident = nameSym "x" in
+      let arg =
+        TmVar { ident = ident, ty = ty21, info = info, frozen = false }
+      in
+      match (
+        match ty11 with OTyLabel {label = label, ty = ty11} then
+          match convertData info env arg (ty21, ty11) with (cost1, arg) in
+          (cost1, OTmLabel { label = label, arg = arg })
+        else
+        match ty21 with OTyLabel {ty = ty21} then
+          convertData info env arg (ty21, ty11)
+        else
+          match convertData info env arg (ty21, ty11) with (cost1, arg) in
+          (cost1, arg)
+      ) with (cost1, arg) in
+      let body =
+        TmApp {
+          lhs = t,
+          rhs = arg,
+          ty = TyUnknown { info = info },
+          info = info
+         }
+      in
+      let label =
+        match ty21 with OTyLabel {label = label} then Some label else None ()
+      in
+      match convertData info env body (ty12, ty22) with (cost2, body) in
+      let t = OTmLam { label = label, ident = ident, body = body } in
+      (addi cost1 cost2, t)
+end
+
+lang OCamlDataConversionString =
+  OCamlDataConversion + OCamlAst
+  + SeqTypeAst + CharTypeAst + UnknownTypeAst + LamAst + AppAst
+
+  sem convertDataInner info env t =
+  | (OTyString _, TySeq {ty = TyChar _} & ty2) ->
+    let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.of_utf8" } in
+    let t =
+      TmApp {
+        lhs = op,
+        rhs = t,
+        ty = ty2,
+        info = info
+      }
+    in
+    (_seqtostringcost, t)
+  | (TySeq {ty = TyChar _}, OTyString _) ->
+    let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.to_utf8" } in
+    let t =
+      TmApp {
+        lhs = op,
+        rhs = t,
+        ty = TyUnknown { info = info },
+        info = info
+      }
+    in
+    (_seqtostringcost, t)
+end
+
+lang OCamlDataConversionHelpers =
+  OCamlDataConversion + OCamlAst + UnknownTypeAst + LamAst + AppAst + VarAst
+
+  sem _convertElements
+    : Int -> Expr -> Info -> GenerateEnv -> Expr -> (Type, Type) -> (Int, Expr)
+  sem _convertElements approxsize mapop info env t =
+  | (ty1, ty2) ->
     let ident = nameSym "x" in
     let var =
       TmVar {
@@ -39,61 +137,71 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
         frozen = false
       }
     in
-    match convertData info env var ty1 ty2 with (cost, body) then
-      let t =
-        if gti cost 0 then
-          TmApp {
-            lhs = TmApp {
-                    lhs = mapop,
-                    rhs =
-                      TmLam {
-                        ident = ident,
-                        tyIdent = TyUnknown { info = info },
-                        body = body,
-                        ty = TyUnknown { info = info },
-                        info = info
-                      },
-                    ty = TyUnknown { info = info },
-                    info = info
-                  },
-            rhs = t,
-            ty = TyUnknown { info = info },
-            info = info
-          }
-        else t
-      in
-      (muli approxsize cost, t)
-    else never
+    match convertData info env var (ty1, ty2) with (cost, body) in
+    let t =
+      if gti cost 0 then
+        TmApp {
+          lhs = TmApp {
+                  lhs = mapop,
+                  rhs =
+                    TmLam {
+                      ident = ident,
+                      tyIdent = TyUnknown { info = info },
+                      body = body,
+                      ty = TyUnknown { info = info },
+                      info = info
+                    },
+                  ty = TyUnknown { info = info },
+                  info = info
+                },
+          rhs = t,
+          ty = TyUnknown { info = info },
+          info = info
+        }
+      else t
+    in
+    (muli approxsize cost, t)
 
-  sem _convertContainer
-    (op : Expr)
-    (opcost : Int)
-    (approxsize : Int)
-    (mapop : Expr)
-    (info : Info)
-    (env : GenerateEnv)
-    (t : Expr)
-    (ty1 : Type) =
-  | ty2 ->
-    match _convertEls _approxsize mapop info env t ty1 ty2 with (cost, t) then
-      let t =
-         TmApp {
-            lhs = op,
-            rhs = t,
-            ty = TyUnknown { info = info },
-            info = info
-          }
-       in
-       (addi cost opcost, t)
-    else never
+  -- Helper function to convert a container.
+  sem convertContainer
+    : Expr                      -- Operation that converts the container.
+    -> Int                      -- Cost of container operation.
+    -> Int                      -- Approximate size of container (influences
+                                -- overall conversion cost).
+    -> Expr                     -- Operation that coverts the elements in the
+                                -- container.
+    -> Info                     -- File info.
+    -> GenerateEnv              -- The environment.
+    -> Expr                     -- The container term to convert.
+    -> (Type, Type)             -- (ty1, ty2), the container element type ty1 to
+                                -- be converted to an element type ty2.
+    -> (Int, Expr)              -- The conversion cost and converted term.
+  sem convertContainer op opcost approxsize mapop info env t =
+  | (ty1, ty2) ->
+    match _convertElements _approxsize mapop info env t (ty1, ty2)
+    with (cost, t) in
+    let t =
+       TmApp {
+          lhs = op,
+          rhs = t,
+          ty = TyUnknown { info = info },
+          info = info
+        }
+     in
+     (addi cost opcost, t)
 
-  sem _convertTuple
-    (info : Info)
-    (env : GenerateEnv)
-    (getTy1 : Type -> Type -> Type)
-    (getTy2 : Type -> Type -> Type)
-    (t : Expr)
-    (fields : Map SID Type) =
+  -- Helper function to convert to and from OCaml tuples to/from MExpr records.
+  sem convertTuple
+  : Info                        -- File info.
+  -> GenerateEnv                -- The environment.
+  -> Bool                       -- If converting from ty1 to ty2 (otherwise ty2
+                                -- to ty1).
+  -> Expr                       -- The term to convert.
+  -> Map SID Type               -- The Record fields of MExpr record type.
+  -> [Type]                     -- The syntactic order of fields of MExpr record
+                                -- type.
+  -> (Int, Expr)                -- The conversion cost and converted term.
+  sem convertTuple info env ty1ToTy2 t fields =
   | tys ->
     let ns = create (length tys) (lam. nameSym "t") in
     let pvars =
@@ -114,7 +222,8 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
                   frozen = false
                 }
               in
-              convertData info env var (getTy1 ty1 ty2) (getTy2 ty1 ty2)
+              if ty1ToTy2 then convertData info env var (ty1, ty2)
+              else convertData info env var (ty2, ty1)
             else
               infoErrorExit info "Cannot convert tuple"
           else never)
@@ -134,381 +243,308 @@ lang OCamlGenerateExternal = OCamlAst + MExprAst
         (addi _tupleConversionCost cost , t)
     else never
 
-  -- Converts the term `t` from `ty1` to `ty2`, returning a tuple `(Int, Expr)`
-  -- which is the cost and result of the conversion, respectively. If, and only
-  -- if, no conversion is necessary, the cost should be 0.
-  sem convertData (info : Info) (env : GenerateEnv) (t : Expr) (ty1 : Type) =
-  | ty2 ->
-    let ty1 = typeUnwrapAlias env.aliases ty1 in
-    let ty2 = typeUnwrapAlias env.aliases ty2 in
-    let tt : (Type, Type) = (ty1, ty2) in
-    match tt with
-      (TyArrow {from = ty11, to = ty12}, TyArrow {from = ty21, to = ty22})
-    then
-      let ident = nameSym "x" in
-      let arg = TmVar { ident = ident, ty = ty21, info = info, frozen = false } in
-      match (
-        match ty11 with OTyLabel {label = label, ty = ty11} then
-          match convertData info env arg ty21 ty11 with (cost1, arg) then
-             (cost1, OTmLabel { label = label, arg = arg })
-          else never
-        else
-        match ty21 with OTyLabel {ty = ty21} then
-          convertData info env arg ty21 ty11
-        else
-          match convertData info env arg ty21 ty11 with (cost1, arg) then
-            (cost1, arg)
-          else never
-      ) with (cost1, arg)
-      then
-        let body =
-          TmApp {
-            lhs = t,
-            rhs = arg,
-            ty = TyUnknown { info = info },
+end
+
+lang OCamlDataConversionList = OCamlDataConversionHelpers + OCamlAst
+  + SeqTypeAst + UnknownTypeAst + ExtAst + LamAst
+
+  sem convertDataInner info env t =
+  | (OTyList {ty = ty1}, TySeq {ty = ty2}) ->
+    let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.of_list" } in
+    let mapop = OTmVarExt { ident = "List.map" } in
+    convertContainer op _listToSeqCost _approxsize mapop info env t (ty1, ty2)
+  | (TySeq {ty = ty1}, OTyList {ty = ty2}) ->
+    let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.to_list" } in
+    let mapop = OTmVarExt { ident = intrinsicOpSeq "map" } in
+    convertContainer op _listToSeqCost _approxsize mapop info env t (ty1, ty2)
+end
+
+lang OCamlDataConversionArray = OCamlDataConversionHelpers + OCamlAst
+  + SeqTypeAst + UnknownTypeAst + ExtAst + LamAst
+
+  sem convertDataInner info env t =
+  | (TySeq {ty = ty1}, OTyArray {ty = ty2}) ->
+    let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.to_array_copy" } in
+    let mapop = OTmVarExt { ident = intrinsicOpSeq "map" } in
+    convertContainer op _arrayToSeqCost _approxsize mapop info env t (ty1, ty2)
+  | (OTyArray {ty = ty1}, TySeq {ty = ty2}) ->
+    let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.of_array_copy" } in
+    let mapop = OTmVarExt { ident = "Array.map" } in
+    convertContainer op _arrayToSeqCost _approxsize mapop info env t (ty1, ty2)
+end
+
+lang OCamlDataConversionTuple = OCamlDataConversionHelpers + OCamlAst
+  + RecordTypeAst + ConTypeAst + UnknownTypeAst
+
+  sem convertDataInner info env t =
+  | (OTyTuple {tys = []}, TyRecord {fields = fields}) |
+    (TyRecord {fields = fields}, OTyTuple {tys = []}) ->
+    if eqi (mapSize fields) 0 then
+      (0, semi_ t (OTmTuple { values = [] }))
+    else infoErrorExit info "Cannot convert unit"
+  | (OTyTuple {tys = tys}, TyCon {ident = ident}) ->
+    match mapLookup ident env.constrs
+    with Some (TyRecord {fields = fields}) then
+      convertTuple info env true t fields tys
+    else infoErrorExit info "Cannot convert from OCaml tuple"
+  | (TyCon {ident = ident}, OTyTuple {tys = tys}) ->
+    match mapLookup ident env.constrs
+    with Some (TyRecord {fields = fields}) then
+      convertTuple info env false t fields tys
+    else infoErrorExit info "Cannot convert to OCaml tuple"
+end
+
+lang OCamlDataConversionRecords = OCamlDataConversion + OCamlAst
+  + RecordTypeAst + ConTypeAst + UnknownTypeAst
+
+  sem convertDataInner info env t =
+  | (OTyRecord {fields = fields1} & ty1,
+    TyCon {ident = ident} & ty2) ->
+    match mapLookup ident env.constrs
+    with Some (TyRecord {fields = fields2, labels = labels2}) then
+      let costsTms =
+        zipWith
+          (lam l2. lam field : (String, Type).
+            match field with (l1, ty1) in
+            match mapLookup l2 fields2 with Some ty2 then
+              convertData
+                info env (OTmProject { field = l1, tm = t }) (ty1, ty2)
+            else infoErrorExit info "impossible")
+          labels2 fields1
+      in
+      match unzip costsTms with (costs, tms) in
+      let ns = create (length labels2) (lam. nameSym "t") in
+      match mapLookup (ocamlTypedFields fields2) env.records
+      with Some id then
+        let bindings =
+          zipWith (lam label. lam t. (label, objRepr t)) labels2 tms
+        in
+        let record =
+          TmRecord {
+            bindings = mapFromSeq cmpSID bindings,
+            ty = ty2,
             info = info
            }
         in
-        let label =
-          match ty21 with OTyLabel {label = label} then Some label else None ()
+        let t = OTmConApp { ident = id, args = [record] } in
+        let cost = addi _recordConversionCost (foldl1 addi costs) in
+        (cost, t)
+      else infoErrorExit info "impossible"
+    else infoErrorExit info "Cannot convert record"
+  | (TyCon {ident = ident} & ty1,
+    OTyRecord {tyident = tyident, fields = fields2} & ty2) ->
+    match mapLookup ident env.constrs
+    with Some (TyRecord {fields = fields1, labels = labels1}) then
+      match mapLookup (ocamlTypedFields fields1) env.records
+      with Some id then
+        let ns = create (length labels1) (lam. nameSym "r") in
+        let pvars =
+          map
+            (lam n.
+              PatNamed {
+                ident = PName n,
+                info = info,
+                ty = tyunknown_
+              })
+            ns
         in
-        match convertData info env body ty12 ty22 with (cost2, body) then
-          let t = OTmLam { label = label, ident = ident, body = body } in
-          (addi cost1 cost2, t)
-        else never
-      else never
-    else match tt with
-      (OTyString _, TySeq {ty = TyChar _})
-    then
-      let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.of_utf8" } in
-      let t =
-        TmApp {
-            lhs = op,
-            rhs = t,
-            ty = ty2,
-            info = info
-        }
-      in
-      (_seqtostringcost, t)
-    else match tt with
-      (TySeq {ty = TyChar _}, OTyString _)
-    then
-      let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.to_utf8" } in
-      let t =
-        TmApp {
-            lhs = op,
-            rhs = t,
-            ty = TyUnknown { info = info },
-            info = info
-        }
-      in
-      (_seqtostringcost, t)
-    else match tt with
-      (OTyList {ty = ty1}, TySeq {ty = ty2})
-    then
-      let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.of_list" } in
-      let mapop = OTmVarExt { ident = "List.map" } in
-      _convertContainer op _listToSeqCost _approxsize mapop info env t ty1 ty2
-    else match tt with
-      (TySeq {ty = ty1}, OTyList {ty = ty2})
-    then
-      let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.to_list" } in
-      let mapop = OTmVarExt { ident = intrinsicOpSeq "map" } in
-      _convertContainer op _listToSeqCost _approxsize mapop info env t ty1 ty2
-    else match tt with
-      (TySeq {ty = ty1}, OTyArray {ty = ty2})
-    then
-      let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.to_array_copy" } in
-      let mapop = OTmVarExt { ident = intrinsicOpSeq "map" } in
-      _convertContainer op _arrayToSeqCost _approxsize mapop info env t ty1 ty2
-    else match tt with
-      (OTyArray {ty = ty1}, TySeq {ty = ty2})
-    then
-      let op = OTmVarExt { ident = intrinsicOpSeq "Helpers.of_array_copy" } in
-      let mapop = OTmVarExt { ident = "Array.map" } in
-      _convertContainer op _arrayToSeqCost _approxsize mapop info env t ty1 ty2
-    else match tt with
-      (OTyTuple {tys = []}, TyRecord {fields = fields}) |
-      (TyRecord {fields = fields}, OTyTuple {tys = []})
-    then
-      if eqi (mapSize fields) 0 then
-        (0, semi_ t (OTmTuple { values = [] }))
-      else infoErrorExit info "Cannot convert unit"
-    else match tt with
-      (OTyTuple {tys = tys}, TyCon {ident = ident})
-    then
-      match mapLookup ident env.constrs
-      with Some (TyRecord {fields = fields}) then
-        _convertTuple info env (lam x. lam. x) (lam. lam x. x) t fields tys
-      else infoErrorExit info "Cannot convert from OCaml tuple"
-    else match tt with
-      (TyCon {ident = ident}, OTyTuple {tys = tys})
-    then
-      match mapLookup ident env.constrs
-      with Some (TyRecord {fields = fields}) then
-        _convertTuple info env (lam. lam x. x) (lam x. lam. x) t fields tys
-      else infoErrorExit info "Cannot convert to OCaml tuple"
-    else match tt with
-      (OTyRecord {fields = fields1}, TyCon {ident = ident})
-    then
-      match mapLookup ident env.constrs
-      with Some (TyRecord {fields = fields2, labels = labels2}) then
+        let rpat =
+          OPatRecord { bindings = mapFromSeq cmpSID (zip labels1 pvars) }
+        in
+        match unzip fields2 with (labels2, tys2) in
         let costsTms =
-          zipWith
-            (lam l2. lam field : (String, Type).
-              match field with (l1, ty1) then
-                match mapLookup l2 fields2 with Some ty2 then
-                  convertData
-                    info env (OTmProject { field = l1, tm = t }) ty1 ty2
-                else never
-              else never)
-            labels2 fields1
+          mapi
+            (lam i. lam x : (Name, Type).
+              match x with (ident, ty2) in
+              let l1 = get labels1 i in
+              match mapLookup l1 fields1 with Some ty1 then
+                let var =
+                  TmVar {
+                    ident = ident,
+                    ty = TyUnknown { info = info },
+                    info = info,
+                    frozen = false
+                  }
+                in
+                convertData info env (objMagic var) (ty1, ty2)
+              else infoErrorExit info "impossible")
+            (zip ns tys2)
         in
-        match unzip costsTms with (costs, tms) then
-          let ns = create (length labels2) (lam. nameSym "t") in
-          match mapLookup (ocamlTypedFields fields2) env.records
-          with Some id then
-            let bindings =
-              zipWith (lam label. lam t. (label, objRepr t)) labels2 tms
-            in
-            let record =
-              TmRecord {
-                bindings = mapFromSeq cmpSID bindings,
-                ty = ty2,
-                info = info
-               }
-            in
-            let t = OTmConApp { ident = id, args = [record] } in
-            let cost = addi _recordConversionCost (foldl1 addi costs) in
-            (cost, t)
-          else never
-        else never
-      else infoErrorExit info "Cannot convert record"
-    else match tt with
-      (TyCon {ident = ident}, OTyRecord {tyident = tyident, fields = fields2})
-    then
-      match mapLookup ident env.constrs
-      with Some (TyRecord {fields = fields1, labels = labels1}) then
-        match mapLookup (ocamlTypedFields fields1) env.records
-        with Some id then
-          let ns = create (length labels1) (lam. nameSym "r") in
-          let pvars =
-            map
-              (lam n.
-                PatNamed {
-                  ident = PName n,
-                  info = info,
-                  ty = tyunknown_
-                })
-              ns
-          in
-          let rpat =
-            OPatRecord { bindings = mapFromSeq cmpSID (zip labels1 pvars) }
-          in
-          match unzip fields2 with (labels2, tys2) then
-            let costsTms =
-              mapi
-                (lam i. lam x : (Name, Type).
-                  match x with (ident, ty2) then
-                    let l1 = get labels1 i in
-                    match mapLookup l1 fields1 with Some ty1 then
-                      let var =
-                        TmVar {
-                          ident = ident,
-                          ty = TyUnknown { info = info },
-                          info = info,
-                          frozen = false
-                        }
-                      in
-                      convertData info env (objMagic var) ty1 ty2
-                    else
-                      infoErrorExit info "impossible"
-                  else never)
-                (zip ns tys2)
-            in
-            match unzip costsTms with (costs, tms) then
-              let rec =
-                OTmRecord { bindings = zip labels2 tms, tyident = tyident }
-              in
-              let cpat = OPatCon { ident = id, args = [rpat] } in
-              let t = OTmMatch { target = t, arms = [(cpat, rec)] } in
-              (foldl1 addi costs, t)
-            else never
-          else never
-        else never
-      else infoErrorExit info "Cannot convert record"
-    else match tt with
-      (OTyBigarrayGenarray
-        {tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]}
-      ,OTyBigarrayGenarray
-        {tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]})
-        |
-      (OTyBigarrayGenarray
-        {tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]}
-      ,OTyBigarrayGenarray
-        {tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]})
-    then
-      (0, t)
-    else match tt with
-      (OTyBigarrayArray {
-          rank = rank1,
-          tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]
-        }
-      ,OTyBigarrayArray {
-          rank = rank2,
-          tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]
-        })
-        |
-      (OTyBigarrayArray {
-          rank = rank1,
-          tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]
-        }
-      ,OTyBigarrayArray {
-          rank = rank2,
-          tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]
-        })
-    then
-      if eqi rank1 rank2 then (0, t)
-      else infoErrorExit info "Bigarray rank mismatch"
-    else match tt with
-      (TyTensor {ty = elty1}
-      ,OTyBigarrayGenarray
-        {tys = [elty2, elty3, OTyBigarrayClayout _]})
-    then
-      match (elty1, elty2, elty3) with
-        (TyInt _, TyInt _, OTyBigarrayIntElt _) |
-        (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _)
-      then
-        let lhs =
-          OTmVarExt
-            { ident = intrinsicOpTensor "Helpers.to_genarray_clayout" }
+        match unzip costsTms with (costs, tms) in
+        let rec =
+          OTmRecord { bindings = zip labels2 tms, tyident = tyident }
         in
-        let t =
-          TmApp {
-            lhs = lhs,
-            rhs = t,
-            ty = ty1,
-            info = info
-          }
-        in
-        (_tensorToGenarrayCost, t)
-      else
-        infoErrorExit info "Cannot convert to bigarray"
-    else match tt with
-      (TyTensor {ty = elty1}
-      ,OTyBigarrayArray {
-          rank = rank,
-          tys = [elty2, elty3, OTyBigarrayClayout _]
-        })
+        let cpat = OPatCon { ident = id, args = [rpat] } in
+        let t = OTmMatch { target = t, arms = [(cpat, rec)] } in
+        (foldl1 addi costs, t)
+      else infoErrorExit info "impossible"
+    else infoErrorExit info "Cannot convert record"
+end
+
+lang OCamlDataConversionBigArray = OCamlDataConversionHelpers + OCamlAst
+  + TensorTypeAst + UnknownTypeAst + ExtAst + LamAst
+
+  sem convertDataInner info env t =
+  | (OTyBigarrayGenarray
+      {tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]}
+    ,OTyBigarrayGenarray
+      {tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]})
+  | (OTyBigarrayGenarray
+      {tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]}
+    ,OTyBigarrayGenarray
+      {tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]})
+  ->
+    (0, t)
+  | (OTyBigarrayArray {
+        rank = rank1,
+        tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]
+      }
+    ,OTyBigarrayArray {
+        rank = rank2,
+        tys = [TyInt _, OTyBigarrayIntElt _, OTyBigarrayClayout _]
+      })
+  | (OTyBigarrayArray {
+        rank = rank1,
+        tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]
+      }
+    ,OTyBigarrayArray {
+        rank = rank2,
+        tys = [TyFloat _, OTyBigarrayFloat64Elt _, OTyBigarrayClayout _]
+      })
+  ->
+    if eqi rank1 rank2 then (0, t)
+    else infoErrorExit info "Bigarray rank mismatch"
+  | (TyTensor {ty = elty1} & ty1
+    ,OTyBigarrayGenarray
+      {tys = [elty2, elty3, OTyBigarrayClayout _]})
+  ->
+    match (elty1, elty2, elty3) with
+      (TyInt _, TyInt _, OTyBigarrayIntElt _) |
+      (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _)
     then
-      match (elty1, elty2, elty3) with
-        (TyInt _, TyInt _, OTyBigarrayIntElt _) |
-        (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _)
-      then
-        let lhs =
-          let op =
-            if eqi rank 1 then
-              "Helpers.to_array1_clayout"
-            else if eqi rank 2 then
-              "Helpers.to_array2_clayout"
-            else
-              infoErrorExit info "Cannot convert bigarray"
-          in
-          OTmVarExt { ident = intrinsicOpTensor op }
-        in
-        let t =
-          TmApp {
-            lhs = lhs,
-            rhs = t,
-            ty = ty1,
-            info = info
-          }
-        in
-        (_tensorToGenarrayCost, t)
-      else
-        infoErrorExit info "Cannot convert to bigarray"
-    else match tt with
-      (OTyBigarrayGenarray
-        {tys = [elty1, elty3, OTyBigarrayClayout _]}
-      ,TyTensor {ty = elty2})
-    then
-      let op =
-        let elt = (elty1, elty2, elty3) in
-        match elt with (TyInt _, TyInt _, OTyBigarrayIntElt _) then
-          "Helpers.of_genarray_clayout"
-        else match elt with (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _)
-        then
-          "Helpers.of_genarray_clayout"
-        else infoErrorExit info "Cannot convert bigarray"
+      let lhs =
+        OTmVarExt
+          { ident = intrinsicOpTensor "Helpers.to_genarray_clayout" }
       in
-      let lhs = OTmVarExt { ident = intrinsicOpTensor op } in
       let t =
         TmApp {
           lhs = lhs,
           rhs = t,
-          ty = ty2,
+          ty = ty1,
           info = info
         }
       in
       (_tensorToGenarrayCost, t)
-    else match tt with
-      (OTyBigarrayArray {
-        rank = rank,
-        tys = [elty1, elty3, OTyBigarrayClayout _]
-       }
-      ,TyTensor {ty = elty2})
-    then
-      let op =
-        let eltr = (elty1, elty2, elty3, rank) in
-        match eltr
-        with (TyInt _, TyInt _, OTyBigarrayIntElt _, 1) then
-          "Helpers.of_array1_clayout"
-        else match eltr
-        with (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _, 1) then
-          "Helpers.of_array1_clayout"
-        else match eltr
-        with (TyInt _, TyInt _, OTyBigarrayIntElt _, 2) then
-          "Helpers.of_array2_clayout"
-        else match eltr
-        with (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _, 2) then
-          "Helpers.of_array2_clayout"
-        else infoErrorExit info "Cannot convert bigarray"
-      in
-      let lhs = OTmVarExt { ident = intrinsicOpTensor op } in
-      let t =
-        TmApp {
-          lhs = lhs,
-          rhs = t,
-          ty = ty2,
-          info = info
-        }
-      in
-      (_tensorToGenarrayCost, t)
-    else match tt with
-      (TyUnknown _, _) | (_, TyUnknown _) |
-      (TyInt _, TyInt _) | (TyFloat _, TyFloat _) | (TyBool _, TyBool _)
-    then
-      (0, t)
-    else match tt with
-      (TyCon {ident = ident}, _) | (_, TyCon {ident = ident}) |
-      (TyApp {lhs = TyCon _}, _) | (_, TyApp {lhs = TyCon _})
-    then
-      (0, t)
     else
-      dprint ty1;
-      print "\n";
-      dprint ty2;
-      infoErrorExit info "Cannot convert data"
+      infoErrorExit info "Cannot convert to bigarray"
+  | (TyTensor {ty = elty1} & ty1
+    ,OTyBigarrayArray {
+        rank = rank,
+        tys = [elty2, elty3, OTyBigarrayClayout _]
+      })
+   ->
+    match (elty1, elty2, elty3) with
+      (TyInt _, TyInt _, OTyBigarrayIntElt _) |
+      (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _)
+    then
+      let lhs =
+        let op =
+          if eqi rank 1 then
+            "Helpers.to_array1_clayout"
+          else if eqi rank 2 then
+            "Helpers.to_array2_clayout"
+          else
+            infoErrorExit info "Cannot convert bigarray"
+        in
+        OTmVarExt { ident = intrinsicOpTensor op }
+      in
+      let t =
+        TmApp {
+          lhs = lhs,
+          rhs = t,
+          ty = ty1,
+          info = info
+        }
+      in
+      (_tensorToGenarrayCost, t)
+    else
+      infoErrorExit info "Cannot convert to bigarray"
+  | (OTyBigarrayGenarray
+      {tys = [elty1, elty3, OTyBigarrayClayout _]}
+    ,TyTensor {ty = elty2} & ty2)
+  ->
+    let op =
+      let elt = (elty1, elty2, elty3) in
+      match elt with (TyInt _, TyInt _, OTyBigarrayIntElt _) then
+        "Helpers.of_genarray_clayout"
+      else match elt with (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _)
+      then
+        "Helpers.of_genarray_clayout"
+      else infoErrorExit info "Cannot convert bigarray"
+    in
+    let lhs = OTmVarExt { ident = intrinsicOpTensor op } in
+    let t =
+      TmApp {
+        lhs = lhs,
+        rhs = t,
+        ty = ty2,
+        info = info
+      }
+    in
+    (_tensorToGenarrayCost, t)
+  | (OTyBigarrayArray {
+      rank = rank,
+      tys = [elty1, elty3, OTyBigarrayClayout _]
+     }
+    ,TyTensor {ty = elty2} & ty2)
+  ->
+    let op =
+      let eltr = (elty1, elty2, elty3, rank) in
+      match eltr
+      with (TyInt _, TyInt _, OTyBigarrayIntElt _, 1) then
+        "Helpers.of_array1_clayout"
+      else match eltr
+      with (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _, 1) then
+        "Helpers.of_array1_clayout"
+      else match eltr
+      with (TyInt _, TyInt _, OTyBigarrayIntElt _, 2) then
+        "Helpers.of_array2_clayout"
+      else match eltr
+      with (TyFloat _, TyFloat _, OTyBigarrayFloat64Elt _, 2) then
+        "Helpers.of_array2_clayout"
+      else infoErrorExit info "Cannot convert bigarray"
+    in
+    let lhs = OTmVarExt { ident = intrinsicOpTensor op } in
+    let t =
+      TmApp {
+        lhs = lhs,
+        rhs = t,
+        ty = ty2,
+        info = info
+      }
+    in
+    (_tensorToGenarrayCost, t)
+end
+
+lang OCamlDataConversionMExpr = OCamlDataConversion + OCamlAst + MExprAst
+  + OCamlDataConversionBase
+  + OCamlDataConversionOpaque
+  + OCamlDataConversionFun
+  + OCamlDataConversionString
+  + OCamlDataConversionList
+  + OCamlDataConversionArray
+  + OCamlDataConversionTuple
+  + OCamlDataConversionRecords
+  + OCamlDataConversionBigArray
 end
 
 -- A naive implementation of external generation where we just pick the
 -- implementation with the lowest cost with respect to the type given at the
 -- external term definition.
-lang OCamlGenerateExternalNaive = OCamlGenerateExternal + ExtAst
-  sem chooseExternalImpls
-        (implsMap : Map String [ExternalImpl])
-        (env : GenerateEnv) =
+lang OCamlGenerateExternalNaive =
+  OCamlDataConversionMExpr + OCamlChooseExternalImpl + ExtAst
 
+  sem chooseExternalImpls implsMap env =
   | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info} ->
     let identStr = nameGetStr ident in
     let impls = mapLookup identStr implsMap in

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -514,8 +514,7 @@ lang OCamlGenerateExternalNaive = OCamlGenerateExternal + ExtAst
     let impls = mapLookup identStr implsMap in
 
     let cost = lam ty1. lam ty2.
-      match convertData info env uunit_ ty1 ty2 with (cost, _) then cost
-      else never
+      match convertData info env uunit_ (ty1, ty2) with (cost, _) in cost
     in
 
     match impls with Some (![] & impls) then

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -118,7 +118,7 @@ lang OCamlTopGenerate = MExprAst + OCamlAst + OCamlGenerateExternalNaive
   | info ->
     match mapLookup ident env.exts with Some r then
       let r : ExternalImpl = head r in
-      match convertData info env (OTmExprExt { expr = r.expr }) r.ty tyIdent
+      match convertData info env (OTmExprExt { expr = r.expr }) (r.ty, tyIdent)
       with (_, body) in
       body
     else

--- a/stdlib/parser/selfhost-sketch.mc
+++ b/stdlib/parser/selfhost-sketch.mc
@@ -1633,4 +1633,5 @@ let content = join
   , "precedence { X Y; A; } \n"
   ] in
 
-dprintLn (parseSelfhostExn filename content)
+-- dprintLn (parseSelfhostExn filename content);
+()

--- a/stdlib/pmexpr/replace-accelerate.mc
+++ b/stdlib/pmexpr/replace-accelerate.mc
@@ -13,7 +13,7 @@ include "pmexpr/extract.mc"
 include "pmexpr/utils.mc"
 
 lang PMExprReplaceAccelerate =
-  PMExprAst + OCamlGenerateExternal + OCamlTopAst + OCamlPrettyPrint
+  PMExprAst + OCamlDataConversionMExpr + OCamlTopAst + OCamlPrettyPrint
 
   sem _tensorToOCamlType =
   | TyTensor {ty = ty & (TyInt _ | TyFloat _), info = info} ->
@@ -88,7 +88,7 @@ lang PMExprReplaceAccelerate =
   | t ->
     let ty = tyTm t in
     match _mexprToOCamlType env acc ty with (acc, ocamlTy) in
-    match convertData (infoTm t) env t ty ocamlTy with (_, e) in
+    match convertData (infoTm t) env t (ty, ocamlTy) with (_, e) in
     let e = addRecordObjWrapping e in
     (acc, e)
 
@@ -104,7 +104,7 @@ lang PMExprReplaceAccelerate =
     match convertAccelerateParametersH env acc ast with (acc, ast) in
     let ty = tyTm ast in
     match _mexprToOCamlType env acc ty with (acc, ocamlTy) in
-    match convertData (infoTm ast) env ast ocamlTy ty with (_, ast) in
+    match convertData (infoTm ast) env ast (ocamlTy, ty) with (_, ast) in
     (acc, ast)
 
   -- We replace the auxilliary acceleration terms in the AST, by removing any

--- a/stdlib/result.mc
+++ b/stdlib/result.mc
@@ -311,7 +311,7 @@ let #var"" =
 -- Convert a Result to an Option, discarding any information present
 -- about warnings or a potential error.
 let _toOption
-  : all w. all e. all a. Result w e a -> Option b
+  : all w. all e. all a. Result w e a -> Option a
   = lam r.
     match r with ResultOk x then Some x.value else None ()
 


### PR DESCRIPTION
This PR mainly re-writes the data conversion for externals into a language fragment that is more modular and easier to extend. It also includes minor fixes such as fixing type-errors and removing accidental (presumably) printouts. Moreover it includes a fix to a bug that made the types incorrect for semantic function signatures with one argument and without implementations by @elegios.