### PR TITLE
Update Unknown type

### DIFF
--- a/stdlib/cuda/pmexpr-ast.mc
+++ b/stdlib/cuda/pmexpr-ast.mc
@@ -90,7 +90,7 @@ lang CudaPMExprAst = PMExprAst
     match f acc t.f with (acc, tf) in
     (acc, TmLoopKernel {{t with n = n} with f = tf})
 
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmSeqMap t ->
     let f = typeCheckExpr env t.f in
     let s = typeCheckExpr env t.s in

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -1199,6 +1199,22 @@ let tests = [
   {name = "Never1",
    tm = never_,
    ty = fa,
+   env = []},
+
+  {name = "Unknown1",
+   tm = bind_
+     (let_ "f" (tyarrow_ tyunknown_ tyunknown_)
+       (ulam_ "x" (var_ "x")))
+     (freeze_ (var_ "f")),
+   ty = tyall_ "a" (tyarrow_ (tyvar_ "a") (tyvar_ "a")),
+   env = []},
+
+  {name = "Unknown2",
+   tm = bind_
+     (let_ "f" (tyarrow_ tyint_ tyunknown_)
+       (ulam_ "x" (var_ "x")))
+     (freeze_ (var_ "f")),
+   ty = tyarrow_ tyint_ tyint_,
    env = []}
 
 ]

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -480,11 +480,6 @@ lang TypeCheck = Unify + Generalize + ResolveLinks
   -- Type check `expr' under the type environment `env'. The resulting
   -- type may contain TyFlex links.
   sem typeCheckExpr : TCEnv -> Expr -> Expr
-  sem typeCheckExpr env =
-  | tm ->
-    typeCheckBase env tm
-
-  sem typeCheckBase : TCEnv -> Expr -> Expr
 end
 
 lang PatTypeCheck = Unify
@@ -492,7 +487,7 @@ lang PatTypeCheck = Unify
 end
 
 lang VarTypeCheck = TypeCheck + VarAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmVar t ->
     match mapLookup t.ident env.varEnv with Some ty then
       let ty =
@@ -509,7 +504,7 @@ lang VarTypeCheck = TypeCheck + VarAst
 end
 
 lang LamTypeCheck = TypeCheck + LamAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmLam t ->
     let tyX = optionGetOrElse
       -- No type annotation: assign a monomorphic type variable to x
@@ -523,7 +518,7 @@ lang LamTypeCheck = TypeCheck + LamAst
 end
 
 lang AppTypeCheck = TypeCheck + AppAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmApp t ->
     let lhs = typeCheckExpr env t.lhs in
     let rhs = typeCheckExpr env t.rhs in
@@ -533,7 +528,7 @@ lang AppTypeCheck = TypeCheck + AppAst
 end
 
 lang LetTypeCheck = TypeCheck + LetAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmLet t ->
     let lvl = env.currentLvl in
     let body = optionMapOr t.body (lam ty. propagateTyAnnot (t.body, ty)) (sremoveUnknown t.tyBody) in
@@ -564,7 +559,7 @@ lang LetTypeCheck = TypeCheck + LetAst
 end
 
 lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmRecLets t ->
     let lvl = env.currentLvl in
 
@@ -611,7 +606,7 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck
 end
 
 lang MatchTypeCheck = TypeCheck + PatTypeCheck + MatchAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmMatch t ->
     let target = typeCheckExpr env t.target in
     match typeCheckPat env t.pat with (thnEnv, pat) in
@@ -627,7 +622,7 @@ lang MatchTypeCheck = TypeCheck + PatTypeCheck + MatchAst
 end
 
 lang ConstTypeCheck = TypeCheck + MExprConstType
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmConst t ->
     recursive let f = lam ty. smap_Type_Type f (tyWithInfo t.info ty) in
     let ty = inst env.tyConEnv env.currentLvl (f (tyConst t.val)) in
@@ -635,7 +630,7 @@ lang ConstTypeCheck = TypeCheck + MExprConstType
 end
 
 lang SeqTypeCheck = TypeCheck + SeqAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmSeq t ->
     let elemTy = newvar env.currentLvl t.info in
     let tms = map (typeCheckExpr env) t.tms in
@@ -656,7 +651,7 @@ lang FlexDisableGeneralize = FlexTypeAst
 end
 
 lang RecordTypeCheck = TypeCheck + RecordAst + RecordTypeAst + FlexDisableGeneralize
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmRecord t ->
     let bindings = mapMap (typeCheckExpr env) t.bindings in
     let bindingTypes = mapMap tyTm bindings in
@@ -672,7 +667,7 @@ lang RecordTypeCheck = TypeCheck + RecordAst + RecordTypeAst + FlexDisableGenera
 end
 
 lang TypeTypeCheck = TypeCheck + TypeAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmType t ->
     let env = _insertTyCon t.ident (t.params, t.tyIdent) env in
     let inexpr = typeCheckExpr env t.inexpr in
@@ -680,7 +675,7 @@ lang TypeTypeCheck = TypeCheck + TypeAst
 end
 
 lang DataTypeCheck = TypeCheck + DataAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmConDef t ->
     let inexpr = typeCheckExpr (_insertCon t.ident t.tyIdent env) t.inexpr in
     TmConDef {t with inexpr = inexpr, ty = tyTm inexpr}
@@ -699,7 +694,7 @@ lang DataTypeCheck = TypeCheck + DataAst
 end
 
 lang UtestTypeCheck = TypeCheck + UtestAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmUtest t ->
     let test = typeCheckExpr env t.test in
     let expected = typeCheckExpr env t.expected in
@@ -717,12 +712,12 @@ lang UtestTypeCheck = TypeCheck + UtestAst
 end
 
 lang NeverTypeCheck = TypeCheck + NeverAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmNever t -> TmNever {t with ty = newvar env.currentLvl t.info}
 end
 
 lang ExtTypeCheck = TypeCheck + ExtAst
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmExt t ->
     let env = {env with varEnv = mapInsert t.ident t.tyIdent env.varEnv} in
     let inexpr = typeCheckExpr env t.inexpr in

--- a/stdlib/pmexpr/ast.mc
+++ b/stdlib/pmexpr/ast.mc
@@ -134,7 +134,7 @@ lang PMExprAst =
     match f acc t.e with (acc, e) in
     (acc, TmParallelSizeCoercion {t with e = e})
 
-  sem typeCheckBase env =
+  sem typeCheckExpr env =
   | TmAccelerate t ->
     let e = typeCheckExpr env t.e in
     TmAccelerate {{t with e = e}

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -130,7 +130,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot + TypeCheck
 
   sem hty : Info -> Hole -> Type
 
-  sem typeCheckBase (env: TCEnv) =
+  sem typeCheckExpr (env: TCEnv) =
   | TmHole t ->
     let default = typeCheckExpr env t.default in
     let ty = hty t.info t.inner in


### PR DESCRIPTION
This PR updates `Unknown` to act as a type hole rather than an unsafe dynamic type. In other words, `Unknown` now indicates a place where you would like the type checker to (safely) infer the type for you. Below follow some examples of programs with `Unknown` annotations and the corresponding output of `mi --debug-type-check` (formatted compactly for readability).

An `Unknown` annotation is equivalent to no annotation at all.
```ocaml
mexpr
let x: Unknown = lam x. (x, x) in x 4
```
~~>
```ocaml
let x: all a. a -> (a, a) = lam x1: a. (x1, x1) in x 4
 : (Int, Int)
```

We can give a more elaborate signature, and it will still get generalized.
```ocaml
mexpr
let x: Unknown -> Unknown = lam x. (x, x) in x 4
```
~~>
```ocaml
let x: all a. a -> (a, a) = lam x1: a. (x1, x1) in x 4
 : (Int, Int)
```

We can fix the parameter to type `Int`, resulting in a specialized function type.
```ocaml
mexpr
let x: Int -> Unknown = lam x. (x, x) in x 4
```
~~>
```ocaml
let x: Int -> (Int, Int) = lam x1: Int. (x1, x1) in x 4
 : (Int, Int)
```

We can use `Unknown` to bring type variables into scope without having to give a full signature.
```ocaml
mexpr
let x: all a. Unknown = lam x : a. (x, x) in x 4
```
~~>
```ocaml
let x: all a. a -> (a, a) = lam x1: a. (x1, x1) in x 4
 : (Int, Int)
```

We can no longer use `Unknown` to perform unsafe operations.
```ocaml
mexpr
let f: (Unknown, Unknown) -> Int = lam x. addi x.0 x.1  in f (4, true)
```
~~>
```
ERROR: Type check failed: unification failure
LHS: Int
RHS: Bool
while unifying these:
LHS: (Int, Int) -> Int
RHS: (Int, Bool) -> a
```

`Unknown` is only allowed in annotations on lambdas and lets, and an error is given if one tries to use it in a definition.
```ocaml
mexpr
type Foo = Unknown in ()
```
~~>
```
ERROR: Type check failed: encountered unexpected Unknown type.
Unknown types are only allowed in type annotations, not in definitions or declarations!
```

EDIT:
Contrary to what I said at the meeting, the typechecker _does_ handle `Unknown` type applications in a sensible way.
If one gives the annotation `x : Unknown a`, then the typechecker will attempt to infer a type `T a` for `x`, where `T` is a non-alias type constructor.

For instance, in the program below, `x1` and `x2` successfully typecheck, but `x3`, `x4`, and `x5` fail.

```ocaml
mexpr

type T1 a in
con C1 : all a. a -> T1 a in

type T2 in
con C2 : Int -> T2 in

type T3 a = a in

let x1: Unknown     = C1 5 in
let x2: Unknown Int = C1 5 in
let x3: Unknown Int = C1 "5" in
let x4: Unknown Int = C2 5 in
let x5: Unknown Int = let x : T3 Int = 5 in x in

(x1,x2,x3,x4,x5)
```