### PR TITLE
Type check `c/*.mc` and add `mexpr/externals.mc`

### DIFF
--- a/make
+++ b/make
@@ -160,9 +160,9 @@ type_check() {
   exit_code=$?
   if [ $exit_code -eq 0 ]
   then
-      echo "$msg Ok"
+      echo "$msg OK\n"
   else
-      echo "$msg FAILED with output\n$output"
+      echo "$msg FAILED with output\n$output\n"
       exit 1
   fi
   set -e

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -257,7 +257,7 @@ let merge_lang_data fi {inters= i1; syns= s1; aliases= a1}
     match (a, b) with
     | None, None ->
         None
-    | None, Some (fi,_) ->
+    | None, Some (fi, _) ->
         Some (fi, [])
     | Some a, None ->
         Some a
@@ -820,9 +820,7 @@ let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function
           , mangle cname
           , Symb.Helpers.nosym
           , TyArrow
-              ( fi
-              , desugar_ty ns ty
-              , TyCon (fi, ty_name, Symb.Helpers.nosym) )
+              (fi, desugar_ty ns ty, TyCon (fi, ty_name, Symb.Helpers.nosym))
           , tm )
       in
       (* TODO(vipa,?): the type will likely be incorrect once we start doing product extensions of constructors *)
@@ -935,8 +933,7 @@ let desugar_post_flatten_with_nss nss (Program (_, tops, t)) =
   let syntydecl =
     List.map
       (fun (syn, fi) tm' ->
-        TmType (fi, syn, Symb.Helpers.nosym, [], TyVariant (fi, []), tm')
-        )
+        TmType (fi, syn, Symb.Helpers.nosym, [], TyVariant (fi, []), tm') )
       (USMap.bindings syns)
   in
   let stack = stack @ syntydecl in

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -14,7 +14,7 @@ include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/anf.mc"
 include "mexpr/symbolize.mc"
-include "mexpr/type-annot.mc"
+include "mexpr/type-check.mc"
 include "mexpr/remove-ascription.mc"
 include "mexpr/type-lift.mc"
 include "mexpr/builtin.mc"
@@ -1354,7 +1354,7 @@ let printCompiledCProg = use CProgPrettyPrint in
 -----------
 
 lang Test =
-  MExprCCompileAlloc + MExprPrettyPrint + MExprTypeAnnot +
+  MExprCCompileAlloc + MExprPrettyPrint + MExprTypeCheck +
   MExprRemoveTypeAscription + MExprANF + MExprSym + BootParser +
   MExprTypeLift + SeqTypeNoStringTypeLift + TensorTypeTypeLift
 end
@@ -1367,8 +1367,8 @@ let compile: CompileCOptions -> Expr -> CProg = lam opts. lam prog.
   -- Symbolize with empty environment
   let prog = symbolizeExpr symEnvEmpty prog in
 
-  -- Type annotate
-  let prog = typeAnnot prog in
+  -- Type check and annotate
+  let prog = typeCheck prog in
 
   -- Remove redundant lets
   let prog = removeTypeAscription prog in

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -73,8 +73,6 @@ let _assign: CExpr -> CExpr -> CExpr = use CAst in
 -- COMPILER DEFINITIONS AND EXTERNALS --
 ----------------------------------------
 
-type ExtInfo = { ident: String, header: String }
-
 -- Collect all maps of externals. Should be done automatically at some point,
 -- but for now these files must be manually included and added to this map.
 let externalsMap: Map String ExtInfo = foldl1 mapUnion [
@@ -82,7 +80,7 @@ let externalsMap: Map String ExtInfo = foldl1 mapUnion [
 ]
 
 -- Retrieve names used for externals. Used for making sure these names are printed without modification during C code generation.
-let externalNames: [String] =
+let externalNames: [Name] =
   map nameNoSym
     (mapFoldWithKey (lam acc. lam. lam v: ExtInfo. cons v.ident acc)
        [] externalsMap)
@@ -127,22 +125,25 @@ con RIdent : Name -> Result
 con RReturn : () -> Result
 con RNone : () -> Result
 
+
+-- TODO(dlunde,2022-04-29): A bug in the MLang transformation currently
+-- prevents this fragment from being put in MExprCCompileBase
+type CompileCOptions = {
+  -- Controls whether 32-bit integers should be used. If this is false (which
+  -- is the default setting), the compiler will use 64-bit integers.
+  use32BitInts : Bool,
+
+  -- Controls whether 32-bit floating-point numbers should be used. If this
+  -- is false (which is the default setting), the compiler will use 64-bit
+  -- floats.
+  use32BitFloats : Bool
+}
+
 lang MExprCCompileBase = MExprAst + CAst
 
   --------------------------
   -- COMPILER ENVIRONMENT --
   --------------------------
-
-  type CompileCOptions = {
-    -- Controls whether 32-bit integers should be used. If this is false (which
-    -- is the default setting), the compiler will use 64-bit integers.
-    use32BitInts : Bool,
-
-    -- Controls whether 32-bit floating-point numbers should be used. If this
-    -- is false (which is the default setting), the compiler will use 64-bit
-    -- floats.
-    use32BitFloats : Bool
-  }
 
   sem defaultCompileCOptions =
   | _ -> {use32BitInts = false, use32BitFloats = false}
@@ -526,7 +527,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile
   | TyVariant _ -> acc -- These are handled by genTyPostDefs instead
   | (TyRecord { fields = fields }) & ty ->
     let labels = tyRecordOrderedLabels ty in
-    let fieldsLs: [(CType,Name)] =
+    let fieldsLs: [(CType,Option Name)] =
       foldl (lam acc. lam k.
         let ty = mapFindExn k fields in
         let ty = compileType env ty in
@@ -1055,7 +1056,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile
           [CSExpr { expr = _assign (CEVar { id = id }) (CEVar { id = n })}]
         ])
       else match res with RReturn _ then
-        if any (lam ty. isPtrType env.ptrTypes ty) (mapValues bindings) then
+        if isPtrType env.ptrTypes ty then
           infoErrorExit (infoTm t) "Returning TmRecord containing pointers is not allowed"
         else
           match compileAlloc env (None ()) t with (env, def, init, n) in

--- a/stdlib/c/externals.mc
+++ b/stdlib/c/externals.mc
@@ -1,0 +1,2 @@
+type ExtInfo = { ident: String, header: String }
+type ExtMap = Map String ExtInfo

--- a/stdlib/ext/math-ext.ext-c.mc
+++ b/stdlib/ext/math-ext.ext-c.mc
@@ -1,4 +1,5 @@
 include "map.mc"
+include "c/externals.mc"
 
 let mathExtMap: ExtMap =
   mapFromSeq cmpString [

--- a/stdlib/ext/math-ext.ext-c.mc
+++ b/stdlib/ext/math-ext.ext-c.mc
@@ -13,6 +13,10 @@ let mathExtMap: ExtMap =
 
     ( "externalPow"
     , { ident = "pow", header = "<math.h>" }
+    ),
+
+    ( "externalSqrt"
+    , { ident = "sqrt", header = "<math.h>" }
     )
 
   ]

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -55,5 +55,5 @@ let pow = lam x: Float. lam y: Float. externalPow x y
 utest pow 3. 2. with 9. using eqf
 
 external externalSqrt : Float -> Float
-let sqrt = lam x. externalSqrt x
+let sqrt: Float -> Float = lam x. externalSqrt x
 utest sqrt 9. with 3. using eqf

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -1,6 +1,6 @@
-let maxf = lam r. lam l. if gtf r l then r else l
+let maxf: Float -> Float -> Float = lam r. lam l. if gtf r l then r else l
 
-let absf = lam f. maxf f (negf f)
+let absf: Float -> Float = lam f. maxf f (negf f)
 
 let eqfApprox = lam epsilon. lam r. lam l.
   if leqf (absf (subf r l)) epsilon then true else false

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -3,7 +3,7 @@ include "ext/math-ext.mc"
 -- Float stuff
 let inf = divf 1.0 0.0
 let nan = mulf 0. inf
-let minf = lam r. lam l. if ltf r l then r else l
+let minf: Float -> Float -> Float = lam r. lam l. if ltf r l then r else l
 
 utest minf 0. 0. with 0. using eqf
 utest minf 1. 0. with 0. using eqf

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -325,8 +325,10 @@ lang ExtEq = Eq + ExtAst
   | TmExt {ident = i2, inexpr = ie2} ->
     match lhs with TmExt {ident = i1, inexpr = ie1} then
       match env with {varEnv = varEnv} in
-      let varEnv = biInsert (i1,i2) varEnv in
-      eqExprH {env with varEnv = varEnv} free ie1 ie2
+      if nameEqStr i1 i2 then -- Externals are a bit special, as the string component of their names are required to be identical
+        let varEnv = biInsert (i1,i2) varEnv in
+        eqExprH {env with varEnv = varEnv} free ie1 ie2
+      else None ()
     else None ()
 end
 
@@ -1179,9 +1181,8 @@ utest eqExpr never_ true_ with false in
 -- Ext
 let ext1 = bind_ (ext_ "x" false tyunit_) a1 in
 let ext2 = bind_ (ext_ "y" false tyunit_) a2 in
-let ext3 = bind_ (ext_ "x" false tyunit_) lam1 in
-utest ext1 with ext2 using eqExpr in
-utest eqExpr ext1 ext3 with false in
+utest ext1 with ext1 using eqExpr in
+utest eqExpr ext1 ext2 with false in
 
 -- Symbolized (and partially symbolized) terms are also supported.
 let sm = symbolize in

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -7,6 +7,7 @@ include "eq.mc"
 
 include "map.mc"
 include "name.mc"
+include "sys.mc"
 
 let _error = "Error in externals.mc: not an external in externalsMap"
 
@@ -52,9 +53,12 @@ lang MExprExternals = Externals + BootParser
   sem readExternalsFromFile : String -> Map String Expr
   sem readExternalsFromFile =
   | filename ->
-    collectExternals (parseMCoreFile
+    let tmpFile = sysTempFileMake () in
+    writeFile tmpFile (join ["include \"", filename, "\""];
+    let r = collectExternals (parseMCoreFile
       { defaultBootParserParseMCoreFileArg
-        with eliminateDeadCode = false } filename)
+        with eliminateDeadCode = false } tmpFile) in
+    sysDeleteFile tmpFile; r
 
 end
 

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -54,7 +54,7 @@ lang MExprExternals = Externals + BootParser
   sem readExternalsFromFile =
   | filename ->
     let tmpFile = sysTempFileMake () in
-    writeFile tmpFile (join ["include \"", filename, "\""];
+    writeFile tmpFile (join ["include \"", filename, "\""]);
     let r = collectExternals (parseMCoreFile
       { defaultBootParserParseMCoreFileArg
         with eliminateDeadCode = false } tmpFile) in

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -1,0 +1,63 @@
+-- Various functions for manipulating externals in MExpr ASTs
+
+include "ast.mc"
+include "boot-parser.mc"
+
+include "map.mc"
+include "name.mc"
+
+lang CollectExternals = ExtAst
+
+  -- Collects all external definitions in a program and returns a
+  -- map from external string identifiers to the variable names
+  -- they introduce. For example,
+  --
+  --   external id : Float -> Float
+  --
+  -- results in a map entry from the string id to the introduced name id.
+  sem collectExternals =
+  | expr -> collectExternalsHelper (mapEmpty cmpString) expr
+
+  sem collectExternalsHelper (acc: Map String Name) =
+  | TmExt t & expr ->
+    let str = nameGetStr t.ident in
+    -- Assumption: No two externals have the same string identifier (this is
+    -- enforced elsewhere)
+    let acc = mapInsert str t.ident acc in
+    sfold_Expr_Expr collectExternalsHelper acc expr
+  | expr -> sfold_Expr_Expr collectExternalsHelper acc expr
+
+end
+
+lang ReadExternals = BootParser
+
+  sem readExternals =
+  | filename ->
+    parseMCoreFile
+      { defaultBootParserParseMCoreFileArg with eliminateDeadCode = false } filename
+
+end
+
+lang Test = CollectExternals + ReadExternals + BootParser
+end
+
+mexpr
+use Test in
+
+let _parse = parseMExprString [] in
+
+let t = _parse "
+  external extA : () -> () in
+  external extB : Float -> Float in
+  external extC : Int -> Float in
+  ()
+------------------------" in
+utest collectExternals t with mapFromSeq cmpString [
+  let str = "extA" in (str, nameNoSym str),
+  let str = "extB" in (str, nameNoSym str),
+  let str = "extC" in (str, nameNoSym str)
+] using mapEq nameEq in
+
+dprint (readExternals "ext/math-ext.mc");
+
+()

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -2,11 +2,15 @@
 
 include "ast.mc"
 include "boot-parser.mc"
+include "ast-builder.mc"
+include "eq.mc"
 
 include "map.mc"
 include "name.mc"
 
-lang CollectExternals = ExtAst
+let _error = "Error in externals.mc: not an external in externalsMap"
+
+lang Externals = ExtAst
 
   -- Collects all external definitions in a program and returns a
   -- map from external string identifiers to the variable names
@@ -15,49 +19,143 @@ lang CollectExternals = ExtAst
   --   external id : Float -> Float
   --
   -- results in a map entry from the string id to the introduced name id.
+  sem collectExternals : Expr -> Map String Expr
   sem collectExternals =
   | expr -> collectExternalsHelper (mapEmpty cmpString) expr
 
-  sem collectExternalsHelper (acc: Map String Name) =
+  sem collectExternalsHelper : Map String Expr -> Expr -> Map String Expr
+  sem collectExternalsHelper acc =
   | TmExt t & expr ->
     let str = nameGetStr t.ident in
     -- Assumption: No two externals have the same string identifier (this is
     -- enforced elsewhere)
-    let acc = mapInsert str t.ident acc in
+    let acc = mapInsert str expr acc in
     sfold_Expr_Expr collectExternalsHelper acc expr
   | expr -> sfold_Expr_Expr collectExternalsHelper acc expr
 
+  sem prependExternals : Map String Expr -> Expr -> Expr
+  sem prependExternals externalsMap =
+  | expr -> mapFoldWithKey (lam acc. lam _k. lam v.
+        match v with TmExt t then TmExt { t with inexpr = acc }
+        else error _error
+      ) expr externalsMap
+
+  sem mergeExternalsPreferLeft
+    : Map String Expr -> Map String Expr -> Map String Expr
+  sem mergeExternalsPreferLeft e1 =
+  | e2 -> mapFoldWithKey (lam e2. lam k. lam v. mapInsert k v e2) e2 e1
+
 end
 
-lang ReadExternals = BootParser
+lang MExprExternals = Externals + BootParser
 
-  sem readExternals =
+  sem readExternalsFromFile : String -> Map String Expr
+  sem readExternalsFromFile =
   | filename ->
-    parseMCoreFile
-      { defaultBootParserParseMCoreFileArg with eliminateDeadCode = false } filename
+    collectExternals (parseMCoreFile
+      { defaultBootParserParseMCoreFileArg
+        with eliminateDeadCode = false } filename)
 
 end
 
-lang Test = CollectExternals + ReadExternals + BootParser
+
+lang Test = Externals + MExprExternals + MExprEq
 end
+
+-----------
+-- TESTS --
+-----------
 
 mexpr
 use Test in
 
-let _parse = parseMExprString [] in
+let _externalsToNames: Map String Expr -> Map String Name = lam m.
+  mapMap (lam v. match v with TmExt t then t.ident else error _error) m
+in
 
-let t = _parse "
+-- Test collectExternals
+let _testCollect = lam prog: String.
+  let expr = parseMExprString [] prog in
+  let m = collectExternals expr in
+  _externalsToNames m
+in
+
+-- Top-level
+let t = "
   external extA : () -> () in
   external extB : Float -> Float in
   external extC : Int -> Float in
   ()
 ------------------------" in
-utest collectExternals t with mapFromSeq cmpString [
+utest _testCollect t with mapFromSeq cmpString [
   let str = "extA" in (str, nameNoSym str),
   let str = "extB" in (str, nameNoSym str),
   let str = "extC" in (str, nameNoSym str)
 ] using mapEq nameEq in
 
-dprint (readExternals "ext/math-ext.mc");
+-- Nested
+let t = "
+  let x =
+    external extA : () -> () in
+    external extB : Float -> Float in
+    external extC : Int -> Float in
+    ()
+  in x
+------------------------" in
+utest _testCollect t with mapFromSeq cmpString [
+  let str = "extA" in (str, nameNoSym str),
+  let str = "extB" in (str, nameNoSym str),
+  let str = "extC" in (str, nameNoSym str)
+] using mapEq nameEq in
+
+-- Test prependExternals
+let _testPrepend: Map String Expr -> Expr = lam m. prependExternals m unit_ in
+let _ext = lam str. lam inexpr. bind_ (ext_ str false tyunit_) inexpr in
+recursive let _eqExtExpr: Expr -> Expr -> Bool = lam e1. lam e2.
+  match (e1,e2) with (TmExt t1, TmExt t2) then
+    if nameEq t1.ident t2.ident then _eqExtExpr t1.inexpr t2.inexpr
+    else false
+  else eqExpr e1 e2
+in
+
+utest _testPrepend (mapFromSeq cmpString [
+  let str = "extA" in (str, _ext str unit_),
+  let str = "extB" in (str, _ext str (int_ 1)), -- The inexpr (int) is ignored
+  let str = "extC" in (str, _ext str unit_)
+]) with bindall_ [
+  _ext "extC" unit_,
+  _ext "extB" unit_,
+  _ext "extA" unit_,
+  unit_
+] using _eqExtExpr in
+
+-- Test mergeExternalsPreferLeft
+let _testMerge = lam m1: Map String Name. lam m2: Map String Name.
+  let m1 = mapMap (lam v. next_ v false tyunit_) m1 in
+  let m2 = mapMap (lam v. next_ v false tyunit_) m2 in
+  let m = mergeExternalsPreferLeft m1 m2 in
+  _externalsToNames m
+in
+
+let extNameA = nameSym "extA" in
+let extNameB = nameSym "extB" in
+let extNameC = nameSym "extC" in
+let extNameD = nameSym "extD" in
+let extNameE = nameSym "extE" in
+utest _testMerge (mapFromSeq cmpString [
+  ("extA", extNameA),
+  ("extB", extNameB),
+  ("extC", extNameC)
+]) (mapFromSeq cmpString [
+  ("extA", nameSym "extA"),
+  ("extD", extNameD),
+  ("extE", extNameE)
+]) with (mapFromSeq cmpString [
+  ("extA", extNameA),
+  ("extB", extNameB),
+  ("extC", extNameC),
+  ("extD", extNameD),
+  ("extE", extNameE)
+]) using mapEq nameEq in
 
 ()

--- a/test-files.mk
+++ b/test-files.mk
@@ -34,6 +34,7 @@ typecheck_files += test/mlang/type-alias.mc
 typecheck_files += $(wildcard stdlib/*.mc)
 typecheck_files += $(wildcard stdlib/mexpr/*.mc)
 typecheck_files += $(wildcard stdlib/ocaml/*.mc)
+typecheck_files += $(wildcard stdlib/c/*.mc)
 typecheck_files += $(wildcard stdlib/tuning/*.mc)
 typecheck_files += stdlib/ext/ext-test.mc
 


### PR DESCRIPTION
## Major updates
- Make `c/*.mc` pass type checking.
- Add `mexpr/externals.mc` that defines functions useful for manipulating externals in the MExpr AST.

## Minor updates
- I got some NO INFO type checking errors related to language fragments when working on making `c/*.mc` and `miking-dppl` pass type checking, so I updated `mlang.mc` to propagate more info in mlang.ml. @elegios It would be great if you could have a (very) brief look at the changes.
- Add support for `externalSqrt` in the C compiler (@gizemcaylak).
- Add some type annotations to `ext/math-ext.mc` and `math.mc` that were required to make things work in `miking-dppl`.
- Add `ExtEq` fragment to `mexpr/eq.mc`.
- Add `sysTempFileMake` and `sysDeleteDir` to `sys.mc`.

## Bonus updates (2022-05-02)
- Replace `typeAnnot` with `typeCheck` in `c/compile.mc` tests.