### PR TITLE
Rewrite CFA framework to use tensors instead of maps

### DIFF
--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -29,7 +29,7 @@ let dependencyAnalysis
     if options.tuneOptions.dependencyAnalysis then
       let ast = typeCheck ast in
       let ast = use HoleANFAll in normalizeTerm ast in
-      let cfaRes = cfaData (graphDataFromEnv env) ast in
+      let cfaRes = cfaData (graphDataInit env) ast in
       let cfaRes = analyzeNested env cfaRes ast in
       let dep = analyzeDependency env cfaRes ast in
       (if options.tuneOptions.debugDependencyAnalysis then

--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -29,7 +29,7 @@ let dependencyAnalysis
     if options.tuneOptions.dependencyAnalysis then
       let ast = typeCheck ast in
       let ast = use HoleANFAll in normalizeTerm ast in
-      let cfaRes = cfaData (graphDataInit env) ast in
+      let cfaRes = cfaData (Some (graphDataInit env)) ast in
       let cfaRes = analyzeNested env cfaRes ast in
       let dep = analyzeDependency env cfaRes ast in
       (if options.tuneOptions.debugDependencyAnalysis then

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -64,11 +64,14 @@ lang CFA = Ast + LetAst + MExprIndex + MExprPrettyPrint
   sem emptyCFAGraph: Expr -> CFAGraph
   sem emptyCFAGraph =
   | t ->
+    -- NOTE(Linnea,2022-06-22): Experiments have shown that lists are better
+    -- than ropes for 'worklist' and 'edges', especially for 'worklist'
     let im = indexGen t in
     let shape = tensorShape im.int2name in
-    { worklist = [],
+    let elist = toList [] in
+    { worklist = elist,
       data = tensorCreateDense shape (lam. setEmpty cmpAbsVal),
-      edges = tensorCreateDense shape (lam. []),
+      edges = tensorCreateDense shape (lam. elist),
       mcgfs = [],
       im = im,
       graphData = None () }

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -86,6 +86,16 @@ lang CFA = Ast + LetAst + MExprIndex + MExprPrettyPrint
   sem pprintVarIName im env =
   | n -> pprintVarName env (int2name im n)
 
+  -- This function converts the data-flow result into a map, which might be more
+  -- convenient to operate on for later analysis steps.
+  sem cfaGraphData: CFAGraph -> Map Name (Set AbsVal)
+  sem cfaGraphData =
+  | graph ->
+    foldl (lam acc. lam b: (IName, Set AbsVal).
+        match b with (id,vals) in
+        mapInsert (int2name graph.im id) vals acc
+      ) (mapEmpty nameCmp) (mapi (lam i. lam x. (i, x)) graph.data)
+
   syn Constraint =
   -- Intentionally left blank
 
@@ -158,7 +168,6 @@ lang CFA = Ast + LetAst + MExprIndex + MExprPrettyPrint
 
   -- Base constraint generation function (must still be included manually in
   -- constraintGenFuns)
-  -- TODO: perhaps only send index map, not the entire graph here
   sem generateConstraints: IndexMap -> Expr -> [Constraint]
   sem generateConstraints im =
   | t -> []

--- a/stdlib/mexpr/index.mc
+++ b/stdlib/mexpr/index.mc
@@ -112,13 +112,19 @@ lang NamedPatIndex = Index + NamedPat
   | PatNamed { ident = PName name } -> addKey name acc
 end
 
+lang SeqEdgePatIndex = Index + SeqEdgePat
+  sem patIndexAdd (acc: IndexAcc) =
+  | PatSeqEdge { middle = PName name } & p ->
+    sfold_Pat_Pat patIndexAdd (addKey name acc) p
+end
+
 --------------------------
 -- MEXPR INDEX FRAGMENT --
 --------------------------
 
 lang MExprIndex =
   Index + VarIndex + LamIndex + LetIndex + RecLetsIndex + ExtIndex + DataIndex +
-  TypeIndex + MatchIndex + NamedPatIndex
+  TypeIndex + MatchIndex + NamedPatIndex + SeqEdgePatIndex
 end
 
 -----------
@@ -212,6 +218,17 @@ utest test "
 ------------------------" with [
   ("T", 0),
   ("C", 1)
+] using eqTest in
+
+utest test "
+  let a = 1 in
+  match a with b in
+  match [a,b] with [_] ++ c in
+  ()
+------------------------" with [
+  ("a", 0),
+  ("b", 1),
+  ("c", 2)
 ] using eqTest in
 
 ()

--- a/stdlib/mexpr/index.mc
+++ b/stdlib/mexpr/index.mc
@@ -1,0 +1,217 @@
+-- This file defines a function `indexGen` that constructs a map from all term
+-- variable names in a program to unique integers from 0 to n-1, where n is the
+-- total number of distinct variable names in the program. Currently, this is
+-- mainly useful for constant-time tensor lookups in `cfa.mc`.
+
+include "ast.mc"
+include "boot-parser.mc"
+include "map.mc"
+include "option.mc"
+
+lang Index = Ast
+
+  type IndexMap = {
+    name2int: Map Name Int,
+    int2name: Tensor[Name]
+  }
+
+  type IndexAcc = {
+    map: Map Name Int,
+    nextIndex: Int
+  }
+
+  sem emptyAcc: () -> IndexAcc
+  sem emptyAcc =
+  | _ -> { map = mapEmpty nameCmp, nextIndex = 0 }
+
+  sem addKey: Name -> IndexAcc -> IndexAcc
+  sem addKey (name: Name) =
+  | acc ->
+    if mapMem name acc.map then acc
+    else {{acc with map = mapInsert name acc.nextIndex acc.map }
+               with nextIndex = addi 1 acc.nextIndex }
+
+  -- Entry point
+  sem indexGen: Expr -> IndexMap
+  sem indexGen =
+  | t ->
+    let acc = indexGenH (emptyAcc ()) t in
+    let name2int = acc.map in
+    let int2name: Tensor[Name] =
+      tensorCreateDense [acc.nextIndex] (lam. nameNoSym "t") in
+    mapMapWithKey (lam n. lam i. tensorLinearSetExn int2name i n) name2int;
+    {name2int = name2int, int2name = int2name}
+
+  sem indexGenH: IndexAcc -> Expr -> IndexAcc
+  sem indexGenH (acc: IndexAcc) =
+  | t -> let acc = indexAdd acc t in sfold_Expr_Expr indexGenH acc t
+
+  sem indexAdd: IndexAcc -> Expr -> IndexAcc
+  sem indexAdd (acc: IndexAcc) =
+  | t -> acc
+
+end
+
+-----------
+-- TERMS --
+-----------
+
+lang VarIndex = Index + VarAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmVar { ident = ident } -> addKey ident acc
+end
+
+lang LamIndex = Index + LamAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmLam { ident = ident } -> addKey ident acc
+end
+
+lang LetIndex = Index + LetAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmLet { ident = ident } -> addKey ident acc
+end
+
+lang RecLetsIndex = Index + RecLetsAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmRecLets { bindings = bindings } ->
+    foldl (lam acc: IndexAcc. lam b: RecLetBinding. addKey b.ident acc)
+      acc bindings
+end
+
+lang ExtIndex = Index + ExtAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmExt { ident = ident } -> addKey ident acc
+end
+
+lang TypeIndex = Index + TypeAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmType { ident = ident } -> addKey ident acc
+end
+
+lang DataIndex = Index + DataAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmConDef { ident = ident } -> addKey ident acc
+  | TmConApp { ident = ident } -> addKey ident acc
+end
+
+lang MatchIndex = Index + MatchAst
+  sem indexAdd (acc: IndexAcc) =
+  | TmMatch { pat = pat } -> patIndexAdd acc pat
+
+  sem patIndexAdd: IndexAcc -> Pat -> IndexAcc
+  sem patIndexAdd (acc: IndexAcc) =
+  | p -> sfold_Pat_Pat patIndexAdd acc p
+end
+
+--------------
+-- PATTERNS --
+--------------
+
+lang NamedPatIndex = Index + NamedPat
+  sem patIndexAdd (acc: IndexAcc) =
+  | PatNamed { ident = PName name } -> addKey name acc
+end
+
+--------------------------
+-- MEXPR INDEX FRAGMENT --
+--------------------------
+
+lang MExprIndex =
+  Index + VarIndex + LamIndex + LetIndex + RecLetsIndex + ExtIndex + DataIndex +
+  TypeIndex + MatchIndex + NamedPatIndex
+end
+
+-----------
+-- TESTS --
+-----------
+
+lang Test = MExprIndex + BootParser
+end
+
+mexpr
+use Test in
+
+let test: String -> IndexMap = lam s.
+  let t = parseMExprStringKeywords [] s in
+  indexGen t
+in
+
+let eqTest: IndexMap -> [(String,Int)] -> Bool = lam i1. lam i2.
+  let name2int: Map Name Int = mapFromSeq nameCmp
+    (map (lam e. (nameNoSym e.0, e.1)) i2) in
+  let int2name: Tensor[Name] =
+    tensorCreateDense [mapSize name2int] (lam. nameNoSym "t") in
+  iter (lam e. tensorSetExn int2name [e.1] (nameNoSym e.0)) i2;
+  and (mapEq eqi i1.name2int name2int) (tensorEq nameEq i1.int2name int2name)
+in
+
+utest test "let x = 1 in ()" with [
+  ("x", 0)
+] using eqTest in
+
+utest test "let x = lam y. let z = 1 in () in ()" with [
+  ("x", 0),
+  ("y", 1),
+  ("z", 2)
+] using eqTest in
+
+utest test "
+  recursive
+    let f = lam x. let xv = 1 in ()
+    let g = lam y. let yv = 2 in ()
+  in ()
+------------------------" with [
+  ("f", 0),
+  ("g", 1),
+  ("x", 2),
+  ("xv", 3),
+  ("y", 4),
+  ("yv", 5)
+] using eqTest in
+
+utest test "
+  external x : Int -> Int in
+  ()
+------------------------" with [
+  ("x", 0)
+] using eqTest in
+
+utest test "
+  match 1 with x in
+  ()
+------------------------" with [
+  ("x", 0)
+] using eqTest in
+
+utest test "
+  match 1 with _ in
+  ()
+------------------------" with []
+using eqTest in
+
+utest test "
+  let x = addi 1 2 in
+  let f = lam y. addi 1 y in
+  let sum1 = addf 1.0 1.0 in
+  let sum2 = f x 1.0 in
+  let res = addf sum1 sum2 in
+  res
+------------------------" with [
+  ("x", 0),
+  ("f", 1),
+  ("y", 2),
+  ("sum1", 3),
+  ("sum2", 4),
+  ("res", 5)
+] using eqTest in
+
+utest test "
+  type T in
+  con C: (a -> a) -> T in
+  C ()
+------------------------" with [
+  ("T", 0),
+  ("C", 1)
+] using eqTest in
+
+()

--- a/stdlib/mexpr/profiling.mc
+++ b/stdlib/mexpr/profiling.mc
@@ -78,7 +78,7 @@ type ProfileData = {
 let emptyProfileData = {id = \"\", exclusiveTime = 0.0, inclusiveTime = 0.0,
                         calls = 0} in
 
-let callStack : [StackEntry] =
+let callStack : Ref [StackEntry] =
   ref (createList 0 (lam. {onTopSince = 0.0, pushedAt = 0.0,
                            functionIndex = 0})) in
 ",

--- a/stdlib/tuning/dependency-analysis.mc
+++ b/stdlib/tuning/dependency-analysis.mc
@@ -277,7 +277,7 @@ let test : Bool -> Bool -> Expr -> (DependencyGraph, CallCtxEnv) =
 
     else
       -- Version without debug printouts
-      let cfaRes : CFAGraph = cfaData graphData tANF in
+      let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
       let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
       match
         if full then assumeFullDependency env tANF

--- a/stdlib/tuning/dependency-analysis.mc
+++ b/stdlib/tuning/dependency-analysis.mc
@@ -52,7 +52,7 @@ lang DependencyAnalysis = MExprHoleCFA
     -- to store both sets as vertices in a graph).
     let nHoles = length env.idx2hole in
     match
-      buildDependencies callGraphTop env cfaGraph.data
+      buildDependencies callGraphTop env (cfaGraphData cfaGraph)
         (_dependencyGraphEmpty, nHoles) t
     with ((graph, _), _) in
     let graph : DependencyGraph = graph in
@@ -246,7 +246,7 @@ let test : Bool -> Bool -> Expr -> (DependencyGraph, CallCtxEnv) =
     match colorCallGraph [] tANFSmall with (env, _) in
 
     -- Initialize the graph data
-    let graphData = graphDataFromEnv env in
+    let graphData = graphDataInit env in
 
     -- Apply full ANF
     let tANF = normalizeTerm tANFSmall in

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -41,35 +41,39 @@ include "context-expansion.mc"
 lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
 
   syn AbsVal =
-  | AVDHole { id : Name, contexts : Set Int }
-  | AVEHole { id : Name, contexts : Set Int }
-  | AVConstHole { const : Const, args : [Name] }
+  | AVDHole { id : IName, contexts : Set Int }
+  | AVEHole { id : IName, contexts : Set Int }
+  | AVConstHole { const : Const, args : [IName] }
 
   syn GraphData =
-  | CtxInfo { contextMap : Map Name (Set Int),
-              prefixMap : Map Name (Map Name (Set Int)) }
+  | HoleCtxEnv { env: CallCtxEnv }
+  | HoleCtxInfo { contextMap : Map IName (Set Int),
+                  prefixMap : Map IName (Map IName (Set Int)) }
 
   sem absValToStringH =
   | AVDHole _ -> "d"
   | AVEHole _ -> "e"
 
-  sem absValToString (env : PprintEnv) =
+  sem absValToString graph (env : PprintEnv) =
   | ( AVDHole {id = id, contexts = contexts}
     | AVEHole {id = id, contexts = contexts} ) & av ->
-    (env, join [absValToStringH av, "hole", "(", nameGetStr id, ",{",
-       strJoin "," (map int2string (setToSeq contexts)), "}", ")"])
+    match pprintVarIName graph.im env id with (env,id) in
+    (env, join [
+        absValToStringH av, "hole", "(", id, ",{",
+        strJoin "," (map int2string (setToSeq contexts)), "}", ")"
+      ])
   | AVConstHole { const = const, args = args } ->
     let const = getConstStringCode 0 const in
-    let args = strJoin ", " (map nameGetStr args) in
-    (env, join [const, "(", args, ")"])
+    match mapAccumL (pprintVarIName graph.im) env args with (env, args) in
+    (env, join [const, "(", strJoin ", " args, ")"])
 
   sem isDirect =
   | AVEHole _ -> false
 
-  sem directTransition (graph: CFAGraph) (rhs: Name) =
+  sem directTransition (graph: CFAGraph) (rhs: Int) =
   | AVDHole ({id = id, contexts = contexts} & av) ->
     match graph with {graphData = graphData} in
-    match graphData with Some (CtxInfo c) then
+    match graphData with Some (HoleCtxInfo c) then
       let labelMap = mapFindExn id c.prefixMap in
       match mapLookup rhs labelMap with Some ids then
         let newContexts = setIntersect contexts ids in
@@ -82,21 +86,21 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
        AVDHole {id = id2, contexts = ctxs2})
     | (AVEHole {id = id1, contexts = ctxs1},
        AVEHole {id = id2, contexts = ctxs2}) ) ->
-    let ncmp = nameCmp id1 id2 in
+    let ncmp = subi id1 id2 in
     if eqi 0 ncmp then setCmp ctxs1 ctxs2 else ncmp
   | (AVConstHole lhs, AVConstHole rhs) ->
     use ConstCmp in
     let cmp = cmpConst lhs.const rhs.const in
-    if eqi 0 cmp then subi (length lhs.args) (length rhs.args)
+    if eqi 0 cmp then seqCmp subi lhs.args rhs.args
     else cmp
 
   syn Constraint =
     -- {dhole} ⊆ lhs ⇒ {dhole} ⊆ rhs
-  | CstrHoleDirectData { lhs: Name, rhs: Name }
+  | CstrHoleDirectData { lhs: IName, rhs: IName }
     -- {dhole} ⊆ lhs ⇒ {ehole} ⊆ rhs
-  | CstrHoleDirectExe { lhs: Name, rhs: Name }
+  | CstrHoleDirectExe { lhs: IName, rhs: IName }
     -- {dhole} ⊆ lhs ⇒ ({dhole} ⊆ res) AND ({ehole} ⊆ res)
-  | CstrHoleApp { lhs: Name, res: Name }
+  | CstrHoleApp { lhs: IName, res: IName }
     -- ({const with args = args} ⊆ lhs AND |args| = arity(const)-1
     --    ⇒ ∀(a,i): (a,i) in ({args} ∪ {rhs} ⨯ [1,...,arity(const)]):
     --        if const is data dep on position i AND {dhole} ⊆ a ⇒ {dhole} ⊆ res
@@ -105,12 +109,12 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
     -- AND
     -- ({const with args = args} ⊆ lhs AND |args| < arity(const)-1
     --    ⇒ {const with args = snoc args rhs } ⊆ res)
-  | CstrHoleConstApp { lhs: Name, rhs : Name, res: Name }
+  | CstrHoleConstApp { lhs: IName, rhs : IName, res: IName }
     -- {dhole} ⊆ lhs ⇒ {ehole} ⊆ res
-  | CstrHoleMatch { lhs: Name, res: Name }
+  | CstrHoleMatch { lhs: IName, res: IName }
     -- {dhole} ⊆ lhs ⇒ {dhole} ⊄ rhs
     -- lhs \ {dhole : dhole ∈ rhs} ⊆ res
-  | CstrHoleIndependent { lhs: Name, rhs: Name, res: Name }
+  | CstrHoleIndependent { lhs: IName, rhs: IName, res: IName }
 
 
   sem initConstraint (graph : CFAGraph) =
@@ -121,7 +125,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
   | CstrHoleMatch r & cstr -> initConstraintName r.lhs graph cstr
   | CstrHoleIndependent r & cstr -> initConstraintName r.lhs graph cstr
 
-  sem propagateConstraint (update : (Name, AbsVal)) (graph : CFAGraph) =
+  sem propagateConstraint (update : (IName, AbsVal)) (graph : CFAGraph) =
   | CstrHoleDirectData { lhs = lhs, rhs = rhs } ->
     match update.1 with AVDHole _ & av then addData graph av rhs else graph
   | CstrHoleDirectExe { lhs = lhs, rhs = rhs } ->
@@ -145,7 +149,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
       if eqi arity (length args) then
         -- Last application, analyse data and execution time
         let cdeps = constDep const in
-        let graph = foldl (lam graph. lam argDep : (Name, (Bool, Bool)).
+        let graph = foldl (lam graph. lam argDep : (IName, (Bool, Bool)).
           let arg = argDep.0 in
           let dep = argDep.1 in
           let isDataDep = dep.0 in
@@ -179,58 +183,66 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
   sem generateHoleConstraints (graph: CFAGraph) =
   | _ -> []
     -- Holes
-  | TmLet { ident = ident, body = TmHole _} ->
+  | TmLet { ident = ident, body = TmHole _, info = info} ->
     match graph with {graphData = graphData} in
-    match graphData with Some (CtxInfo {contextMap = contextMap}) then
-      [ CstrInit {lhs = AVDHole {
-          id=ident,
-          contexts=mapFindExn ident contextMap
-        }, rhs=ident } ]
-    else
-      error "Expected context information"
-  | TmLet { ident = ident, body = TmConst { val = c } } ->
+    match graphData with Some (HoleCtxInfo {contextMap = contextMap}) then
+      let ident = name2int graph.im info ident in
+      let av = AVDHole {
+        id = ident,
+        contexts = mapFindExn ident contextMap
+      } in
+      [ CstrInit {lhs = av, rhs = ident } ]
+    else errorSingle [info] "Expected context information"
+  | TmLet { ident = ident, body = TmConst { val = c }, info = info } ->
     let arity = constArity c in
     if eqi arity 0 then []
-    else [ CstrInit { lhs = AVConstHole { const = c, args = [] }, rhs = ident }
-         ]
-  | TmLet { ident = ident, body = TmApp app} ->
+    else [ CstrInit {
+             lhs = AVConstHole { const = c, args = [] },
+             rhs = name2int graph.im info ident } ]
+  | TmLet { ident = ident, body = TmApp app, info = info } ->
     match app.lhs with TmVar l then
-      match app.rhs with TmVar r then [
-        CstrHoleApp { lhs = l.ident, res = ident},
-        CstrHoleConstApp { lhs = l.ident, rhs = r.ident, res = ident }
-      ]
+      match app.rhs with TmVar r then
+        let lhs = name2int graph.im l.info l.ident in
+        let rhs = name2int graph.im r.info r.ident in
+        let ident = name2int graph.im info ident in
+        [ CstrHoleApp { lhs = lhs, res = ident},
+          CstrHoleConstApp { lhs = lhs, rhs = rhs, res = ident }
+        ]
       else errorSingle [infoTm app.rhs] "Not a TmVar in application"
     else errorSingle [infoTm app.lhs] "Not a TmVar in application"
-  | TmLet { ident = ident, body = TmIndependent t} ->
+  | TmLet { ident = ident, body = TmIndependent t, info = info} ->
     match t.lhs with TmVar lhs then
       match t.rhs with TmVar rhs then
-        [ CstrHoleIndependent {lhs = lhs.ident, rhs = rhs.ident, res = ident} ]
+        let lhs = name2int graph.im lhs.info lhs.ident in
+        let rhs = name2int graph.im rhs.info rhs.ident in
+        let ident = name2int graph.im info ident in
+        [ CstrHoleIndependent {lhs = lhs, rhs = rhs, res = ident} ]
       else errorSingle [infoTm t.rhs] "Not a TmVar in independent annotation"
     else errorSingle [infoTm t.lhs] "Not a TmVar in independent annotation"
 
-  sem constraintToString (env: PprintEnv) =
+  sem constraintToString graph (env: PprintEnv) =
   | CstrHoleDirectData { lhs = lhs, rhs = rhs } ->
-    match pprintVarName env rhs with (env,rhs) in
-    match pprintVarName env lhs with (env,lhs) in
+    match pprintVarIName graph.im env rhs with (env,rhs) in
+    match pprintVarIName graph.im env lhs with (env,lhs) in
     (env, join [ "{dhole} ⊆ ", lhs, " ⇒ {dhole} ⊆ ", rhs ])
   | CstrHoleDirectExe { lhs = lhs, rhs = rhs } ->
-    match pprintVarName env rhs with (env,rhs) in
-    match pprintVarName env lhs with (env,lhs) in
+    match pprintVarIName graph.im env rhs with (env,rhs) in
+    match pprintVarIName graph.im env lhs with (env,lhs) in
     (env, join [ "{dhole} ⊆ ", lhs, " ⇒ {ehole} ⊆ ", rhs ])
   | CstrHoleApp { lhs = lhs, res = res } ->
-    match pprintVarName env lhs with (env,lhs) in
-    match pprintVarName env res with (env,res) in
+    match pprintVarIName graph.im env lhs with (env,lhs) in
+    match pprintVarIName graph.im env res with (env,res) in
     (env, join [
       "{dhole} ⊆ ", lhs, " ⇒ {dhole} ⊆ ", res ])
   | CstrHoleMatch { lhs = lhs, res = res } ->
-    match pprintVarName env lhs with (env,lhs) in
-    match pprintVarName env res with (env,res) in
+    match pprintVarIName graph.im env lhs with (env,lhs) in
+    match pprintVarIName graph.im env res with (env,res) in
     (env, join [
       "{dhole} ⊆ ", lhs, " ⇒ {ehole} ⊆ ", res ])
   | CstrHoleConstApp { lhs = lhs, rhs = rhs, res = res } ->
-    match pprintVarName env lhs with (env,lhs) in
-    match pprintVarName env rhs with (env,rhs) in
-    match pprintVarName env res with (env,res) in
+    match pprintVarIName graph.im env lhs with (env,lhs) in
+    match pprintVarIName graph.im env rhs with (env,rhs) in
+    match pprintVarIName graph.im env res with (env,res) in
     (env, join [
       "({const with args = args} ⊆ ", lhs, " AND |args| = arity(const)-1\n",
       "  ⇒ ∀(a,i): (a,i) in ({args} ∪ {", rhs, "} ⨯ [1,...,arity(const)]):\n",
@@ -242,13 +254,13 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
       "  ⇒ {const with args = snoc args ", rhs, "} ⊆ ", res, ")"
     ])
   | CstrHoleIndependent { lhs = lhs, rhs = rhs, res = res } ->
-    match pprintVarName env lhs with (env,lhs) in
-    match pprintVarName env rhs with (env,rhs) in
-    match pprintVarName env res with (env,res) in
+    match pprintVarIName graph.im env lhs with (env,lhs) in
+    match pprintVarIName graph.im env rhs with (env,rhs) in
+    match pprintVarIName graph.im env res with (env,res) in
     (env, join [lhs, " \\ {dhole : dhole ∈ ", rhs, "} ⊆ ", res])
 
 
-  sem generateHoleMatchResConstraints (id: Name) (target: Name) =
+  sem generateHoleMatchResConstraints (id: Int) (target: Int) =
   | ( PatSeqTot _
     | PatSeqEdge _
     | PatCon _
@@ -280,16 +292,17 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
   | CModRef _ -> []
   | CDeRef _ -> []
 
-  sem generateHoleMatchConstraints (id: Name) (target: Name) =
+  sem generateHoleMatchConstraints (im: IndexMap) (id: Int) (target: Int) =
   | pat ->
     recursive let f = lam acc. lam pat.
-      let acc = match pat with PatNamed { ident = PName name }
-                             | PatSeqEdge { middle = PName name }
-                then cons name acc else acc in
+      let acc =
+        match pat with PatNamed { ident = PName name, info = info }
+                     | PatSeqEdge { middle = PName name, info = info }
+        then cons (name2int im info name) acc else acc in
       sfold_Pat_Pat f acc pat
     in
     let pnames = f [] pat in
-    foldl (lam acc. lam name.
+    foldl (lam acc. lam name: IName.
       cons (CstrHoleDirectData { lhs = target, rhs = name }) acc
     ) [] pnames
 
@@ -298,20 +311,21 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
   | t ->
 
     -- Initial graph
-    let graph = emptyCFAGraph () in
+    let graph = emptyCFAGraph t in
 
     -- Initialize graph data
-    let graph = {graph with graphData = graphData} in
+    match graphData with Some (HoleCtxEnv {env = env}) in
+    let graph = {graph with graphData = Some (graphDataFromEnv graph.im env)} in
 
     -- Initialize match constraint generating functions
     let graph = { graph with mcgfs = [ generateMatchConstraints
-                                     , generateHoleMatchConstraints
+                                     , generateHoleMatchConstraints graph.im
                                      , generateHoleMatchResConstraints
                                      ] } in
 
     -- Initialize constraint generating functions
-    let cgfs = [ generateConstraints
-               , generateConstraintsMatch graph.mcgfs
+    let cgfs = [ generateConstraints graph.im
+               , generateConstraintsMatch graph.im graph.mcgfs
                , generateHoleConstraints graph
                ] in
 
@@ -324,51 +338,64 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
     -- Return graph
     graph
 
-  -- Extracts info from graph coloring transformation.
-  -- Type: CtxEnv -> GraphData.
-  sem graphDataFromEnv =
+  sem graphDataInit: CallCtxEnv -> GraphData
+  sem graphDataInit =
+  | env -> HoleCtxEnv {env = env}
+
+  sem graphDataFromEnv: IndexMap -> CallCtxEnv -> GraphData
+  sem graphDataFromEnv im =
   | env ->
     -- Converts a prefix tree for a hole to a mapping from a call site to the
     -- set of contexts that pass through the call site.
-    let treeToCallSiteCtxUnion : PTree NameInfo -> Map Name (Set Int) = lam tree.
+    let treeToCallSiteCtxUnion
+    : PTree NameInfo -> Map IName (Set Int) = lam tree.
       match tree with Node {children = children} then
-        recursive let work = lam acc. lam children.
+        recursive let work = lam acc: Map IName (Set Int). lam children.
           mapFoldWithKey (lam acc. lam root. lam subtree.
-            let s = match mapLookup (nameInfoGetName root) acc with Some s
-                    then s else setEmpty subi in
-            switch subtree
-            case Leaf id then
-              mapInsert (nameInfoGetName root) (setInsert id s) acc
-            case Node {ids = ids, children = children} then
-              let acc = work acc children in
-              mapInsert (nameInfoGetName root) (
-                  foldl (lam acc. lam id. setInsert id acc) s ids
-                ) acc
-            end) acc children
-        in work (mapEmpty nameCmp) children
+            -- NOTE(Linnea, 2022-06-20): If a name is not mapped by an index, it
+            -- is not part of the program, but a sentinel in the prefix tree.
+            -- Thus, we will never look it up during CFA, and it is safe to not
+            -- insert it in the map.
+            if mapMem (nameInfoGetName root) im.name2int then
+              let r = name2int im (nameInfoGetInfo root) (nameInfoGetName root) in
+              let s: Set Int =
+                match mapLookup r acc with Some s
+                then s else setEmpty subi in
+              switch subtree
+              case Leaf id then mapInsert r (setInsert id s) acc
+              case Node {ids = ids, children = children} then
+                let acc = work acc children in
+                mapInsert r (
+                    foldl (lam acc. lam id. setInsert id acc) s ids
+                  ) acc
+              end
+            else acc) acc children
+        in work (mapEmpty subi) children
       else error "Missing sentinel node"
     in
 
     let env : CallCtxEnv = env in
 
     -- Maps a hole to its set of contexts.
-    let contextMap : Map Name (Set Int) =
+    let contextMap : Map IName (Set Int) =
       mapFoldWithKey
-        (lam acc : Map Name (Set Int). lam nameInfo : NameInfo.
+        (lam acc : Map IName (Set Int). lam n: NameInfo.
          lam vals : Map [NameInfo] Int.
-           mapInsert nameInfo.0 (setOfSeq subi (mapValues vals)) acc
-        ) (mapEmpty nameCmp) env.hole2idx
+           let n = name2int im (nameInfoGetInfo n) (nameInfoGetName n) in
+           mapInsert n (setOfSeq subi (mapValues vals)) acc
+        ) (mapEmpty subi) env.hole2idx
     in
     -- Maps a hole to its call site map.
-    let prefixMap : Map Name (Map Name (Set Int)) =
+    let prefixMap : Map IName (Map IName (Set Int)) =
       mapFoldWithKey
-        (lam acc : Map Name (Map Name (Set Int)).
-         lam nameInfo : NameInfo.
+        (lam acc : Map IName (Map IName (Set Int)).
+         lam n : NameInfo.
          lam tree : PTree NameInfo.
-           mapInsert nameInfo.0 (treeToCallSiteCtxUnion tree) acc
-        ) (mapEmpty nameCmp) env.contexts
+           let n = name2int im (nameInfoGetInfo n) (nameInfoGetName n) in
+           mapInsert n (treeToCallSiteCtxUnion tree) acc
+        ) (mapEmpty subi) env.contexts
     in
-    CtxInfo { contextMap = contextMap, prefixMap = prefixMap }
+    HoleCtxInfo { contextMap = contextMap, prefixMap = prefixMap }
 end
 
 lang Test = MExprHoleCFA + BootParser + MExprANFAll + MExprSym + GraphColoring
@@ -388,7 +415,8 @@ let parse = lam str.
   let ast = makeKeywords [] ast in
   symbolizeExpr {symEnvEmpty with strictTypeVars = false} ast
 in
-let test: Bool -> Expr -> [String] -> [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
+let test
+: Bool -> Expr -> [String] -> [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
   lam debug: Bool. lam t: Expr. lam vars: [String].
     -- Use small ANF first, needed for context expansion
     let tANFSmall = use MExprHoles in normalizeTerm t in
@@ -397,7 +425,7 @@ let test: Bool -> Expr -> [String] -> [(String, [AbsVal], Map NameInfo (Map [Nam
     match colorCallGraph [] tANFSmall with (env, _) in
 
     -- Initialize the graph data
-    let graphData = graphDataFromEnv env in
+    let graphData = graphDataInit env in
 
     -- Apply full ANF
     let tANF = normalizeTerm tANFSmall in
@@ -415,26 +443,28 @@ let test: Bool -> Expr -> [String] -> [(String, [AbsVal], Map NameInfo (Map [Nam
       printLn "\n--- FINAL CFA GRAPH ---";
       printLn resStr;
       let cfaRes : CFAGraph = cfaRes in
-      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
+      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
         map (lam var: String.
-          let binds = mapBindings cfaRes.data in
+          let binds = mapi (lam i. lam s: Set AbsVal.
+            (int2name cfaRes.im i, s)) cfaRes.data in
           let res = foldl (lam acc. lam b : (Name, Set AbsVal).
             if eqString var (nameGetStr b.0) then setToSeq b.1 else acc
           ) [] binds in
-          (var, res, env.hole2idx)
+          (var, res, env.hole2idx, cfaRes.im)
         ) vars
       in avs
 
     else
       -- Version without debug printouts
       let cfaRes : CFAGraph = cfaData graphData tANF in
-      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int))] =
+      let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
         map (lam var: String.
-          let binds = mapBindings cfaRes.data in
+          let binds = mapi (lam i. lam s: Set AbsVal.
+            (int2name cfaRes.im i, s)) cfaRes.data in
           let res = foldl (lam acc. lam b : (Name, Set AbsVal).
             if eqString var (nameGetStr b.0) then setToSeq b.1 else acc
           ) [] binds in
-          (var, res, env.hole2idx)
+          (var, res, env.hole2idx, cfaRes.im)
         ) vars
       in avs
 in
@@ -443,7 +473,7 @@ in
 type Dep = {d: [(String,[[String]])], e: [(String,[[String]])]} in
 let gbl = lam s. (s,[[]]) in
 let eqTestHole = eqSeq
-  (lam t1:(String,[AbsVal],Map NameInfo (Map [NameInfo] Int)).
+  (lam t1:(String,[AbsVal],Map NameInfo (Map [NameInfo] Int),IndexMap).
    lam t2:(String,Dep).
      let index2Path : String -> Int -> [String] = lam str. lam i.
        let pathMap =
@@ -463,16 +493,20 @@ let eqTestHole = eqSeq
        else error "impossible"
      in
 
+     match t1 with (_,_,_,im) in
      if eqString t1.0 t2.0 then
        let data : [(String,Set Int)] = foldl (lam acc. lam av.
            match av with AVDHole {id = id, contexts = contexts}
            then
+             let id = int2name im id in
              cons (nameGetStr id, contexts) acc else acc
          ) [] t1.1
        in
        let exe : [(String,Set Int)] = foldl (lam acc. lam av.
            match av with AVEHole {id = id, contexts = contexts}
-           then cons (nameGetStr id, contexts) acc else acc
+           then
+             let id = int2name im id in
+             cons (nameGetStr id, contexts) acc else acc
          ) [] t1.1
        in
        let deps : Dep = t2.1 in

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -457,7 +457,7 @@ let test
 
     else
       -- Version without debug printouts
-      let cfaRes : CFAGraph = cfaData graphData tANF in
+      let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
       let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
         map (lam var: String.
           let binds = mapi (lam i. lam s: Set AbsVal.

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -33,6 +33,7 @@ include "mexpr/cmp.mc"
 
 include "name.mc"
 include "common.mc"
+include "tensor.mc"
 
 include "ast.mc"
 include "const-dep.mc"
@@ -446,7 +447,7 @@ let test
       let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
         map (lam var: String.
           let binds = mapi (lam i. lam s: Set AbsVal.
-            (int2name cfaRes.im i, s)) cfaRes.data in
+            (int2name cfaRes.im i, s)) (tensorToSeqExn cfaRes.data) in
           let res = foldl (lam acc. lam b : (Name, Set AbsVal).
             if eqString var (nameGetStr b.0) then setToSeq b.1 else acc
           ) [] binds in
@@ -460,7 +461,7 @@ let test
       let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
         map (lam var: String.
           let binds = mapi (lam i. lam s: Set AbsVal.
-            (int2name cfaRes.im i, s)) cfaRes.data in
+            (int2name cfaRes.im i, s)) (tensorToSeqExn cfaRes.data) in
           let res = foldl (lam acc. lam b : (Name, Set AbsVal).
             if eqString var (nameGetStr b.0) then setToSeq b.1 else acc
           ) [] binds in

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -298,7 +298,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
   | t ->
 
     -- Initial graph
-    let graph = emptyCFAGraph in
+    let graph = emptyCFAGraph () in
 
     -- Initialize graph data
     let graph = {graph with graphData = graphData} in

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -406,7 +406,7 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   debugPrintLn debug "";
 
   -- Perform CFA
-  let cfaRes : CFAGraph = cfaData graphData tANF in
+  let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
 
   -- Analyze nested
   let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -394,7 +394,7 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   match colorCallGraph [] tANFSmall with (env, ast) in
 
   -- Initialize the graph data
-  let graphData = graphDataFromEnv env in
+  let graphData = graphDataInit env in
   debugPrintLn debug "\n-------- COLORED PROGRAM --------";
   debugPrintLn debug (expr2str ast);
   debugPrintLn debug "";

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -102,13 +102,14 @@ lang NestedMeasuringPoints = MExprHoleCFA
     in
 
     -- Convert back to direct style map
-    let data: [Set AbsVal] = create (mapSize data) (lam i.
-        match mapLookup (int2name cfaGraph.im i) data with Some s then s
+    tensorIteri (lam i. lam.
+      let d =
+        match mapLookup (int2name cfaGraph.im (get i 0)) data with Some s then s
         else setEmpty cmpAbsVal
-      )
-    in
+      in
+      tensorSetExn cfaGraph.data i d) cfaGraph.data;
 
-    {cfaGraph with data = data}
+    cfaGraph
 
   sem buildCallGraph (im: IndexMap) (avLams : Set Name) (top : Name)
                      (data : Map Name (Set AbsVal)) =

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -397,7 +397,7 @@ let test: Bool -> Expr -> [String] -> [(String,[AbsVal],Map NameInfo (Map [NameI
 
     else
       -- Version without debug printouts
-      let cfaRes : CFAGraph = cfaData graphData tANF in
+      let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
       let cfaRes : CFAGraph  = analyzeNested env cfaRes tANF in
       let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
         map (lam var: String.

--- a/stdlib/tuning/tune-stats.mc
+++ b/stdlib/tuning/tune-stats.mc
@@ -333,7 +333,7 @@ let test
 
     -- Perform dependency analysis
     match
-      let graphData = graphDataFromEnv env in
+      let graphData = graphDataInit env in
       let cfaRes : CFAGraph = cfaData graphData tANF in
       let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
       (analyzeDependency env cfaRes tANF, tANF)

--- a/stdlib/tuning/tune-stats.mc
+++ b/stdlib/tuning/tune-stats.mc
@@ -334,7 +334,7 @@ let test
     -- Perform dependency analysis
     match
       let graphData = graphDataInit env in
-      let cfaRes : CFAGraph = cfaData graphData tANF in
+      let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
       let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
       (analyzeDependency env cfaRes tANF, tANF)
     with (dep, ast) in

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -595,7 +595,7 @@ let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchSta
       if full then assumeFullDependency env tANF
       else
         -- Perform CFA
-        let graphData = graphDataFromEnv env in
+        let graphData = graphDataInit env in
         let cfaRes : CFAGraph = cfaData graphData tANF in
         let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
         (analyzeDependency env cfaRes tANF, tANF)

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -596,7 +596,7 @@ let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchSta
       else
         -- Perform CFA
         let graphData = graphDataInit env in
-        let cfaRes : CFAGraph = cfaData graphData tANF in
+        let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
         let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
         (analyzeDependency env cfaRes tANF, tANF)
     with (dep, ast) in


### PR DESCRIPTION
# Updated PR
This PR implements 3 optimizations in the CFA framework
* Refactors the CFA framework to use tensors for constant time lookups/inserts instead of maps. E.g., the type of the dataflow result is changed from `Map Name (Set AbsVal)` to `Tensor[Set AbsVal]`. Made possible by a file `index.mc` that maps each name in an AST to an integer in the range 0..n-1 (mainly authored by @dlunde).
* Changes the entry point of the CFA algorithm so that we don't match on the pretty print environment in each iteration.
* Uses lists instead of ropes in the CFA graph data structure.

Minor updates:
* Fixes a type error in `profiling.mc`

Benchmark results (shows the effect of each optimization):
```
$ hyperfine -L n before,after,entry,lists "./run-cfa-{n} src/main/mi-lite.mc" -r 10 --warmup 1
Benchmark 1: ./run-cfa-before src/main/mi-lite.mc
  Time (mean ± σ):     19.854 s ±  0.070 s    [User: 17.467 s, System: 2.300 s]
  Range (min … max):   19.768 s … 20.008 s    10 runs
 
Benchmark 2: ./run-cfa-after src/main/mi-lite.mc
  Time (mean ± σ):     18.502 s ±  0.169 s    [User: 16.209 s, System: 2.210 s]
  Range (min … max):   18.266 s … 18.748 s    10 runs
 
Benchmark 3: ./run-cfa-entry src/main/mi-lite.mc
  Time (mean ± σ):     18.232 s ±  0.061 s    [User: 15.962 s, System: 2.187 s]
  Range (min … max):   18.144 s … 18.313 s    10 runs
 
Benchmark 4: ./run-cfa-lists src/main/mi-lite.mc
  Time (mean ± σ):      3.270 s ±  0.091 s    [User: 3.153 s, System: 0.089 s]
  Range (min … max):    3.204 s …  3.517 s    10 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  './run-cfa-lists src/main/mi-lite.mc' ran
    5.57 ± 0.16 times faster than './run-cfa-entry src/main/mi-lite.mc'
    5.66 ± 0.16 times faster than './run-cfa-after src/main/mi-lite.mc'
    6.07 ± 0.17 times faster than './run-cfa-before src/main/mi-lite.mc'
```

# Original PR text
This PR
* Refactors the CFA framework to use tensors for constant time lookups/inserts instead of maps. E.g., the type of the dataflow result is changed from `Map Name (Set AbsVal)` to `Tensor[Set AbsVal]`.
* Adds a file `index.mc` that maps each name in an AST to an integer in the range 0..n-1 (mainly authored by @dlunde).
* Fixes a type error in `profiling.mc`.

The updates give a speedup, but not as much as I hoped for, only about 7% when running 0-CFA on `src/main/mi-lite.mc` (the test program I used does other stuff like parsing and symbolize but the majority of the execution time is spent in 0-CFA):
```
$ hyperfine -L n before,after "./run-cfa-{n} src/main/mi-lite.mc" -r 5 --warmup 1
Benchmark 1: ./run-cfa-before src/main/mi-lite.mc
  Time (mean ± σ):     20.373 s ±  0.055 s    [User: 17.795 s, System: 2.449 s]
  Range (min … max):   20.310 s … 20.441 s    5 runs
 
Benchmark 2: ./run-cfa-after src/main/mi-lite.mc
  Time (mean ± σ):     19.069 s ±  0.022 s    [User: 16.521 s, System: 2.433 s]
  Range (min … max):   19.043 s … 19.090 s    5 runs
 
Summary
  './run-cfa-after src/main/mi-lite.mc' ran
    1.07 ± 0.00 times faster than './run-cfa-before src/main/mi-lite.mc'
```

I ran profiling before and after and here is the result:

<details>
  <summary>Before</summary>
 
```
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cfaDebug 1 17.8193515625 40.1607590332
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[150:0-150:35] nameCmp 29589702 7.87225561523 13.632543457
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[140:0-140:40] nameGetSym 59179404 5.7602878418 5.7602878418
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[13:0-13:68] mapLookupOrElse 1051596 2.00848022461 9.24700195313
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cmpAbsValH 6762891 1.92069116211 5.45887866211
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_parseMCoreFile 1 1.66842993164 2.40410766602
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cmpAbsVal 6762891 1.1793371582 6.63821582031
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_addData 579651 0.901028808594 16.3323684082
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[27:0-27:40] setMem 579651 0.7157578125 4.92321508789
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[21:0-21:44] setInsert 383608 0.478016357422 2.9983996582
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateDirectConstraint 570275 0.207435546875 16.4471188965
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateConstraint 705318 0.205118896484 21.3227683105
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[449:0-449:58] seqCmp 469030 0.143559814453 0.189784179687
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchInfo 143484 0.1243125 0.319838378906
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_addEdge 57954 0.1224921875 1.0053894043
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_dataLookup 637605 0.118795166016 5.70698730469
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[17:0-17:10] gint 641066 0.118783203125 0.118783203125
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateMatchConstraint 369209 0.1034765625 9.31878759766
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_edgesLookup 413991 0.101509765625 3.76031958008
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[15:0-15:10] gstr 154696 0.0931943359375 0.0931943359375
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_collectConstraints 156988 0.0906799316406 4832.50118359
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_bind 46408 0.0793859863281 2330.22574951
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[48:0-48:31] nameHasSym 342231 0.0633068847656 0.0904008789062
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_Expr_Expr 241656 0.0628583984375 4876.78063525
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_ginfo 143484 0.053509765625 0.373348144531
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchTerm 64172 0.0533232421875 407.339964355
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_isDirect 570275 0.0530070800781 0.0530070800781
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_directTransition 570275 0.0510161132812 0.0510161132812
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalize 63972 0.0486403808594 2742.47061743
/Users/lingmar/Documents/miking-lang/miking/stdlib/char.mc[15:0-15:13] cmpChar 523937 0.0462243652344 0.0462243652344
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_sfold_Expr_Expr 156988 0.0462150878906 4832.19071436
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[50:0-50:72] setFold 60498 0.045466796875 3.7213347168
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_ctWorker 64172 0.0393466796875 104.933276367
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_generateConstraints 156988 0.0384020996094 0.181380859375
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gterm 64171 0.0346735839844 406.786919922
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolizeExpr 64172 0.0345144042969 157.380069336
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[58:0-58:38] nameEqSym 106854 0.02948828125 0.0861081542969
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_generateConstraintsMatch 156988 0.02834375 0.0384084472656
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalizeName 62294 0.0272666015625 2599.06319434
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[77:0-77:35] nameEq 106854 0.0271306152344 0.139542236328
/Users/lingmar/Documents/miking-lang/miking/stdlib/bool.mc[9:0-9:23] not 342231 0.0270939941406 0.0270939941406
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_tyTm 181353 0.0258198242187 0.0258198242187
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_initConstraintName 57954 0.0217895507812 5.08496411133
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[23:0-23:56] mapLookup 22126 0.0199213867187 0.0948217773437
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_infoTm 92816 0.0186762695313 0.0186762695313
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gconst 52282 0.0160478515625 0.0377756347656
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_initConstraint 64876 0.0160227050781 5.21208569336
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[152:0-152:81] mapAccumL 8935 0.0157922363281 0.475690917969
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[12:0-12:48] setEmpty 61183 0.0153295898437 0.0153295898437
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_liftANF 62294 0.0147749023438 0.0147749023438
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smap_Expr_Expr 84668 0.0147080078125 44.6508439941
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[16:0-16:11] gname 22889 0.0141450195313 0.0169724121094
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchConst 52282 0.0136665039063 0.0217277832031
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolizeType 70730 0.0135219726563 0.0481899414062
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[55:0-56:71] mapMapAccum 9683 0.0134931640625 0.130529296875
/Users/lingmar/Documents/miking-lang/miking/stdlib/stringid.mc[32:0-32:33] stringToSid 7063 0.0128442382812 0.0353715820313
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_exprName 42388 0.0108815917969 0.258694580078
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smap_Type_Type 68847 0.0105891113281 0.0281372070312
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[28:0-28:30] nameSym 46417 0.010263671875 0.010263671875
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[69:0-69:71] mapAllWithKey 5218 0.007447265625 0.00835205078125
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_generateConstraintsConst 26942 0.00739013671875 0.00739013671875
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchPat 8341 0.00670336914063 0.0914162597656
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[41:0-41:71] mapFromSeq 4294 0.00593798828125 0.00594018554687
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_Type_Type 68847 0.00571923828125 0.0175480957031
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[131:0-131:33] nameGetStr 47296 0.004931640625 0.004931640625
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[44:0-44:55] setOfSeq 2908 0.00492895507813 0.133905517578
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gtype 6599 0.0048212890625 0.0952541503906
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[5:2-5:48] MyLang_initGraph 1 0.0047978515625 1.30635424805
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[33:0-33:60] mapUnion 3574 0.00473852539062 0.0100358886719
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_withType 42129 0.00364819335937 0.00364819335937
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalizeTerm 8512 0.00357641601562 2.78678588867
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[22:0-22:32] nameNoSym 26345 0.00333569335938 0.00333569335938
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[19:0-19:14] glistlen 7452 0.00301977539062 0.00301977539062
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchType 6599 0.0029453125 0.0904328613281
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_generateMatchConstraints 18389 0.00293188476563 0.00293188476563
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gpat 8341 0.00243701171875 0.0938532714844
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolizePat 8341 0.00230419921875 0.0346303710938
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/symbolize.mc[416:0-416:82] _symbolize_patname 4149 0.00205151367188 0.00475073242187
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_ctGetPatVars 8341 0.00189965820312 0.008921875
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_strToPatName 4149 0.00147290039063 0.00198022460938
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_Pat_Pat 6802 0.00141040039063 0.0176726074219
/Users/lingmar/Documents/miking-lang/miking/stdlib/bool.mc[17:0-17:31] and 8501 0.00090478515625 0.00090478515625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_sfold_Pat_Pat 4213 0.000646240234375 0.00654125976562
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[95:0-95:34] nameSetNewSym 6831 0.00062646484375 0.00062646484375
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalizeLams 1363 0.0003662109375 0.379798828125
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_stripTyAll 1584 0.00029248046875 0.000430419921875
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_stripTyAllBase 1701 0.000137939453125 0.000152099609375
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateConstraintConst 263 0.000106689453125 0.144532226563
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/const-transformer.mc[15:0-15:43] _constWithInfos 812 0.000102783203125 0.000102783203125
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_constTransform 1 9.66796875e-05 0.147959716797
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_constArity 392 5.3466796875e-05 5.3466796875e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/common.mc[15:0-15:13] printLn 2 3.1005859375e-05 3.1005859375e-05
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smap_VarSort_Type 123 2.3681640625e-05 3.857421875e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[109:0-109:11] range 69 1.513671875e-05 2.587890625e-05
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_VarSort_Type 123 1.4892578125e-05 1.4892578125e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[123:0-127:6] foldl2 69 1.318359375e-05 1.318359375e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[98:0-99:18] unfoldr 83 1.07421875e-05 1.3671875e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/common.mc[18:0-18:14] dprintLn 1 4.150390625e-06 6.103515625e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[82:0-82:13] ntycon_ 2 1.220703125e-06 1.220703125e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[86:0-86:12] tycon_ 2 9.765625e-07 2.197265625e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[58:0-58:42] tyrecord_ 1 9.765625e-07 9.765625e-07
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[483:0-483:12] const_ 135 9.765625e-07 9.765625e-07
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[12:0-12:46] mapLength 16 9.765625e-07 9.765625e-07
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[18:0-18:12] gfloat 4 0. 0.
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[393:0-393:14] reclets_ 1 0. 0.
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[381:0-381:15] nreclets_ 1 0. 0.
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolize 1 0. 0.2219609375
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cfa 1 0. 40.1607590332
```
 
</details>

<details>
  <summary>After</summary>

```
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cfaDebug 1 13.8517719727 23.0971838379
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[150:0-150:35] nameCmp 7702234 2.1614387207 3.7354765625
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[140:0-140:40] nameGetSym 15404468 1.5740378418 1.5740378418
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_parseMCoreFile 1 1.39923999023 2.03292285156
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cmpAbsValH 6756768 1.01073925781 1.01073925781
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cmpAbsVal 6756768 0.948954833984 1.9596940918
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[13:0-13:68] mapLookupOrElse 336957 0.609076904297 2.80848217773
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[27:0-27:40] setMem 579642 0.581265380859 1.79769726563
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_addKey 114873 0.387479248047 1.92355053711
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[21:0-21:44] setInsert 383608 0.355199707031 1.09846191406
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_addData 579642 0.178779296875 3.12902587891
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateDirectConstraint 570266 0.164769775391 3.35125292969
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateConstraint 705309 0.152726806641 6.47130957031
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[449:0-449:58] seqCmp 469030 0.122626708984 0.160662597656
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchInfo 143484 0.105157958984 0.275333251953
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateMatchConstraint 369209 0.102244628906 4.08731835937
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[17:0-17:10] gint 641066 0.100200927734 0.100200927734
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_Expr_Expr 398644 0.0890349121094 41380.9746914
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[15:0-15:10] gstr 154696 0.0827766113281 0.0827766113281
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_dataLookup 637596 0.07537890625 0.07537890625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_edgesLookup 413991 0.0728500976563 0.0728500976563
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_collectConstraints 156988 0.072818359375 16562.7575222
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_sfold_Expr_Expr 313976 0.0700400390625 41342.8923352
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_name2int 336957 0.0597404785156 2.86822265625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_bind 46408 0.0586520996094 1769.33770679
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[48:0-48:31] nameHasSym 342231 0.053701171875 0.0761586914063
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_indexGenH 156988 0.0514602050781 24783.5191033
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_ginfo 143484 0.0487951660156 0.324128417969
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchTerm 64172 0.0448415527344 352.947270508
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_directTransition 570266 0.041880859375 0.041880859375
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_isDirect 570266 0.0411843261719 0.0411843261719
/Users/lingmar/Documents/miking-lang/miking/stdlib/char.mc[15:0-15:13] cmpChar 523937 0.0380358886719 0.0380358886719
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_indexAdd 156988 0.0367106933594 1.97185595703
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[50:0-50:72] setFold 60498 0.036111328125 1.03613256836
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_generateConstraints 156988 0.0349721679688 1.08873901367
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_ctWorker 64172 0.0340148925781 89.9821999512
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalize 63972 0.0334541015625 2079.30283545
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gterm 64171 0.0307800292969 352.47180249
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolizeExpr 64172 0.0297915039062 135.55033252
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_indexGen 1 0.02927734375 2.15184692383
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_emptyCFAGraph 1 0.0270874023438 2.19642602539
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_generateConstraintsMatch 156988 0.02383984375 0.199416748047
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[58:0-58:38] nameEqSym 106854 0.023361328125 0.0713000488281
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[152:0-152:81] mapAccumL 11969 0.0227280273437 2.9124597168
/Users/lingmar/Documents/miking-lang/miking/stdlib/bool.mc[9:0-9:23] not 342231 0.0224575195313 0.0224575195313
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[55:0-56:71] mapMapAccum 13475 0.0223596191406 0.221981689453
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[77:0-77:35] nameEq 106854 0.0221411132812 0.114737792969
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalizeName 62294 0.0208649902344 1973.49003369
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_tyTm 181353 0.0201704101562 0.0201704101562
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[12:0-12:48] setEmpty 56010 0.0187292480469 0.0187292480469
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_initConstraintName 57954 0.0176062011719 1.06819580078
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[23:0-23:56] mapLookup 22126 0.0168657226562 0.0799653320313
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[22:0-22:32] nameNoSym 79447 0.0147683105469 0.0147683105469
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_addEdge 57954 0.0146701660156 0.0208503417969
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gconst 52282 0.0146477050781 0.0339936523437
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_infoTm 101327 0.0144760742187 0.0144760742187
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchConst 52282 0.0125512695312 0.0193459472656
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolizeType 70730 0.0125300292969 0.0449235839844
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_int2name 106854 0.012515625 0.012515625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smap_Expr_Expr 84668 0.01248828125 38.1648845215
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_initConstraint 64876 0.0115969238281 1.0855378418
/Users/lingmar/Documents/miking-lang/miking/stdlib/stringid.mc[32:0-32:33] stringToSid 7063 0.0107087402344 0.0288395996094
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[16:0-16:11] gname 22889 0.01062890625 0.0134567871094
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_liftANF 62294 0.0104807128906 0.0104807128906
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_exprName 42388 0.00930224609375 0.116945068359
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smap_Type_Type 68847 0.009267578125 0.0258698730469
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[28:0-28:30] nameSym 46417 0.00706958007813 0.00706958007813
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[50:2-50:43] MyLang_generateConstraintsConst 26942 0.0065283203125 0.0065283203125
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchPat 8341 0.00617529296875 0.0784555664062
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[69:0-69:71] mapAllWithKey 5218 0.00522021484375 0.00585009765625
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[41:0-41:71] mapFromSeq 4294 0.00521508789063 0.00521728515625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_Type_Type 68847 0.00483569335937 0.0166022949219
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[131:0-131:33] nameGetStr 47296 0.00447875976562 0.00447875976562
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[33:0-33:60] mapUnion 3574 0.0043466796875 0.00916723632812
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[27:2-27:48] MyLang_initGraph 1 0.00393872070312 3.69685107422
/Users/lingmar/Documents/miking-lang/miking/stdlib/set.mc[44:0-44:55] setOfSeq 2908 0.003630859375 0.0201579589844
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gtype 6599 0.00341674804687 0.0554772949219
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_patIndexAdd 8341 0.00327270507812 0.200385742187
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_withType 42129 0.00317578125 0.00317578125
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[19:0-19:14] glistlen 7452 0.00304296875 0.00304296875
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_Pat_Pat 11714 0.00264990234375 0.128316894531
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalizeTerm 8512 0.00256494140625 2.28887402344
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_gpat 8341 0.00218579101562 0.0806413574219
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolizePat 8341 0.00214990234375 0.0311103515625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_matchType 6599 0.00197680664062 0.052060546875
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_generateMatchConstraints 18389 0.00190454101563 0.00190454101563
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/symbolize.mc[416:0-416:82] _symbolize_patname 4149 0.00177490234375 0.00433618164062
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_ctGetPatVars 8341 0.0017353515625 0.00837670898437
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_sfold_Pat_Pat 9125 0.00173120117188 0.118486572266
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_strToPatName 4149 0.00122021484375 0.00217895507813
/Users/lingmar/Documents/miking-lang/miking/stdlib/bool.mc[17:0-17:31] and 8501 0.0006298828125 0.0006298828125
/Users/lingmar/Documents/miking-lang/miking/stdlib/name.mc[95:0-95:34] nameSetNewSym 6831 0.00059619140625 0.00059619140625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_stripTyAll 1584 0.00023291015625 0.00040380859375
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_normalizeLams 1363 0.0002197265625 0.282027099609
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_stripTyAllBase 1701 0.0001708984375 0.00018994140625
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_constTransform 1 0.000114990234375 0.127434814453
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/const-transformer.mc[15:0-15:43] _constWithInfos 812 0.000102783203125 0.000102783203125
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_propagateConstraintConst 263 7.958984375e-05 0.0333618164063
/Users/lingmar/Documents/miking-lang/miking/stdlib/common.mc[15:0-15:13] printLn 3 4.4921875e-05 4.4921875e-05
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_constArity 392 4.00390625e-05 4.00390625e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/common.mc[18:0-18:14] dprintLn 2 2.5146484375e-05 5.5908203125e-05
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smap_VarSort_Type 123 1.708984375e-05 2.587890625e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[98:0-99:18] unfoldr 83 1.4404296875e-05 1.5380859375e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[123:0-127:6] foldl2 69 1.1962890625e-05 1.1962890625e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[483:0-483:12] const_ 135 1.0009765625e-05 1.0009765625e-05
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_smapAccumL_VarSort_Type 123 8.7890625e-06 8.7890625e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/seq.mc[109:0-109:11] range 69 8.056640625e-06 2.24609375e-05
/Users/lingmar/Documents/miking-lang/miking/stdlib/tensor.mc[178:0-183:13] tensorOfSeqOrElse 1 7.080078125e-06 7.080078125e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/map.mc[12:0-12:46] mapLength 16 4.8828125e-06 4.8828125e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[381:0-381:15] nreclets_ 1 9.765625e-07 9.765625e-07
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[86:0-86:12] tycon_ 2 7.32421875e-07 3.90625e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/boot-parser.mc[18:0-18:12] gfloat 4 0. 0.
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[82:0-82:13] ntycon_ 2 0. 0.
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[58:0-58:42] tyrecord_ 1 0. 2.685546875e-06
/Users/lingmar/Documents/miking-lang/miking/stdlib/mexpr/ast-builder.mc[393:0-393:14] reclets_ 1 0. 9.765625e-07
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_symbolize 1 0. 0.193269042969
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_emptyAcc 1 0. 0.
/Users/lingmar/Documents/miking-lang/miking/run-cfa.mc[3:0-3:60] MyLang_cfa 1 0. 23.0971838379

```
</details>

We see that the time spent in map lookups has indeed been reduced. We also see that when in profiling mode, the difference in execution time between the two programs is much larger, 40 s vs 23 s. For some reason, the profiling exaggerates the differences and seems to penalize map operations. This is why I thought the optimization would have a larger effect.

Includes changes from #605 so needs to be rebased after that PR is merged.

Co-authored-by: Daniel Lundén <dlunde@kth.se>