### PR TITLE
Better errors

### DIFF
--- a/mcore-comby.json
+++ b/mcore-comby.json
@@ -1,0 +1,22 @@
+{
+    "user_defined_delimiters": [
+        [ "lang", "end" ],
+        [ "(", ")" ],
+        [ "[", "]" ],
+        [ "{", "}" ],
+        [ "let", "in" ],
+        [ "recursive", "in" ],
+        [ "recursive", "end" ],
+        [ "type", "in" ],
+        [ "use", "in" ]
+    ],
+    "escapable_string_literals": {
+        "delimiters": [ "\"" ],
+        "escape_character": "\\"
+    },
+    "raw_string_literals": [],
+    "comments": [
+        [ "Multiline", "/-", "-/" ],
+        [ "Until_newline", "--" ]
+    ]
+}

--- a/stdlib/cuda/compile.mc
+++ b/stdlib/cuda/compile.mc
@@ -33,10 +33,10 @@ lang CudaCompile = MExprCCompileAlloc + CudaPMExprAst + CudaAst
   | t & (TmApp _) ->
     match collectAppArguments t with (_, args) in
     map (lam arg. compileType env (tyTm arg)) args
-  | t -> infoErrorExit (infoTm t) "Unsupported function type"
+  | t -> errorSingle [infoTm t] "Unsupported function type"
 
   sem compileExpr (env : CompileCEnv) =
-  | TmSeqMap t -> infoErrorExit t.info "Maps are not supported"
+  | TmSeqMap t -> errorSingle [t.info] "Maps are not supported"
   | TmSeqFoldl t ->
     let argTypes = _getFunctionArgTypes env t.f in
     CESeqFoldl {
@@ -59,8 +59,8 @@ lang CudaCompile = MExprCCompileAlloc + CudaPMExprAst + CudaAst
     CETensorSubExn {
       t = compileExpr env t.t, ofs = compileExpr env t.ofs,
       len = compileExpr env t.len, ty = compileType env t.ty}
-  | TmMapKernel t -> infoErrorExit t.info "Maps are not supported"
-  | TmReduceKernel t -> infoErrorExit t.info "not implemented yet"
+  | TmMapKernel t -> errorSingle [t.info] "Maps are not supported"
+  | TmReduceKernel t -> errorSingle [t.info] "not implemented yet"
   | TmLoop t | TmParallelLoop t ->
     -- NOTE(larshum, 2022-03-08): Parallel loops that were not promoted to a
     -- kernel are compiled to sequential loops.

--- a/stdlib/cuda/intrinsics/intrinsic.mc
+++ b/stdlib/cuda/intrinsics/intrinsic.mc
@@ -10,7 +10,7 @@ lang CudaIntrinsic = CudaAst + CudaCompile
     -- TODO(larshum, 2022-02-08): Assumes 1d sequence
     match _unwrapType env.typeEnv ty with TySeq {ty = ty} then
       compileType env ty
-    else infoErrorExit (infoTy ty) "Could not unwrap sequence type"
+    else errorSingle [infoTy ty] "Could not unwrap sequence type"
 
   sem _getStructDataElemType (env : CompileCEnv) =
   | cty ->

--- a/stdlib/cuda/pmexpr-ast.mc
+++ b/stdlib/cuda/pmexpr-ast.mc
@@ -96,8 +96,8 @@ lang CudaPMExprAst = PMExprAst
     let s = typeCheckExpr env t.s in
     let inElemType = newvar env.currentLvl t.info in
     let outElemType = newvar env.currentLvl t.info in
-    unify t.info env (tyTm s) (ityseq_ t.info inElemType);
-    unify t.info env (tyTm f) (ityarrow_ t.info inElemType outElemType);
+    unify [infoTm s, t.info] env (tyTm s) (ityseq_ t.info inElemType);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info inElemType outElemType);
     TmSeqMap {{{t with f = f}
                   with s = s}
                   with ty = TySeq {ty = outElemType, info = t.info}}
@@ -106,8 +106,8 @@ lang CudaPMExprAst = PMExprAst
     let acc = typeCheckExpr env t.acc in
     let s = typeCheckExpr env t.s in
     let sElemTy = newvar env.currentLvl t.info in
-    unify t.info env (tyTm s) (ityseq_ t.info sElemTy);
-    unify t.info env (tyTm f) (ityarrow_ t.info (tyTm acc)
+    unify [infoTm s, t.info] env (tyTm s) (ityseq_ t.info sElemTy);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info (tyTm acc)
                                          (ityarrow_ t.info sElemTy (tyTm acc)));
     TmSeqFoldl {{{{t with f = f}
                      with acc = acc}
@@ -117,8 +117,8 @@ lang CudaPMExprAst = PMExprAst
     let tt = typeCheckExpr env t.t in
     let slice = typeCheckExpr env t.slice in
     let elemTy = newvar env.currentLvl t.info in
-    unify t.info env (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
-    unify t.info env (tyTm slice) (ityseq_ t.info (tyWithInfo t.info tyint_));
+    unify [infoTm tt, t.info] env (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
+    unify [infoTm slice, t.info] env (tyTm slice) (ityseq_ t.info (tyWithInfo t.info tyint_));
     TmTensorSliceExn {{{t with t = tt}
                           with slice = slice}
                           with ty = tyTm tt}
@@ -127,9 +127,9 @@ lang CudaPMExprAst = PMExprAst
     let ofs = typeCheckExpr env t.ofs in
     let len = typeCheckExpr env t.len in
     let elemTy = newvar env.currentLvl t.info in
-    unify t.info env (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
-    unify t.info env (tyTm ofs) (tyWithInfo t.info tyint_);
-    unify t.info env (tyTm len) (tyWithInfo t.info tyint_);
+    unify [infoTm tt, t.info] env (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
+    unify [infoTm ofs, t.info] env (tyTm ofs) (tyWithInfo t.info tyint_);
+    unify [infoTm len, t.info] env (tyTm len) (tyWithInfo t.info tyint_);
     TmTensorSubExn {{{{t with t = tt}
                          with ofs = ofs}
                          with len = len}
@@ -139,8 +139,8 @@ lang CudaPMExprAst = PMExprAst
     let s = typeCheckExpr env t.s in
     let inElemType = newvar env.currentLvl t.info in
     let outElemType = newvar env.currentLvl t.info in
-    unify t.info env (tyTm s) (ityseq_ t.info inElemType);
-    unify t.info env (tyTm f) (ityarrow_ t.info inElemType outElemType);
+    unify [infoTm s, t.info] env (tyTm s) (ityseq_ t.info inElemType);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info inElemType outElemType);
     TmMapKernel {{{t with f = f}
                      with s = s}
                      with ty = TySeq {ty = outElemType, info = t.info}}
@@ -150,8 +150,8 @@ lang CudaPMExprAst = PMExprAst
     let s = typeCheckExpr env t.s in
     let seqElemTy = newvar env.currentLvl t.info in
     let neTy = tyTm ne in
-    unify t.info env (tyTm s) (ityseq_ t.info neTy);
-    unify t.info env (tyTm f) (ityarrow_ t.info neTy (ityarrow_ t.info neTy neTy));
+    unify [infoTm s, t.info] env (tyTm s) (ityseq_ t.info neTy);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info neTy (ityarrow_ t.info neTy neTy));
     TmReduceKernel {{{{t with f = f}
                          with ne = ne}
                          with s = s}
@@ -160,8 +160,8 @@ lang CudaPMExprAst = PMExprAst
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify t.info env (tyTm n) (tyWithInfo t.info tyint_);
-    unify t.info env (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
+    unify [infoTm n, t.info] env (tyTm n) (tyWithInfo t.info tyint_);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
     TmLoopKernel {{{t with n = n}
                       with f = f}
                       with ty = unitType}

--- a/stdlib/cuda/wrapper.mc
+++ b/stdlib/cuda/wrapper.mc
@@ -97,8 +97,7 @@ lang CudaCWrapperBase = PMExprCWrapper + CudaAst + MExprAst + CudaCompile
         CTyPtr {ty = CTyVar {id = id}}
       else CTyVar {id = id}
     else
-      infoErrorExit
-        (infoTy ty)
+      errorSingle [infoTy ty]
         "Reverse type lookup failed when generating CUDA wrapper code"
   | ty & (TySeq _ | TyTensor _ | TyVariant _) ->
     match env with CudaTargetEnv cenv in
@@ -107,8 +106,7 @@ lang CudaCWrapperBase = PMExprCWrapper + CudaAst + MExprAst + CudaCompile
         CTyPtr {ty = CTyVar {id = id}}
       else CTyVar {id = id}
     else
-      infoErrorExit
-        (infoTy ty)
+      errorSingle [infoTy ty]
         "Reverse type lookup failed when generating CUDA wrapper code"
   | ty ->
     match env with CudaTargetEnv cenv in
@@ -118,8 +116,7 @@ lang CudaCWrapperBase = PMExprCWrapper + CudaAst + MExprAst + CudaCompile
   | TyFloat _ -> CTyDouble ()
   | TyInt _ -> CTyInt64 ()
   | ty ->
-      infoErrorExit
-        (infoTy ty)
+      errorSingle [infoTy ty]
         "Type is not supported for CUDA tensors yet"
 
   sem _generateCDataRepresentation (env : CWrapperEnv) =
@@ -149,7 +146,7 @@ lang CudaCWrapperBase = PMExprCWrapper + CudaAst + MExprAst + CudaCompile
           match mapLookup label t.fields with Some ty then
             let ty = _unwrapType cenv.compileCEnv.typeEnv ty in
             _generateCudaDataRepresentation env ty
-          else infoErrorExit t.info "Inconsistent labels in record type")
+          else errorSingle [t.info] "Inconsistent labels in record type")
         labels in
     CudaRecordRepr {
       ident = nameSym "cuda_rec_tmp", labels = labels, fields = fields,
@@ -169,7 +166,7 @@ lang CudaCWrapperBase = PMExprCWrapper + CudaAst + MExprAst + CudaCompile
   | ty & (TyCon _) ->
     match env.targetEnv with CudaTargetEnv cenv in
     let ty = _unwrapType cenv.compileCEnv.typeEnv ty in
-    match ty with TyCon _ then infoErrorExit (infoTy ty) "Could not unwrap type"
+    match ty with TyCon _ then errorSingle [infoTy ty] "Could not unwrap type"
     else  _generateCudaDataRepresentation env ty
   | ty ->
     CudaBaseTypeRepr {

--- a/stdlib/error.mc
+++ b/stdlib/error.mc
@@ -1,3 +1,48 @@
+/-
+
+This module provides functions for highlighting sections of a file,
+primarily intended for error reporting in a compiler.
+
+The underlying workhorse is `formatHighlights`, which takes the source
+of a file and a sequence of ranges to highlight (`Highlight`s,
+essentially `Info`s with some extra information).
+
+There is also a high-level interface for reporting errors and
+immediately exiting. This centers around the `ErrorSection` type:
+
+```
+type ErrorSection = {msg : String, multi : String, info : Info, infos : [Info]}
+let err : ErrorSection = {msg = "", multi = "", info = NoInfo (), infos = []}
+```
+
+An `ErrorSection` represents a single contiguous range in a file,
+possibly with multiple sub-ranges to highlight, and with an optional
+related message. Typically you would construct this through record
+updates on `err`, since most fields are optional:
+
+- `infos`: The ranges to highlight. Default to [`info`] if absent.
+- `info`: The complete section to display. Defaults to `foldl
+  mergeInfo (NoInfo ()) infos` if absent.
+- `msg`: The message to display above the highlighted section, if any.
+- `multi`: Used instead of `msg` if present and `infos` contains at
+  least two elements (useful for pluralizing messages).
+
+There are three functions for displaying an error and immediately
+exiting:
+- `errorGeneral` takes a sequence of `ErrorSection`s and a record with
+  two fields (both are optional):
+  - `single`: The message to display if only one `ErrorSection` is
+    given.
+  - `multi`: The message to display if more than one `ErrorSection` is
+    given. Defaults to `single` if absent.
+- `errorSingle` is a helper for when you have only one section; it
+  takes a sequence of `Info`s and the error message as a `String`.
+- `errorMulti` correspondingly handles the simplest case with multiple
+  sections; it takes a sequence of `(Info, String)`, treating each as
+  a section, as well as the error message as a `String`.
+
+-/
+
 include "seq.mc"
 include "char.mc"
 include "map.mc"

--- a/stdlib/futhark/record-lift.mc
+++ b/stdlib/futhark/record-lift.mc
@@ -94,7 +94,7 @@ lang FutharkRecordParamLift = FutharkAst
                  ty = FTyArrow {from = tyFutTm extraArg,
                                 to = tyFutTm acc,
                                 info = info}}
-        else infoErrorExit info "")
+        else errorSingle [info] "")
       (_constructAppSeq target appArgs)
       addedArgs
 
@@ -151,7 +151,7 @@ lang FutharkRecordParamLift = FutharkAst
           -- record projections found here should also be found in the
           -- collection phase. If we were to get here, there is a bug in the
           -- implementation. What would be a good error message here?
-          infoErrorExit t.info "Failed to replace record with its fields"
+          errorSingle [t.info] "Failed to replace record with its fields"
       else smap_FExpr_FExpr (replaceProjections paramReplace) (FERecordProj t)
     else smap_FExpr_FExpr (replaceProjections paramReplace) (FERecordProj t)
   | t -> smap_FExpr_FExpr (replaceProjections paramReplace) t

--- a/stdlib/futhark/wrapper.mc
+++ b/stdlib/futhark/wrapper.mc
@@ -58,8 +58,7 @@ lang FutharkCWrapperBase = PMExprCWrapper
   | TyChar _ -> CTyChar ()
   | ty ->
     let tystr = use MExprPrettyPrint in type2str ty in
-    infoErrorExit
-      (infoTy ty)
+    errorSingle [infoTy ty]
       (join ["Type ", tystr, " is not supported by C wrapper"])
 
   sem _generateCDataRepresentation (env : CWrapperEnv) =
@@ -81,11 +80,9 @@ lang FutharkCWrapperBase = PMExprCWrapper
         elemTy = mexprToCType elemType}
     else
       let tystr = use MExprPrettyPrint in type2str (TySeq ty) in
-      infoErrorExit
-        ty.info
-        (join ["Sequences of ", tystr, " are not supported in Futhark wrapper"])
+      errorSingle [ty.info] (join ["Sequences of ", tystr, " are not supported in Futhark wrapper"])
   | TyTensor {info = info} ->
-    infoErrorExit info "Tensors are not supported in Futhark wrapper"
+    errorSingle [info] "Tensors are not supported in Futhark wrapper"
   | (TyRecord t) & ty ->
     let labels = tyRecordOrderedLabels ty in
     let fields : [CDataRepr] =
@@ -94,7 +91,7 @@ lang FutharkCWrapperBase = PMExprCWrapper
           match mapLookup label t.fields with Some ty then
             _generateFutharkDataRepresentation ty
           else
-            infoErrorExit t.info "Inconsistent labels in record type")
+            errorSingle [t.info] "Inconsistent labels in record type")
         labels in
     FutharkRecordRepr {fields = fields}
   | ty -> FutharkBaseTypeRepr {ident = nameSym "c_tmp", ty = mexprToCType ty}

--- a/stdlib/javascript/compile.mc
+++ b/stdlib/javascript/compile.mc
@@ -144,7 +144,7 @@ lang MExprJSCompile = MExprAst + JSProgAst
     -- Check if sequence of characters, then concatenate them into a string
     if _isCharSeq tms then
       match (_charSeq2String tms) with Some str then JSEString { s = str }
-      else infoErrorExit (infoTm t) "Non-literal strings currently unsupported."
+      else errorSingle [infoTm t] "Non-literal strings currently unsupported."
     else
       -- infoErrorExit (infoTm t) "Non-literal strings currently unsupported."
       -- Else compile each expression in sequence and return a list

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -10,6 +10,7 @@ include "pprint.mc"
 include "symbolize.mc"
 include "eq.mc"
 include "info.mc"
+include "error.mc"
 
 lang ANF = LetAst + VarAst + UnknownTypeAst
 
@@ -166,7 +167,7 @@ lang RecLetsANFBase = ANF + RecLetsAst + LamAst
     let bindings = map (
       lam b: RecLetBinding. { b with body =
         match b.body with TmLam _ & t then normalizeLams t
-        else infoErrorExit (infoTm b.body)
+        else errorSingle [infoTm b.body]
           "Error: Not a TmLam in TmRecLet binding in ANF transformation"
       }
     )

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -4,6 +4,7 @@
 include "mexpr/ast.mc"
 include "assoc.mc"
 include "info.mc"
+include "error.mc"
 include "stringid.mc"
 include "map.mc"
 
@@ -423,7 +424,7 @@ let nreclets_add = use MExprAst in
     let newbind = {ident = n, tyBody = ty, body = body, info = NoInfo ()} in
     TmRecLets {t with bindings = cons newbind t.bindings}
   else
-    infoErrorExit (infoTm reclets) "reclets is not a TmRecLets construct"
+    errorSingle [infoTm reclets] "reclets is not a TmRecLets construct"
 
 let reclets_add = use MExprAst in
   lam s. lam ty. lam body. lam reclets.
@@ -465,7 +466,7 @@ let var_ = use MExprAst in
 let freeze_ = use MExprAst in
   lam var.
   match var with TmVar t then TmVar {t with frozen = true}
-  else infoErrorExit (infoTm var) "var is not a TmVar construct"
+  else errorSingle [infoTm var] "var is not a TmVar construct"
 
 let nconapp_ = use MExprAst in
   lam n. lam b.
@@ -570,7 +571,7 @@ let record_add = use MExprAst in
   match record with TmRecord t then
       TmRecord {t with bindings = mapInsert (stringToSid key) value t.bindings}
   else
-      infoErrorExit (infoTm record) "record is not a TmRecord construct"
+      errorSingle [infoTm record] "record is not a TmRecord construct"
 
 let record_add_bindings : [(String, Expr)] -> Expr -> Expr =
   lam bindings. lam record.
@@ -589,7 +590,7 @@ let matchall_ = use MExprAst in
     foldr1 (lam m. lam acc.
       match m with TmMatch t then
         TmMatch {t with els = acc}
-      else infoErrorExit (infoTm m) "expected match expression")
+      else errorSingle [infoTm m] "expected match expression")
       matches
 
 let nrecordproj_ = use MExprAst in

--- a/stdlib/mexpr/call-graph.mc
+++ b/stdlib/mexpr/call-graph.mc
@@ -15,7 +15,7 @@ lang MExprCallGraph = MExprAst
     let g = _addGraphVertices g (TmRecLets {t with inexpr = unit_}) in
     _addGraphCallEdges g t.bindings
   | t ->
-    infoErrorExit (infoTm t) (join ["A call graph can only be constructed ",
+    errorSingle [infoTm t] (join ["A call graph can only be constructed ",
                                     "from a recursive let-expression"])
 
   sem _addGraphVertices (g : Digraph Name Int) =

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -17,7 +17,7 @@ lang Cmp = Ast
   | (lhs, rhs) /- (Expr, Expr) -/ ->
     let res = subi (constructorTag lhs) (constructorTag rhs) in
     if eqi res 0 then
-      infoErrorExit (mergeInfo (infoTm lhs) (infoTm rhs))
+      errorSingle [infoTm lhs, infoTm rhs]
                     "Missing case in cmpExprH for expressions with equal indices."
     else res
 
@@ -37,7 +37,7 @@ lang Cmp = Ast
   | (lhs, rhs) /- (Pat, Pat) -/ ->
     let res = subi (constructorTag lhs) (constructorTag rhs) in
     if eqi res 0 then
-      infoErrorExit (mergeInfo (infoPat lhs) (infoPat rhs))
+      errorSingle [infoPat lhs, infoPat rhs]
                     "Missing case in cmpPatH for patterns with equal indices."
     else res
 
@@ -49,7 +49,7 @@ lang Cmp = Ast
   | (lhs, rhs) /- (Type, Type) -/ ->
     let res = subi (constructorTag lhs) (constructorTag rhs) in
     if eqi res 0 then
-      infoErrorExit (mergeInfo (infoTy lhs) (infoTy rhs))
+      errorSingle [infoTy lhs, infoTy rhs]
                     "Missing case in cmpTypeH for types with equal indices."
     else res
 end

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -38,7 +38,7 @@ lang FunCPS = LamSym + LamEq + UnknownTypeAst + UnknownTypeEq
       t.lhs
 
   sem cpsM =
-  | TmApp t -> infoErrorExit t.info "CPS: TmApp is not atomic"
+  | TmApp t -> errorSingle [t.info] "CPS: TmApp is not atomic"
   | TmVar t -> TmVar t
   | TmLam t ->
     let k = nameSym "k" in

--- a/stdlib/mexpr/keyword-maker.mc
+++ b/stdlib/mexpr/keyword-maker.mc
@@ -10,6 +10,7 @@
 
 include "ast.mc"
 include "info.mc"
+include "error.mc"
 include "mexpr.mc"
 include "ast-builder.mc"
 include "eq.mc"
@@ -25,7 +26,7 @@ lang KeywordMakerBase = VarAst + AppAst
   | _ -> None ()
 
   sem makeKeywordError (info: Info) (n1: Int) (n2: Int) =
-  | ident -> infoErrorExit info (join ["Unexpected number of arguments for construct '",
+  | ident -> errorSingle [info] (join ["Unexpected number of arguments for construct '",
              ident, "'. ", "Expected ", int2string n1,
              " arguments, but found ", int2string n2, "."])
 
@@ -61,7 +62,7 @@ lang KeywordMakerData = KeywordMakerBase + DataAst
   | TmConDef r ->
      let ident = nameGetStr r.ident in
      match matchKeywordString r.info ident with Some _ then
-       infoErrorExit r.info (join ["Keyword '", ident,
+       errorSingle [r.info] (join ["Keyword '", ident,
        "' cannot be used in a constructor definition."])
      else TmConDef {r with inexpr = makeKeywords [] r.inexpr}
 end
@@ -72,7 +73,7 @@ lang KeywordMakerLam = KeywordMakerBase + LamAst
   | TmLam r ->
      let ident = nameGetStr r.ident in
      match matchKeywordString r.info ident with Some _ then
-       infoErrorExit r.info (join ["Keyword '", ident, "' cannot be used in a lambda expressions."])
+       errorSingle [r.info] (join ["Keyword '", ident, "' cannot be used in a lambda expressions."])
      else TmLam {r with body = makeKeywords [] r.body}
 end
 
@@ -83,7 +84,7 @@ lang KeywordMakerLet = KeywordMakerBase + LetAst
   | TmLet r ->
      let ident = nameGetStr r.ident in
      match matchKeywordString r.info ident with Some _ then
-       infoErrorExit r.info (join ["Keyword '", ident, "' cannot be used in a let expressions."])
+       errorSingle [r.info] (join ["Keyword '", ident, "' cannot be used in a let expressions."])
      else
        TmLet {{r with body = makeKeywords [] r.body} with inexpr = makeKeywords [] r.inexpr}
 end
@@ -96,7 +97,7 @@ lang KeywordMakerMatch = KeywordMakerBase + MatchAst + NamedPat
       match r.ident with PName name then
         let ident = nameGetStr name in
         match matchKeywordString r.info ident with Some _ then
-          infoErrorExit r.info (join ["Keyword '", ident, "' cannot be used inside a pattern."])
+          errorSingle [r.info] (join ["Keyword '", ident, "' cannot be used inside a pattern."])
         else PatNamed r
       else PatNamed r
   | pat -> smap_Pat_Pat matchKeywordPat pat

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -210,7 +210,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
             let appType =
               match tyTm acc with TyArrow {to = to} then
                 to
-              else infoErrorExit info "Application on non-arrow type"
+              else errorSingle [info] "Application on non-arrow type"
             in
             TmApp {lhs = acc, rhs = x, ty = appType, info = info})
           (TmVar {ident = t.ident, ty = tyBody, info = info, frozen = false})
@@ -221,7 +221,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
         (subMap, TmLet {{{t with tyBody = tyBody}
                             with body = body}
                             with inexpr = inexpr})
-    else infoErrorExit t.info (join ["Found no free variable solution for ",
+    else errorSingle [t.info] (join ["Found no free variable solution for ",
                                      nameGetStr t.ident])
   | TmRecLets t ->
     let addBindingSubExpression =
@@ -240,13 +240,13 @@ lang LambdaLiftInsertFreeVariables = MExprAst
               let appType =
                 match tyTm acc with TyArrow {to = to} then
                   to
-                else infoErrorExit info "Application on non-arrow type"
+                else errorSingle [info] "Application on non-arrow type"
               in
               TmApp {lhs = acc, rhs = x, ty = appType, info = info})
             (TmVar {ident = bind.ident, ty = bindType, info = info, frozen = false})
             (reverse (mapBindings freeVars)) in
         mapInsert bind.ident subExpr subMap
-      else infoErrorExit bind.info (join ["Lambda lifting error: No solution found for binding ",
+      else errorSingle [bind.info] (join ["Lambda lifting error: No solution found for binding ",
                                           nameGetStr bind.ident])
     in
     let insertFreeVarsBinding =
@@ -265,7 +265,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
         let tyBody = tyTm body in
         match insertFreeVariablesH solutions subMap body with (subMap, body) in
         (subMap, {{bind with tyBody = tyBody} with body = body})
-      else infoErrorExit bind.info (join ["Lambda lifting error: No solution found for binding ",
+      else errorSingle [bind.info] (join ["Lambda lifting error: No solution found for binding ",
                                           nameGetStr bind.ident])
     in
     let subMap = foldl addBindingSubExpression subMap t.bindings in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -282,7 +282,7 @@ lang AppPrettyPrint = PrettyPrint + AppAst
       match printArgs aindent env (tail apps) with (env,args) then
         (env, join [fun, pprintNewline aindent, args])
       else never
-    else infoErrorExit t.info "Impossible"
+    else errorSingle [t.info] "Impossible"
 end
 
 lang LamPrettyPrint = PrettyPrint + LamAst + UnknownTypeAst

--- a/stdlib/mexpr/record.mc
+++ b/stdlib/mexpr/record.mc
@@ -3,6 +3,7 @@
 
 include "stringid.mc"
 include "mexpr/ast.mc"
+include "error.mc"
 
 let recordOrderedLabels = lam labels: [SID].
   let isTupleLabel = lam sid.
@@ -23,7 +24,7 @@ let tyRecordOrderedLabels = use RecordTypeAst in
   match ty with TyRecord {fields = fields} then
     recordOrderedLabels (mapKeys fields)
   else
-    infoErrorExit (infoTy ty) "Not a TyRecord, cannot extract labels."
+    errorSingle [infoTy ty] "Not a TyRecord, cannot extract labels."
 
 let tyRecordOrderedFields = use RecordTypeAst in
   lam ty: Type.
@@ -31,4 +32,4 @@ let tyRecordOrderedFields = use RecordTypeAst in
     let labels = recordOrderedLabels (mapKeys fields) in
     map (lam sid. (sid, mapFindExn sid fields)) labels
   else
-    infoErrorExit (infoTy ty) "Not a TyRecord, cannot extract fields."
+    errorSingle [infoTy ty] "Not a TyRecord, cannot extract fields."

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -13,6 +13,7 @@ include "ast.mc"
 include "ast-builder.mc"
 include "builtin.mc"
 include "info.mc"
+include "error.mc"
 include "pprint.mc"
 
 ---------------------------
@@ -108,7 +109,7 @@ lang VarSym = Sym + VarAst
         let ident =
           match mapLookup str varEnv with Some ident then ident
           else if env.allowFree then t.ident
-          else infoErrorExit t.info (concat "Unknown variable in symbolizeExpr: " str)
+          else errorSingle [t.info] (concat "Unknown variable in symbolizeExpr: " str)
         in
         TmVar {{t with ident = ident}
                   with ty = symbolizeType env t.ty}
@@ -318,7 +319,7 @@ lang DataSym = Sym + DataAst
         let ident =
           match mapLookup str conEnv with Some ident then ident
           else if env.allowFree then t.ident
-          else infoErrorExit t.info (concat "Unknown constructor in symbolizeExpr: " str)
+          else errorSingle [t.info] (concat "Unknown constructor in symbolizeExpr: " str)
         in
         TmConApp {{{t with ident = ident}
                       with body = symbolizeExpr env t.body}
@@ -354,7 +355,7 @@ lang VariantTypeSym = VariantTypeAst
   sem symbolizeType (env : SymEnv) =
   | TyVariant t & ty ->
     if eqi (mapLength t.constrs) 0 then ty
-    else infoErrorExit t.info "Symbolizing non-empty variant types not yet supported"
+    else errorSingle [t.info] "Symbolizing non-empty variant types not yet supported"
 end
 
 lang ConTypeSym = ConTypeAst + UnknownTypeAst
@@ -368,7 +369,7 @@ lang ConTypeSym = ConTypeAst + UnknownTypeAst
           TyCon {t with ident = ident}
         else if env.strictTypeVars then
           if env.allowFree then TyCon t
-          else infoErrorExit t.info (concat "Unknown type constructor in symbolizeExpr: " str)
+          else errorSingle [t.info] (concat "Unknown type constructor in symbolizeExpr: " str)
         else
           TyUnknown {info = t.info}
     else never
@@ -385,7 +386,7 @@ lang VarTypeSym = VarTypeAst + UnknownTypeAst
                   with level = lvl}
       else if env.strictTypeVars then
         if env.allowFree then TyVar t
-        else infoErrorExit t.info (concat "Unknown type variable in symbolizeExpr: " str)
+        else errorSingle [t.info] (concat "Unknown type variable in symbolizeExpr: " str)
       else
         TyUnknown {info = t.info}
 end
@@ -455,7 +456,7 @@ lang DataPatSym = DataPat
         else
           let str = nameGetStr r.ident in
           match mapLookup str conEnv with Some ident then ident
-          else infoErrorExit r.info (concat "Unknown constructor in symbolizeExpr: " str)
+          else errorSingle [r.info] (concat "Unknown constructor in symbolizeExpr: " str)
       in
       match symbolizePat env patEnv r.subpat with (patEnv, subpat) then
         (patEnv, PatCon {{r with ident = ident} with subpat = subpat})

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -102,7 +102,7 @@ lang ConCompatibleType = CompatibleType + ConTypeAst
   sem reduceType (tyEnv : Map Name Type) =
   | TyCon {info = info, ident = id} ->
     match mapLookup id tyEnv with Some ty then Some ty else
-      infoErrorExit info (concat "Unbound TyCon in reduceType: " (nameGetStr id))
+      errorSingle [info] (concat "Unbound TyCon in reduceType: " (nameGetStr id))
 
 end
 
@@ -245,7 +245,7 @@ lang VarTypeAnnot = TypeAnnot + VarAst
               "Variable annotated with type: ", _pprintType t.ty, "\n",
               "Type in variable environment: ", _pprintType ty
             ] in
-            infoErrorExit t.info msg
+            errorSingle [t.info] msg
         else t.ty
       else never
     in
@@ -308,7 +308,7 @@ lang LetTypeAnnot = TypeAnnot + TypePropagation + LetAst +  UnknownTypeAst + All
           "Expected type: ", _pprintType (tyTm body), "\n",
           "Annotated type: ", _pprintType t.tyBody
         ] in
-        infoErrorExit t.info msg
+        errorSingle [t.info] msg
     else never
 end
 
@@ -334,7 +334,7 @@ lang PropagateArrowLambda = TypePropagation + FunTypeAst + LamAst
         "Type from let: ", _pprintType from, "\n",
         "Type from lambda: ", _pprintType t.tyIdent
       ] in
-      infoErrorExit t.info msg
+      errorSingle [t.info] msg
 end
 
 lang ExpTypeAnnot = TypeAnnot + ExtAst
@@ -376,7 +376,7 @@ lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsAst + LamAst + Unkn
               "Expected type: ", _pprintType (tyTm body), "\n",
               "Annotated type: ", _pprintType binding.tyBody
             ] in
-            infoErrorExit t.info msg
+            errorSingle [t.info] msg
         in
         {{binding with body = body}
                   with tyBody = tyBody}
@@ -472,12 +472,12 @@ lang DataTypeAnnot = TypeAnnot + DataAst + MExprEq
                 "Constructor expected argument of type ", _pprintType from,
                 ", but the actual type was ", _pprintType (tyTm body)
               ] in
-              infoErrorExit t.info msg
+              errorSingle [t.info] msg
           else (ityunknown_ t.info)
         else
           let msg = join ["Application of untyped constructor: ",
                           nameGetStr t.ident] in
-          infoErrorExit t.info msg
+          errorSingle [t.info] msg
       in
       TmConApp {{t with body = body}
                    with ty = ty}
@@ -532,20 +532,20 @@ lang UtestTypeAnnot = TypeAnnot + UtestAst + MExprEq
               _pprintType rty, ", got argument of incompatible type ",
               _pprintType (tyTm expected)
             ] in
-            infoErrorExit t.info msg
+            errorSingle [t.info] msg
         else
           let msg = join [
             "Custom equality function expected left-hand side of type ",
             _pprintType lty, ", got argument of incompatible type ",
             _pprintType (tyTm test)
           ] in
-          infoErrorExit t.info msg
+          errorSingle [t.info] msg
       else
         let msg = join [
           "Equality function was found to have incorrect type.\n",
           "Type was inferred to be ", _pprintType (tyTm tu)
         ] in
-        infoErrorExit t.info msg
+        errorSingle [t.info] msg
     else match compatibleType env.tyEnv (tyTm test) (tyTm expected) with Some eTy then
       TmUtest {{{{t with test = withType eTy test}
                     with expected = withType eTy expected}
@@ -556,7 +556,7 @@ lang UtestTypeAnnot = TypeAnnot + UtestAst + MExprEq
         "Arguments to utest have incompatible types\n",
         "LHS: ", _pprintType (tyTm test), "\nRHS: ", _pprintType (tyTm expected)
       ] in
-      infoErrorExit t.info msg
+      errorSingle [t.info] msg
 end
 
 lang NeverTypeAnnot = TypeAnnot + NeverAst

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -75,7 +75,7 @@ lang TypeLiftBase = MExprAst + VariantNameTypeAst
         match mapLookup ident env.variants with Some constrs then
           TyVariant {constrs = constrs, info = info/-infoTy ty-/}
         else
-          infoErrorExit info (join ["No variant type ", nameGetStr ident,
+          errorSingle [info] (join ["No variant type ", nameGetStr ident,
                                     " found in environment"])
       else ty
     in
@@ -233,7 +233,7 @@ lang DataTypeLift = TypeLift + DataAst + FunTypeAst + ConTypeAst + AppTypeAst
           match typeLiftType env from with (env, from) then
             let f = lam variantMap. mapInsert t.ident from variantMap in
             let err = lam.
-              infoErrorExit t.info (join ["Constructor ", nameGetStr t.ident,
+              errorSingle [t.info] (join ["Constructor ", nameGetStr t.ident,
                                           " defined before referenced variant type ",
                                           nameGetStr ident])
             in

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -233,7 +233,7 @@ let collectKnownProgramTypes = use MExprAst in
     let msg = join [
       "Expected constructor of arrow type, got ", tyIdentStr
     ] in
-    infoErrorExit info msg
+    errorSingle [info] msg
   in
   recursive let collectTypes : UtestTypeEnv -> Expr -> UtestTypeEnv =
     lam acc : UtestTypeEnv. lam expr.
@@ -257,7 +257,7 @@ let collectKnownProgramTypes = use MExprAst in
                 "Constructor definition refers to undefined type ",
                 nameGetStr ident
               ] in
-              infoErrorExit (infoTm expr) msg
+              errorSingle [infoTm expr] msg
           in
           let variants = mapInsert ident constructors acc.variants in
           let acc = collectType acc argTy in
@@ -278,7 +278,7 @@ let collectKnownProgramTypes = use MExprAst in
             let msg = join [
               "Arguments of equality function must be properly annotated"
             ] in
-            infoErrorExit (infoTm t) msg
+            errorSingle [infoTm t] msg
         else acc
       in
       let acc = collectTypes acc t.test in
@@ -515,7 +515,7 @@ let getTypeFunctions =
   lam env : UtestTypeEnv. lam ty.
   let reportError = lam msg : String -> String.
     match getTypeStringCode 0 pprintEnvEmpty ty with (_, tyStr) then
-      infoErrorExit (infoTy ty) (msg tyStr)
+      errorSingle [infoTy ty] (msg tyStr)
     else never
   in
   match ty with TyInt _ then
@@ -611,7 +611,7 @@ lang UtestViaMatch = Ast + PrettyPrint
       let msg = join [
         "Utest needs a custom equality function to be provided, or for the expected value to be a literal. ",
         "No default equality implemented for type ", pprintTy ty, "."
-      ] in infoErrorExit (infoTm t) msg
+      ] in errorSingle [infoTm t] msg
 end
 
 lang UtestViaMatchInt = UtestViaMatch + IntAst
@@ -725,7 +725,7 @@ let _generateUtest = use MExprTypeAnnot in
             "Utest needs a custom equality function to be provided. ",
             "No default equality implemented for type ", pprintTy eTy, "."
           ] in
-          infoErrorExit t.info msg
+          errorSingle [t.info] msg
       in
       utestRunnerCall utestInfo usingStr pprintFunc pprintFunc eqFunc t.test
                       t.expected

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -155,7 +155,7 @@ include "map.mc"
 include "set.mc"
 include "either.mc"
 include "common.mc"
-include "parser/error-highlight.mc"
+include "error.mc"
 
 type AllowedDirection
 con GNeither : () -> AllowedDirection

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -7,7 +7,7 @@ include "map.mc"
 include "string.mc"
 include "either.mc"
 include "common.mc"
-include "error-highlight.mc"
+include "error.mc"
 include "name.mc"
 
 type Dyn

--- a/stdlib/pmexpr/ast.mc
+++ b/stdlib/pmexpr/ast.mc
@@ -142,7 +142,7 @@ lang PMExprAst =
   | TmFlatten t ->
     let e = typeCheckExpr env t.e in
     let elemTy = newvar env.currentLvl t.info in
-    unify t.info env (tyTm e) (ityseq_ t.info (ityseq_ t.info elemTy));
+    unify [infoTm e, t.info] env (tyTm e) (ityseq_ t.info (ityseq_ t.info elemTy));
     TmFlatten {{t with e = e}
                   with ty = TySeq {ty = elemTy, info = t.info}}
   | TmMap2 t ->
@@ -152,9 +152,9 @@ lang PMExprAst =
     let aElemTy = newvar env.currentLvl t.info in
     let bElemTy = newvar env.currentLvl t.info in
     let outElemTy = newvar env.currentLvl t.info in
-    unify t.info env (tyTm as) (ityseq_ t.info aElemTy);
-    unify t.info env (tyTm bs) (ityseq_ t.info bElemTy);
-    unify t.info env (tyTm f)
+    unify [infoTm as, t.info] env (tyTm as) (ityseq_ t.info aElemTy);
+    unify [infoTm bs, t.info] env (tyTm bs) (ityseq_ t.info bElemTy);
+    unify [infoTm f, t.info] env (tyTm f)
       (ityarrow_ t.info aElemTy (ityarrow_ t.info bElemTy outElemTy));
     TmMap2 {{{{t with f = f}
                  with as = as}
@@ -165,8 +165,8 @@ lang PMExprAst =
     let ne = typeCheckExpr env t.ne in
     let as = typeCheckExpr env t.as in
     let accType = tyTm ne in
-    unify t.info env (tyTm as) (ityseq_ t.info accType);
-    unify t.info env (tyTm f)
+    unify [infoTm as, t.info] env (tyTm as) (ityseq_ t.info accType);
+    unify [infoTm f, t.info] env (tyTm f)
       (ityarrow_ t.info accType (ityarrow_ t.info accType accType));
     TmParallelReduce {{{{t with f = f}
                            with ne = ne}
@@ -176,8 +176,8 @@ lang PMExprAst =
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify t.info env (tyTm n) (tyWithInfo t.info tyint_);
-    unify t.info env (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
+    unify [infoTm n, t.info] env (tyTm n) (tyWithInfo t.info tyint_);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
     TmLoop {{{t with n = n}
                 with f = f}
                 with ty = unitType}
@@ -185,8 +185,8 @@ lang PMExprAst =
     let ne = typeCheckExpr env t.ne in
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
-    unify t.info env (tyTm n) (tyWithInfo t.info tyint_);
-    unify t.info env (tyTm f) (ityarrow_ t.info (tyTm ne)
+    unify [infoTm n, t.info] env (tyTm n) (tyWithInfo t.info tyint_);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info (tyTm ne)
                                          (ityarrow_ t.info (tyTm n) (tyTm ne)));
     TmLoopAcc {{{{t with ne = ne}
                     with n = n}
@@ -196,15 +196,15 @@ lang PMExprAst =
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify t.info env (tyTm n) (tyWithInfo t.info tyint_);
-    unify t.info env (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
+    unify [infoTm n, t.info] env (tyTm n) (tyWithInfo t.info tyint_);
+    unify [infoTm f, t.info] env (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
     TmParallelLoop {{{t with n = n}
                         with f = f}
                         with ty = unitType}
   | TmPrintFloat t ->
     let e = typeCheckExpr env t.e in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify t.info env (tyTm e) (tyWithInfo t.info tyfloat_);
+    unify [infoTm e, t.info] env (tyTm e) (tyWithInfo t.info tyfloat_);
     TmPrintFloat {{t with e = e} with ty = unitType}
   | TmParallelSizeCoercion t ->
     let e = typeCheckExpr env t.e in

--- a/stdlib/pmexpr/extract.mc
+++ b/stdlib/pmexpr/extract.mc
@@ -324,12 +324,12 @@ lang PMExprExtractAccelerate = PMExprAst + MExprCallGraph
   sem eliminateInnermostParameterType =
   | TyArrow {from = TyInt _, to = to & !(TyArrow _)} -> to
   | TyArrow t -> TyArrow {t with to = eliminateInnermostParameterType t.to}
-  | t -> infoErrorExit (infoTy t) "Unexpected type of accelerate function body"
+  | t -> errorSingle [infoTy t] "Unexpected type of accelerate function body"
 
   sem eliminateInnermostLambda =
   | TmLam {body = body & !(TmLam _)} -> body
   | TmLam t -> TmLam {t with body = eliminateInnermostLambda t.body}
-  | t -> infoErrorExit (infoTm t) "Unexpected structure of accelerate body"
+  | t -> errorSingle [infoTm t] "Unexpected structure of accelerate body"
 end
 
 lang TestLang =

--- a/stdlib/pmexpr/nested-accelerate.mc
+++ b/stdlib/pmexpr/nested-accelerate.mc
@@ -13,7 +13,7 @@ include "pmexpr/extract.mc"
 lang PMExprNestedAccelerate = PMExprAst
   sem _reportNestedAccelerateError =
   | info /- : Info -/ ->
-    infoErrorExit info "Nested accelerate terms are not supported"
+    errorSingle [info] "Nested accelerate terms are not supported"
 
   sem containsMarkedTerm (marked : Set Name) (flag : Bool) =
   | TmVar t -> if flag then flag else setMem t.ident marked

--- a/stdlib/pmexpr/parallel-patterns.mc
+++ b/stdlib/pmexpr/parallel-patterns.mc
@@ -375,8 +375,8 @@ let reducePattern : () -> Pattern =
       match tyTm f with TyArrow {from = tya, to = TyArrow {from = tyb, to = tyc}} then
         if eqType tya tyc then
           (tya, tyb)
-        else infoErrorExit info errMsg
-      else infoErrorExit info errMsg
+        else errorSingle [info] errMsg
+      else errorSingle [info] errMsg
     in
     let seqReduce = lam f. lam acc. lam s.
       match getReduceFunctionTypes f with (accType, seqElemType) in

--- a/stdlib/pmexpr/parallel-rewrite.mc
+++ b/stdlib/pmexpr/parallel-rewrite.mc
@@ -109,7 +109,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
             Some (performSubstitution exprWrappedInLambdas params args)
           else if eqi nargs nparams then
             Some (performSubstitution expr params args)
-          else infoErrorExit info (concat "Too many arguments passed to "
+          else errorSingle [info] (concat "Too many arguments passed to "
                                           (nameGetStr ident))
         else None ()
       else None ()

--- a/stdlib/pmexpr/replace-accelerate.mc
+++ b/stdlib/pmexpr/replace-accelerate.mc
@@ -24,7 +24,7 @@ lang PMExprReplaceAccelerate =
       else OTyBigarrayFloat64Elt {info = info} in
     OTyBigarrayGenarray {info = info, ty = ty, elty = elemType, layout = layout}
   | TyTensor t ->
-    infoErrorExit t.info "Cannot convert tensor of unsupported type"
+    errorSingle [t.info] "Cannot convert tensor of unsupported type"
 
   sem _mexprToOCamlType (env : GenerateEnv) (acc : [Top]) =
   | ty & (TyCon {info = info, ident = ident}) ->

--- a/stdlib/pmexpr/well-formed.mc
+++ b/stdlib/pmexpr/well-formed.mc
@@ -129,7 +129,7 @@ lang PMExprWellFormed = WellFormed + PMExprAst
       let accTy = tyTm t.ne in
       let elemTy =
         match tyTm t.as with TySeq {ty = ty} then ty
-        else infoErrorExit (infoTm t.as) "Invalid type of sequence argument" in
+        else errorSingle [infoTm t.as] "Invalid type of sequence argument" in
       if eqType accTy elemTy then acc
       else cons (PMExprParallelReduceType t.info) acc
   | t ->

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -134,7 +134,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot + TypeCheck
   | TmHole t ->
     let default = typeCheckExpr env t.default in
     let ty = hty t.info t.inner in
-    unify t.info env ty (tyTm default);
+    unify [t.info] env ty (tyTm default);
     TmHole {{t with default = default}
                with ty = ty}
 end

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -199,14 +199,14 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
         CstrHoleApp { lhs = l.ident, res = ident},
         CstrHoleConstApp { lhs = l.ident, rhs = r.ident, res = ident }
       ]
-      else infoErrorExit (infoTm app.rhs) "Not a TmVar in application"
-    else infoErrorExit (infoTm app.lhs) "Not a TmVar in application"
+      else errorSingle [infoTm app.rhs] "Not a TmVar in application"
+    else errorSingle [infoTm app.lhs] "Not a TmVar in application"
   | TmLet { ident = ident, body = TmIndependent t} ->
     match t.lhs with TmVar lhs then
       match t.rhs with TmVar rhs then
         [ CstrHoleIndependent {lhs = lhs.ident, rhs = rhs.ident, res = ident} ]
-      else infoErrorExit (infoTm t.rhs) "Not a TmVar in independent annotation"
-    else infoErrorExit (infoTm t.lhs) "Not a TmVar in independent annotation"
+      else errorSingle [infoTm t.rhs] "Not a TmVar in independent annotation"
+    else errorSingle [infoTm t.lhs] "Not a TmVar in independent annotation"
 
   sem constraintToString (env: PprintEnv) =
   | CstrHoleDirectData { lhs = lhs, rhs = rhs } ->

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -67,7 +67,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
       let incVarName = mapFindExn (mapFindExn ident graph.meas2fun) env.fun2inc in
       let lookup = lam i. int_ i in
       contextExpansionLookupCallCtx lookup tree incVarName env
-    else infoErrorExit info "Measuring point without id"
+    else errorSingle [info] "Measuring point without id"
 
   -- Recursive helper for instrument
   sem instrumentH (env : CallCtxEnv) (graph : DependencyGraph) (str2name : String -> Name) =

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -132,7 +132,7 @@ lang NestedMeasuringPoints = MExprHoleCFA
           map (lam l. (cur,l,gensym ())) (setToSeq avLamsLhs)
         else []
       in concat res acc
-    else infoErrorExit (infoTm t.lhs) "Not a TmVar in application"
+    else errorSingle [infoTm t.lhs] "Not a TmVar in application"
 
   | t ->
     sfold_Expr_Expr (_callGraphEdges data avLams cur) acc t
@@ -265,7 +265,7 @@ lang NestedMeasuringPoints = MExprHoleCFA
             ) [] avLamsLhs
           in reachable
         else []
-      else infoErrorExit (infoTm app.lhs) "Not a TmVar in application"
+      else errorSingle [infoTm app.lhs] "Not a TmVar in application"
     in
     let resLet = optionGetOr [] (mapLookup t.ident dataEholes) in
     let resInexpr = sfold_Expr_Expr


### PR DESCRIPTION
This PR is based on #588 and should thus be merged after it.

I got tired of following purely textual `Info`s in error outputs, so I moved all the errors I could find to using my error highlighting library instead.

- This moves `stdlib/parser/error-highlight.mc` to `stdlib/error.mc`.
- There are now two helper functions for printing errors and immediately exiting, one for highlighting a single range (possibly with sub-ranges) and one for highlighting multiple ranges (that could be in different files). These do a cached `readFile` on the `filename` in the supplied `Info`s, so it should be as easy to use as possible.
- I also changed `type-check.mc` to use the multi-range highlighting when there are two clear things to highlight (e.g., the scrutinee and pattern in a `match`).
- One of the commits is essentially auto-generated, I used [Comby](https://comby.dev/) to rewrite calls to `infoErrorExit` into the new `errorSingle`. In the process I made a configuration file for it which is also in this PR, if we want it.

----

### `error.mc` documentation, copied here for convenience:

This module provides functions for highlighting sections of a file, primarily intended for error reporting in a compiler.

The underlying workhorse is `formatHighlights`, which takes the source of a file and a sequence of ranges to highlight (`Highlight`s, essentially `Info`s with some extra information).

There is also a high-level interface for reporting errors and immediately exiting. This centers around the `ErrorSection` type:

```
type ErrorSection = {msg : String, multi : String, info : Info, infos : [Info]}
let err : ErrorSection = {msg = "", multi = "", info = NoInfo (), infos = []}
```

An `ErrorSection` represents a single contiguous range in a file, possibly with multiple sub-ranges to highlight, and with an optional related message. Typically you would construct this through record updates on `err`, since most fields are optional:

- `infos`: The ranges to highlight. Default to `[info]` if absent.
- `info`: The complete section to display. Defaults to `foldl mergeInfo (NoInfo ()) infos` if absent.
- `msg`: The message to display above the highlighted section, if any.
- `multi`: Used instead of `msg` if present and `infos` contains at least two elements (useful for pluralizing messages).

There are two functions for displaying an error and immediately exiting:
- `errorSingle` takes a single `ErrorSection`.
- `errorMulti` takes a sequence of `ErrorSection`s and a record with two fields (both are optional):
  - `single`: The message to display if only one `ErrorSection` is given.
  - `multi`: The message to display if more than one `ErrorSection` is given. Defaults to `single` if absent.
