### PR TITLE
Mixed additions and updates

### DIFF
--- a/make
+++ b/make
@@ -113,20 +113,18 @@ fix () {
 
 compile_test () {
   set +e
+  binary=$(mktemp)
   output=$1
-  output="$output\n$($2 $1 2>&1)"
+  output="$output\n$($2 --output $binary $1 2>&1)"
   exit_code=$?
   if [ $exit_code -eq 0 ]
   then
-    binary=$(basename "$1" .mc)
-    output="$output$(./$binary)"
+    output="$output$($binary)"
     exit_code=$?
-    if [ $exit_code -eq 0 ]
+    rm $binary
+    if [ $exit_code -ne 0 ]
     then
-        rm $binary
-    else
-        echo "ERROR: command ./$binary exited with $exit_code"
-        rm $binary
+        echo "ERROR: the compiled binary for $1 exited with $exit_code"
         exit 1
     fi
   else

--- a/make
+++ b/make
@@ -129,8 +129,9 @@ compile_test () {
         exit 1
     fi
   else
-      echo "ERROR: command '$compile $1 2>&1' exited with $exit_code"
-      exit 1
+    echo "ERROR: command '$compile $1 2>&1' exited with $exit_code"
+    rm $binary
+    exit 1
   fi
   echo "$output\n"
   set -e

--- a/make
+++ b/make
@@ -115,7 +115,8 @@ compile_test () {
   set +e
   binary=$(mktemp)
   output=$1
-  output="$output\n$($2 --output $binary $1 2>&1)"
+  compile="$2 --output $binary"
+  output="$output\n$($compile $1 2>&1)"
   exit_code=$?
   if [ $exit_code -eq 0 ]
   then
@@ -128,7 +129,7 @@ compile_test () {
         exit 1
     fi
   else
-      echo "ERROR: command '$2 $1 2>&1' exited with $exit_code"
+      echo "ERROR: command '$compile $1 2>&1' exited with $exit_code"
       exit 1
   fi
   echo "$output\n"

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -224,7 +224,7 @@ and const =
   | Ctensor2string of tm option
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree of ptree
-  | CbootParserParseMExprString of int Mseq.t Mseq.t option
+  | CbootParserParseMExprString of bool option * int Mseq.t Mseq.t option
   | CbootParserParseMCoreFile of
       (bool * bool * int Mseq.t Mseq.t * bool * bool * bool) option
       * int Mseq.t Mseq.t option

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -226,7 +226,7 @@ and const =
   | CbootParserTree of ptree
   | CbootParserParseMExprString of int Mseq.t Mseq.t option
   | CbootParserParseMCoreFile of
-      (bool * bool * int Mseq.t Mseq.t * bool * bool * bool) option
+      (bool * bool * int Mseq.t Mseq.t * bool * bool) option
       * int Mseq.t Mseq.t option
   | CbootParserGetId
   | CbootParserGetTerm of tm option

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -226,7 +226,7 @@ and const =
   | CbootParserTree of ptree
   | CbootParserParseMExprString of int Mseq.t Mseq.t option
   | CbootParserParseMCoreFile of
-      (bool * bool * int Mseq.t Mseq.t * bool * bool) option
+      (bool * bool * int Mseq.t Mseq.t * bool * bool * bool) option
       * int Mseq.t Mseq.t option
   | CbootParserGetId
   | CbootParserGetTerm of tm option

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -155,8 +155,7 @@ let parseMCoreFile
     , prune_external_utests
     , externals_exclude
     , warn
-    , eliminate_deadcode
-    , parse_only ) keywords filename =
+    , eliminate_deadcode ) keywords filename =
   try
     let keywords = Mseq.map Mseq.Helpers.to_ustring keywords in
     let symKeywordsMap = symbolizeEnvWithKeywords keywords in
@@ -182,23 +181,18 @@ let parseMCoreFile
       else fun x -> x
     in
     PTreeTm
-      (let ast =
-         filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
-         |> Utils.normalize_path |> Parserutils.parse_mcore_file
-         |> Mlang.flatten |> Mlang.desugar_post_flatten
-       in
-       if parse_only then ast
-       else
-         ast |> Parserutils.raise_parse_error_on_non_unique_external_id
-         |> Symbolize.symbolize name2sym
-         |> Parserutils.raise_parse_error_on_partially_applied_external
-         |> (fun t ->
-              if keep_utests then t else Parserutils.remove_all_utests t )
-         |> deadcode_elimination
-         |> Parserutils.prune_external_utests
-              ~enable:(keep_utests && prune_external_utests)
-              ~externals_exclude ~warn
-         |> deadcode_elimination )
+      ( filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
+      |> Utils.normalize_path |> Parserutils.parse_mcore_file |> Mlang.flatten
+      |> Mlang.desugar_post_flatten
+      |> Parserutils.raise_parse_error_on_non_unique_external_id
+      |> Symbolize.symbolize name2sym
+      |> Parserutils.raise_parse_error_on_partially_applied_external
+      |> (fun t -> if keep_utests then t else Parserutils.remove_all_utests t)
+      |> deadcode_elimination
+      |> Parserutils.prune_external_utests
+           ~enable:(keep_utests && prune_external_utests)
+           ~externals_exclude ~warn
+      |> deadcode_elimination )
   with (Lexer.Lex_error _ | Msg.Error _ | Parsing.Parse_error) as e ->
     reportErrorAndExit e
 

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -182,21 +182,23 @@ let parseMCoreFile
       else fun x -> x
     in
     let allow_free_prev = !Symbolize.allow_free in
-    Symbolize.allow_free := allow_free;
-    let r = PTreeTm
-      ( filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
-      |> Utils.normalize_path |> Parserutils.parse_mcore_file |> Mlang.flatten
-      |> Mlang.desugar_post_flatten
-      |> Parserutils.raise_parse_error_on_non_unique_external_id
-      |> Symbolize.symbolize name2sym
-      |> Parserutils.raise_parse_error_on_partially_applied_external
-      |> (fun t -> if keep_utests then t else Parserutils.remove_all_utests t)
-      |> deadcode_elimination
-      |> Parserutils.prune_external_utests
-           ~enable:(keep_utests && prune_external_utests)
-           ~externals_exclude ~warn
-      |> deadcode_elimination ) in
-    Symbolize.allow_free := allow_free_prev;
+    Symbolize.allow_free := allow_free ;
+    let r =
+      PTreeTm
+        ( filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
+        |> Utils.normalize_path |> Parserutils.parse_mcore_file
+        |> Mlang.flatten |> Mlang.desugar_post_flatten
+        |> Parserutils.raise_parse_error_on_non_unique_external_id
+        |> Symbolize.symbolize name2sym
+        |> Parserutils.raise_parse_error_on_partially_applied_external
+        |> (fun t -> if keep_utests then t else Parserutils.remove_all_utests t)
+        |> deadcode_elimination
+        |> Parserutils.prune_external_utests
+             ~enable:(keep_utests && prune_external_utests)
+             ~externals_exclude ~warn
+        |> deadcode_elimination )
+    in
+    Symbolize.allow_free := allow_free_prev ;
     r
   with (Lexer.Lex_error _ | Msg.Error _ | Parsing.Parse_error) as e ->
     reportErrorAndExit e

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -155,7 +155,8 @@ let parseMCoreFile
     , prune_external_utests
     , externals_exclude
     , warn
-    , eliminate_deadcode ) keywords filename =
+    , eliminate_deadcode
+    , parse_only ) keywords filename =
   try
     let keywords = Mseq.map Mseq.Helpers.to_ustring keywords in
     let symKeywordsMap = symbolizeEnvWithKeywords keywords in
@@ -181,18 +182,23 @@ let parseMCoreFile
       else fun x -> x
     in
     PTreeTm
-      ( filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
-      |> Utils.normalize_path |> Parserutils.parse_mcore_file |> Mlang.flatten
-      |> Mlang.desugar_post_flatten
-      |> Parserutils.raise_parse_error_on_non_unique_external_id
-      |> Symbolize.symbolize name2sym
-      |> Parserutils.raise_parse_error_on_partially_applied_external
-      |> (fun t -> if keep_utests then t else Parserutils.remove_all_utests t)
-      |> deadcode_elimination
-      |> Parserutils.prune_external_utests
-           ~enable:(keep_utests && prune_external_utests)
-           ~externals_exclude ~warn
-      |> deadcode_elimination )
+      (let ast =
+         filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
+         |> Utils.normalize_path |> Parserutils.parse_mcore_file
+         |> Mlang.flatten |> Mlang.desugar_post_flatten
+       in
+       if parse_only then ast
+       else
+         ast |> Parserutils.raise_parse_error_on_non_unique_external_id
+         |> Symbolize.symbolize name2sym
+         |> Parserutils.raise_parse_error_on_partially_applied_external
+         |> (fun t ->
+              if keep_utests then t else Parserutils.remove_all_utests t )
+         |> deadcode_elimination
+         |> Parserutils.prune_external_utests
+              ~enable:(keep_utests && prune_external_utests)
+              ~externals_exclude ~warn
+         |> deadcode_elimination )
   with (Lexer.Lex_error _ | Msg.Error _ | Parsing.Parse_error) as e ->
     reportErrorAndExit e
 

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -159,7 +159,7 @@ let builtin =
   ; ("tensorEq", f (CtensorEq (None, None)))
   ; ("tensor2string", f (Ctensor2string None))
     (* MCore intrinsics: Boot parser *)
-  ; ("bootParserParseMExprString", f (CbootParserParseMExprString None))
+  ; ("bootParserParseMExprString", f (CbootParserParseMExprString (None, None)))
   ; ("bootParserParseMCoreFile", f (CbootParserParseMCoreFile (None, None)))
   ; ("bootParserGetId", f CbootParserGetId)
   ; ("bootParserGetTerm", f (CbootParserGetTerm None))

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -2,6 +2,7 @@ open Ast
 open Symbutils
 open Ustring.Op
 open Printf
+open Intrinsics
 
 (* Can be used when debugging symbol maps *)
 let _symbmap = ref SymbMap.empty
@@ -225,6 +226,9 @@ let elimination builtin_sym2term builtin_name2sym symKeywords t =
     (* Collect all lets and store a graph in 'nmap' and free variable in 'free' *)
     let nmap = make_builtin_nmap builtin_sym2term in
     let nmap = add_keywords nmap symKeywords in
+    (* The below line ensures that free variables are treated as having a side
+     * effect (as it is unknown) *)
+    let nmap = add_keywords nmap [Symb.Helpers.nosym] in
     let nmap, free = collect_lets nmap t in
     if !enable_debug_dead_code_info then (
       print_endline "-- Dead code info: collected lets --" ;

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -209,7 +209,11 @@ let extend_symb_map_builtin builtin_name2sym symbmap =
   List.fold_left f symbmap builtin_name2sym
 
 (* Add keywords from the keyword maker to nmap, indicating sideeffect so that
-   they do not disappear *)
+ * they do not disappear.
+ * NOTE(dlunde,2022-05-11): Is this really what we want in general? It seems
+ * likely that some keywords may not have side-effects and should therefore not
+ * affect the dead code elimination.
+ *)
 let add_keywords nmap symKeywords =
   let f acc s = SymbMap.add s (SymbSet.empty, false, true, 0) acc in
   List.fold_left f nmap symKeywords

--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -231,7 +231,7 @@ let elimination builtin_sym2term builtin_name2sym symKeywords t =
     let nmap = make_builtin_nmap builtin_sym2term in
     let nmap = add_keywords nmap symKeywords in
     (* The below line ensures that free variables are treated as having a side
-     * effect (as it is unknown) *)
+     * effect (as they are unknown) *)
     let nmap = add_keywords nmap [Symb.Helpers.nosym] in
     let nmap, free = collect_lets nmap t in
     if !enable_debug_dead_code_info then (

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1551,13 +1551,15 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
         , Record.find (us "1") r
         , Record.find (us "2") r
         , Record.find (us "3") r
-        , Record.find (us "4") r )
+        , Record.find (us "4") r
+        , Record.find (us "5") r )
       with
       | ( TmConst (_, CBool keep_utests)
         , TmConst (_, CBool prune_external_utests)
         , TmSeq (_, externals_exclude)
         , TmConst (_, CBool warn)
-        , TmConst (_, CBool eliminate_deadcode) ) ->
+        , TmConst (_, CBool eliminate_deadcode)
+        , TmConst (_, CBool parse_only) ) ->
           let externals_exclude =
             Mseq.map
               (function
@@ -1573,7 +1575,8 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
                     , prune_external_utests
                     , externals_exclude
                     , warn
-                    , eliminate_deadcode )
+                    , eliminate_deadcode
+                    , parse_only )
                 , None ) )
       | _ ->
           fail_constapp fi

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1551,15 +1551,13 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
         , Record.find (us "1") r
         , Record.find (us "2") r
         , Record.find (us "3") r
-        , Record.find (us "4") r
-        , Record.find (us "5") r )
+        , Record.find (us "4") r )
       with
       | ( TmConst (_, CBool keep_utests)
         , TmConst (_, CBool prune_external_utests)
         , TmSeq (_, externals_exclude)
         , TmConst (_, CBool warn)
-        , TmConst (_, CBool eliminate_deadcode)
-        , TmConst (_, CBool parse_only) ) ->
+        , TmConst (_, CBool eliminate_deadcode) ) ->
           let externals_exclude =
             Mseq.map
               (function
@@ -1575,8 +1573,7 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
                     , prune_external_utests
                     , externals_exclude
                     , warn
-                    , eliminate_deadcode
-                    , parse_only )
+                    , eliminate_deadcode )
                 , None ) )
       | _ ->
           fail_constapp fi

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1549,8 +1549,11 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
       |> fun str -> TmSeq (fi, ustring2tmseq fi str)
   | Ctensor2string _, _ ->
       fail_constapp fi
-  | CbootParserParseMExprString (Some options, Some keywords), TmSeq (fi, seq) ->
-      let t = Bootparser.parseMExprString options keywords (tmseq2seq_of_int fi seq) in
+  | CbootParserParseMExprString (Some options, Some keywords), TmSeq (fi, seq)
+    ->
+      let t =
+        Bootparser.parseMExprString options keywords (tmseq2seq_of_int fi seq)
+      in
       TmConst (fi, CbootParserTree t)
   | CbootParserParseMExprString _, _ ->
       fail_constapp fi

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -465,9 +465,11 @@ let arity = function
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree _ ->
       0
-  | CbootParserParseMExprString None ->
+  | CbootParserParseMExprString (None, None) ->
+      3
+  | CbootParserParseMExprString (Some _, None) ->
       2
-  | CbootParserParseMExprString (Some _) ->
+  | CbootParserParseMExprString (_, Some _) ->
       1
   | CbootParserParseMCoreFile (None, None) ->
       3
@@ -1507,14 +1509,22 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
   (* MCore intrinsics: Boot parser *)
   | CbootParserTree _, _ ->
       fail_constapp fi
-  | CbootParserParseMExprString None, TmSeq (fi, seq) ->
+  | CbootParserParseMExprString (None, None), TmRecord (_, r) -> (
+    try
+      match Record.find (us "0") r with
+      | TmConst (_, CBool allow_free) ->
+          TmConst (fi, CbootParserParseMExprString (Some allow_free, None))
+      | _ ->
+          fail_constapp fi
+    with Not_found -> fail_constapp fi )
+  | CbootParserParseMExprString (Some options, None), TmSeq (fi, seq) ->
       let keywords =
         Mseq.map
           (function
             | TmSeq (_, s) -> tmseq2seq_of_int fi s | _ -> fail_constapp fi )
           seq
       in
-      TmConst (fi, CbootParserParseMExprString (Some keywords))
+      TmConst (fi, CbootParserParseMExprString (Some options, Some keywords))
   | Ctensor2string None, tm ->
       TmConst (fi, Ctensor2string (Some tm))
   | Ctensor2string (Some el2str), TmTensor (_, t) ->
@@ -1539,8 +1549,8 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
       |> fun str -> TmSeq (fi, ustring2tmseq fi str)
   | Ctensor2string _, _ ->
       fail_constapp fi
-  | CbootParserParseMExprString (Some keywords), TmSeq (fi, seq) ->
-      let t = Bootparser.parseMExprString keywords (tmseq2seq_of_int fi seq) in
+  | CbootParserParseMExprString (Some options, Some keywords), TmSeq (fi, seq) ->
+      let t = Bootparser.parseMExprString options keywords (tmseq2seq_of_int fi seq) in
       TmConst (fi, CbootParserTree t)
   | CbootParserParseMExprString _, _ ->
       fail_constapp fi

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1551,13 +1551,15 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
         , Record.find (us "1") r
         , Record.find (us "2") r
         , Record.find (us "3") r
-        , Record.find (us "4") r )
+        , Record.find (us "4") r
+        , Record.find (us "5") r )
       with
       | ( TmConst (_, CBool keep_utests)
         , TmConst (_, CBool prune_external_utests)
         , TmSeq (_, externals_exclude)
         , TmConst (_, CBool warn)
-        , TmConst (_, CBool eliminate_deadcode) ) ->
+        , TmConst (_, CBool eliminate_deadcode)
+        , TmConst (_, CBool allow_free) ) ->
           let externals_exclude =
             Mseq.map
               (function
@@ -1573,7 +1575,8 @@ let delta (apply : info -> tm -> tm -> tm) fi c v =
                     , prune_external_utests
                     , externals_exclude
                     , warn
-                    , eliminate_deadcode )
+                    , eliminate_deadcode
+                    , allow_free )
                 , None ) )
       | _ ->
           fail_constapp fi

--- a/src/boot/lib/symbolize.ml
+++ b/src/boot/lib/symbolize.ml
@@ -12,6 +12,9 @@ type sym_env =
 let empty_sym_env =
   {var= SidMap.empty; con= SidMap.empty; ty= SidMap.empty; label= SidMap.empty}
 
+(* Option for allowing/disallowing free variables in symbolize *)
+let allow_free = ref false
+
 let sym_env_to_assoc env =
   let vars = List.map (fun (k, v) -> (IdVar k, v)) (SidMap.bindings env.var) in
   let cons = List.map (fun (k, v) -> (IdCon k, v)) (SidMap.bindings env.con) in
@@ -44,7 +47,8 @@ let findsym fi id env =
       | IdLabel x ->
           (x, "label")
     in
-    raise_error fi ("Unknown " ^ kindstr ^ " '" ^ string_of_sid x ^ "'")
+    if !allow_free then Symb.Helpers.nosym
+    else raise_error fi ("Unknown " ^ kindstr ^ " '" ^ string_of_sid x ^ "'")
 
 let findsym_opt id env =
   match id with

--- a/src/main/parse.mc
+++ b/src/main/parse.mc
@@ -22,15 +22,6 @@ type ParseOptions = {
   keywords : [String]
 }
 
-let defaultParseOptions = {
-  keepUtests = true,
-  pruneExternalUtests = false,
-  pruneExternalUtestsWarning = true,
-  findExternalsExclude = false,
-  eliminateDeadCode = true,
-  keywords = []
-}
-
 let parseParseMCoreFile : ParseOptions -> String -> Expr = lam opt. lam file.
   use BootParser in
   if opt.pruneExternalUtests then
@@ -39,20 +30,18 @@ let parseParseMCoreFile : ParseOptions -> String -> Expr = lam opt. lam file.
         mapKeys (externalGetSupportedExternalImpls ())
       else []
     in
-    parseMCoreFile {
-      keepUtests = opt.keepUtests,
-      pruneExternalUtests = true,
-      externalsExclude = externalsExclude,
-      pruneExternalUtestsWarning = opt.pruneExternalUtestsWarning,
-      eliminateDeadCode = opt.eliminateDeadCode,
-      keywords = opt.keywords
-    } file
+    parseMCoreFile {{{{{{ defaultBootParserParseMCoreFileArg
+      with keepUtests = opt.keepUtests }
+      with pruneExternalUtests = true }
+      with externalsExclude = externalsExclude }
+      with pruneExternalUtestsWarning = opt.pruneExternalUtestsWarning }
+      with eliminateDeadCode = opt.eliminateDeadCode }
+      with keywords = opt.keywords } file
   else
-    parseMCoreFile {
-      keepUtests = opt.keepUtests,
-      pruneExternalUtests = false,
-      externalsExclude = [],
-      pruneExternalUtestsWarning = false,
-      eliminateDeadCode = opt.eliminateDeadCode,
-      keywords = opt.keywords
-  } file
+    parseMCoreFile {{{{{{ defaultBootParserParseMCoreFileArg
+      with keepUtests = opt.keepUtests }
+      with pruneExternalUtests = false }
+      with externalsExclude = [] }
+      with pruneExternalUtestsWarning = false }
+      with eliminateDeadCode = opt.eliminateDeadCode }
+      with keywords = opt.keywords } file

--- a/stdlib/common.mc
+++ b/stdlib/common.mc
@@ -22,6 +22,12 @@ recursive
     lam f. lam e. f (fix f) e
 end
 
+-- Function repetition (for side-effects)
+let repeat : (() -> ()) -> Int -> () = lam f. lam n.
+  recursive let rec = lam n.
+    if leqi n 0 then () else (f (); rec (subi n 1))
+  in rec n
+
 -- Fixpoint computation for mutual recursion. Thanks Oleg Kiselyov!
 -- (http://okmij.org/ftp/Computation/fixed-point-combinators.html)
 let fixMutual : all a. all b. [[a -> b] -> a -> b] -> [a -> b] =
@@ -41,4 +47,11 @@ let sum_tuple = lam t : (Int, Int). addi t.0 t.1 in
 utest (curry sum_tuple) 3 2 with 5 in
 utest (uncurry addi) (3,2) with 5 in
 utest curry (uncurry addi) 3 2 with (uncurry (curry sum_tuple)) (3,2) using eqi in
+
+let r = ref 0 in
+let f = lam. modref r (addi (deref r) 1) in
+utest modref r 0; repeat f 4; deref r with 4 in
+utest modref r 0; repeat f 0; deref r with 0 in
+utest modref r 0; repeat f (negi 5); deref r with 0 in
+
 ()

--- a/stdlib/ext/dist-ext.ext-ocaml.mc
+++ b/stdlib/ext/dist-ext.ext-ocaml.mc
@@ -7,6 +7,20 @@ let distExtMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
   [
+    ("externalGammaLogPdf", [
+      { expr = "Owl_stats.gamma_logpdf",
+        ty = tyarrows_ [tyfloat_, otylabel_ "shape" tyfloat_, otylabel_ "scale" tyfloat_, tyfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ]),
+    ("externalGammaSample", [
+      { expr = "Owl_stats.gamma_rvs",
+        ty = tyarrows_ [otylabel_ "shape" tyfloat_, otylabel_ "scale" tyfloat_, tyfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ]),
     ("externalBinomialLogPmf", [
       { expr = "Owl_stats.binomial_logpdf",
         ty = tyarrows_ [tyint_, otylabel_ "p" tyfloat_, otylabel_ "n" tyint_, tyfloat_],
@@ -84,14 +98,14 @@ let distExtMap =
         cLibraries = []
       }
     ]),
-    ("uniformSample", [
-      { expr = "Owl_stats.std_uniform_rvs",
-        ty = tyarrows_ [tyunit_, tyfloat_],
+    ("externalUniformContinuousSample", [
+      { expr = "Owl_stats.uniform_rvs",
+        ty = tyarrows_ [tyfloat_, tyfloat_, tyfloat_],
         libraries = ["owl"],
         cLibraries = []
       }
     ]),
-    ("externalRandomSample", [
+    ("externalUniformDiscreteSample", [
       { expr = "Owl_stats.uniform_int_rvs",
         ty = tyarrows_ [tyint_, tyint_, tyint_],
         libraries = ["owl"],

--- a/stdlib/ext/dist-ext.ext-ocaml.mc
+++ b/stdlib/ext/dist-ext.ext-ocaml.mc
@@ -7,6 +7,13 @@ let distExtMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
   [
+    ("externalExponentialSample", [
+      { expr = "Owl_stats.exponential_rvs",
+        ty = tyarrows_ [otylabel_ "lambda" tyfloat_, tyfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ]),
     ("externalGammaLogPdf", [
       { expr = "Owl_stats.gamma_logpdf",
         ty = tyarrows_ [tyfloat_, otylabel_ "shape" tyfloat_, otylabel_ "scale" tyfloat_, tyfloat_],

--- a/stdlib/ext/dist-ext.mc
+++ b/stdlib/ext/dist-ext.mc
@@ -11,12 +11,12 @@ let binomialLogPmf = lam p:Float. lam n:Int. lam x:Int.
   externalBinomialLogPmf x p n
 let binomialSample = lam p:Float. lam n:Int.
   externalBinomialSample p n
-let bernoulliPmf = lam p:Float. lam x:Int.
-  if eqi x 0 then subf 1. p else p
-let bernoulliLogPmf = lam p:Float. lam x:Int.
+let bernoulliPmf = lam p:Float. lam x:Bool.
+  if x then p else subf 1. p
+let bernoulliLogPmf = lam p:Float. lam x:Bool.
   log (bernoulliPmf p x)
 let bernoulliSample = lam p:Float.
-  externalBinomialSample p 1
+  if eqi 1 (externalBinomialSample p 1) then true else false
 
 -- Beta
 external externalBetaLogPdf : Float -> Float -> Float -> Float
@@ -65,8 +65,16 @@ let dirichletPdf : [Float] -> [Float] -> Float =
 let dirichletSample : [Float] -> [Float] =
   lam alpha. externalDirichletSample alpha
 
--- Uniform (continuous)
+-- Uniform (continuous between 0 and 1)
 external uniformSample ! : Unit -> Float
+
+-- Uniform (continuous between a and b)
+let uniformContinuousSample = lam a. lam b.
+  addf a (mulf (subf b a) (uniformSample ()))
+let uniformContinuousLogPdf = lam a. lam b.
+  subf (log 1.0) (log (subf b a))
+let uniformContinuousPdf = lam a. lam b.
+  divf 1.0 (subf b a)
 
 -- Random (discrete)
 external externalRandomSample ! : Int -> Int -> Int

--- a/stdlib/ext/dist-ext.mc
+++ b/stdlib/ext/dist-ext.mc
@@ -1,6 +1,15 @@
-
-include "math-ext.mc"
+include "math.mc"
 include "bool.mc"
+
+-- Gamma
+external externalGammaLogPdf : Float -> Float -> Float -> Float
+external externalGammaSample ! : Float -> Float -> Float
+let gammaPdf = lam shape:Float. lam scale:Float. lam x:Float.
+  exp (externalGammaLogPdf x shape scale)
+let gammaLogPdf = lam shape:Float. lam scale:Float. lam x:Float.
+  externalGammaLogPdf x shape scale
+let gammaSample = lam shape:Float. lam scale:Float.
+  externalGammaSample shape scale
 
 -- Binomial and Bernoulli
 external externalBinomialLogPmf : Int -> Float -> Int -> Float
@@ -65,24 +74,62 @@ let dirichletPdf : [Float] -> [Float] -> Float =
 let dirichletSample : [Float] -> [Float] =
   lam alpha. externalDirichletSample alpha
 
--- Uniform (continuous between 0 and 1)
-external uniformSample ! : Unit -> Float
-
 -- Uniform (continuous between a and b)
+external externalUniformContinuousSample ! : Float -> Float -> Float
 let uniformContinuousSample = lam a. lam b.
-  addf a (mulf (subf b a) (uniformSample ()))
-let uniformContinuousLogPdf = lam a. lam b.
-  subf (log 1.0) (log (subf b a))
-let uniformContinuousPdf = lam a. lam b.
-  divf 1.0 (subf b a)
+  externalUniformContinuousSample a b
+let uniformContinuousLogPdf = lam a. lam b. lam x.
+  if geqf x a then
+    if leqf x b then subf (log 1.0) (log (subf b a))
+    else 0.
+  else 0.
+let uniformContinuousPdf = lam a. lam b. lam x.
+  if geqf x a then
+    if leqf x b then divf 1.0 (subf b a)
+    else 0.
+  else 0.
+
+-- Uniform on 0 1
+let uniformSample : () -> Float = lam. uniformContinuousSample 0. 1.
 
 -- Random (discrete)
-external externalRandomSample ! : Int -> Int -> Int
-let randomSample = lam a:Int. lam b:Int.
-  externalRandomSample a b
+external externalUniformDiscreteSample ! : Int -> Int -> Int
+let uniformDiscreteSample = lam a:Int. lam b:Int.
+  externalUniformDiscreteSample a b
+let uniformDiscreteLogPdf : Int -> Int -> Int -> Float = lam a. lam b. lam x.
+  if geqi x a then
+    if leqi x b then subf (log 1.0) (log (int2float (addi 1 (subi b a))))
+    else 0.
+  else 0.
+let uniformDiscretePdf : Int -> Int -> Int -> Float = lam a. lam b. lam x.
+  if geqi x a then
+    if leqi x b then divf 1.0 (int2float (addi 1 (subi b a)))
+    else 0.
+  else 0.
 
+-- Poisson
+let poissonLogPmf = lam lambda:Float. lam x:Int.
+  subf (subf (mulf (int2float x) (log lambda)) lambda) (logFactorial x)
+let poissonPmf = lam lambda:Float. lam x:Int.
+  exp (poissonLogPmf lambda x)
+-- Simple but inefficient algorithm for drawing from Poisson. Translated from
+-- numpy C source code and originally from Knuth according to Wikipedia.
+-- OPT(dlunde,2022-05-16): We want to use an external for this eventually.
+let poissonSample = lam lambda:Float.
+  let enlam = exp (negf lambda) in
+  let x = 0 in
+  let prod = 1. in
+  recursive let rec = lam x. lam prod.
+    let u = uniformSample () in
+    let prod = mulf prod u in
+    if gtf prod enlam then rec (addi x 1) prod
+    else x
+  in rec x prod
+
+-- TODO Add exponential
 
 mexpr
+
 
 -- Functions for testing floats. Should perhaps be in another library.
 let maxf = lam r. lam l. if gtf r l then r else l in
@@ -97,13 +144,18 @@ let intRange = lam lower. lam upper. lam r. lam l.
 let floatRange = lam lower. lam upper. lam r. lam l.
   and (and (leqf r upper) (geqf r lower)) (and (leqf l upper) (geqf l lower)) in
 
+-- Testing Gamma
+utest gammaPdf 1. 2. 1. with 0.303265329856 using _eqf in
+utest exp (gammaLogPdf 2. 3. 1.) with 0.0796145900638 using _eqf in
+utest gammaSample 1. 2. with 1. using floatRange 0. inf in
+
 -- Testing Binomial and Bernoulli
 utest binomialPmf 0.7 20 15 with 0.17886305057 using _eqf in
 utest exp (binomialLogPmf 0.5 40 20) with 0.12537068762 using _eqf in
 utest binomialSample 0.7 20 with 0 using intRange 0 20 in
-utest bernoulliPmf 0.3 0 with 0.7 using _eqf in
-utest exp (bernoulliLogPmf 0.6 1) with 0.6 using _eqf in
-utest bernoulliSample 0.6 with 0 using intRange 0 1 in
+utest bernoulliPmf 0.3 false with 0.7 using _eqf in
+utest exp (bernoulliLogPmf 0.6 true) with 0.6 using _eqf in
+utest bernoulliSample 0.6 with false using lam. lam. true in
 
 -- Testing Beta
 utest betaPdf 2. 2. 0.5 with 1.5 using _eqf in
@@ -133,10 +185,22 @@ utest dirichletPdf [1.0, 1.0, 2.0] [0.01, 0.01, 0.98] with 5.88 using _eqf in
 utest dirichletSample [5.0, 5.0, 5.0] with [0.] using
   lam l. lam r. _eqf (foldl addf 0. l) 1.0 in
 
--- Testing Uniform
+-- Testing Continuous uniform
+utest uniformContinuousSample 1.0 2.0 with 0. using floatRange 0. 2. in
+utest exp (uniformContinuousLogPdf 1.0 2.0 1.5) with 1.0 using _eqf in
+utest uniformContinuousPdf 1.0 2.0 1.5 with 1.0 using _eqf in
+
+-- Testing (0,1)-uniform
 utest uniformSample () with 0. using floatRange 0. 1. in
 
--- Testing Random
-utest randomSample 3 8 with 3 using intRange 3 8 in
+-- Testing Discrete uniform
+utest uniformDiscreteSample 3 8 with 3 using intRange 3 8 in
+utest exp (uniformDiscreteLogPdf 1 2 1) with 0.5 using _eqf in
+utest uniformDiscretePdf 1 2 1 with 0.5 using _eqf in
+
+-- Testing Poisson
+utest poissonPmf 2.0 2 with 0.270670566473 using _eqf in
+utest exp (poissonLogPmf 3.0 2) with 0.224041807655 using _eqf in
+utest poissonSample 2.0 with 3 using intRange 0 100000 in
 
 ()

--- a/stdlib/ext/dist-ext.mc
+++ b/stdlib/ext/dist-ext.mc
@@ -126,7 +126,14 @@ let poissonSample = lam lambda:Float.
     else x
   in rec x prod
 
--- TODO Add exponential
+-- Add exponential
+external externalExponentialSample ! : Float -> Float
+let exponentialSample = lam lambda:Float.
+  externalExponentialSample lambda
+let exponentialLogPdf : Float -> Float -> Float = lam lambda. lam x.
+  subf (log lambda) (mulf lambda x)
+let exponentialPdf : Float -> Float -> Float = lam lambda. lam x.
+  exp (exponentialLogPdf lambda x)
 
 mexpr
 
@@ -202,5 +209,10 @@ utest uniformDiscretePdf 1 2 1 with 0.5 using _eqf in
 utest poissonPmf 2.0 2 with 0.270670566473 using _eqf in
 utest exp (poissonLogPmf 3.0 2) with 0.224041807655 using _eqf in
 utest poissonSample 2.0 with 3 using intRange 0 100000 in
+
+-- Testing Exponential
+utest exponentialSample 1.0 with 0. using floatRange 0. inf in
+utest exp (exponentialLogPdf 1.0 2.0) with 0.135335283237 using _eqf in
+utest exponentialPdf 2.0 2.0 with 0.0366312777775 using _eqf in
 
 ()

--- a/stdlib/ext/file-ext.mc
+++ b/stdlib/ext/file-ext.mc
@@ -11,7 +11,7 @@ external fileExists ! : String -> Bool
 -- Deletes the file from the file system. If the file does not
 -- exist, no error is reported. Use function fileExists to check
 -- if the file exists.
-external deleteFile ! : String -> Unit
+external deleteFile ! : String -> ()
 let deleteFile = lam s. if fileExists s then deleteFile s else ()
 
 -- Returns the size in bytes of a given file
@@ -29,15 +29,15 @@ let writeOpen : String -> Option WriteChannel =
 -- Write a text string to the output channel
 -- Right now, it does not handle Unicode correctly
 -- It should default to UTF-8
-external writeString ! : WriteChannel -> String -> Unit
-let writeString : WriteChannel -> String -> Unit =
+external writeString ! : WriteChannel -> String -> ()
+let writeString : WriteChannel -> String -> () =
   lam c. lam s. writeString c s
 
 -- Flush output channel
-external writeFlush ! : WriteChannel -> Unit
+external writeFlush ! : WriteChannel -> ()
 
 -- Close a write channel
-external writeClose ! : WriteChannel -> Unit
+external writeClose ! : WriteChannel -> ()
 
 -- Open a file for reading. Read open either return
 -- Note: the external function is shadowed. Use the second signature
@@ -59,7 +59,7 @@ let readLine : ReadChannel -> Option String =
 external readString ! : ReadChannel -> String
 
 -- Closes a channel that was opened for reading
-external readClose ! : ReadChannel -> Unit
+external readClose ! : ReadChannel -> ()
 
 -- Standard in read channel
 external stdin ! : ReadChannel

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -23,6 +23,16 @@ utest cmpfApprox 0.1 0. 0.1 with 0
 utest cmpfApprox 0. 0.1 0.2 with subi 0 1
 utest cmpfApprox 0.1 0.4 0.2 with 1
 
+-- Inefficient version of logFactorial
+let logFactorial : Int -> Float = lam n.
+  recursive let work = lam acc. lam n.
+    if gti n 0 then work (addf (log (int2float n)) acc) (subi n 1)
+    else acc
+  in work 0.0 n
+
+utest roundfi (exp (logFactorial 3)) with 6
+utest roundfi (exp (logFactorial 4)) with 24
+
 -- Int stuff
 let maxi = lam r. lam l. if gti r l then r else l
 let mini = lam r. lam l. if lti r l then r else l

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -1146,7 +1146,8 @@ let utensor2string_ = tensor2string_ tyunknown_
 
 -- Bootparser
 let bootParserParseMExprString_ = use MExprAst in
-  lam key. lam str. appf2_ (uconst_ (CBootParserParseMExprString ())) key str
+  lam options. lam key. lam str.
+    appf3_ (uconst_ (CBootParserParseMExprString ())) options key str
 
 let bootParserParseMCoreFile_ = use MExprAst in
   lam pruneArgs.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -54,6 +54,39 @@ lang Ast
     let res: (acc, Expr) = smapAccumL_Expr_Expr (lam acc. lam a. (f acc a, a)) acc p in
     res.0
 
+  sem mapAccumLPre_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem mapAccumLPre_Expr_Expr f acc =
+  | expr ->
+    match f acc expr with (acc,expr) in
+    smapAccumL_Expr_Expr (mapAccumLPre_Expr_Expr f) acc expr
+
+  sem mapAccumLPost_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
+  sem mapAccumLPost_Expr_Expr f acc =
+  | expr ->
+    match smapAccumL_Expr_Expr (mapAccumLPost_Expr_Expr f) acc expr with (acc,expr) in
+    f acc expr
+
+  sem mapPre_Expr_Expr : (Expr -> Expr) -> Expr -> Expr
+  sem mapPre_Expr_Expr f =
+  | expr ->
+    let expr = f expr in
+    smap_Expr_Expr (mapPre_Expr_Expr f) expr
+
+  sem mapPost_Expr_Expr : (Expr -> Expr) -> Expr -> Expr
+  sem mapPost_Expr_Expr f =
+  | expr -> f (smap_Expr_Expr (mapPost_Expr_Expr f) expr)
+
+  sem foldPre_Expr_Expr : all acc. (acc -> Expr -> acc) -> acc -> Expr -> acc
+  sem foldPre_Expr_Expr f acc =
+  | expr ->
+    let acc = f acc expr in
+    sfold_Expr_Expr (foldPre_Expr_Expr f) acc expr
+
+  sem foldPost_Expr_Expr : all acc. (acc -> Expr -> acc) -> acc -> Expr -> acc
+  sem foldPost_Expr_Expr f acc =
+  | expr ->
+    f (sfold_Expr_Expr (foldPost_Expr_Expr f) acc expr) expr
+
   -- NOTE(vipa, 2021-05-28): This function *does not* touch the `ty`
   -- field. It only covers nodes in the AST, so to speak, not
   -- annotations thereof.

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -36,9 +36,7 @@ type BootParserParseMCoreFileArg = {
   externalsExclude : [String],
 
   -- Additional keywords
-  keywords : [String],
-
-  parseOnly : Bool
+  keywords : [String]
 }
 
 let defaultBootParserParseMCoreFileArg = {
@@ -47,8 +45,7 @@ let defaultBootParserParseMCoreFileArg = {
   pruneExternalUtestsWarning = true,
   eliminateDeadCode = true,
   externalsExclude = [],
-  keywords = [],
-  parseOnly = false
+  keywords = []
 }
 
 lang BootParser = MExprAst + ConstTransformer
@@ -65,8 +62,7 @@ lang BootParser = MExprAst + ConstTransformer
           arg.pruneExternalUtests,
           arg.externalsExclude,
           arg.pruneExternalUtestsWarning,
-          arg.eliminateDeadCode,
-          arg.parseOnly
+          arg.eliminateDeadCode
         )
         arg.keywords
         filename

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -36,7 +36,9 @@ type BootParserParseMCoreFileArg = {
   externalsExclude : [String],
 
   -- Additional keywords
-  keywords : [String]
+  keywords : [String],
+
+  allowFree : Bool
 }
 
 let defaultBootParserParseMCoreFileArg = {
@@ -45,7 +47,8 @@ let defaultBootParserParseMCoreFileArg = {
   pruneExternalUtestsWarning = true,
   eliminateDeadCode = true,
   externalsExclude = [],
-  keywords = []
+  keywords = [],
+  allowFree = false
 }
 
 lang BootParser = MExprAst + ConstTransformer
@@ -62,7 +65,8 @@ lang BootParser = MExprAst + ConstTransformer
           arg.pruneExternalUtests,
           arg.externalsExclude,
           arg.pruneExternalUtestsWarning,
-          arg.eliminateDeadCode
+          arg.eliminateDeadCode,
+          arg.allowFree
         )
         arg.keywords
         filename

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -376,7 +376,7 @@ let norm : String -> String = lam str.
   filter (lam x. not (or (or (eqChar x ' ') (eqChar x '\n')) (eqChar x '\t'))) str in
 
 let parseMExprStringKeywords = lam ks.
-  parseMExprString { defaultBootParserParseMCoreFileArg with keywords = ks }
+  parseMExprString { defaultBootParserParseMExprStringArg with keywords = ks }
 in
 
 -- Test the combination of parsing and pretty printing

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -36,7 +36,9 @@ type BootParserParseMCoreFileArg = {
   externalsExclude : [String],
 
   -- Additional keywords
-  keywords : [String]
+  keywords : [String],
+
+  parseOnly : Bool
 }
 
 let defaultBootParserParseMCoreFileArg = {
@@ -45,7 +47,8 @@ let defaultBootParserParseMCoreFileArg = {
   pruneExternalUtestsWarning = true,
   eliminateDeadCode = true,
   externalsExclude = [],
-  keywords = []
+  keywords = [],
+  parseOnly = false
 }
 
 lang BootParser = MExprAst + ConstTransformer
@@ -62,7 +65,8 @@ lang BootParser = MExprAst + ConstTransformer
           arg.pruneExternalUtests,
           arg.externalsExclude,
           arg.pruneExternalUtestsWarning,
-          arg.eliminateDeadCode
+          arg.eliminateDeadCode,
+          arg.parseOnly
         )
         arg.keywords
         filename

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -991,7 +991,7 @@ mexpr
 use Test in
 
 -- Test functions --
-let _parse = parseMExprString [] in
+let _parse = parseMExprStringKeywords [] in
 let _testBase: Option PprintEnv -> Expr -> (Option PprintEnv, CFAGraph) =
   lam env: Option PprintEnv. lam t: Expr.
     match env with Some env then

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -372,7 +372,12 @@ end
 
 lang BootParserTypeAst = BootParserAst
   sem tyConst =
-  | CBootParserParseMExprString _ -> tyarrows_ [tyseq_ tystr_, tystr_, tybootparsetree_]
+  | CBootParserParseMExprString _ -> tyarrows_ [
+      tytuple_ [tybool_],
+      tyseq_ tystr_,
+      tystr_,
+      tybootparsetree_
+    ]
   | CBootParserParseMCoreFile _ -> tyarrows_ [
       tytuple_ [tybool_, tybool_ ,tyseq_ tystr_, tybool_, tybool_, tybool_],
       tyseq_ tystr_,

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -374,7 +374,7 @@ lang BootParserTypeAst = BootParserAst
   sem tyConst =
   | CBootParserParseMExprString _ -> tyarrows_ [tyseq_ tystr_, tystr_, tybootparsetree_]
   | CBootParserParseMCoreFile _ -> tyarrows_ [
-      tytuple_ [tybool_, tybool_ ,tyseq_ tystr_, tybool_, tybool_],
+      tytuple_ [tybool_, tybool_ ,tyseq_ tystr_, tybool_, tybool_, tybool_],
       tyseq_ tystr_,
       tystr_,
       tybootparsetree_

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -374,7 +374,7 @@ lang BootParserTypeAst = BootParserAst
   sem tyConst =
   | CBootParserParseMExprString _ -> tyarrows_ [tyseq_ tystr_, tystr_, tybootparsetree_]
   | CBootParserParseMCoreFile _ -> tyarrows_ [
-      tytuple_ [tybool_, tybool_ ,tyseq_ tystr_, tybool_, tybool_, tybool_],
+      tytuple_ [tybool_, tybool_ ,tyseq_ tystr_, tybool_, tybool_],
       tyseq_ tystr_,
       tystr_,
       tybootparsetree_

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1763,8 +1763,8 @@ lang BootParserEval =
   syn Const =
   | CBootParserTree {val : BootParseTree}
   | CBootParserParseMExprString2 [String]
-  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool)
-  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool), [String])
+  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool, Bool)
+  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool, Bool), [String])
   | CBootParserGetTerm2 BootParseTree
   | CBootParserGetType2 BootParseTree
   | CBootParserGetString2 BootParseTree
@@ -1823,13 +1823,14 @@ lang BootParserEval =
   | CBootParserParseMCoreFile _ ->
     match arg with TmRecord {bindings = bs} then
       match
-        map (lam b. mapLookup b bs) (map stringToSid ["0", "1", "2", "3", "4"])
+        map (lam b. mapLookup b bs) (map stringToSid ["0", "1", "2", "3", "4", "5"])
       with [
         Some (TmConst { val = CBool { val = keepUtests } }),
         Some (TmConst { val = CBool { val = pruneExternalUtests } }),
         Some (TmSeq { tms = externalsExclude }),
         Some (TmConst { val = CBool { val = warn } }),
-        Some (TmConst { val = CBool { val = eliminateDeadCode } })
+        Some (TmConst { val = CBool { val = eliminateDeadCode } }),
+        Some (TmConst { val = CBool { val = parseOnly } })
       ]
       then
         let externalsExclude =
@@ -1850,7 +1851,8 @@ lang BootParserEval =
                   pruneExternalUtests,
                   externalsExclude,
                   warn,
-                  eliminateDeadCode ),
+                  eliminateDeadCode,
+                  parseOnly ),
                  ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}
       else
         infoErrorExit info

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1763,8 +1763,8 @@ lang BootParserEval =
   syn Const =
   | CBootParserTree {val : BootParseTree}
   | CBootParserParseMExprString2 [String]
-  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool)
-  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool), [String])
+  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool, Bool)
+  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool, Bool), [String])
   | CBootParserGetTerm2 BootParseTree
   | CBootParserGetType2 BootParseTree
   | CBootParserGetString2 BootParseTree
@@ -1829,7 +1829,8 @@ lang BootParserEval =
         Some (TmConst { val = CBool { val = pruneExternalUtests } }),
         Some (TmSeq { tms = externalsExclude }),
         Some (TmConst { val = CBool { val = warn } }),
-        Some (TmConst { val = CBool { val = eliminateDeadCode } })
+        Some (TmConst { val = CBool { val = eliminateDeadCode } }),
+        Some (TmConst { val = CBool { val = allowFree } })
       ]
       then
         let externalsExclude =
@@ -1850,7 +1851,8 @@ lang BootParserEval =
                   pruneExternalUtests,
                   externalsExclude,
                   warn,
-                  eliminateDeadCode ),
+                  eliminateDeadCode,
+                  allowFree ),
                  ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}
       else
         infoErrorExit info

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1831,7 +1831,7 @@ lang BootParserEval =
   | CBootParserParseMExprString3 (options, keywords) ->
     match arg with TmSeq {tms = seq} then
       let t =
-        bootParserParseMExprString options keywords (_evalSeqOfCharsToString info seq)
+        bootParserParseMExprString (options,) keywords (_evalSeqOfCharsToString info seq)
       in
       TmConst {val = CBootParserTree {val = t},
                ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1763,8 +1763,8 @@ lang BootParserEval =
   syn Const =
   | CBootParserTree {val : BootParseTree}
   | CBootParserParseMExprString2 [String]
-  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool, Bool)
-  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool, Bool), [String])
+  | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool)
+  | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool), [String])
   | CBootParserGetTerm2 BootParseTree
   | CBootParserGetType2 BootParseTree
   | CBootParserGetString2 BootParseTree
@@ -1829,8 +1829,7 @@ lang BootParserEval =
         Some (TmConst { val = CBool { val = pruneExternalUtests } }),
         Some (TmSeq { tms = externalsExclude }),
         Some (TmConst { val = CBool { val = warn } }),
-        Some (TmConst { val = CBool { val = eliminateDeadCode } }),
-        Some (TmConst { val = CBool { val = parseOnly } })
+        Some (TmConst { val = CBool { val = eliminateDeadCode } })
       ]
       then
         let externalsExclude =
@@ -1851,8 +1850,7 @@ lang BootParserEval =
                   pruneExternalUtests,
                   externalsExclude,
                   warn,
-                  eliminateDeadCode,
-                  parseOnly ),
+                  eliminateDeadCode ),
                  ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}
       else
         infoErrorExit info

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1762,7 +1762,8 @@ lang BootParserEval =
 
   syn Const =
   | CBootParserTree {val : BootParseTree}
-  | CBootParserParseMExprString2 [String]
+  | CBootParserParseMExprString2 (Bool)
+  | CBootParserParseMExprString3 (Bool, [String])
   | CBootParserParseMCoreFile2 (Bool, Bool, [String], Bool, Bool, Bool)
   | CBootParserParseMCoreFile3 ((Bool, Bool, [String], Bool, Bool, Bool), [String])
   | CBootParserGetTerm2 BootParseTree
@@ -1777,7 +1778,8 @@ lang BootParserEval =
 
   sem constArity =
   | CBootParserTree _ -> 0
-  | CBootParserParseMExprString2 _ -> 1
+  | CBootParserParseMExprString2 _ -> 2
+  | CBootParserParseMExprString3 _ -> 3
   | CBootParserParseMCoreFile2 _ -> 2
   | CBootParserParseMCoreFile3 _ -> 3
   | CBootParserGetTerm2 _ -> 1
@@ -1792,6 +1794,22 @@ lang BootParserEval =
 
   sem delta info arg =
   | CBootParserParseMExprString _ ->
+    match arg with TmRecord {bindings = bs} then
+      match
+        map (lam b. mapLookup b bs) (map stringToSid ["0"])
+      with [
+        Some (TmConst { val = CBool { val = allowFree } })
+      ]
+      then
+        TmConst {val = CBootParserParseMExprString2 ( allowFree ),
+                 ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}
+      else
+        infoErrorExit info
+          "First argument to bootParserParseMExprString incorrect record"
+    else
+      infoErrorExit info
+        "First argument to bootParserParseMExprString not a record"
+  | CBootParserParseMExprString2 options ->
     match arg with TmSeq {tms = seq} then
       let keywords =
         map
@@ -1805,15 +1823,15 @@ lang BootParserEval =
                   "bootParserParseMExprString not a sequence"
                 ]))
           seq in
-      TmConst {val = CBootParserParseMExprString2 keywords,
+      TmConst {val = CBootParserParseMExprString3 (options,keywords),
                ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}
     else
       infoErrorExit info
         "First argument to bootParserParseMExprString not a sequence"
-  | CBootParserParseMExprString2 keywords ->
+  | CBootParserParseMExprString3 (options, keywords) ->
     match arg with TmSeq {tms = seq} then
       let t =
-        bootParserParseMExprString keywords (_evalSeqOfCharsToString info seq)
+        bootParserParseMExprString options keywords (_evalSeqOfCharsToString info seq)
       in
       TmConst {val = CBootParserTree {val = t},
                ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -1,7 +1,6 @@
 -- Various functions for manipulating externals in MExpr ASTs
 
 include "ast.mc"
-include "boot-parser.mc"
 include "ast-builder.mc"
 include "eq.mc"
 
@@ -11,155 +10,49 @@ include "sys.mc"
 
 let _error = "Error in externals.mc: not an external in externalsMap"
 
-lang Externals = ExtAst
+lang Externals = ExtAst + VarAst
 
-  -- Collects all external definitions in a program and returns a
-  -- map from external string identifiers to the variable names
-  -- they introduce. For example,
-  --
-  --   external id : Float -> Float
-  --
-  -- results in a map entry from the string id to the introduced name id.
-  sem collectExternals : Expr -> Map String Expr
-  sem collectExternals =
-  | expr -> collectExternalsHelper (mapEmpty cmpString) expr
+  -- Removes the symbols from all variables referring to externals. Assumes the
+  -- program has been symbolized beforehand.
+  sem unSymbolizeExternals : Expr -> Expr
+  sem unSymbolizeExternals =
+  | expr -> unSymbolizeExternalsH (setEmpty nameCmp) expr
+  sem unSymbolizeExternalsH : Set Name -> Expr -> Expr
+  sem unSymbolizeExternalsH env =
+  | TmExt t ->
+    let env = setInsert t.ident env in
+    let inexpr = unSymbolizeExternalsH env t.inexpr in
+    TmExt {{ t with ident = nameNoSym (nameGetStr t.ident) }
+               with inexpr = inexpr }
+  | TmVar t ->
+    if setMem t.ident env then
+      TmVar { t with ident = nameNoSym (nameGetStr t.ident) }
+    else TmVar t
+  | expr -> smap_Expr_Expr (unSymbolizeExternalsH env) expr
 
-  sem collectExternalsHelper : Map String Expr -> Expr -> Map String Expr
-  sem collectExternalsHelper acc =
-  | TmExt t & expr ->
-    let str = nameGetStr t.ident in
-    -- Assumption: No two externals have the same string identifier (this is
-    -- enforced elsewhere)
-    let acc = mapInsert str expr acc in
-    sfold_Expr_Expr collectExternalsHelper acc expr
-  | expr -> sfold_Expr_Expr collectExternalsHelper acc expr
+  -- Removes the given set of external definitions from the program.
+  sem removeExternalDefs : Set String -> Expr -> Expr
+  sem removeExternalDefs env =
+  | TmExt t ->
+    if setMem (nameGetStr t.ident) env then t.inexpr else
+    let inexpr = removeExternalDefs env t.inexpr in
+    TmExt { t with inexpr = inexpr }
+  | expr -> smap_Expr_Expr (removeExternalDefs env) expr
 
-  sem prependExternals : Map String Expr -> Expr -> Expr
-  sem prependExternals externalsMap =
-  | expr -> mapFoldWithKey (lam acc. lam _k. lam v.
-        match v with TmExt t then TmExt { t with inexpr = acc }
-        else error _error
-      ) expr externalsMap
-
-  sem mergeExternalsPreferLeft
-    : Map String Expr -> Map String Expr -> Map String Expr
-  sem mergeExternalsPreferLeft e1 =
-  | e2 -> mapFoldWithKey (lam e2. lam k. lam v. mapInsert k v e2) e2 e1
-
-end
-
-lang MExprExternals = Externals + BootParser
-
-  sem readExternalsFromFile : String -> Map String Expr
-  sem readExternalsFromFile =
-  | filename ->
-    let tmpFile = sysTempFileMake () in
-    writeFile tmpFile (join ["include \"", filename, "\""]);
-    let r = collectExternals (parseMCoreFile
-      { defaultBootParserParseMCoreFileArg
-        with eliminateDeadCode = false } tmpFile) in
-    sysDeleteFile tmpFile; r
+  sem getExternalIds : Expr -> Set String
+  sem getExternalIds =
+  | expr -> getExternalIdsH (setEmpty cmpString) expr
+  sem getExternalIdsH : Set String -> Expr -> Set String
+  sem getExternalIdsH acc =
+  | TmExt t -> getExternalIdsH (setInsert (nameGetStr t.ident) acc) t.inexpr
+  | expr -> sfold_Expr_Expr getExternalIdsH acc expr
 
 end
 
-
-lang Test = Externals + MExprExternals + MExprEq
+lang Test = Externals + MExprEq
 end
 
 -----------
 -- TESTS --
 -----------
-
-mexpr
-use Test in
-
-let _externalsToNames: Map String Expr -> Map String Name = lam m.
-  mapMap (lam v. match v with TmExt t then t.ident else error _error) m
-in
-
--- Test collectExternals
-let _testCollect = lam prog: String.
-  let expr = parseMExprString [] prog in
-  let m = collectExternals expr in
-  _externalsToNames m
-in
-
--- Top-level
-let t = "
-  external extA : () -> () in
-  external extB : Float -> Float in
-  external extC : Int -> Float in
-  ()
-------------------------" in
-utest _testCollect t with mapFromSeq cmpString [
-  let str = "extA" in (str, nameNoSym str),
-  let str = "extB" in (str, nameNoSym str),
-  let str = "extC" in (str, nameNoSym str)
-] using mapEq nameEq in
-
--- Nested
-let t = "
-  let x =
-    external extA : () -> () in
-    external extB : Float -> Float in
-    external extC : Int -> Float in
-    ()
-  in x
-------------------------" in
-utest _testCollect t with mapFromSeq cmpString [
-  let str = "extA" in (str, nameNoSym str),
-  let str = "extB" in (str, nameNoSym str),
-  let str = "extC" in (str, nameNoSym str)
-] using mapEq nameEq in
-
--- Test prependExternals
-let _testPrepend: Map String Expr -> Expr = lam m. prependExternals m unit_ in
-let _ext = lam str. lam inexpr. bind_ (ext_ str false tyunit_) inexpr in
-recursive let _eqExtExpr: Expr -> Expr -> Bool = lam e1. lam e2.
-  match (e1,e2) with (TmExt t1, TmExt t2) then
-    if nameEq t1.ident t2.ident then _eqExtExpr t1.inexpr t2.inexpr
-    else false
-  else eqExpr e1 e2
-in
-
-utest _testPrepend (mapFromSeq cmpString [
-  let str = "extA" in (str, _ext str unit_),
-  let str = "extB" in (str, _ext str (int_ 1)), -- The inexpr (int) is ignored
-  let str = "extC" in (str, _ext str unit_)
-]) with bindall_ [
-  _ext "extC" unit_,
-  _ext "extB" unit_,
-  _ext "extA" unit_,
-  unit_
-] using _eqExtExpr in
-
--- Test mergeExternalsPreferLeft
-let _testMerge = lam m1: Map String Name. lam m2: Map String Name.
-  let m1 = mapMap (lam v. next_ v false tyunit_) m1 in
-  let m2 = mapMap (lam v. next_ v false tyunit_) m2 in
-  let m = mergeExternalsPreferLeft m1 m2 in
-  _externalsToNames m
-in
-
-let extNameA = nameSym "extA" in
-let extNameB = nameSym "extB" in
-let extNameC = nameSym "extC" in
-let extNameD = nameSym "extD" in
-let extNameE = nameSym "extE" in
-utest _testMerge (mapFromSeq cmpString [
-  ("extA", extNameA),
-  ("extB", extNameB),
-  ("extC", extNameC)
-]) (mapFromSeq cmpString [
-  ("extA", nameSym "extA"),
-  ("extD", extNameD),
-  ("extE", extNameE)
-]) with (mapFromSeq cmpString [
-  ("extA", extNameA),
-  ("extB", extNameB),
-  ("extC", extNameC),
-  ("extD", extNameD),
-  ("extE", extNameE)
-]) using mapEq nameEq in
-
-()
+-- TODO Write some tests

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -3,6 +3,7 @@
 include "ast.mc"
 include "ast-builder.mc"
 include "eq.mc"
+include "boot-parser.mc"
 
 include "map.mc"
 include "name.mc"
@@ -12,31 +13,13 @@ let _error = "Error in externals.mc: not an external in externalsMap"
 
 lang Externals = ExtAst + VarAst
 
-  -- Removes the symbols from all variables referring to externals. Assumes the
-  -- program has been symbolized beforehand.
-  sem unSymbolizeExternals : Expr -> Expr
-  sem unSymbolizeExternals =
-  | expr -> unSymbolizeExternalsH (setEmpty nameCmp) expr
-  sem unSymbolizeExternalsH : Set Name -> Expr -> Expr
-  sem unSymbolizeExternalsH env =
-  | TmExt t ->
-    let env = setInsert t.ident env in
-    let inexpr = unSymbolizeExternalsH env t.inexpr in
-    TmExt {{ t with ident = nameNoSym (nameGetStr t.ident) }
-               with inexpr = inexpr }
-  | TmVar t ->
-    if setMem t.ident env then
-      TmVar { t with ident = nameNoSym (nameGetStr t.ident) }
-    else TmVar t
-  | expr -> smap_Expr_Expr (unSymbolizeExternalsH env) expr
-
   -- Removes the given set of external definitions from the program.
   sem removeExternalDefs : Set String -> Expr -> Expr
   sem removeExternalDefs env =
   | TmExt t ->
-    if setMem (nameGetStr t.ident) env then t.inexpr else
     let inexpr = removeExternalDefs env t.inexpr in
-    TmExt { t with inexpr = inexpr }
+    if setMem (nameGetStr t.ident) env then inexpr
+    else TmExt { t with inexpr = inexpr }
   | expr -> smap_Expr_Expr (removeExternalDefs env) expr
 
   sem getExternalIds : Expr -> Set String
@@ -49,10 +32,43 @@ lang Externals = ExtAst + VarAst
 
 end
 
-lang Test = Externals + MExprEq
+lang Test = Externals + MExprEq + BootParser
 end
 
 -----------
 -- TESTS --
 -----------
--- TODO Write some tests
+mexpr
+use Test in
+
+let parse = parseMExprString
+  { defaultBootParserParseMExprStringArg with allowFree = true } in
+let ast1 = parse "
+  external a: Int -> Int in
+  external b: Float -> Float in
+  a 1; b 1.0
+" in
+let ast2 = parse "
+  external b: Float -> Float in
+  a 1; b 1.0
+" in
+let ast3 = parse "
+  external a: Int -> Int in
+  a 1; b 1.0
+" in
+
+utest removeExternalDefs (setOfSeq cmpString ["a"]) ast1
+with ast2
+using eqExpr in
+
+utest removeExternalDefs (setOfSeq cmpString ["b"]) ast1
+with ast3
+using eqExpr in
+
+utest getExternalIds ast1 with setOfSeq cmpString ["a", "b"]
+using setEq in
+
+utest getExternalIds ast2 with setOfSeq cmpString ["b"]
+using setEq in
+
+()

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -1,9 +1,9 @@
 -- Various functions for manipulating externals in MExpr ASTs
 
 include "ast.mc"
+include "boot-parser.mc"
 include "ast-builder.mc"
 include "eq.mc"
-include "boot-parser.mc"
 
 include "map.mc"
 include "name.mc"

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -402,7 +402,7 @@ lang ExtPrettyPrint = PrettyPrint + ExtAst + UnknownTypeAst
     else never
 end
 
-lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst
+lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst + VariantTypeAst
   sem isAtomic =
   | TmType _ -> false
 
@@ -414,7 +414,7 @@ lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst
       let paramStr = strJoin " " (cons "" params) in
       match pprintCode indent env t.inexpr with (env,inexpr) then
         match getTypeStringCode indent env t.tyIdent with (env, tyIdent) then
-          match t.tyIdent with TyUnknown _ then
+          match t.tyIdent with TyUnknown _ | TyVariant _ then
             (env, join ["type ", ident, paramStr, pprintNewline indent,
                          "in", pprintNewline indent,
                          inexpr])

--- a/stdlib/mexpr/profiling.mc
+++ b/stdlib/mexpr/profiling.mc
@@ -190,7 +190,7 @@ let getProfilerReportCode = lam.
   match deref _profilerReportCodeRef with Some t then t
   else
     use BootParser in
-    let code = parseMExprString ["functionProfileData"] _profilerReportStr in
+    let code = parseMExprStringKeywords ["functionProfileData"] _profilerReportStr in
     modref _profilerReportCodeRef (Some code);
     code
 
@@ -251,7 +251,7 @@ lang MExprProfileInstrument = MExprAst + BootParser
     let emptyEnv = mapEmpty nameCmp in
     let env = collectToplevelFunctions emptyEnv t in
     bindall_ [
-      parseMExprString [] (_profilerInitStr env),
+      parseMExprStringKeywords [] (_profilerInitStr env),
       ulet_ "" (instrumentProfilingH env t),
       getProfilerReportCode ()]
 end

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -27,21 +27,24 @@ type SymEnv = {
   tyVarEnv: Map String (Name, Level),
   tyConEnv: Map String Name,
   currentLvl : Level,
-  strictTypeVars: Bool
+  strictTypeVars: Bool,
+  ignoreFree: Bool
 }
 
-let symEnvEmpty =
-  {varEnv = mapEmpty cmpString,
-   conEnv = mapEmpty cmpString,
-   tyVarEnv = mapEmpty cmpString,
+let symEnvEmpty = {
+  varEnv = mapEmpty cmpString,
+  conEnv = mapEmpty cmpString,
+  tyVarEnv = mapEmpty cmpString,
 
-   -- Built-in type constructors
-   tyConEnv = mapFromSeq cmpString (
-     map (lam t: (String, [String]). (t.0, nameNoSym t.0)) builtinTypes
-   ),
+  -- Built-in type constructors
+  tyConEnv = mapFromSeq cmpString (
+    map (lam t: (String, [String]). (t.0, nameNoSym t.0)) builtinTypes
+  ),
 
-   currentLvl = 1,
-   strictTypeVars = false}
+  currentLvl = 1,
+  strictTypeVars = false,
+  ignoreFree = false
+}
 
 -----------
 -- TERMS --
@@ -71,6 +74,12 @@ lang Sym = Ast
   | expr ->
     let env = symEnvEmpty in
     symbolizeExpr env expr
+
+  -- Symbolize with builtin environment and ignore errors
+  sem symbolizeIgnoreFree =
+  | expr ->
+    let env = { symEnvEmpty with ignoreFree = true } in
+    symbolizeExpr env expr
 end
 
 lang VarSym = Sym + VarAst
@@ -80,10 +89,13 @@ lang VarSym = Sym + VarAst
       if nameHasSym t.ident then TmVar t
       else
         let str = nameGetStr t.ident in
-        match mapLookup str varEnv with Some ident then
-          TmVar {{t with ident = ident}
-                    with ty = symbolizeType env t.ty}
-        else infoErrorExit t.info (concat "Unknown variable in symbolizeExpr: " str)
+        let ident =
+          match mapLookup str varEnv with Some ident then ident
+          else if env.ignoreFree then t.ident
+          else infoErrorExit t.info (concat "Unknown variable in symbolizeExpr: " str)
+        in
+        TmVar {{t with ident = ident}
+                  with ty = symbolizeType env t.ty}
     else never
 end
 
@@ -259,11 +271,14 @@ lang DataSym = Sym + DataAst
                      with ty = ty}
       else
         let str = nameGetStr t.ident in
-        match mapLookup str conEnv with Some ident then
-          TmConApp {{{t with ident = ident}
-                        with body = symbolizeExpr env t.body}
-                        with ty = ty}
-        else infoErrorExit t.info (concat "Unknown constructor in symbolizeExpr: " str)
+        let ident =
+          match mapLookup str conEnv with Some ident then ident
+          else if env.ignoreFree then t.ident
+          else infoErrorExit t.info (concat "Unknown constructor in symbolizeExpr: " str)
+        in
+        TmConApp {{{t with ident = ident}
+                      with body = symbolizeExpr env t.body}
+                      with ty = ty}
     else never
 end
 
@@ -302,7 +317,8 @@ lang ConTypeSym = ConTypeAst + UnknownTypeAst
         match mapLookup str tyConEnv with Some ident then
           TyCon {t with ident = ident}
         else if env.strictTypeVars then
-          infoErrorExit t.info (concat "Unknown type constructor in symbolizeExpr: " str)
+          if env.ignoreFree then TyCon t
+          else infoErrorExit t.info (concat "Unknown type constructor in symbolizeExpr: " str)
         else
           TyUnknown {info = t.info}
     else never
@@ -318,7 +334,8 @@ lang VarTypeSym = VarTypeAst + UnknownTypeAst
         TyVar {{t with ident = ident}
                   with level = lvl}
       else if env.strictTypeVars then
-        infoErrorExit t.info (concat "Unknown type variable in symbolizeExpr: " str)
+        if env.ignoreFree then TyVar t
+        else infoErrorExit t.info (concat "Unknown type variable in symbolizeExpr: " str)
       else
         TyUnknown {info = t.info}
 end
@@ -545,6 +562,5 @@ mapi debugPrint [
     matchoredge,
     lettyvar
   ];
-
 
 ()

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -91,7 +91,7 @@ lang Sym = Ast
     symbolizeTopExpr env expr
 
   -- Symbolize with builtin environment and ignore errors
-  sem symbolizeallowFree =
+  sem symbolizeAllowFree =
   | expr ->
     let env = { symEnvEmpty with allowFree = true } in
     symbolizeExpr env expr

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -271,7 +271,7 @@ lang RecLetsSym = Sym + RecLetsAst + AllTypeAst
            mapInsert (nameGetStr bind.ident) bind.ident varEnv)
         env.varEnv t.bindings
     in
-    addTopNames {env with varEnv = varEnv} t.inexpr in
+    addTopNames {env with varEnv = varEnv} t.inexpr
 end
 
 lang DataSym = Sym + DataAst

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -118,7 +118,7 @@ let utestRunner = lam.
   match deref _utestRunnerCode with Some t then t
   else
     use BootParser in
-    let code = parseMExprString [] _utestRunnerStr in
+    let code = parseMExprStringKeywords [] _utestRunnerStr in
     modref _utestRunnerCode (Some code);
     code
 
@@ -153,7 +153,7 @@ let findName : String -> Expr -> Option Name = use MExprAst in
 
 let _expr =
   use BootParser in
-  parseMExprString [] "let foo = lam. 42 in ()"
+  parseMExprStringKeywords [] "let foo = lam. 42 in ()"
 utest
   match findName "foo" _expr
   with Some n
@@ -163,7 +163,7 @@ with true
 
 let _expr =
   use BootParser in
-  parseMExprString [] "recursive let foo = lam. 42 in ()"
+  parseMExprStringKeywords [] "recursive let foo = lam. 42 in ()"
 utest
   match findName "foo" _expr
   with Some n
@@ -173,7 +173,7 @@ with true
 
 let _expr =
   use BootParser in
-  parseMExprString [] "external foo : () in ()"
+  parseMExprStringKeywords [] "external foo : () in ()"
 utest
   match findName "foo" _expr
   with Some n

--- a/stdlib/stdlib.mc
+++ b/stdlib/stdlib.mc
@@ -1,0 +1,18 @@
+-- Mimics the approach used to find the stdlib location in
+-- src/boot/lib/parserutils.ml
+
+include "sys.mc"
+
+let stdlibCwd = join [sysGetCwd (), "/stdlib"]
+
+let stdlibLocUnix =
+  match sysGetEnv "HOME" with Some path then
+    join [path, "/.local/lib/mcore/stdlib"]
+  else stdlibCwd
+
+let stdlibLoc =
+  match sysGetEnv "MCORE_STDLIB" with Some path then path
+  else
+    -- NOTE(dlunde,2022-05-04) The boot parser also checks if the OS type is
+    -- "Unix" here
+    if sysFileExists stdlibLocUnix then stdlibLocUnix else stdlibCwd

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -24,6 +24,9 @@ let _commandListTimeoutWrap : Float -> [String] -> [String] = lam timeoutSec. la
        , ["\'}"]
        ]
 
+let sysFileExists: String -> Bool = lam file.
+  if eqi (_commandList ["test", "-e", file]) 0 then true else false
+
 let sysMoveFile = lam fromFile. lam toFile.
   _commandList ["mv", "-f", fromFile, toFile]
 
@@ -104,5 +107,12 @@ let sysRunCommand : [String] -> String -> String -> ExecResult =
 
 let sysCommandExists : String -> Bool = lam cmd.
   eqi 0 (command (join ["which ", cmd, " >/dev/null 2>&1"]))
+
+let sysGetCwd : () -> String = lam. strTrim (sysRunCommand ["pwd"] "" ".").stdout
+
+let sysGetEnv : String -> Option String = lam env.
+  let res = strTrim (sysRunCommand ["echo", concat "$" env] "" ".").stdout in
+  if null res then None ()
+  else Some res
 
 utest sysCommandExists "ls" with true

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -121,7 +121,7 @@ lang ContextExpand = HoleAst
   sem _wrapReadFile (env : CallCtxEnv) (tuneFile : String) =
   | tm ->
     use BootParser in
-    let impl = parseMExprString [] "
+    let impl = parseMExprStringKeywords [] "
     let or: Bool -> Bool -> Bool =
       lam a. lam b. if a then true else b in
 
@@ -298,7 +298,7 @@ let anf = compose normalizeTerm symbolize in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in

--- a/stdlib/tuning/dependency-analysis.mc
+++ b/stdlib/tuning/dependency-analysis.mc
@@ -232,7 +232,7 @@ use TestLang in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -382,7 +382,7 @@ use Test in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -203,7 +203,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
        in\n"
     , "()\n"
     ] in
-    let ex = use BootParser in parseMExprString [] str in
+    let ex = use BootParser in parseMExprStringKeywords [] str in
     let str2name = lam str.
       match findName str ex with Some n then n
       else error (concat str " not found in instrumentation header")
@@ -307,7 +307,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
       in"
     , "()\n"
     ] in
-    let ex = use BootParser in parseMExprString [] str in
+    let ex = use BootParser in parseMExprStringKeywords [] str in
     let fun = match findName "dumpLog" ex with Some n then n else error "impossible" in
     (ex, fun)
 
@@ -353,7 +353,7 @@ let debugPrintLn = lam debug.
 in
 
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -335,7 +335,7 @@ use TestLang in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in

--- a/stdlib/tuning/tail-positions.mc
+++ b/stdlib/tuning/tail-positions.mc
@@ -137,7 +137,7 @@ use TestLang in
 let debug = false in
 
 let parse = lam str.
-  let ast = parseMExprString [] str in
+  let ast = parseMExprStringKeywords [] str in
   symbolize ast
 in
 

--- a/stdlib/tuning/tune-file.mc
+++ b/stdlib/tuning/tune-file.mc
@@ -145,4 +145,4 @@ let tuneFileReadTable : String -> LookupTable = lam file.
   let n = string2int (head rows) in
   let strVals = subsequence rows 1 n in
   let strVals = map (lam x. get (strSplit ": " x) 1) strVals in
-  map (parseMExprString []) strVals
+  map (parseMExprStringKeywords []) strVals

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -559,7 +559,7 @@ let debug = false in
 let timeSensitive = false in
 
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in


### PR DESCRIPTION
# Changes (mostly minor)
- Update `make` so that the tests compile to a proper temporary binary (and not a temporary binary in the current working directory).
- Change `bootParserParseMExprString` and `bootParserParseMCoreFile` to also accept an option (`allowFree`) indicating if free variables are allowed. This also includes a minor addition to the dead code elimination. Note that the previous function `parseMExprString` is now renamed to `parseMExprStringKeywords`. `parseMExprString` is now more general and accepts a complete options record.
- Add `repeat f times` function to `common.mc`.
- Add support for Exponential, Gamma, and Poisson distributions, and add missing functions for Discrete Uniform and Continuous Uniform distributions. Note that the Poisson implementation does _not_ use an external, as this was not directly available in Owl (it seems to be available in lower-level Owl code though, but it is not clear how it should be used). Instead, I implemented a very basic (and probably inefficient, especially for large Poisson rates) Poisson sampler directly in MCore.
- Update Bernoulli distribution to be over type `Bool` (previous was `Int`).
- Fix a type error in `stdlib/ext/file-ext.mc` (`Unit` -> `()`).
- Add `logFactorial` function to `math.mc`.
- Rewrite most of `stdlib/mexpr/externals.mc`.
- Print `TyVariant`s simply as `type Type in` instead of `type Type = <> in` as the latter version cannot be parsed.
- Add symbolize functions: `symbolizeTop` and `symbolizeAllowFree`. `symbolizeTop` corresponds to the top-level symbolize in boot, and `symbolizeAllowFree` allows free variables.
- Add `stdlib/stdlib.mc` for determining the stdlib path on the current system (mimics the approach used in `parserutils.ml`).
- Add `sysFileExists`, `sysGetCwd`, and `sysGetEnv` to `stdlib/sys.mc`
- Add `mapAccumLPre_Expr_Expr`, `mapAccumLPost_Expr_Expr`, and also corresponding folds and maps.