### PR TITLE
Add work from dependency analysis paper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           make install
 
       - name: Run tests
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: |
           eval $(opam env)
           make test-all
@@ -85,7 +85,7 @@ jobs:
           make install
 
       - name: Run tests
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: |
           eval $(opam env)
           make test-all

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -48,6 +48,7 @@ let generateTests = lam ast. lam testsEnabled. lam typeChecked.
 
 let insertTunedOrDefaults = lam options : Options. lam ast. lam file.
   use MCoreCompile in
+  let ast = stripTuneAnnotations ast in
   if options.useTuned then
     let tuneFile = tuneFileName file in
     if fileExists tuneFile then

--- a/src/main/tune-config.mc
+++ b/src/main/tune-config.mc
@@ -40,33 +40,19 @@ let tuneOptionsConfig : ParseConfig Options = concat optionsConfig [
       else
         modref p.fail (Some (ParseTypeGeneric ("Unknown search method", p.str)));
         o),
-  ([("--input", " ", "<s>")],
-    "Input data to the tuned program. Note that several inputs can be given by providing several --input",
+  ([("--args", " ", "<s>")],
+    "Command line arguments (space-separated) to provide to the the tuned program. Note that several inputs can be given by providing several --args.",
     lam p: ArgPart Options.
       let o: Options = p.options in
       let to : TuneOptions = o.tuneOptions in
-      {o with tuneOptions = {to with input = snoc to.input p.str}}),
-  ([("--sa-init-temp", " ", "<t>")],
-    join ["If --method simulated-annealing is used, this gives the initial temperature (default ",
-          float2string tuneOptionsDefault.saInitTemp, ")"],
+      {o with tuneOptions = {to with args = snoc to.args p.str}}),
+  ([("--epsilon-ms", " ", "<n>")],
+    join ["Threshold value for execution time difference (default ",
+          float2string tuneOptionsDefault.epsilonMs, ")"],
     lam p: ArgPart Options.
       let o: Options = p.options in
       let to : TuneOptions = o.tuneOptions in
-      {o with tuneOptions = {to with saInitTemp = argToFloatMin p 0.0}}),
-  ([("--sa-decay-factor", " ", "<d>")],
-    join ["If --method simulated-annealing is used, this gives the decay factor (default ",
-          float2string tuneOptionsDefault.saDecayFactor, ")"],
-    lam p: ArgPart Options.
-      let o: Options = p.options in
-      let to : TuneOptions = o.tuneOptions in
-      {o with tuneOptions = {to with saDecayFactor = argToFloatMin p 0.0}}),
-  ([("--tabu-size", " ", "<n>")],
-    join ["If --method tabu-search is used, this gives the number of configurations to keep in the tabu list (default ",
-          int2string tuneOptionsDefault.tabuSize, ")"],
-    lam p: ArgPart Options.
-      let o: Options = p.options in
-      let to : TuneOptions = o.tuneOptions in
-      {o with tuneOptions = {to with tabuSize = argToIntMin p 0}}),
+      {o with tuneOptions = {to with epsilonMs = argToFloatMin p 0.0}}),
   ([("--step-size", " ", "<n>")],
     join ["Step size for integer ranges (default ",
           int2string tuneOptionsDefault.stepSize, ")"],
@@ -98,6 +84,31 @@ let tuneOptionsConfig : ParseConfig Options = concat optionsConfig [
       let o: Options = p.options in
       let to : TuneOptions = o.tuneOptions in
       {o with tuneOptions = {to with dependencyAnalysis = true}}),
+  ([("--debug-dependency-analysis", "", "")],
+    "Debug dependency analysis",
+    lam p: ArgPart Options.
+      let o: Options = p.options in
+      let to : TuneOptions = o.tuneOptions in
+      {o with tuneOptions = {to with debugDependencyAnalysis = true}}),
+  ([("--debug-instrumentation", "", "")],
+    "Debug instrumentation",
+    lam p: ArgPart Options.
+      let o: Options = p.options in
+      let to : TuneOptions = o.tuneOptions in
+      {o with tuneOptions = {to with debugInstrumentation = true}}),
+  ([("--seq-transform", "", "")],
+    "Transform sequence literals into create function choosing between rope and list",
+    lam p: ArgPart Options.
+      let o: Options = p.options in
+      let to : TuneOptions = o.tuneOptions in
+      {o with tuneOptions = {to with seqTransform = true}}),
+  ([("--reduce-dependencies", " ", "<t>")],
+    join ["Reduce the dependency graph by filtering out measuring points with runtimes below this threshold value (default ",
+          float2string tuneOptionsDefault.reduceDependencies, ")"],
+    lam p: ArgPart Options.
+      let o: Options = p.options in
+      let to : TuneOptions = o.tuneOptions in
+      {o with tuneOptions = {to with reduceDependencies = argToFloatMin p 0.0}}),
   ([("--enable-cleanup", "", "")],
     "Clean up tune file after tuning",
     lam p: ArgPart Options.

--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -13,8 +13,9 @@ include "tuning/instrumentation.mc"
 include "tuning/tune.mc"
 
 lang MCoreTune =
-  BootParser +
-  MExprHoles + MExprHoleCFA + DependencyAnalysis + Instrumentation + MExprTune
+  BootParser + MExprTypeAnnot +
+  MExprHoles + MExprHoleCFA + NestedMeasuringPoints + DependencyAnalysis +
+  Instrumentation + MExprTune
 end
 
 let tableFromFile = lam file.
@@ -30,9 +31,17 @@ let dependencyAnalysis
   lam options : TuneOptions. lam env : CallCtxEnv. lam ast.
     use MCoreTune in
     if options.dependencyAnalysis then
+      let ast = typeAnnot ast in
       let ast = use HoleANFAll in normalizeTerm ast in
       let cfaRes = cfaData (graphDataFromEnv env) ast in
+      let cfaRes = analyzeNested env cfaRes ast in
       let dep = analyzeDependency env cfaRes ast in
+      (if options.debugDependencyAnalysis then
+         match pprintCode 0 pprintEnvEmpty ast with (pprintEnv, astStr) in
+         printLn astStr;
+         match cfaGraphToString pprintEnv cfaRes with (pprintEnv, resStr) in
+         printLn resStr
+       else ());
       (dep, ast)
     else assumeFullDependency env ast
 
@@ -67,12 +76,18 @@ let tune = lam files. lam options : Options. lam args.
     -- Instrument the program
     match instrument env dep ast with (instRes, ast) in
 
+    -- If option --debug-instrumentation, then pretty print the instrumented AST
+    (if tuneOptions.debugInstrumentation then printLn (expr2str ast) else ());
+
     -- Context expand the holes
     match contextExpand env ast with (r, ast) in
 
     -- If option --tuned is given, then use tune file as defaults
     let table =
       if options.useTuned then tableFromFile (tuneFileName file) else r.table in
+
+    -- Strip annotations before compiling
+    let ast = stripTuneAnnotations ast in
 
     -- Compile the program and write to temporary directory
     let binary = ocamlCompileAstWithUtests

--- a/stdlib/csv.mc
+++ b/stdlib/csv.mc
@@ -1,0 +1,98 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Defines a simple language fragment CSV for reading and writing data in CSV
+-- format.
+
+include "string.mc"
+
+lang CSV
+  syn CSVRow =
+
+  sem csvHeader : CSVRow -> [String]
+
+  sem csvRow2string : CSVRow -> [String]
+
+  sem csvString2Row : [String] -> CSVRow
+
+  sem csvWrite : String -> [CSVRow] -> String
+  sem csvWrite sep =
+  | rows ->
+    match rows with [] then ""
+    else
+      let header: String = strJoin sep (csvHeader (head rows)) in
+      let strRows: [[String]] = map csvRow2string rows in
+      let strRowsSep: [String] = map (strJoin sep) strRows in
+      let str = cons header strRowsSep in
+      concat (strJoin "\n" str) "\n"
+
+  sem csvRead : ([String] -> CSVRow) -> String -> Bool -> String -> [CSVRow]
+  sem csvRead string2row sep header =
+  | str ->
+    let rows: [String] = strSplit "\n" (strTrim str) in
+    let rows: [[String]] = map (strSplit sep) rows in
+    match rows with [] then []
+    else
+      let rows = if header then tail rows else rows in
+      map string2row rows
+end
+
+lang _testCSV = CSV
+  syn CSVRow =
+  | Data {col1: Int, col2: Float}
+
+  sem csvRow2string =
+  | Data {col1 = col1, col2 = col2} ->
+    [ int2string col1
+    , float2string col2
+    ]
+
+  sem csvHeader =
+  | Data {col1 = col1, col2 = col2} ->
+    [ "col1"
+    , "col2"
+    ]
+
+  sem csvString2Row =
+  | row ->
+    Data {col1 = string2int (get row 0),
+          col2 = string2float (get row 1)}
+end
+
+mexpr
+
+use _testCSV in
+
+let data = [Data {col1 = 1, col2 = 0.}, Data {col1 = 4, col2 = 3.14}] in
+
+utest csvWrite "," data with
+"col1,col2
+1,0.
+4,3.14
+" in
+
+utest csvWrite ";" data with
+"col1;col2
+1;0.
+4;3.14
+" in
+
+utest csvRead csvString2Row "," true
+"
+col1,col2
+1,0.
+4,3.14
+
+" with [Data {col1 = 1, col2 = 0.}, Data {col1 = 4, col2 = 3.14}]
+in
+
+utest csvRead csvString2Row ";" false
+"
+
+1;0.
+4;3.14
+
+" with [Data {col1 = 1, col2 = 0.}, Data {col1 = 4, col2 = 3.14}]
+in
+
+()

--- a/stdlib/csv.mc
+++ b/stdlib/csv.mc
@@ -1,0 +1,103 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Defines a simple language fragment CSV for reading and writing data in CSV
+-- format.
+
+include "string.mc"
+
+lang CSV
+  syn CSVRow =
+
+  sem csvRowNbrColumns : CSVRow -> Int
+
+  sem csvHeader : CSVRow -> [String]
+
+  sem csvRow2string : CSVRow -> [String]
+
+  sem csvString2Row : [String] -> CSVRow
+
+  sem csvWrite : String -> [CSVRow] -> String
+  sem csvWrite sep =
+  | rows ->
+    match rows with [] then ""
+    else
+      let header: String = strJoin sep (csvHeader (head rows)) in
+      let strRows: [[String]] = map csvRow2string rows in
+      let strRowsSep: [String] = map (strJoin sep) strRows in
+      let str = cons header strRowsSep in
+      concat (strJoin "\n" str) "\n"
+
+  sem csvRead : ([String] -> CSVRow) -> String -> Bool -> String -> [CSVRow]
+  sem csvRead string2row sep header =
+  | str ->
+    let rows: [String] = strSplit "\n" (strTrim str) in
+    let rows: [[String]] = map (strSplit sep) rows in
+    match rows with [] then []
+    else
+      let rows = if header then tail rows else rows in
+      map string2row rows
+end
+
+lang _testCSV = CSV
+  syn CSVRow =
+  | Data {col1: Int, col2: Float}
+
+  sem csvRowNbrColumns =
+  | Data _ -> 2
+
+  sem csvRow2string =
+  | Data {col1 = col1, col2 = col2} ->
+    [ int2string col1
+    , float2string col2
+    ]
+
+  sem csvHeader =
+  | Data {col1 = col1, col2 = col2} ->
+    [ "col1"
+    , "col2"
+    ]
+
+  sem csvString2Row =
+  | row ->
+    Data {col1 = string2int (get row 0),
+          col2 = string2float (get row 1)}
+end
+
+mexpr
+
+use _testCSV in
+
+let data = [Data {col1 = 1, col2 = 0.}, Data {col1 = 4, col2 = 3.14}] in
+
+utest csvWrite "," data with
+"col1,col2
+1,0.
+4,3.14
+" in
+
+utest csvWrite ";" data with
+"col1;col2
+1;0.
+4;3.14
+" in
+
+utest csvRead csvString2Row "," true
+"
+col1,col2
+1,0.
+4,3.14
+
+" with [Data {col1 = 1, col2 = 0.}, Data {col1 = 4, col2 = 3.14}]
+in
+
+utest csvRead csvString2Row ";" false
+"
+
+1;0.
+4;3.14
+
+" with [Data {col1 = 1, col2 = 0.}, Data {col1 = 4, col2 = 3.14}]
+in
+
+()

--- a/stdlib/csv.mc
+++ b/stdlib/csv.mc
@@ -9,8 +9,6 @@ include "string.mc"
 lang CSV
   syn CSVRow =
 
-  sem csvRowNbrColumns : CSVRow -> Int
-
   sem csvHeader : CSVRow -> [String]
 
   sem csvRow2string : CSVRow -> [String]
@@ -42,9 +40,6 @@ end
 lang _testCSV = CSV
   syn CSVRow =
   | Data {col1: Int, col2: Float}
-
-  sem csvRowNbrColumns =
-  | Data _ -> 2
 
   sem csvRow2string =
   | Data {col1 = col1, col2 = col2} ->

--- a/stdlib/ext/local-search.mc
+++ b/stdlib/ext/local-search.mc
@@ -19,19 +19,23 @@ include "string.mc"
 include "digraph.mc"
 include "iterator.mc"
 
--- A local search solution: an assignment with a cost.
-type Solution = {assignment : Assignment, cost : Cost}
+-- TODO(Linnea, 2022-04-22): These type declarations should be put inside the
+-- language fragment, but gives a type error right now.
 
--- Search state.
-type SearchState = {
-  cur : Solution,                               -- current solution
-  inc : Solution,                               -- incumbent (best solution thus far)
-  iter : Int,                                   -- number of iterations thus far
-  stuck : Bool,                                 -- whether the search is stuck
-                                                -- (no local moves possible)
-  cost : Option Solution -> Assignment -> Cost, -- cost of an assignment
-  cmp : Cost -> Cost -> Int                     -- comparison of costs
-}
+  -- A local search solution: an assignment with a cost.
+  type Solution = {assignment : Assignment, cost : Cost}
+
+  -- Search state
+  type SearchState = {
+    cur : Solution,                               -- current solution
+    inc : Solution,                               -- incumbent (best solution thus far)
+    iter : Int,                                   -- number of iterations thus far
+    stuck : Bool,                                 -- whether the search is stuck
+                                                  -- (no local moves possible)
+    cost : Option Solution -> Assignment -> Cost, -- cost of an assignment
+    cmp : Cost -> Cost -> Int,                    -- comparison of costs
+    data : Option LSData                          -- any custom data
+  }
 
 ----------------------------
 -- Base language fragment --
@@ -48,55 +52,59 @@ lang LocalSearchBase
   -- Cost of an assignment.
   syn Cost =
 
-  -- Initialize the search state from an initial assignment.
-  -- : (Assignment -> Cost) -> Assignment -> SearchState
-  sem initSearchState (cost : Option Solution -> Assignment -> Cost) (cmp : Cost -> Cost -> Int) =
-  | a ->
-    let sol = {assignment = a, cost = cost (None ()) a} in
-    {cur = sol, inc = sol, iter = 0, stuck = false, cost = cost, cmp = cmp}
+  -- Custom data to carry around in the search state
+  syn LSData =
+
+  -- Initialize the search state from an initial solution.
+  sem initSearchState (cost : Option Solution -> Assignment -> Cost)
+                      (cmp : Cost -> Cost -> Int) =
+  | sol ->
+    { cur = sol, inc = sol, iter = 0, stuck = false, cost = cost, cmp = cmp,
+      data = None () }
+
+  -- Initialize the search state from data and solution.
+  sem initSearchStateData (cost : Option Solution -> Assignment -> Cost)
+                          (cmp : Cost -> Cost -> Int) (data : LSData) =
+  | sol ->
+    { cur = sol, inc = sol, iter = 0, stuck = false, cost = cost, cmp = cmp,
+      data = Some data }
 
   -- The neighbouring assignments from a search state.
-  -- : SearchState -> (Iterator Assignment)
-  sem neighbourhood =
+  sem neighbourhood : SearchState -> Iterator [Assignment] Assignment
 
   -- Select a solution among the neighbours.
-  -- : Iterator Assignment -> SearchState -> Option Solution
-  sem select (assignments : Iterator Assignment) =
+  sem select : Iterator [Assignment] Assignment -> SearchState -> Option Solution
 
   -- Take one step, return both the next solution (if there is one), and the
   -- resulting meta state.
-  -- : SearchState -> MetaState -> (Option Solution, MetaState)
-  sem step (searchState : SearchState) =
+  sem step : SearchState -> MetaState -> (Option Solution, MetaState)
 
   -- Take one step and update search state accordingly, return both the
   -- resulting search state and meta state.
-  -- : SearchState -> MetaState -> (SearchState, MetaState)
+  sem minimize : SearchState -> MetaState -> (SearchState, MetaState)
   sem minimize (searchState : SearchState) =
   | metaState ->
     match searchState with {stuck = true} then
       (searchState, metaState)
-    else match searchState with {inc = inc, cmp = cmp} then
-      let searchState = {searchState with iter = addi searchState.iter 1} in
-      let next = step searchState metaState in
-      match next with (None (), _) then
-        ({searchState with stuck = true}, metaState)
-      else match next with (Some cur, metaState) then
-        let cur : Solution = cur in
-        let inc : Solution = inc in
-        let inc = if lti (cmp cur.cost inc.cost) 0 then cur else inc in
-        let searchState = {{searchState with cur = cur} with inc = inc} in
-        (searchState, metaState)
-      else never
-    else never
+    else match searchState with {inc = inc, cmp = cmp} in
+    let searchState = {searchState with iter = addi searchState.iter 1} in
+    let next = step searchState metaState in
+    match next with (None (), _) then
+      ({searchState with stuck = true}, metaState)
+    else match next with (Some cur, metaState) in
+      let cur : Solution = cur in
+      let inc : Solution = inc in
+      let inc = if lti (cmp cur.cost inc.cost) 0 then cur else inc in
+      let searchState = {{searchState with cur = cur} with inc = inc} in
+      (searchState, metaState)
 
   -- Debug a meta state.
-  -- : MetaState -> Unit
+  sem debugMeta : MetaState -> ()
   sem debugMeta =
   | meta -> ()
 
   -- Debug a search state.
-  -- : SearchState -> Unit
-  sem debugSearch =
+  sem debugSearch : SearchState -> ()
 end
 
 ------------------------------------
@@ -106,12 +114,13 @@ end
 
 -- Select a solution among the neighbours uniformly at random.
 lang LocalSearchSelectRandomUniform = LocalSearchBase
-  sem select (assignments : Iterator Assignment) =
+  sem select assignments =
   | searchState ->
     let searchState : SearchState = searchState in
     match searchState with {cost = cost, inc = inc} then
-      match randElem (iteratorToSeq assignments) with Some a then
-        Some {assignment = a, cost = cost (Some inc) a}
+      let as: [Assignment] = (iteratorToSeq assignments) in
+      match randElem as with Some a then
+        Some { assignment = a, cost = cost (Some searchState.inc) a }
       else
         None ()
     else never
@@ -119,7 +128,7 @@ end
 
 -- Select a random best neighbour.
 lang LocalSearchSelectRandomBest = LocalSearchBase
-  sem select (assignments : Iterator Assignment) =
+  sem select assignments =
   | searchState ->
     let searchState : SearchState = searchState in
     match searchState with {cost = cost, cmp = cmp, inc = inc} then
@@ -127,7 +136,7 @@ lang LocalSearchSelectRandomBest = LocalSearchBase
       match assignments with [] then None () else
 
       -- Find minimum and filter out other elements in one pass.
-      recursive let filterMin : a -> [a] -> (a -> a -> Int) -> [a] -> [a] =
+      recursive let filterMin : all a. a -> [a] -> (a -> a -> Int) -> [a] -> [a] =
         lam e. lam acc. lam cmp. lam xs.
         match xs with [] then acc
         else match xs with [x] ++ xs then
@@ -142,7 +151,7 @@ lang LocalSearchSelectRandomBest = LocalSearchBase
       in
       utest filterMin 1000 [] subi [42,1,1,3] with [1,1] in
 
-      let sols = map (lam a. {assignment = a, cost = cost (Some inc) a}) assignments in
+      let sols = map (lam a. {assignment = a, cost = cost (Some searchState.inc) a}) assignments in
       let s = head sols in
       let minSols =
         filterMin s [s] (lam s1 : Solution. lam s2 : Solution.
@@ -153,15 +162,15 @@ end
 
 -- Select the first improving neighbour.
 lang LocalSearchSelectFirstImproving = LocalSearchBase
-  sem select (assignments : Iterator Assignment) =
+  sem select assignments =
   | searchState ->
     let searchState : SearchState = searchState in
     match searchState with {cur = cur, cost = cost, cmp = cmp, inc = inc} then
       let cur : Solution = cur in
       let curCost = cur.cost in
-      recursive let firstImproving = lam as : Iterator Assignment.
+      recursive let firstImproving = lam as.
         match iteratorNext as with (as, Some a) then
-          let acost = cost (Some inc) a in
+          let acost = cost (Some searchState.inc) a in
           if lti (cmp acost curCost) 0 then
             Some {assignment = a, cost = acost}
           else firstImproving as
@@ -172,12 +181,12 @@ lang LocalSearchSelectFirstImproving = LocalSearchBase
 end
 
 lang LocalSearchSelectFirst = LocalSearchBase
-  sem select (assignments : Iterator Assignment) =
+  sem select assignments =
   | searchState ->
     let searchState : SearchState = searchState in
     match searchState with {cost = cost, inc = inc} then
       match iteratorNext assignments with (_, Some a) then
-        Some {assignment = a, cost = cost (Some inc) a}
+        Some {assignment = a, cost = cost (Some searchState.inc) a}
       else None ()
     else never
 end
@@ -188,8 +197,7 @@ lang LocalSearchSimulatedAnnealing = LocalSearchBase
   | SimulatedAnnealing {temp : Float}
 
   -- Modifies the temperature in each iteration
-  -- : SearchState -> MetaState -> MetaState
-  sem decay (searchState : SearchState) =
+  sem decay : SearchState -> MetaState -> MetaState
 
   sem step (searchState : SearchState) =
   | SimulatedAnnealing t ->
@@ -224,12 +232,10 @@ lang LocalSearchTabuSearch = LocalSearchBase
   syn MetaState =
   | TabuSearch {tabu : TabuSet}
 
-  -- : (Assignment, TabuSet) -> Bool
-  sem isTabu =
+  sem isTabu : (Assignment, TabuSet) -> Bool
 
   -- Update the tabu set
-  -- : (Assignment, TabuSet) -> TabuSet
-  sem tabuUpdate =
+  sem tabuUpdate : (Assignment, TabuSet) -> TabuSet
 
   sem step (searchState : SearchState) =
   | TabuSearch ({tabu = tabu} & t) ->
@@ -327,7 +333,7 @@ lang _testTsp = LocalSearchBase
 
   sem neighbourhood =
   | searchState ->
-    let ns =
+    let ns: [Assignment] =
       let searchState : SearchState = searchState in
       match searchState with {cur = {assignment = TspTour {tour = tour}}} then
         map (lam tour. TspTour {tour = tour})
@@ -392,8 +398,8 @@ let nIters = lam n. lam state : SearchState.
 recursive let loop =
   lam terminate : SearchState -> Bool.
   lam state : (SearchState, MetaState).
-  lam debugMeta : MetaState -> Unit.
-  lam debugSearch : SearchState -> Unit.
+  lam debugMeta : MetaState -> ().
+  lam debugSearch : SearchState -> ().
   lam minimize : SearchState -> MetaState -> (SearchState, MetaState).
   match state with (searchState, metaState) then
     (if debug then debugSearch searchState else ());
@@ -407,16 +413,23 @@ recursive let loop =
 
 use _testTsp in
 
-let startState = initSearchState
-  (lam. lam tour : Assignment.
-     match tour with TspTour {tour = tour} then
-       TspCost {cost = foldl (lam acc. lam e : TspEdge. addi acc e.2) 0 tour}
-     else never)
-  (lam c1. lam c2.
-     match (c1, c2) with (TspCost {cost = v1}, TspCost {cost = v2}) then
-       subi v1 v2
-     else never)
-  (TspTour {tour = _initTour}) in
+let costFun : Option Solution -> Assignment -> Cost = lam. lam tour : Assignment.
+  match tour with TspTour {tour = tour} in
+  TspCost {cost = foldl (lam acc. lam e : TspEdge. addi acc e.2) 0 tour}
+in
+
+let cmpFun : Cost -> Cost -> Int = lam c1. lam c2.
+  match (c1, c2) with (TspCost {cost = v1}, TspCost {cost = v2}) in
+  subi v1 v2
+in
+
+let initAssignment = TspTour {tour = _initTour} in
+let initSol = {
+  assignment = initAssignment,
+  cost = costFun (None ()) initAssignment
+} in
+
+let startState = initSearchState costFun cmpFun initSol in
 
 -- Use simulated annealing.
 use _testTspSimulatedAnnealing in

--- a/stdlib/graph.mc
+++ b/stdlib/graph.mc
@@ -54,7 +54,7 @@ let graphHasVertices = digraphHasVertices
 
 let graphNeighbors = digraphSuccessors
 
-let graphIsAdjecent = digraphIsSuccessor
+let graphIsAdjacent = digraphIsSuccessor
 
 -- Add vertices and edges
 let graphAddVertex = digraphAddVertex
@@ -63,6 +63,32 @@ let graphMaybeAddVertex = digraphMaybeAddVertex
 
 let graphAddEdge = lam v1. lam v2. lam l. lam g.
     digraphAddEdge v1 v2 l (digraphAddEdge v2 v1 l g)
+
+let graphAddVertices = lam vs. lam g.
+  foldl (lam g. lam v. graphAddVertex v g) g vs
+
+let graphAddEdges : all v. all l. [DigraphEdge v l] -> Graph v l -> Graph v l =
+  lam es. lam g.
+    foldl (lam g. lam e : DigraphEdge v l. graphAddEdge e.0 e.1 e.2 g) g es
+
+let graphConnectedComponents : all v. all l. Graph v l -> [[v]] = lam g.
+  let cs : [Map v Int] = foldl (
+    lam acc: [Map v Int]. lam v: v.
+      if any (mapMem v) acc then acc
+      else cons (digraphBFS v g) acc
+    ) [] (graphVertices g)
+  in map mapKeys cs
+
+let graphRemoveVertex: all v. all l. v -> Graph v l -> Graph v l = lam v. lam g.
+  -- Remove all edges containing 'v'
+  let edges = graphEdgesFrom v g in
+  let g: Graph v l = foldl (lam acc. lam e: (v, v, l).
+      let acc = digraphRemoveEdge e.0 e.1 e.2 acc in
+      digraphRemoveEdge e.1 e.0 e.2 acc
+    ) g edges
+  in
+  -- Remove 'v' itself
+  {g with adj = mapRemove v g.adj}
 
 mexpr
 
@@ -102,15 +128,15 @@ let l1 = gensym () in
 let g = graphAddVertex 1 (graphAddVertex 2 (graphAddVertex 3 empty)) in
 let g1 = graphAddEdge 1 2 l1 g in
 utest graphNeighbors 1 g1 with [2] in
-utest graphIsAdjecent 2 1 g1 with true in
-utest graphIsAdjecent 1 2 g1 with true in
+utest graphIsAdjacent 2 1 g1 with true in
+utest graphIsAdjacent 1 2 g1 with true in
 utest any (eqsym l1) (graphLabels 1 2 g1) with true in
 utest any (eqsym l1) (graphLabels 1 2 g1) with true in
 
 let l3 = gensym () in
 let g2 = graphAddEdge 3 2 l3 g1 in
-utest graphIsAdjecent 2 3 g2 with true in
-utest graphIsAdjecent 3 2 g2 with true in
+utest graphIsAdjacent 2 3 g2 with true in
+utest graphIsAdjacent 3 2 g2 with true in
 utest any (eqsym l3) (graphLabels 3 2 g2) with true in
 
 let compsEq = eqsetEqual (eqsetEqual eqi) in
@@ -148,5 +174,27 @@ let g3 = graphAddEdge 8 1 (gensym ()) g3 in
 let g3 = graphAddEdge 8 7 (gensym ()) g3 in
 
 utest compsEq (digraphStrongConnects g3) [[1,2,8,3,4,5,7,6]] with true in
+
+let gcc = graphAddEdges
+  [ (0,4,gensym ())
+  , (1,4,gensym ())
+  , (1,5,gensym ())
+  , (2,6,gensym ())
+  , (3,6,gensym ())
+  ] (graphAddVertices [0,1,2,3,4,5,6] empty)
+in
+
+utest graphConnectedComponents gcc with [[0,1,4,5],[2,3,6]] using compsEq in
+
+utest
+  let g = graphAddEdges
+  [ (0,1,gensym ())
+  , (0,2,gensym ())
+  , (1,2,gensym ())
+  ] (graphAddVertices [0,1,2] empty)
+  in
+  let g = graphRemoveVertex 0 g in
+  (graphVertices g, graphCountEdges g, graphIsAdjacent 1 2 g)
+with ([1,2], 1, true) in
 
 ()

--- a/stdlib/iterator.mc
+++ b/stdlib/iterator.mc
@@ -39,7 +39,7 @@ let iteratorNext : all a. all b. Iterator a b -> (Iterator a b, Option b) = lam 
   let it = iteratorStep it in
   (it, iteratorGet it)
 
--- 'iteratorFromSeq it' converts 'it' into a sequence.
+-- 'iteratorToSeq it' converts 'it' into a sequence.
 let iteratorToSeq : all a. all b. Iterator a b -> [b] = lam it.
   recursive let work = lam acc. lam it.
     let n = iteratorNext it in

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -13,6 +13,16 @@ utest absf 0. with 0. using eqf
 utest absf 1. with 1. using eqf
 utest absf (negf 1.) with 1. using eqf
 
+let cmpfApprox : Float -> Float -> Float -> Int =
+  lam epsilon. lam l. lam r.
+    if eqfApprox epsilon l r then 0
+    else if ltf l r then subi 0 1
+    else 1
+
+utest cmpfApprox 0.1 0. 0.1 with 0
+utest cmpfApprox 0. 0.1 0.2 with subi 0 1
+utest cmpfApprox 0.1 0.4 0.2 with 1
+
 -- Int stuff
 let maxi = lam r. lam l. if gti r l then r else l
 let mini = lam r. lam l. if lti r l then r else l

--- a/stdlib/multicore/multicore.mc
+++ b/stdlib/multicore/multicore.mc
@@ -1,0 +1,25 @@
+-- A collection of useful functions for multicore programming.
+
+include "sys.mc"
+include "string.mc"
+
+-- Get the available number of processing units, as reported by the command
+-- 'nproc'.
+let multicoreNbrOfCores : Unit -> Int = lam.
+    let res = sysRunCommand ["nproc"] "" "." in
+    if eqi res.returncode 0 then
+      let nprocStr = strTrim res.stdout in
+      string2int nprocStr
+    else error "Command 'nproc' exited with failure, is it installed?"
+
+mexpr
+
+let debug = false in
+
+utest
+  if debug then
+    print (int2string (multicoreNbrOfCores ())); print "\n"
+  else ()
+with () in
+
+()

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -512,33 +512,3 @@ utest permute "abc" [1, 2, 0] with "cab"
 utest permute "xy" [0, 1] with "xy"
 utest permute "abcd" [0, 3, 1, 2] with "acdb"
 utest permute [0, 1, 2] [2, 0, 1] with [1, 2, 0]
-
--- 'product seqs' computes the Cartesian product of the sequences in 'seqs'.
-recursive let product : all a. [[a]] -> [[a]] = lam seqs.
-  recursive let work = lam acc. lam s1. lam s2.
-    if null s1 then acc
-    else if null s2 then acc
-    else match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) in
-      let acc = cons (cons h1 h2) acc in
-      let acc = work acc t1 s2 in
-      work acc [h1] t2
-  in
-  if null seqs then []
-  else match seqs with [s] then
-    map (lam x. [x]) s
-  else
-    let t = product (tail seqs) in
-    work [] (head seqs) t
-end
-
-let _productEq : all a. (a -> a -> Int) -> [[a]] -> [[a]] -> Bool =
-  lam cmp : a -> a -> Int. lam p1 : [[a]]. lam p2 : [[a]].
-    let p1 = sort (seqCmp cmp) p1 in
-    let p2 = sort (seqCmp cmp) p1 in
-    let eq = lam s1. lam s2. eqi (seqCmp cmp s1 s2) 0 in
-    eqSeq eq p1 p2
-
-utest product [[],[1,2,3]] with [] using _productEq subi
-utest product [[1,2,3]] with [[1],[2],[3]] using _productEq subi
-utest product [[1,2,3],[4,5]] with [[1,4],[1,5],[2,4],[2,5],[3,4],[3,5]] using _productEq subi
-utest product [[1],[2,3],[4]] with [[1,2,4],[1,3,4]] using _productEq subi

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -2,20 +2,23 @@ include "mexpr/ast.mc"
 include "mexpr/anf.mc"
 include "mexpr/keyword-maker.mc"
 include "mexpr/boot-parser.mc"
+include "mexpr/type-annot.mc"
 
 -- Defines AST nodes for holes.
 
-let holeKeywords = ["hole", "Boolean", "IntRange"]
+let holeKeywords = ["hole", "Boolean", "IntRange", "independent"]
 
-let _lookupExit = lam info : Info. lam s : String. lam m : Map String a.
-  mapLookupOrElse (lam. infoErrorExit info (concat s " not found")) s m
+let _lookupExit : all a. Info -> String -> Map String a -> a =
+  lam info : Info. lam s : String. lam m : Map String a.
+    mapLookupOrElse (lam. infoErrorExit info (concat s " not found")) s m
 
-let _expectConstInt = lam info : Info. lam s. lam i.
-  use IntAst in
-  match i with TmConst {val = CInt {val = i}} then i
-  else infoErrorExit info (concat "Expected a constant integer: " s)
+let _expectConstInt : Info -> String -> Expr -> Int =
+  lam info : Info. lam s. lam i.
+    use IntAst in
+    match i with TmConst {val = CInt {val = i}} then i
+    else infoErrorExit info (concat "Expected a constant integer: " s)
 
-lang HoleAstBase = IntAst + ANF + KeywordMaker
+lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot
   syn Hole =
 
   syn Expr =
@@ -31,6 +34,9 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker
   sem tyTm =
   | TmHole {ty = ty} -> ty
 
+  sem withType (ty : Type) =
+  | TmHole t -> TmHole {t with ty = ty}
+
   sem symbolizeExpr (env : SymEnv) =
   | TmHole h -> TmHole h
 
@@ -43,7 +49,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker
 
   sem pprintHole =
 
-  sem pprintCode (indent : Int) (env : SymEnv) =
+  sem pprintCode (indent : Int) (env : PprintEnv) =
   | TmHole t ->
     match pprintCode indent env t.default with (env, default) then
       match pprintHole t.inner with (keyword, bindings) then
@@ -68,11 +74,23 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker
 
   sem hnext (last : Option Expr) (stepSize : Int) =
 
-  sem sample =
+  sem domainSize (stepSize : Int) =
   | TmHole {inner = inner} ->
-    hsample inner
+    hdomainSize stepSize inner
 
-  sem hsample =
+  sem hdomainSize (stepSize : Int) =
+
+  sem domain (stepSize : Int) =
+  | TmHole {inner = inner} ->
+    hdomain stepSize inner
+
+  sem hdomain (stepSize : Int) =
+
+  sem sample (stepSize : Int) =
+  | TmHole {inner = inner} ->
+    hsample stepSize inner
+
+  sem hsample (stepSize : Int) =
 
   sem normalize (k : Expr -> Expr) =
   | TmHole ({default = default} & t) ->
@@ -89,7 +107,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker
   | arg ->
     use RecordAst in
     match arg with TmRecord {bindings = bindings} then
-      let bindings = mapFromSeq cmpString
+      let bindings: Map String Expr = mapFromSeq cmpString
         (map (lam t : (SID, Expr). (sidToString t.0, t.1))
            (mapBindings bindings)) in
       let default = _lookupExit info "default" bindings in
@@ -101,14 +119,24 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker
                 , ty = hty
                 , inner = holeMap bindings})
     else error "impossible"
+
+  sem typeAnnotExpr (env : TypeEnv) =
+  | TmHole t ->
+    let default = typeAnnotExpr env t.default in
+    let ty = hty t.inner in
+    TmHole {{t with default = default}
+               with ty = ty}
+
+  sem hty : Hole -> Type
+
 end
 
 -- A Boolean hole.
-lang HoleBoolAst = BoolAst + HoleAstBase
+lang HoleBoolAst = BoolAst + HoleAstBase + BoolTypeAst
   syn Hole =
   | BoolHole {}
 
-  sem hsample =
+  sem hsample (stepSize : Int) =
   | BoolHole {} ->
     get [true_, false_] (randIntU 0 2)
 
@@ -120,6 +148,12 @@ lang HoleBoolAst = BoolAst + HoleAstBase
     else match last with Some (TmConst {val = CBool {val = true}}) then
       None ()
     else never
+
+  sem hdomainSize (stepSize : Int) =
+  | BoolHole {} -> 2
+
+  sem hdomain (stepSize : Int) =
+  | BoolHole {} -> [true_, false_]
 
   sem fromString =
   | "true" -> true
@@ -139,17 +173,22 @@ lang HoleBoolAst = BoolAst + HoleAstBase
   sem pprintHole =
   | BoolHole {} ->
     ("Boolean", [])
+
+  sem hty =
+  | BoolHole {} -> TyBool {info = NoInfo ()}
 end
 
 -- An integer hole (range of integers).
-lang HoleIntRangeAst = IntAst + HoleAstBase
+lang HoleIntRangeAst = IntAst + HoleAstBase + IntTypeAst
   syn Hole =
   | HIntRange {min : Int,
-              max : Int}
+               max : Int}
 
-  sem hsample =
-  | HIntRange {min = min, max = max} ->
-    int_ (randIntU min (addi max 1))
+  sem hsample (stepSize : Int) =
+  | HIntRange h ->
+    let size = hdomainSize stepSize (HIntRange h) in
+    let i = randIntU 0 size in
+    int_ (addi h.min (muli i stepSize))
 
   sem hnext (last : Option Expr) (stepSize : Int) =
   | HIntRange {min = min, max = max} ->
@@ -164,6 +203,18 @@ lang HoleIntRangeAst = IntAst + HoleAstBase
         else None ()
     else never
 
+  sem hdomainSize (stepSize : Int) =
+  | HIntRange {min = min, max = max} ->
+    let len = addi (subi max min) 1 in
+    let r = divi len stepSize in
+    let m = if eqi 0 (modi len stepSize) then 0 else 1 in
+    addi r m
+
+  sem hdomain (stepSize : Int) =
+  | HIntRange ({min = min} & h) ->
+    map (lam i. int_ (addi min (muli i stepSize)))
+      (create (hdomainSize stepSize (HIntRange h)) (lam i. i))
+
   sem matchKeywordString (info : Info) =
   | "IntRange" ->
     Some (1,
@@ -177,7 +228,7 @@ lang HoleIntRangeAst = IntAst + HoleAstBase
         else infoErrorExit info "Not a hole" in
 
       lam lst. _mkHole info tyint_
-        (lam m.
+        (lam m: Map String Expr.
            let min = _expectConstInt info "min" (_lookupExit info "min" m) in
            let max = _expectConstInt info "max" (_lookupExit info "max" m) in
            if leqi min max then
@@ -189,26 +240,142 @@ lang HoleIntRangeAst = IntAst + HoleAstBase
   sem pprintHole =
   | HIntRange {min = min, max = max} ->
     ("IntRange", [("min", int2string min), ("max", int2string max)])
+
+  sem hty =
+  | HIntRange {} -> TyInt {info = NoInfo ()}
 end
 
-let holeBool_ = use HoleBoolAst in
+lang HoleAnnotation = Ast
+  sem stripTuneAnnotations =
+  | t -> smap_Expr_Expr stripTuneAnnotations t
+end
+
+-- Independency annotation
+lang IndependentAst = HoleAnnotation + KeywordMaker + ANF + PrettyPrint + TypeAnnot
+  syn Expr =
+  | TmIndependent {lhs : Expr,
+                   rhs : Expr,
+                   info: Info,
+                   ty : Type}
+
+  sem stripTuneAnnotations =
+  | TmIndependent t -> t.lhs
+
+  sem isKeyword =
+  | TmIndependent _ -> true
+
+  sem matchKeywordString (info : Info) =
+  | "independent" -> Some (2, lam lst.
+    let e1 = get lst 0 in
+    let e2 = get lst 1 in
+    TmIndependent {lhs = e1, rhs = e2, info = info, ty = tyTm e1})
+
+  sem normalize (k : Expr -> Expr) =
+  | TmIndependent t ->
+    normalizeName (lam l.
+      normalizeName (lam r.
+        k (TmIndependent {{t with lhs = l}
+                             with rhs = r})
+        )
+      t.rhs)
+    t.lhs
+
+  sem infoTm =
+  | TmIndependent {info = info} -> info
+
+  sem tyTm =
+  | TmIndependent {ty = ty} -> ty
+
+  sem withType (ty : Type) =
+  | TmIndependent t -> TmIndependent {t with ty = ty}
+
+  sem smapAccumL_Expr_Expr f acc =
+  | TmIndependent t ->
+    match f acc t.lhs with (acc, lhs) then
+      match f acc t.rhs with (acc, rhs) then
+        (acc, TmIndependent {{t with lhs = lhs} with rhs = rhs})
+      else never
+    else never
+
+  sem pprintCode (indent : Int) (env : PprintEnv) =
+  | TmIndependent t ->
+    match printParen indent env t.lhs with (env, lhs) in
+    let aindent = pprintIncr indent in
+    match printParen aindent env t.rhs with (env, rhs) in
+    (env, join ["independent ", lhs, pprintNewline aindent, rhs])
+
+  sem typeAnnotExpr (env : TypeEnv) =
+  | TmIndependent t ->
+    let lhs = typeAnnotExpr env t.lhs in
+    TmIndependent {t with lhs = lhs}
+end
+
+let holeBool_ : Bool -> Int -> Expr =
+  use HoleBoolAst in
   lam default. lam depth.
-  TmHole { default = default
+  TmHole { default = bool_ default
          , depth = depth
          , ty = tybool_
          , info = NoInfo ()
          , inner = BoolHole {}}
 
-let holeIntRange_ = use HoleIntRangeAst in
+let holeIntRange_ : Int -> Int -> Int -> Int -> Expr =
+  use HoleIntRangeAst in
   lam default. lam depth. lam min. lam max.
-  TmHole { default = default
+  TmHole { default = int_ default
          , depth = depth
          , ty = tyint_
          , info = NoInfo ()
-         , inner = HIntRange {min = min, max = max}}
+         , inner = HIntRange {min = min, max = max}
+         }
 
-lang HoleAst = HoleAstBase + HoleBoolAst + HoleIntRangeAst end
+lang HoleAst = HoleAstBase + HoleBoolAst + HoleIntRangeAst + IndependentAst end
 
 lang HoleANF = HoleAst + MExprANF end
 
 lang HoleANFAll = HoleAst + MExprANFAll end
+
+lang Test = HoleAst + MExprEq end
+
+mexpr
+
+use Test in
+
+let h = holeBool_ true 0 in
+utest domainSize 100 h with 2 in
+
+let h = holeIntRange_ 5 0 1 10 in
+utest domainSize 2 h with 5 in
+utest domain 2 h with [int_ 1, int_ 3, int_ 5, int_ 7, int_ 9] using eqSeq eqExpr in
+
+let h = holeIntRange_ 5 0 2 10 in
+utest domainSize 2 h with 5 in
+utest domain 2 h with [int_ 2, int_ 4, int_ 6, int_ 8, int_ 10] using eqSeq eqExpr in
+
+let h = holeIntRange_ 5 0 2 9 in
+utest domainSize 2 h with 4 in
+utest domain 2 h with [int_ 2, int_ 4, int_ 6, int_ 8] using eqSeq eqExpr in
+
+let h = holeIntRange_ 5 0 5 5 in
+utest domainSize 100 h with 1 in
+utest domain 100 h with [int_ 5] using eqSeq eqExpr in
+
+let h = holeIntRange_ 2 0 1 3 in
+utest
+  let s = create 1000 (lam. sample 1 h) in
+  [ optionIsSome (find (eqExpr (int_ 1)) s)
+  , optionIsSome (find (eqExpr (int_ 2)) s)
+  , optionIsSome (find (eqExpr (int_ 3)) s)
+  ]
+with [true, true, true] in
+
+let h = holeIntRange_ 2 0 1 3 in
+utest
+  let s = create 1000 (lam. sample 2 h) in
+  [ optionIsSome (find (eqExpr (int_ 1)) s)
+  , optionIsSome (find (eqExpr (int_ 2)) s)
+  , optionIsSome (find (eqExpr (int_ 3)) s)
+  ]
+with [true, false, true] in
+
+()

--- a/stdlib/tuning/const-dep.mc
+++ b/stdlib/tuning/const-dep.mc
@@ -255,18 +255,18 @@ end
 
 lang BootParserDep = BootParserAst
   sem constDep =
-  | CBootParserParseMExprString _ -> error "BootParserDep not implemented yet"
-  | CBootParserParseMCoreFile _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetId _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetTerm _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetType _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetString _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetInt _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetFloat _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetListLength _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetConst _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetPat _ -> error "BootParserDep not implemented yet"
-  | CBootParserGetInfo _ -> error "BootParserDep not implemented yet"
+  | CBootParserParseMExprString _ -> []
+  | CBootParserParseMCoreFile _ -> []
+  | CBootParserGetId _ -> []
+  | CBootParserGetTerm _ -> []
+  | CBootParserGetType _ -> []
+  | CBootParserGetString _ -> []
+  | CBootParserGetInt _ -> []
+  | CBootParserGetFloat _ -> []
+  | CBootParserGetListLength _ -> []
+  | CBootParserGetConst _ -> []
+  | CBootParserGetPat _ -> []
+  | CBootParserGetInfo _ -> []
 end
 
 lang MExprConstDep =

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -18,15 +18,15 @@ type ContextExpanded =
 { table : LookupTable    -- The initial lookup table
 , tempDir : String       -- The temporary directory
 , tempFile : String      -- The file from which hole values are read
-, cleanup : Unit -> Unit -- Removes all temporary files from the disk
+, cleanup : () -> ()     -- Removes all temporary files from the disk
 }
 
 -- Generate code for looking up a value of a hole depending on its call history
-let contextExpansionLookupCallCtx
-  : (Int -> Expr) -> PTree Name -> Name -> CallCtxEnv -> Expr =
-  lam lookup. lam tree. lam incVarName. lam env.
+let contextExpansionLookupCallCtx =
+  use Ast in
+  lam lookup: (Int -> Expr). lam tree: PTree NameInfo. lam incVarName: Name. lam env: CallCtxEnv.
     use MExprAst in
-    recursive let work : NameInfo -> [PTree NameInfo] -> [NameInfo] -> Expr =
+    recursive let work : Name -> Map NameInfo (PTree NameInfo) -> [NameInfo] -> Expr =
       lam incVarName. lam children. lam acc.
         let children = mapValues children in
         match children with [] then never_
@@ -78,7 +78,7 @@ lang ContextExpand = HoleAst
     ( { table = _initAssignments env
       , tempDir = tempDir
       , tempFile = tuneFile
-      , cleanup = sysTempDirDelete tempDir
+      , cleanup = lam. sysTempDirDelete tempDir (); ()
       }, ast )
 
   -- 'insert public table t' replaces the holes in expression 't' by the values
@@ -99,11 +99,13 @@ lang ContextExpand = HoleAst
         if nameInfoEq funDefined callGraphTop then
           -- Context-sensitive hole on top-level: handle as a global hole
           lookupGlobal t.info
-        else
-          let iv = callCtxFun2Inc funDefined.0 env in
+        else match callCtxFunLookup funDefined.0 env with Some iv then
           let tree = mapFindExn (ident, t.info) env.contexts in
           let res = contextExpansionLookupCallCtx lookup tree iv env in
           res
+        else
+          -- Context-sensitive hole without any incoming calls
+          lookupGlobal t.info
     in TmLet {{t with body = body}
                  with inexpr = _contextExpandWithLookup env lookup t.inexpr}
 
@@ -302,8 +304,9 @@ let parse = lam str.
 in
 
 --let test : Bool -> Expr -> Map String (Map [String] Expr) -> Expr =
-let test : Bool -> Expr -> Map String (Map [String] Expr) -> Expr =
-  lam debug: Bool. lam ast: Expr. lam lookupMap: Map String (Map [String] Expr).
+-- let test : Bool -> Expr -> Map String (Map [String] Expr) -> Expr =
+let test : Bool -> Expr -> [(String, [([String],Expr)])] -> String =
+  lam debug: Bool. lam ast: Expr. lam lookupMap: [(String, [([String],Expr)])].
     (if debug then
        printLn "-------- BEFORE ANF --------";
        printLn (expr2str ast)
@@ -323,7 +326,7 @@ let test : Bool -> Expr -> Map String (Map [String] Expr) -> Expr =
      else ());
 
     -- Convert map to lookup table, use default for no value provided
-    let lookupMap : [(String, Map [String] Expr)] = map (lam t : (String, [([String],Expr)]).
+    let lookupMap: [(String, Map [String] Expr)] = map (lam t : (String, [([String],Expr)]).
       (t.0, mapFromSeq (seqCmp cmpString) t.1)) lookupMap in
     let lookupMap : Map String (Map [String] Expr) = mapFromSeq cmpString lookupMap in
 
@@ -449,5 +452,20 @@ map f [1,2,3]
 utest test debug t
 [ ("h", [ (["a"], int_ 1) ]) ]
 with "[2,3,4]" using eqTest in
+
+
+-- Context-sensitive hole that is not used (dead code). Use default value.
+let t = parse
+"
+let f = lam x.
+  let h = hole (Boolean {depth = 1, default = true}) in
+  h
+in
+1
+" in
+
+utest test debug t
+[ ("h", [ ([], true_) ]) ]
+with "1" using eqTest in
 
 ()

--- a/stdlib/tuning/data-frame.mc
+++ b/stdlib/tuning/data-frame.mc
@@ -1,0 +1,212 @@
+
+-- Implements a data structure for storing a matrix of values. Slicing out
+-- certain columns of the matrix is simple.
+
+include "seq.mc"
+include "common.mc"
+include "string.mc"
+include "eqset.mc"
+
+type DataFrame a = {
+  data : [[a]],
+  ncols : Int
+}
+
+-- 'dataFrameFromSeq data ncols' creates a new data frame from 'data', where
+-- 'ncols' is the length of each row in 'data'.
+let dataFrameFromSeq
+  : all a. [[a]] -> Int -> DataFrame a
+  = lam data : [[a]]. lam ncols : Int.
+    -- Assert dimensions match
+    utest forAll (lam row. eqi (length row) ncols) data with true in
+    {data = data, ncols = ncols}
+
+-- 'dataFrameLength df' returns the number of rows stored in 'df'.
+let dataFrameLength : all a. DataFrame a -> Int = lam df : DataFrame a.
+  length df.data
+
+-- 'dataFrameSlice idxs df' returns all rows of 'df' for the column indices
+-- listed in 'idxs'. Produces a runtime error if an index in 'idxs' is outside
+-- the range of 'df.ncols'.
+let dataFrameSlice
+  : all a. [Int] -> DataFrame a -> [[a]]
+  = lam idxs : [Int]. lam df : DataFrame a.
+    utest forAll (lam i. lti i df.ncols) idxs with true in
+    map (lam row. map (get row) idxs) df.data
+
+-- 'dataFrameHasRowSlice eq idxs row df' returns optionally the index of 'row'
+-- in 'df', slicing out the indices listed in 'idxs' and comparing using 'eq'.
+let dataFrameHasRowSlice
+  : all a. (a -> a -> Bool) -> [Int] -> [a] -> DataFrame a -> Option Int
+  = lam eq. lam idxs: [Int]. lam row: [a]. lam df.
+    utest length idxs with length row in
+
+    let slice = dataFrameSlice idxs df in
+    match
+      foldl (lam acc : (Int, Option Int). lam r.
+        match acc with (_, Some _) then acc
+        else
+          if eqSeq eq r row then (addi 1 acc.0, Some acc.0)
+          else (addi 1 acc.0, None ())
+      ) (0, None ()) slice
+    with (_, opt) in opt
+
+-- 'dataFrameHasRow eq row df' returns optionally the index of 'row' in 'df',
+-- comparing values using 'eq'.
+let dataFrameHasRow
+  : all a. (a -> a -> Bool)  -> [a] -> DataFrame a -> Option Int
+  = lam eq. lam row: [a]. lam df.
+  utest length row with df.ncols using eqi in
+
+  match
+    foldl (lam acc : (Int, Option Int). lam r.
+      match acc with (_, Some _) then acc
+      else
+        if eqSeq eq r row then (addi 1 acc.0, Some acc.0)
+        else (addi 1 acc.0, None ())
+    ) (0, None ()) df.data
+  with (_, opt) in opt
+
+-- 'dataFrameGetRow i df' returns the 'i'th row in 'df'.
+let dataFrameGetRow
+  : all a. Int -> DataFrame a -> [a]
+  = lam i. lam df.
+  utest lti i (length df.data) with true in
+  get df.data i
+
+-- 'dataFrameGetRowSlice i idxs df' returns the 'i'th row, with column indices in
+-- 'idxs'.
+let dataFrameGetRowSlice
+  : all a. Int -> [Int] -> DataFrame a -> [a]
+  = lam i. lam idxs. lam df.
+  utest lti i (length df.data) with true in
+  utest forAll (lam i. lti i df.ncols) idxs with true in
+  let row = get df.data i in
+  map (get row) idxs
+
+-- 'dataFrameSetRowSlice i idxs row df' returns a new data frame where the row at
+-- index 'i' has been replaced by 'row' on the positions specified by 'idxs'.
+let dataFrameSetRowSlice
+  : all a. Int -> [Int] -> [a] -> DataFrame a -> DataFrame a
+  = lam i. lam idxs: [Int]. lam row: [a]. lam df: DataFrame a.
+  utest forAll (lam i. lti i df.ncols) idxs with true in
+
+  let old = get df.data i in
+  let new = foldl (lam acc. lam idxVal.
+    match idxVal with (i, v) in
+    set acc i v) old (zip idxs row)
+  in {df with data = set df.data i new}
+
+-- 'dataFrameSetRow i row df' returns a new data frame where the row at index
+-- 'i' has been replaced by 'row'.
+let dataFrameSetRow
+  : all a. Int -> [a] -> DataFrame a -> DataFrame a
+  = lam i. lam row: [a]. lam df: DataFrame a.
+  utest length row with df.ncols in
+  {df with data = set df.data i row}
+
+-- 'dataFrameExtendCols n idxs v df' returns a new data frame with 'n' columns,
+-- where 'n' >= 'df.ncols'. The old columns are mapped to the indices in 'idxs',
+-- where 'length idxs = df.ncols'. The new locations are filled with the value
+-- 'v'.
+let dataFrameExtendCols
+  : all a. Int -> [Int] -> a -> DataFrame a -> DataFrame a
+  = lam n. lam idxs. lam v. lam df.
+  utest length idxs with df.ncols using eqi in
+  utest geqi n df.ncols with true in
+
+  let data = map (lam old.
+    let new = create n (lam. v) in
+    foldl (lam acc. lam idxVal.
+      match idxVal with (i,val) in
+      set acc i val) new (zip idxs old)
+  ) df.data in
+  {data = data, ncols = n}
+
+-- 'dataFrameAddRow row df' adds the 'row' to 'df'.
+let dataFrameAddRow
+  : all a. [a] -> DataFrame a -> DataFrame a
+  = lam row. lam df.
+  utest length row with df.ncols using eqi in
+  {df with data = snoc df.data row}
+
+-- 'dataFrameAddRow row df' adds the 'row' to 'df'.
+let dataFrameRemoveRow
+  : all a. Int -> DataFrame a -> DataFrame a
+  = lam i. lam df.
+  match splitAt df.data i with (l, r) in
+  {df with data = concat l (tail r)}
+
+-- 'dataFrameMap f df' returns a new data frame where 'f' has been applied to
+-- each element in 'df'.
+let dataFrameMap
+  : all a. all b. (a -> b) -> DataFrame a -> DataFrame b
+  = lam f. lam df.
+    let data = map (map f) df.data in
+    {data = data, ncols = df.ncols}
+
+-- 'dataFrame2str toStr df' returns a string representation of 'df', where each
+-- element is converted to string using 'toStr'.
+let dataFrame2str = lam toStr. lam df.
+  let df = dataFrameMap toStr df in
+  strJoin "\n" (map (strJoin " ") df.data)
+
+-- 'dataFrameEq eq df1 df2' checks whether 'df1' and 'df2' are equal, using
+-- element-wise equality function 'eq'. Two data frames are equal if they
+-- contain the same rows, order not considered.
+let dataFrameEq
+  : all a. all b. (a -> b -> Bool) -> DataFrame a -> DataFrame b -> Bool
+  = lam eq : a -> b -> Bool. lam df1 : DataFrame a. lam df2 : DataFrame b.
+    if eqi df1.ncols df2.ncols then
+      eqsetEqual (eqSeq eq) df1.data df2.data
+    else false
+
+mexpr
+
+let debug = false in
+
+let df = dataFrameFromSeq [[1,2,3],[4,5,6]] 3 in
+
+utest df with {data = [[1,2,3],[4,5,6]], ncols = 3} in
+
+utest dataFrameLength df with 2 in
+
+utest dataFrameSlice [0,2] df with [[1,3],[4,6]] in
+
+utest dataFrameHasRowSlice eqi [0,2] [1,3] df with Some 0 in
+utest dataFrameHasRowSlice eqi [0,2] [4,6] df with Some 1 in
+utest dataFrameHasRowSlice eqi [0,2] [4,7] df with None () in
+
+utest dataFrameHasRow eqi [1,2,3] df with Some 0 in
+utest dataFrameHasRow eqi [4,5,6] df with Some 1 in
+utest dataFrameHasRow eqi [4,4,6] df with None () in
+
+utest dataFrameSetRowSlice 0 [0] [42] df with {data = [[42,2,3],[4,5,6]], ncols=3} in
+utest dataFrameSetRowSlice 1 [1,2] [42,43] df with {data = [[1,2,3],[4,42,43]], ncols=3} in
+utest dataFrameSetRow 1 [42,43,3] df with {data = [[1,2,3],[42,43,3]], ncols=3} in
+
+utest dataFrameExtendCols 5 [0,1,3] 0 df with {data = [[1,2,0,3,0],[4,5,0,6,0]], ncols=5} in
+utest dataFrameExtendCols 3 [0,1,2] 0 df with {data = [[1,2,3],[4,5,6]], ncols=3} in
+utest dataFrameExtendCols 3 [2,1,0] 0 df with {data = [[3,2,1],[6,5,4]], ncols=3} in
+
+utest dataFrameMap (addi 1) df with {data = [[2,3,4],[5,6,7]], ncols = 3} in
+
+utest
+  let s = dataFrame2str int2string df in
+  if debug then printLn s else ()
+with () in
+
+utest dataFrameEq eqi df df with true in
+utest dataFrameEq eqi df (dataFrameFromSeq [[4,5,6],[1,2,3]] 3) with true in
+utest dataFrameEq eqi df (dataFrameFromSeq [[0,2,3],[4,5,6]] 3) with false in
+utest dataFrameEq eqi df (dataFrameFromSeq [[4,5,6,7],[1,2,3,4]] 4) with false in
+
+utest dataFrameAddRow [7,8,9] df with dataFrameFromSeq [[1,2,3],[4,5,6],[7,8,9]] 3
+using dataFrameEq eqi in
+
+utest dataFrameRemoveRow 0 df with dataFrameFromSeq [[4,5,6]] 3
+using dataFrameEq eqi in
+utest dataFrameRemoveRow 1 df with dataFrameFromSeq [[1,2,3]] 3
+using dataFrameEq eqi in
+
+()

--- a/stdlib/tuning/database.mc
+++ b/stdlib/tuning/database.mc
@@ -1,0 +1,185 @@
+
+include "data-frame.mc"
+include "search-space.mc"
+include "instrumentation.mc"
+include "math.mc"
+
+include "mexpr/cmp.mc"
+
+lang Database = MExprEq + MExprCmp + Instrumentation
+  syn Database =
+  | Database {
+      -- The 'i'th row of 'tables' gives the table used in the 'i'th iteration.
+      tables : DataFrame Expr,
+      -- The 'i'th row of 'runs' gives the count of how many times a measuring
+      -- point was run in the 'i'th iteration. The 'j'th element of each row
+      -- considers the measuring point with id 'j + offset', with 'offset' from
+      -- the dependency graph.
+      runs : DataFrame Int,
+      -- Like 'runs', but stores the total time spent (in ms) in a measuring
+      -- point.
+      totals : DataFrame Float
+    }
+
+  -- 'databaseEmpty n m' returns a new database designed for 'n' holes and 'm'
+  -- measuring points.
+  sem databaseEmpty (nbrHoles : Int) =
+  | nbrMeas ->
+    Database {
+      tables = dataFrameFromSeq [] nbrHoles,
+      runs = dataFrameFromSeq [] nbrMeas,
+      totals = dataFrameFromSeq [] nbrMeas
+    }
+
+  -- 'databaseAddRun str db' reads the profiled result 'str' from a program run and
+  -- stores it in 'db'.
+  sem databaseAddRun (table: [Expr]) (profile: InstrumentationProfile)
+                     (offset: Int) =
+  | Database db ->
+    match profile with
+      {ids= ids, nbrRuns= nbrRuns, totalMs= totalMs} in
+    -- Assert: dimensions match
+    utest length ids with db.runs.ncols using eqi in
+    utest length nbrRuns with db.runs.ncols using eqi in
+    utest length totalMs with db.runs.ncols using eqi in
+    -- Assert: the 'ids' are stored contiguously as offset..(offset+nbrMeas-1)
+    utest ids with create db.runs.ncols (lam i. addi offset i)
+    using eqSeq eqi in
+
+    Database { { { db with runs = dataFrameAddRow nbrRuns db.runs }
+                      with totals = dataFrameAddRow totalMs db.totals }
+                      with tables = dataFrameAddRow table db.tables }
+
+  -- 'databaseCost i dep' returns the estimated total execution time in ms of
+  -- the 'i'th entry stored in 'db'.
+  sem databaseCost (i : Int) =
+  | Database db ->
+    let row = dataFrameGetRow i db.totals in
+    foldl addf 0. row
+
+  -- 'databaseCostSlice i idxs dep' returns the estimated total execution time
+  -- in ms of the 'i'th entry stored in 'db', with measuring point indices
+  -- 'idxs' sliced out.
+  sem databaseCostSlice (i : Int) (idxs : [Int]) =
+  | Database db ->
+    let row = dataFrameGetRowSlice i idxs db.totals in
+    foldl addf 0. row
+
+  -- 'databaseOptimal epsilon ss db' returns the most optimal table and its
+  -- estimated execution time, given the result in 'db' and taking into account
+  -- the dependencies in 'dep'.
+  sem databaseOptimal (epsilon : Float) (dep : DependencyGraph)
+                      (ss : SearchSpaceSize) =
+  | Database db ->
+    -- Find connected components
+    let ccs : [[Int]] = map (lam c: ([Int], Float). c.0) ss.connectedComponents in
+    -- Partition into holes and measuring points, and offset measuring points
+    -- (to use as indices into database)
+    let ccs : [([Int],[Int])] = map (lam cc: [Int].
+        let p = partition (lam v. lti v dep.offset) cc in
+        (p.0, map (lam m. subi m dep.offset) p.1)
+      ) ccs in
+    -- For each connected component, choose the table minimizing the total
+    -- execution time, add to the table
+    match foldl (lam acc : (DataFrame (Option Expr), Float). lam hm : ([Int],[Int]).
+      match hm with (hIdxs, mIdxs) in
+      match databaseOptimalH epsilon hIdxs mIdxs dep (Database db) with
+        (minCost, slice)
+      in
+        ( dataFrameSetRowSlice 0 hIdxs (map (lam v. Some v) slice) acc.0,
+          addf acc.1 minCost )
+      ) (dataFrameFromSeq [make db.tables.ncols (None ())] db.tables.ncols, 0.) ccs
+    with (minDF, minMs) in
+    -- Convert the data frame to a lookup table
+    let minOpt: [Option Expr] = dataFrameGetRow 0 minDF in
+    let table: [Expr] = mapi (lam i. lam o.
+        match o with Some v then v
+        -- If a hole was not assigned a value, it means it does not affect a
+        -- measuring point. Use its first recorded value in the data base.
+        else
+          get (dataFrameGetRow 0 db.tables) i
+      ) minOpt in
+    (table, minMs)
+
+    sem databaseOptimalH (epsilon : Float) (hIdxs : [Int]) (mIdxs : [Int])
+                         (dep : DependencyGraph) =
+    | Database db ->
+      -- Assert that indices are monotonically increasing (or indexing breaks)
+      utest eqSeq eqi hIdxs (sort subi hIdxs) with true in
+      -- Pick out the domains from the database
+      let tables = dataFrameSlice hIdxs db.tables in
+      let totals = dataFrameSlice mIdxs db.totals in
+      let domains : Map Int (Set Expr) = foldl (lam acc. lam h.
+          mapInsert h (setEmpty cmpExpr) acc
+        ) (mapEmpty subi) hIdxs
+      in
+      let domains : Map Int (Set Expr) = foldl (lam acc. lam row.
+          foldl (lam acc. lam hVal.
+              match hVal with (h, val) in
+              let old = mapFindExn h acc in
+              let new = setInsert val old in
+              mapInsert h new acc
+            ) acc (zip hIdxs row)
+        ) domains tables
+      in
+
+      let tupleCost : [Expr] -> Option Float = lam tuple.
+        -- Check whether the tuple is valid for each measuring point, add the
+        -- cost if it is.
+        foldl (lam acc: Option Float. lam m: Int.
+          match acc with Some someAcc then
+            let hs = graphNeighbors (addi m dep.offset) dep.graph in
+            -- Assert that indices are monotonically increasing (or indexing breaks)
+            utest eqSeq eqi hs (sort subi hs) with true in
+            let idxs = map (lam h.
+                match index (eqi h) hIdxs with Some i then i
+                else error "impossible"
+              ) hs
+            in
+            let tupleSlice = map (lam i. get tuple i) idxs in
+            match dataFrameHasRowSlice eqExpr hs tupleSlice db.tables
+            with Some row
+            then Some (addf someAcc (head (dataFrameGetRowSlice row [m] db.totals)))
+            else None ()
+          else None ()
+        ) (Some 0.) mIdxs
+      in
+
+      let domainSeqs : [[Expr]] = map setToSeq (mapValues domains) in
+
+      let tuples = product domainSeqs in
+      let costs : [Option Float] = map tupleCost tuples in
+      let someCosts : [(Float, [Expr])] = foldl (lam acc. lam costTuple.
+          match costTuple with (c, tuple) in
+          match c with Some c then snoc acc (c, tuple)
+          else acc
+        ) [] (zip costs tuples)
+      in
+      match
+        min (lam c1: (Float, [Expr]). lam c2: (Float, [Expr]).
+            cmpfApprox epsilon c1.0 c2.0
+          ) someCosts
+      with Some costTuple then costTuple
+      else error "Impossible: no valid configuration"
+
+    -- 'databaseCount db' returns the number of entries stored in the database.
+    sem databaseCount =
+    | Database db ->
+      dataFrameLength db.tables
+
+    -- 'databaseGetTable i db' returns the 'i'th table stored in the database.
+    sem databaseGetTable (i : Int) =
+    | Database db ->
+      dataFrameGetRow i (db.tables)
+
+    -- 'databaseHasTableSlice idxs row db' returns true if the tables contains
+    -- the slice specified by 'idxs' and 'row', otherwise false.
+    sem databaseHasTableSlice (idxs : [Int]) (row : [Expr]) =
+    | Database db ->
+      use MExprEq in
+      optionIsSome (dataFrameHasRowSlice eqExpr idxs row db.tables)
+  end
+
+mexpr
+
+()

--- a/stdlib/tuning/database.mc
+++ b/stdlib/tuning/database.mc
@@ -147,7 +147,7 @@ lang Database = MExprEq + MExprCmp + Instrumentation
 
       let domainSeqs : [[Expr]] = map setToSeq (mapValues domains) in
 
-      let tuples = product domainSeqs in
+      let tuples = searchSpaceProduct domainSeqs in
       let costs : [Option Float] = map tupleCost tuples in
       let someCosts : [(Float, [Expr])] = foldl (lam acc. lam costTuple.
           match costTuple with (c, tuple) in

--- a/stdlib/tuning/dependency-analysis.mc
+++ b/stdlib/tuning/dependency-analysis.mc
@@ -5,15 +5,16 @@
 
 include "hole-cfa.mc"
 include "prefix-tree.mc"
+include "nested.mc"
 
-include "digraph.mc"
+include "graph.mc"
 include "set.mc"
 include "name.mc"
 
 type DependencyGraph = {
   -- A bipartite graph from context-expanded holes to measuring points (labels
   -- unused)
-  graph : Digraph Int Int,
+  graph : Graph Int Int,
 
   -- Maps a context-sensitive measuring point to its prefix tree, which gives a
   -- compact representation of the context strings
@@ -27,15 +28,20 @@ type DependencyGraph = {
   offset: Int,
 
   -- The total number of context-sensitive measuring points
-  nbrMeas: Int
+  nbrMeas: Int,
+
+  -- The currently 'alive' measuring points are those that are considered to
+  -- affect the total execution time of the program
+  alive: Set Int
 }
 
 let _dependencyGraphEmpty =
-  { graph = digraphEmpty subi (lam. lam. false) -- disable graph labels
+  { graph = graphEmpty subi eqi
   , measuringPoints = mapEmpty nameCmp
   , meas2fun = mapEmpty nameCmp
   , offset = 0
   , nbrMeas = 0
+  , alive = setEmpty subi
   }
 
 lang DependencyAnalysis = MExprHoleCFA
@@ -51,11 +57,14 @@ lang DependencyAnalysis = MExprHoleCFA
     with ((graph, _), _) in
     let graph : DependencyGraph = graph in
     let nMeas = mapFoldWithKey (
-      lam acc. lam. lam tree.
+      lam acc: Int. lam. lam tree: PTree NameInfo.
         addi acc (length (prefixTreeGetIds tree []))
-      ) 0 graph.measuringPoints in
-    { { graph with offset = nHoles }
-              with nbrMeas = nMeas }
+      ) 0 graph.measuringPoints
+    in
+    let alive = setOfSeq subi (map (addi nHoles) (create nMeas (lam i. i))) in
+    { { { graph with offset = nHoles }
+                with nbrMeas = nMeas }
+                with alive = alive }
 
   sem buildDependencies (cur : NameInfo) (env : CallCtxEnv)
                         (data : Map Name (Set AbsVal))
@@ -66,18 +75,18 @@ lang DependencyAnalysis = MExprHoleCFA
 
     -- Function to keep the part of a path that happened before the current node
     -- in the call history
-    recursive let shortenPath = lam path.
-      match path with [] then []
-      else match path with [(from,to,lbl)] ++ path in
-        if nameInfoEq cur from then []
-        else cons (from,to,lbl) (shortenPath path)
+    recursive let shortenPath = lam path. lam acc.
+      match path with [] then [] else
+      match path with [(from,to,lbl)] ++ path in
+        if nameInfoEq cur to then snoc acc (from,to,lbl)
+        else shortenPath path (snoc acc (from,to,lbl))
     in
 
     -- Update 'cur' when recursing in body if defining a function that is part
     -- of the call graph.
     let curBody =
       match t.body with TmLam lm then
-        if digraphHasVertex (ident, t.info) env.callGraph then (ident, t.info)
+        if graphHasVertex (ident, t.info) env.callGraph then (ident, t.info)
         else cur
       else cur
     in
@@ -97,7 +106,7 @@ lang DependencyAnalysis = MExprHoleCFA
 
                 -- The part of the context string that happened before the
                 -- current node in the call graph.
-                let shortPath : Path = shortenPath (mapFindExn c env.verbosePath) in
+                let shortPath : Path = shortenPath (mapFindExn c env.verbosePath) [] in
                 let lblPath : [NameInfo] = map (lam e : Edge. e.2) shortPath in
 
                 -- Insert base hole in the graph, and accumulate context
@@ -125,15 +134,15 @@ lang DependencyAnalysis = MExprHoleCFA
           -- For each context-sensitive hole, add an edge to the set of
           -- measuring id's it affects
           let graphGraph = mapFoldWithKey (
-            lam acc: Digraph Int Int. lam id: Int. lam path: [NameInfo].
+            lam acc: Graph Int Int. lam id: Int. lam path: [NameInfo].
               -- Set of measuring points that this context string affects.
               let measPoints : [Int] = prefixTreeGetIds tree (reverse path) in
               -- Add context-expanded hole to dependency graph
-              let acc = digraphMaybeAddVertex id acc in
+              let acc = graphMaybeAddVertex id acc in
               -- Add corresponding edges to dependency graph
-              foldl (lam acc : Digraph Int Int. lam mp: Int.
-                let acc = digraphMaybeAddVertex mp acc in
-                digraphAddEdge id mp 0 acc
+              foldl (lam acc : Graph Int Int. lam mp: Int.
+                let acc = graphMaybeAddVertex mp acc in
+                graphAddEdge id mp 0 acc
               ) acc measPoints
             ) graph.graph shortContexts
           in
@@ -156,7 +165,7 @@ lang DependencyAnalysis = MExprHoleCFA
       mapAccumL (lam acc : (DependencyGraph, Int). lam bind : RecLetBinding.
         let curBody =
           match bind with {body = TmLam lm, ident = ident} then
-            if digraphHasVertex (ident, t.info) env.callGraph then
+            if graphHasVertex (ident, t.info) env.callGraph then
               (ident, t.info)
             else cur
           else cur
@@ -194,8 +203,8 @@ lang DependencyAnalysis = MExprHoleCFA
     -- Build bipartite graph
     let vertices = cons mId holeIds in
     let edges = map (lam h. (h,mId,0)) holeIds in
-    let graphGraph = digraphAddEdges edges (
-      digraphAddVertices vertices dep.graph)
+    let graphGraph = graphAddEdges edges (
+      graphAddVertices vertices dep.graph)
     in
     -- Create empty context tree (measuring point has no context)
     let tree = prefixTreeEmpty nameInfoCmp (nameSym "", NoInfo ()) in
@@ -203,17 +212,19 @@ lang DependencyAnalysis = MExprHoleCFA
     let measuringPoints = mapInsert m tree dep.measuringPoints in
     -- Closest enclosing call graph function is top-level
     let meas2fun = mapInsert m (nameInfoGetName callGraphTop) dep.meas2fun in
-    let dep = {{{{{dep with graph = graphGraph}
-                       with measuringPoints = measuringPoints}
-                       with meas2fun = meas2fun}
-                       with offset = nHoles}
-                       with nbrMeas = 1} in
+    let dep = {{{{{{dep with graph = graphGraph}
+                        with measuringPoints = measuringPoints}
+                        with meas2fun = meas2fun}
+                        with offset = nHoles}
+                        with nbrMeas = 1}
+                        with alive = setOfSeq subi [nHoles]} in
     (dep, t)
 
 end
 
-lang TestLang = DependencyAnalysis + MExprHoleCFA + GraphColoring + BootParser +
-                MExprPrettyPrint + MExprANFAll + MExprSym
+lang TestLang = DependencyAnalysis + MExprHoleCFA + GraphColoring +
+                NestedMeasuringPoints +
+                BootParser + MExprPrettyPrint + MExprANFAll + MExprSym
 end
 
 mexpr
@@ -253,6 +264,7 @@ let test : Bool -> Bool -> Expr -> (DependencyGraph, CallCtxEnv) =
       printLn "\n--- FINAL CFA GRAPH ---";
       printLn resStr;
       let cfaRes : CFAGraph = cfaRes in
+      let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
       match
         if full then assumeFullDependency env tANF
         else (analyzeDependency env cfaRes tANF, tANF)
@@ -266,6 +278,7 @@ let test : Bool -> Bool -> Expr -> (DependencyGraph, CallCtxEnv) =
     else
       -- Version without debug printouts
       let cfaRes : CFAGraph = cfaData graphData tANF in
+      let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
       match
         if full then assumeFullDependency env tANF
         else (analyzeDependency env cfaRes tANF, tANF)
@@ -305,7 +318,7 @@ in
 
 -- Helper for eqTest, to check that a given dependency edge exists.
 let depExists = lam holeTree : PTree NameInfo. lam measTree : PTree NameInfo.
-                lam graph : Digraph Int Int.
+                lam graph : Graph Int Int.
                 lam edge : ([String], [String]).
   -- Convert name info paths to string paths
   let holeIdPath : [(Int,[NameInfo])] = prefixTreeBindings holeTree in
@@ -334,7 +347,7 @@ let depExists = lam holeTree : PTree NameInfo. lam measTree : PTree NameInfo.
 
   -- Edge lookup ignoring label
   let edgeExists = lam from. lam to.
-    not (null (digraphEdgesBetween from to graph))
+    graphIsAdjacent from to graph
   in
 
   -- Check whether the bipartite graph contains the edge.
@@ -389,7 +402,7 @@ let eqTest = lam lhs : (DependencyGraph, CallCtxEnv). lam rhs : TestResult.
 
   -- Number of dependency edges match
   let nbrEdges1 = length rhs.deps in
-  let nbrEdges2 = digraphCountEdges dep.graph in
+  let nbrEdges2 = graphCountEdges dep.graph in
   let nbrEdgesMatch = eqi nbrEdges1 nbrEdges2 in
 
   -- meas2fun match
@@ -457,12 +470,12 @@ let eqTest = lam lhs : (DependencyGraph, CallCtxEnv). lam rhs : TestResult.
   , (nbrMeasEq, "\nFAIL: Mismatch in nbrMeas")
   ] in
 
-  iter (lam b: (Bool, String, Unit -> Unit).
+  iter (lam b: (Bool, String).
     if b.0 then ()
     else printLn b.1; failPrint ()
   ) result;
 
-  forAll (lam b : (Bool, String, Unit -> Unit). b.0) result
+  forAll (lam b : (Bool, String). b.0) result
 in
 
 let t = parse
@@ -630,5 +643,121 @@ utest test debug true t with {
   offset = 4,
   nbrMeas = 1
 } using eqTest in
+
+
+let t = parse
+"
+let f1 = lam x.
+  let h1 = hole (IntRange{min=100,max=200,default=200}) in
+  let m1 = sleepMs h1 in
+  ()
+in
+recursive let f2 = lam x.
+  let c = f1 x in c
+in
+recursive let f3 = lam x.
+  ()
+in
+let h2 = hole (IntRange{min=100,max=200,default=200}) in
+let m2 = if h2 then let a = f2 () in a else () in
+let m3 = if h2 then () else let b = f1 () in b in
+let m4 = if h2 then f3 () else () in
+()
+"
+in
+
+utest test debug false t with {
+  measuringPoints =
+  [ ("m1", [[]])
+  , ("m2", [[]])
+  , ("m3", [[]])
+  , ("m4", [[]])
+  ],
+  deps =
+  [ ( ("h1", []), ("m1", []) )
+  , ( ("h1", []), ("m2", []) )
+  , ( ("h1", []), ("m3", []) )
+  , ( ("h2", []), ("m2", []) )
+  , ( ("h2", []), ("m3", []) )
+  , ( ("h2", []), ("m4", []) )
+  ],
+  meas2fun = [("m1","top"),("m2","top"),("m3","top"),("m4","top")],
+  offset = 2,
+  nbrMeas = 4
+} using eqTest in
+
+
+-- Syntactically scoped points
+let t = parse
+"
+let h1 = hole (Boolean {default = true}) in
+let h2 = hole (IntRange {default = 1, min = 0, max = 10}) in
+let m1 =
+  if h1 then
+    let a = sleepMs h2 in
+    ()
+  else ()
+in
+()
+"
+in
+
+utest test debug false t with {
+  measuringPoints =
+  [ ("m1", [[]])
+  ],
+  deps =
+  [ ( ("h1", []), ("m1", []) )
+  , ( ("h2", []), ("m1", []) )
+  ],
+  meas2fun = [("m1","top")],
+  offset = 2,
+  nbrMeas = 1
+} using eqTest in
+
+
+-- Nested measuring points with several contexts
+let t = parse
+"
+let f = lam x.
+  let h = hole (Boolean {default = true, depth = 1}) in
+  let m1 = if h then 1 else 2 in
+  h
+in
+
+let g = lam x.
+  let v1 = f () in
+  let m =
+    if v1 then
+      let v2 = f () in
+      v2
+    else false
+  in m
+in
+
+let v3 = f () in
+
+g ()
+"
+in
+
+utest test debug false t with {
+  measuringPoints =
+  [ ("m", [[]])
+  , ("m1", [["v1"],["v2"],["v3"]])
+  ],
+  deps =
+  [ ( ("h", ["v1"]), ("m", []) )
+  , ( ("h", ["v2"]), ("m", []) )
+  , ( ("h", ["v1"]), ("m1", ["v1"]) )
+  , ( ("h", ["v2"]), ("m1", ["v2"]) )
+  , ( ("h", ["v3"]), ("m1", ["v3"]) )
+  ],
+  meas2fun = [("m","g"),("m1","f")],
+  offset = 3,
+  nbrMeas = 4
+}
+using eqTest in
+
 
 ()

--- a/stdlib/tuning/eq-paths.mc
+++ b/stdlib/tuning/eq-paths.mc
@@ -8,13 +8,13 @@ include "eqset.mc"
 -- call graph 'g' for the equivalence classes used for classifying computation
 -- contexts for holes. The paths are suffixes of paths starting in any of the
 -- 'startNodes' and end in 'endNode'.
-let eqPaths : Digraph -> a -> Int -> [a] -> [[a]] =
+let eqPaths : all v. all l. Digraph v l -> v -> Int -> [v] -> [[(v,v,l)]] =
   lam g. lam endNode. lam depth. lam startNodes.
     -- Reverse graph for forward search (more efficient for adjacency map)
     let gRev = digraphReverse g in
     let eqv = lam v1. lam v2. eqi (digraphCmpv g v1 v2) 0 in
 
-    recursive let traverse : Digraph -> a -> [b] -> [a] -> Int -> [[a]] =
+    recursive let traverse : Digraph v l -> v -> [(v,v,l)] -> [v] -> Int -> [[(v,v,l)]] =
       lam g. lam v. lam curPath. lam visited. lam d.
         let fromEdges = digraphEdgesFrom v g in
         if eqi d 0 then [curPath]
@@ -31,18 +31,19 @@ let eqPaths : Digraph -> a -> Int -> [a] -> [[a]] =
             else paths in
           foldl concat [] paths
     in
-    let res = traverse gRev endNode [] [] depth in
-    map (lam p. map (lam e : (Unknown, Unknown, Unknown). (e.1, e.0, e.2)) p) res
+    let res: [[(v,v,l)]] = traverse gRev endNode [] [] depth in
+    map (lam p: [(v,v,l)]. map (lam e: (v, v, l). (e.1, e.0, e.2)) p) res
 
-let eqPathsToLbls : [[DigraphEdge v l]] -> [[l]] = lam paths.
+let eqPathsToLbls : all v. all l. [[DigraphEdge v l]] -> [[l]] = lam paths.
   map (lam p. map (lam e : DigraphEdge v l. e.2) p) paths
 
 mexpr
 -- To construct test graphs
 let empty = digraphEmpty subi eqChar in
 let fromList = lam vs. foldl (lam g. lam v. digraphAddVertex v g) empty vs in
-let addEdges = lam g. lam es.
-  foldl (lam acc. lam e : DigraphEdge v l. digraphAddEdge e.0 e.1 e.2 acc) g es
+let addEdges : all v. all l. Digraph v l -> [DigraphEdge v l] -> Digraph v l =
+  lam g. lam es.
+    foldl (lam acc. lam e : DigraphEdge v l. digraphAddEdge e.0 e.1 e.2 acc) g es
 in
 
 let eqPaths = lam g. lam endNode. lam depth. lam startNodes.

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -92,7 +92,9 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
 
   syn Constraint =
     -- {dhole} ⊆ lhs ⇒ {dhole} ⊆ rhs
-  | CstrHoleDirect { lhs: Name, rhs: Name }
+  | CstrHoleDirectData { lhs: Name, rhs: Name }
+    -- {dhole} ⊆ lhs ⇒ {ehole} ⊆ rhs
+  | CstrHoleDirectExe { lhs: Name, rhs: Name }
     -- {dhole} ⊆ lhs ⇒ ({dhole} ⊆ res) AND ({ehole} ⊆ res)
   | CstrHoleApp { lhs: Name, res: Name }
     -- ({const with args = args} ⊆ lhs AND |args| = arity(const)-1
@@ -106,16 +108,24 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
   | CstrConstApp { lhs: Name, rhs : Name, res: Name }
     -- {dhole} ⊆ lhs ⇒ {ehole} ⊆ res
   | CstrHoleMatch { lhs: Name, res: Name }
+    -- {dhole} ⊆ lhs ⇒ {dhole} ⊄ rhs
+    -- lhs \ {dhole : dhole ∈ rhs} ⊆ res
+  | CstrHoleIndependent { lhs: Name, rhs: Name, res: Name }
+
 
   sem initConstraint (graph : CFAGraph) =
   | CstrHoleApp r & cstr -> initConstraintName r.lhs graph cstr
-  | CstrHoleDirect r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrHoleDirectData r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrHoleDirectExe r & cstr -> initConstraintName r.lhs graph cstr
   | CstrConstApp r & cstr -> initConstraintName r.lhs graph cstr
   | CstrHoleMatch r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrHoleIndependent r & cstr -> initConstraintName r.lhs graph cstr
 
   sem propagateConstraint (update : (Name, AbsVal)) (graph : CFAGraph) =
-  | CstrHoleDirect { lhs = lhs, rhs = rhs } ->
+  | CstrHoleDirectData { lhs = lhs, rhs = rhs } ->
     match update.1 with AVDHole _ & av then addData graph av rhs else graph
+  | CstrHoleDirectExe { lhs = lhs, rhs = rhs } ->
+    match update.1 with AVDHole a then addData graph (AVEHole a) rhs else graph
   | CstrHoleApp { lhs = lhs, res = res } ->
     match update.1 with AVDHole {id = id, contexts = contexts} & av then
       let graph = addData graph av res in
@@ -138,32 +148,31 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
           let dep = argDep.1 in
           let isDataDep = dep.0 in
           let isExeDep = dep.1 in
-          let s = dataLookup arg graph in
-          let avHoles : [(Name, Set Int)] = setFold (lam acc. lam e.
-            match e with AVDHole {id=id, contexts=ctxs} then cons (id, ctxs) acc
-            else acc) [] s
-          in
           -- Add data dependencies to the result
           let graph =
             if isDataDep then
-              foldl (lam acc. lam idCtxs.
-                match idCtxs with (id, ctxs) in
-                addData acc (AVDHole {id=id, contexts=ctxs}) res
-              ) graph avHoles
+              initConstraint graph (CstrHoleDirectData {lhs = arg, rhs = res})
             else graph
           in
           -- Add execution time dependencies the result
-          if isExeDep then
-            foldl (lam acc. lam idCtxs.
-              match idCtxs with (id, ctxs) in
-              addData acc (AVEHole {id=id, contexts=ctxs}) res
-            ) graph avHoles
-          else graph) graph (zip args cdeps) in
+          let graph =
+            if isExeDep then
+              initConstraint graph (CstrHoleDirectExe {lhs = arg, rhs = res})
+            else graph
+          in
+          graph) graph (zip args cdeps) in
         graph
       else
         -- Curried application, just add the new argument
         addData graph (AVConst { avc with args = args }) res
     else graph
+  | CstrHoleIndependent { lhs = lhs, rhs = rhs, res = res } ->
+    match update.1 with AVDHole _ & av then
+      -- Only add the dependency if it is not part of rhs
+      let d = dataLookup rhs graph in
+      if setMem av d then graph
+      else propagateDirectConstraint res graph av
+    else propagateDirectConstraint res graph update.1
 
   sem generateHoleConstraints (graph: CFAGraph) =
   | _ -> []
@@ -176,7 +185,6 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
           contexts=mapFindExn ident contextMap
         }, rhs=ident } ]
     else
-      dprintLn graphData;
       error "Expected context information"
   | TmLet { ident = ident, body = TmConst { val = c } } ->
     let arity = constArity c in
@@ -191,12 +199,22 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
       ]
       else infoErrorExit (infoTm app.rhs) "Not a TmVar in application"
     else infoErrorExit (infoTm app.lhs) "Not a TmVar in application"
+  | TmLet { ident = ident, body = TmIndependent t} ->
+    match t.lhs with TmVar lhs then
+      match t.rhs with TmVar rhs then
+        [ CstrHoleIndependent {lhs = lhs.ident, rhs = rhs.ident, res = ident} ]
+      else infoErrorExit (infoTm t.rhs) "Not a TmVar in independent annotation"
+    else infoErrorExit (infoTm t.lhs) "Not a TmVar in independent annotation"
 
   sem constraintToString (env: PprintEnv) =
-  | CstrHoleDirect { lhs = lhs, rhs = rhs } ->
+  | CstrHoleDirectData { lhs = lhs, rhs = rhs } ->
     match pprintVarName env rhs with (env,rhs) in
     match pprintVarName env lhs with (env,lhs) in
     (env, join [ "{dhole} ⊆ ", lhs, " ⇒ {dhole} ⊆ ", rhs ])
+  | CstrHoleDirectExe { lhs = lhs, rhs = rhs } ->
+    match pprintVarName env rhs with (env,rhs) in
+    match pprintVarName env lhs with (env,lhs) in
+    (env, join [ "{dhole} ⊆ ", lhs, " ⇒ {ehole} ⊆ ", rhs ])
   | CstrHoleApp { lhs = lhs, res = res } ->
     match pprintVarName env lhs with (env,lhs) in
     match pprintVarName env res with (env,res) in
@@ -221,6 +239,12 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
       "({const with args = args} ⊆ ", lhs, " AND |args| < arity(const)-1\n",
       "  ⇒ {const with args = snoc args ", rhs, "} ⊆ ", res, ")"
     ])
+  | CstrHoleIndependent { lhs = lhs, rhs = rhs, res = res } ->
+    match pprintVarName env lhs with (env,lhs) in
+    match pprintVarName env rhs with (env,rhs) in
+    match pprintVarName env res with (env,res) in
+    (env, join [lhs, " \\ {dhole : dhole ∈ ", rhs, "} ⊆ ", res])
+
 
   sem generateHoleMatchResConstraints (id: Name) (target: Name) =
   | ( PatSeqTot _
@@ -231,13 +255,18 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
     | PatBool _
     | PatRecord _
     ) & pat -> [
-      CstrHoleDirect { lhs = target, rhs = id },
+      CstrHoleDirectData { lhs = target, rhs = id },
       CstrHoleMatch { lhs = target, res = id }
     ]
-  | ( PatAnd p
-    | PatOr p
-    | PatNot p
-    ) -> infoErrorExit p.info "Pattern currently not supported"
+  | PatAnd p ->
+    let lres = generateHoleMatchResConstraints id target p.lpat in
+    let rres = generateHoleMatchResConstraints id target p.rpat in
+    concat lres rres
+  | PatOr p ->
+    let lres = generateHoleMatchResConstraints id target p.lpat in
+    let rres = generateHoleMatchResConstraints id target p.rpat in
+    concat lres rres
+  | PatNot p  -> []
   | _ -> []
 
   -- NOTE(Linnea, 2021-12-17): We need to handle references, since references
@@ -259,7 +288,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
     in
     let pnames = f [] pat in
     foldl (lam acc. lam name.
-      cons (CstrHoleDirect { lhs = target, rhs = name }) acc
+      cons (CstrHoleDirectData { lhs = target, rhs = name }) acc
     ) [] pnames
 
   -- Type: Expr -> CFAGraph
@@ -333,7 +362,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
       mapFoldWithKey
         (lam acc : Map Name (Map Name (Set Int)).
          lam nameInfo : NameInfo.
-         lam tree : Ptree NameInfo.
+         lam tree : PTree NameInfo.
            mapInsert nameInfo.0 (treeToCallSiteCtxUnion tree) acc
         ) (mapEmpty nameCmp) env.contexts
     in
@@ -357,7 +386,7 @@ let parse = lam str.
   let ast = makeKeywords [] ast in
   symbolize ast
 in
-let test: Bool -> Expr -> [String] -> [(String,Set AbsVal,Map NameInfo (Map [NameInfo] Int))] =
+let test: Bool -> Expr -> [String] -> [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
   lam debug: Bool. lam t: Expr. lam vars: [String].
     -- Use small ANF first, needed for context expansion
     let tANFSmall = use MExprHoles in normalizeTerm t in
@@ -384,7 +413,7 @@ let test: Bool -> Expr -> [String] -> [(String,Set AbsVal,Map NameInfo (Map [Nam
       printLn "\n--- FINAL CFA GRAPH ---";
       printLn resStr;
       let cfaRes : CFAGraph = cfaRes in
-      let avs : [(String, Set AbsVal, Map NameInfo (Map [NameInfo] Int))] =
+      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
         map (lam var: String.
           let binds = mapBindings cfaRes.data in
           let res = foldl (lam acc. lam b : (Name, Set AbsVal).
@@ -397,7 +426,7 @@ let test: Bool -> Expr -> [String] -> [(String,Set AbsVal,Map NameInfo (Map [Nam
     else
       -- Version without debug printouts
       let cfaRes : CFAGraph = cfaData graphData tANF in
-      let avs : [(String, Set AbsVal, Map NameInfo (Map [NameInfo] Int))] =
+      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
         map (lam var: String.
           let binds = mapBindings cfaRes.data in
           let res = foldl (lam acc. lam b : (Name, Set AbsVal).
@@ -447,8 +476,8 @@ let eqTestHole = eqSeq
        let deps : Dep = t2.1 in
        -- Comparison of names
        let namesEq =
-         let dataStrs = map (lam e : (String,[Int]). e.0) data in
-         let exeStrs = map (lam e : (String,[Int]). e.0) exe in
+         let dataStrs = map (lam e : (String,Set Int). e.0) data in
+         let exeStrs = map (lam e : (String,Set Int). e.0) exe in
          let depDataStrs = map (lam e : (String,[[String]]). e.0) deps.d in
          let depExeStrs = map (lam e : (String,[[String]]). e.0) deps.e in
          if setEq (setOfSeq cmpString dataStrs) (setOfSeq cmpString depDataStrs) then
@@ -457,16 +486,16 @@ let eqTestHole = eqSeq
        in
        -- Comparison of contexts
        if namesEq then
-         let dataCtxs : [(String, [Int])] = map (lam e : (String,Set Int). (e.0, setToSeq e.1)) data in
-         let dataCtxPaths : [[String]] = map (lam e : (String, [Int]). map (index2Path e.0) e.1) dataCtxs in
-         let dataCtxPaths : [Set [String]] = map (setOfSeq (seqCmp cmpString)) dataCtxPaths in
+         let dataCtxs: [(String,[Int])] = map (lam e : (String,Set Int). (e.0, setToSeq e.1)) data in
+         let dataCtxPaths = map (lam e : (String, [Int]). map (index2Path e.0) e.1) dataCtxs in
+         let dataCtxPaths = map (setOfSeq (seqCmp cmpString)) dataCtxPaths in
 
-         let exeCtxs : [(String, [Int])] = map (lam e : (String,Set Int). (e.0, setToSeq e.1)) exe in
-         let exeCtxPaths : [[String]] = map (lam e : (String, [Int]). map (index2Path e.0) e.1) exeCtxs in
-         let exeCtxPaths : [Set [String]] = map (setOfSeq (seqCmp cmpString)) exeCtxPaths in
+         let exeCtxs = map (lam e : (String,Set Int). (e.0, setToSeq e.1)) exe in
+         let exeCtxPaths = map (lam e : (String, [Int]). map (index2Path e.0) e.1) exeCtxs in
+         let exeCtxPaths = map (setOfSeq (seqCmp cmpString)) exeCtxPaths in
 
-         let depDataCtxs : [Set [String]] = map (lam e : (String,[[String]]). setOfSeq (seqCmp cmpString) e.1) deps.d in
-         let depExeCtxs : [Set [String]] = map (lam e : (String,[[String]]). setOfSeq (seqCmp cmpString) e.1) deps.e in
+         let depDataCtxs: [Set [String]] = map (lam e : (String,[[String]]). setOfSeq (seqCmp cmpString) e.1) deps.d in
+         let depExeCtxs: [Set [String]] = map (lam e : (String,[[String]]). setOfSeq (seqCmp cmpString) e.1) deps.e in
 
          if setEq (setOfSeq setCmp dataCtxPaths) (setOfSeq setCmp depDataCtxs) then
            setEq (setOfSeq setCmp exeCtxPaths) (setOfSeq setCmp depExeCtxs)
@@ -637,6 +666,47 @@ in
 utest test debug t ["x", "z"]
 with [ ("x", {d=[gbl "h"],e=[]})
      , ("z", {d=[gbl "h"],e=[gbl "h"]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+let res = match h with a & b then 1 else 2 in
+let res2 = match h with c & true then 1 else 2 in
+()
+"
+in
+
+utest test debug t ["a", "b", "c", "res", "res2"]
+with [ ("a", {d=[gbl "h"],e=[]})
+     , ("b", {d=[gbl "h"],e=[]})
+     , ("c", {d=[gbl "h"],e=[]})
+     , ("res", {d=[],e=[]})
+     , ("res2", {d=[gbl "h"],e=[gbl "h"]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+type T in
+con C: Bool -> t in
+let h = hole (Boolean {default = true}) in
+let p = C h in
+let res = match h with a | true then 1 else 2 in
+let res2 = match p with C true | C false then 1 else 2 in
+let res3 = match p with C aa | (C true & aa) then 1 else 2 in
+()
+"
+in
+
+utest test debug t ["res", "res2", "res3", "aa"]
+with [ ("res", {d=[gbl "h"],e=[gbl "h"]})
+     , ("res2", {d=[gbl "h"],e=[gbl "h"]})
+     , ("res3", {d=[gbl "h"],e=[gbl "h"]})
+     , ("aa", {d=[gbl "h"],e=[]})
      ]
 using eqTestHole in
 
@@ -863,5 +933,68 @@ with
 ]
 using eqTestHole
 in
+
+-- Tests for independency annotation
+let t = parse
+"
+let x = hole (Boolean {default = true}) in
+let y = if x then 1 else 2 in
+let z = independent y x in
+()
+"
+in
+
+utest test debug t ["x","y","z"] with
+[ ("x", {d=[gbl "x"],e=[]})
+, ("y", {d=[gbl "x"],e=[gbl "x"]})
+, ("z", {d=[],e=[]})
+]
+using eqTestHole in
+
+
+let t = parse
+"
+let and: Bool -> Bool -> Bool =
+  lam a. lam b. if a then b else false
+in
+
+let x1 = hole (Boolean {default = true}) in
+let x2 = hole (Boolean {default = true}) in
+let y = if and x1 x2 then 1 else 2 in
+let z1 = independent y x1 in
+let z2 = independent y x2 in
+let z3 = independent z1 x2 in
+let z4 = independent z1 x1 in
+()
+"
+in
+
+utest test debug t ["x1", "x2", "y", "z1", "z2", "z3", "z4"] with
+[ ("x1", {d=[gbl "x1"],e=[]})
+, ("x2", {d=[gbl "x2"],e=[]})
+, ("y", {d=[gbl "x1", gbl "x2"],e=[gbl "x1", gbl "x2"]})
+, ("z1", {d=[gbl "x2"],e=[]})
+, ("z2", {d=[gbl "x1"],e=[]})
+, ("z3", {d=[],e=[]})
+, ("z4", {d=[gbl "x2"],e=[]})
+]
+using eqTestHole in
+
+
+let t = parse
+"
+let x = hole (Boolean {default = true}) in
+let f = lam y. x in
+let i = independent f x in
+let r = i 1 in
+()
+"
+in
+
+utest test debug t ["i", "r"] with
+[ ("i", {d=[],e=[]})
+, ("r", {d=[gbl "x"],e=[]})
+]
+using eqTestHole in
 
 ()

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -11,6 +11,8 @@
 
 include "ast.mc"
 include "dependency-analysis.mc"
+include "data-frame.mc"
+include "tail-positions.mc"
 
 include "common.mc"
 include "set.mc"
@@ -24,83 +26,204 @@ type InstrumentedResult = {
   fileName : String,
 
   -- Cleanup function for removing all temporary files
-  cleanup : Unit -> Unit
+  cleanup : () -> ()
 }
 
-lang Instrumentation = LetAst
+let _instrumentationHeader = "id,nbrRuns,totalMs"
+
+lang Instrumentation = MExprAst + HoleAst + TailPositions
+  sem tailPositionBaseCase =
+  | TmHole _ -> true
+  | TmIndependent t ->
+    tailPositionBaseCase t.lhs
+
   sem instrument (env : CallCtxEnv) (graph : DependencyGraph) =
   | t ->
     -- Create header
     match instrumentHeader (graph.nbrMeas, graph.offset)
-    with (header, logName, funName) in
+    with (header, str2name) in
     -- Create footer
     let tempDir = sysTempDirMake () in
     let fileName = sysJoinPath tempDir ".profile" in
-    match instrumentFooter fileName graph.offset with (footer, dumpToFile) in
+    match instrumentFooter fileName str2name graph.offset with (footer, dumpToFile) in
     -- Instrument the program
-    let expr = instrumentH env graph funName t in
+    let expr = instrumentH env graph str2name t in
 
     -- Put together the final AST
     let ast =
       bindall_
       [ header
       , bindSemi_ expr footer
-      , app_ (nvar_ dumpToFile) (nvar_ logName)
+      , appf2_ (nvar_ dumpToFile) (nvar_ (str2name "log")) (nvar_ (str2name "lock"))
       ]
     in
-    let res = {fileName = fileName, cleanup = sysTempDirDelete tempDir} in
+    let res = {fileName = fileName, cleanup = lam. sysTempDirDelete tempDir (); ()} in
     (res, ast)
 
+  sem idExpr (info: Info) (ident: Name) (graph: DependencyGraph) (env: CallCtxEnv) (tree: PTree NameInfo) =
+  | ids ->
+    match ids with [id] then int_ id
+    else match ids with [_] ++ _ then
+      let incVarName = mapFindExn (mapFindExn ident graph.meas2fun) env.fun2inc in
+      let lookup = lam i. int_ i in
+      contextExpansionLookupCallCtx lookup tree incVarName env
+    else infoErrorExit info "Measuring point without id"
+
   -- Recursive helper for instrument
-  sem instrumentH (env : CallCtxEnv) (graph : DependencyGraph) (funName : Name) =
-  | TmLet ({ident = ident} & t) ->
-    match mapLookup ident graph.measuringPoints with Some tree then
+  sem instrumentH (env : CallCtxEnv) (graph : DependencyGraph) (str2name : String -> Name) =
+  | TmRecLets r ->
+    let lets : [Name] = map (lam b: RecLetBinding. b.ident) r.bindings in
+    match lets with [] then instrumentH env graph str2name r.inexpr
+    else
+      -- Identify a reclet by the ident of its first binding
+      let reclet = head lets in
+      -- Find the set of measuring points with a tail call within a reclet
+      let acc: [Int] = [] in
+      let ids: [Int] = [] in
+      let baseCase = lam acc. lam ids. lam expr. expr in
+      let tailCall = lam acc. lam ids. lam expr.
+        if not (null ids) then
+          -- Found a tail call within a measuring point
+          (concat ids acc, expr)
+        else (acc, expr)
+      in
+      let letexpr = lam ids. lam expr.
+        -- Check if a let expression is a measuring point
+        let ids =
+          if not (null ids) then ids
+          else
+            match expr with TmLet t in
+            match mapLookup t.ident graph.measuringPoints with Some tree then
+              prefixTreeGetIds tree []
+            else []
+        in
+        (ids, lam x. x)
+      in
+      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmRecLets r) with
+      (tailCalls, _) in
+      let tailCalls = setToSeq (setOfSeq subi tailCalls) in
+
+      -- Instrument the reclet
+      let acc = () in
+      let ids = [] in
+      let baseCase = lam. lam ids. lam expr.
+        instrumentBaseCase tailCalls ids str2name expr
+      in
+      let tailCall = lam acc. lam ids. lam expr.
+        -- Instrument a tail call: do nothing!
+        (acc, expr)
+      in
+      let acquireLock = str2name "acquireLock" in
+      let letexpr = lam ids. lam expr.
+        -- Check if a let expression is a measuring point
+        if not (null ids) then (ids, lam x. x)
+        else
+          match expr with TmLet t in
+          match mapLookup t.ident graph.measuringPoints with Some tree then
+            -- Found measuring point, update ids and acquire lock
+            let ids = prefixTreeGetIds tree [] in
+            utest not (null ids) with true in
+            let id: Expr = idExpr (infoTm expr) t.ident graph env tree ids in
+            (ids, lam e. bindSemi_ (app_ (nvar_ acquireLock) id) e)
+          else ([], lam x. x)
+      in
+      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmRecLets r)
+      with (_, TmRecLets r) in
+      TmRecLets {r with inexpr = instrumentH env graph str2name r.inexpr}
+
+  | TmLet t ->
+    match mapLookup t.ident graph.measuringPoints with Some tree then
       let ids = prefixTreeGetIds tree [] in
       let expr = TmLet {t with inexpr = uunit_} in
-      -- One or several contexts?
-      match ids with [id] then
-        instrumentPoint env graph funName expr t.inexpr (int_ id)
-      else match ids with [_] ++ _ in
-        let incVarName = mapFindExn (mapFindExn ident graph.meas2fun) env.fun2inc in
-        let lookup = lam i. int_ i in
-        let idExpr = contextExpansionLookupCallCtx lookup tree incVarName env in
-        instrumentPoint env graph funName expr t.inexpr idExpr
-    else smap_Expr_Expr (instrumentH env graph funName) (TmLet t)
-  | t -> smap_Expr_Expr (instrumentH env graph funName) t
+      let id = idExpr (infoTm (TmLet t)) t.ident graph env tree ids in
+      instrumentPoint env graph str2name expr t.inexpr id
+    else smap_Expr_Expr (instrumentH env graph str2name) (TmLet t)
+  | t -> smap_Expr_Expr (instrumentH env graph str2name) t
 
-  -- Insert instrumentation code around a measuring point
-  sem instrumentPoint (env : CallCtxEnv) (graph : DependencyGraph)
-        (funName : Name) (expr : Expr) (inexpr : Expr) =
-  | idExpr ->
-    let startName = nameSym "s" in
-    let endName = nameSym "e" in
+
+  sem instrumentBaseCase (tailCalls: [Int]) (ids: [Int]) (str2name: String -> Name) =
+  | TmLet t ->
+    -- Instrument a base case: Release locks of _all_ measuring points that
+    -- have tail-recursive calls, as well as the current measuring point, if
+    -- any.
+    let expr = TmLet {t with inexpr = uunit_} in
+    let ids = setToSeq (setOfSeq subi (concat ids tailCalls)) in
+    let releaseExpr =
+      if null ids then uunit_ else
+      let releaseLock = str2name "releaseLock" in
+      foldr1 bindSemi_ (map (lam id. app_ (nvar_ releaseLock) (int_ id)) ids)
+    in
+    let semi = nameSym "" in
     bindall_
-    [ nulet_ startName (wallTimeMs_ uunit_)
+    [ expr
+    , nulet_ semi releaseExpr
+    , t.inexpr
+    ]
+
+  -- Insert instrumentation code around a measuring point. Assumes that the
+  -- point does not contain any tail calls.
+  sem instrumentPoint (env : CallCtxEnv) (graph : DependencyGraph)
+        (str2name : String -> Name) (expr : Expr) (inexpr : Expr) =
+  | id ->
+    let i = nameSym "iid" in
+    let semi = nameSym "" in
+    bindall_
+    [ nulet_ i id
+    , nulet_ semi (app_ (nvar_ (str2name "acquireLock")) (nvar_ i))
     , expr
-    , nulet_ endName (wallTimeMs_ uunit_)
-    , nulet_ (nameSym "") (
-        appf3_ (nvar_ funName) idExpr
-          (nvar_ startName) (nvar_ endName))
-    , instrumentH env graph funName inexpr
+    , nulet_ semi (app_ (nvar_ (str2name "releaseLock")) (nvar_ i))
+    , instrumentH env graph str2name inexpr
     ]
 
   sem instrumentHeader =
   | (size, offset) ->
     let str = join
     [ "let log = tensorCreateDense [", int2string size, "] (lam is. (0, 0.0)) in\n"
-    , "let record = lam id. lam startTime. lam endTime.\n"
-    , "  let idx = subi id ", int2string offset, "in \n"
-    , "  match tensorGetExn log [idx] with (nbrRuns, totalTime) in\n"
-    , "  tensorSetExn log [idx] (addi nbrRuns 1, addf totalTime (subf endTime startTime))\n"
-    , "in ()\n"
+    , "let s = tensorCreateDense [", int2string size, "] (lam is. 0.0) in\n"
+    , "let lock = ref 0 in\n"
+    , "let recordTime = lam id. lam s. lam e.
+         let idx = subi id ", int2string offset, " in
+         match tensorGetExn log [idx] with (nbrRuns, totalMs) in
+         let res = (addi nbrRuns 1, addf totalMs (subf e s)) in
+         tensorSetExn log [idx] res
+       in\n"
+    , "let acquireLock = lam id.
+         if eqi (deref lock) 0 then
+           let idx = subi id ", int2string offset, "in
+           tensorSetExn s [idx] (wallTimeMs ());
+           modref lock id
+         else ()
+       in\n"
+    , "let releaseLock = lam id.
+         if eqi (deref lock) id then
+           let idx = subi id ", int2string offset, "in
+           recordTime id (tensorGetExn s [idx]) (wallTimeMs ());
+           modref lock 0
+         else ()
+       in\n"
+    , "()\n"
     ] in
     let ex = use BootParser in parseMExprString [] str in
-    let log = match findName "log" ex with Some n then n else "impossible" in
-    let fun = match findName "record" ex with Some n then n else "impossible" in
-    (ex, log, fun)
+    let str2name = lam str.
+      match findName str ex with Some n then n
+      else error (concat str " not found in instrumentation header")
+    in
+    let nameMap : Map String Name = mapFromSeq cmpString
+      (map (lam str. (str, str2name str))
+        [ "log"
+        , "acquireLock"
+        , "releaseLock"
+        , "lock"
+        ])
+    in
+    let lookupFun : String -> Name = lam str.
+      match mapLookup str nameMap with Some n then n
+      else error (concat str " not found in instrumentation header")
+    in
+    (ex, lookupFun)
 
   -- Write to file
-  sem instrumentFooter (fileName : String) =
+  sem instrumentFooter (fileName : String) (str2name : String -> Name) =
   | offset ->
     let str = join
     [ "
@@ -123,6 +246,8 @@ lang Instrumentation = LetAst
       let join = lam seqs. foldl concat [] seqs in
 
       -- Tensor operations
+      let _prod = foldl muli 1 in
+
       let linearToCartesianIndex = lam shape. lam k.
         let f = lam d. lam kidx.
           match kidx with (k, idx) then
@@ -133,12 +258,12 @@ lang Instrumentation = LetAst
         r.1
       in
 
-      let tensorSize : Tensor[a] -> Int =
-        lam t. foldl muli 1 (tensorShape t)
+      let tensorSize : all a. Tensor[a] -> Int =
+        lam t. _prod (tensorShape t)
       in
 
       let tensorFoldliSlice
-        : (b -> Int -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
+        : all a. all b. (b -> Int -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
         lam f. lam acc. lam t1.
         let accr = ref acc in
         tensorIterSlice
@@ -149,7 +274,7 @@ lang Instrumentation = LetAst
         deref accr
       in
 
-      let tensorFoldi : (b -> [Int] -> a -> b) -> b -> Tensor[a] -> b =
+      let tensorFoldi : all a. all b. (b -> [Int] -> a -> b) -> b -> Tensor[a] -> b =
         lam f. lam acc. lam t.
         let shape = tensorShape t in
         let t = tensorReshapeExn t [tensorSize t] in
@@ -157,38 +282,62 @@ lang Instrumentation = LetAst
           (lam acc. lam i. lam t.
             f acc (linearToCartesianIndex shape i) (tensorGetExn t []))
           acc t
-      in
-
-      -- Dump the log to file
-      let dumpLog = lam log.
-        let str = \"id,nbrRuns,totalMs\\n\" in
+      in"
+    , "-- Dump the log to file
+      let dumpLog = lam log. lam lock.
+        let str = \"", _instrumentationHeader, "\\n\" in
         let offset = ", int2string offset, " in\n"
     , " let str =
         tensorFoldi (lam acc. lam i. lam x.
-          match x with (nbrRuns, totalTime) in
+          match x with (nbrRuns, totalMs) in
           match i with [i] in
           let acc = concat acc (join
             [ int2string (addi offset i), \",\"
             , int2string nbrRuns, \",\"
-            , float2string totalTime
+            , float2string totalMs, \",\"
             ])
           in
           concat acc \"\\n\"
         ) str log
         in
-        writeFile \"", fileName, "\" (concat str \"\\n\")"
-    , "in ()\n"
+        -- Check that the 'lock' variable is freed
+        (if neqi (deref lock) 0 then error (concat (\"WARN: lock is not free \") (int2string (deref lock)))
+         else ());
+        writeFile \"", fileName, "\" (concat str \"\\n\")
+      in"
+    , "()\n"
     ] in
     let ex = use BootParser in parseMExprString [] str in
-    let fun = match findName "dumpLog" ex with Some n then n else "impossible" in
+    let fun = match findName "dumpLog" ex with Some n then n else error "impossible" in
     (ex, fun)
 
+  -- Reads the profiled result after the instrumented program has been run.
+  type InstrumentationProfile = {ids: [Int], nbrRuns: [Int], totalMs: [Float]}
+  sem readProfile =
+  | str ->
+    let rows = strSplit "\n" (strTrim str) in
+    let header = head rows in
+    if eqString header _instrumentationHeader then
+      let df = foldl (lam acc. lam r.
+        let r = strSplit "," r in
+        dataFrameAddRow r acc
+      ) (dataFrameFromSeq [] 4) (tail rows)
+      in
+      { ids = map (lam x. string2int (head x)) (dataFrameSlice [0] df)
+      , nbrRuns = map (lam x. string2int (head x)) (dataFrameSlice [1] df)
+      , totalMs = map (lam x. string2float (head x)) (dataFrameSlice [2] df)
+      }
+    else error (join [ "Mismatch in expected and actual header of profile: \n"
+                     , "got ", header
+                     , "expected ", _instrumentationHeader
+                     ])
 
 end
 
 lang TestLang = Instrumentation + GraphColoring + MExprHoleCFA + ContextExpand +
-                DependencyAnalysis + BootParser + MExprSym + MExprPrettyPrint +
-                MExprANFAll + MExprEval
+                NestedMeasuringPoints + DependencyAnalysis +
+                BootParser + MExprSym + MExprPrettyPrint + MExprANFAll +
+                MExprEval
 end
 
 mexpr
@@ -196,11 +345,11 @@ mexpr
 use TestLang in
 
 let debug = false in
-let epsilon = 10.0 in
+let epsilon = 20.0 in
 let epsilonEnabled = false in
 
 let debugPrintLn = lam debug.
-  if debug then printLn else lam x. x
+  if debug then printLn else lam. ()
 in
 
 let parse = lam str.
@@ -210,13 +359,17 @@ let parse = lam str.
 in
 
 type TestResult = {
-  data : [{point : (String,[String]), nbrRuns : Int, totalTime : Float}],
+  data : [{ point : (String,[String]),
+            nbrRuns : Int,
+            totalMs : Float
+          }],
   epsilon : Float
 } in
 
-let resolveId =
+let resolveId
+  : all k. (String, [String]) -> Map k (PTree NameInfo) -> (k -> String) -> Int =
   lam point : (String, [String]). lam m : Map k (PTree NameInfo). lam keyToStr : k -> String.
-    let strMap = mapFoldWithKey (lam acc. lam k : Name. lam v.
+    let strMap = mapFoldWithKey (lam acc. lam k : k. lam v.
         mapInsert (keyToStr k) v acc
       ) (mapEmpty cmpString) m
     in
@@ -255,6 +408,9 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   -- Perform CFA
   let cfaRes : CFAGraph = cfaData graphData tANF in
 
+  -- Analyze nested
+  let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
+
   -- Perform dependency analysis
   match
     if full then assumeFullDependency env tANF
@@ -289,14 +445,14 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   debugPrintLn debug "";
 
   -- Return the log as a map
-  let rows = tail (strSplit "\n" logStr) in
-  let log : Map Int (Int,Float) = foldl (
-    lam acc. lam row.
-      match row with "" then acc
-      else match strSplit "," row with [id,nbrRuns,totalMs] then
-        mapInsert (string2int id) (string2int nbrRuns, string2float totalMs) acc
-      else error (concat "Unexpectedly formatted row: " row)
-    ) (mapEmpty subi) rows
+  match readProfile logStr
+  with {ids = ids, nbrRuns = ns, totalMs = totalS} in
+  let log : Map Int (Int, Float) = foldl (lam acc. lam i.
+      let id = get ids i in
+      let runsS = get ns i in
+      let totalS = get totalS i in
+      mapInsert id (runsS,totalS) acc
+    ) (mapEmpty subi) (create (length ids) (lam i. i))
   in
 
   -- Clean up temporary files
@@ -310,22 +466,25 @@ let eqTest = lam lhs. lam rhs : TestResult.
   let env : CallCtxEnv = env in
   let graph : DependencyGraph = graph in
   let res : [Bool] = map (
-    lam d : {point : (String,[String]), nbrRuns : Int, totalTime : Float}.
+    lam d : {point : (String,[String]), nbrRuns : Int, totalMs : Float}.
       let id : Int = resolveId d.point graph.measuringPoints nameGetStr in
-      match mapLookup id log with Some (nbrRunsReal, totalTimeReal) then
+      match mapLookup id log with Some (nbrRunsReal, totalMsReal) then
         if eqi d.nbrRuns nbrRunsReal then
           if not epsilonEnabled then true else
           -- Allow one epsilon of error for each run
           let margin = mulf (int2float nbrRunsReal) rhs.epsilon in
-          if eqfApprox margin totalTimeReal d.totalTime then true
+          if eqfApprox margin totalMsReal d.totalMs then true
           else error (join
-          [ "Total time mismatch: got ", float2string totalTimeReal
-          , ", expected ", float2string d.totalTime
+          [ "Total time mismatch: got "
+          , float2string totalMsReal, " (self) and "
+          , ", expected "
+          , float2string d.totalMs, " (self) and "
           ]
           )
         else
           error (join
-            [ "Number of runs do not match: got ", int2string nbrRunsReal
+            [ "Number of runs do not match: got "
+            , int2string nbrRunsReal, " runs"
             , ", expected ", int2string d.nbrRuns
             , " for id ", int2string id
             , " with name ", d.point.0
@@ -354,13 +513,109 @@ foo ()
 " in
 
 utest test debug false [(("h", []), int_ 50), (("h1", []), true_)] t with {
-  data = [ {point = ("a",[]), nbrRuns = 1, totalTime = 50.0}
-         , {point = ("b",[]), nbrRuns = 1, totalTime = 50.0}
-         , {point = ("c",[]), nbrRuns = 0, totalTime = 0.}
+  data = [ {point = ("a",[]), nbrRuns = 1, totalMs = 50.0}
+         , {point = ("b",[]), nbrRuns = 1, totalMs = 50.0}
+         , {point = ("c",[]), nbrRuns = 0, totalMs = 0.}
          ],
   epsilon = epsilon
 }
 using eqTest in
+
+-- Tail calls
+let t = parse
+"
+let h = hole (IntRange {default = 0, min = 0, max = 10}) in
+recursive
+let g = lam x.
+  f x 1
+let f = lam x. lam y.
+  let fMatch =
+    if eqi x 0 then 0
+    else f (subi x 1) y
+  in fMatch
+let silly = lam x.
+  let sillyMatch =
+    if eqi x 42 then silly x
+    else true
+  in sillyMatch
+let fakeRecursive = lam x.
+  let fakeMatch =
+    if eqi x 0 then baseCase 10
+    else if eqi x 2 then baseCase 30
+    else baseCase 100
+  in
+  fakeMatch
+let baseCase = lam x.
+  sleepMs x
+in
+f h 1;
+g h;
+silly h;
+fakeRecursive h
+" in
+
+utest test debug false [(("h", []), int_ 2)] t with {
+  data = [ {point = ("fMatch",[]), nbrRuns = 2, totalMs = 0.0}
+         , {point = ("sillyMatch",[]), nbrRuns = 1, totalMs = 0.0}
+         , {point = ("fakeMatch",[]), nbrRuns = 1, totalMs = 30.0}
+         ],
+  epsilon = epsilon
+}
+using eqTest in
+
+-- Tail calls with nested reclets
+let t = parse
+"
+let h = hole (IntRange {default = 0, min = 0, max = 10}) in
+recursive
+let f = lam x. lam y.
+  recursive let inner = lam x.
+    let matchInner =
+      if eqi x 42 then inner 1
+      -- Will not be seen as a tail-recursive call
+      else if eqi x 43 then f 1 2
+      else sleepMs 10; 2
+    in matchInner
+  in
+  inner x;
+  let matchF =
+    if eqi x 0 then 0
+    else
+      sleepMs 20;
+      f (subi x 1) y
+  in
+  matchF
+in
+f h 1
+" in
+
+utest test debug false [(("h", []), int_ 2)] t with {
+  data = [ -- (20 + 10) + (20 + 10) + 10
+           {point = ("matchF",[]), nbrRuns =3, totalMs= 70.}
+           -- Has only one run because the other two are nested within matchF
+         , {point = ("matchInner",[]), nbrRuns =1, totalMs = 10.}
+         ],
+  epsilon = epsilon
+}
+using eqTest in
+
+-- Recursive let followed by other stuff
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+recursive let f = lam x. x
+in
+let m = if h then sleepMs 25 else () in
+()
+" in
+
+utest test debug false [(("h", []), true_)] t with {
+  data = [ {point = ("m",[]), nbrRuns =1, totalMs= 25.}
+         ],
+  epsilon = epsilon
+}
+using eqTest in
+
 
 -- Context-sensitive, but only one context
 let t = parse
@@ -386,7 +641,7 @@ f4 ()
 " in
 
 utest test debug false [(("h", ["d", "c", "a"]), int_ 40)] t with {
-  data = [ {point = ("m", ["d", "c", "a"]), nbrRuns = 1, totalTime = 40.0} ],
+  data = [ {point = ("m", ["d", "c", "a"]), nbrRuns = 1, totalMs = 40.0} ],
   epsilon = epsilon
 }
 using eqTest in
@@ -435,10 +690,10 @@ let table =
 in
 utest test debug false table t with {
   data =
-  [ {point = ("cc", ["d"]), nbrRuns = 1, totalTime = 60.0}
-  , {point = ("cc", ["e"]), nbrRuns = 1, totalTime = 140.0}
-  , {point = ("cc", ["i"]), nbrRuns = 2, totalTime = 160.0}
-  , {point = ("g", []), nbrRuns = 1, totalTime = 200.0}
+  [ {point = ("cc", ["d"]), nbrRuns = 1, totalMs = 60.0}
+  , {point = ("cc", ["e"]), nbrRuns = 1, totalMs = 140.0}
+  , {point = ("cc", ["i"]), nbrRuns = 2, totalMs = 160.0}
+  , {point = ("g", []), nbrRuns = 1, totalMs = 200.0}
   ],
   epsilon = epsilon
 } using eqTest in
@@ -479,8 +734,8 @@ let table =
 ] in
 utest test debug false table t with {
   data =
-  [ {point = ("m", ["d", "c", "a"]), nbrRuns = 2, totalTime = 60.0}
-  , {point = ("m", ["e", "c", "a"]), nbrRuns = 1, totalTime = 40.0}
+  [ {point = ("m", ["d", "c", "a"]), nbrRuns = 2, totalMs = 60.0}
+  , {point = ("m", ["e", "c", "a"]), nbrRuns = 1, totalMs = 40.0}
   ],
   epsilon = epsilon
 } using eqTest in
@@ -517,9 +772,35 @@ let table =
 ] in
 utest test debug true table t with {
   data =
-  [ {point = ("m", []), nbrRuns = 1, totalTime = 160.0} ],
+  [ {point = ("m", []), nbrRuns = 1, totalMs = 160.0} ],
   -- Use larger epsilon since total execution time is measured
   epsilon = mulf 3.0 epsilon
+} using eqTest in
+
+
+-- Nested points
+let t = parse
+"
+let f1 = lam x.
+  let h1 = hole (IntRange {default = 1, min = 0, max = 500}) in
+  let m0 = sleepMs h1 in
+  ()
+in
+let h2 = hole (Boolean {default = true}) in
+let m1 = if h2 then f1 () else () in
+f1 ()
+" in
+
+let table =
+[ ( ("h1", []), int_ 200)
+, ( ("h2", []), true_)
+] in
+utest test debug false table t with {
+  data =
+  [ {point = ("m1", []), nbrRuns = 1, totalMs = 200.0}
+  , {point = ("m0", []), nbrRuns = 1, totalMs = 200.0}
+  ],
+  epsilon = epsilon
 } using eqTest in
 
 

--- a/stdlib/tuning/name-info.mc
+++ b/stdlib/tuning/name-info.mc
@@ -1,4 +1,5 @@
 include "name.mc"
+include "mexpr/info.mc"
 
 -- Defines simple convenience functions for name-info tuples.
 

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -1,0 +1,573 @@
+-- Analyzes nested measuring points. A measuring point A is nested within a
+-- measuring point B if A is reachable from within the subexpressions of B. This
+-- is only possible if B is a match expression. This file augments the execution
+-- time dependencies of such measuring points B so that they contain the
+-- execution time dependencies of A.
+
+-- Furthermore, if a measuring point A is syntactically scoped within another
+-- measuring point B, we remove the A measuring point. Since A's dependencies
+-- are already added to B, and since A will _always_ be executed within B, we do
+-- not need A as a separate measuring point.
+
+include "hole-cfa.mc"
+include "digraph.mc"
+include "common.mc"
+
+lang NestedMeasuringPoints = MExprHoleCFA
+  sem analyzeNested (env: CallCtxEnv) (cfaGraph : CFAGraph) =
+  | t ->
+    -- Collect all lambda abstract values
+    let avLams : Set Name = mapFoldWithKey (
+      lam acc. lam. lam v : Set AbsVal.
+        setFold (lam acc. lam abs.
+          match abs with AVLam {ident = ident} then
+            setInsert ident acc
+          else acc) acc v
+      ) (setEmpty nameCmp) cfaGraph.data
+    in
+    -- Build call graph from flow information
+    let top = nameSym "top" in
+    let callGraph = buildCallGraph avLams top cfaGraph.data t in
+
+    -- Compute the set of eholes for each measuring point
+    let eholes : Map Name [AbsVal] = mapFoldWithKey (
+      lam acc. lam ident. lam avs.
+        let eholes = setFold (lam acc. lam av.
+          match av with AVEHole _ then cons av acc
+          else acc
+        ) [] avs
+        in
+        if null eholes then acc
+        else mapInsert ident eholes acc
+    ) (mapEmpty nameCmp) cfaGraph.data
+    in
+
+    let identDepsEnclosing : [(Name, [AbsVal], Name)] =
+      _measEnclosingLam eholes avLams top [] t
+    in
+
+    -- Maps a measuring point to its enclosing lambda, and its dependencies
+    let measEnclosingMap : Map Name (Name, [AbsVal]) = foldl (
+      lam acc. lam x : (Name, [AbsVal], Name).
+        mapInsert x.0 (x.2, x.1) acc
+      ) (mapEmpty nameCmp) identDepsEnclosing
+    in
+
+    -- Maps a lambda to the set of measuring points that it contains
+    let measInLam : Map Name (Set Name) = foldl (
+      lam acc. lam x : (Name, [AbsVal], Name).
+        match x with (meas, _, encLam) in
+        let measSet =
+          match mapLookup encLam acc with Some set then
+            setInsert meas set
+          else setOfSeq nameCmp [meas]
+        in
+        mapInsert encLam measSet acc
+      ) (mapEmpty nameCmp) identDepsEnclosing
+    in
+
+    -- The set of measuring point names
+    let measSet = setOfSeq nameCmp (mapKeys measInLam) in
+
+    -- Collect augmented dependencies
+    let deps : [(Name, [AbsVal])] =
+      augmentDependencies
+       env measEnclosingMap measInLam measSet cfaGraph.data eholes callGraph [] t
+    in
+
+    -- Collect syntactically scoped measuring points
+    let synScoped : [Name] = collectSyntacticallyScoped eholes [] t in
+
+    -- Remove the syntactically scoped measuring points to the CFA result
+    let data : Map Name (Set AbsVal) = foldl (lam acc. lam ident.
+        mapRemove ident acc
+      ) cfaGraph.data synScoped
+    in
+
+    -- Add the augmented dependencies to the CFA result
+    let data : Map Name (Set AbsVal) = foldl (
+      lam acc. lam identAvs : (Name, [AbsVal]).
+        match identAvs with (ident, avs) in
+        match mapLookup ident acc with Some oldAvs then
+          let newAvs = setUnion oldAvs (setOfSeq cmpAbsVal avs) in
+          mapInsert ident newAvs acc
+        else
+          -- No dependencies, cannot spawn new ones
+          acc
+      ) data deps
+    in
+
+    {cfaGraph with data = data}
+
+  sem buildCallGraph (avLams : Set Name) (top : Name)
+                     (data : Map Name (Set AbsVal)) =
+  | t ->
+    -- The nodes are the AVLams recorded in the data flow
+    let g = digraphEmpty nameCmp eqsym in
+    let g = digraphAddVertices (cons top (setToSeq avLams)) g in
+    -- The edges are applications
+    let edges = _callGraphEdges data avLams top [] t in
+    let g = digraphAddEdges edges g in
+    g
+
+  sem _callGraphEdges (data : Map Name (Set AbsVal)) (avLams : Set Name)
+                      (cur : Name) (acc : [(Name,Name,Symbol)]) =
+  | TmLam t ->
+    if setMem t.ident avLams then
+      _callGraphEdges data avLams t.ident acc t.body
+    else
+      -- Lambda expression not reachable, we are done.
+      acc
+
+  | TmApp t ->
+    match t.lhs with TmVar v then
+      let res =
+        match mapLookup v.ident data with Some avs then
+          let avLamsLhs = setFold (lam acc. lam av.
+            match av with AVLam {ident = ident} then
+              setInsert ident acc
+            else acc) (setEmpty nameCmp) avs
+          in
+          -- Add an edge for each lam that flows to lhs
+          map (lam l. (cur,l,gensym ())) (setToSeq avLamsLhs)
+        else []
+      in concat res acc
+    else infoErrorExit (infoTm t.lhs) "Not a TmVar in application"
+
+  | t ->
+    sfold_Expr_Expr (_callGraphEdges data avLams cur) acc t
+
+  -- Find the closest enclosing lambda for each measuring point
+  sem _measEnclosingLam (data : Map Name [AbsVal]) (avLams : Set Name)
+                        (cur : Name) (acc : [(Name,[AbsVal],Name)]) =
+  | TmLam t ->
+    if setMem t.ident avLams then
+      _measEnclosingLam data avLams t.ident acc t.body
+    else
+      -- Lambda expression not reachable, we are done.
+      acc
+
+  | TmLet ({ ident = ident, body = TmApp app } & t) ->
+    let resInexpr = _measEnclosingLam data avLams cur acc t.inexpr in
+    match mapLookup ident data with Some eholes then
+      concat [(ident, eholes, cur)] resInexpr
+    else resInexpr
+
+  | TmLet ({ ident = ident, body = TmMatch m } & t) ->
+    let resInexpr = _measEnclosingLam data avLams cur acc t.inexpr in
+    let resMatch = sfold_Expr_Expr (_measEnclosingLam data avLams cur) [] (TmMatch m) in
+    match mapLookup ident data with Some eholes then
+      join [[(ident, eholes, cur)], resInexpr, resMatch]
+    else concat resInexpr resMatch
+
+  | t ->
+    sfold_Expr_Expr (_measEnclosingLam data avLams cur) acc t
+
+  -- Augment dependencies for nested measuring points.
+  sem augmentDependencies (env: CallCtxEnv)
+                          (enclosingLam : Map Name (Name, [AbsVal]))
+                          (measInLam : Map Name (Set Name))
+                          (measSet : Set Name)
+                          (data : Map Name (Set AbsVal))
+                          (dataEholes : Map Name [AbsVal])
+                          (callGraph : Digraph Name Symbol)
+                          (acc: [(Name, [AbsVal])]) =
+  -- A match is the only type of measuring point that can have a nested
+  -- measuring point, since it is the only one that consists of several
+  -- subexpressions.
+  | TmLet ({ ident = ident, body = TmMatch m } & t) ->
+    let resInexpr =
+      augmentDependencies
+        env enclosingLam measInLam measSet data dataEholes callGraph acc t.inexpr
+    in
+    let resMatch = sfold_Expr_Expr (
+        augmentDependencies env enclosingLam measInLam measSet data dataEholes callGraph)
+        [] (TmMatch m)
+    in
+    match mapLookup ident enclosingLam with Some (encLam, _) then
+      -- Check what measuring points that are reachable from the branches
+      let depThn =
+        augmentDependenciesH
+          ident env enclosingLam measInLam measSet data dataEholes callGraph [] m.thn in
+      let depEls =
+        augmentDependenciesH
+          ident env enclosingLam measInLam measSet data dataEholes callGraph [] m.els in
+      let deps = (ident, concat depThn depEls) in
+      join [resInexpr, resMatch, [deps]]
+    else concat resInexpr resMatch
+
+  | t ->
+    sfold_Expr_Expr
+      (augmentDependencies env enclosingLam measInLam measSet data dataEholes callGraph)
+      acc t
+
+  sem eholesOf (info : Info) (env: CallCtxEnv) (ident: Name) =
+  | avs ->
+    let avs : [AbsVal] = avs in
+    recursive let passesThrough = lam path.
+      match path with [] then false
+      else match path with [(from,to,lbl)] ++ path in
+        if nameEq (nameInfoGetName lbl) ident then true
+        else passesThrough path
+    in
+    foldl (lam acc. lam av.
+        match av with AVEHole r then
+          let contexts = setToSeq r.contexts in
+          match contexts with [_] then cons (AVEHole r) acc
+          else
+            let idPaths = map (lam c. (c, mapFindExn c env.verbosePath)) contexts in
+            let keep = filter (lam t: (Int, Path). passesThrough t.1) idPaths in
+            let keepIds = map (lam t: (Int, Path). t.0) keep in
+            utest gti (length keepIds) 0 with true in
+            cons (AVEHole {r with contexts = setOfSeq subi keepIds}) acc
+        else acc
+      ) [] avs
+
+  -- Collect all dependencies reachable from an expression, either from function
+  -- applications or from one of the subexpressions themselves.
+  sem augmentDependenciesH (ident: Name) -- The enclosing measuring point
+                           (env: CallCtxEnv)
+                           (enclosingLam : Map Name (Name, [AbsVal]))
+                           (measInLam : Map Name (Set Name))
+                           (measSet : Set Name)
+                           (data : Map Name (Set AbsVal))
+                           (dataEholes : Map Name [AbsVal])
+                           (callGraph : Digraph Name Symbol)
+                           (acc : [AbsVal]) =
+  | TmLet ({body = TmApp app} & t) ->
+    let resBody =
+      match app.lhs with TmVar v then
+        match mapLookup v.ident data with Some avs then
+          -- What lambdas can flow to lhs?
+          let avLamsLhs = setFold (lam acc. lam av.
+            match av with AVLam {ident = ident} then
+              setInsert ident acc
+            else acc) (setEmpty nameCmp) avs
+          in
+          -- What measuring points are reachable from these lambdas?
+          let reachable : [AbsVal] = setFold (
+            lam acc. lam lamIdent.
+              let reachNodes =
+                setOfSeq nameCmp (mapKeys (digraphBFS lamIdent callGraph))
+              in
+              -- Reachable nodes that contain measuring points
+              let reachMeasNodes = setIntersect reachNodes measSet in
+              -- Collect dependencies of the reachable measuring points
+              setFold (lam acc : [AbsVal]. lam node : Name.
+                match mapLookup node measInLam with Some set then
+                  setFold (lam acc. lam measIdent.
+                    match mapLookup measIdent enclosingLam with Some (_, deps)
+                    then eholesOf (infoTm (TmApp app)) env t.ident deps
+                    else error "impossible"
+                  ) [] set
+                else error "impossible"
+              ) acc reachMeasNodes
+            ) [] avLamsLhs
+          in reachable
+        else []
+      else infoErrorExit (infoTm app.lhs) "Not a TmVar in application"
+    in
+    let resLet = optionGetOr [] (mapLookup t.ident dataEholes) in
+    let resInexpr = sfold_Expr_Expr
+      (augmentDependenciesH ident env enclosingLam measInLam measSet data dataEholes callGraph)
+      acc t.inexpr
+    in join [resBody, resLet, resInexpr]
+
+  | TmLet t ->
+    let resLet = optionGetOr [] (mapLookup t.ident dataEholes) in
+    let resRest = sfold_Expr_Expr
+        (augmentDependenciesH ident env enclosingLam measInLam measSet data dataEholes callGraph)
+        acc (TmLet t)
+    in concat resLet resRest
+
+  | t ->
+    sfold_Expr_Expr
+      (augmentDependenciesH ident env enclosingLam measInLam measSet data dataEholes callGraph)
+      acc t
+
+  -- Collect measuring points that are syntactically scoped within another
+  -- measuring point. They are not needed, because their dependencies have
+  -- already been added to the enclosing measuring point, and will always be
+  -- executed within the enclosing measuring point.
+  sem collectSyntacticallyScoped (eholes : Map Name [AbsVal]) (acc : [Name]) =
+  -- Need only consider match expressions, by same logic as for
+  -- 'augmentDependencies'
+  | TmLet ({ ident = ident, body = TmMatch m } & t) ->
+    -- Recurse inexpr and body
+    let resInexpr = collectSyntacticallyScoped eholes acc t.inexpr in
+    let resMatch = sfold_Expr_Expr (collectSyntacticallyScoped eholes)
+        [] (TmMatch m)
+    in
+    -- Are we in a measuring point?
+    if mapMem ident eholes then
+      -- Collect syntactically scoped measuring points
+      let scopedThn = collectSyntacticallyScopedH eholes [] m.thn in
+      let scopedEls = collectSyntacticallyScopedH eholes [] m.els in
+      join [resInexpr, resMatch, scopedThn, scopedEls]
+    else concat resInexpr resMatch
+
+  | t ->
+    sfold_Expr_Expr (collectSyntacticallyScoped eholes) acc t
+
+  -- Return the measuring points syntactically scoped in an expression
+  sem collectSyntacticallyScopedH (eholes : Map Name [AbsVal]) (acc: [Name]) =
+  | TmLet t ->
+    let resLet = if mapMem t.ident eholes then [t.ident] else [] in
+    let resRest = sfold_Expr_Expr (collectSyntacticallyScopedH eholes)
+        acc (TmLet t)
+    in concat resLet resRest
+
+  | t ->
+    sfold_Expr_Expr (collectSyntacticallyScopedH eholes) acc t
+
+end
+
+lang TestLang = GraphColoring + MExprHoleCFA + ContextExpand +
+                NestedMeasuringPoints +
+                BootParser + MExprSym + MExprPrettyPrint + MExprANFAll
+end
+
+mexpr
+
+use TestLang in
+
+-- Test functions --
+
+let debug = false in
+let parse = lam str.
+  let ast = parseMExprString holeKeywords str in
+  let ast = makeKeywords [] ast in
+  symbolize ast
+in
+let test: Bool -> Expr -> [String] -> [(String,[AbsVal],Map NameInfo (Map [NameInfo] Int))] =
+  lam debug: Bool. lam t: Expr. lam vars: [String].
+    -- Use small ANF first, needed for context expansion
+    let tANFSmall = use MExprHoles in normalizeTerm t in
+
+    -- Do graph coloring to get context information (throw away the AST).
+    match colorCallGraph [] tANFSmall with (env, _) in
+
+    -- Initialize the graph data
+    let graphData = graphDataFromEnv env in
+
+    -- Apply full ANF
+    let tANF = normalizeTerm tANFSmall in
+
+    if debug then
+      -- Version with debug printouts
+      match pprintCode 0 pprintEnvEmpty t with (_,tStr) in
+      printLn "\n--- ORIGINAL PROGRAM ---";
+      printLn tStr;
+      match pprintCode 0 pprintEnvEmpty tANF with (pprintEnv,tANFStr) in
+      printLn "\n--- ANF ---";
+      printLn tANFStr;
+      match cfaDebug (Some graphData) (Some pprintEnv) tANF with (Some pprintEnv,cfaRes) in
+      match cfaGraphToString pprintEnv cfaRes with (_, resStr) in
+      printLn "\n--- CFA GRAPH ---";
+      printLn resStr;
+      let cfaRes : CFAGraph = cfaRes in
+      let cfaRes : CFAGraph  = analyzeNested env cfaRes tANF in
+      match cfaGraphToString pprintEnv cfaRes with (_, resStr) in
+      printLn "\n--- AUGMENTED CFA GRAPH ---";
+      printLn resStr;
+      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
+        map (lam var: String.
+          let binds = mapBindings cfaRes.data in
+          let res = foldl (lam acc. lam b : (Name, Set AbsVal).
+            if eqString var (nameGetStr b.0) then setToSeq b.1 else acc
+          ) [] binds in
+          (var, res, env.hole2idx)
+        ) vars
+      in avs
+
+    else
+      -- Version without debug printouts
+      let cfaRes : CFAGraph = cfaData graphData tANF in
+      let cfaRes : CFAGraph  = analyzeNested env cfaRes tANF in
+      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
+        map (lam var: String.
+          let binds = mapBindings cfaRes.data in
+          let res = foldl (lam acc. lam b : (Name, Set AbsVal).
+            if eqString var (nameGetStr b.0) then setToSeq b.1 else acc
+          ) [] binds in
+          (var, res, env.hole2idx)
+        ) vars
+      in avs
+in
+
+-- Custom equality function
+type Dep = {d: [(String,[[String]])], e: [(String,[[String]])]} in
+let gbl = lam s. (s,[[]]) in
+let eqTestHole = eqSeq
+  (lam t1:(String,[AbsVal],Map NameInfo (Map [NameInfo] Int)).
+   lam t2:(String,Dep).
+     let index2Path : String -> Int -> [String] = lam str. lam i.
+       let pathMap =
+         match mapFoldWithKey (lam acc. lam nameInfo. lam bind.
+           match acc with Some _ then acc
+           else if eqString (nameInfoGetStr nameInfo) str then Some bind
+           else acc
+         ) (None ()) t1.2
+         with Some pathMap then pathMap
+         else error "impossible"
+       in
+       match mapFoldWithKey (lam acc. lam path. lam index.
+         if eqi index i then Some (map nameInfoGetStr path)
+         else acc
+       ) (None ()) pathMap
+       with Some path then path
+       else error "impossible"
+     in
+
+     if eqString t1.0 t2.0 then
+       let data : [(String,Set Int)] = foldl (lam acc. lam av.
+           match av with AVDHole {id = id, contexts = contexts}
+           then
+             cons (nameGetStr id, contexts) acc else acc
+         ) [] t1.1
+       in
+       let exe : [(String,Set Int)] = foldl (lam acc. lam av.
+           match av with AVEHole {id = id, contexts = contexts}
+           then cons (nameGetStr id, contexts) acc else acc
+         ) [] t1.1
+       in
+       let deps : Dep = t2.1 in
+       -- Comparison of names
+       let namesEq =
+         let dataStrs = map (lam e : (String,Set Int). e.0) data in
+         let exeStrs = map (lam e : (String,Set Int). e.0) exe in
+         let depDataStrs = map (lam e : (String,[[String]]). e.0) deps.d in
+         let depExeStrs = map (lam e : (String,[[String]]). e.0) deps.e in
+         if setEq (setOfSeq cmpString dataStrs) (setOfSeq cmpString depDataStrs) then
+           setEq (setOfSeq cmpString exeStrs) (setOfSeq cmpString depExeStrs)
+         else false
+       in
+       -- Comparison of contexts
+       if namesEq then
+         let dataCtxs = map (lam e : (String,Set Int). (e.0, setToSeq e.1)) data in
+         let dataCtxPaths = map (lam e : (String, [Int]). map (index2Path e.0) e.1) dataCtxs in
+         let dataCtxPaths = map (setOfSeq (seqCmp cmpString)) dataCtxPaths in
+
+         let exeCtxs = map (lam e : (String,Set Int). (e.0, setToSeq e.1)) exe in
+         let exeCtxPaths = map (lam e : (String, [Int]). map (index2Path e.0) e.1) exeCtxs in
+         let exeCtxPaths = map (setOfSeq (seqCmp cmpString)) exeCtxPaths in
+
+         let depDataCtxs : [Set [String]] = map (lam e : (String,[[String]]). setOfSeq (seqCmp cmpString) e.1) deps.d in
+         let depExeCtxs : [Set [String]] = map (lam e : (String,[[String]]). setOfSeq (seqCmp cmpString) e.1) deps.e in
+
+         if setEq (setOfSeq setCmp dataCtxPaths) (setOfSeq setCmp depDataCtxs) then
+           setEq (setOfSeq setCmp exeCtxPaths) (setOfSeq setCmp depExeCtxs)
+         else false
+       else false
+     else false
+) in
+--------------------
+
+
+let t = parse
+"
+let f1 = lam x.
+  let h1 = hole (IntRange{min=100,max=200,default=200}) in
+  if lti x 10 then
+    -- Start measuring point m1 --
+    let res = sleepMs h1 in
+    res
+    -- End measuring point m1 --
+  else ()
+in
+let h2 = hole (Boolean{default=true}) in
+let foo =
+-- Start measuring point m2 --
+  if h2 then f1 5 else sleepMs 150
+-- End measuring point m2 --
+in
+f1 10
+"
+in
+
+utest test debug t ["h1", "h2", "res", "foo"]
+with [ ("h1", {d=[gbl "h1"], e=[]})
+     , ("h2", {d=[gbl "h2"], e=[]})
+     , ("res", {d=[], e=[gbl "h1"]})
+     , ("foo", {d=[gbl "h2"], e=[gbl "h1", gbl "h2"]})
+     ]
+using eqTestHole in
+
+let t = parse
+"
+recursive let f1 = lam x.
+  let h1 = hole (IntRange{min=100,max=200,default=200}) in
+  let m1 = sleepMs h1 in
+  ()
+in
+recursive let f2 = lam x.
+  let c = f1 x in c
+in
+recursive let f3 = lam x.
+  ()
+in
+let h2 = hole (IntRange{min=100,max=200,default=200}) in
+let m2 = if h2 then let a = f2 () in a else () in
+let m3 = if h2 then () else let b = f1 () in b in
+let m4 = if h2 then f3 () else () in
+()
+"
+in
+
+utest test debug t ["h1", "h2", "m1", "m2", "m3", "m4"]
+with [ ("h1", {d=[ gbl "h1" ], e=[]})
+     , ("h2", {d=[ gbl "h2" ], e=[]})
+     , ("m1", {d=[], e=[ gbl "h1" ]})
+     , ("m2", {d=[ gbl "h2" ], e=[ gbl "h2", gbl "h1" ]})
+     , ("m3", {d=[ gbl "h2" ], e=[ gbl "h2", gbl "h1" ]})
+     , ("m4", {d=[ gbl "h2" ], e=[ gbl "h2" ]})
+     ]
+using eqTestHole in
+
+let t = parse
+"
+let g1 = lam x.
+  let h2 = hole (IntRange{min=100,max=200,default=200}) in
+  sleepMs h2
+in
+let f1 = lam x.
+  let h1 = hole (IntRange{min=100,max=200,default=200}) in
+  let m1 =
+    if h1 then
+      let f2 = lam x. g1 x in
+      f2 x
+    else ()
+  in m1
+in
+f1 ()
+"
+in
+
+utest test debug t ["m1"]
+with [ ("m1", {d=[ gbl "h1" ], e=[ gbl "h1", gbl "h2"]})
+     ]
+using eqTestHole in
+
+
+let t = parse
+"
+let f1 = lam x.
+  let h1 = hole (IntRange{min=100,max=200,default=200}) in
+  let h2 = hole (Boolean {default=true}) in
+  let h3 = hole (Boolean {default=true}) in
+  let h4 = hole (IntRange{min=100,max=200,default=200}) in
+  let m1 =
+    if h2 then
+      let sleepVar = sleepMs in
+      let m2 = sleepVar h1 in
+      let m3 =
+        if h3 then 1 else sleepMs h4
+      in m3
+    else ()
+  in m1
+in
+f1 ()
+"
+in
+
+()

--- a/stdlib/tuning/search-space.mc
+++ b/stdlib/tuning/search-space.mc
@@ -1,0 +1,353 @@
+
+-- Implements helper functions for analyzing the search space of a program with
+-- holes, given a dependency graph.
+
+include "dependency-analysis.mc"
+include "data-frame.mc"
+
+include "map.mc"
+include "graph.mc"
+include "eqset.mc"
+
+-- NOTE: floats because of numerical overflows with ints
+type SearchSpaceSize = {
+  -- Maps the id of a measuring point to its search space size.
+  measuringPoints : Map Int Float,
+  -- The connected components and their search space size.
+  connectedComponents : [([Int], Float)],
+  -- The total size of the search space (Cartesian product)
+  sizeTotal : Float,
+  -- The size of the reduced search space (taking dependencies into account)
+  sizeReduced : Float
+}
+
+let _searchSpaceTestEq = lam lhs: Map Int Float. lam rhs: [(Int,Float)].
+  eqSeq (lam t1: (Int,Float). lam t2: (Int,Float).
+    and (eqi t1.0 t2.0) (eqf t1.1 t2.1)
+  ) (mapBindings lhs) rhs
+
+let searchSpaceSizeMeasuringPoint
+  : [Int] -> Graph Int Int -> [Float] -> Map Int Float =
+  lam points. lam graph. lam holeDomainSize.
+    foldl (lam acc : Map Int Float. lam m.
+      let holes = graphNeighbors m graph in
+      let size =
+        if null holes then 0.
+        else
+          foldl (
+            lam acc. lam h.
+              mulf acc (get holeDomainSize h)
+            ) 1. holes
+      in
+      mapInsert m size acc
+    ) (mapEmpty subi) points
+
+utest
+  let g = graphAddEdges [(0,2,0),(0,3,0),(1,3,0),(1,4,0)] (
+    graphAddVertices [0,1,2,3,4] (graphEmpty subi eqi))
+  in
+  let domains = [3.,5.] in
+  searchSpaceSizeMeasuringPoint [2,3,4] g domains
+with [(2,3.),(3,15.),(4,5.)]
+using _searchSpaceTestEq
+
+let searchSpaceSizeConnectedComponent
+  : Map Int Float -> Graph Int Int -> [Float] -> [([Int], Float)] =
+  lam pointSizes. lam graph. lam holeDomainSize.
+    let ccs = graphConnectedComponents graph in
+    map (lam cc : [Int].
+      let maxSize = foldl (lam acc. lam v.
+        match mapLookup v pointSizes with Some s then
+          if gtf s acc then s else acc
+        else acc) 0. cc
+      in
+      (cc, maxSize)
+    ) ccs
+
+utest
+  let g = graphAddEdges [(0,4,0),(1,4,0),(1,5,0),(2,6,0),(3,6,0)] (
+    graphAddVertices [0,1,2,3, 4,5,6] (graphEmpty subi eqi))
+  in
+  let domains = [2.,3.,4.,5.] in
+  let pointSizes = searchSpaceSizeMeasuringPoint [4,5,6] g domains in
+  searchSpaceSizeConnectedComponent pointSizes g domains
+with [ ([0,1,4,5],6.), ([2,3,6],20.) ]
+using eqsetEqual (lam t1: ([Int],Float). lam t2: ([Int],Float).
+  and (eqSeq eqi t1.0 t2.0) (eqf t1.1 t2.1))
+
+lang SearchSpace = DependencyAnalysis
+  sem searchSpaceSize (stepSize : Int) (env : CallCtxEnv) =
+  | dep ->
+    let dep : DependencyGraph = dep in
+    let holeDomainSizes = map (domainSize stepSize) env.idx2hole in
+    let holeDomainSizes: [Float] = map int2float holeDomainSizes in
+    let mps = setToSeq dep.alive in
+    if null mps then
+      { measuringPoints = mapEmpty subi, connectedComponents = [],
+        sizeTotal = 0., sizeReduced = 0. }
+    else
+      let sizeMps: Map Int Float = searchSpaceSizeMeasuringPoint mps dep.graph holeDomainSizes in
+      let sizeCC: [([Int], Float)] = searchSpaceSizeConnectedComponent sizeMps dep.graph holeDomainSizes in
+      let sizeTotal: Float = foldl mulf 1. holeDomainSizes in
+      let sizeReduced: Float = optionGetOrElse (lam. error "Empty search space")
+        (max (cmpfApprox 0.) (map (lam c : ([Int], Float). c.1) sizeCC))
+      in
+      { measuringPoints = sizeMps, connectedComponents = sizeCC,
+        sizeTotal = sizeTotal, sizeReduced = sizeReduced }
+
+  sem searchSpaceExhaustive (stepSize : Int) (env : CallCtxEnv) =
+  | dep ->
+    let dep : DependencyGraph = dep in
+    let domains : [[Expr]] = map (domain stepSize) env.idx2hole in
+    let mps = setToSeq dep.alive in
+    searchSpaceExhaustiveH mps dep.graph domains
+
+  sem searchSpaceExhaustiveMeasPoints (mp : [Int]) (graph : Graph Int Int) =
+  | domains ->
+    let domains : [[Expr]] = domains in
+    -- Generate exhaustive tables for each measuring point
+    let tables = map (lam m.
+      let holes = graphNeighbors m graph in
+      let doms = map (get domains) holes in
+      let prod = product doms in
+      (holes, prod)
+    ) mp
+    in tables
+
+  sem searchSpaceExhaustiveH (mp : [Int]) (graph : Graph Int Int) =
+  | domains ->
+    let tables = searchSpaceExhaustiveMeasPoints mp graph domains in
+
+    -- The longest table is the initial base table
+    match
+      foldl (lam acc. lam table: ([Int],[[Expr]]).
+        match acc with (cur, longest, t) in
+        if gti (length table.1) (length t) then (addi cur 1, cur, table.1)
+        else (addi cur 1, longest, t)
+      ) (0, subi 0 1, []) tables
+    with (_, longestIdx, longestTable) in
+
+    utest geqi longestIdx 0 with true in
+
+    -- Create a data frame from the base table
+    let ncols = if null longestTable then 0 else length (head longestTable) in
+    let df = dataFrameFromSeq longestTable ncols in
+    let df = dataFrameMap (lam x. Some x) df in
+
+    -- Extend columns of base table to include all holes, add empty slots for
+    -- unknown values
+    let ncols = length domains in
+    let idxs =
+      let t : ([Int],[[Expr]]) = get tables longestIdx in
+      t.0
+    in
+    let df =
+      -- No need to extend if already fully sized
+      if eqi ncols df.ncols then df
+      else dataFrameExtendCols ncols idxs (None ()) df
+    in
+
+    -- Equality function: handle None () as a match.
+    -- OPT(Linnea,2022-02-02): Check fuzzy vs. exact match
+    let eq = lam e1. lam e2.
+      use MExprEq in
+      switch (e1, e2)
+      case ((None (), _) | (_, None ())) then true
+      case (Some v1, Some v2) then eqExpr v1 v2
+      end
+    in
+
+    -- For each row in each table: find first matching row in data frame, add
+    -- the row there.
+    match
+      -- For each table
+      foldl (lam acc. lam t : ([Int],[[Expr]]).
+        match acc with (i, df) in
+        -- Skip the original base table (already in the data frame)
+        if eqi i longestIdx then (addi i 1, df) else
+
+        match t with (idxs, table) in
+        -- For each row in the table
+        let df =
+          foldl (lam df. lam row.
+            let row = map (lam x. Some x) row in
+            -- By construction, there has to be a matching row
+            match dataFrameHasRowSlice eq idxs row df with Some i then
+              dataFrameSetRowSlice i idxs row df
+            else error "Impossible: no match in data frame"
+            ) df table
+        in (addi i 1, df)
+      ) (0, df) tables
+    with (_, df) in
+    df
+end
+
+lang Test = SearchSpace + MExprEq end
+
+mexpr
+
+use Test in
+
+let debug = false in
+
+let optionInt2str = lam x.
+  use MExprAst in
+  match x with Some (TmConst {val = CInt {val = i}}) then int2string i
+  else match x with None () then "-"
+  else never
+in
+
+let eqTestMeasPoints = lam lhs : [([Int],[[Expr]])]. lam rhs : [([Int],[[Expr]])].
+  let eqElem = lam l : ([Int],[[Expr]]). lam r : ([Int],[[Expr]]).
+    if eqSeq eqi l.0 r.0 then
+      eqsetEqual (eqSeq eqExpr) l.1 r.1
+    else false
+  in eqsetEqual eqElem lhs rhs
+in
+
+let eqOptionInt = lam lhs : Option Expr. lam rhs : Option Int.
+  use MExprEq in
+  switch (lhs, rhs)
+  case (None (), None ()) then true
+  case (Some e1, Some i2) then eqExpr e1 (int_ i2)
+  case ((None (), _) | (_, None ())) then false
+  case t then dprintLn t; error "impossible"
+  end
+in
+
+let eqTestDF = lam lhs : DataFrame (Option Expr). lam rhs : [[Option Int]].
+  dataFrameEq eqOptionInt lhs (dataFrameFromSeq rhs (length (head rhs)))
+in
+
+utest
+  let g = graphAddEdges [(0,2,0),(0,3,0),(1,3,0),(1,4,0)] (
+    graphAddVertices [0,1,2,3,4] (graphEmpty subi eqi))
+  in
+  let mp = [2,3,4] in
+  let domains = [[int_ 0, int_ 1], [int_ 2, int_ 3, int_ 4]] in
+  searchSpaceExhaustiveMeasPoints mp g domains
+with
+[ ([0],  [ [int_ 0], [int_ 1] ])
+, ([0,1],[ [int_ 0, int_ 2]
+         , [int_ 0, int_ 3]
+         , [int_ 0, int_ 4]
+         , [int_ 1, int_ 2]
+         , [int_ 1, int_ 3]
+         , [int_ 1, int_ 4]
+         ])
+, ([1],  [ [int_ 2], [int_ 3], [int_ 4] ])
+] using eqTestMeasPoints in
+
+
+utest
+  let g = graphAddEdges [(0,2,0),(0,3,0),(1,3,0),(1,4,0)] (
+    graphAddVertices [0,1,2,3,4] (graphEmpty subi eqi))
+  in
+  let mp = [2,3,4] in
+  let domains = [[int_ 0, int_ 1], [int_ 2, int_ 3, int_ 4]] in
+  let df = searchSpaceExhaustiveH mp g domains in
+  (if debug then printLn (dataFrame2str optionInt2str df) else ());
+  df
+with
+[ [Some 0, Some 2]
+, [Some 0, Some 3]
+, [Some 0, Some 4]
+, [Some 1, Some 2]
+, [Some 1, Some 3]
+, [Some 1, Some 4]
+] using eqTestDF in
+
+
+utest
+  let g = graphAddEdges [(0,3,0),(1,3,0),(1,4,0),(2,4,0)] (
+    graphAddVertices [0,1,2,3,4] (graphEmpty subi eqi))
+  in
+  let mp = [3,4] in
+  let domains = [[int_ 0, int_ 1, int_ 2], [int_ 0, int_ 1, int_ 2], [int_ 0, int_ 1, int_ 2]] in
+  let df : DataFrame (Option Expr) = searchSpaceExhaustiveH mp g domains in
+  (if debug then printLn (dataFrame2str optionInt2str df) else ());
+  -- Several different data frames are possible, so we check its properties
+  let eq = optionEq eqExpr in
+  let _oe = lam row: [Int]. map (lam i. Some (int_ i)) row in
+  forAll (lam x. x)
+  [ eqi df.ncols 3
+  , eqi (length df.data) 9
+  -- Measuring point 3
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [0,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [0,1]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [0,2]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [1,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [1,1]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [1,2]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [2,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [2,1]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0,1] (_oe [2,2]) df)
+  -- Measuring point 4
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [0,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [0,1]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [0,2]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [1,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [1,1]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [1,2]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [2,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [2,1]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [2,2]) df)
+  ]
+with true in
+
+
+utest
+  let g = graphAddEdges [(0,2,0),(1,3,0)] (
+    graphAddVertices [0,1,2,3] (graphEmpty subi eqi))
+  in
+  let mp = [2,3] in
+  let domains = [[int_ 0, int_ 1], [int_ 2, int_ 3, int_ 4]] in
+  let df : DataFrame (Option Expr) = searchSpaceExhaustiveH mp g domains in
+  (if debug then printLn (dataFrame2str optionInt2str df) else ());
+  -- Several different data frames are possible, so we check its properties
+  let eq = optionEq eqExpr in
+  let _oe = lam row: [Int]. map (lam i. Some (int_ i)) row in
+  use MExprEq in
+  forAll (lam x. x)
+  [ eqi df.ncols 2
+  , eqi (length df.data) 3
+  -- Measuring point 2 (has one 'bubble')
+  , optionIsSome (dataFrameHasRowSlice eq [0] (_oe [0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0] (_oe [1]) df)
+  , optionIsSome (dataFrameHasRowSlice (optionEq eqExpr) [0] [None ()] df)
+  -- Measuring point 4
+  , optionIsSome (dataFrameHasRowSlice eq [1] (_oe [2]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1] (_oe [3]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1] (_oe [4]) df)
+  ]
+with true in
+
+
+utest
+  let g = graphAddEdges [(0,3,0),(1,4,0),(2,4,0)] (
+    graphAddVertices [0,1,2,3,4] (graphEmpty subi eqi))
+  in
+  let mp = [3,4] in
+  let domains = [[int_ 0, int_ 1], [int_ 0, int_ 1], [int_ 0, int_ 1]] in
+  let df : DataFrame (Option Expr) = searchSpaceExhaustiveH mp g domains in
+  (if debug then printLn (dataFrame2str optionInt2str df) else ());
+  -- Several different data frames are possible, so we check its properties
+  let eq = optionEq eqExpr in
+  let _oe = lam row: [Int]. map (lam i. Some (int_ i)) row in
+  use MExprEq in
+  forAll (lam x. x)
+  [ eqi df.ncols 3
+  , eqi (length df.data) 4
+  -- Measuring point 3 (has two 'bubbles')
+  , optionIsSome (dataFrameHasRowSlice eq [0] (_oe [0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [0] (_oe [1]) df)
+  , optionIsSome (dataFrameHasRowSlice (optionEq eqExpr) [0] [None ()] df)
+  -- Measuring point 4
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [0,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [0,1]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [1,0]) df)
+  , optionIsSome (dataFrameHasRowSlice eq [1,2] (_oe [1,1]) df)
+  ]
+with true in
+
+()

--- a/stdlib/tuning/search-space.mc
+++ b/stdlib/tuning/search-space.mc
@@ -21,6 +21,37 @@ type SearchSpaceSize = {
   sizeReduced : Float
 }
 
+-- Computes the Cartesian product of the sequences in 'seqs', ordering
+-- unspecified.
+recursive let searchSpaceProduct : all a. [[a]] -> [[a]] = lam seqs.
+  recursive let work = lam acc. lam s1. lam s2.
+    if null s1 then acc
+    else if null s2 then acc
+    else match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) in
+      let acc = cons (cons h1 h2) acc in
+      let acc = work acc t1 s2 in
+      work acc [h1] t2
+  in
+  if null seqs then []
+  else match seqs with [s] then
+    map (lam x. [x]) s
+  else
+    let t = searchSpaceProduct (tail seqs) in
+    work [] (head seqs) t
+end
+
+let _productEq : all a. (a -> a -> Int) -> [[a]] -> [[a]] -> Bool =
+  lam cmp : a -> a -> Int. lam p1 : [[a]]. lam p2 : [[a]].
+    let p1 = sort (seqCmp cmp) p1 in
+    let p2 = sort (seqCmp cmp) p1 in
+    let eq = lam s1. lam s2. eqi (seqCmp cmp s1 s2) 0 in
+    eqSeq eq p1 p2
+
+utest searchSpaceProduct [[],[1,2,3]] with [] using _productEq subi
+utest searchSpaceProduct [[1,2,3]] with [[1],[2],[3]] using _productEq subi
+utest searchSpaceProduct [[1,2,3],[4,5]] with [[1,4],[1,5],[2,4],[2,5],[3,4],[3,5]] using _productEq subi
+utest searchSpaceProduct [[1],[2,3],[4]] with [[1,2,4],[1,3,4]] using _productEq subi
+
 let _searchSpaceTestEq = lam lhs: Map Int Float. lam rhs: [(Int,Float)].
   eqSeq (lam t1: (Int,Float). lam t2: (Int,Float).
     and (eqi t1.0 t2.0) (eqf t1.1 t2.1)
@@ -109,7 +140,7 @@ lang SearchSpace = DependencyAnalysis
     let tables = map (lam m.
       let holes = graphNeighbors m graph in
       let doms = map (get domains) holes in
-      let prod = product doms in
+      let prod = searchSpaceProduct doms in
       (holes, prod)
     ) mp
     in tables

--- a/stdlib/tuning/tail-positions.mc
+++ b/stdlib/tuning/tail-positions.mc
@@ -1,0 +1,359 @@
+-- Traverse tail positions in a recursive let.
+
+include "set.mc"
+
+include "mexpr/mexpr.mc"
+include "mexpr/anf.mc"
+include "mexpr/boot-parser.mc"
+include "mexpr/symbolize.mc"
+
+lang TailPositions = MExprAst
+  sem tailPositionsReclet : all a. all b.
+       (a -> b -> Expr -> Expr)
+    -> (a -> b -> Expr -> (a, Expr))
+    -> (b -> Expr -> (b, Expr -> Expr))
+    -> b -> a -> Expr
+    -> (a, Expr)
+  sem tailPositionsReclet baseCase tailCall letexpr lacc acc =
+  | TmRecLets t ->
+    let lets: [Name] = map (lam b: RecLetBinding. b.ident) t.bindings in
+    let lets = setOfSeq nameCmp lets in
+    match mapAccumL (lam acc: a. lam b: RecLetBinding.
+        match visitTailPositions baseCase tailCall letexpr (lets, acc, lacc) b.body
+        with ((_,acc,_), body)
+        in (acc, {b with body = body})
+      ) acc t.bindings
+    with (acc, bindings) in
+    (acc, TmRecLets {t with bindings = bindings})
+
+  | t ->
+    smapAccumL_Expr_Expr (tailPositionsReclet baseCase tailCall letexpr lacc) acc t
+
+  sem tailPositionBaseCase =
+  | TmConst _ -> true
+  | TmRecord _ -> true
+  | TmRecordUpdate _ -> true
+  | TmVar _ -> true
+  | TmConApp _ -> true
+  | TmSeq _ -> true
+  | TmType _ -> true
+  | TmConDef _ -> true
+  | t -> false
+
+  sem visitTailPositions : all a. all b.
+       (a -> b -> Expr -> Expr)
+    -> (a -> b -> Expr -> (a, Expr))
+    -> (b -> Expr -> (b, Expr -> Expr))
+    -> (Set Name, a, b)
+    -> Expr
+    -> ((Set Name, a, b), Expr)
+
+  sem visitTailPositions baseCase tailCall letexpr acc =
+  | TmLam ({ body = (TmVar v)} & t) ->
+    match acc with (_, tacc, lacc) in
+    let helperLetExpr = bind_ (nulet_ v.ident t.body) t.body in
+    (acc, TmLam { t with body = baseCase tacc lacc helperLetExpr })
+  | TmRecLets t ->
+    match acc with (env, tacc, lacc) in
+    match tailPositionsReclet baseCase tailCall letexpr lacc tacc (TmRecLets t)
+    with (tacc, TmRecLets t) in
+    match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc) t.inexpr
+    with (acc, inexpr) in
+    (acc, TmRecLets {t with inexpr = inexpr})
+  | TmLet t ->
+    match acc with (env, tacc, lacc) in
+    match letexpr lacc (TmLet t) with (lacc, prepend) in
+    let acc = (env, tacc, lacc) in
+    match
+    switch t
+    case { inexpr = TmVar vin } then
+      -- The case 'let t = ... in t', i.e. the body of the let is in tail
+      -- position.
+      if nameEq vin.ident t.ident then
+        -- Yes.
+        switch t
+        -- Application: tail call?
+        case { body = TmApp {lhs = TmVar vlhs} } then
+          if setMem vlhs.ident env then
+            match tailCall tacc lacc t.body with (tacc, body) in
+            ((env, tacc, lacc), TmLet { t with body = body })
+          else (acc, baseCase tacc lacc (TmLet t))
+        -- Match: one of the branches returns a variable?
+        case { body = TmMatch m } then
+          match
+            match m with {thn = TmVar v} then
+              let helperLetExpr = bind_ (nulet_ v.ident m.thn) m.thn in
+              (acc, baseCase tacc lacc helperLetExpr)
+            else visitTailPositions baseCase tailCall letexpr acc m.thn
+          with (acc, thn) in
+          match
+            match m with {els = TmVar v} then
+              let helperLetExpr = bind_ (nulet_ v.ident m.els) m.els in
+              (acc, baseCase tacc lacc helperLetExpr)
+            else visitTailPositions baseCase tailCall letexpr acc m.els
+          with (acc, els) in
+          let body = TmMatch {{m with thn = thn} with els = els} in
+          (acc, TmLet {t with body = body})
+        -- All other cases
+        case _ then
+          if tailPositionBaseCase t.body then
+            (acc, baseCase tacc lacc (TmLet t))
+          else
+            smapAccumL_Expr_Expr (
+              visitTailPositions baseCase tailCall letexpr) acc (TmLet t)
+        end
+      else
+        -- No, only the variable being returned is in tail position.
+        let helperLetExpr = bind_ (nulet_ vin.ident t.inexpr) t.inexpr in
+        (acc, TmLet {t with inexpr = baseCase tacc lacc helperLetExpr})
+    -- Redefinition of recursive functions
+    case ({body = (TmApp {lhs = TmVar v} | TmVar v)}) & (!{inexpr = TmVar _}) then
+      let env =
+        if setMem v.ident env then
+          setInsert t.ident env
+        else env
+      in
+      match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc) t.inexpr
+      with (acc, inexpr) in
+      (acc, TmLet { t with inexpr = inexpr })
+    case _ then
+      smapAccumL_Expr_Expr (visitTailPositions baseCase tailCall letexpr) acc (TmLet t)
+    end
+    with (acc, expr) in
+    (acc, prepend expr)
+  | t ->
+    smapAccumL_Expr_Expr (visitTailPositions baseCase tailCall letexpr) acc t
+end
+
+lang TestLang =
+  TailPositions + BootParser + MExprPrettyPrint + MExprANFAll + MExprSym +
+  MExprEval
+end
+
+mexpr
+
+use TestLang in
+
+let debug = false in
+
+let parse = lam str.
+  let ast = parseMExprString [] str in
+  symbolize ast
+in
+
+let debugPrint = lam debug.
+  if debug then printLn
+  else (lam. ())
+in
+
+let test = lam debug. lam t. lam acc. lam lacc. lam baseCase. lam tailCall. lam letexpr.
+  use MExprPrettyPrint in
+  debugPrint debug "--- BEFORE ---";
+  debugPrint debug (expr2str t);
+  debugPrint debug "--- ANF ---";
+  let t = normalizeTerm t in
+  debugPrint debug (expr2str t);
+  debugPrint debug "--- AFTER ---";
+  match tailPositionsReclet baseCase tailCall letexpr lacc acc t with (acc, t) in
+  debugPrint debug (expr2str t);
+  debugPrint debug "-------------";
+  let res = eval {env = evalEnvEmpty} t in
+  debugPrint debug (expr2str res);
+  (acc, expr2str res)
+in
+
+let letexprNoop = lam lacc. lam e. (lacc, lam x. x) in
+let baseCaseInexpr = lam inexpr. lam. lam. lam x.
+  match x with TmLet t in TmLet {t with inexpr = inexpr}
+in
+
+-- Base cases
+let t = parse
+"
+type Foo in
+con Con : Int -> Foo in
+recursive
+  let a = lam x.
+    1
+  let b = lam x.
+    x
+  let c = lam x.
+    let y = negi x in
+    3
+  let d = lam x.
+    let y = addi x 2 in
+    let z = subi x 2 in
+    y
+  let e = lam x.
+    match x with true then false
+    else true
+  let f = lam x.
+    let t =
+      match x with true then false
+      else true
+    in
+    addi 3 1
+  let g = lam x.
+    {key = x}
+  let h = lam x.
+    let v = x in
+    v
+  let i = lam x.
+    Con 1
+  let j = lam x.
+    let s = [1,2,3] in
+    x
+in
+(a (), b (), c 1, d 1, e (), f (), g (), h (), i (), j ())
+"
+in
+
+utest test debug t 0 0 (baseCaseInexpr (int_ 42)) (lam a. lam. lam x. (a,x)) letexprNoop
+with (0, "(42, 42, 42, 42, 42, 42, 42, 42, 42, 42)") in
+
+-- Tail calls
+let t = parse
+"
+let t = 4 in
+recursive
+  let a = lam x.
+    if eqi x 0 then 2
+    else a (subi x 1)
+  let b = lam x.
+    a x
+  let c = lam x.
+    let res = a x in
+    addi res 1
+  let d = lam x. lam y.
+    d x y
+  let e = lam x. lam y.
+    d x y
+  let f = lam x.
+    if eqi x 0 then 1
+    else
+      let res = f (subi x 1) in
+      let t = addi 1 2 in
+      res
+in
+(a 2, b 3, c 1, d 0 0, e 0 0, f 2)
+" in
+
+utest test debug t 0 0 (lam. lam. lam x. x) (lam acc. lam lacc. lam x. (addi acc 1, addi_ (int_ 1) (int_ 2))) letexprNoop
+with (4, "(3, 3, 4, 3, 3, 1)") in
+
+-- Nested reclets
+let t = parse
+"
+recursive
+  let f = lam x.
+    recursive
+      let a = lam x.
+        if eqi x 0 then a x
+        else
+          let callF = f 0 in
+          callF
+    in
+    let res = a x in
+    addi res 1
+in
+f 2
+" in
+
+utest test debug t 0 0 (baseCaseInexpr (int_ 10)) (lam acc. lam lacc. lam x. (addi acc 1, int_ 42)) letexprNoop
+with (1, "10") in
+
+-- Only consider some let expressions
+let t = parse
+"
+let t = 4 in
+recursive
+  let a = lam x.
+    let aExpr =
+      if eqi x 0 then 2
+      else a (subi x 1)
+    in aExpr
+  let b = lam x.
+    a x
+  let c = lam x.
+    let res = a x in
+    addi res 1
+  let d = lam x. lam y.
+    d x y
+  let e = lam x. lam y.
+    let eExpr = d x y in eExpr
+  let f = lam x.
+    if eqi x 0 then 1
+    else
+      let res = f (subi x 1) in
+      let t = addi 1 2 in
+      res
+in
+(a 2, b 3, c 1, d 0 0, e 0 0, f 2)
+" in
+
+let strs = setOfSeq cmpString ["aExpr","eExpr"] in
+
+let letexpr = lam flag: Bool. lam e: Expr.
+  match e with TmLet t in
+  if flag then (true, lam x. x) else
+    let newFlag = setMem (nameGetStr t.ident) strs in
+    if newFlag then (true, lam e. bindSemi_ (negi_ (int_ 1)) e)
+    else (false, lam x. x)
+in
+
+let tailCall = lam acc: Int. lam flag. lam x.
+  if flag then (addi acc 1, int_ 42) else (acc, int_ 3)
+in
+
+utest test debug t 0 false (lam. lam. lam x. x) tailCall letexpr
+with (2, "(42, 3, 43, 3, 42, 1)") in
+
+-- Base case within a match
+let t = parse
+"
+recursive
+  let f1 = lam x.
+    match x with 1 then x
+    else x
+
+  let f2 = lam x.
+    match x with 1 then {lbl=1}
+    else {lbl=2}
+in
+
+(f1 1, f1 2, f2 1, f2 2)
+" in
+
+let baseCase = baseCaseInexpr (int_ 42) in
+let tailCall = lam a. lam b. lam e. (a, e) in
+
+utest test debug t 0 0 baseCase tailCall letexprNoop
+with (0, "(42, 42, 42, 42)") in
+
+
+-- Base case within a match
+let t = parse
+"
+let r = ref 0 in
+
+recursive
+  let f1 = lam x.
+    let t =
+      match x with 1 then modref r 1
+      else ()
+    in
+    x
+in
+let res = f1 1 in
+(res, deref r)
+" in
+
+let baseCase = baseCaseInexpr (int_ 42) in
+let tailCall = lam a. lam b. lam e. (a, e) in
+
+utest test debug t 0 0 baseCase tailCall letexprNoop
+with (0, "(42, 1)") in
+
+
+
+()

--- a/stdlib/tuning/tune-file.mc
+++ b/stdlib/tuning/tune-file.mc
@@ -110,7 +110,7 @@ let tuneFileDump = lam env : CallCtxEnv. lam table : LookupTable. lam format : T
   in
   let taggedEntries =
     mapFoldWithKey
-      (lam acc : [String]. lam h : NameInfo. lam pathMap : Map [NameInfo] Int.
+      (lam acc : [(Int, String)]. lam h : NameInfo. lam pathMap : Map [NameInfo] Int.
          concat acc (map (lam b : ([NameInfo], Int). (b.1, entry2str h b.0 b.1)) (mapBindings pathMap)))
       [] hole2idx
   in

--- a/stdlib/tuning/tune-options.mc
+++ b/stdlib/tuning/tune-options.mc
@@ -1,20 +1,10 @@
 include "option.mc"
 
 type SearchMethod
-con SimulatedAnnealing : () -> SearchMethod
-con TabuSearch         : () -> SearchMethod
-con RandomWalk         : () -> SearchMethod
 con Exhaustive         : () -> SearchMethod
-con SemiExhaustive     : () -> SearchMethod
-con BinarySearch       : () -> SearchMethod
 
 let tuneSearchMethodMap =
-[ ("simulated-annealing", SimulatedAnnealing {})
-, ("tabu-search", TabuSearch {})
-, ("random-walk", RandomWalk {})
-, ("exhaustive", Exhaustive {})
-, ("semi-exhaustive", SemiExhaustive {})
-, ("binary-search", BinarySearch {})
+[ ("exhaustive", Exhaustive ())
 ]
 
 -- Options for tuning
@@ -24,10 +14,7 @@ type TuneOptions =
 , timeoutMs : Option Float
 , warmups : Int
 , method : SearchMethod
-, input : [String]
-, saInitTemp : Float
-, saDecayFactor : Float
-, tabuSize : Int
+, args : [String]
 , epsilonMs : Float
 , stepSize : Int
 , ignoreErrors : Bool
@@ -35,6 +22,10 @@ type TuneOptions =
 , seed : Option Int
 , dependencyAnalysis : Bool
 , cleanup : Bool
+, debugDependencyAnalysis : Bool
+, debugInstrumentation : Bool
+, reduceDependencies : Float
+, seqTransform : Bool
 }
 
 -- Default options
@@ -43,16 +34,17 @@ let tuneOptionsDefault : TuneOptions =
 , iters = 10
 , timeoutMs = None ()
 , warmups = 1
-, method = RandomWalk ()
-, input = []
-, saInitTemp = 100.0
-, saDecayFactor = 0.95
-, tabuSize = 10
+, method = Exhaustive ()
+, args = []
 , epsilonMs = 10.0
 , stepSize = 1
 , ignoreErrors = false
 , exitEarly = true
 , seed = None ()
 , dependencyAnalysis = false
+, debugDependencyAnalysis = false
+, debugInstrumentation = false
+, seqTransform = false
+, reduceDependencies = 0.0
 , cleanup = false
 }

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -8,17 +8,23 @@ include "common.mc"
 include "context-expansion.mc"
 include "tune-options.mc"
 include "tune-file.mc"
+include "search-space.mc"
+include "database.mc"
+
+-- Included for testing
+include "ocaml/mcore.mc"
+include "ocaml/pprint.mc"
 
 -- Performs tuning of a context expanded program with holes.
 
 -- Start time of search.
 let tuneSearchStart = ref 0.
 
--- Default input if program takes no input data
-let _inputEmpty = [""]
-
 -- Return code for timeout
 let _returnCodeTimeout = 124
+
+-- Default command line options if program takes no input
+let _inputEmpty = [""]
 
 -- Convert from ms to s
 let _ms2s = lam ms. divf ms 1000.
@@ -32,6 +38,7 @@ utest _distinct subi [1,2,1] with [1,2]
 ------------------------------
 -- Base fragment for tuning --
 ------------------------------
+
 type Runner = String -> Option Float -> (Float, ExecResult)
 
 type TimingResult
@@ -39,21 +46,14 @@ con Success : {ms : Float} -> TimingResult
 con Error : {msg : String, returncode : Int} -> TimingResult
 con Timeout : {ms : Float} -> TimingResult
 
-let _timingResult2str : TimingResult -> String = lam t.
-  switch t
-  case Success {ms = ms} then float2string ms
-  case Error {msg = msg, returncode = returncode} then
-    join [msg, "\n", concat "returncode: " (int2string returncode)]
-  case Timeout {ms = ms} then join ["Timeout at ", float2string ms, " ms"]
-  end
-
 lang TuneBase = HoleAst
-  sem tune (options : TuneOptions) (runner : Runner) (holes : [Expr])
-           (hole2idx : Map NameInfo (Map [NameInfo] Int)) (file : String) =
-  -- Intentionally left blank
+  sem tune : TuneOptions -> Runner -> CallCtxEnv -> DependencyGraph
+           -> InstrumentedResult -> String -> (() -> ()) -> LookupTable
+           -> LookupTable
 
   sem measure (table : LookupTable) (runner : Runner) (file : String)
-              (options : TuneOptions) (timeout : Option Float) =
+              (options : TuneOptions) (timeout : Option Float)
+              (onFailure : () -> ()) =
   | args ->
     let timeout = if options.exitEarly then timeout else None () in
     tuneFileDumpTable file (None ()) table;
@@ -74,512 +74,445 @@ lang TuneBase = HoleAst
         ] in
         if options.ignoreErrors then
           Error {msg = msg, returncode = res.returncode}
-        else error msg
+        else
+          onFailure ();
+          error msg
     else never
+
+  sem programInput =
+  | options ->
+    let options : TuneOptions = options in
+    let input =
+      match options.args with [] then _inputEmpty else options.args
+    in
+    input
 end
 
---------------------------
--- Local search methods --
---------------------------
+--------------------------------
+-- Local search base fragment --
+--------------------------------
 
 lang TuneLocalSearch = TuneBase + LocalSearchBase
+  syn LSData =
+
+  sem initMeta : LSData -> MetaState
+
+  sem debugSearch : SearchState -> ()
+
+  sem debugMeta : MetaState -> ()
+
+  sem updateSearchState : SearchState -> SearchState
+
+  -- Default master search loop
+  sem search (options : TuneOptions) (stop : SearchState -> Bool) (state : SearchState) =
+  | meta ->
+    let iter = state.iter in
+    let printState = lam header. lam state. lam meta.
+      if options.verbose then
+        printLn header;
+        debugSearch state;
+        debugMeta meta;
+        printLn (make (length header) '-')
+       else ()
+    in
+    (if eqi iter 0 then
+      printState "----- Initial state -----" state meta
+     else ());
+
+    if stop state then
+      printState "----- Final state -----" state meta;
+      (state, meta)
+    else match minimize state meta with (state, meta) in
+      let state = updateSearchState state in
+      printState "            " state meta;
+      search options stop state meta
+
+  -- When to stop the search
+  sem stopCond (maxIters : Int) (timeoutMs : Option Float) =
+  | state ->
+    let state : SearchState = state in
+    if state.stuck then true
+    else if geqi state.iter maxIters then true
+    else match timeoutMs with Some timeout then
+      let elapsed = subf (wallTimeMs ()) (deref tuneSearchStart) in
+      geqf elapsed timeout
+    else stopCondState state
+
+  -- Additional stop condition based on search state
+  sem stopCondState : SearchState -> Bool
+
+  -- By default, the default table is also the initial table.
+  sem initialTable (defaultTable : LookupTable) =
+  | _ -> defaultTable
+
+  -- By default, the search space is not reduced
+  sem reduceSearchSpace (costF : Option Solution -> Assignment -> Cost) =
+  | d -> d
+
+  -- Check if the search space is empty
+  sem emptySearchSpace =
+  | _ -> false
+
+  -- Entry point for tuning
+  sem tune (options : TuneOptions) (run : Runner) (env : CallCtxEnv)
+           (dep : DependencyGraph) (inst : InstrumentedResult)
+           (tuneFile : String) (onFailure : () -> ()) =
+  | defaultTable ->
+    match tuneDebug options run env dep inst tuneFile onFailure defaultTable
+    with (table, _) in table
+
+  -- Like 'tune', but also returns the final search state (for testing)
+  sem tuneDebug (options : TuneOptions) (run : Runner) (env : CallCtxEnv)
+                (dep : DependencyGraph) (inst : InstrumentedResult)
+                (tuneFile : String) (onFailure : () -> ()) =
+  | defaultTable ->
+    -- Nothing to tune?
+    if null defaultTable then ([], None ()) else
+
+    let data = initData options run env dep inst in
+    let costF : Option Solution -> Assignment -> Cost =
+      costFun run tuneFile options (programInput options) data onFailure
+    in
+    let data = reduceSearchSpace costF data in
+    if emptySearchSpace data then
+      (if options.verbose then
+         printLn "Empty search space detected, tuning will use the default configuration for the program holes.";
+         print "Default table: ";
+         printLn (strJoin " " (map expr2str defaultTable))
+       else ());
+       (defaultTable, None ())
+    else
+      let meta = initMeta data in
+      let initTable = initialTable defaultTable meta in
+
+      -- Warmup runs
+      match warmupInit costF initTable data options with (initTime, startState) in
+      let startState = updateSearchState startState in
+      warmupSearch initTime options meta startState;
+
+      -- Do the search!
+      let stop = stopCond options.iters options.timeoutMs in
+      modref tuneSearchStart (subf (wallTimeMs ()) initTime);
+      match search options stop startState meta
+      with (searchState, _) in
+      (optimalLookupTable searchState, Some searchState)
+
+  sem initData : TuneOptions -> Runner -> CallCtxEnv -> DependencyGraph
+               -> InstrumentedResult -> LSData
+
+  sem costFun : Runner -> String -> TuneOptions -> [String] -> LSData
+              -> (() -> ()) -> (Option Solution) -> Assignment -> Cost
+
+  sem cmpCost : Cost -> Cost -> Int
+
+  sem mkStartState : (Option Solution -> Assignment -> Cost) -> LookupTable -> LSData
+                   -> SearchState
+
+  sem warmupInit (costF : Option Solution -> Assignment -> Cost)
+                 (table : LookupTable) (data : LSData) =
+  | options ->
+    let options : TuneOptions = options in
+    let normalStop = stopCond options.iters options.timeoutMs in
+    let warmupStop = stopCond options.warmups options.timeoutMs in
+
+    -- Set up initial search state. Repeat the computation of the initial cost n
+    -- times, where n is the number of warmup runs, because the cost function is
+    -- applied once per setup.
+    map (mkStartState costF table) (make options.warmups data);
+    -- Warmed up and ready, create the actual start state
+    let beforeStartState = wallTimeMs () in
+    let startState = mkStartState costF table data in
+    let afterStartState = wallTimeMs () in
+
+    (subf afterStartState beforeStartState, startState)
+
+  sem warmupSearch (initTime : Float) (options : TuneOptions) (meta : MetaState) =
+  | startState ->
+    let normalStop = stopCond options.iters options.timeoutMs in
+    let warmupStop = stopCond options.warmups options.timeoutMs in
+
+    -- Do warmup runs and throw away results
+    modref tuneSearchStart (subf (wallTimeMs ()) initTime);
+    (if options.verbose then
+       printLn "----------------------- WARMUP RUNS -----------------------"
+     else ());
+    search options warmupStop startState meta;
+    (if options.verbose then
+      printLn "-----------------------------------------------------------"
+     else ())
+
+  sem optimalLookupTable : SearchState -> LookupTable
+end
+
+-----------------------------
+-- Dependency-aware tuning --
+-----------------------------
+
+lang TuneDep = TuneLocalSearch + Database
+  syn LSData =
+  | TuneData { options : TuneOptions, run : Runner, env : CallCtxEnv,
+               dep : DependencyGraph, inst : InstrumentedResult,
+               database : Database, searchSpace : SearchSpaceSize }
+
   syn Assignment =
-  | Table {table : LookupTable,
-           start : LookupTable,
-           holes : [Expr],
-           options : TuneOptions,
-           hole2idx : Map NameInfo (Map [NameInfo] Int)}
+  | Table { table : LookupTable }
 
   syn Cost =
-  | Runtime {time : TimingResult}
-
-  sem initMeta =
+  | Runtime { time : TimingResult, profiles : [String] }
 
   sem debugSearch =
   | searchState ->
     let searchState : SearchState = searchState in
     match searchState
-    with {iter = iter
+    with { iter = iter
          , inc = {assignment = Table {table = inc},
                   cost = Runtime {time = incTime}}
          , cur = {assignment = Table {table = cur},
-                  cost = Runtime {time = curTime}}}
+                  cost = Runtime {time = curTime}}
+         , data = Some (TuneData { searchSpace = space, database = db })
+         }
     then
       use MExprPrettyPrint in
-      let incValues = map expr2str inc in
-      let curValues = map expr2str cur in
       let elapsed = subf (wallTimeMs ()) (deref tuneSearchStart) in
+      -- OPT(Linnea, 2022-02-08): Increase % incrementally
+      let entries = databaseCount db in
+      let exploredReduced = divf (int2float entries) space.sizeReduced in
+      let exploredTotal = divf (int2float entries) space.sizeTotal in
+      match optimalAssignment searchState with (table, ms) in
+      let table = map expr2str table in
+      let cur = map expr2str cur in
+
       printLn (join ["Iteration: ", int2string iter, "\n",
-                     "Current table: ", strJoin ", " curValues, "\n",
-                     "Current time: ", _timingResult2str curTime, "\n",
-                     "Best time: ", _timingResult2str incTime, "\n",
-                     "Best table: ", strJoin ", " incValues, "\n",
-                     "Elapsed ms: ", float2string elapsed
+                     "Elapsed: ", float2string elapsed, " ms \n",
+                     "Just evaluated: ", strJoin ", " cur, "\n",
+                     "Best table: ", strJoin ", " table, "\n",
+                     "Estimated cost: ", float2string ms, " ms \n",
+                     "# assignments explored: ", int2string entries, "\n",
+                     "% of total search space explored: ", float2string (mulf 100. exploredTotal), "\n",
+                     "% of reduced search space explored: ", float2string (mulf 100. exploredReduced)
                     ])
 
     else never
 
-  sem tune (options : TuneOptions) (runner : Runner) (holes : [Expr])
-           (hole2idx : Map NameInfo (Map [NameInfo] Int)) (file : String) =
-  | table ->
-    let input =
-      match options.input with [] then _inputEmpty else options.input
+  sem initData (options : TuneOptions) (run : Runner) (env : CallCtxEnv)
+               (dep : DependencyGraph) =
+  | instrumentedResult ->
+    -- Compute size of the search space
+    let searchSpace =
+      use SearchSpace in
+      searchSpaceSize options.stepSize env dep
     in
+    -- Initialize database
+    -- NOTE: uses the total number of measuring points (including dead ones).
+    -- The reason is that the database collects profiling data, which will
+    -- include data from _all_ measuring points.
+    let database = databaseEmpty dep.offset dep.nbrMeas in
 
-    -- Cost function: sum of execution times over all inputs
-    let costF : Option Solution -> Assignment -> Cost =
-      lam inc : Option Solution. lam lookup : Assignment.
-        let timeoutVal : Option Float =
-          match inc with Some sol then
-            let sol : Solution = sol in
-            match sol with {cost = Runtime {time = time}} then
-              switch time
-              case Success {ms = ms} then Some ms
-              case Error _ then None ()
-              case Timeout _ then error "impossible"
-              end
-            else never
-          else None ()
-        in
-        match lookup with Table {table = table} then
-          let f = lam t1. lam t2.
-            switch (t1, t2)
-            case (Success {ms = ms1}, Success {ms = ms2}) then
-              Success {ms = addf ms1 ms2}
-            case ((Error e, _) | (_, Error e)) then Error e
-            end
-          in
-          Runtime {time = foldr1 f (map (measure table runner file options timeoutVal) input)}
-        else error "impossible" in
-
-    -- Comparing costs: negative if 't1' is better than 't2'
-    let cmpF : Cost -> Cost -> Int = lam t1. lam t2.
-      match (t1, t2) with (Runtime {time = t1}, Runtime {time = t2}) then
-        switch (t1, t2)
-        case (Success {ms = ms1}, Success {ms = ms2}) then
-          let diff = subf ms1 ms2 in
-          if geqf (absf diff) options.epsilonMs then roundfi diff
-          else 0
-        case (Success {ms = ms}, Error _ | Timeout _) then roundfi (subf 0. ms)
-        case (Error _, Error _) then 0
-        case (Error _, Success {ms = ms}) then roundfi ms
-        case (Error _, Timeout _) then 0
-        case (Timeout _, Timeout _) then 0
-        case (Timeout _, Error _) then 0
-        case (Timeout _, Success {ms = ms}) then roundfi ms
-        end
-      else error "impossible" in
-
-    -- When to stop the search
-    let stopCond = lam niters. lam timeoutMs : Option Float. lam state : SearchState.
-      if state.stuck then true
-      else if geqi state.iter niters then true
-      else match timeoutMs with Some timeout then
-        let elapsed = subf (wallTimeMs ()) (deref tuneSearchStart) in
-        if geqf elapsed timeout then true else false
-      else false
-    in
-
-    let normalStop = stopCond options.iters options.timeoutMs in
-
-    let warmupStop = stopCond options.warmups (None ()) in
-
-    recursive let search =
-      lam stop.
-      lam searchState.
-      lam metaState.
-      lam iter.
-        let printState = lam header. lam searchState. lam metaState.
-          if options.verbose then
-            printLn header;
-            debugSearch searchState;
-            debugMeta metaState;
-            printLn (make (length header) '-')
-          else ()
-        in
-
-        (if eqi iter 0 then
-          printState "----- Initial state -----" searchState metaState
-         else ());
-
-        if stop searchState then
-          printState "----- Final state -----" searchState metaState;
-          (searchState, metaState)
-        else
-          match minimize searchState metaState with (searchState, metaState)
-          in
-            printState (join [
-              "----- Iteration ", int2string (addi iter 1), " -----"])
-              searchState metaState;
-            search stop searchState metaState (addi iter 1)
-    in
-
-    -- Set up initial search state. Repeat the computation n times, where n is
-    -- the number of warmup runs, because the cost function is applied once per
-    -- setup.
-    let mkStartState = lam.
-      initSearchState costF cmpF
-        (Table { table = table
-               , start = table
-               , holes = holes
-               , options = options
-               , hole2idx = hole2idx
-               })
-    in
-    iter mkStartState (make options.warmups ());
-    let beforeStartState = wallTimeMs () in
-    let startState = mkStartState () in
-    let afterStartState = wallTimeMs () in
-
-    -- Timestamp of start of search (including time to create the start state)
-    let startOfSearch = lam.
-      subf (wallTimeMs ()) (subf afterStartState beforeStartState)
-    in
-
-    -- Do warmup runs and throw away results
-    modref tuneSearchStart (startOfSearch ());
-    (if options.verbose then
-       printLn "----------------------- WARMUP RUNS -----------------------"
-       else ());
-    search warmupStop startState (initMeta startState) 0;
-    (if options.verbose then
-       printLn "-----------------------------------------------------------"
-       else ());
-
-    -- Do the search!
-    modref tuneSearchStart (startOfSearch ());
-    match search normalStop startState (initMeta startState) 0
-    with (searchState, _) then
-      let searchState : SearchState = searchState in
-      match searchState with {inc = {assignment = Table {table = table}}}
-      then table
-      else never
-    else never
-end
-
--- Explore the search space exhaustively, i.e. try all combinations of all
--- holes. The holes are explored from left to right.
-lang TuneExhaustive = TuneLocalSearch
-  syn MetaState =
-  | Exhaustive {prev : [Option Expr], exhausted : Bool}
-
-  sem step (searchState : SearchState) =
-  | Exhaustive ({prev = prev, exhausted = exhausted} & x) ->
-    if exhausted then
-      (None (), Exhaustive x)
-    else match searchState with
-      {cur =
-         {assignment = Table ({table = table, holes = holes} & t)},
-       cost = cost,
-       inc = inc}
-    then
-      let exhausted = ref false in
-      let options : TuneOptions = t.options in
-      let stepSize = options.stepSize in
-
-      recursive let nextConfig = lam prev. lam holes.
-        match holes with [] then []
-        else match holes with [h] then
-          match next (head prev) stepSize h with Some v then
-            [Some v]
-          else
-            modref exhausted true; []
-        else match holes with [h] ++ holes then
-          match next (head prev) stepSize h with Some v then
-            cons (Some v) (tail prev)
-          else
-            cons (next (None ()) stepSize h) (nextConfig (tail prev) holes)
-        else never
-      in
-
-      let newTable =
-        Table {t with table = map (optionGetOrElse (lam. "impossible")) prev}
-      in
-      let newPrev = nextConfig prev holes in
-      ( Some {assignment = newTable, cost = cost (Some inc) newTable},
-        Exhaustive {prev = newPrev, exhausted = deref exhausted})
-    else never
-
-  sem initMeta =
-  | initState ->
-    let initState : SearchState = initState in
-    match initState with {cur = {assignment = Table {holes = holes}}} then
-      let initVals = map (next (None ()) 1) holes in
-      utest forAll optionIsSome initVals with true in
-      Exhaustive {prev = initVals, exhausted = false}
-    else never
-end
-
--- Explore the values of each hole one by one, from left to right,
--- while keeping the rest fixed (to their tuned values, or their defaults if
--- they have note yet been tuned). Hence, it assumes a total independence of the
--- holes.
-lang TuneSemiExhaustive = TuneLocalSearch
-  syn MetaState =
-  | SemiExhaustive {curIdx : Int, lastImproved : Int, prev : Option Expr}
-
-  sem step (searchState : SearchState) =
-  | SemiExhaustive ({curIdx = i, prev = prev, lastImproved = lastImproved} & state) ->
-    match searchState
-    with {inc = {assignment = Table ({table = table, start = start, holes = holes} & t),
-                 cost = incCost},
-          cost = cost, cmp = cmp}
-    then
-      let options : TuneOptions = t.options in
-      let stepSize = options.stepSize in
-
-      let return = lam i. lam prev.
-        let assignment = Table {t with table = set table i prev} in
-        let score = cost (Some searchState.inc) assignment in
-        let lastImproved =
-          if lti (cmp score incCost) 0 then i else lastImproved in
-        ( Some {assignment = assignment, cost = score},
-          SemiExhaustive {curIdx = i, prev = Some prev, lastImproved = lastImproved} )
-      in
-
-      recursive let nextSkipStart = lam prev. lam i.
-        if eqi i (length holes) then
-          -- Finished the search
-          (None (), SemiExhaustive state)
-        else
-          let prev = next prev stepSize (get holes i) in
-          match prev with Some v then
-          -- Skip start value, already explored
-          if (use MExprEq in eqExpr v (get start i)) then
-            nextSkipStart prev i
-          else
-            return i v
-        else match prev with None () then
-          -- Current hole is exhausted, move to the next
-          nextSkipStart (None ()) (addi i 1)
-        else never
-      in
-      nextSkipStart prev i
-
-    else never
-
-  sem initMeta =
-  | _ -> SemiExhaustive
-    { curIdx = 0
-    , lastImproved = subi 0 1
-    , prev = None ()
+    TuneData {
+      options = options,
+      run = run,
+      env = env,
+      dep = dep,
+      inst = instrumentedResult,
+      database = database,
+      searchSpace = searchSpace
     }
 
-  sem debugMeta =
-  | SemiExhaustive {curIdx = i, lastImproved = j, prev = prev} ->
-    printLn (join ["Exploring index: ", int2string i, "\n",
-                   "Last improved at: ", int2string j, "\n",
-                   "Prev: ",
-                   optionMapOrElse (lam. "None")
-                     (use MExprPrettyPrint in expr2str) prev])
-end
+  sem reduceSearchSpace (costF: Option Solution -> Assignment -> Cost) =
+  | TuneData d ->
+    -- Do a number of measurement with randomized tables
+    let data =
+      if gtf d.options.reduceDependencies 0. then
+        let nbrRandRuns = 10 in
+        let profiles = foldl (lam acc. lam.
+            let randomTable: [Expr] = map (sample d.options.stepSize) d.env.idx2hole in
+            match costF (None ()) (Table { table = randomTable }) with Runtime r in
+            concat acc r.profiles
+          ) [] (create nbrRandRuns (lam i. i))
+        in
+        let profile: InstrumentationProfile = getProfile profiles in
+        match profile with {ids= ids, nbrRuns= nbrRuns, totalMs= totalMs} in
+        let idRuns: [(Int,Int)] = zip ids nbrRuns in
+        let idRunsTotalMs: [(Int,Int,Float)] =
+            zipWith (lam x1: (Int,Int). lam x2: Float.
+              (x1.0, x1.1, x2)
+          ) idRuns totalMs
+        in
+        let sorted = sort (lam t1: (Int, Int, Float). lam t2: (Int, Int, Float).
+          cmpfApprox 0. t1.2 t2.2) idRunsTotalMs
+        in
 
-lang TuneOneRandomNeighbourModifyOne = TuneLocalSearch
-  sem neighbourhood =
+        -- Collect those id's that are below the threshold. Multiply by nbrRuns so
+        -- that we are considering the mean.
+        let threshold = mulf d.options.reduceDependencies (int2float nbrRandRuns) in
+        let idsToRemove = foldl (lam acc. lam t: (Int,Int,Float).
+            if ltf (subf t.2 threshold) 0. then cons t.0 acc
+            else acc
+          ) [] sorted
+        in
+        -- Remove the corresponding nodes from the dependency graph
+        let graph = foldl (lam acc. lam id.
+            graphRemoveVertex id acc
+          ) d.dep.graph idsToRemove
+        in
+        let dep = {d.dep with graph = graph} in
+        -- Mark the removed measuring points as not alive
+        let alive = foldl (lam acc. lam id.
+            setRemove id acc
+          ) d.dep.alive idsToRemove
+        in
+        let dep = {d.dep with alive = alive} in
+        -- Re-initialize the data from the updated graph
+        initData d.options d.run d.env dep d.inst
+      else TuneData d
+    in
+    data
+
+  -- Check if the search space is empty
+  sem emptySearchSpace =
+  | TuneData d ->
+    eqf d.searchSpace.sizeReduced 0.
+
+  sem getProfile =
+  | profiles ->
+    use Instrumentation in
+    let mergeProfiles = lam p1: InstrumentationProfile. lam p2: InstrumentationProfile.
+      match (p1, p2) with
+        ( {ids= ids1, nbrRuns= nbrRuns1, totalMs= totalMs1}
+        , {ids= ids2, nbrRuns= nbrRuns2, totalMs= totalMs2}
+        ) in
+      utest eqSeq eqi ids1 ids2 with true in
+      let ids = ids1 in
+      let nbrRuns = zipWith addi nbrRuns1 nbrRuns2 in
+      let totalMs = zipWith addf totalMs1 totalMs2 in
+      {ids=ids, nbrRuns=nbrRuns, totalMs=totalMs}
+    in
+    let profiles = map readProfile profiles in
+    let profile = foldl1 mergeProfiles profiles in
+    profile
+
+  -- Add a table to the data base, and return the updated search state.
+  sem addToDatabase (searchState: SearchState) (profiles: [String]) =
+  | Table { table = table } ->
+    match searchState with {data = Some (TuneData d)} in
+    let profile = getProfile profiles in
+    let newDb = databaseAddRun table profile d.dep.offset d.database in
+    { searchState with data = Some (TuneData {d with database = newDb}) }
+
+  sem updateSearchState =
+  | state ->
+    let state : SearchState = state in
+    -- Update search state with database
+    match state with {cur = {assignment = a, cost  = Runtime {profiles = strs}}} then
+      addToDatabase state strs a
+    else error "Unexpected search state"
+
+  -- Check for exhausted search space
+  sem stopCondState =
+  | state ->
+    let state : SearchState = state in
+    match state with {data = Some (TuneData {database = db, searchSpace = ss})}
+    then geqf (int2float (databaseCount db)) ss.sizeReduced
+    else error "Expected tune data"
+
+  sem costFun (run : Runner) (tuneFile : String) (options : TuneOptions)
+              (input : [String]) (data : LSData) (onFailure : () -> ())
+              (inc : Option Solution) =
+  | Table { table = table } ->
+    let f = lam i. measure table run tuneFile options (None ()) onFailure i in
+    match data with TuneData {inst = inst} in
+    match foldl (lam acc: (Float, [String]). lam inp.
+        match acc with (ms, strs) in
+        match f inp with Success {ms = ms2} then
+          let s = readFile inst.fileName in
+          (addf ms ms2, snoc strs s)
+        else error "Program had errors"
+      ) (0., []) input
+    with (totalMs, profiles) in
+    Runtime {time = Success {ms = totalMs}, profiles = profiles}
+
+  -- Disable comparison (optimality is computed from database)
+  sem cmpCost (cost : Cost) =
+  | _ -> 0
+
+  sem mkStartState (costF : Option Solution -> Assignment -> Cost)
+                   (table : LookupTable) =
+  | TuneData d ->
+    let a = (Table { table = table }) in
+    let cost = costF (None ()) a in
+    initSearchStateData costF cmpCost (TuneData d) {assignment=a, cost=cost}
+
+  sem optimalAssignment =
   | searchState ->
     let searchState : SearchState = searchState in
-    match searchState
-    with {cur =
-           {assignment =
-             Table ({holes = holes, table = table} & t)}}
+    match searchState with
+      {data = Some (TuneData { database = db, options = opt, dep = dep,
+                               searchSpace = ss })}
     then
-      let table =
-        switch randIndex table
-        case None () then table
-        case Some i then
-          let randHole = get holes i in
-          let modifiedHole = sample randHole in
-          set table i modifiedHole
-        end
-      in iteratorFromSeq [Table {t with table = table}]
-    else never
-end
+      databaseOptimal 0.0 dep ss db
+    else error "Expected tune data"
 
-lang TuneOneRandomNeighbourModifyAll = TuneLocalSearch
-  sem neighbourhood =
+  sem optimalLookupTable =
   | searchState ->
-    let searchState : SearchState = searchState in
-    match searchState
-    with {cur =
-           {assignment =
-             Table ({holes = holes, table = table} & t)}}
-    then
-      let table = map (lam h. sample h) holes in
-      iteratorFromSeq [Table {t with table = table}]
-    else never
+    match optimalAssignment searchState with (table, _) in table
 end
 
-lang TuneManyRandomNeighboursModifyAll = TuneLocalSearch
-  sem neighbourhood =
-  | searchState ->
-    let searchState : SearchState = searchState in
-    match searchState
-    with {cur =
-           {assignment =
-           Table ({holes = holes, table = table} & t)}}
-    then
-      let step = lam.
-        let table = map (lam h. sample h) holes in
-        Some (Table {t with table = table})
-      in
-      iteratorInit step identity
-    else never
-end
-
-lang TuneRandomWalk = TuneLocalSearch
-                    + TuneOneRandomNeighbourModifyAll
-                    + LocalSearchSelectRandomUniform
+lang TuneDepExhaustive = TuneDep + SearchSpace
   syn MetaState =
-  | Empty {}
+  | Exhaustive { tables : DataFrame (Option Expr) }
+
+  sem initMeta =
+  | TuneData d ->
+    let df: DataFrame (Option Expr) = searchSpaceExhaustive d.options.stepSize d.env d.dep in
+    -- If the first row contains a None (), it means that hole is not connected
+    -- to a measuring point. Set those to the default value.
+    let row0 = mapi (lam i. lam v.
+        match v with Some _ then v
+        else Some (default (get d.env.idx2hole i))
+      ) (head df.data)
+    in
+    let df = dataFrameSetRow 0 row0 df in
+    Exhaustive {tables = df}
+
+  sem initialTable (defaultTable : LookupTable) =
+  | Exhaustive {tables = tables} ->
+    let res =
+    mapi (lam i. lam v.
+      match v with Some v then v
+      -- If first value is None (), then the hole affects no measuring point.
+      -- Use default value instead.
+      else get defaultTable i
+    ) (head tables.data)
+    in
+    res
 
   sem step (searchState : SearchState) =
-  | Empty {} ->
-    (select (neighbourhood searchState) searchState, Empty {})
-
-  sem initMeta =
-  | _ -> Empty {}
+  | Exhaustive { tables = tables } ->
+    match searchState with { iter = iter, cost = cost, data = data } in
+    match data with Some (TuneData {env = env, options = options}) then
+      let row = iter in
+      if lti row (dataFrameLength tables) then
+        let r : [Option Expr] = dataFrameGetRow row tables in
+        -- TODO(Linnea, 2022-02-08): What is the best value to fill a bubble
+        -- with?
+        let t = mapi (lam i. lam o.
+          match o with Some e then e
+          else match o with None () then
+            -- For now, pick the default value
+            default (get env.idx2hole i)
+          else never) r
+        in
+        let a = Table {table = t} in
+        ( Some {assignment = a, cost = cost (None ()) a}
+        , Exhaustive {tables = tables} )
+      else ( None(), Exhaustive {tables = tables} )
+    else error "Expected tune data"
 end
 
-lang TuneSimulatedAnnealing = TuneLocalSearch
-                            + TuneOneRandomNeighbourModifyOne
-                            + LocalSearchSimulatedAnnealing
-                            + LocalSearchSelectRandomUniform
-  sem decay (searchState : SearchState) =
-  | SimulatedAnnealing t ->
-    match searchState with {cur = {assignment = Table {options = options}}} then
-      let options : TuneOptions = options in
-      SimulatedAnnealing {t with temp = mulf options.saDecayFactor t.temp}
-    else never
-
-  sem initMeta =
-  | startState ->
-    let startState : SearchState = startState in
-    match startState with {cur = {assignment = Table {options = options}}} then
-      let options : TuneOptions = options in
-      SimulatedAnnealing {temp = options.saInitTemp}
-    else never
-
-  sem debugMeta =
-  | SimulatedAnnealing {temp = temp} ->
-    printLn (join ["Temperature: ", float2string temp])
-end
-
-lang TuneTabuSearch = TuneLocalSearch
-                    + TuneManyRandomNeighboursModifyAll
-                    + LocalSearchTabuSearch
-                    + LocalSearchSelectFirst
-  syn TabuSet =
-  | Tabu {tabu : [LookupTable]}
-
-  sem isTabu =
-  | (Table {table = table}, Tabu {tabu = tabu}) ->
-    use MExprEq in
-    match find (lam t. eqSeq eqExpr table t) tabu
-    with Some _ then true else false
-
-  sem tabuUpdate =
-  | (Table {table = table, options = options}, Tabu ({tabu = tabu} & t)) ->
-    let options : TuneOptions = options in
-    let tabu = cons table
-      (if eqi (length tabu) options.tabuSize then init tabu else tabu) in
-    Tabu {t with tabu = tabu}
-
-  sem initMeta =
-  | startState ->
-    let startState : SearchState = startState in
-    match startState with {cur = {assignment = Table {table = table}}} then
-      TabuSearch {tabu = Tabu {tabu = [table]}}
-    else never
-
-  sem debugMeta =
-  | TabuSearch {tabu = Tabu {tabu = tabu}} ->
-    printLn (join ["Tabu size: ", int2string (length tabu)])
-end
-
-
-let _binarySearch = lam lower : Int. lam mid : Int. lam upper : Int. lam curCost : a. lam cost : Int -> a. lam cmp : a -> a -> Int.
-  -- Avoid applying cost function on the same value twice
-  let memoized = mapInsert mid curCost (mapEmpty subi) in
-
-  recursive let work = lam mem : Map Int a. lam lower : Int. lam mid : Int. lam upper : Int. lam curCost : a.
-    if eqi lower upper then (curCost, mid)
-    else
-      let lowPoint = divi (addi lower mid) 2 in
-      let highPoint = ceilfi (divf (int2float (addi upper mid)) 2.) in
-
-      match
-        if eqi lowPoint mid then (curCost, mem)
-        else match mapLookup lowPoint mem with Some v then (v, mem)
-        else
-          let c = cost lowPoint in
-          (c, mapInsert lowPoint c mem)
-      with (lowCost, mem) then match
-        if eqi highPoint mid then (curCost, mem)
-        else match mapLookup highPoint mem with Some v then (v, mem)
-        else
-          let c = cost highPoint in
-          (c, mapInsert highPoint c mem)
-      with (highCost, mem) then
-        -- lower is better, recurse
-        if lti (cmp lowCost curCost) 0 then
-          work mem lower lowPoint mid lowCost
-        -- higher is better, recurse
-        else if lti (cmp highCost curCost) 0 then
-          work mem mid highPoint upper highCost
-        -- none is better, end
-          else (curCost, mid)
-      else never else never
-  in work memoized lower mid upper curCost
-
-utest _binarySearch 1 1 1 0 (lam x. x) subi with (0, 1)
-utest _binarySearch 1 2 3 2 (lam x. x) subi with (1, 1)
-utest _binarySearch 1 2 3 (negi 2) (lam x. negi x) subi with (negi 3, 3)
-utest _binarySearch 1 1 2 1 (lam x. x) subi with (1, 1)
-utest _binarySearch 1 3 10 9 (lam x. muli x x) subi with (1, 1)
-
-lang TuneBinarySearch = TuneLocalSearch
-   syn MetaState =
-   | BS {curIdx : Int}
-
-   sem initMeta =
-   | _ ->
-     BS {curIdx = 0}
-
-   sem step (searchState : SearchState) =
-   | BS ({curIdx = curIdx} & t) ->
-     match searchState with {cur = {assignment = Table ({table = table, holes = holes} & a), cost = curCost}, cost = costF, cmp = cmpF, inc = inc}
-     then
-       if eqi curIdx (length holes) then (None (), BS t) else
-       let h = get holes curIdx in
-       let lowerUpper = use MExprHoles in
-                        match h with TmHole {inner = HIntRange {min = min, max = max}}
-                        then (min, max)
-                        else dprintLn h; error "Binary search only supported for IntRange"
-       in
-       let curExpr = get table curIdx in
-       let curVal = match curExpr with TmConst {val = CInt {val = i}} then i else error "impossible" in
-
-       let assignmentWithVal = lam v : Int.
-         Table {a with table = set a.table curIdx (int_ v)}
-       in
-       let costFromVal = lam v : Int.
-         costF (Some inc) (assignmentWithVal v)
-       in
-
-       match _binarySearch lowerUpper.0 curVal lowerUpper.1 curCost costFromVal cmpF
-       with (bestCost, bestVal)
-       then (Some {assignment = assignmentWithVal bestVal, cost = bestCost},
-             BS {t with curIdx = addi curIdx 1})
-       else never
-     else never
-
-  sem debugMeta =
-  | BS {curIdx = i} ->
-    printLn (join ["Next index to explore: ", int2string i, "\n"])
-
-end
-
-lang MExprTune = MExpr + TuneBase end
+let _tuneMethod = lam options : TuneOptions.
+  switch options.method
+  case Exhaustive {} then use TuneDepExhaustive in tune
+  end
 
 -- Entry point for tuning
 let tuneEntry =
@@ -598,16 +531,363 @@ let tuneEntry =
 
     -- Runs the program with a given command-line input and optional timeout
     let runner = lam input : String. lam timeoutMs : Option Float.
-      sysRunCommandWithTimingTimeout (optionMap _ms2s timeoutMs) [binary] input "."
+      sysRunCommandWithTimingTimeout (optionMap _ms2s timeoutMs) [binary, input] "" "."
     in
 
-    -- Choose search method
-    (switch options.method
-     case RandomWalk {} then use TuneRandomWalk in tune
-     case SimulatedAnnealing {} then use TuneSimulatedAnnealing in tune
-     case TabuSearch {} then use TuneTabuSearch in tune
-     case Exhaustive {} then use TuneExhaustive in tune
-     case SemiExhaustive {} then use TuneSemiExhaustive in tune
-     case BinarySearch {} then use TuneBinarySearch in tune
-     end)
-     options runner holes hole2idx exp.tempFile exp.table
+    let cleanup = lam.
+      exp.cleanup ();
+      inst.cleanup ()
+    in
+
+    (_tuneMethod options) options runner env dep inst exp.tempFile cleanup
+      exp.table
+
+lang MExprTune = MExpr + TuneBase end
+lang TestLang =
+  TuneDep + GraphColoring + MExprHoleCFA + DependencyAnalysis +
+  NestedMeasuringPoints + ContextExpand + Instrumentation +
+  BootParser + MExprSym + MExprPrettyPrint + MExprEval
+end
+
+mexpr
+
+use TestLang in
+
+-- Enable debug prints
+let debug = false in
+-- Enable tests that depend on timing of runs
+let timeSensitive = false in
+
+let parse = lam str.
+  let ast = parseMExprString holeKeywords str in
+  let ast = makeKeywords [] ast in
+  symbolize ast
+in
+
+let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchState) =
+  lam debug. lam full. lam options: TuneOptions. lam expr.
+    -- Use small ANF first, needed for context expansion
+    let tANFSmall = use HoleANF in normalizeTerm expr in
+
+    -- Do graph coloring to get context information (throw away the AST).
+    match colorCallGraph [] tANFSmall with (env, _) in
+
+    -- Apply full ANF
+    let tANF = use HoleANFAll in normalizeTerm tANFSmall in
+
+    -- Perform dependency analysis
+    match
+      if full then assumeFullDependency env tANF
+      else
+        -- Perform CFA
+        let graphData = graphDataFromEnv env in
+        let cfaRes : CFAGraph = cfaData graphData tANF in
+        let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
+        (analyzeDependency env cfaRes tANF, tANF)
+    with (dep, ast) in
+
+    -- Do instrumentation
+    match instrument env dep ast with (inst, ast) in
+
+    -- Context expansion
+    match contextExpand env ast with (exp, ast) in
+
+    -- Compile the program
+    let compileOCaml = lam libs. lam clibs. lam ocamlProg.
+      let opt = {optimize = true, libraries = libs, cLibraries = clibs} in
+      ocamlCompileWithConfig opt ocamlProg
+    in
+    let cunit: CompileResult = compileMCore ast (mkEmptyHooks compileOCaml) in
+
+    -- Run the program
+    let runner = lam input : String. lam timeoutMs : Option Float.
+      let t1 = wallTimeMs () in
+      let res: ExecResult = cunit.run "" [input] in
+      let t2 = wallTimeMs () in
+      (subf t2 t1, res)
+    in
+
+    -- Run tuning
+    let cleanup = lam.
+      exp.cleanup ();
+      inst.cleanup ();
+      cunit.cleanup ()
+    in
+    use TuneDep in
+    let tune =
+      switch options.method
+      case Exhaustive () then use TuneDepExhaustive in tuneDebug
+      end
+    in
+    let res = tune options runner env dep inst exp.tempFile cleanup exp.table in
+    cleanup ();
+    res
+in
+
+type TestResult = {
+  finalTable : [Expr],
+  nbrRuns : Int
+} in
+
+let eqTable = lam t1 : [Expr]. lam t2 : [Expr].
+  use MExprEq in
+  eqSeq eqExpr t1 t2
+in
+
+let eqTest = lam lhs: (LookupTable, Option SearchState). lam rhs : TestResult.
+  match lhs with (lookupTable, searchState) in
+  match searchState with None () then
+    match rhs with {nbrRuns = 0} then true
+    else error "fail"
+  else match searchState with Some s in
+  let s : SearchState = s in
+  match s with {data = Some (TuneData {database = db})} then
+  match db with Database {runs = runs, tables = tables} then
+
+    let tableEq =
+      if timeSensitive then
+        eqTable lookupTable rhs.finalTable
+      else true
+    in
+
+    let runsEq = eqi (length tables.data) rhs.nbrRuns in
+
+    forAll (lam x. x) [
+      tableEq,
+      runsEq
+    ]
+  else error "expected database"
+  else error "expected tune data"
+in
+
+let opt = {tuneOptionsDefault with verbose = debug} in
+
+-- No holes
+let t = parse
+"
+sleepMs 1
+"
+in
+
+utest test debug false opt t with {
+  finalTable = [],
+  nbrRuns = 0
+} using eqTest in
+
+-- Empty search space due to reduction. Should do 0 runs and use the default
+-- table.
+let t = parse
+"
+let h = hole (IntRange {default = 1, min = 1, max = 3}) in
+if eqi h 1 then () else sleepMs 100
+"
+in
+
+let opt = {opt with method = Exhaustive ()} in
+
+utest test debug false {opt with reduceDependencies = 200.} t with {
+  finalTable = [int_ 1],
+  nbrRuns = 0
+} using eqTest in
+
+-- One measuring point filtered out due to reduction.
+let t = parse
+"
+let h1 = hole (IntRange {default = 1, min = 1, max = 3}) in
+let m1 = if eqi h1 1 then 1 else 2 in
+let h2 = hole (Boolean {default = true}) in
+if h2 then sleepMs 100 else sleepMs 200
+"
+in
+
+let opt = {opt with method = Exhaustive ()} in
+
+utest test true false {opt with reduceDependencies = 20.} t with {
+  finalTable = [int_ 1, true_],
+  nbrRuns = 2
+} using eqTest in
+
+-- No measuring points for some holes
+let t = parse
+"
+let h1 = hole (Boolean {default = true}) in
+let h2 = hole (Boolean {default = true}) in
+let m = if h2 then sleepMs 100 else sleepMs 0 in
+m
+" in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [true_, false_],
+  nbrRuns = 2
+} using eqTest in
+
+-- No measuring points for any holes
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+h
+" in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [true_],
+  nbrRuns = 0
+} using eqTest in
+
+
+-- The three following tests check that each of the hole values (1, 2, and 3)
+-- are found.
+let t = parse
+"
+let h = hole (IntRange {default = 1, min = 1, max = 3}) in
+if eqi h 1 then () else sleepMs 100
+"
+in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [int_ 1],
+  nbrRuns = 3
+} using eqTest in
+
+
+let t = parse
+"
+let h = hole (IntRange {default = 1, min = 1, max = 3}) in
+if eqi h 2 then () else sleepMs 100
+"
+in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [int_ 2],
+  nbrRuns = 3
+} using eqTest in
+
+
+let t = parse
+"
+let h = hole (IntRange {default = 1, min = 1, max = 3}) in
+if eqi h 3 then () else sleepMs 100
+"
+in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [int_ 3],
+  nbrRuns = 3
+} using eqTest in
+
+
+-- Two holes, independent.
+let t = parse
+"
+let h1 = hole (IntRange {default = 10, min = 10, max = 300}) in
+let h2 = hole (IntRange {default = 10, min = 10, max = 300}) in
+sleepMs h1;
+sleepMs h2
+"
+in
+
+let opt = {{tuneOptionsDefault with stepSize = 290}
+                               with verbose = debug} in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [int_ 10, int_ 10],
+  nbrRuns = 2
+} using eqTest in
+
+-- Three holes, partially dependent.
+let t = parse
+"
+let h1 = hole (IntRange {default = 10, min = 10, max = 300}) in
+let h2 = hole (IntRange {default = 10, min = 10, max = 300}) in
+let h3 = hole (IntRange {default = 10, min = 10, max = 300}) in
+sleepMs h1;
+sleepMs (addi h2 h3)
+"
+in
+
+let opt = {{tuneOptionsDefault with stepSize = 290}
+                               with verbose = debug} in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [int_ 10, int_ 10, int_ 10],
+  nbrRuns = 4
+} using eqTest in
+
+-- Four holes, example from the paper
+let t = parse
+"
+let h1 = hole (Boolean {default = true}) in
+let h2 = hole (Boolean {default = true}) in
+let h3 = hole (Boolean {default = true}) in
+let h4 = hole (Boolean {default = true}) in
+let m1 =
+  switch (h1, h2)
+  case (false, false) then 700
+  case (false, true) then 200
+  case (true, false) then 300
+  case (true, true) then 600
+  end
+in
+let m2 =
+  switch (h2, h3)
+  case (false, false) then 500
+  case (true, false) then 400
+  case (false, true) then 600
+  case (true, true) then 300
+  end
+in
+let m3 =
+  switch h4
+  case false then 100
+  case true then 200
+  end
+in
+sleepMs m1;
+sleepMs m2;
+sleepMs m3
+"
+in
+
+utest test debug false {opt with method = Exhaustive ()} t with {
+  finalTable = [false_, true_, true_, false_],
+  nbrRuns = 4
+} using eqTest in
+
+-- Input arguments
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+let a = get argv 1 in
+if h then
+  if eqi (length a) 3 then sleepMs 300
+  else ()
+else sleepMs 100
+" in
+
+utest test debug true {opt with args = ["arg"]} t with {
+  finalTable = [false_],
+  nbrRuns = 2
+} using eqTest in
+
+utest test debug true {opt with args = ["a"]} t with {
+  finalTable = [true_],
+  nbrRuns = 2
+} using eqTest in
+
+utest test debug true {opt with args = ["a","arg"]} t with {
+  finalTable = [false_],
+  nbrRuns = 2
+} using eqTest in
+
+-- No dependency analysis
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+if h then sleepMs 100 else ()
+" in
+
+utest test debug true opt t with {
+  finalTable = [false_],
+  nbrRuns = 2
+} using eqTest in
+
+()

--- a/test-files.mk
+++ b/test-files.mk
@@ -34,6 +34,7 @@ typecheck_files += test/mlang/type-alias.mc
 typecheck_files += $(wildcard stdlib/*.mc)
 typecheck_files += $(wildcard stdlib/mexpr/*.mc)
 typecheck_files += $(wildcard stdlib/ocaml/*.mc)
+typecheck_files += $(wildcard stdlib/tuning/*.mc)
 
 
 # Programs that we currently cannot compile/test. These are programs written


### PR DESCRIPTION
Adds a complete toolchain for tuning with dependency analysis. The entire folder `stdlib/tuning` now typechecks, which increases the time for `make test-all`.

Changes to `stdlib`:
- Some additions and fixes to `graph.mc`:
  - Fix spelling of `graphIsAdjacent`
  - Add `graphAddVertices`
  - Add `graphAddEdges`
  - Add `graphConnectedComponents`
  - Add `graphRemoveVertex`
- Adds a `cmpfApprox` function to `math.mc` (useful for sorting sequences of floats).
- Adds a file `stdlib/multicore/multicore.mc`, currently with one function `multicoreNbrOfCores`.
- Adds a function `minIdx` to `seq.mc` that returns an `Option (Int, a)` (index of as well as the minimum element).
- Adds a function `product` to `seq.mc` for computing the Cartesian product of a sequence of sequences.

This PR contains #571, so it should be merged after that one.