### PR TITLE
Fix type error when mixing holes of different types

### DIFF
--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -22,10 +22,6 @@ let tableFromFile = lam file.
   if fileExists file then tuneFileReadTable file
   else error (join ["Tune file ", file, " does not exist"])
 
-let dumpTable = lam file. lam env. lam table.
-  let destination = tuneFileName file in
-  tuneFileDumpTable destination env table
-
 let dependencyAnalysis
   : Options -> CallCtxEnv -> Expr -> (DependencyGraph, Expr) =
   lam options : Options. lam env : CallCtxEnv. lam ast.
@@ -100,7 +96,7 @@ let tune = lam files. lam options : Options. lam args.
     let result = tuneEntry binary tuneOptions env dep instRes r ast in
 
     -- Write the best found values to filename.tune
-    tuneFileDumpTable (tuneFileName file) (Some env) result;
+    tuneFileDumpTable (tuneFileName file) env result true;
 
     -- If option --compile is given, then compile the program using the
     -- tuned values

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -733,6 +733,7 @@ end
 
 lang FloatStringConversionCFA = CFA + ConstCFA + FloatStringConversionAst
   sem generateConstraintsConst info ident =
+  | CStringIsFloat _ -> []
   | CString2float _ -> []
   | CFloat2string _ -> []
 end
@@ -935,6 +936,8 @@ end
 -- probably be added.
 lang TensorOpCFA = CFA + ConstCFA + TensorOpAst
   sem generateConstraintsConst info ident =
+  -- | CTensorCreateUninitInt _ -> []
+  -- | CTensorCreateUninitFloat _ -> []
   -- | CTensorCreateInt _ -> []
   -- | CTensorCreateFloat _ -> []
   -- | CTensorCreate _ -> []

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -198,7 +198,7 @@ lang HoleBoolAst = BoolAst + HoleAstBase + BoolTypeAst
 
   sem hfromInt =
   | BoolHole {} ->
-    lam e. if_ (eqi_ (int_ 0) e) false_ true_
+    lam e. neqi_ (int_ 0) e
 
   sem htoInt info v =
   | BoolHole {} ->

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -137,6 +137,17 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot + TypeCheck
     unify [t.info] env ty (tyTm default);
     TmHole {{t with default = default}
                with ty = ty}
+
+  sem fromInt =
+  | TmHole t -> hfromInt t.inner
+
+  sem toInt (e: Expr) =
+  | TmHole t -> htoInt t.info e t.inner
+
+  sem hfromInt : Hole -> (Expr -> Expr)
+
+  sem htoInt : Info -> Expr -> Hole -> Int
+
 end
 
 -- A Boolean hole.
@@ -184,6 +195,17 @@ lang HoleBoolAst = BoolAst + HoleAstBase + BoolTypeAst
 
   sem hty info =
   | BoolHole {} -> TyBool {info = info}
+
+  sem hfromInt =
+  | BoolHole {} ->
+    lam e. if_ (eqi_ (int_ 0) e) false_ true_
+
+  sem htoInt info v =
+  | BoolHole {} ->
+    match v with TmConst {val = CBool {val = b}} then
+      if b then 1 else 0
+    else errorSingle [info] "Expected a Boolean expression"
+
 end
 
 -- An integer hole (range of integers).
@@ -250,6 +272,17 @@ lang HoleIntRangeAst = IntAst + HoleAstBase + IntTypeAst
 
   sem hty info =
   | HIntRange {} -> TyInt {info = info}
+
+  sem hfromInt =
+  | HIntRange {} ->
+    lam e. e
+
+  sem htoInt info v =
+  | HIntRange {} ->
+    match v with TmConst {val = CInt {val = i}} then i
+    else errorSingle [info] "Expected an Int expression"
+
+
 end
 
 lang HoleAnnotation = Ast

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -70,7 +70,10 @@ lang ContextExpand = HoleAst
   --  replace them by lookups in a static table.
   sem contextExpand (env : CallCtxEnv) =
   | t ->
-    let lookup = lam i. tensorGetExn_ tyunknown_ (nvar_ _table) (seq_ [int_ i]) in
+    let lookup = lam i.
+      let intExpr = tensorGetExn_ tyunknown_ (nvar_ _table) (seq_ [int_ i]) in
+      fromInt (get env.idx2hole i) intExpr
+    in
     let ast = _contextExpandWithLookup env lookup t in
     let tempDir = sysTempDirMake () in
     let tuneFile = sysJoinPath tempDir ".tune" in
@@ -122,18 +125,6 @@ lang ContextExpand = HoleAst
   | tm ->
     use BootParser in
     let impl = parseMExprStringKeywords [] "
-    let or: Bool -> Bool -> Bool =
-      lam a. lam b. if a then true else b in
-
-    let zipWith = lam f. lam seq1. lam seq2.
-      recursive let work = lam a. lam s1. lam s2.
-        if or (null s1) (null s2) then a
-        else
-          work (snoc a (f (head s1) (head s2))) (tail s1) (tail s2)
-        in
-        work [] seq1 seq2
-    in
-
     let eqSeq = lam eq : (a -> b -> Bool). lam s1 : [a]. lam s2 : [b].
       recursive let work = lam s1. lam s2.
         match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) then
@@ -178,12 +169,6 @@ lang ContextExpand = HoleAst
       in
       if null delim then [s]
       else work [] 0 0
-    in
-
-    let string2bool = lam s : String.
-      match s with \"true\" then true
-      else match s with \"false\" then false
-      else error (join [\"Cannot be converted to Bool: \'\", s, \"\'\"])
     in
 
     recursive let any = lam p. lam seq.
@@ -237,22 +222,10 @@ lang ContextExpand = HoleAst
       match findName s expr with Some n then n
       else error (concat "not found: " s) in
 
-    let zipWithName = getName "zipWith" impl in
-    let string2boolName = getName "string2bool" impl in
     let string2intName = getName "string2int" impl in
     let strSplitName = getName "strSplit" impl in
     let strTrimName = getName "strTrim" impl in
     let seq2TensorName = getName "seq2Tensor" impl in
-
-    let convertFuns = map (lam h.
-      match h with TmHole {ty = TyBool _} then string2boolName
-      else match h with TmHole {ty = TyInt _} then string2intName
-      else error "Unsupported type"
-    ) env.idx2hole in
-
-    let x = nameSym "x" in
-    let y = nameSym "y" in
-    let doConvert = nulam_ x (nulam_ y (app_ (nvar_ x) (nvar_ y))) in
 
     let fileContent = nameSym "fileContent" in
     let strVals = nameSym "strVals" in
@@ -272,9 +245,7 @@ lang ContextExpand = HoleAst
         (get_ (appf2_ (nvar_ strSplitName) (str_ ": ") (nvar_ x)) (int_ 1)))
         (nvar_ strVals))
     -- Convert strings into values
-    , nulet_ _table
-      (appf3_ (nvar_ zipWithName) doConvert
-        (seq_ (map nvar_ convertFuns)) (nvar_ strVals))
+    , nulet_ _table (map_ (nvar_ string2intName) (nvar_ strVals))
     -- Convert table into a tensor (for constant-time lookups)
     , nulet_ _table (app_ (nvar_ seq2TensorName) (nvar_ _table))
     , tm
@@ -349,7 +320,8 @@ let test : Bool -> Expr -> [(String, [([String],Expr)])] -> String =
     let dumpTable = lam table : LookupTable.
       use MExprPrettyPrint in
       let rows = mapi (lam i. lam expr.
-        join [int2string i, ": ", expr2str expr]) table in
+        let v = toInt expr (get env.idx2hole i) in
+        join [int2string i, ": ", int2string v]) table in
       let rows = cons (int2string (length table)) rows in
       let str = strJoin "\n" (concat rows ["="]) in
       writeFile res.tempFile str

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -70,9 +70,8 @@ lang ContextExpand = HoleAst
   --  replace them by lookups in a static table.
   sem contextExpand (env : CallCtxEnv) =
   | t ->
-    let lookup = lam i.
-      let intExpr = tensorGetExn_ tyunknown_ (nvar_ _table) (seq_ [int_ i]) in
-      fromInt (get env.idx2hole i) intExpr
+    let lookup = _lookupFromInt env (lam i.
+      tensorGetExn_ tyint_ (nvar_ _table) (seq_ [int_ i]))
     in
     let ast = _contextExpandWithLookup env lookup t in
     let tempDir = sysTempDirMake () in
@@ -87,7 +86,13 @@ lang ContextExpand = HoleAst
   -- 'insert public table t' replaces the holes in expression 't' by the values
   -- in 'table'
   sem insert (env : CallCtxEnv) (table : LookupTable) =
-  | t -> _contextExpandWithLookup env (lam i. get table i) t
+  | t ->
+    _contextExpandWithLookup env (_lookupFromInt env (lam i. get table i)) t
+
+  -- Converts the ith table entry from an integer to the type of the hole
+  sem _lookupFromInt (env: CallCtxEnv) (lookup: Int -> Expr) =
+  | i ->
+    fromInt (get env.idx2hole i) (lookup i)
 
   sem _contextExpandWithLookup (env : CallCtxEnv) (lookup : Int -> Expr) =
   -- Hole: lookup the value depending on call history.

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -337,7 +337,7 @@ end
 lang TestLang = Instrumentation + GraphColoring + MExprHoleCFA + ContextExpand +
                 NestedMeasuringPoints + DependencyAnalysis +
                 BootParser + MExprSym + MExprPrettyPrint + MExprANFAll +
-                MExprEval
+                MExprEval + MExprTypeCheck
 end
 
 mexpr
@@ -427,13 +427,17 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   let tableMap : Map Int Expr = foldl (
     lam acc. lam t : ((String,[String]),Expr).
       let id = resolveId t.0 env.contexts nameInfoGetStr in
-      mapInsert id t.1 acc
+      let intExpr = int_ (toInt t.1 (get env.idx2hole id)) in
+      mapInsert id intExpr acc
     ) (mapEmpty subi) table in
   let lookupTable = mapValues tableMap in
   let ast = insert env lookupTable ast in
   debugPrintLn debug "\n-------- CONTEXT EXPANSION --------";
   debugPrintLn debug (expr2str ast);
   debugPrintLn debug "";
+
+  -- Transformations should produce an AST that type checks
+  let ast = typeCheck ast in
 
   -- Evaluate the program
   eval { env = evalEnvEmpty } ast;
@@ -616,7 +620,6 @@ utest test debug false [(("h", []), true_)] t with {
 }
 using eqTest in
 
-
 -- Context-sensitive, but only one context
 let t = parse
 "
@@ -703,7 +706,7 @@ utest test debug false table t with {
 let t = parse
 "
 let f1 = lam x.
-  let h = hole (Boolean {default = true, depth = 3}) in
+  let h = hole (IntRange {default = 0, depth = 3, min = 0, max = 40}) in
   let m = sleepMs h in
   m
 in
@@ -744,7 +747,7 @@ utest test debug false table t with {
 let t = parse
 "
 let f1 = lam x.
-  let h = hole (Boolean {default = true, depth = 2}) in
+  let h = hole (IntRange {default = 0, depth = 2, min = 0, max = 100}) in
   h
 in
 let f2 = lam x.

--- a/stdlib/tuning/tune-file.mc
+++ b/stdlib/tuning/tune-file.mc
@@ -59,10 +59,10 @@ let _vertexPath : NameInfo -> Int -> CallCtxEnv -> [NameInfo] = lam h : NameInfo
       destination
   else never
 
-let _tuneTable2str = lam table : LookupTable.
-  use MExprPrettyPrint in
+let _tuneTable2str = lam env: CallCtxEnv. lam table : LookupTable.
+  use HoleAst in
   let rows = mapi (lam i. lam expr.
-    join [int2string i, ": ", expr2str expr]) table in
+    join [int2string i, ": ", int2string (toInt expr (get env.idx2hole i))]) table in
   strJoin _delim rows
 
 let tuneFileDump = lam env : CallCtxEnv. lam table : LookupTable. lam format : TuneFileFormat.
@@ -125,16 +125,17 @@ let tuneFileDump = lam env : CallCtxEnv. lam table : LookupTable. lam format : T
     concat "[[hole]]\n" (strJoin (join ["\n", "[[hole]]", "\n"]) entries)
   else never
 
-let tuneFileDumpTable = lam file : String. lam env : Option CallCtxEnv. lam table : LookupTable.
+let tuneFileDumpTable
+= lam file: String. lam env: CallCtxEnv. lam table: LookupTable. lam verbose: Bool.
   let str =
   join
   [ int2string (length table)
   , "\n"
-  , _tuneTable2str table
+  , _tuneTable2str env table
   , "\n"
   , make _sepLength '='
   , "\n"
-  , match env with Some env then tuneFileDump env table (CSV ()) else ""
+  , if verbose then tuneFileDump env table (CSV ()) else ""
   , "\n"
   ] in writeFile file str
 

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -52,12 +52,12 @@ lang TuneBase = HoleAst
            -> InstrumentedResult -> String -> (() -> ()) -> LookupTable -> Expr
            -> LookupTable
 
-  sem measure (table : LookupTable) (runner : Runner) (file : String)
-              (options : TuneOptions) (timeout : Option Float)
-              (onFailure : () -> ()) =
+  sem measure (env: CallCtxEnv) (table: LookupTable) (runner: Runner)
+              (file: String) (options: TuneOptions) (timeout: Option Float)
+              (onFailure: () -> ()) =
   | args ->
     let timeout = if options.exitEarly then timeout else None () in
-    tuneFileDumpTable file (None ()) table;
+    tuneFileDumpTable file env table false;
     match runner args timeout with (ms, res) then
       let res : ExecResult = res in
       let rcode = res.returncode in
@@ -68,7 +68,7 @@ lang TuneBase = HoleAst
       else
         let msg = strJoin " "
         [ "Program returned non-zero exit code during tuning\n"
-        , "hole values:\n", _tuneTable2str table, "\n"
+        , "hole values:\n", _tuneTable2str env table, "\n"
         , "command line arguments:", args, "\n"
         , "stdout:", res.stdout, "\n"
         , "stderr:", res.stderr
@@ -434,8 +434,8 @@ lang TuneDep = TuneLocalSearch + Database
               (input : [String]) (data : LSData) (onFailure : () -> ())
               (inc : Option Solution) =
   | Table { table = table } ->
-    let f = lam i. measure table run tuneFile options (None ()) onFailure i in
-    match data with TuneData {inst = inst} in
+    match data with TuneData {inst = inst, env = env} in
+    let f = lam i. measure env table run tuneFile options (None ()) onFailure i in
     match foldl (lam acc: (Float, [String]). lam inp.
         match acc with (ms, strs) in
         match f inp with Success {ms = ms2} then
@@ -606,6 +606,8 @@ let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchSta
 
     -- Context expansion
     match contextExpand env ast with (exp, ast) in
+
+    (if debug then printLn (expr2str ast) else ());
 
     -- Compile the program
     let compileOCaml = lam libs. lam clibs. lam ocamlProg.

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -561,7 +561,7 @@ lang MExprTune = MExpr + TuneBase end
 lang TestLang =
   TuneDep + GraphColoring + MExprHoleCFA + DependencyAnalysis +
   NestedMeasuringPoints + ContextExpand + Instrumentation +
-  BootParser + MExprSym + MExprPrettyPrint + MExprEval
+  BootParser + MExprSym + MExprPrettyPrint + MExprEval + MExprTypeCheck
 end
 
 mexpr
@@ -607,7 +607,8 @@ let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchSta
     -- Context expansion
     match contextExpand env ast with (exp, ast) in
 
-    (if debug then printLn (expr2str ast) else ());
+    -- Transformations should produce an AST that type checks
+    let ast = typeCheck ast in
 
     -- Compile the program
     let compileOCaml = lam libs. lam clibs. lam ocamlProg.


### PR DESCRIPTION
* Fixes a type error arising when mixing holes of different types in the same program. The solution is to represent all holes as integers in the lookup table, and convert them to Bool when needed.
* Adds a few missing constants to CFA.