### PR TITLE
Add support for full CPS transformation of MExpr programs

### DIFF
--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -63,3 +63,9 @@ utest eqBool false true  with false
 utest eqBool true  false with false
 utest eqBool true  true  with true
 
+-- Boolean to string
+let bool2string: Bool -> String = lam b.
+  if b then "true" else "false"
+
+utest bool2string true with "true"
+utest bool2string false with "false"

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -216,10 +216,22 @@ lang UtestANF = ANF + UtestAst
 
   sem normalize (k : Expr -> Expr) =
   | TmUtest t -> let tusing = optionMap normalizeTerm t.tusing in
-    TmUtest {{{{t with test = normalizeTerm t.test}
-                 with expected = normalizeTerm t.expected}
-                 with next = normalize k t.next}
-                 with tusing = tusing}
+    normalizeName
+      (lam test.
+         normalizeName
+           (lam expected.
+              let inner = lam tusing.
+                TmUtest { t with test = test,
+                                 expected = expected,
+                                 next = normalize k t.next,
+                                 tusing = tusing }
+              in
+              match t.tusing with Some tusing then
+                normalizeName (lam tusing. inner (Some tusing)) tusing
+              else
+                inner (None ()))
+           t.expected)
+      t.test
 
 end
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -100,6 +100,10 @@ let nstyall_ = use AllTypeAst in
 
 let styall_ = lam s. nstyall_ (nameNoSym s)
 
+let ntyall_ : Name -> Type -> Type  = use VarSortAst in
+  lam n.
+  nstyall_ n (TypeVar ())
+
 let tyall_ = use VarSortAst in
   lam s.
   styall_ s (TypeVar ())

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -50,9 +50,6 @@ type CFAGraph = {
   -- NOTE(dlunde,2021-11-18): Data needed for analyses based on this framework
   -- must be put below directly, since we do not yet have product extensions.
 
-  -- Used for alignment analysis in miking-dppl
-  stochMatches: Set Name,
-
   -- Used to store any custom data in the graph
   graphData: Option GraphData
 
@@ -63,7 +60,6 @@ let emptyCFAGraph: CFAGraph = {
   data = mapEmpty nameCmp,
   edges = mapEmpty nameCmp,
   mcgfs = [],
-  stochMatches = setEmpty nameCmp,
   graphData = None ()
 }
 

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -222,11 +222,9 @@ lang FunTypeCPS = CPS + FunTypeAst
     let i = tyWithInfo b.info in
     let from = tyCps from in
     let to = tyCps to in
-    let resTyName = nameSym "r" in
-    let cont = i (tyarrow_ to (i (ntyvar_ resTyName))) in
-    i (ntyall_ resTyName
-        (i (tyarrow_ cont
-              (TyArrow { b with from = from, to = (i (ntyvar_ resTyName)) }))))
+    let cont = i (tyarrow_ to (i tyunknown_)) in
+    (i (tyarrow_ cont
+        (TyArrow { b with from = from, to = (i tyunknown_) })))
 end
 
 ---------------

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -222,6 +222,10 @@ lang FunTypeCPS = CPS + FunTypeAst
     let i = tyWithInfo b.info in
     let from = tyCps from in
     let to = tyCps to in
+    -- NOTE(dlunde,2022-06-08): We replace all continuation return types with
+    -- the unknown type. No polymorphism should be needed, as all of these
+    -- unknown types should ultimately be the same type: the return type of the
+    -- program (I think). This can easily be inferred by the type checker.
     let cont = i (tyarrow_ to (i tyunknown_)) in
     (i (tyarrow_ cont
         (TyArrow { b with from = from, to = (i tyunknown_) })))

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -22,12 +22,10 @@ lang CPS = LamAst + VarAst + LetAst
 
   sem exprCps : Expr -> Expr -> Expr
 
-  -- TODO This does NOT currently work as expected
   sem exprTyCps : Expr -> Expr
   sem exprTyCps =
-  | e -> e -- Default is identity function
+  | e -> e -- Default is identity function (do nothing)
 
-  -- TODO This does NOT currently work as expected
   sem tyCps : Type -> Type
   sem tyCps =
   | t -> smap_Type_Type tyCps t
@@ -202,7 +200,6 @@ end
 -- TYPES --
 -----------
 
--- TODO This does NOT currently work as expected
 lang FunTypeCPS = CPS + FunTypeAst
   sem tyCps =
   -- Function type a -> b becomes (b -> res) -> a -> res
@@ -440,10 +437,51 @@ using eqExpr in
 
 -- Types (not supported in equality, check the string output from pprint)
 let typestest = _cps "
+  external e : Float -> Float in
+  let f: Float -> Float = lam x: Float. e x in
   let g: (Float -> Float) -> Float = lam h: (Float -> Float). h 1.0 in
-  g
+  recursive let h : all a. a -> a = lam y: a. y in
+  g f
 " in
-print (mexprToString typestest);
--- utest mexprToString typestest with "" in
+-- print (mexprToString typestest);
+utest mexprToString typestest with
+"external e : (Float) -> (Float)
+in
+let e1 =
+  lam k11.
+    lam a1.
+      k11
+        (e
+           a1)
+in
+let f: all r4. ((Float) -> (r4)) -> ((Float) -> (r4)) =
+  lam k2.
+    lam x: Float.
+      e1
+        k2
+        x
+in
+let g: all r1. ((Float) -> (r1)) -> ((all r2. ((Float) -> (r2)) -> ((Float) -> (r2))) -> (r1)) =
+  lam k1.
+    lam h: all r3. ((Float) -> (r3)) -> ((Float) -> (r3)).
+      let t =
+        1.
+      in
+      h
+        k1
+        t
+in
+recursive
+  let h: all a. all r. ((a) -> (r)) -> ((a) -> (r)) =
+    lam k.
+      lam y: a.
+        k
+          y
+in
+g
+  (lam x.
+     x)
+  f"
+in
 
 ()

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -187,11 +187,9 @@ lang ExtCPS = CPS + ExtAst
   sem exprCps k =
   | TmExt t ->
     let arity = arityFunType t.tyIdent in
-    let newExtIdent = nameSetNewSym t.ident in
     TmExt { t with
-      ident = newExtIdent,
       inexpr = bindall_
-        [ nulet_ t.ident (wrapDirect arity (nvar_ newExtIdent)),
+        [ nulet_ t.ident (wrapDirect arity (nvar_ t.ident)),
           exprCps k t.inexpr ]
     }
 end

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -5,6 +5,7 @@ include "ast-builder.mc"
 include "boot-parser.mc"
 include "eq.mc"
 include "anf.mc"
+include "const-arity.mc"
 
 lang CPS = LamAst + VarAst + LetAst
 
@@ -13,6 +14,11 @@ lang CPS = LamAst + VarAst + LetAst
   | e -> cpsCont (ulam_ "x" (var_ "x")) e
 
   sem cpsCont : Expr -> Expr -> Expr
+
+  sem tailCall =
+  | TmLet { ident = ident, inexpr = inexpr } ->
+    match inexpr with TmVar { ident = varIdent } then nameEq ident varIdent
+    else false
 
 end
 
@@ -23,12 +29,8 @@ end
 
 lang AppCPS = CPS + AppAst
   sem cpsCont k =
-  | TmLet { ident = ident, body = TmApp app, inexpr = inexpr } ->
-    let tailCall =
-      match inexpr with TmVar { ident = varIdent } then nameEq ident varIdent
-      else false
-    in
-    if tailCall then
+  | TmLet { ident = ident, body = TmApp app, inexpr = inexpr } & t ->
+    if tailCall t then
       -- Optimize tail call
       appf2_ app.lhs k app.rhs
     else
@@ -47,17 +49,115 @@ lang LamCPS = CPS + LamAst
     let kName = nameSym "k" in
     let body =
       nulam_ kName (TmLam {t with body = cpsCont (nvar_ kName) t.body}) in
-    TmLet { r with body = body }
+    TmLet { r with body = body, inexpr = cpsCont k inexpr }
 end
 
-lang MExprCPS = CPS + VarCPS + AppCPS + LamCPS
+lang RecLetsCPS = CPS + RecLetsAst + LamAst
+  sem cpsCont k =
+  | TmRecLets t ->
+    let bindings = map (lam b: RecLetBinding. { b with body =
+        match b.body with TmLam t then
+          let kName = nameSym "k" in
+          nulam_ kName (TmLam {t with body = cpsCont (nvar_ kName) t.body})
+        else errorSingle [infoTm b.body]
+          "Error: Not a TmLam in TmRecLet binding in CPS transformation"
+      }) t.bindings
+    in TmRecLets { t with bindings = bindings, inexpr = cpsCont k t.inexpr }
+end
+
+-- Wraps a direct-style (function) expression with given arity as a CPS function
+let wrapDirect = use MExprAst in
+  lam arity: Int. lam e: Expr.
+    recursive let vars = lam acc. lam arity.
+      if lti arity 1 then acc
+      else
+        let arg = nameNoSym (concat "a" (int2string arity)) in
+        let cont = nameNoSym (concat "k" (int2string arity)) in
+        vars (cons (arg, cont) acc) (subi arity 1)
+    in
+    let varNames = vars [] arity in
+    let inner = foldl (lam acc. lam v. app_ acc (nvar_ v.0)) e varNames in
+    foldr (lam v. lam acc.
+        nulam_ v.0 (nulam_ v.1 (app_ (nvar_ v.0) acc))
+      ) inner varNames
+
+lang ConstCPS = CPS + ConstAst + MExprArity
+  sem cpsCont k =
+  | TmLet ({ body = TmConst { val = c } & body} & t) ->
+    -- Constants are not in CPS, so we must wrap them all in CPS lambdas
+    let body = wrapDirect (constArity c) body in
+    TmLet { t with body = body, inexpr = cpsCont k t.inexpr }
+end
+
+-- Thanks to ANF, we don't need to do anything at all when constructing data
+-- (TmRecord, TmSeq, TmConApp, etc.)
+lang SeqCPS = CPS + SeqAst
+  sem cpsCont k =
+  | TmLet ({ body = TmSeq _ } & t) ->
+    TmLet { t with inexpr = cpsCont k t.inexpr }
+end
+
+lang RecordCPS = CPS + RecordAst
+  sem cpsCont k =
+  | TmLet ({ body = TmRecord _ } & t) ->
+    TmLet { t with inexpr = cpsCont k t.inexpr }
+end
+
+lang TypeCPS = CPS + TypeAst
+  sem cpsCont k =
+  | TmType t -> TmType { t with inexpr = cpsCont k t.inexpr }
+end
+
+lang DataCPS = CPS + DataAst
+  sem cpsCont k =
+  | TmLet ({ body = TmConApp _ } & t) ->
+    TmLet { t with inexpr = cpsCont k t.inexpr }
+  | TmConDef t ->
+    TmConDef { t with inexpr = cpsCont k t.inexpr }
+end
+
+lang MatchCPS = CPS + MatchAst
+  sem cpsCont k =
+  | TmLet { ident = ident, body = TmMatch m, inexpr = inexpr } & t ->
+    if tailCall t then
+      -- Optimize tail call
+      TmMatch { m with thn = cpsCont k m.thn, els = cpsCont k m.els }
+    else
+      let inexpr = cpsCont k inexpr in
+      let kName = nameSym "k" in
+      let k = nulam_ ident inexpr in
+      bindall_ [
+        nulet_ kName k,
+        TmMatch { m with
+          thn = cpsCont (nvar_ kName) m.thn,
+          els = cpsCont (nvar_ kName) m.els
+        }
+      ]
+end
+
+lang UtestCPS = CPS + UtestAst
+  -- TODO
+end
+
+lang NeverCPS = CPS + NeverAst
+  -- TODO
+end
+
+lang ExtCPS = CPS + ExtAst
+  -- TODO We must have some way of getting the arity of externals (to wrap them
+  -- in continuations just like with intrinsics/constants)
+end
+
+lang MExprCPS =
+  CPS + VarCPS + AppCPS + LamCPS + RecLetsCPS + ConstCPS + SeqCPS + RecordCPS + TypeCPS
+  + DataCPS + MatchCPS + UtestCPS + NeverCPS + ExtCPS
 end
 
 -----------
 -- TESTS --
 -----------
 
-lang Test = MExprCPS + BootParser + MExprEq + MExprANFAll
+lang Test = MExprCPS + BootParser + MExprEq + MExprANFAll + MExprPrettyPrint
 end
 mexpr
 use Test in
@@ -66,10 +166,144 @@ let _parse =
   parseMExprString { defaultBootParserParseMExprStringArg with allowFree = true }
 in
 let _cps = lam e. cps (normalizeTerm (_parse e)) in
+
+-- Simple base cases
+utest _cps "
+  a
+" with _parse "
+  (lam x. x) a
+"
+using eqExpr in
+
 utest _cps "
   a b
 " with _parse "
   a (lam x. x) b
-" using eqExpr in
+"
+using eqExpr in
+
+-- Recursive lets
+let recletsTest = _cps "
+  recursive
+    let f1 = lam a. lam b. b
+    let f2 = lam b. b
+  in
+  let x = f1 1 2 in
+  let y = f2 3 in
+  and x y
+" in
+-- print (mexprToString recletsTest);
+utest recletsTest with _parse "
+  recursive
+    let f1 = lam k. lam a. let t = lam k1. lam b. k1 b in k t
+    let f2 = lam k2. lam b. k2 b
+  in
+  let t1 = 1 in
+  let k3 = lam t2.
+    let t3 = 2 in
+    let k4 = lam x.
+      let t4 = 3 in
+      let k5 = lam y.
+          let k6 = lam t5.
+              (lam x. x) y
+          in
+          and k6 x
+      in
+      f2 k5 t4
+    in
+    t2 k4 t3
+  in
+  f1 k3 t1
+"
+using eqExpr in
+
+-- Constants
+utest _cps "
+  addi 1 2
+" with _parse "
+  let t = lam a1. lam k1. a1 (lam a2. lam k2. a2 (addi a1 a2)) in
+  let t1 = 1 in
+  let k = lam t2.
+    let t3 = 2 in
+    t2 (lam x. x) t3
+  in
+  t k t1
+"
+using eqExpr in
+
+-- Sequences
+let seqtest = _cps "
+  [a b, c, d, e]
+" in
+-- print (mexprToString seqtest);
+utest seqtest with _parse "
+  let k = lam t.
+    let t1 = [ t, c, d, e ] in
+    (lam x. x) t1
+  in
+  a k b
+"
+using eqExpr in
+
+-- Records
+let rectest = _cps "
+  { k1 = a, k2 = b, k3 = c d }
+" in
+-- print (mexprToString rectest);
+utest rectest with _parse "
+  let k = lam t.
+    let t1 = { k1 = a, k2 = b, k3 = t } in
+    (lam x. x) t1
+  in
+  c k d
+"
+using eqExpr in
+
+-- Types
+-- NOTE(dlunde,2022-06-02): Not supported in eqExpr?
+
+-- Data/constructors
+let datatest = _cps "
+  Constructor (a b)
+" in
+-- print (mexprToString rectest);
+utest datatest with _parse "
+  let k = lam t.
+    let t1 = Constructor t in
+    (lam x. x) t1
+  in
+  a k b
+"
+using eqExpr in
+
+-- Match
+let matchtest = _cps "
+  let x1 =
+    match a b with (p1 | 3 | 7) & p3 then
+      c d
+    else
+      false
+  in
+  or x1 false
+" in
+-- print (mexprToString matchtest);
+utest matchtest with _parse "
+  let k = lam t.
+    let k1 = lam x1.
+      let k2 = lam t2.
+        let t3 = false in
+        t2 (lam x. x) t3
+      in
+      or k2 x1
+    in
+    match t with (p1 | (3 | 7)) & p3 then
+      c k1 d
+    else
+      let t1 = false in
+      k1 t1
+  in
+  a k b
+"
+using eqExpr in
 
 ()

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -10,8 +10,8 @@ include "const-arity.mc"
 
 lang CPS = LamAst + VarAst + LetAst
 
-  sem cps : Expr -> Expr
-  sem cps =
+  sem cpsIdentity : Expr -> Expr
+  sem cpsIdentity =
   | e -> cpsCont (ulam_ "x" (var_ "x")) e
 
   sem cpsCont : Expr -> Expr -> Expr
@@ -164,6 +164,12 @@ lang ExtCPS = CPS + ExtAst
     }
 end
 
+-- TODO: We need CPS for the types as well
+
+---------------
+-- MEXPR CPS --
+---------------
+
 lang MExprCPS =
   CPS + VarCPS + AppCPS + LamCPS + RecLetsCPS + ConstCPS + SeqCPS + RecordCPS +
   TypeCPS + DataCPS + MatchCPS + UtestCPS + NeverCPS + ExtCPS
@@ -181,7 +187,7 @@ use Test in
 let _parse =
   parseMExprString { defaultBootParserParseMExprStringArg with allowFree = true }
 in
-let _cps = lam e. cps (normalizeTerm (_parse e)) in
+let _cps = lam e. cpsIdentity (normalizeTerm (_parse e)) in
 
 -- Simple base cases
 utest _cps "

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -475,16 +475,16 @@ let e =
         (e
            a1)
 in
-let f: all r5. ((Float) -> (r5)) -> ((Float) -> (r5)) =
+let f: ((Float) -> (Unknown)) -> ((Float) -> (Unknown)) =
   lam k2.
     lam x: Float.
       e
         k2
         x
 in
-let g: all r2. ((Float) -> (r2)) -> ((all r3. ((Float) -> (r3)) -> ((Float) -> (r3))) -> (r2)) =
+let g: ((Float) -> (Unknown)) -> ((((Float) -> (Unknown)) -> ((Float) -> (Unknown))) -> (Unknown)) =
   lam k1.
-    lam h: all r4. ((Float) -> (r4)) -> ((Float) -> (r4)).
+    lam h: ((Float) -> (Unknown)) -> ((Float) -> (Unknown)).
       let t =
         1.
       in
@@ -493,7 +493,7 @@ let g: all r2. ((Float) -> (r2)) -> ((all r3. ((Float) -> (r3)) -> ((Float) -> (
         t
 in
 recursive
-  let h: all a. all r. ((a) -> (r)) -> ((a) -> (r)) =
+  let h: all a. ((a) -> (Unknown)) -> ((a) -> (Unknown)) =
     lam k.
       lam y: a.
         k
@@ -501,7 +501,7 @@ recursive
 in
 type T
 in
-con C: (all x. all r1. ((x) -> (r1)) -> ((x) -> (r1))) -> (T) in
+con C: (all x. ((x) -> (Unknown)) -> ((x) -> (Unknown))) -> (T) in
 g
   (lam x.
      x)

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -29,7 +29,8 @@ type SymEnv = {
   tyConEnv: Map String Name,
   currentLvl : Level,
   strictTypeVars: Bool,
-  allowFree: Bool
+  allowFree: Bool,
+  ignoreExternals: Bool
 }
 
 let symEnvEmpty = {
@@ -44,7 +45,8 @@ let symEnvEmpty = {
 
   currentLvl = 1,
   strictTypeVars = true,
-  allowFree = false
+  allowFree = false,
+  ignoreExternals = false
 }
 
 -----------
@@ -182,7 +184,7 @@ lang ExtSym = Sym + ExtAst
   | TmExt t ->
     match env with {varEnv = varEnv} then
       let tyIdent = symbolizeType env t.tyIdent in
-      if nameHasSym t.ident then
+      if or env.ignoreExternals (nameHasSym t.ident) then
         TmExt {{t with inexpr = symbolizeExpr env t.inexpr}
                   with tyIdent = tyIdent}
       else

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -1,6 +1,11 @@
 include "map.mc"
 include "mexpr/ast.mc"
 
+-- Returns the arity of a function type
+recursive let arityFunType = use MExprAst in lam ty.
+  match ty with TyArrow t then addi 1 (arityFunType t.to) else 0
+end
+
 -- Unwraps type alias `ty` from `aliases`.
 recursive let typeUnwrapAlias = use MExprAst in
   lam aliases : Map Name Type. lam ty : Type.


### PR DESCRIPTION
## Major updates
- Add support for full CPS transformation of MExpr programs. This was not too hard thanks to ANF (it is currently only possible to CPS transform programs that are already in ANF). The CPS transformation also takes care to properly transform arrow types in type annotations, but it seems the type checker cannot yet handle the result of this transformation. @aathn is looking into it.

## Minor updates
- Add `bool2string` function
- Update ANF for `TmUtest` so that all subexpressions (both test branches and the comparison function) are lifted (required for CPS).
- Remove `stochMatches` from aligment analysis (no longer needed due to updates in `miking-dppl`).
- Add `ignoreExternals` option to symbolize.
- Add a function `arityFunType` to `mexpr/type.mc` that gives the arity of arrow types.
