### PR TITLE
Update the JSON library to not use parser combinators

### DIFF
--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -353,6 +353,9 @@ utest json2string (JsonInt 1233) with "1233" in
 utest jsonParse "-1233" with Left (JsonInt (negi 1233)) in
 utest json2string (JsonInt (negi 1233)) with "-1233" in
 
+utest jsonParse "\"foo\\u0020bar\"" with Left (JsonString "foo bar") in
+utest json2string (JsonString "foo bar") with "\"foo bar\"" in
+
 utest jsonParse "true" with Left (JsonBool true) in
 utest json2string (JsonBool true) with "true" in
 

--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -331,7 +331,7 @@ recursive let jsonEq: JsonValue -> JsonValue -> Bool =
   case (JsonFloat lv, JsonFloat rv) then eqf lv rv
   case (JsonInt lv, JsonInt rv) then eqi lv rv
   case (JsonBool lv, JsonBool rv) then eqBool lv rv
-  case (JsonNull lv, JsonNull rv) then true
+  case (JsonNull (), JsonNull ()) then true
   case _ then false
   end
 end

--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -1,184 +1,400 @@
-include "parser-combinators.mc"
-include "common.mc"
+-- Compiant with the specification from
+-- https://www.json.org/json-en.html
+-- Only divergence from the spec is the distinction between floats and integers
+
+include "either.mc"
+include "map.mc"
+include "string.mc"
 
 type JsonValue
-con JsonObject : [ (String, JsonValue) ] -> JsonValue
-con JsonArray  : [ JsonValue ]           -> JsonValue
-con JsonString : String                  -> JsonValue
-con JsonFloat  : Float                   -> JsonValue
-con JsonInt    : Int                     -> JsonValue
-con JsonBool   : Bool                    -> JsonValue
-con JsonNull   : ()                      -> JsonValue
+con JsonObject: Map String JsonValue -> JsonValue
+con JsonArray: [JsonValue] -> JsonValue
+con JsonString: String -> JsonValue
+con JsonFloat: Float -> JsonValue
+con JsonInt: Int -> JsonValue
+con JsonBool: Bool -> JsonValue
+con JsonNull: () -> JsonValue
 
 
-let withWs = wrappedIn spaces spaces
-
-let listOrSpaces = lam left. lam right. lam elem.
-  (wrappedIn left right
-    (apr spaces
-         (sepBy (lexChar ',') elem)))
-
-
-let jsonNumber =
-  let maybe = lam p. alt p (pure "") in
-  let decimals = label "decimals" (liftA2 cons (lexChar '.') lexDigits) in
-  let exponent = label "exponent" (
-    liftA2 cons (alt (lexChar 'e') (lexChar 'E'))
-           (liftA2 concat (foldr1 alt [lexString "-", lexString "+", pure ""])
-                          lexDigits))
-  in
-  let string2JsonFloat = lam x. JsonFloat (string2float x) in
-  let string2JsonInt = lam x. JsonInt (string2int x) in
-  bind (liftA2 concat (maybe (lexString "-")) lexDigits) (lam digits.
-  alt (fmap (compose string2JsonFloat (concat digits))
-            (alt exponent (liftA2 concat decimals (maybe exponent))))
-      (pure (string2JsonInt digits)))
-
-let jsonString = fmap (lam x. JsonString x) lexStringLit
-
-let jsonNull = apr (lexString "null") (pure (JsonNull ()))
-
-let lexTrue = apr (lexString "true") (pure true)
-let lexFalse = apr (lexString "false") (pure false)
-let jsonBool = fmap (lam x. JsonBool x) (alt lexTrue lexFalse)
-
+-- Parsing utilities
 recursive
--- These functions are all eta expanded, because recursive lets must begin with a lambda.
-let jsonMember = lam x.
-  let makeMember = lam k. lam v. (k, v) in
-  (liftA2 makeMember (apl (withWs lexStringLit) (lexChar ':')) jsonValue) x
+  let _jsonErrorString: Int -> String -> String =
+    lam pos. lam msg.
+    join ["Error at position ", int2string pos, ": ", msg]
 
-let jsonObject = lam x.
-  fmap (lam x. JsonObject x)
-  (listOrSpaces (lexChar '{') (lexChar '}') jsonMember) x
+  let _jsonError: Int -> String -> Either (JsonValue, String, Int) String =
+    lam pos. lam msg.
+    Right (_jsonErrorString pos msg)
 
-let jsonArray = lam x.
-  fmap (lam x. JsonArray x)
-  (listOrSpaces (lexChar '[') (lexChar ']') jsonValue) x
-
--- jsonValue : Parser JsonValue
---
--- Parse a JSON value from a string
-let jsonValue = lam x.
-  let jsonValues =
-    [ jsonObject
-    , jsonArray
-    , jsonString
-    , jsonNumber
-    , jsonBool
-    , jsonNull
-    ]
-  in
-  (withWs (foldr1 alt jsonValues)) x
-end
-
--- parseJson : String -> Option
---
--- Try to parse a JSON value from a string, returning None if the string is
--- not valid JSON.
-let parseJson = lam str.
-  match testParser jsonValue str with Success (result, _) then Some result
-  else None ()
-
-let wrapString = lam left. lam right. lam x.
-  cons left (snoc x right)
-
-let formatNull = const "null"
-let formatBool = lam b. if b then "true" else "false"
-let formatInt = int2string
-let formatFloat = float2string
-let formatString = wrapString '\"' '\"'
-
-let formatSeq = lam left. lam right. lam show. lam x.
-  let contents =
-    if null x then
-      ""
+  -- Eats whitespaces starting from the provided index
+  let _jsonEatWhitespace: String -> Int -> (String, Int) =
+    lam s. lam pos.
+    match s with [' ' | '\n' | '\r' | '\t'] ++ ws then
+      _jsonEatWhitespace ws (addi pos 1)
     else
-      let i = init x in
-      let l = last x in
-      foldr (lam v. lam s. concat (show v) (concat ", " s)) (show l) i
-  in wrapString left right contents
+      (s, pos)
 
-recursive
-let formatArray = lam x. formatSeq '[' ']' formatValue x
-let formatObject = lam x.
-  let formatMember = lam t.
-    concat (formatString t.0) (concat ": " (formatValue t.1))
-  in formatSeq '{' '}' formatMember x
+  let _jsonEatInt: [Char] -> String -> Int -> (String, String, Int) =
+    lam revacc. lam s. lam pos.
+    match s with [c] ++ ws then
+      if and (geqChar c '0') (leqChar c '9') then
+        _jsonEatInt (cons c revacc) ws (addi pos 1)
+      else
+        (reverse revacc, s, pos)
+    else
+      (reverse revacc, s, pos)
 
-let formatValue : JsonValue -> String = lam x.
-  match x with JsonObject o then
-    formatObject o
-  else match x with JsonArray a then
-    formatArray a
-  else match x with JsonString s then
-    formatString s
-  else match x with JsonFloat f then
-    formatFloat f
-  else match x with JsonInt n then
-    formatInt n
-  else match x with JsonBool b then
-    formatBool b
-  else match x with JsonNull n then
-    formatNull n
-  else
-    error "formatValue: Arg is not a JSON value"
+  let _jsonParse: String -> Int -> Either (JsonValue, String, Int) String =
+    lam s. lam pos.
+    match _jsonEatWhitespace s pos with (s, pos) in
+    match s with ['{'] ++ ws then
+      _jsonParseObject ws (addi pos 1)
+    else match s with ['['] ++ ws then
+      _jsonParseArray ws (addi pos 1)
+    else match s with ['\"'] ++ ws then
+      _jsonParseString (toList []) ws (addi pos 1)
+    else match s with ['-'] ++ ws then
+      _jsonParseNegativeNumber ws (addi pos 1)
+    else match s with ['0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'] ++ _ then
+      _jsonParseNumber s pos
+    else match s with "true" ++ ws then
+      Left (JsonBool true, ws, addi pos 4)
+    else match s with "false" ++ ws then
+      Left (JsonBool false, ws, addi pos 5)
+    else match s with "null" ++ ws then
+      Left (JsonNull (), ws, addi pos 4)
+    else
+      _jsonError pos "Invalid start to a JSON value."
+
+  let _jsonParseObject: String -> Int -> Either (JsonValue, String, Int) String =
+    lam s. lam pos.
+    match _jsonEatWhitespace s pos with (s, pos) in
+    let acc = mapEmpty cmpString in
+    match s with ['}'] ++ ws then
+      Left (JsonObject acc, ws, addi pos 1)
+    else
+      _jsonParseObjectContents acc s pos
+
+  let _jsonParseObjectContents: Map String JsonValue -> String -> Int -> Either (JsonValue, String, Int) String =
+    lam acc. lam s. lam pos.
+    match _jsonEatWhitespace s pos with (s, pos) in
+    switch _jsonParse s pos
+    case Left (JsonString key, s, pos) then
+      match _jsonEatWhitespace s pos with (s, pos) in
+      match s with [':'] ++ ws then
+        match _jsonEatWhitespace ws (addi pos 1) with (s, pos) in
+        switch _jsonParse s pos
+        case Left (value, s, pos) then
+          let acc = mapInsert key value acc in
+          match s with [','] ++ ws then
+            _jsonParseObjectContents acc ws (addi pos 1)
+          else match s with ['}'] ++ ws then
+            Left (JsonObject acc, ws, addi pos 1)
+          else
+            _jsonError pos "Expected comma or closing bracket for JSON object."
+        case Right err then
+          Right err
+        end
+      else
+        _jsonError pos "Expected colon after property key."
+    case Left _ then
+      _jsonError pos "Expected string as property key."
+    case Right err then
+      Right err
+    end
+
+  let _jsonParseArray: String -> Int -> Either (JsonValue, String, Int) String =
+    lam s. lam pos.
+    match _jsonEatWhitespace s pos with (s, pos) in
+    match s with [']'] ++ ws then
+      Left (JsonArray [], ws, addi pos 1)
+    else
+      _jsonParseArrayContents [] s pos
+
+  let _jsonParseArrayContents: [JsonValue] -> String -> Int -> Either (JsonValue, String, Int) String =
+    lam revacc. lam s. lam pos.
+    match _jsonEatWhitespace s pos with (s, pos) in
+    let result = _jsonParse s pos in
+    switch result
+    case Left (value, s, pos) then
+      let revacc = cons value revacc in
+      match _jsonEatWhitespace s pos with (s, pos) in
+      match s with [','] ++ ws then
+        _jsonParseArrayContents revacc ws (addi pos 1)
+      else match s with [']'] ++ ws then
+        Left (JsonArray (reverse revacc), ws, addi pos 1)
+      else
+        _jsonError pos "Expected comma or closing bracket of JSON array."
+    case Right err then
+      Right err
+    end
+
+  let _jsonParseString: [Char] -> String -> Int -> Either (JsonValue, String, Int) String =
+    lam revacc. lam s. lam pos.
+    match s with ['\\', c] ++ ws then
+      -- NOTE(johnwikman, 2022-05-13): Might look wierd to match at two
+      -- characters at the same time, but since we know that the following
+      -- character cannot terminate a string, we will anyways get an error if s
+      -- was just the singleton string ['\\']
+      switch c
+      case '\"' then _jsonParseString (cons ('\"') revacc) ws (addi pos 2)
+      case '\\' then _jsonParseString (cons ('\\') revacc) ws (addi pos 2)
+      case '/'  then _jsonParseString (cons ('/') revacc) ws (addi pos 2)
+      case 'b'  then _jsonParseString (cons (int2char 8) revacc) ws (addi pos 2)
+      case 'f'  then _jsonParseString (cons (int2char 12) revacc) ws (addi pos 2)
+      case 'n'  then _jsonParseString (cons ('\n') revacc) ws (addi pos 2)
+      case 'r'  then _jsonParseString (cons ('\r') revacc) ws (addi pos 2)
+      case 't'  then _jsonParseString (cons ('\t') revacc) ws (addi pos 2)
+      case 'u' then
+        match ws with [h3, h2, h1, h0] ++ ws then
+          let hex2int: Char -> Option Int = lam hc.
+            if and (geqChar hc '0') (leqChar hc '9') then
+              Some (subi (char2int hc) (char2int '0'))
+            else if and (geqChar hc 'A') (leqChar hc 'F') then
+              Some (addi (subi (char2int hc) (char2int 'A')) 10)
+            else if and (geqChar hc 'a') (leqChar hc 'f') then
+              Some (addi (subi (char2int hc) (char2int 'a')) 10)
+            else
+              None ()
+          in
+          let conv = foldl (lam acc: Option Int. lam hc.
+            match acc with Some accv then
+              match hex2int hc with Some hv then
+                Some (addi (muli accv 16) hv)
+              else None ()
+            else None ()
+          ) (Some 0) [h3, h2, h1, h0] in
+          match conv with Some v then
+            _jsonParseString (cons (int2char v) revacc) ws (addi pos 6)
+          else
+            _jsonError (addi pos 2) "Expected 4 hexadecimal characters"
+        else
+          _jsonError (addi pos 2) "Expected 4 hexadecimal characters"
+      case _ then
+        _jsonError (addi pos 1) (join [
+          "Invalid escape char \'", [c], "\' (decimal value: ",
+          int2string (char2int c), ")"
+        ])
+      end
+    else match s with ['\"'] ++ ws then
+      Left (JsonString (reverse revacc), ws, addi pos 1)
+    else match s with [c] ++ ws then
+      _jsonParseString (cons c revacc) ws (addi pos 1)
+    else
+      _jsonError pos "Non-terminated string."
+
+  let _jsonParseNegativeNumber: String -> Int -> Either (JsonValue, String, Int) String =
+    lam s. lam pos.
+    let num = _jsonParseNumber s pos in
+    switch num
+    case Left (JsonInt i, s, pos) then
+      Left (JsonInt (negi i), s, pos)
+    case Left (JsonFloat f, s, pos) then
+      Left (JsonFloat (negf f), s, pos)
+    case Left _ then
+      _jsonError pos "Internal error, did not get a number back."
+    case Right err then
+      Right err
+    end
+
+  let _jsonParseNumber: String -> Int -> Either (JsonValue, String, Int) String =
+    lam s. lam pos.
+    match s with ['0'] ++ ws then
+      _jsonParseNumberDecimals "0" ws (addi pos 1)
+    else match s with [c & ('1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9')] ++ ws then
+      match _jsonEatInt [c] ws (addi pos 1) with (intStr, ws, pos) in
+      _jsonParseNumberDecimals intStr ws pos
+    else
+      _jsonError pos "Expected a number."
+
+  let _jsonParseNumberDecimals: String -> String -> Int -> Either (JsonValue, String, Int) String =
+    lam intStr. lam s. lam pos.
+    match s with ['.'] ++ ws then
+      match _jsonEatInt [] ws (addi pos 1) with (decimals, ws, pos) in
+      if null decimals then
+        _jsonError pos "Expected decimals after dot in a number."
+      else
+        _jsonParseNumberExponent intStr decimals ws pos
+    else match s with ['e'|'E'] ++ _ then
+      _jsonParseNumberExponent intStr "0" s pos
+    else
+      Left (JsonInt (string2int intStr), s, pos)
+
+  let _jsonParseNumberExponent: String -> String -> String -> Int -> Either (JsonValue, String, Int) String =
+    lam intStr. lam decimals. lam s. lam pos.
+    match s with ['e'|'E'] ++ ws then
+      match ws with [c & ('+'|'-')] ++ ws then
+        match _jsonEatInt [] ws (addi pos 2) with (exponent, ws, pos) in
+        if null exponent then
+          _jsonError pos "Expected exponent digits."
+        else
+          let floatStr = join [intStr, ".", decimals, "e", [c], exponent] in
+          Left (JsonFloat (string2float floatStr), ws, pos)
+      else
+        match _jsonEatInt [] ws (addi pos 1) with (exponent, ws, pos) in
+        if null exponent then
+          _jsonError pos "Expected exponent digits."
+        else
+          let floatStr = join [intStr, ".", decimals, "e", exponent] in
+          Left (JsonFloat (string2float floatStr), ws, pos)
+    else
+      let floatStr = join [intStr, ".", decimals] in
+      Left (JsonFloat (string2float floatStr), s, pos)
 end
 
--- formatJson : JsonValue -> String
---
--- Format an MCore JsonValue to a JSON string representation
-let formatJson = formatValue
+-- Parses a JSON string, returning a `Left JsonValue` if the parsing was
+-- successful. Returns a `Right String` with an error message if the formatting
+-- was incorrect.
+let jsonParse: String -> Either JsonValue String = lam s.
+  let result = _jsonParse s 0 in
+  switch result
+  case Left (value, s, pos) then
+    match _jsonEatWhitespace s pos with (s, pos) in
+    if null s then
+      Left value
+    else
+      Right (_jsonErrorString pos "Trailing JSON content.")
+  case Right err then
+    Right err
+  end
+
+-- Parse JSON string, but exit on error.
+let jsonParseExn: String -> JsonValue = lam s.
+  let result = jsonParse s in
+  switch result
+  case Left value then value
+  case Right errmsg then error errmsg
+  end
+
+-- Convert JSON value to its minimal string representation
+-- TODO(johnwikman, 2022-05-13): A pprint version with indentation and linebreaks
+recursive let json2string: JsonValue -> String = lam value.
+  switch value
+  case JsonObject properties then
+    let proplist = mapFoldWithKey (lam acc. lam k. lam v.
+      snoc acc (join [json2string (JsonString k), ":", json2string v])
+    ) [] properties in
+    cons '{' (snoc (strJoin "," proplist) '}')
+  case JsonArray values then
+    cons '[' (snoc (strJoin "," (map json2string values)) ']')
+  case JsonString s then
+    let escape: [Char] -> Char -> String = lam revacc. lam c.
+      let cval: Int = char2int c in
+      if eqi cval 8 then
+        cons 'b' (cons '\\' revacc)
+      else if eqi cval 12 then
+        cons 'f' (cons '\\' revacc)
+      else if or (lti cval 20) (eqi cval 127) then
+        let tohex: Int -> Char = lam x.
+          if lti x 10 then
+            int2char (addi x (char2int '0'))
+          else
+            int2char (addi (subi x 10) (char2int 'a'))
+        in
+        cons (tohex (modi cval 16)) (
+          cons (tohex (divi cval 16)) (
+            cons '0' (cons '0' (cons 'u' (cons '\\' revacc)))))
+      else
+        switch c
+        case '\"' then cons '\"' (cons '\\' revacc)
+        case '\\' then cons '\\' (cons '\\' revacc)
+        case '/' then cons '/' (cons '\\' revacc)
+        case '\n' then cons 'n' (cons '\\' revacc)
+        case '\r' then cons 'r' (cons '\\' revacc)
+        case '\t' then cons 't' (cons '\\' revacc)
+        case _ then
+          -- NOTE(johnwikman, 2022-05-13): Ignoring the upper bound on JSON
+          -- character size here.
+          cons c revacc
+        end
+    in
+    reverse (cons '\"' (foldl escape ['\"'] s))
+  case JsonFloat f then
+    -- TODO(johnwikman, 2022-05-13): Verify that this 2string method actually
+    -- conforms to JSON. ".01" and "13." are not valid floats in JSON.
+    float2string f
+  case JsonInt i then
+    int2string i
+  case JsonBool b then
+    if b then "true" else "false"
+  case JsonNull () then
+    "null"
+  end
+end
+
+recursive let jsonEq: JsonValue -> JsonValue -> Bool =
+  lam lhs. lam rhs.
+  switch (lhs, rhs)
+  case (JsonObject lv, JsonObject rv) then mapEq jsonEq lv rv
+  case (JsonArray lv, JsonArray rv) then eqSeq jsonEq lv rv
+  case (JsonString lv, JsonString rv) then eqString lv rv
+  case (JsonFloat lv, JsonFloat rv) then eqf lv rv
+  case (JsonInt lv, JsonInt rv) then eqi lv rv
+  case (JsonBool lv, JsonBool rv) then eqBool lv rv
+  case (JsonNull lv, JsonNull rv) then true
+  case _ then false
+  end
+end
+
 
 mexpr
 
-utest parseJson "123.45" with Some (JsonFloat 123.45) in
-utest formatJson (JsonFloat 123.45) with "123.45" in
+jsonParseExn "{\"list\":[{},{}]}";
 
-utest parseJson "-1e-5" with Some (JsonFloat (negf 1e-5)) in
-utest formatJson (JsonFloat (negf 1e-5)) with "-1e-05" in
+utest jsonParse "123.45" with Left (JsonFloat 123.45) in
+utest json2string (JsonFloat 123.45) with "123.45" in
 
-utest parseJson "1233" with Some (JsonInt 1233) in
-utest formatJson (JsonInt 1233) with "1233" in
+utest jsonParse "-1e-5" with Left (JsonFloat (negf 1e-5)) in
+utest json2string (JsonFloat (negf 1e-5)) with "-1e-05" in
 
-utest parseJson "-1233" with Some (JsonInt (negi 1233)) in
-utest formatJson (JsonInt (negi 1233)) with "-1233" in
+utest jsonParse "1233" with Left (JsonInt 1233) in
+utest json2string (JsonInt 1233) with "1233" in
 
-utest parseJson "true" with Some (JsonBool true) in
-utest formatJson (JsonBool true) with "true" in
+utest jsonParse "-1233" with Left (JsonInt (negi 1233)) in
+utest json2string (JsonInt (negi 1233)) with "-1233" in
 
-utest parseJson "false" with Some (JsonBool false) in
-utest formatJson (JsonBool false) with "false" in
+utest jsonParse "true" with Left (JsonBool true) in
+utest json2string (JsonBool true) with "true" in
 
-utest parseJson "null" with Some (JsonNull ()) in
-utest formatJson (JsonNull ()) with "null" in
+utest jsonParse "false" with Left (JsonBool false) in
+utest json2string (JsonBool false) with "false" in
 
-utest parseJson "{}" with Some (JsonObject []) in
-utest formatJson (JsonObject []) with "{}" in
+utest jsonParse "null" with Left (JsonNull ()) in
+utest json2string (JsonNull ()) with "null" in
 
-utest parseJson "[]" with Some (JsonArray []) in
-utest formatJson (JsonArray []) with "[]" in
+utest jsonParse "{}" with Left (JsonObject (mapEmpty cmpString)) using eitherEq jsonEq eqString in
+utest json2string (JsonObject (mapEmpty cmpString)) with "{}" in
 
-utest parseJson "{ \t\n}" with Some (JsonObject []) in
-utest parseJson "[ \n\t]" with Some (JsonArray []) in
+utest jsonParse "[]" with Left (JsonArray []) in
+utest json2string (JsonArray []) with "[]" in
 
-utest parseJson "{\"list\":[{},{}]}" with Some (JsonObject [("list", JsonArray [JsonObject [], JsonObject []])]) in
-utest formatJson (JsonObject [("list", JsonArray [JsonObject [], JsonObject []])]) with "{\"list\": [{}, {}]}" in
-utest parseJson "[{\n}\n,[\n{\t}]\n]" with Some (JsonArray [JsonObject [], JsonArray [JsonObject []]]) in
-utest formatJson (JsonArray [JsonObject [], JsonArray [JsonObject []]]) with "[{}, [{}]]" in
+utest jsonParse "{ \t\n}" with Left (JsonObject (mapEmpty cmpString)) using eitherEq jsonEq eqString in
+utest jsonParse "[ \n\t]" with Left (JsonArray []) in
 
-utest showError (testParser jsonValue "{\"mystr\" : foo}")
-with "Parse error at 1:12: Unexpected 'f'. Expected '{' or '[' or '\"' or digit or 'true' or 'false' or 'null'" in
+
+utest jsonParse "{\"list\":[{},{}]}" with Left (JsonObject (mapFromSeq cmpString [("list", JsonArray [JsonObject (mapEmpty cmpString), JsonObject (mapEmpty cmpString)])])) using eitherEq jsonEq eqString in
+utest json2string (JsonObject (mapFromSeq cmpString [("list", JsonArray [JsonObject (mapEmpty cmpString), JsonObject (mapEmpty cmpString)])])) with "{\"list\":[{},{}]}" in
+utest jsonParse "[{\n}\n,[\n{\t}]\n]" with Left (JsonArray [JsonObject (mapEmpty cmpString), JsonArray [JsonObject (mapEmpty cmpString)]]) using eitherEq jsonEq eqString in
+utest json2string (JsonArray [JsonObject (mapEmpty cmpString), JsonArray [JsonObject (mapEmpty cmpString)]]) with "[{},[{}]]" in
+
+
+utest jsonParse "{\"mystr\" : foo}" with Right "Error at position 11: Invalid start to a JSON value." using eitherEq jsonEq eqString in
+
 let myJsonObject =
-  JsonObject [ ("mylist", JsonArray [JsonObject [], JsonInt 2, JsonFloat 3e-2])
+  JsonObject (mapFromSeq cmpString
+             [ ("mylist", JsonArray [JsonObject (mapEmpty cmpString), JsonInt 2, JsonFloat 3e-2])
              , ("mystr", JsonString "foo")
              , ("mybool", JsonBool true)
              , ("mynull", JsonNull ())
-             ]
+             ])
 in
-utest testParser jsonValue "{\"mylist\" : [{},2,3e-2], \"mystr\" : \n\"foo\", \"mybool\" :\ttrue, \"mynull\":null}abc"
-with Success (myJsonObject, ("abc", {file ="", row = 2, col = 39})) in
-utest formatValue myJsonObject
-with "{\"mylist\": [{}, 2, 0.03], \"mystr\": \"foo\", \"mybool\": true, \"mynull\": null}" in
-utest parseJson (formatValue myJsonObject) with Some myJsonObject in
+
+utest jsonParse "{\"mylist\" : [{},2,3e-2], \"mystr\" : \n\"foo\", \"mybool\" :\ttrue, \"mynull\":null}"
+with Left myJsonObject using eitherEq jsonEq eqString in
+
+utest json2string myJsonObject
+with "{\"mystr\":\"foo\",\"mybool\":true,\"mylist\":[{},2,0.03],\"mynull\":null}" in
+
+utest jsonParse (json2string myJsonObject) with Left myJsonObject using eitherEq jsonEq eqString in
+
 ()

--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -339,8 +339,6 @@ end
 
 mexpr
 
-jsonParseExn "{\"list\":[{},{}]}";
-
 utest jsonParse "123.45" with Left (JsonFloat 123.45) in
 utest json2string (JsonFloat 123.45) with "123.45" in
 

--- a/test-files.mk
+++ b/test-files.mk
@@ -44,7 +44,6 @@ typecheck_files += stdlib/ext/ext-test.mc
 # Programs that we currently cannot compile/test. These are programs written
 # before the compiler was implemented. It is forbidden to add to this list of
 # programs but removing from it is very welcome.
-compile_files_exclude += stdlib/json.mc
 compile_files_exclude += stdlib/parser-combinators.mc
 compile_files_exclude += stdlib/regex.mc
 compile_files_exclude += test/mexpr/nestedpatterns.mc

--- a/test/examples/json/genjson.py
+++ b/test/examples/json/genjson.py
@@ -17,8 +17,13 @@ def sizetype(v):
 parser = argparse.ArgumentParser()
 parser.add_argument("size", type=sizetype,
                     help="Number of elements to include in the blob.")
+parser.add_argument("--seed", metavar="VALUE", dest="seed",
+                    type=int, default=None,
+                    help="Seed to use for the randomization.")
 
 args = parser.parse_args()
+if args.seed is not None:
+    random.seed(args.seed)
 
 state = {"remaining": args.size}
 

--- a/test/examples/json/genjson.py
+++ b/test/examples/json/genjson.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import random
+
+MIN_SIZE = 1
+CHARSET = ["\n", "\t"] + \
+          [chr(c) for c in range(0x20,0x7F)]
+
+def sizetype(v):
+    v = int(v)
+    if v < MIN_SIZE:
+        raise ValueError(f"Minimum size is {MIN_SIZE}")
+    return v
+
+parser = argparse.ArgumentParser()
+parser.add_argument("size", type=sizetype,
+                    help="Number of elements to include in the blob.")
+
+args = parser.parse_args()
+
+state = {"remaining": args.size}
+
+def random_string(minlen=1, maxlen=16):
+    l = random.randint(minlen, maxlen)
+    return "".join([random.choice(CHARSET) for _ in range(l)])
+
+def gen():
+    choice = random.choice(["object", "array", "int", "float", "bool", "null"])
+    if choice == "object":
+        obj = {}
+        count = random.randint(0, state["remaining"])
+        state["remaining"] -= count
+        for _ in range(count):
+            obj[random_string()] = gen()
+        return obj
+    elif choice == "array":
+        arr = []
+        count = random.randint(0, state["remaining"])
+        state["remaining"] -= count
+        for _ in range(count):
+            arr.append(gen())
+        return arr
+    elif choice == "int":
+        return random.randint(-(2**30), 2**30)
+    elif choice == "float":
+        return random.random()
+    elif choice == "bool":
+        return (random.randint(0,1) == 0)
+    elif choice == "null":
+        return None
+
+items = []
+while state["remaining"] > 0:
+    state["remaining"] -= 1
+    items.append(gen())
+
+s = json.dumps(items)
+print(s)

--- a/test/examples/json/perftest-mc.mc
+++ b/test/examples/json/perftest-mc.mc
@@ -1,0 +1,39 @@
+-- perftest-mc.mc
+
+include "common.mc"
+include "json.mc"
+include "math.mc"
+
+let n_runs = 10
+
+mexpr
+let file = get argv 1 in
+printLn "[MCore JSON benchmark]";
+printLn (join ["loading file ", file, "..."]);
+
+let contents: String = readFile file in
+
+printLn (join ["measuring over ", int2string n_runs, " runs"]);
+
+recursive let measure = lam times. lam i.
+  if eqi i n_runs then (
+  	times
+  ) else (
+  	printLn (join ["Run ", int2string (addi i 1), "/", int2string n_runs]);
+  	let t_start = wallTimeMs () in
+  	let obj = jsonParseExn contents in
+  	let t_end = wallTimeMs () in
+  	let acc = snoc times (subf t_end t_start) in
+  	measure acc (addi i 1)
+  )
+in
+
+let times = measure [] 0 in
+
+let avg = divf (foldl addf 0.0 times) (int2float (length times)) in
+let min = foldl minf (head times) (tail times) in
+let max = foldl maxf (head times) (tail times) in
+
+printLn (join ["avg: ", float2string avg, " ms | min: ", float2string min, " ms | max: ", float2string max, " ms"]);
+
+()

--- a/test/examples/json/perftest-py.py
+++ b/test/examples/json/perftest-py.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import time
+
+N_RUNS = 10
+
+parser = argparse.ArgumentParser()
+parser.add_argument("file", type=os.path.realpath,
+                    help="File to load contents from.")
+
+args = parser.parse_args()
+
+print("[Python JSON benchmark]");
+print(f"loading file {args.file}...")
+with open(args.file) as f:
+    contents = f.read()
+
+print(f"measuring over {N_RUNS} runs")
+times = []
+for i in range(N_RUNS):
+    print(f"Run {i+1}/{N_RUNS}")
+    t_start = time.time()
+    obj = json.loads(contents)
+    t_end = time.time()
+    times.append((t_end - t_start) * 1000.0)
+
+avg = sum(times) / len(times)
+print(f"avg: {avg} ms | min: {min(times)} ms | max: {max(times)} ms")


### PR DESCRIPTION
Have tested this on JSON that are just over 6MB is size. Takes ~600 ms, which is too slow at the moment, but it works. For comparison, cpython takes just over 100 ms, and pypy takes just under 100 ms to parse the same file.