### PR TITLE
Add support for partial CPS transformations

### DIFF
--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -674,7 +674,8 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile
           match ty with TyArrow { from = fromTy } then
             if _isUnitTy fromTy then detachParams acc rest
             else detachParams (snoc acc ident) rest
-          else errorSingle [infoTy ty] "Incorrect type in compileFun"
+          else
+            errorSingle [infoTy ty] "Incorrect type in compileFun"
         else (acc, rest)
     in
     recursive let funTypes: [Type] -> Type -> ([Type], Type) =
@@ -1383,7 +1384,6 @@ end
 
 mexpr
 use Test in
-
 let compile: CompileCOptions -> Expr -> CProg = lam opts. lam prog.
 
   -- Symbolize with empty environment
@@ -1397,6 +1397,9 @@ let compile: CompileCOptions -> Expr -> CProg = lam opts. lam prog.
 
   -- ANF transformation
   let prog = normalizeTerm prog in
+
+  -- Second type check (needed after ANF)
+  let prog = typeCheck prog in
 
   -- Type lift
   match typeLift prog with (env, prog) then
@@ -1707,6 +1710,9 @@ utest testCompile ext with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
   "#include <math.h>",
+  "double externalLog(double a1) {",
+  "  return log(a1);",
+  "}",
   "double x;",
   "int main(int argc, char (*argv[])) {",
   "  (x = log(2.));",
@@ -2010,6 +2016,5 @@ let seqs = bindall_ [
   int_ 0
 
 ] in
-
 
 ()

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -526,19 +526,17 @@ utest _test lamseq with _parse "
 -- Externals
 let ext = _parse "
   external e: Int -> Int -> Int in
-  e 1 2 3
+  e 1 2
 " in
 -- printLn (mexprToString (_test ext));
 utest _test ext with _parse "
-  external e : Int -> Int -> Int in
-  let e = lam a1. lam a2. e a1 a2 in
-  let t = 1 in
-  let t1 = e t in
-  let t2 = 2 in
-  let t3 = t1 t2 in
-  let t4 = 3 in
-  let t5 = t3 t4 in
-  t5
+external e : Int -> Int -> Int in
+let e: Int -> Int -> Int = lam a1.  lam a2.  e a1 a2 in
+let t = 1 in
+let t1 = e t in
+let t2 = 2 in
+let t3 = t1 t2 in
+t3
 " using eqExpr in
 
 ()

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -284,7 +284,7 @@ lang ExtANF = ANF + ExtAst
       foldr (lam v. lam acc. i (nulam_ v acc )) inner varNames in
     TmExt { t with
       inexpr = bindall_
-        [ i (nulet_ t.ident etaExpansion),
+        [ i (nlet_ t.ident t.tyIdent etaExpansion),
           normalize k t.inexpr ] }
 
 end
@@ -530,15 +530,15 @@ let ext = _parse "
 " in
 -- printLn (mexprToString (_test ext));
 utest _test ext with _parse "
-external e : Int -> Int -> Int in
-let e = lam a1. lam a2. e a1 a2 in
-let t = 1 in
-let t1 = e t in
-let t2 = 2 in
-let t3 = t1 t2 in
-let t4 = 3 in
-let t5 = t3 t4 in
-t5
+  external e : Int -> Int -> Int in
+  let e = lam a1. lam a2. e a1 a2 in
+  let t = 1 in
+  let t1 = e t in
+  let t2 = 2 in
+  let t3 = t1 t2 in
+  let t4 = 3 in
+  let t5 = t3 t4 in
+  t5
 " using eqExpr in
 
 ()

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -5,7 +5,9 @@ include "name.mc"
 include "stringid.mc"
 
 include "ast.mc"
+include "type.mc"
 include "ast-builder.mc"
+include "boot-parser.mc"
 include "pprint.mc"
 include "symbolize.mc"
 include "eq.mc"
@@ -262,7 +264,28 @@ lang ExtANF = ANF + ExtAst
 
   sem normalize (k : Expr -> Expr) =
   | TmExt ({inexpr = inexpr} & t) ->
-    TmExt {t with inexpr = normalize k t.inexpr}
+    -- TmExt {t with inexpr = normalize k t.inexpr}
+
+    -- NOTE(dlunde,2022-06-14): Externals must always be fully applied (otherwise the parser throws an
+    -- erro). To make this compatible with ANF, we eta expand definitions of
+    -- externals.
+    let arity = arityFunType t.tyIdent in
+    let i = withInfo t.info in
+    recursive let vars = lam acc. lam arity.
+      if lti arity 1 then acc
+      else
+        let arg = nameNoSym (concat "a" (int2string arity)) in
+        vars (cons arg acc) (subi arity 1)
+    in
+    let varNames: [Name] = vars [] arity in
+    let inner = foldl (lam acc. lam v.
+        i (app_ acc (nvar_ v))) (nvar_ t.ident) varNames in
+    let etaExpansion =
+      foldr (lam v. lam acc. i (nulam_ v acc )) inner varNames in
+    TmExt { t with
+      inexpr = bindall_
+        [ i (nulet_ t.ident etaExpansion),
+          normalize k t.inexpr ] }
 
 end
 
@@ -279,7 +302,7 @@ lang MExprANF =
 
 end
 
--- Full ANF transformation. Lifts everything
+-- Full ANF transformation. Lifts everything.
 lang MExprANFAll =
   VarANF + AppANFAll + LamANFAll + RecordANF + LetANF + TypeANF + RecLetsANFAll +
   ConstANF + DataANF + MatchANF + UtestANF + SeqANF + NeverANF + ExtANF
@@ -291,9 +314,9 @@ end
 
 lang TestBase = MExprSym + MExprPrettyPrint end
 
-lang TestANF = MExprANF + MExprEq end
+lang TestANF = MExprANF + MExprEq + BootParser end
 
-lang TestANFAll = MExprANFAll + MExprEq end
+lang TestANFAll = MExprANFAll + MExprEq + BootParser end
 
 mexpr
 
@@ -319,220 +342,203 @@ in
 use TestANF in
 
 let _test = _testConstr normalizeTerm in
+let _parse = parseMExprStringKeywords [] in
 
-let basic =
-  bind_ (ulet_ "f" (ulam_ "x" (var_ "x")))
-  (addi_ (addi_ (int_ 2) (int_ 2))
-    (bind_ (ulet_ "x" (int_ 1)) (app_ (var_ "f") (var_ "x")))) in
-utest _test basic with
-  bindall_ [
-    ulet_ "f" (ulam_ "x" (var_ "x")),
-    ulet_ "t" (addi_ (int_ 2) (int_ 2)),
-    ulet_ "x1" (int_ 1),
-    ulet_ "t1" (app_ (var_ "f") (var_ "x1")),
-    ulet_ "t2" (addi_ (var_ "t") (var_ "t1")),
-    var_ "t2"
-  ]
-using eqExpr in
+let basic = _parse "
+  let f = (lam x. x) in
+  addi (addi 2 2) (let x = 1 in f x)
+" in
+utest _test basic with _parse "
+  let f = (lam x. x) in
+  let t = addi 2 2 in
+  let x1 = 1 in
+  let t1 = f x1 in
+  let t2 = addi t t1 in
+  t2
+" using eqExpr in
 
 
-let ext =
-  bindall_
-    [ulet_ "f" (ulam_ "x" (var_ "x")),
-     ulet_ "x" (int_ 3),
-     (addi_ (addi_ (int_ 2) (var_ "x")))
-       (bind_ (ulet_ "x" (int_ 1)) (app_ (var_ "f") (var_ "x")))] in
-utest _test ext with
-  bindall_ [
-    ulet_ "f" (ulam_ "x" (var_ "x")),
-    ulet_ "x1" (int_ 3),
-    ulet_ "t" (addi_ (int_ 2) (var_ "x1")),
-    ulet_ "x2" (int_ 1),
-    ulet_ "t1" (app_ (var_ "f") (var_ "x2")),
-    ulet_ "t2" (addi_ (var_ "t") (var_ "t1")),
-    var_ "t2"
-  ]
-using eqExpr in
+let ext = _parse "
+  let f = (lam x. x) in
+  let x = 3 in
+  addi (addi 2 x) (let x = 1 in f x)
+" in
+utest _test ext with _parse "
+  let f = (lam x. x) in
+  let x1 = 3 in
+  let t = addi 2 x1 in
+  let x2 = 1 in
+  let t1 = f x2 in
+  let t2 = addi t t1 in
+  t2
+" using eqExpr in
 
-let lambda =
-  app_
-    (ulam_ "x" (bind_ (ulet_ "y" (int_ 3)) (addi_ (var_ "x") (var_ "y"))))
-    (int_ 4)
-in
-utest _test lambda with
-  bindall_ [
-    ulet_ "t"
-      (app_
-        (ulam_ "x" (bindall_ [
-          (ulet_ "y" (int_ 3)),
-          (ulet_ "t1" (addi_ (var_ "x") (var_ "y"))),
-          (var_ "t1")
-        ]))
-        (int_ 4)),
-    var_ "t"
-  ]
-using eqExpr in
+let lambda = _parse "
+  (lam x. let y = 3 in addi x y) 4
+" in
+utest _test lambda with _parse "
+  let t = (lam x. let y = 3 in let t1 = addi x y in t1) 4 in
+  t
+" using eqExpr in
 
-let apps =
-  app_ (app_ (int_ 1) (app_ (int_ 2) (int_ 3))) (app_ (int_ 4) (app_ (int_ 5) (int_ 6)))
-in
-utest _test apps with
-  bindall_ [
-    ulet_ "x"  (app_ (int_ 2) (int_ 3)),
-    ulet_ "x1" (app_ (int_ 5) (int_ 6)),
-    ulet_ "x2" (app_ (int_ 4) (var_ "x1")),
-    ulet_ "x3" (app_ (app_ (int_ 1) (var_ "x")) (var_ "x2")),
-    var_ "x3"
-  ]
-using eqExpr in
+let apps = _parse "
+  (1 (2 3)) (4 (5 6))
+" in
+utest _test apps with _parse "
+  let x = 2 3 in
+  let x1 = 5 6 in
+  let x2 = 4 x1 in
+  let x3 = 1 x x2 in
+  x3
+" using eqExpr in
 
-let record =
-  urecord_ [
-    ("a",(app_ (int_ 1) (app_ (int_ 2) (int_ 3)))),
-    ("b", (int_ 4)),
-    ("c", (app_ (int_ 5) (int_ 6)))
-  ]
-in
-let rupdate = recordupdate_ record "b" (int_ 7) in
+let record = _parse "
+  {a = 1 (2 3), b = 4, c = 5 6}
+" in
+-- printLn (mexprToString (_test record));
+utest _test record with _parse "
+  let t = 5 6 in
+  let t1 = 2 3 in
+  let t2 = 1 t1 in
+  let t3 = { a = t2, b = 4, c = t } in
+  t3
+" using eqExpr in
 
-let factorial =
-  ureclet_ "fact"
-    (ulam_ "n"
-      (if_ (eqi_ (var_ "n") (int_ 0))
-        (int_ 1)
-        (muli_ (var_ "n") (app_ (var_ "fact") (subi_ (var_ "n") (int_ 1))))))
-in
-utest _test factorial with
-  bindall_ [
-    ureclet_ "fact"
-      (ulam_ "n" (bindall_ [
-        ulet_ "t" (eqi_ (var_ "n") (int_ 0)),
-        ulet_ "t1" (if_ (var_ "t")
-          (int_ 1)
-          (bindall_ [
-            ulet_ "t2" (subi_ (var_ "n") (int_ 1)),
-            ulet_ "t3" (app_ (var_ "fact") (var_ "t2")),
-            ulet_ "t4" (muli_ (var_ "n") (var_ "t3")),
-            var_ "t4"
-          ])
-        ),
-        var_ "t1"
-      ])),
-    ulet_ "t5" uunit_,
-    var_ "t5"
-  ]
-using eqExpr in
+let rupdate = _parse "
+  {{a = 1 (2 3), b = 4, c = 5 6} with b = 7}
+" in
+utest _test rupdate with _parse "
+  let t = 5 6 in
+  let t1 = 2 3 in
+  let t2 = 1 t1 in
+  let t3 = { a = t2, b = 4, c = t } in
+  let t4 = { t3 with b = 7 } in
+  t4
+" using eqExpr in
 
-let const = (int_ 1) in
-utest _test const with
-  (int_ 1)
-using eqExpr in
+let factorial = _parse "
+  recursive let fact = lam n. if eqi n 0 then 1 else muli n (fact (subi n 1)) in
+  ()
+" in
+-- printLn (mexprToString (_test factorial));
+utest _test factorial with _parse "
+  recursive let fact = lam n.
+    let t = eqi n 0 in
+    let t1 = if t then 1 else
+      let t2 = subi n 1 in
+      let t3 = fact t2 in
+      let t4 = muli n t3 in
+      t4
+    in
+    t1
+  in
+  let t5 = () in
+  t5
+" using eqExpr in
 
-let data = bind_ (ucondef_ "A") (conapp_ "A" (app_ (int_ 1) (int_ 2))) in
-utest _test data with
-  bindall_ [
-    (ucondef_ "A"),
-    ulet_ "t" (app_ (int_ 1) (int_ 2)),
-    ulet_ "t1" (conapp_ "A" (var_ "t")),
-    var_ "t1"
-  ]
-using eqExpr in
+let const = _parse "1" in
+utest _test const with const using eqExpr in
 
-let seq =
-  seq_ [
-    (app_ (int_ 1) (app_ (int_ 2) (int_ 3))),
-    (int_ 4),
-    (app_ (int_ 5) (int_ 6))
-  ]
-in
-utest _test seq with
-  bindall_ [
-    ulet_ "t" (app_ (int_ 5) (int_ 6)),
-    ulet_ "t1" (app_ (int_ 2) (int_ 3)),
-    ulet_ "t2" (app_ (int_ 1) (var_ "t1")),
-    ulet_ "t3" (seq_ [var_ "t2", (int_ 4), var_ "t"]),
-    var_ "t3"
-  ]
-using eqExpr in
+let data = _parse "
+  con A: Unknown in A (1 2)
+" in
+utest _test data with _parse "
+  con A: Unknown in
+  let t = 1 2 in
+  let t1 = A t in
+  t1
+" using eqExpr in
 
-let smatch = if_ (app_ (int_ 1) (int_ 2)) (int_ 3) (int_ 4) in
-utest _test smatch with
-  bindall_ [
-    ulet_ "t" (app_ (int_ 1) (int_ 2)),
-    ulet_ "t1" (if_ (var_ "t") (int_ 3) (int_ 4)),
-    var_ "t1"
-  ]
-using eqExpr in
+let seq = _parse " [1 (2 3), 4, 5 6] " in
+utest _test seq with _parse "
+  let t = 5 6 in
+  let t1 = 2 3 in
+  let t2 = 1 t1 in
+  let t3 = [t2, 4, t] in
+  t3
+" using eqExpr in
 
-let simple = bind_ (ulet_ "x" (int_ 1)) (var_ "x") in
+let smatch = _parse "
+  if 1 2 then 3 else 4
+" in
+utest _test smatch with _parse "
+  let t = 1 2 in
+  let t1 = if t then 3 else 4 in
+  t1
+" using eqExpr in
+
+let simple = _parse "let x = 1 in x" in
 utest _test simple with simple using eqExpr in
 
-let simple2 = app_ (int_ 1) simple in
-utest _test simple2 with
-  bindall_ [
-    ulet_ "x" (int_ 1),
-    ulet_ "t" (app_ (int_ 1) (var_ "x")),
-    var_ "t"
-  ]
-using eqExpr in
+let simple2 = _parse "1 (let x = 1 in x)" in
+utest _test simple2 with _parse "
+  let x = 1 in
+  let t = 1 x in
+  t
+" using eqExpr in
 
-let inv1 = bind_ (ulet_ "x" (app_ (int_ 1) (int_ 2))) (var_ "x") in
+let inv1 = _parse "let x = 1 2 in x" in
 utest _test inv1 with inv1 using eqExpr in
 
-let nested = ulam_ "x" (ulam_ "x" (ulam_ "x" (var_ "x"))) in
-utest _test nested with
-  (ulam_ "x" (ulam_ "x" (ulam_ "x" (var_ "x"))))
-using eqExpr in
+let nested = _parse "lam x. lam x. lam x. x" in
+utest _test nested with nested using eqExpr in
 
-let nestedreclet =
-  ureclet_ "f"
-    (ulam_ "a"
-      (ulam_ "b"
-        (ulam_ "c" (int_ 1)))) in
-utest _test nestedreclet with
-  ureclet_ "f"
-    (ulam_ "a"
-      (ulam_ "b"
-        (ulam_ "c" (int_ 1))))
-using eqExpr in
-
-let constant = int_ 1 in
-utest _test constant with int_ 1
-using eqExpr in
+let nestedreclet = _parse "
+  recursive let f = lam a. lam b. lam c. 1 in
+  ()
+" in
+utest _test nestedreclet with _parse "
+  recursive let f = lam a. lam b. lam c. 1 in
+  let t = () in t
+" using eqExpr in
 
 -- Tests for full ANF
 use TestANFAll in
 
 let _test = _testConstr normalizeTerm in
 
-let appseq = addi_ (int_ 1) (int_ 2) in
-utest _test appseq with
-  bindall_ [
-    ulet_ "t" (uconst_ (CAddi {})),
-    ulet_ "t1" (int_ 1),
-    ulet_ "t2" (app_ (var_ "t") (var_ "t1")),
-    ulet_ "t3" (int_ 2),
-    ulet_ "t4" (app_ (var_ "t2") (var_ "t3")),
-    var_ "t4"
-  ]
-using eqExpr in
+let appseq = _parse "addi 1 2" in
+utest _test appseq with _parse "
+  let t = addi in
+  let t1 = 1 in
+  let t2 = t t1 in
+  let t3 = 2 in
+  let t4 = t2 t3 in
+  t4
+" using eqExpr in
 
-let lamseq = ulam_ "x" (ulam_ "y" (ulam_ "z" (int_ 1))) in
-utest _test lamseq with
-  let ulet_ = lam s. lam body. lam inexpr. bind_ (ulet_ s body) inexpr in
-  ulet_ "t" (
-    ulam_ "x" (
-      ulet_ "t1" (
-        ulam_ "y" (
-          ulet_ "t2" (
-            ulam_ "z" (
-              ulet_ "t3" (int_ 1) (var_ "t3")
-            )
-          ) (var_ "t2")
-        )
-      ) (var_ "t1")
-    )
-  ) (var_ "t")
-using eqExpr in
+let lamseq = _parse "lam x. lam y. lam z. 1" in
+-- printLn (mexprToString (_test lamseq));
+utest _test lamseq with _parse "
+  let t = lam x.
+    let t1 = lam y.
+      let t2 = lam z.
+        let t3 = 1 in
+        t3
+      in
+      t2
+    in
+    t1
+  in
+  t
+" using eqExpr in
+
+-- Externals
+let ext = _parse "
+  external e: Int -> Int -> Int in
+  e 1 2 3
+" in
+-- printLn (mexprToString (_test ext));
+utest _test ext with _parse "
+external e : Int -> Int -> Int in
+let e = lam a1. lam a2. e a1 a2 in
+let t = 1 in
+let t1 = e t in
+let t2 = 2 in
+let t3 = t1 t2 in
+let t4 = 3 in
+let t5 = t3 t4 in
+t5
+" using eqExpr in
 
 ()

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -250,24 +250,46 @@ end
 -- BASE CONSTRAINTS --
 ----------------------
 
-lang InitConstraint = CFA
+lang BaseConstraint = CFA
 
   syn Constraint =
   -- {lhs} ⊆ rhs
   | CstrInit { lhs: AbsVal, rhs: Name }
+  -- lhs ⊆ rhs
+  | CstrDirect { lhs: Name, rhs: Name }
+  -- {lhsav} ⊆ lhs ⇒ {rhsav} ⊆ rhs
+  | CstrDirectAv { lhs: Name, lhsav: AbsVal, rhs: Name, rhsav: AbsVal }
+  -- {lhsav} ⊆ lhs ⇒ [rhs]
+  | CstrDirectAvCstrs { lhs: Name, lhsav: AbsVal, rhs: [Constraint] }
 
   sem initConstraint (graph: CFAGraph) =
   | CstrInit r -> addData graph r.lhs r.rhs
+  | CstrDirect r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrDirectAv r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrDirectAvCstrs r & cstr -> initConstraintName r.lhs graph cstr
 
   sem constraintToString (env: PprintEnv) =
   | CstrInit { lhs = lhs, rhs = rhs } ->
     match absValToString env lhs with (env,lhs) in
     match pprintVarName env rhs with (env,rhs) in
     (env, join ["{", lhs, "}", " ⊆ ", rhs])
+  | CstrDirect { lhs = lhs, rhs = rhs } ->
+    match pprintVarName env lhs with (env,lhs) in
+    match pprintVarName env rhs with (env,rhs) in
+    (env, join [lhs, " ⊆ ", rhs])
+  | CstrDirectAv { lhs = lhs, lhsav = lhsav, rhs = rhs, rhsav = rhsav } ->
+    match pprintVarName env lhs with (env,lhs) in
+    match absValToString env lhsav with (env,lhsav) in
+    match pprintVarName env rhs with (env,rhs) in
+    match absValToString env rhsav with (env,rhsav) in
+    (env, join ["{", lhsav ,"} ⊆ ", lhs, " ⇒ {", rhsav ,"} ⊆ ", rhs])
+  | CstrDirectAvCstrs { lhs = lhs, lhsav = lhsav, rhs = rhs } ->
+    match mapAccumL constraintToString env rhs with (env,rhs) in
+    let rhs = strJoin " AND " rhs in
+    match pprintVarName env lhs with (env,lhs) in
+    match absValToString env lhsav with (env,lhsav) in
+    (env, join [ "{", lhsav, "} ⊆ ", lhs, " ⇒ (", rhs, ")" ])
 
-end
-
-lang DirectConstraintOptions = CFA
   sem isDirect: AbsVal -> Bool
   sem isDirect =
   | _ -> true
@@ -275,6 +297,17 @@ lang DirectConstraintOptions = CFA
   sem directTransition: CFAGraph -> Name -> AbsVal -> AbsVal
   sem directTransition (graph: CFAGraph) (rhs: Name) =
   | av -> av
+
+  sem propagateConstraint (update: (Name,AbsVal)) (graph: CFAGraph) =
+  | CstrDirect r -> propagateDirectConstraint r.rhs graph update.1
+  | CstrDirectAv r ->
+    if eqAbsVal update.1 r.lhsav then
+      addData graph r.rhsav r.rhs
+    else graph
+  | CstrDirectAvCstrs r & cstr ->
+    if eqAbsVal update.1 r.lhsav then
+      foldl initConstraint graph r.rhs
+    else graph
 
   sem propagateDirectConstraint: Name -> CFAGraph -> AbsVal -> CFAGraph
   sem propagateDirectConstraint (rhs: Name) (graph: CFAGraph) =
@@ -284,56 +317,11 @@ lang DirectConstraintOptions = CFA
     else graph
 end
 
-lang DirectConstraint = CFA + DirectConstraintOptions
-
-  syn Constraint =
-  -- lhs ⊆ rhs
-  | CstrDirect { lhs: Name, rhs: Name }
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrDirect r & cstr -> initConstraintName r.lhs graph cstr
-
-  sem propagateConstraint (update: (Name,AbsVal)) (graph: CFAGraph) =
-  | CstrDirect r -> propagateDirectConstraint r.rhs graph update.1
-
-  sem constraintToString (env: PprintEnv) =
-  | CstrDirect { lhs = lhs, rhs = rhs } ->
-    match pprintVarName env lhs with (env,lhs) in
-    match pprintVarName env rhs with (env,rhs) in
-    (env, join [lhs, " ⊆ ", rhs])
-
-end
-
-lang DirectAbsValConstraint = CFA
-
-  syn Constraint =
-  -- {lhsav} ⊆ lhs ⇒ {rhsav} ⊆ rhs
-  | CstrDirectAv { lhs: Name, lhsav: AbsVal, rhs: Name, rhsav: AbsVal }
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrDirectAv r & cstr -> initConstraintName r.lhs graph cstr
-
-  sem propagateConstraint (update: (Name,AbsVal)) (graph: CFAGraph) =
-  | CstrDirectAv r ->
-    if eqAbsVal update.1 r.lhsav then
-      addData graph r.rhsav r.rhs
-    else graph
-
-  sem constraintToString (env: PprintEnv) =
-  | CstrDirectAv { lhs = lhs, lhsav = lhsav, rhs = rhs, rhsav = rhsav } ->
-    match pprintVarName env lhs with (env,lhs) in
-    match absValToString env lhsav with (env,lhsav) in
-    match pprintVarName env rhs with (env,rhs) in
-    match absValToString env rhsav with (env,rhsav) in
-    (env, join ["{", lhsav ,"} ⊆ ", lhs, " ⇒ {", rhsav ,"} ⊆ ", rhs])
-
-end
-
 -----------
 -- TERMS --
 -----------
 
-lang VarCFA = CFA + DirectConstraint + VarAst
+lang VarCFA = CFA + BaseConstraint + VarAst
 
   sem generateConstraints =
   | TmLet { ident = ident, body = TmVar t } ->
@@ -344,7 +332,7 @@ lang VarCFA = CFA + DirectConstraint + VarAst
 
 end
 
-lang LamCFA = CFA + InitConstraint + LamAst
+lang LamCFA = CFA + BaseConstraint + LamAst
 
   -- Abstract representation of lambdas.
   syn AbsVal =
@@ -366,6 +354,8 @@ lang LamCFA = CFA + InitConstraint + LamAst
     match pprintVarName env ident with (env,ident) in
     match pprintVarName env body with (env,body) in
     (env, join ["lam ", ident, ". ", body])
+
+
 
 end
 
@@ -389,7 +379,7 @@ lang RecLetsCFA = CFA + LamCFA + RecLetsAst
 
 end
 
-lang ConstCFA = CFA + ConstAst + InitConstraint
+lang ConstCFA = CFA + ConstAst + BaseConstraint + Cmp
 
   syn AbsVal =
   -- Abstract representation of constants. Contains the constant and the
@@ -409,10 +399,12 @@ lang ConstCFA = CFA + ConstAst + InitConstraint
 
   sem cmpAbsValH =
   | (AVConst lhs, AVConst rhs) ->
-    use MExprCmp in
     let cmp = cmpConst lhs.const rhs.const in
     if eqi 0 cmp then
       let ncmp = nameCmp lhs.id rhs.id in
+      -- NOTE(dlunde,2022-06-15): Is simply checking the diff of the number of
+      -- arguments correct here? Shouldn't the argument list be compared with
+      -- (cmpSeq nameCmp) or similar?
       if eqi 0 ncmp then subi (length lhs.args) (length rhs.args)
       else ncmp
     else cmp
@@ -426,7 +418,7 @@ lang ConstCFA = CFA + ConstAst + InitConstraint
   | _ -> errorSingle [info] "Constant not supported in CFA"
 end
 
-lang AppCFA = CFA + ConstCFA + DirectConstraint + LamCFA + AppAst + MExprArity
+lang AppCFA = CFA + ConstCFA + BaseConstraint + LamCFA + AppAst + MExprArity
 
   syn Constraint =
   -- {lam x. b} ⊆ lhs ⇒ (rhs ⊆ x and b ⊆ res)
@@ -485,7 +477,7 @@ lang AppCFA = CFA + ConstCFA + DirectConstraint + LamCFA + AppAst + MExprArity
   sem propagateConstraintConst : Name -> [Name] -> CFAGraph -> Const -> CFAGraph
 end
 
-lang RecordCFA = CFA + InitConstraint + RecordAst
+lang RecordCFA = CFA + BaseConstraint + RecordAst
   -- NOTE(dlunde,2021-11-10) TmRecordUpdate is currently not supported.
 
   syn AbsVal =
@@ -520,7 +512,7 @@ lang RecordCFA = CFA + InitConstraint + RecordAst
 
 end
 
-lang SeqCFA = CFA + InitConstraint + SeqAst
+lang SeqCFA = CFA + BaseConstraint + SeqAst
 
   syn AbsVal =
   -- Abstract representation of sequences. Contains a set of names that may
@@ -550,7 +542,7 @@ lang TypeCFA = CFA + TypeAst
   | TmType t -> exprName t.inexpr
 end
 
-lang DataCFA = CFA + InitConstraint + DataAst
+lang DataCFA = CFA + BaseConstraint + DataAst
   syn AbsVal =
   -- Abstract representation of constructed data.
   | AVCon { ident: Name, body: Name }
@@ -579,7 +571,7 @@ lang DataCFA = CFA + InitConstraint + DataAst
 
 end
 
-lang MatchCFA = CFA + DirectConstraint + MatchAst
+lang MatchCFA = CFA + BaseConstraint + MatchAst
 
   syn Constraint =
   | CstrMatch { id: Name, pat: Pat, target: Name }
@@ -631,10 +623,88 @@ lang NeverCFA = CFA + NeverAst
   -- Nothing to be done here
 end
 
--- TODO Treat this in the same way as constants
 lang ExtCFA = CFA + ExtAst
+
+  syn AbsVal =
+  -- Abstract representation of externals. Handled in the same way as
+  -- constants, but with a string identifying the external rather than a value
+  -- of Const type. Also, we directly store the external arity in the abstract
+  -- value. Note that ANF eta expands all external definitions, so from the
+  -- perspective of CFA, externals are curried (need not be fully applied as in
+  -- standard MExpr).
+  -- NOTE(dlunde,2022-06-15): I'm not convinced the current approach for
+  -- handling externals is optimal. The additional `let` added by ANF to shadow
+  -- the original external definition is quite clunky. Maybe we can
+  -- incorporate the fact that externals are always fully applied into the
+  -- analysis somehow?
+  | AVExt { id: Name, ext: String, arity: Int, args: [Name] }
+
+  sem absValToString (env: PprintEnv) =
+  | AVExt { id = id, ext = ext, args = args } ->
+    -- We ignore the arity (one can simply look up the ext to get the arity)
+    match mapAccumL pprintVarName env args with (env,args) in
+    let args = strJoin ", " args in
+    match pprintVarName env id with (env,id) in
+    (env, join [ext,"<", id, ">", "(", args, ")"])
+
+  sem cmpAbsValH =
+  | (AVExt lhs, AVExt rhs) ->
+    -- We ignore the arity (if ext is the same, arity is the same)
+    let cmp = cmpString lhs.ext rhs.ext in
+    if eqi 0 cmp then
+      let ncmp = nameCmp lhs.id rhs.id in
+      -- NOTE(dlunde,2022-06-15): Is simply checking the diff of the number of
+      -- arguments correct here? Shouldn't the argument list be compared with
+      -- (cmpSeq nameCmp) or similar?
+      if eqi 0 ncmp then subi (length lhs.args) (length rhs.args)
+      else ncmp
+    else cmp
+
+  syn Constraint =
+  -- {ext args} ⊆ lhs ⇒ {ext args lhs} ⊆ res
+  | CstrExtApp { lhs: Name, rhs : Name, res: Name }
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrExtApp r & cstr -> initConstraintName r.lhs graph cstr
+
+  sem propagateConstraint (update: (Name,AbsVal)) (graph: CFAGraph) =
+  | CstrExtApp { lhs = lhs, rhs = rhs, res = res } ->
+    match update.1
+    with AVExt ({ ext = ext, args = args, arity = arity } & ave) then
+      let args = snoc args rhs in
+      if eqi arity (length args) then
+        -- Last application
+        -- TODO(dlunde,2022-06-15): We currently do nothing here. Optimally, we
+        -- would like to delegate to a `propagateConstraintExt` here, similar
+        -- to constants. I'm not sure where/how `propagateConstraintExt` should
+        -- be defined.
+        graph
+      else
+        -- Curried application, add the new argument
+        addData graph (AVExt { ave with args = args }) res
+    else graph
+
+  -- This ensures that `collectConstraints` does _not_ try to collect constraints
+  -- from `let`s immediately following externals. These `let`s are generated by
+  -- the ANF transform and define eta expanded versions of the externals (so
+  -- that they can be curried).
+  sem collectConstraints cgfs acc =
+  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } & t ->
+    let acc = foldl (lam acc. lam f. concat (f t) acc) acc cgfs in
+    sfold_Expr_Expr (collectConstraints cgfs) acc inexpr
+
+  sem generateConstraints =
+  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
+    -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
+    -- for externals. Similarly to constants, we probably want to delegate to
+    -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
+    -- not clear where the `generateConstraintsExts` function should be defined.
+    --
+    []
+
   sem exprName =
   | TmExt t -> exprName t.inexpr
+
 end
 
 ---------------
@@ -753,7 +823,7 @@ lang CmpSymbCFA = CFA + ConstCFA + CmpSymbAst
   | CEqsym _ -> []
 end
 
-lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + DirectConstraint
+lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint
 
   syn Constraint =
   -- [{names}] ⊆ lhs ⇒ ∀n ∈ names: {n} ⊆ rhs
@@ -980,7 +1050,7 @@ end
 -- PATTERNS --
 --------------
 
-lang NamedPatCFA = MatchCFA + NamedPat + DirectConstraintOptions
+lang NamedPatCFA = MatchCFA + NamedPat + BaseConstraint
   sem propagateMatchConstraint (graph: CFAGraph) (id: Name) =
   | (PatNamed { ident = PName n }, av) -> propagateDirectConstraint n graph av
   | (PatNamed { ident = PWildcard _ }, _) -> graph
@@ -1081,7 +1151,7 @@ end
 lang MExprCFA = CFA +
 
   -- Base constraints
-  InitConstraint + DirectConstraint + DirectAbsValConstraint +
+  BaseConstraint +
 
   -- Terms
   VarCFA + LamCFA + AppCFA +

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -509,18 +509,17 @@ utest _cps "
 using eqExpr in
 
 -- Externals
--- TODO Use arity > 1
 let externaltest = _cps "
-  external f : Float -> Float in
-  let x = f g in
-  y
+  external f : Float -> Float -> Float in
+  let x = f a b in
+  x
 " in
--- print (mexprToString externaltest);
+print (mexprToString externaltest);
 utest externaltest with _parse "
-  external f : Float -> Float in
-  let f1 = lam k1. lam a1. k1 (f a1) in
-  let k = lam x. (lam x. x) y in
-  f1 k g
+  external f : Float -> Float -> Float in
+  let f = lam k1. lam a1. k1 (lam k2. lam a2. k2 (f a1 a2)) in
+  let k = lam t. t (lam x. x) b in
+  f k a
 "
 using eqExpr in
 

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -141,7 +141,7 @@ end
 lang LamCPS = CPS + LamAst
   sem exprCps env k =
   | TmLet ({ ident = ident, body = TmLam t, inexpr = inexpr } & r) ->
-    if not (transform env ident) then
+    if not (or (transform env ident) (transform env t.ident)) then
       TmLet { r with
         body = TmLam { t with body = exprCps env (None ()) t.body },
         inexpr = exprCps env k inexpr

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -40,6 +40,13 @@ let setIntersect : all a. Set a -> Set a -> Set a = lam s1. lam s2.
     if setMem key s2 then setInsert key acc else acc
   ) (setEmpty cmp) s1
 
+-- `setSubtract s1 s2` is the relative complement of set `s2` in `s1` (set
+-- difference, i.e., s1 - s2).
+let setSubtract : all a. Set a -> Set a -> Set a = lam s1. lam s2.
+  let cmp = mapGetCmpFun s1 in
+  mapFoldWithKey (lam acc. lam key. lam. mapRemove key acc) s1 s2
+
+
 -- `setOfSeq cmp seq` construct a set ordered by `cmp` from a sequence `seq`.
 let setOfSeq : all a. (a -> a -> Int) -> [a] -> Set a =
 lam cmp. lam seq.
@@ -128,6 +135,9 @@ utest setSize sInt1 with 0 in
 let sInt2 = setIntersect (setOfSeq subi [1,2]) (setOfSeq subi [2]) in
 utest setSize sInt2 with 1 in
 utest setMem 2 sInt2 with true in
+
+utest setSubtract s5 (setEmpty subi) with s5 using setEq in
+utest setSubtract s5 s6 with setOfSeq subi [4,5] using setEq in
 
 utest setCmp s5 s5 with 0 in
 utest setCmp s5 s6 with 1 in


### PR DESCRIPTION
## Major
- Add support for partial CPS transformations. It's unfortunately a bit hard to use (see comments at the top of `cps.mc`). Example:
  ```
  recursive
    let f1 = lam a. let t = lam b. b in t
    let f2 = lam c. c
  in
  let x = f1 1 2 in
  let y = f2 3 in
  addi x y
  ```
  with [`b`,`t`,`x`] specifying the partial transformation results in
  ```
  recursive
    let f1 = lam a. let t = lam k. lam b. k b in t
    let f2 = lam c. c
  in
  let t1 = 1 in
  let t2 = f1 t1 in
  let t3 = 2 in
  let k1 =
    lam x.
      let t4 = 3 in
      let y = f2 t4 in
      let t5 = addi in
      let t6 = t5 x in
      let t7 = t6 y in
      (lam x. x) t7
  in
  t2 k1 t3
  ```

## Minor
- Add tracking of externals (in the same way as for constants) to `cfa.mc`.
- Update `AVConst` in `cfa.mc` to also register its binding let, enabling syntactically distinguishing different instances of the same constant in programs.
- Merge various base constraint language fragments in `cfa.mc` to one joint `BaseConstraint` fragment to improve readability.
- Rework ANF of externals. Previously,
  ```
  external e: Int -> Int -> Int in
  e 1 2
  ```
  would transform to
  ```
  external e : Int -> Int -> Int in
  let e: Int -> Int -> Int = lam a1.  lam a2.  e a1 a2 in
  let t = 1 in
  let t1 = e t in
  let t2 = 2 in
  let t3 = t1 t2 in
  t3
  ```
  which doesn't compile (externals must be fully applied). Now, it instead eta expands the external as
  ```
  external e : Int -> Int -> Int in
  let e = lam a1. lam a2. e a1 a2 in
  ...
  ```
- Update `anf.mc` tests to use boot parser instead of ast-builder.
- Fix bug for `TmRecLets` in `eq.mc`
