### PR TITLE
Fix errors caused by incompatible PRs

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -102,7 +102,7 @@ let styall_ = lam s. nstyall_ (nameNoSym s)
 
 let ntyall_ : Name -> Type -> Type  = use VarSortAst in
   lam n.
-  nstyall_ n (TypeVar ())
+  nstyall_ n (PolyVar ())
 
 let tyall_ = use VarSortAst in
   lam s.

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -466,7 +466,7 @@ let typestest = _cps "
 " in
 -- print (mexprToString typestest);
 utest mexprToString typestest with
-"external e : (Float) -> (Float)
+"external e : Float -> Float
 in
 let e =
   lam k11.
@@ -475,16 +475,16 @@ let e =
         (e
            a1)
 in
-let f: ((Float) -> (Unknown)) -> ((Float) -> (Unknown)) =
+let f: (Float -> Unknown) -> Float -> Unknown =
   lam k2.
     lam x: Float.
       e
         k2
         x
 in
-let g: ((Float) -> (Unknown)) -> ((((Float) -> (Unknown)) -> ((Float) -> (Unknown))) -> (Unknown)) =
+let g: (Float -> Unknown) -> ((Float -> Unknown) -> Float -> Unknown) -> Unknown =
   lam k1.
-    lam h: ((Float) -> (Unknown)) -> ((Float) -> (Unknown)).
+    lam h: (Float -> Unknown) -> Float -> Unknown.
       let t =
         1.
       in
@@ -493,7 +493,7 @@ let g: ((Float) -> (Unknown)) -> ((((Float) -> (Unknown)) -> ((Float) -> (Unknow
         t
 in
 recursive
-  let h: all a. ((a) -> (Unknown)) -> ((a) -> (Unknown)) =
+  let h: all a. (a -> Unknown) -> a -> Unknown =
     lam k.
       lam y: a.
         k
@@ -501,7 +501,7 @@ recursive
 in
 type T
 in
-con C: (all x. ((x) -> (Unknown)) -> ((x) -> (Unknown))) -> (T) in
+con C: (all x. (x -> Unknown) -> x -> Unknown) -> T in
 g
   (lam x.
      x)


### PR DESCRIPTION
It seems #600 and #601 had some slight incompatibilities, but somehow #601 passed the pre-merge tests anyways after #600 was merged...

Currently the bootstrapping and one test case fail; this PR fixes the problem.