### PR TITLE
Use a random string when generating temporary directories and files

### DIFF
--- a/stdlib/char.mc
+++ b/stdlib/char.mc
@@ -164,3 +164,12 @@ utest isLowerAlphaOrUnderscore 'A' with false
 utest isLowerAlphaOrUnderscore '{' with false
 utest isLowerAlphaOrUnderscore '_' with true
 utest isLowerAlphaOrUnderscore '\n' with false
+
+-- Generates a random ASCII letter or digit character.
+let randAlphanum : () -> Char = lam.
+  -- NOTE(larshum, 2021-09-15): The total number of digits or ASCII letters
+  -- (lower- and upper-case) is 10 + 26 + 26 = 62.
+  let r = randIntU 0 62 in
+  if lti r 10 then int2char (addi r 48)
+  else if lti r 36 then int2char (addi r 55)
+  else int2char (addi r 61)

--- a/stdlib/pmexpr/extract.mc
+++ b/stdlib/pmexpr/extract.mc
@@ -15,15 +15,6 @@ include "mexpr/type-check.mc"
 include "pmexpr/ast.mc"
 include "pmexpr/utils.mc"
 
--- Generates a random ASCII letter or digit character.
-let _randAlphanum : () -> Char = lam.
-  -- NOTE(larshum, 2021-09-15): The total number of digits or ASCII letters
-  -- (lower- and upper-case) is 10 + 26 + 26 = 62.
-  let r = randIntU 0 62 in
-  if lti r 10 then int2char (addi r 48)
-  else if lti r 36 then int2char (addi r 55)
-  else int2char (addi r 61)
-
 lang PMExprExtractAccelerate = PMExprAst + MExprCallGraph
   syn CopyStatus =
   | CopyBoth ()
@@ -68,7 +59,7 @@ lang PMExprExtractAccelerate = PMExprAst + MExprCallGraph
     recursive let genstr = lam acc. lam n.
       if eqi n 0 then acc
       else
-        let nextchr = _randAlphanum () in
+        let nextchr = randAlphanum () in
         genstr (snoc acc nextchr) (subi n 1)
     in
     -- NOTE(larshum, 2021-09-15): Start the string with a hard-coded alphabetic

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -6,8 +6,6 @@ let _pathSep = "/"
 let _tempBase = "/tmp"
 let _null = "/dev/null"
 
-let _tempIdx = ref 0
-
 let _commandListTime : [String] -> (Float, Int) = lam cmd.
   let cmd = strJoin " " cmd in
   let t1 = wallTimeMs () in

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -59,8 +59,8 @@ let sysTempMake = lam dir: Bool. lam prefix: String. lam.
 let sysTempDirMakePrefix: String -> () -> String = sysTempMake true
 let sysTempFileMakePrefix: String -> () -> String = sysTempMake false
 
-let sysTempDirMake: () -> String = sysTempDirMakePrefix "tmp."
-let sysTempFileMake: () -> String = sysTempFileMakePrefix "tmp."
+let sysTempDirMake: () -> String = sysTempDirMakePrefix "miking-tmp."
+let sysTempFileMake: () -> String = sysTempFileMakePrefix "miking-tmp."
 
 let sysTempDirName = lam td. td
 let sysTempDirDelete = lam td. lam. sysDeleteDir td

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -42,7 +42,7 @@ let sysChmodWriteAccessFile = lam file.
 let sysJoinPath = lam p1. lam p2.
   strJoin _pathSep [p1, p2]
 
-let sysTempMake = lam dir: Bool. lam.
+let sysTempMake = lam dir: Bool. lam prefix: String. lam.
   recursive let mk = lam base. lam i.
     let name = concat base (int2string i) in
     match
@@ -51,18 +51,28 @@ let sysTempMake = lam dir: Bool. lam.
         sysJoinPath _tempBase name, "2>", _null
       ]
     with 0
-    then (addi i 1, name)
+    then name
     else mk base (addi i 1) in
-  match mk "tmp" (deref _tempIdx) with (i, name) then
-    modref _tempIdx i;
-    sysJoinPath _tempBase name
-  else never
+  let alphanumStr = create 10 (lam. randAlphanum ()) in
+  let base = concat prefix alphanumStr in
+  let name = mk base 0 in
+  sysJoinPath _tempBase name
 
-let sysTempDirMake = sysTempMake true
-let sysTempFileMake = sysTempMake false
+let sysTempDirMakePrefix: String -> () -> String = sysTempMake true
+let sysTempFileMakePrefix: String -> () -> String = sysTempMake false
+
+let sysTempDirMake: () -> String = sysTempDirMakePrefix "tmp."
+let sysTempFileMake: () -> String = sysTempFileMakePrefix "tmp."
 
 let sysTempDirName = lam td. td
 let sysTempDirDelete = lam td. lam. sysDeleteDir td
+
+utest
+  let d = sysTempDirMake () in
+  let exists = sysFileExists (sysTempDirName d) in
+  sysTempDirDelete d ();
+  [exists, sysFileExists (sysTempDirName d)]
+with [true, false]
 
 let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> String -> (Float, ExecResult) =
   lam timeoutSec. lam cmd. lam stdin. lam cwd.


### PR DESCRIPTION
Addresses #566 by using a random string when generating names for temporary directories and files. Files/directories are now named
```
/tmp/<prefix><randstring>
```
Where the default prefix is `tmp.` and the random string is of length 10 and consists of alphanumeric characters.