### PR TITLE
Frontend fixes and singleton tuple type syntax

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -308,8 +308,8 @@ and tm =
   (* Record update *)
   | TmRecordUpdate of info * tm * ustring * tm
   (* Type let *)
-  (* NOTE(aathn, 2022-03-02): Type parameters are not symbolized currently *)
-  | TmType of info * ustring * Symb.t * ustring list * ty * tm
+  (* NOTE(aathn, 2022-06-10): Types are not symbolized in boot *)
+  | TmType of info * ustring * ustring list * ty * tm
   (* Constructor definition *)
   | TmConDef of info * ustring * Symb.t * ty * tm
   (* Constructor application *)
@@ -368,6 +368,7 @@ and pat =
   | PatNot of info * pat
 
 (* Types *)
+(* NOTE(aathn, 2022-06-10): Types are not symbolized in boot *)
 and ty =
   (* Unknown type *)
   | TyUnknown of info
@@ -382,7 +383,6 @@ and ty =
   (* Function type *)
   | TyArrow of info * ty * ty
   (* Forall quantifier *)
-  (* NOTE(aathn, 2022-03-02): Type variables are not symbolized currently *)
   | TyAll of info * ustring * ty
   (* Sequence type *)
   | TySeq of info * ty
@@ -391,11 +391,10 @@ and ty =
   (* Record type *)
   | TyRecord of info * ty Record.t
   (* Variant type *)
-  | TyVariant of info * (ustring * Symb.t) list
+  | TyVariant of info * ustring list
   (* Type constructors *)
-  | TyCon of info * ustring * Symb.t
+  | TyCon of info * ustring
   (* Type variables *)
-  (* NOTE(aathn, 2022-03-02): Type variables are not symbolized currently *)
   | TyVar of info * ustring
   (* Type application *)
   | TyApp of info * ty * ty
@@ -445,8 +444,8 @@ let smap_accum_left_tm_tm (f : 'a -> tm -> 'a * tm) (acc : 'a) : tm -> 'a * tm
       f acc r
       |> fun (acc, r') ->
       f acc t |> fun (acc, t') -> (acc, TmRecordUpdate (fi, r', l, t'))
-  | TmType (fi, x, s, params, ty, t) ->
-      f acc t |> fun (acc, t') -> (acc, TmType (fi, x, s, params, ty, t'))
+  | TmType (fi, x, params, ty, t) ->
+      f acc t |> fun (acc, t') -> (acc, TmType (fi, x, params, ty, t'))
   | TmConDef (fi, x, s, ty, t) ->
       f acc t |> fun (acc, t') -> (acc, TmConDef (fi, x, s, ty, t'))
   | TmConApp (fi, k, s, t) ->
@@ -503,7 +502,7 @@ let tm_info = function
   | TmSeq (fi, _)
   | TmRecord (fi, _)
   | TmRecordUpdate (fi, _, _, _)
-  | TmType (fi, _, _, _, _, _)
+  | TmType (fi, _, _, _, _)
   | TmConDef (fi, _, _, _, _)
   | TmConApp (fi, _, _, _)
   | TmMatch (fi, _, _, _, _)
@@ -543,7 +542,7 @@ let ty_info = function
   | TyTensor (fi, _)
   | TyRecord (fi, _)
   | TyVariant (fi, _)
-  | TyCon (fi, _, _)
+  | TyCon (fi, _)
   | TyVar (fi, _)
   | TyApp (fi, _, _) ->
       fi

--- a/src/boot/lib/bootparser.ml
+++ b/src/boot/lib/bootparser.ml
@@ -250,7 +250,7 @@ let getData = function
       (idTmRecord, [fi], [List.length slst], [], tlst, slst, [], [], [], [])
   | PTreeTm (TmRecordUpdate (fi, t1, x, t2)) ->
       (idTmRecordUpdate, [fi], [], [], [t1; t2], [x], [], [], [], [])
-  | PTreeTm (TmType (fi, x, _, params, ty, t)) ->
+  | PTreeTm (TmType (fi, x, params, ty, t)) ->
       let len = List.length params + 1 in
       (idTmType, [fi], [len], [ty], [t], x :: params, [], [], [], [])
   | PTreeTm (TmConDef (fi, x, _, ty, t)) ->
@@ -292,11 +292,10 @@ let getData = function
       let slst, tylst = List.split (Record.bindings tymap) in
       let len = List.length slst in
       (idTyRecord, [fi], [len], tylst, [], slst, [], [], [], [])
-  | PTreeTy (TyVariant (fi, lst)) ->
-      let strs = List.map (fun (x, _) -> x) lst in
-      let len = List.length lst in
+  | PTreeTy (TyVariant (fi, strs)) ->
+      let len = List.length strs in
       (idTyVariant, [fi], [len], [], [], strs, [], [], [], [])
-  | PTreeTy (TyCon (fi, x, _)) ->
+  | PTreeTy (TyCon (fi, x)) ->
       (idTyCon, [fi], [], [], [], [x], [], [], [], [])
   | PTreeTy (TyVar (fi, x)) ->
       (idTyVar, [fi], [], [], [], [x], [], [], [], [])

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1978,7 +1978,7 @@ and eval (env : (Symb.t * tm) list) (t : tm) =
           ( "Cannot update the term. The term is not a record: "
           ^ Ustring.to_utf8 (ustring_of_tm v) ) )
   (* Type (ignore) *)
-  | TmType (_, _, _, _, _, t1) ->
+  | TmType (_, _, _, _, t1) ->
       eval env t1
   (* Data constructors *)
   | TmConDef (_, _, _, _, t) ->
@@ -2045,7 +2045,7 @@ and eval (env : (Symb.t * tm) list) (t : tm) =
 let rec eval_toplevel (env : (Symb.t * tm) list) = function
   | TmLet (_, _, s, _ty, t1, t2) ->
       eval_toplevel ((s, eval env t1) :: env) t2
-  | TmType (_, _, _, _, _, t1) ->
+  | TmType (_, _, _, _, t1) ->
       eval_toplevel env t1
   | TmRecLets (_, lst, t2) ->
       let rec env' =

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -555,6 +555,8 @@ ty_atom:
     { TySeq(mkinfo $1.i $3.i, $2) }
   | LPAREN ty COMMA ty_list RPAREN
     { tuplety2recordty (mkinfo $1.i $5.i) ($2::$4) }
+  | LPAREN ty COMMA RPAREN
+    { TyRecord(mkinfo $1.i $4.i, Record.singleton (us "0") $2) }
   | LBRACKET RBRACKET
     { ty_unit (mkinfo $1.i $2.i) }
   | LBRACKET label_tys RBRACKET

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -297,10 +297,10 @@ mexpr:
       { $1 }
   | TYPE type_ident type_params IN mexpr
       { let fi = mkinfo $1.i $4.i in
-        TmType(fi, $2.v, Symb.Helpers.nosym, $3, TyVariant (fi, []), $5) }
+        TmType(fi, $2.v, $3, TyVariant (fi, []), $5) }
   | TYPE type_ident type_params EQ ty IN mexpr
       { let fi = mkinfo $1.i (tm_info $7) in
-        TmType(fi, $2.v, Symb.Helpers.nosym, $3, $5, $7) }
+        TmType(fi, $2.v, $3, $5, $7) }
   | REC lets IN mexpr
       { let fi = mkinfo $1.i $3.i in
         let lst = List.map (fun (fi,x,ty,t) -> (fi,x,Symb.Helpers.nosym,ty,t)) $2 in
@@ -580,7 +580,7 @@ ty_atom:
   | TSTRING
     { TySeq($1.i,TyChar $1.i) }
   | type_ident
-    { TyCon($1.i,$1.v,Symb.Helpers.nosym) }
+    { TyCon($1.i,$1.v) }
   | var_ident
     { TyVar($1.i,$1.v)}
 

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -204,8 +204,8 @@ let rec ustring_of_ty = function
       us "<>"
   | TyVariant _ ->
       failwith "Printing of non-empty variant types not yet supported"
-  | TyCon (_, x, s) ->
-      ustring_of_type x s
+  | TyCon (_, x) ->
+      pprint_type_str x
   | TyVar (_, x) ->
       pprint_var_str x
   | TyApp (_, ty1, ty2) ->
@@ -661,8 +661,8 @@ and print_tm' fmt t =
         let ty = ty |> ustring_of_ty |> string_of_ustring in
         fprintf fmt "@[<hov 0>@[<hov %d>let %s%s =@ %a in@]@ %a@]" !ref_indent
           x (print_ty_if_known ty) print_tm (Match, t1) print_tm (Match, t2)
-  | TmType (_, x, s, params, ty, t1) ->
-      let x = string_of_ustring (ustring_of_type x s) in
+  | TmType (_, x, params, ty, t1) ->
+      let x = string_of_ustring (pprint_type_str x) in
       let params =
         params |> List.map string_of_ustring |> List.cons ""
         |> String.concat " "

--- a/src/boot/lib/symbolize.ml
+++ b/src/boot/lib/symbolize.ml
@@ -79,33 +79,6 @@ let merge_sym_envs_pick_left l r =
   ; ty= SidMap.union pick_left l.ty r.ty
   ; label= SidMap.union pick_left l.label r.label }
 
-let rec symbolize_type env ty =
-  match ty with
-  | TyUnknown _ | TyBool _ | TyInt _ | TyFloat _ | TyChar _ | TyVar _ | TyAll _
-    ->
-      ty
-  | TyArrow (fi, ty1, ty2) ->
-      TyArrow (fi, symbolize_type env ty1, symbolize_type env ty2)
-  | TySeq (fi, ty) ->
-      TySeq (fi, symbolize_type env ty)
-  | TyTensor (fi, ty) ->
-      TyTensor (fi, symbolize_type env ty)
-  | TyRecord (fi, r) ->
-      let r = Record.map (fun ty -> symbolize_type env ty) r in
-      TyRecord (fi, r)
-  | TyVariant (_, tys) when tys = [] ->
-      ty
-  | TyVariant _ ->
-      failwith "Symbolizing non-empty variant types not yet supported"
-  | TyCon (fi, x, s) ->
-      (* NOTE(dlunde,2020-11-24): Currently, unbound type variables are heavily
-         used for documentation purposes. Hence, we simply ignore these for
-         now. *)
-      let s = try findsym fi (IdType (sid_of_ustring x)) env with _ -> s in
-      TyCon (fi, x, s)
-  | TyApp (fi, ty1, ty2) ->
-      TyApp (fi, symbolize_type env ty1, symbolize_type env ty2)
-
 (* Add symbol associations between lambdas, patterns, and variables. The function also
    constructs TmConApp terms from the combination of variables and function applications. *)
 let rec symbolize (env : sym_env) (t : tm) =
@@ -195,11 +168,7 @@ let rec symbolize (env : sym_env) (t : tm) =
   | TmLam (fi, x, _, ty, t1) ->
       let s = Symb.gensym () in
       TmLam
-        ( fi
-        , x
-        , s
-        , symbolize_type env ty
-        , symbolize (addsym (IdVar (sid_of_ustring x)) s env) t1 )
+        (fi, x, s, ty, symbolize (addsym (IdVar (sid_of_ustring x)) s env) t1)
   | TmClos (_, _, _, _, _) ->
       failwith "Closures should not be available."
   | TmLet (fi, x, _, ty, t1, t2) ->
@@ -208,20 +177,13 @@ let rec symbolize (env : sym_env) (t : tm) =
         ( fi
         , x
         , s
-        , symbolize_type env ty
+        , ty
         , symbolize env t1
         , symbolize (addsym (IdVar (sid_of_ustring x)) s env) t2 )
-  | TmType (fi, x, _, params, ty, t1) ->
+  | TmType (fi, x, params, ty, t1) ->
       (* TODO(dlunde,2020-11-23): Should type lets be recursive? Right now,
          they are not.*)
-      let s = Symb.gensym () in
-      TmType
-        ( fi
-        , x
-        , s
-        , params
-        , symbolize_type env ty
-        , symbolize (addsym (IdType (sid_of_ustring x)) s env) t1 )
+      TmType (fi, x, params, ty, symbolize env t1)
   | TmRecLets (fi, lst, tm) ->
       let env2 =
         List.fold_left
@@ -237,7 +199,7 @@ let rec symbolize (env : sym_env) (t : tm) =
               ( fi
               , x
               , findsym fi (IdVar (sid_of_ustring x)) env2
-              , symbolize_type env ty
+              , ty
               , symbolize env2 t ) )
             lst
         , symbolize env2 tm )
@@ -252,11 +214,7 @@ let rec symbolize (env : sym_env) (t : tm) =
   | TmConDef (fi, x, _, ty, t) ->
       let s = Symb.gensym () in
       TmConDef
-        ( fi
-        , x
-        , s
-        , symbolize_type env ty
-        , symbolize (addsym (IdCon (sid_of_ustring x)) s env) t )
+        (fi, x, s, ty, symbolize (addsym (IdCon (sid_of_ustring x)) s env) t)
   | TmConApp (fi, x, _, t) ->
       TmConApp
         (fi, x, findsym fi (IdCon (sid_of_ustring x)) env, symbolize env t)
@@ -277,12 +235,7 @@ let rec symbolize (env : sym_env) (t : tm) =
   | TmExt (fi, x, _, e, ty, t) ->
       let s = Symb.gensym () in
       TmExt
-        ( fi
-        , x
-        , s
-        , e
-        , symbolize_type env ty
-        , symbolize (addsym (IdVar (sid_of_ustring x)) s env) t )
+        (fi, x, s, e, ty, symbolize (addsym (IdVar (sid_of_ustring x)) s env) t)
   | TmConst _ | TmFix _ | TmNever _ | TmRef _ | TmTensor _ ->
       t
 
@@ -294,14 +247,7 @@ let rec symbolize_toplevel (env : sym_env) = function
       let new_env, new_t2 =
         symbolize_toplevel (addsym (IdVar (sid_of_ustring x)) s env) t2
       in
-      ( new_env
-      , TmLet (fi, x, s, symbolize_type env ty, symbolize env t1, new_t2) )
-  | TmType (fi, x, _, params, ty, t1) ->
-      let s = Symb.gensym () in
-      let new_env, new_t1 =
-        symbolize_toplevel (addsym (IdType (sid_of_ustring x)) s env) t1
-      in
-      (new_env, TmType (fi, x, s, params, symbolize_type env ty, new_t1))
+      (new_env, TmLet (fi, x, s, ty, symbolize env t1, new_t2))
   | TmRecLets (fi, lst, tm) ->
       let env2 =
         List.fold_left
@@ -319,7 +265,7 @@ let rec symbolize_toplevel (env : sym_env) = function
                 ( fi
                 , x
                 , findsym fi (IdVar (sid_of_ustring x)) env2
-                , symbolize_type env ty
+                , ty
                 , symbolize env2 t ) )
               lst
           , new_tm ) )
@@ -328,16 +274,17 @@ let rec symbolize_toplevel (env : sym_env) = function
       let new_env, new_t2 =
         symbolize_toplevel (addsym (IdCon (sid_of_ustring x)) s env) t
       in
-      (new_env, TmConDef (fi, x, s, symbolize_type env ty, new_t2))
+      (new_env, TmConDef (fi, x, s, ty, new_t2))
   | TmExt (fi, x, _, e, ty, t) ->
       let s = Symb.gensym () in
       let new_env, new_t =
         symbolize_toplevel (addsym (IdVar (sid_of_ustring x)) s env) t
       in
-      (new_env, TmExt (fi, x, s, e, symbolize_type env ty, new_t))
+      (new_env, TmExt (fi, x, s, e, ty, new_t))
   | ( TmVar _
     | TmLam _
     | TmApp _
+    | TmType _
     | TmConst _
     | TmSeq _
     | TmRecord _

--- a/src/boot/lib/symbutils.ml
+++ b/src/boot/lib/symbutils.ml
@@ -16,10 +16,8 @@ let symbmap t =
   let rec work acc = function
     | TmVar (_, x, s, _) ->
         SymbMap.add s x acc
-    | TmLam (_, x, s, _, t)
-    | TmType (_, x, s, _, _, t)
-    | TmConDef (_, x, s, _, t)
-    | TmConApp (_, x, s, t) ->
+    | TmLam (_, x, s, _, t) | TmConDef (_, x, s, _, t) | TmConApp (_, x, s, t)
+      ->
         work (SymbMap.add s x acc) t
     | TmLet (_, x, s, _, t1, t2) ->
         work (work (SymbMap.add s x acc) t1) t2

--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -37,6 +37,7 @@ let escapeIdentifier = lam str: String.
   else "_"
 
 let pprintEnvGetStr = lam env. lam id: Name.
+  use IdentifierPrettyPrint in
   -- Set this to true to print names with their symbols (for debugging)
   if false then
     (env,join [

--- a/stdlib/javascript/pprint.mc
+++ b/stdlib/javascript/pprint.mc
@@ -16,6 +16,7 @@ include "mexpr/pprint.mc"
 let _par = lam str. join ["(",str,")"]
 
 let pprintEnvGetStr = lam env. lam id: Name.
+  use IdentifierPrettyPrint in
   -- Set this to true to print names with their symbols (for debugging)
   if false then
     (env,join [

--- a/stdlib/mexpr/const-transformer.mc
+++ b/stdlib/mexpr/const-transformer.mc
@@ -20,7 +20,7 @@ let _constWithInfos: Info -> Expr -> Expr = use MExprAst in
       TmConst {{t with info = i} with ty = TyUnknown {ty with info = i}}
     else tm
 
-lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + NamedPat
+lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + ExtAst + NamedPat
 
   sem constTransform =
   | t ->
@@ -33,10 +33,10 @@ lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + Named
 
   sem ctWorker (env: Map String (Option Expr)) =
   | TmLet r ->
-    let env = mapInsert (nameGetStr r.ident) (None()) env in
     let t1 = ctWorker env r.body in
+    let env = mapInsert (nameGetStr r.ident) (None()) env in
     let t2 = ctWorker env r.inexpr in
-    TmLet {{r with body = t1} with inexpr = t2}
+    TmLet {r with body = t1, inexpr = t2}
   | TmLam r ->
     let t = ctWorker (mapInsert (nameGetStr r.ident) (None()) env) r.body in
     TmLam {r with body = t}
@@ -45,17 +45,19 @@ lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + Named
     match mapFindOrElse (lam. Some (TmVar r)) ident env with Some tm
     then _constWithInfos r.info tm else TmVar r
   | TmRecLets r ->
-     let fEnv = lam acc. lam b:RecLetBinding. mapInsert (nameGetStr b.ident) (None()) acc in
-     let env = foldl fEnv env r.bindings in
-     let bindings = map (lam b:RecLetBinding. {b with body = ctWorker env b.body}) r.bindings in
-     TmRecLets {{r with bindings = bindings}
-                   with inexpr = ctWorker env r.inexpr}
+    let fEnv = lam acc. lam b:RecLetBinding. mapInsert (nameGetStr b.ident) (None()) acc in
+    let env = foldl fEnv env r.bindings in
+    let bindings = map (lam b:RecLetBinding. {b with body = ctWorker env b.body}) r.bindings in
+    TmRecLets {r with bindings = bindings, inexpr = ctWorker env r.inexpr}
   | TmMatch r ->
-     let fEnv = lam acc. lam x. mapInsert x (None()) acc in
-     let env2 = foldl fEnv env (ctGetPatVars [] r.pat) in
-     TmMatch {{{r with target = ctWorker env r.target}
-                  with thn = ctWorker env2 r.thn}
-                  with els = ctWorker env r.els}
+    let fEnv = lam acc. lam x. mapInsert x (None()) acc in
+    let env2 = foldl fEnv env (ctGetPatVars [] r.pat) in
+    TmMatch {r with target = ctWorker env r.target
+                  , thn = ctWorker env2 r.thn
+                  , els = ctWorker env r.els}
+  | TmExt r ->
+    let t = ctWorker (mapInsert (nameGetStr r.ident) (None()) env) r.inexpr in
+    TmExt {r with inexpr = t}
   | t -> smap_Expr_Expr (ctWorker env) t
 
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1079,7 +1079,8 @@ lang RecordTypePrettyPrint = IdentifierPrettyPrint + RecordTypeAst
       in
       match tuple with Some tuple then
         match mapAccumL (getTypeStringCode indent) env tuple with (env, tuple) in
-        (env, join ["(", strJoin ", " tuple, ")"])
+        let singletonComma = match tuple with [_] then "," else "" in
+        (env, join ["(", strJoin ", " tuple, singletonComma, ")"])
       else
         let f = lam env. lam field.
           match field with (sid, ty) in

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -315,7 +315,7 @@ lang OCamlPrettyPrint =
         env
       else
         {{env with nameMap = mapInsert name str env.nameMap}
-              with strings = mapInsert str 1 env.strings}
+              with strings = setInsert str env.strings}
     in
     let f = lam top. lam env.
       switch top


### PR DESCRIPTION
This PR makes a number of fixes to the MExpr frontend:
- Fix a bug in `const-transformer.mc` where intrinsics would not be available in the body of a let shadowing them. For instance, in `let head = lam x. if null x then None () else head x`, the `head` in the right-hand side would not be transformed to an intrinsic call and instead be treated as an unbound variable.
- Fix a bug in `const-transformer.mc` where external definitions were not able to shadow intrinsic names. (This bug was hidden by the previous bug :sweat_smile:)
- Update pretty-printer to print type variables and type constructor names with hashtag literals if needed, and fix bugs related to the hashtag literal printing.
- Move `pprintEnvGetStr` in `mexpr/pprint.mc` into a language fragment to prevent a bug where it was shadowed by the corresponding functions from `{c,javascript}/pprint.mc`. (Thanks @larshum for managing to debug this one!)
- Update pretty-printer to not use hashtag literals for tuple projection. In other words, print `x.0` instead of `x.#label"0"`.
- Add singleton tuple type syntax `(T,)` (equivalent to `{#label"0" : T}`).

EDIT:
This PR now also removes boot's symbolizing of types, since it was incomplete and redundant anyways.
Also, as a point of discussion, the type variables currently use the same hashtag literal as term variables (`#var`). Is this ok, or should they have their own literals (something like `#tvar`)?