### PR TITLE
Typechecker and printing improvements

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -33,6 +33,10 @@ let pprintMcore = lam ast.
   use MExprPrettyPrint in
   expr2str ast
 
+let pprintType = lam ty.
+  use MExprPrettyPrint in
+  type2str ty
+
 let generateTests = lam ast. lam testsEnabled.
   use MCoreCompile in
   if testsEnabled then
@@ -68,6 +72,8 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
     in
 
     let ast = typeCheck ast in
+    (if options.debugTypeCheck then
+       printLn (join [pprintMcore ast, "\n : ", pprintType (tyTm ast)]) else ());
 
     -- If --runtime-checks is set, runtime safety checks are instrumented in
     -- the AST. This includes for example bounds checking on sequence

--- a/src/main/eval.mc
+++ b/src/main/eval.mc
@@ -69,6 +69,8 @@ let eval = lam files. lam options : Options. lam args.
     in
 
     let ast = typeCheck ast in
+    (if options.debugTypeCheck then
+       printLn (join [expr2str ast, "\n : ", type2str (tyTm ast)]) else ());
 
     -- If option --test, then generate utest runner calls. Otherwise strip away
     -- all utest nodes from the AST.

--- a/src/main/options-config.mc
+++ b/src/main/options-config.mc
@@ -15,6 +15,10 @@ let optionsConfig : ParseConfig Options = [
     "Print the AST after adding type annotations",
     lam p: ArgPart Options.
       let o: Options = p.options in {o with debugTypeAnnot = true}),
+  ([("--debug-type-check", "", "")],
+    "Print the AST after type checking",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with debugTypeCheck = true}),
   ([("--debug-profile", "", "")],
     "Instrument profiling expressions to AST",
     lam p: ArgPart Options.

--- a/src/main/options-type.mc
+++ b/src/main/options-type.mc
@@ -5,6 +5,7 @@ type Options = {
   debugParse : Bool,
   debugGenerate : Bool,
   debugTypeAnnot : Bool,
+  debugTypeCheck : Bool,
   debugProfile : Bool,
   exitBefore : Bool,
   disablePruneExternalUtests : Bool,

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -8,6 +8,7 @@ let optionsDefault : Options = {
   debugParse = false,
   debugGenerate = false,
   debugTypeAnnot = false,
+  debugTypeCheck = false,
   debugProfile = false,
   exitBefore = false,
   disablePruneExternalUtests = false,

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -102,23 +102,23 @@ let styall_ = lam s. nstyall_ (nameNoSym s)
 
 let tyall_ = use VarSortAst in
   lam s.
-  styall_ s (TypeVar ())
+  styall_ s (PolyVar ())
 
 let tyalls_ =
   lam strs. lam ty.
   foldr tyall_ ty strs
 
 let tyFlexUnbound = use FlexTypeAst in
-  lam info. lam ident. lam level. lam sort. lam allowGeneralize.
+  lam info. lam ident. lam level. lam sort. lam isWeak.
   TyFlex {info = info,
           contents = ref (Unbound {ident = ident,
                                    level = level,
                                    sort = sort,
-                                   allowGeneralize = allowGeneralize})}
+                                   isWeak = isWeak})}
 
 let tyflexunbound_ = use FlexTypeAst in
   lam s.
-  tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 (TypeVar ()) true
+  tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 (PolyVar ()) true
 
 let tyflexlink_ = use FlexTypeAst in
   lam ty.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1348,8 +1348,8 @@ lang VarSortAst
   -- VarSort indicates the sort of a type variable, like type variable or
   -- record variable, and contains related data
   syn VarSort =
-  | TypeVar ()
-  | WeakVar ()
+  | PolyVar ()
+  | MonoVar ()
   | RecordVar {fields : Map SID Type}
 
   sem smapAccumL_VarSort_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> VarSort -> (acc, VarSort)
@@ -1371,10 +1371,10 @@ lang VarSortAst
     match smapAccumL_VarSort_Type (lam a. lam x. (f a x, x)) acc s with (a, _) in a
 end
 
-type FlexVarRec = {ident : Name,
-                   level : Level,
-                   sort  : VarSort,
-                   allowGeneralize : Bool}
+type FlexVarRec = {ident  : Name,
+                   level  : Level,
+                   sort   : VarSort,
+                   isWeak : Bool}
 
 lang FlexTypeAst = VarSortAst + Ast
   syn FlexVar =

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -262,7 +262,7 @@ lang BootParser = MExprAst + ConstTransformer
     TyAll {info = ginfo t 0,
            ident = gname t 0,
            ty = gtype t 0,
-           sort = TypeVar ()}
+           sort = PolyVar ()}
 
 
   -- Get constant help function

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -490,7 +490,7 @@ utest l_infoClosed "  type Bar in () " with r_info 1 2 1 13 in
 -- TmConDef
 let s = "con Foo in x" in
 utest lside ["x"] s with rside s in
-let s = "con Foo : (Int) -> (Tree) in x" in
+let s = "con Foo : Int -> Tree in x" in
 utest lside ["x"] s with rside s in
 utest l_infoClosed "  con Bar in 10 " with r_info 1 2 1 12 in
 
@@ -628,16 +628,16 @@ utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else
 with r_info 1 6 1 10 in
 
 -- TyArrow
-let s = "let y:(Int)->(Int) = lam x.x in y" in
+let s = "let y:Int->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
-with r_info 1 7 1 17 in
+with r_info 1 6 1 14 in
 
 -- Nested TyArrow
-let s = "let y:([Float])->(Int) = lam x.x in y" in
+let s = "let y:[Float]->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
-with r_info 1 7 1 21 in
+with r_info 1 6 1 18 in
 
 -- TySeq
 let s = "let y:[Int] = lam x.x in y" in
@@ -721,10 +721,10 @@ utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else
 with r_info 1 6 1 13 in
 
 -- Nested TyAll
-let s = "let y:all x.(all y.all z.z)->(all w.w) = lam x.x in y" in
+let s = "let y:all x.(all y.all z.z)->all w.w = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
-with r_info 1 6 1 37 in
+with r_info 1 6 1 36 in
 
 -- TyCon
 let s = "let y:Foo = lam x.x in y" in
@@ -733,16 +733,16 @@ utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else
 with r_info 1 6 1 9 in
 
 -- TyApp
-let s = "let y:((Int)->(Int))(Int) = lam x.x in y" in
+let s = "let y:(Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
-with r_info 1 8 1 24 in
+with r_info 1 7 1 19 in
 
 -- Nested TyApp
-let s = "let y:((((Int)->(Int))(Int))->(Int))(Int) = lam x.x in y" in
+let s = "let y:((Int->Int)Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
-with r_info 1 10 1 40 in
+with r_info 1 8 1 29 in
 
 -- Allow free variables
 utest

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -55,26 +55,23 @@ let pprintEnvEmpty = { nameMap = mapEmpty nameCmp,
 
 -- Look up the string associated with a name in the environment
 let pprintEnvLookup : Name -> PprintEnv -> Option String = lam name. lam env : PprintEnv.
-  match env with { nameMap = nameMap } then
-    mapLookup name nameMap
-  else never
+  match env with { nameMap = nameMap } in
+  mapLookup name nameMap
 
 -- Check if a string is free in the environment.
 let pprintEnvFree : String -> PprintEnv -> Bool = lam str. lam env : PprintEnv.
-  match env with { strings = strings } then
-    not (mapMem str strings)
-  else never
+  match env with { strings = strings } in
+  not (mapMem str strings)
 
 -- Add a binding to the environment
 let pprintEnvAdd : Name -> String -> Int -> PprintEnv -> PprintEnv =
   lam name. lam str. lam i. lam env : PprintEnv.
-    match env with {nameMap = nameMap, count = count, strings = strings} then
-      let baseStr = nameGetStr name in
-      let count = mapInsert baseStr i count in
-      let nameMap = mapInsert name str nameMap in
-      let strings = mapInsert str 0 strings in
-      {nameMap = nameMap, count = count, strings = strings}
-    else never
+    match env with {nameMap = nameMap, count = count, strings = strings} in
+    let baseStr = nameGetStr name in
+    let count = mapInsert baseStr i count in
+    let nameMap = mapInsert name str nameMap in
+    let strings = mapInsert str 0 strings in
+    {nameMap = nameMap, count = count, strings = strings}
 
 -- Get a string for the current name. Returns both the string and a new
 -- environment.
@@ -85,20 +82,18 @@ let pprintEnvGetStr : PprintEnv -> Name -> (PprintEnv, String) =
       let baseStr = nameGetStr name in
       if pprintEnvFree baseStr env then (pprintEnvAdd name baseStr 1 env, baseStr)
       else
-        match env with {count = count} then
-          let start =
-            match mapLookup baseStr count
-            with Some i then i else 1 in
-          recursive let findFree : String -> Int -> (String, Int) =
-            lam baseStr. lam i.
-              let proposal = concat baseStr (int2string i) in
-              if pprintEnvFree proposal env then (proposal, i)
-              else findFree baseStr (addi i 1)
-          in
-          match findFree baseStr start with (str, i) then
-            (pprintEnvAdd name str (addi i 1) env, str)
-          else never
-        else never
+        match env with {count = count} in
+        let start =
+          match mapLookup baseStr count
+          with Some i then i else 1 in
+        recursive let findFree : String -> Int -> (String, Int) =
+          lam baseStr. lam i.
+            let proposal = concat baseStr (int2string i) in
+            if pprintEnvFree proposal env then (proposal, i)
+            else findFree baseStr (addi i 1)
+        in
+        match findFree baseStr start with (str, i) in
+        (pprintEnvAdd name str (addi i 1) env, str)
 
 -- Adds the given name to the environment, if its exact string is not already
 -- mapped to. If the exact string is already mapped to, return None (). This
@@ -143,7 +138,7 @@ let record2tuple
     let sortedKeys = sort subi intKeys in
     -- Check if keys are a sequence 0..(n-1)
     match sortedKeys with [] then None ()
-    else match sortedKeys with [h] ++ _ then
+    else match sortedKeys with [h] ++ _ in
       if and (eqi 0 h)
              (eqi (subi (length intKeys) 1) (last sortedKeys)) then
         Some (map (lam key. mapLookupOrElse
@@ -151,7 +146,6 @@ let record2tuple
                               (stringToSid (int2string key)) bindings)
                    sortedKeys)
       else None ()
-    else never
 
 
 -----------
@@ -167,17 +161,15 @@ end
 lang MExprIdentifierPrettyPrint = IdentifierPrettyPrint
   sem pprintConName (env: PprintEnv) =
   | name ->
-    match pprintEnvGetStr env name with (env,str) then
-      let s = pprintConString str in
-      (env, s)
-    else never
+    match pprintEnvGetStr env name with (env,str) in
+    let s = pprintConString str in
+    (env, s)
 
   sem pprintVarName (env: PprintEnv) =
   | name ->
-    match pprintEnvGetStr env name with (env,str) then
-      let s = pprintVarString str in
-      (env, s)
-    else never
+    match pprintEnvGetStr env name with (env,str) in
+    let s = pprintVarString str in
+    (env, s)
 
   sem pprintLabelString =
   | sid -> _parserStr (sidToString sid) "#label" (lam str. isLowerAlphaOrUnderscore (head str))
@@ -199,8 +191,7 @@ lang PrettyPrint = IdentifierPrettyPrint
 
   sem exprToString (env: PprintEnv) =
   | expr ->
-    match pprintCode 0 env expr with (_,str)
-    then str else never
+    match pprintCode 0 env expr with (_,str) in str
 
   sem exprToStringKeywords (keywords: [String]) =
   | expr ->
@@ -214,8 +205,7 @@ lang PrettyPrint = IdentifierPrettyPrint
 
   sem typeToString (env: PprintEnv) =
   | ty ->
-    match getTypeStringCode 0 env ty with (_,str)
-    then str else never
+    match getTypeStringCode 0 env ty with (_,str) in str
 
   sem expr2str =
   | expr -> exprToString pprintEnvEmpty expr
@@ -227,26 +217,23 @@ lang PrettyPrint = IdentifierPrettyPrint
   sem printParen (indent : Int) (env: PprintEnv) =
   | expr ->
     let i = if isAtomic expr then indent else addi 1 indent in
-    match pprintCode i env expr with (env,str) then
-      if isAtomic expr then (env,str)
-      else (env,join ["(", str, ")"])
-    else never
+    match pprintCode i env expr with (env,str) in
+    if isAtomic expr then (env,str)
+    else (env,join ["(", str, ")"])
 
   -- Helper function for printing a list of arguments
   sem printArgs (indent : Int) (env : PprintEnv) =
   | exprs ->
-    match mapAccumL (printParen indent) env exprs with (env,args) then
-      (env, strJoin (pprintNewline indent) args)
-    else never
+    match mapAccumL (printParen indent) env exprs with (env,args) in
+    (env, strJoin (pprintNewline indent) args)
 
   -- Helper function for printing parentheses (around patterns)
   sem printPatParen (indent : Int) (env : PprintEnv) =
   | pat ->
     let i = if patIsAtomic pat then indent else addi 1 indent in
-    match getPatStringCode i env pat with (env, str) then
-      if patIsAtomic pat then (env, str)
-      else (env, join ["(", str, ")"])
-    else never
+    match getPatStringCode i env pat with (env, str) in
+    if patIsAtomic pat then (env, str)
+    else (env, join ["(", str, ")"])
 
 end
 
@@ -257,9 +244,8 @@ lang VarPrettyPrint = PrettyPrint + VarAst
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmVar {ident = ident, frozen = frozen} ->
     if frozen then
-      match pprintEnvGetStr env ident with (env,str) then
-        (env, join ["#frozen\"", str, "\""])
-      else never
+      match pprintEnvGetStr env ident with (env,str) in
+      (env, join ["#frozen\"", str, "\""])
     else
       pprintVarName env ident
 end
@@ -279,9 +265,8 @@ lang AppPrettyPrint = PrettyPrint + AppAst
 
     match printParen indent env (head apps) with (env,fun) then
       let aindent = pprintIncr indent in
-      match printArgs aindent env (tail apps) with (env,args) then
-        (env, join [fun, pprintNewline aindent, args])
-      else never
+      match printArgs aindent env (tail apps) with (env,args) in
+      (env, join [fun, pprintNewline aindent, args])
     else errorSingle [t.info] "Impossible"
 end
 
@@ -291,16 +276,13 @@ lang LamPrettyPrint = PrettyPrint + LamAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmLam t ->
-    match pprintVarName env t.ident with (env,str) then
-      match getTypeStringCode indent env t.tyIdent with (env, ty) then
-        let ty = if eqString ty "Unknown" then "" else concat ": " ty in
-        match pprintCode (pprintIncr indent) env t.body with (env,body) then
-          (env,
-           join ["lam ", str, ty, ".", pprintNewline (pprintIncr indent),
-                 body])
-        else never
-      else never
-    else never
+    match pprintVarName env t.ident with (env,str) in
+    match getTypeStringCode indent env t.tyIdent with (env, ty) in
+    let ty = if eqString ty "Unknown" then "" else concat ": " ty in
+    match pprintCode (pprintIncr indent) env t.body with (env,body) in
+    (env,
+     join ["lam ", str, ty, ".", pprintNewline (pprintIncr indent),
+           body])
 end
 
 lang RecordPrettyPrint = PrettyPrint + RecordAst
@@ -313,42 +295,37 @@ lang RecordPrettyPrint = PrettyPrint + RecordAst
     if mapIsEmpty bindings then (env,"{}")
     else match record2tuple bindings with Some tms then
       match mapAccumL (lam env. lam e. pprintCode indent env e) env tms
-      with (env,tupleExprs) then
-        let merged = match tupleExprs with [e] then
-                       concat e ","
-                     else strJoin ", " tupleExprs in
-        (env, join ["(", merged, ")"])
-      else never
+      with (env,tupleExprs) in
+      let merged = match tupleExprs with [e] then
+                     concat e ","
+                   else strJoin ", " tupleExprs in
+      (env, join ["(", merged, ")"])
     else
       let innerIndent = pprintIncr (pprintIncr indent) in
       match
         mapMapAccum
           (lam env. lam k. lam v.
-             match pprintCode innerIndent env v with (env, str) then
-               (env,
-                join [pprintLabelString k, " =", pprintNewline innerIndent,
-                      str])
-             else never)
+             match pprintCode innerIndent env v with (env, str) in
+             (env,
+              join [pprintLabelString k, " =", pprintNewline innerIndent,
+                    str]))
            env bindings
-      with (env, bindMap) then
-        let binds = mapValues bindMap in
-        let merged =
-          strJoin (concat "," (pprintNewline (pprintIncr indent))) binds
-        in
-        (env,join ["{ ", merged, " }"])
-      else never
+      with (env, bindMap) in
+      let binds = mapValues bindMap in
+      let merged =
+        strJoin (concat "," (pprintNewline (pprintIncr indent))) binds
+      in
+      (env,join ["{ ", merged, " }"])
 
   | TmRecordUpdate t ->
     let i = pprintIncr indent in
     let ii = pprintIncr i in
-    match pprintCode i env t.rec with (env,rec) then
-      match pprintCode ii env t.value with (env,value) then
+    match pprintCode i env t.rec with (env,rec) in
+      match pprintCode ii env t.value with (env,value) in
         (env,join ["{ ", rec, pprintNewline i,
                    "with", pprintNewline i,
                    pprintLabelString t.key, " =", pprintNewline ii, value,
                    " }"])
-      else never
-    else never
 end
 
 lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
@@ -357,27 +334,21 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmLet t ->
-    match pprintVarName env t.ident with (env,str) then
-      match pprintCode indent env t.inexpr with (env,inexpr) then
-        match getTypeStringCode indent env t.tyBody with (env, ty) then
-          let ty = if eqString ty "Unknown" then "" else concat ": " ty in
-          if eqString (nameGetStr t.ident) "" then
-             match printParen (pprintIncr indent) env t.body with (env,body)
-             then
-               (env, join [body, pprintNewline indent, ";", inexpr])
-             else never
-           else
-             match pprintCode (pprintIncr indent) env t.body with (env,body)
-             then
-               (env,
-                join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
-                      body, pprintNewline indent,
-                      "in", pprintNewline indent,
-                      inexpr])
-             else never
-          else never
-      else never
-    else never
+    match pprintVarName env t.ident with (env,str) in
+    match pprintCode indent env t.inexpr with (env,inexpr) in
+    match getTypeStringCode indent env t.tyBody with (env, ty) in
+    let ty = if eqString ty "Unknown" then "" else concat ": " ty in
+    if eqString (nameGetStr t.ident) "" then
+       match printParen (pprintIncr indent) env t.body with (env,body)
+       in (env, join [body, pprintNewline indent, ";", inexpr])
+     else
+       match pprintCode (pprintIncr indent) env t.body with (env,body)
+       in
+         (env,
+          join ["let ", str, ty, " =", pprintNewline (pprintIncr indent),
+                body, pprintNewline indent,
+                "in", pprintNewline indent,
+                inexpr])
 end
 
 lang ExtPrettyPrint = PrettyPrint + ExtAst + UnknownTypeAst
@@ -389,17 +360,14 @@ lang ExtPrettyPrint = PrettyPrint + ExtAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmExt t ->
-    match pprintVarName env t.ident with (env,str) then
-      match pprintCode indent env t.inexpr with (env,inexpr) then
-        match getTypeStringCode indent env t.tyIdent with (env,ty) then
-          let e = if t.effect then "!" else "" in
-          (env,
-           join ["external ", str, e, " : ", ty, pprintNewline indent,
-                 "in", pprintNewline indent,
-                 inexpr])
-        else never
-      else never
-    else never
+    match pprintVarName env t.ident with (env,str) in
+    match pprintCode indent env t.inexpr with (env,inexpr) in
+    match getTypeStringCode indent env t.tyIdent with (env,ty) in
+      let e = if t.effect then "!" else "" in
+      (env,
+       join ["external ", str, e, " : ", ty, pprintNewline indent,
+             "in", pprintNewline indent,
+             inexpr])
 end
 
 lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst + VariantTypeAst
@@ -408,25 +376,22 @@ lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst + VariantTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmType t ->
-    match pprintEnvGetStr env t.ident with (env,str) then
-      let ident = str in -- TODO(dlunde,2020-11-24): change to pprintTypeName
-      match mapAccumL pprintEnvGetStr env t.params with (env, params) in
-      let paramStr = strJoin " " (cons "" params) in
-      match pprintCode indent env t.inexpr with (env,inexpr) then
-        match getTypeStringCode indent env t.tyIdent with (env, tyIdent) then
-          match t.tyIdent with TyUnknown _ | TyVariant _ then
-            (env, join ["type ", ident, paramStr, pprintNewline indent,
-                         "in", pprintNewline indent,
-                         inexpr])
-          else
-            (env, join ["type ", ident, paramStr, " =",
-                      pprintNewline (pprintIncr indent),
-                      tyIdent, pprintNewline indent,
-                      "in", pprintNewline indent,
-                      inexpr])
-        else never
-      else never
-    else never
+    match pprintEnvGetStr env t.ident with (env,str) in
+    let ident = str in -- TODO(dlunde,2020-11-24): change to pprintTypeName
+    match mapAccumL pprintEnvGetStr env t.params with (env, params) in
+    let paramStr = strJoin " " (cons "" params) in
+    match pprintCode indent env t.inexpr with (env,inexpr) in
+    match getTypeStringCode indent env t.tyIdent with (env, tyIdent) in
+    match t.tyIdent with TyUnknown _ | TyVariant _ then
+      (env, join ["type ", ident, paramStr, pprintNewline indent,
+                   "in", pprintNewline indent,
+                   inexpr])
+    else
+      (env, join ["type ", ident, paramStr, " =",
+                pprintNewline (pprintIncr indent),
+                tyIdent, pprintNewline indent,
+                "in", pprintNewline indent,
+                inexpr])
 end
 
 lang RecLetsPrettyPrint = PrettyPrint + RecLetsAst + UnknownTypeAst
@@ -439,25 +404,20 @@ lang RecLetsPrettyPrint = PrettyPrint + RecLetsAst + UnknownTypeAst
     let ii = pprintIncr i in
     let iii = pprintIncr ii in
     let f = lam env. lam bind : RecLetBinding.
-      match pprintVarName env bind.ident with (env,str) then
-        match pprintCode iii env bind.body with (env,body) then
-          match getTypeStringCode indent env bind.tyBody with (env, ty) then
-            let ty = if eqString ty "Unknown" then "" else concat ": " ty in
-            (env, join ["let ", str, ty, " =", pprintNewline iii, body])
-          else never
-        else never
-      else never
+      match pprintVarName env bind.ident with (env,str) in
+      match pprintCode iii env bind.body with (env,body) in
+      match getTypeStringCode indent env bind.tyBody with (env, ty) in
+        let ty = if eqString ty "Unknown" then "" else concat ": " ty in
+        (env, join ["let ", str, ty, " =", pprintNewline iii, body])
     in
-    match mapAccumL f env t.bindings with (env,bindings) then
-      match pprintCode indent env t.inexpr with (env,inexpr) then
-        match bindings with [] then (env, inexpr) else
-        let bindings = strJoin (pprintNewline ii) bindings in
-        (env,join ["recursive", pprintNewline ii,
-                   bindings, pprintNewline i,
-                   "in", pprintNewline i,
-                   inexpr])
-      else never
-    else never
+    match mapAccumL f env t.bindings with (env,bindings) in
+    match pprintCode indent env t.inexpr with (env,inexpr) in
+    match bindings with [] then (env, inexpr) else
+    let bindings = strJoin (pprintNewline ii) bindings in
+    (env,join ["recursive", pprintNewline ii,
+               bindings, pprintNewline i,
+               "in", pprintNewline i,
+               inexpr])
 end
 
 lang ConstPrettyPrint = PrettyPrint + ConstAst
@@ -478,21 +438,16 @@ lang DataPrettyPrint = PrettyPrint + DataAst + UnknownTypeAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmConDef t ->
-    match pprintConName env t.ident with (env,str) then
-      match getTypeStringCode indent env t.tyIdent with (env, ty) then
-        let ty = if eqString ty "Unknown" then "" else concat ": " ty in
-        match pprintCode indent env t.inexpr with (env,inexpr) then
-          (env,join ["con ", str, ty, " in", pprintNewline indent, inexpr])
-        else never
-      else never
-    else never
+    match pprintConName env t.ident with (env,str) in
+    match getTypeStringCode indent env t.tyIdent with (env, ty) in
+    let ty = if eqString ty "Unknown" then "" else concat ": " ty in
+    match pprintCode indent env t.inexpr with (env,inexpr) in
+    (env,join ["con ", str, ty, " in", pprintNewline indent, inexpr])
 
   | TmConApp t ->
-    match pprintConName env t.ident with (env,str) then
-      match printParen (pprintIncr indent) env t.body with (env,body) then
-        (env, join [str, pprintNewline (pprintIncr indent), body])
-      else never
-    else never
+    match pprintConName env t.ident with (env,str) in
+    match printParen (pprintIncr indent) env t.body with (env,body) in
+    (env, join [str, pprintNewline (pprintIncr indent), body])
 end
 
 lang MatchPrettyPrint = PrettyPrint + MatchAst
@@ -515,18 +470,14 @@ lang MatchPrettyPrint = PrettyPrint + MatchAst
             , info : Info } = t in
     let i = indent in
     let ii = pprintIncr indent in
-    match pprintCode ii env t.target with (env,target) then
-      match getPatStringCode ii env t.pat with (env,pat) then
-        match pprintCode ii env t.thn with (env,thn) then
-          match pprintCode ii env t.els with (env,els) then
-            (env,join ["match", pprintNewline ii, target, pprintNewline i,
-                       "with", pprintNewline ii, pat, pprintNewline i,
-                       "then", pprintNewline ii, thn, pprintNewline i,
-                       "else", pprintNewline ii, els])
-          else never
-        else never
-      else never
-    else never
+    match pprintCode ii env t.target with (env,target) in
+    match getPatStringCode ii env t.pat with (env,pat) in
+    match pprintCode ii env t.thn with (env,thn) in
+    match pprintCode ii env t.els with (env,els) in
+    (env,join ["match", pprintNewline ii, target, pprintNewline i,
+               "with", pprintNewline ii, pat, pprintNewline i,
+               "then", pprintNewline ii, thn, pprintNewline i,
+               "else", pprintNewline ii, els])
 end
 
 lang RecordProjectionSyntaxSugarPrettyPrint = MatchPrettyPrint + RecordPat + NeverAst + NamedPat + VarAst
@@ -545,9 +496,8 @@ lang RecordProjectionSyntaxSugarPrettyPrint = MatchPrettyPrint + RecordPat + Nev
       then
       if nameEq patName exprName
       then
-        match printParen indent env expr with (env, expr) then
-          (env, join [expr, ".", pprintLabelString fieldLabel])
-        else never
+        match printParen indent env expr with (env, expr) in
+        (env, join [expr, ".", pprintLabelString fieldLabel])
       else pprintTmMatchNormally indent env t
     else pprintTmMatchNormally indent env t
 end
@@ -592,12 +542,11 @@ lang SeqPrettyPrint = PrettyPrint + SeqAst + ConstPrettyPrint + CharAst
     else
     match mapAccumL (lam env. lam tm. pprintCode (pprintIncr indent) env tm)
                     env t.tms
-    with (env,tms) then
-      let merged =
-        strJoin (concat "," (pprintNewline (pprintIncr indent))) tms
-      in
-      (env,join ["[ ", merged, " ]"])
-    else never
+    with (env,tms) in
+    let merged =
+      strJoin (concat "," (pprintNewline (pprintIncr indent))) tms
+    in
+    (env,join ["[ ", merged, " ]"])
 end
 
 lang NeverPrettyPrint = PrettyPrint + NeverAst
@@ -874,8 +823,7 @@ end
 lang PatNamePrettyPrint = IdentifierPrettyPrint
   sem _pprint_patname (env : PprintEnv) =
   | PName name ->
-    match pprintVarName env name with (env, str)
-    then (env,str) else never
+    pprintVarName env name
   | PWildcard () -> (env, "_")
 end
 
@@ -897,11 +845,10 @@ lam recur. lam indent. lam env. lam pats.
   match optionMapM extract_char pats with Some str then
     (env, join ["\"", str, "\""])
   else match mapAccumL (recur (pprintIncr indent)) env pats
-  with (env, pats) then
-    let merged =
-      strJoin (concat "," (pprintNewline (pprintIncr indent))) pats in
-    (env, join ["[ ", merged, " ]"])
-  else never
+  with (env, pats) in
+  let merged =
+    strJoin (concat "," (pprintNewline (pprintIncr indent))) pats in
+  (env, join ["[ ", merged, " ]"])
 
 lang SeqTotPatPrettyPrint = SeqTotPat + CharPat
   sem patIsAtomic =
@@ -917,11 +864,10 @@ lang SeqEdgePatPrettyPrint = SeqEdgePat + PatNamePrettyPrint
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
   | PatSeqEdge {prefix = pre, middle = patname, postfix = post} ->
-    match _pprint_patseq getPatStringCode indent env pre with (env, pre) then
-    match _pprint_patname env patname with (env, pname) then
-    match _pprint_patseq getPatStringCode indent env post with (env, post) then
+    match _pprint_patseq getPatStringCode indent env pre with (env, pre) in
+    match _pprint_patname env patname with (env, pname) in
+    match _pprint_patseq getPatStringCode indent env post with (env, post) in
       (env, join [pre, " ++ ", pname, " ++ ", post])
-    else never else never else never
 end
 
 lang RecordPatPrettyPrint = RecordPat + IdentifierPrettyPrint
@@ -933,23 +879,20 @@ lang RecordPatPrettyPrint = RecordPat + IdentifierPrettyPrint
     if mapIsEmpty bindings then (env, "{}")
     else match record2tuple bindings with Some pats then
       match mapAccumL (lam env. lam e. getPatStringCode indent env e) env pats
-      with (env, tuplePats) then
-        let merged =
-          match tuplePats with [e]
-          then concat e ","
-          else strJoin ", " tuplePats in
-        (env, join ["(", merged, ")"])
-      else never
+      with (env, tuplePats) in
+      let merged =
+        match tuplePats with [e]
+        then concat e ","
+        else strJoin ", " tuplePats in
+      (env, join ["(", merged, ")"])
     else match
       mapMapAccum
         (lam env. lam k. lam v.
-           match getPatStringCode indent env v with (env,str) then
-             (env,join [pprintLabelString k, " = ", str])
-           else never)
+           match getPatStringCode indent env v with (env,str) in
+           (env,join [pprintLabelString k, " = ", str]))
          env bindings
-    with (env,bindMap) then
-      (env,join ["{", strJoin ", " (mapValues bindMap), "}"])
-    else never
+    with (env,bindMap) in
+    (env,join ["{", strJoin ", " (mapValues bindMap), "}"])
 end
 
 lang DataPatPrettyPrint = DataPat + IdentifierPrettyPrint
@@ -958,13 +901,11 @@ lang DataPatPrettyPrint = DataPat + IdentifierPrettyPrint
 
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
   | PatCon t ->
-    match pprintConName env t.ident with (env,str) then
-      match getPatStringCode indent env t.subpat with (env,subpat) then
-        let subpat = if patIsAtomic t.subpat then subpat
-                     else join ["(", subpat, ")"]
-        in (env, join [str, " ", subpat])
-      else never
-    else never
+    match pprintConName env t.ident with (env,str) in
+    match getPatStringCode indent env t.subpat with (env,subpat) in
+    let subpat = if patIsAtomic t.subpat then subpat
+                 else join ["(", subpat, ")"]
+    in (env, join [str, " ", subpat])
 end
 
 lang IntPatPrettyPrint = IntPat
@@ -997,10 +938,9 @@ lang AndPatPrettyPrint = PrettyPrint + AndPat
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
   | PatAnd {lpat = l, rpat = r} ->
-    match printPatParen indent env l with (env, l2) then
-    match printPatParen indent env r with (env, r2) then
+    match printPatParen indent env l with (env, l2) in
+    match printPatParen indent env r with (env, r2) in
     (env, join [l2, " & ", r2])
-    else never else never
 end
 
 lang OrPatPrettyPrint = PrettyPrint + OrPat
@@ -1009,10 +949,9 @@ lang OrPatPrettyPrint = PrettyPrint + OrPat
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
   | PatOr {lpat = l, rpat = r} ->
-    match printPatParen indent env l with (env, l2) then
-    match printPatParen indent env r with (env, r2) then
+    match printPatParen indent env l with (env, l2) in
+    match printPatParen indent env r with (env, r2) in
     (env, join [l2, " | ", r2])
-    else never else never
 end
 
 lang NotPatPrettyPrint = PrettyPrint + NotPat
@@ -1021,9 +960,8 @@ lang NotPatPrettyPrint = PrettyPrint + NotPat
 
   sem getPatStringCode (indent : Int) (env : PprintEnv) =
   | PatNot {subpat = p} ->
-    match printPatParen indent env p with (env, p2) then
+    match printPatParen indent env p with (env, p2) in
     (env, join ["!", p2])
-    else never
 end
 
 -----------

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1144,8 +1144,8 @@ end
 
 lang VarSortPrettyPrint = VarSortAst + RecordTypePrettyPrint
   sem getVarSortStringCode (indent : Int) (env : PprintEnv) (idstr : String) =
-  | TypeVar () -> (env, idstr)
-  | WeakVar () -> (env, concat "_" idstr)
+  | PolyVar () -> (env, idstr)
+  | MonoVar () -> (env, concat "_" idstr)
   | RecordVar r ->
     let recty =
       TyRecord {info = NoInfo (), fields = r.fields} in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1144,13 +1144,12 @@ end
 
 lang VarSortPrettyPrint = VarSortAst + RecordTypePrettyPrint
   sem getVarSortStringCode (indent : Int) (env : PprintEnv) (idstr : String) =
-  | PolyVar () -> (env, idstr)
-  | MonoVar () -> (env, concat "_" idstr)
   | RecordVar r ->
     let recty =
       TyRecord {info = NoInfo (), fields = r.fields} in
     match getTypeStringCode indent env recty with (env, recstr) in
     (env, join [idstr, "<:", recstr])
+  | _ -> (env, idstr)
 end
 
 lang FlexTypePrettyPrint = FlexTypeAst + VarSortPrettyPrint
@@ -1158,7 +1157,9 @@ lang FlexTypePrettyPrint = FlexTypeAst + VarSortPrettyPrint
   | TyFlex t & ty ->
     match deref t.contents with Unbound t then
       match pprintEnvGetStr env t.ident with (env, idstr) in
-      getVarSortStringCode indent env idstr t.sort
+      match getVarSortStringCode indent env idstr t.sort with (env, str) in
+      let weakPrefix = if t.isWeak then "_" else "" in
+      (env, concat weakPrefix str)
     else
       getTypeStringCode indent env (resolveLink ty)
 end

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -584,7 +584,7 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck
           unify [infoTm body] env ty (tyTm body))
         -- Type annotation: unify the inferred type of the body with the annotated one
         (lam ty.
-          match stripTyAll ty with (_, tyAnnot) in
+          match stripTyAll (resolveAlias env.tyConEnv ty) with (_, tyAnnot) in
           unify [infoTy ty, infoTm body] env tyAnnot (tyTm body))
         (sremoveUnknown b.tyBody);
       {b with body = body}

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -196,6 +196,9 @@ lang VarTypeUnify = Unify + VarTypeAst
 
   sem unifyCheckBase info boundVars tv =
   | TyVar t ->
+    -- NOTE(aathn, 2022-06-09): We should also disallow unifying weak variables
+    -- with type variables in the future. For now, we allow it to facilitate
+    -- polymorphic type signatures containing records
     if leqi tv.level t.level then
       if not (setMem t.ident boundVars) then
         let msg = join [


### PR DESCRIPTION
This PR fixes two bugs in the typechecker:

- The typechecker would not look through aliases in annotations on recursive let bindings.
- The type variable scope check was incorrect, which prevented applying functions to polymorphic arguments in some cases.

The second bug was discovered by @dlunde in connection with https://github.com/miking-lang/miking/pull/600.
For example, the following program would fail:
```
mexpr
let id : all a. a -> a = lam y. y in
id #frozen"id"
```
When unifying `a1` with `all a2. a2 -> a2`, the type checker would think that the `a2` in the right hand side is escaping its scope, even though the unification keeps `a2` inside its binder. The scope check is now updated to only check variables occurring free in the right-hand side.

EDIT:
This PR now also includes some general code improvements to type-check.mc and pprint.mc, and updates the pretty-printer to use precedence to reduce the number of parentheses. What was previously printed as
```
all r125. ((all r126. ((Bool) -> (r126)) -> ((Bool) -> (r126))) -> (r125)) -> ((Bool) -> (r125))
```
is now printed as
```
all r125. ((all r126. (Bool -> r126) -> Bool -> r126) -> r125) -> Bool -> r125
```
In addition, monomorphic type variables are no longer prefixed with underscore when printed, this is instead used for non-generalizable (weak) variables (which are currently only introduced by un-annotated records, but would occur more frequently if we implemented a value restriction). The monomorphic type variables are no longer referred to as 'weak' in the code base, since they are not generally 'weak' in this sense.