### PR TITLE
Typechecker modifications + progress on typechecking stdlib/parser

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -79,6 +79,7 @@ end
 type env = (Symb.t * tm) list
 
 and const =
+  | CunsafeCoerce
   (* MCore intrinsics: Booleans *)
   | CBool of bool
   (* MCore intrinsics: Integers *)
@@ -548,6 +549,7 @@ let ty_info = function
 (* Checks if a constant _may_ have a side effect. It is conservative
    and returns only false if it is _sure_ to not have a side effect *)
 let const_has_side_effect = function
+  | CunsafeCoerce
   | CBool _
   | CInt _
   | Caddi _

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -25,7 +25,8 @@ let argv_boot, argv_prog =
 let builtin =
   let f c = TmConst (NoInfo, c) in
   (* MCore intrinsics: Integers *)
-  [ ("addi", f (Caddi None))
+  [ ("unsafeCoerce", f CunsafeCoerce)
+  ; ("addi", f (Caddi None))
   ; ("subi", f (Csubi None))
   ; ("muli", f (Cmuli None))
   ; ("divi", f (Cdivi None))

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -17,6 +17,8 @@ let program_output = ref uprint_string
 
 (* Returns the number of expected arguments of a constant *)
 let arity = function
+  | CunsafeCoerce ->
+      1
   (* MCore intrinsics: Booleans *)
   | CBool _ ->
       0
@@ -555,6 +557,8 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
         fail_constapp fi
   in
   match (c, v) with
+  | CunsafeCoerce, v ->
+      v
   (* MCore intrinsics: Booleans *)
   | CBool _, _ ->
       fail_constapp fi

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -221,6 +221,8 @@ type prec = Match | Lam | Semicolon | If | Tup | App | Atom
  *  TODO(dlunde,?): Precendece?
  *  TODO(dlunde,?): Break hints? *)
 let rec print_const fmt = function
+  | CunsafeCoerce ->
+      fprintf fmt "unsafeCoerce"
   (* MCore intrinsics: Booleans *)
   | CBool b ->
       fprintf fmt "%B" b

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -672,6 +672,10 @@ let asc_ = use MExprAst in
 
 -- Constants --
 
+let unsafeCoerce_ = use MExprAst in
+  lam e.
+  app_ (uconst_ (CUnsafeCoerce ())) e
+
 let int_ = use MExprAst in
   lam i.
   uconst_ (CInt {val = i})

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -607,6 +607,11 @@ end
 -- CONSTANTS --
 ---------------
 
+lang UnsafeCoerceAst = ConstAst
+  syn Const =
+  | CUnsafeCoerce {}
+end
+
 lang IntAst = ConstAst
   syn Const =
   | CInt {val : Int}
@@ -1441,7 +1446,7 @@ lang MExprAst =
   SymbAst + CmpSymbAst + SeqOpAst + FileOpAst + IOAst +
   RandomNumberGeneratorAst + SysAst + FloatIntConversionAst +
   FloatStringConversionAst + TimeAst + ConTagAst + RefOpAst + MapAst +
-  TensorOpAst + BootParserAst +
+  TensorOpAst + BootParserAst + UnsafeCoerceAst +
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +

--- a/stdlib/mexpr/builtin.mc
+++ b/stdlib/mexpr/builtin.mc
@@ -5,7 +5,8 @@ include "set.mc"
 include "stringid.mc"
 
 let builtin = use MExprAst in
-  [ ("addi", CAddi ())
+  [ ("unsafeCoerce", CUnsafeCoerce ())
+  , ("addi", CAddi ())
   , ("subi", CSubi ())
   , ("muli", CMuli ())
   , ("divi", CDivi ())

--- a/stdlib/mexpr/const-arity.mc
+++ b/stdlib/mexpr/const-arity.mc
@@ -1,5 +1,10 @@
 include "ast.mc"
 
+lang UnsafeCoerceArity = UnsafeCoerceAst
+  sem constArity =
+  | CUnsafeCoerce _ -> 1
+end
+
 lang IntArity = IntAst
   sem constArity =
   | CInt _ -> 0
@@ -247,7 +252,8 @@ lang MExprArity =
   CharArity + CmpCharArity + IntCharConversionArity +
   FloatStringConversionArity + SymbArity + CmpSymbArity + SeqOpArity +
   FileOpArity + IOArity + RandomNumberGeneratorArity + SysArity + TimeArity +
-  ConTagArity + RefOpArity + MapArity + TensorOpArity + BootParserArity
+  ConTagArity + RefOpArity + MapArity + TensorOpArity + BootParserArity +
+  UnsafeCoerceArity
 end
 
 mexpr

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -11,6 +11,11 @@ let tybootparsetree_ = tycon_ "BootParseTree"
 
 let tyvarseq_ = lam id. tyseq_ (tyvar_ id)
 
+lang UnsafeCoerceTypeAst = UnsafeCoerceAst
+  sem tyConst =
+  | CUnsafeCoerce _ -> tyall_ "a" (tyall_ "b" (tyarrow_ (tyvar_ "a") (tyvar_ "b")))
+end
+
 lang LiteralTypeAst = IntAst + FloatAst + BoolAst + CharAst
   sem tyConst =
   | CInt _ -> tyint_
@@ -390,5 +395,5 @@ lang MExprConstType =
   SymbTypeAst + CmpSymbTypeAst + SeqOpTypeAst + FileOpTypeAst + IOTypeAst +
   RandomNumberGeneratorTypeAst + SysTypeAst + FloatIntConversionTypeAst +
   FloatStringConversionTypeAst + TimeTypeAst + RefOpTypeAst + ConTagTypeAst +
-  MapTypeAst + TensorOpTypeAst + BootParserTypeAst
+  MapTypeAst + TensorOpTypeAst + BootParserTypeAst + UnsafeCoerceTypeAst
 end

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -307,6 +307,11 @@ end
 -- All constants in boot have not been implemented. Missing ones can be added
 -- as needed.
 
+lang UnsafeCoerceEval = UnsafeCoerceAst + ConstEval
+  sem delta (arg : Expr) =
+  | CUnsafeCoerce _ -> arg
+end
+
 lang ArithIntEval = ArithIntAst + ConstEval
   syn Const =
   | CAddi2 Int
@@ -2053,7 +2058,7 @@ lang MExprEval =
   SymbEval + CmpSymbEval + SeqOpEval + FileOpEval + IOEval + SysEval +
   RandomNumberGeneratorEval + FloatIntConversionEval + CmpCharEval +
   IntCharConversionEval + FloatStringConversionEval + TimeEval + RefOpEval +
-  ConTagEval + MapEval + TensorOpEval + BootParserEval
+  ConTagEval + MapEval + TensorOpEval + BootParserEval + UnsafeCoerceEval
 
   -- Patterns
   + NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -609,6 +609,11 @@ end
 -- All constants in boot have not been implemented. Missing ones can be added
 -- as needed.
 
+lang UnsafeCoercePrettyPrint = UnsafeCoerceAst + ConstPrettyPrint
+  sem getConstStringCode (indent : Int) =
+  | CUnsafeCoerce _ -> "unsafeCoerce"
+end
+
 lang IntPrettyPrint = IntAst + IntPat + ConstPrettyPrint
   sem getConstStringCode (indent : Int) =
   | CInt t -> int2string t.val
@@ -1198,7 +1203,7 @@ lang MExprPrettyPrint =
   SeqOpPrettyPrint + FileOpPrettyPrint + IOPrettyPrint +
   RandomNumberGeneratorPrettyPrint + SysPrettyPrint + TimePrettyPrint +
   ConTagPrettyPrint + RefOpPrettyPrint + MapPrettyPrint + TensorOpPrettyPrint +
-  BootParserPrettyPrint +
+  BootParserPrettyPrint + UnsafeCoercePrettyPrint +
 
   -- Patterns
   NamedPatPrettyPrint + SeqTotPatPrettyPrint + SeqEdgePatPrettyPrint +

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -101,7 +101,7 @@ lang AppTypeGetArgs = AppTypeAst
 end
 
 lang ResolveAlias = VarTypeSubstitute + AppTypeGetArgs + ConTypeAst + VariantTypeAst
-  sem resolveAlias (env : Map Name ([Name], Type)) =
+  sem tryResolveAlias (env : Map Name ([Name], Type)) =
   | ty ->
     match getTypeArgs ty with (TyCon t, args) then
       match mapLookup t.ident env with Some (params, def) then
@@ -112,10 +112,14 @@ lang ResolveAlias = VarTypeSubstitute + AppTypeGetArgs + ConTypeAst + VariantTyp
           let subst =
             foldl2 (lam s. lam v. lam t. mapInsert v t s) (mapEmpty nameCmp) params args
           in
-          resolveAlias env (substituteVars subst def)
-        else ty
+          let ty = substituteVars subst def in
+          optionOr (tryResolveAlias env ty) (Some ty)
+        else None ()
       else error "Encountered unknown constructor in resolveAlias!"
-    else ty
+    else None ()
+
+  sem resolveAlias (env : Map Name ([Name], Type)) =
+  | ty -> optionGetOr ty (tryResolveAlias env ty)
 end
 
 ----------------------
@@ -360,11 +364,21 @@ let newvar = use VarSortAst in
 let newrecvar = use VarSortAst in
   lam fields. newflexvar (RecordVar {fields = fields})
 
-lang Generalize = AllTypeAst + VarTypeSubstitute
-  -- Instantiate the top-level type variables of `ty' with fresh schematic variables.
-  sem inst (lvl : Level) =
+lang Generalize = AllTypeAst + VarTypeSubstitute + ResolveAlias + FlexTypeAst
+  sem stripTyAllAlias (env : Map Name ([Name], Type)) =
+  | ty -> stripTyAllBaseAlias env [] (resolveLink ty)
+
+  sem stripTyAllBaseAlias (env : Map Name ([Name], Type)) (vars : [(Name, VarSort)]) =
+  | TyAll t -> stripTyAllBaseAlias env (snoc vars (t.ident, t.sort)) t.ty
   | ty ->
-    match stripTyAll ty with (vars, ty) in
+    match tryResolveAlias env (resolveLink ty) with Some ty
+    then stripTyAllBaseAlias env vars ty
+    else (vars, ty)
+
+  -- Instantiate the top-level type variables of `ty' with fresh schematic variables.
+  sem inst (env : Map Name ([Name], Type)) (lvl : Level) =
+  | ty ->
+    match stripTyAllAlias env ty with (vars, ty) in
     if gti (length vars) 0 then
       let inserter = lam subst. lam v : (Name, VarSort).
         let sort = smap_VarSort_Type (substituteVars subst) v.1 in
@@ -468,7 +482,7 @@ lang VarTypeCheck = TypeCheck + VarAst
     match mapLookup t.ident env.varEnv with Some ty then
       let ty =
         if t.frozen then ty
-        else inst env.currentLvl ty
+        else inst env.tyConEnv env.currentLvl ty
       in
       TmVar {t with ty = ty}
     else
@@ -518,7 +532,7 @@ lang LetTypeCheck = TypeCheck + LetAst
       (lam. gen lvl (tyTm body))
       -- Type annotation: unify the annotated type with the inferred one
       (lam ty.
-        match stripTyAll ty with (_, tyAnnot) in
+        match stripTyAll (resolveAlias env.tyConEnv ty) with (_, tyAnnot) in
         unify env tyAnnot (tyTm body);
         ty)
       (sremoveUnknown t.tyBody)
@@ -606,7 +620,7 @@ lang ConstTypeCheck = TypeCheck + MExprConstType
   sem typeCheckBase (env : TCEnv) =
   | TmConst t ->
     recursive let f = lam ty. smap_Type_Type f (tyWithInfo t.info ty) in
-    let ty = inst env.currentLvl (f (tyConst t.val)) in
+    let ty = inst env.tyConEnv env.currentLvl (f (tyConst t.val)) in
     TmConst {t with ty = ty}
 end
 
@@ -669,7 +683,7 @@ lang DataTypeCheck = TypeCheck + DataAst
   | TmConApp t ->
     let body = typeCheckExpr env t.body in
     match mapLookup t.ident env.conEnv with Some lty then
-      match inst env.currentLvl lty with TyArrow {from = from, to = to} in
+      match inst env.tyConEnv env.currentLvl lty with TyArrow {from = from, to = to} in
       unify env (tyTm body) from;
       TmConApp {{t with body = body}
                    with ty   = to}
@@ -774,7 +788,7 @@ lang DataPatTypeCheck = TypeCheck + DataPat
   sem typeCheckPat (env : TCEnv) =
   | PatCon t ->
     match mapLookup t.ident env.conEnv with Some ty then
-      match inst env.currentLvl ty with TyArrow {from = from, to = to} in
+      match inst env.tyConEnv env.currentLvl ty with TyArrow {from = from, to = to} in
       match typeCheckPat env t.subpat with (env, subpat) in
       unify env (tyPat subpat) from;
       (env, PatCon {{t with subpat = subpat}

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -96,7 +96,7 @@ lang OCamlTypePrettyPrint =
 end
 
 lang OCamlPrettyPrint =
-  VarPrettyPrint + ConstPrettyPrint + OCamlAst +
+  ConstPrettyPrint + OCamlAst +
   IdentifierPrettyPrint + NamedPatPrettyPrint + IntPatPrettyPrint +
   CharPatPrettyPrint + BoolPatPrettyPrint + OCamlTypePrettyPrint +
   AppPrettyPrint + MExprAst-- TODO(vipa, 2021-05-12): should MExprAst be here? It wasn't before, but some of the copied constants aren't in the others
@@ -159,6 +159,7 @@ lang OCamlPrettyPrint =
   | OTmRecord _ -> true
   | OTmProject _ -> true
   | OTmLam _ -> false
+  | TmVar _ -> true
 
   sem patIsAtomic =
   | OPatRecord _ -> false
@@ -424,6 +425,7 @@ lang OCamlPrettyPrint =
 
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmVar {ident = ident} -> pprintVarName env ident
   | OTmVarExt {ident = ident} -> (env, ident)
   | OTmExprExt {expr = expr} -> (env, expr)
   | OTmConApp {ident = ident, args = []} -> pprintConName env ident

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -168,6 +168,7 @@ lang OCamlPrettyPrint =
   | OPatConExt _ -> false
 
   sem getConstStringCode (indent : Int) =
+  | CUnsafeCoerce _ -> "(fun x -> x)"
   | CInt {val = i} -> int2string i
   | CAddi _ -> "Int.add"
   | CSubi _ -> "Int.sub"

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -91,7 +91,7 @@ lang EOFTokenParser = TokenParser
     let info = makeInfo pos pos in
     {token = EOFTok {info = info}, lit = "", info = info, stream = {pos = pos, str = []}}
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | EOFTok _ -> match tokRepr with EOFRepr _ then true else false
 
   sem tokInfo =
@@ -151,7 +151,7 @@ lang LIdentTokenParser = TokenParser
       }
     else never
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | LIdentTok _ -> match tokRepr with LIdentRepr _ then true else false
 
   sem tokInfo =
@@ -188,7 +188,7 @@ lang UIdentTokenParser = TokenParser
       }
     else never
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | UIdentTok _ -> match tokRepr with UIdentRepr _ then true else false
 
   sem tokInfo =
@@ -248,7 +248,7 @@ lang UIntTokenParser = TokenParser
     , stream = {pos = pos2, str = str}
     }
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | IntTok _ -> match tokRepr with IntRepr _ then true else false
 
   sem tokInfo =
@@ -329,7 +329,7 @@ lang UFloatTokenParser = UIntTokenParser
     , stream = {pos = pos2, str = str}
     }
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | FloatTok _ -> match tokRepr with FloatRepr _ then true else false
 
   sem tokInfo =
@@ -384,7 +384,7 @@ lang OperatorTokenParser = TokenParser
       , stream = stream}
     else never
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | OperatorTok _ -> match tokRepr with OperatorRepr _ then true else false
 
   sem tokInfo =
@@ -442,7 +442,7 @@ lang BracketTokenParser = TokenParser
     let info = makeInfo pos pos2 in
     {token = RBraceTok {info = info}, lit = "}", info = info, stream = {pos = pos2, str = str}}
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | LParenTok _ -> match tokRepr with LParenRepr _ then true else false
   | RParenTok _ -> match tokRepr with RParenRepr _ then true else false
   | LBracketTok _ -> match tokRepr with LBracketRepr _ then true else false
@@ -495,7 +495,7 @@ lang SemiTokenParser = TokenParser
     let info = makeInfo pos pos2 in
     {token = SemiTok {info = info}, lit = ";", info = info, stream = {pos = pos2, str = str}}
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | SemiTok _ -> match tokRepr with SemiRepr _ then true else false
 
   sem tokInfo =
@@ -523,7 +523,7 @@ lang CommaTokenParser = TokenParser
     let info = makeInfo pos pos2 in
     {token = CommaTok {info = info}, lit = ",", info = info, stream = {pos = pos2, str = str}}
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | CommaTok _ -> match tokRepr with CommaRepr _ then true else false
 
   sem tokInfo =
@@ -580,7 +580,7 @@ lang StringTokenParser = TokenParser
       }
     else never
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | StringTok _ -> match tokRepr with StringRepr _ then true else false
 
   sem tokInfo =
@@ -616,7 +616,7 @@ lang CharTokenParser = TokenParser
       else posErrorExit pos "Expected ' to close character literal."
     else never
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | CharTok _ -> match tokRepr with CharRepr _ then true else false
 
   sem tokInfo =
@@ -659,7 +659,7 @@ lang HashStringTokenParser = TokenParser
       else posErrorExit pos2 "Expected \" to begin hash string"
     else never
 
-  sem tokKindEq (tokRepr : TokRepr) =
+  sem tokKindEq (tokRepr : TokenRepr) =
   | HashStringTok {hash = hash} -> match tokRepr with HashStringRepr {hash = hash2}
     then eqString hash hash2
     else false

--- a/test-files.mk
+++ b/test-files.mk
@@ -36,6 +36,8 @@ typecheck_files += $(wildcard stdlib/mexpr/*.mc)
 typecheck_files += $(wildcard stdlib/ocaml/*.mc)
 typecheck_files += $(wildcard stdlib/c/*.mc)
 typecheck_files += $(wildcard stdlib/tuning/*.mc)
+typecheck_files += stdlib/parser/lexer.mc
+typecheck_files += stdlib/parser/breakable.mc
 typecheck_files += stdlib/ext/ext-test.mc
 
 


### PR DESCRIPTION
This PR makes some progress towards getting everything used by `parser/tool.mc` to typecheck, currently `lexer.mc` and `breakable.mc`.

To make this work I also had to make some changes to the typechecker:
- Added `unsafeCoerce: all a. all b. a -> b` as an intrinsic. This is used to work around the lack of support for GADTs (see the note in the beginning of `breakable.mc` for details on how it's used), and will be used to make `Dyn` work for `ll1.mc`.
- The typechecker will now propagate type signatures on a `let` binding to (syntactical) lambdas in the body. This never matters for functions of rank 1, but does matter for higher rank functions, since function arguments are inferred as monomorphic in lieu of type annotations. For example, previously `let applyId : (all a. a -> a) -> (Int, Char) = lam id. (id 1, id 'c')` would not typecheck, but `let applyId = lam id: all a. a -> a. (id 1, id 'c')` would. Now both work.
- Polymorphic functions wouldn't always be instantiated when used (even through non-`frozen` variables), for two reasons:
  - `inst` would not look through aliases. Ex:
    ```
    type Id = all a. a -> a in
    let id: Id = lam x. x in
    -- This would not typecheck because `id : all a. a -> a` instead of `_a -> _a`
    id 4
    ```
  - `inst` would not look through `TyFlex` variables which meant that variables would stay frozen depending on implementation details of the typechecker. For example, `type Foo = {id : all a. a -> a} in lam foo: Foo. foo.id 1` would not typecheck, because `foo.id` is actually `match foo with {id = x} in x`, where the typevariable created for `x` initially has no information from the type of `foo`, then eventually unification makes it into a `TyFlex` pointing to a type `all a. a -> a`, but since `inst` didn't look through `TyFlex` it wasn't instantiated, thus `foo.id : all a. a -> a` instead of `foo.id : _a -> _a`.

Finally, there's a detail about how record updates are typed that I don't remember if we've discussed: I believe that currently `{foo with bar = ...}` is not allowed to change the type of `bar`. You can make an argument that that kind of update is frequently a mistake that should be caught by the compiler (I think Elm has that stance), so if you want to change the type you need to construct a new record, but that is difficult if we have row-type polymorphism, which we do want to have eventually.