### PR TITLE
Only call splitAt once if an edge pattern only uses one edge

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -25,6 +25,22 @@ module Mseq = struct
     | List s ->
         List.length s
 
+  let is_length_at_least s i =
+    match s with
+    | Rope s ->
+        Rope.length_array s >= i
+    | List s ->
+        let rec work j s =
+          match (j, s) with
+          | 0, _ ->
+              true
+          | _, [] ->
+              false
+          | _, _ :: t ->
+              work (j - 1) t
+        in
+        work i s
+
   let concat s1 s2 =
     match (s1, s2) with
     | Rope s1, Rope s2 ->

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -52,6 +52,12 @@ module Mseq : sig
 
   (* Complexity:
    * rope (?): O(1) assuming OCaml's Array.length is O(1)
+   * list (?): O(i), where i is the provided length to compare with
+   *)
+  val is_length_at_least : 'a t -> int -> bool
+
+  (* Complexity:
+   * rope (?): O(1) assuming OCaml's Array.length is O(1)
    * list (?): O(n), where n is the length of the first argument
    *)
   val concat : 'a t -> 'a t -> 'a t

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -48,6 +48,10 @@ let _none = use OCamlAst in OTmConAppExt {ident = _noneName, args = []}
 let _if = use OCamlAst in lam cond. lam thn. lam els. _omatch_ cond [(ptrue_, thn), (pfalse_, els)]
 let _tuplet = use OCamlAst in lam pats. lam val. lam body. _omatch_ val [(OPatTuple {pats = pats}, body)]
 
+let _isLengthAtLeastName = intrinsicOpSeq "is_length_at_least"
+let _isLengthAtLeast = use OCamlAst in
+  appf2_ (OTmVarExt {ident = _isLengthAtLeastName})
+
 let _builtinNameMap : Map String Name =
   let builtinStrs =
     match unzip builtin with (strs, _) then
@@ -452,22 +456,45 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
   | PatSeqTot {pats = pats} ->
     let genOne = lam i. lam pat.
       let n = nameSym "_seqElem" in
-      match generatePat env n pat with (names, innerWrap) then
-        let wrap = lam cont.
-          bind_
-            (nulet_ n (get_ (nvar_ targetName) (int_ i)))
-            (innerWrap cont)
-        in (names, wrap)
-      else never in
-    match unzip (mapi genOne pats) with (allNames, allWraps) then
+      match generatePat env n pat with (names, innerWrap) in
       let wrap = lam cont.
-        _if (eqi_ (length_ (nvar_ targetName)) (int_ (length pats)))
-          (foldr (lam f. lam v. f v) cont allWraps)
-          _none in
-      ( foldl (assocMergePreferRight {eq=nameEqSym}) assocEmpty allNames
-      , wrap
-      )
-    else never
+        bind_
+          (nulet_ n (get_ (nvar_ targetName) (int_ i)))
+          (innerWrap cont)
+      in (names, wrap) in
+    match unzip (mapi genOne pats) with (allNames, allWraps) in
+    let cond =
+      if null pats then _if (null_ (nvar_ targetName))
+      else _if (eqi_ (length_ (nvar_ targetName)) (int_ (length pats))) in
+    let wrap = lam cont.
+      cond
+        (foldr (lam f. lam v. f v) cont allWraps)
+        _none in
+    ( foldl (assocMergePreferRight {eq=nameEqSym}) assocEmpty allNames
+    , wrap
+    )
+  | PatSeqEdge {prefix = [head], middle = middle, postfix = []} ->
+    let apply = lam f. lam x. f x in
+    let headName = nameSym "_hd" in
+    let tailName = nameSym "_tl" in
+    match generatePat env headName head with (headNames, headWrap) in
+    match middle with PName mid then
+      let tl = PatNamed {ident = middle, info = NoInfo (), ty = tyunknown_} in
+      match generatePat env tailName tl with (tailNames, tailWrap) in
+      let wrap = lam cont.
+        _if (null_ (nvar_ targetName))
+          _none
+          (bindall_ [
+            nulet_ headName (head_ (nvar_ targetName)),
+            nulet_ tailName (tail_ (nvar_ targetName)),
+            headWrap (tailWrap cont)]) in
+      (assocMergePreferRight {eq=nameEqSym} headNames tailNames, wrap)
+    else
+      let wrap = lam cont.
+        _if (null_ (nvar_ targetName))
+          _none
+          (bind_ (nulet_ headName (head_ (nvar_ targetName))) (headWrap cont)) in
+      (headNames, wrap)
   | PatSeqEdge {prefix = prefix, middle = middle, postfix = postfix} ->
     let apply = lam f. lam x. f x in
     let mergeNames = assocMergePreferRight {eq=nameEqSym} in
@@ -479,13 +506,12 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
     let lenName = nameSym "_len" in
     let genOne = lam targetName. lam i. lam pat.
       let n = nameSym "_seqElem" in
-      match generatePat env n pat with (names, innerWrap) then
-        let wrap = lam cont.
-          bind_
-            (nlet_ n tyunknown_ (get_ (nvar_ targetName) (int_ i)))
-            (innerWrap cont)
-        in (names, wrap)
-      else never in
+      match generatePat env n pat with (names, innerWrap) in
+      let wrap = lam cont.
+        bind_
+          (nlet_ n tyunknown_ (get_ (nvar_ targetName) (int_ i)))
+          (innerWrap cont)
+      in (names, wrap) in
     match
       match prefix with [] then (identity, [], targetName) else
       match unzip (mapi (genOne preName) prefix) with (preNames, preWraps) in
@@ -505,11 +531,16 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
       (wrap, postNames, midName)
     with (postWrap, postNames, midName) in
     let wrap = lam cont.
-      bind_
-        (nulet_ lenName (length_ (nvar_ targetName)))
-        (_if (lti_ (nvar_ lenName) (int_ minLen))
+      match postfix with [] then
+        _if (_isLengthAtLeast (nvar_ targetName) (int_ minLen))
+          (preWrap (postWrap cont))
           _none
-          (preWrap (postWrap cont))) in
+      else
+        bind_
+          (nulet_ lenName (length_ (nvar_ targetName)))
+          (_if (lti_ (nvar_ lenName) (int_ minLen))
+            _none
+            (preWrap (postWrap cont))) in
     let names = foldl mergeNames assocEmpty (concat preNames postNames) in
     let names = match middle with PName n then assocInsert {eq=nameEqSym} n midName names else names in
     (names, wrap)

--- a/stdlib/tuning/tune-stats.mc
+++ b/stdlib/tuning/tune-stats.mc
@@ -314,7 +314,7 @@ use TestLang in
 let debug = true in
 
 let parse = lam str.
-  let ast = parseMExprString holeKeywords str in
+  let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords [] ast in
   symbolize ast
 in


### PR DESCRIPTION
The current approach for generating code for a `[] ++ _ ++ []` pattern is not necessarily ideal:
- It always calls `splitAt` twice, even if the prefix or postfix is empty.
- I *believe* it was written before we had the option of lists underlying a sequence, thus it assumes that `length` is cheap.

This PR fixes the first part, and also decreases the number of `length` calls to one. The solution is still not ideal for lists, but I don't think I should spend more time on this at the moment.

As for the performance implications of this:
- There seems to be no difference when using the rope representation (or at least it's lost in noise). It's also worth noting that there seems to be no difference between using a `[x] ++ xs` pattern and directly calling `head` and `tail`, which is as it should be, but it's not obviously true since `splitAt` could be more expensive.
- This seems to help the list case a lot, though it's still not ideal because of the remaining `length` call.

<details>
<summary> (Highly unscientific) benchmarking </summary>

### Program (via @dlunde and @lingmar)

```
include "string.mc"

mexpr

recursive let printSamples = lam weights. lam samples.
    if and (null weights) (null samples) then () else
      match (weights,samples) with ([w] ++ weights, [s] ++ samples) in
      -- let w = head weights in
      -- let weights = tail weights in
      -- let s = head samples in
      -- let samples = tail samples in
      print (float2string s);
      print " ";
      print (float2string w);
      print "\n";
      printSamples weights samples
  in

let n = string2int (get argv 1) in

printSamples (createList n (lam. 0.)) (createList n (lam. 0.))

```

### lists with match before compiler change
```
Benchmark 1: ./prog 1000
  Time (mean ± σ):      11.8 ms ±   1.2 ms    [User: 10.2 ms, System: 1.6 ms]
  Range (min … max):    10.8 ms …  17.0 ms    211 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: ./prog 2000
  Time (mean ± σ):      42.6 ms ±   4.0 ms    [User: 41.0 ms, System: 1.6 ms]
  Range (min … max):    40.4 ms …  55.8 ms    53 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (55.6 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
 
Benchmark 3: ./prog 4000
  Time (mean ± σ):     218.8 ms ±  26.8 ms    [User: 215.7 ms, System: 2.4 ms]
  Range (min … max):   198.0 ms … 267.1 ms    14 runs
 
Summary
  './prog 1000' ran
    3.61 ± 0.50 times faster than './prog 2000'
   18.56 ± 2.95 times faster than './prog 4000'
```

### match lists after compiler change
```
Benchmark 1: ./prog 1000
  Time (mean ± σ):       4.1 ms ±   0.5 ms    [User: 3.1 ms, System: 1.1 ms]
  Range (min … max):     3.5 ms …   6.8 ms    614 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: ./prog 2000
  Time (mean ± σ):       9.6 ms ±   1.3 ms    [User: 8.4 ms, System: 1.2 ms]
  Range (min … max):     8.3 ms …  18.6 ms    291 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 3: ./prog 4000
  Time (mean ± σ):      27.8 ms ±   2.4 ms    [User: 26.4 ms, System: 1.4 ms]
  Range (min … max):    26.0 ms …  40.0 ms    111 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  './prog 1000' ran
    2.32 ± 0.41 times faster than './prog 2000'
    6.72 ± 0.94 times faster than './prog 4000'
```

### lists with head and tail before compiler change
```
Benchmark 1: ./prog 1000
  Time (mean ± σ):       2.7 ms ±   0.3 ms    [User: 2.1 ms, System: 0.6 ms]
  Range (min … max):     2.2 ms …   5.7 ms    821 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: ./prog 2000
  Time (mean ± σ):       3.9 ms ±   0.6 ms    [User: 2.8 ms, System: 1.1 ms]
  Range (min … max):     3.3 ms …   8.3 ms    703 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 3: ./prog 4000
  Time (mean ± σ):       6.4 ms ±   1.3 ms    [User: 5.3 ms, System: 1.2 ms]
  Range (min … max):     5.3 ms …  14.1 ms    450 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  './prog 1000' ran
    1.45 ± 0.28 times faster than './prog 2000'
    2.39 ± 0.57 times faster than './prog 4000'
```

### head and tail lists after compiler change
```
Benchmark 1: ./prog 1000
  Time (mean ± σ):       2.5 ms ±   0.3 ms    [User: 1.9 ms, System: 0.6 ms]
  Range (min … max):     2.1 ms …   4.5 ms    891 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: ./prog 2000
  Time (mean ± σ):       3.9 ms ±   0.5 ms    [User: 2.9 ms, System: 1.0 ms]
  Range (min … max):     3.3 ms …   6.5 ms    672 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 3: ./prog 4000
  Time (mean ± σ):       5.9 ms ±   0.6 ms    [User: 4.9 ms, System: 1.1 ms]
  Range (min … max):     5.3 ms …   9.1 ms    467 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  './prog 1000' ran
    1.56 ± 0.27 times faster than './prog 2000'
    2.38 ± 0.36 times faster than './prog 4000'
```

</details>

