### PR TITLE
Fix C pprint namespacing errors

### DIFF
--- a/stdlib/c/pprint.mc
+++ b/stdlib/c/pprint.mc
@@ -36,7 +36,7 @@ let escapeIdentifier = lam str: String.
     concat h (map replaceInvalidChar t)
   else "_"
 
-let pprintEnvGetStr = lam env. lam id: Name.
+let cPprintEnvGetStr = lam env. lam id: Name.
   use IdentifierPrettyPrint in
   -- Set this to true to print names with their symbols (for debugging)
   if false then
@@ -46,12 +46,12 @@ let pprintEnvGetStr = lam env. lam id: Name.
     ])
   else
     let id = nameSetStr id (escapeIdentifier (nameGetStr id)) in
-    pprintEnvGetStr env id -- Note that this is not a recursive call!
+    pprintEnvGetStr env id
 
--- Similar to pprintEnvGetStr in mexpr/pprint.mc, but takes an Option Name as
+-- Similar to cPprintEnvGetStr above, but takes an Option Name as
 -- argument. If it is None (), the returned string is "".
-let pprintEnvGetOptStr = lam env. lam id.
-  match id with Some id then pprintEnvGetStr env id else (env,"")
+let cPprintEnvGetOptStr = lam env. lam id.
+  match id with Some id then cPprintEnvGetStr env id else (env,"")
 
 --------------
 -- KEYWORDs --
@@ -87,7 +87,7 @@ lang CExprTypePrettyPrint = CExprTypeAst
   sem printCType (decl: String) (env: PprintEnv) =
 
   | CTyVar { id = id } ->
-    match pprintEnvGetStr env id with (env,id) then
+    match cPprintEnvGetStr env id with (env,id) then
       (env, _joinSpace id decl)
     else never
 
@@ -115,12 +115,12 @@ lang CExprTypePrettyPrint = CExprTypeAst
 
   | CTyStruct { id = id, mem = mem } ->
     let idtup =
-      match id with Some id then pprintEnvGetStr env id else (env, "") in
+      match id with Some id then cPprintEnvGetStr env id else (env, "") in
     match idtup with (env,id) then
       match mem with Some mem then
         let f = lam env. lam t: (CType, Option Name).
           match t.1 with Some n then
-            match pprintEnvGetStr env n with (env,n) then
+            match cPprintEnvGetStr env n with (env,n) then
               printCType n env t.0
             else never
           else match t.1 with None _ then
@@ -139,12 +139,12 @@ lang CExprTypePrettyPrint = CExprTypeAst
 
   | CTyUnion { id = id, mem = mem } ->
     let idtup =
-      match id with Some id then pprintEnvGetStr env id else (env, "") in
+      match id with Some id then cPprintEnvGetStr env id else (env, "") in
     match idtup with (env,id) then
       match mem with Some mem then
         let f = lam env. lam t: (CType, Option Name).
           match t.1 with Some n then
-            match pprintEnvGetStr env n with (env,n) then
+            match cPprintEnvGetStr env n with (env,n) then
               printCType n env t.0
             else never
           else printCType "" env t.0
@@ -159,10 +159,10 @@ lang CExprTypePrettyPrint = CExprTypeAst
 
   | CTyEnum { id = id, mem = mem } ->
     let idtup =
-      match id with Some id then pprintEnvGetStr env id else (env, "") in
+      match id with Some id then cPprintEnvGetStr env id else (env, "") in
     match idtup with (env,id) then
       match mem with Some mem then
-        match mapAccumL pprintEnvGetStr env mem with (env,mem) then
+        match mapAccumL cPprintEnvGetStr env mem with (env,mem) then
           let mem = strJoin ", " mem in
           (env, _joinSpace (join [_joinSpace "enum" id, " {", mem, "}"]) decl)
         else never
@@ -172,13 +172,13 @@ lang CExprTypePrettyPrint = CExprTypeAst
 
   sem printCExpr (env: PprintEnv) =
 
-  | CEVar { id = id } -> pprintEnvGetStr env id
+  | CEVar { id = id } -> cPprintEnvGetStr env id
 
   -- NOTE(larshum, 2021-09-03): We might need to add parentheses around
   -- applications in the future, if we add support for scope resolution
   -- (see https://en.cppreference.com/w/cpp/language/operator_precedence).
   | CEApp { fun = fun, args = args } ->
-    match pprintEnvGetStr env fun with (env,fun) then
+    match cPprintEnvGetStr env fun with (env,fun) then
       match mapAccumL printCExpr env args with (env,args) then
         (env, join [fun, "(", (strJoin ", " args), ")"])
       else never
@@ -203,14 +203,14 @@ lang CExprTypePrettyPrint = CExprTypeAst
     else never
 
   | CEMember { lhs = lhs, id = id } ->
-    match pprintEnvGetStr env id with (env,id) then
+    match cPprintEnvGetStr env id with (env,id) then
       match printCExpr env lhs with (env,lhs) then
         (env, _par (join [lhs, ".", escapeIdentifier id]))
       else never
     else never
 
   | CEArrow { lhs = lhs, id = id } ->
-    match pprintEnvGetStr env id with (env,id) then
+    match cPprintEnvGetStr env id with (env,id) then
       match printCExpr env lhs with (env,lhs) then
         (env, _par (join [lhs, "->", escapeIdentifier id]))
       else never
@@ -311,7 +311,7 @@ lang CStmtPrettyPrint =
   sem printCStmt (indent: Int) (env: PprintEnv) =
 
   | CSDef { ty = ty, id = id, init = init } ->
-    match pprintEnvGetOptStr env id with (env,id) then
+    match cPprintEnvGetOptStr env id with (env,id) then
       match printCDef env ty id init with (env,str) then
         (env, join [str, ";"])
       else never
@@ -404,14 +404,14 @@ lang CTopPrettyPrint =
 
   sem printCTop (indent : Int) (env: PprintEnv) =
   | CTTyDef { ty = ty, id = id } ->
-    match pprintEnvGetStr env id with (env,id) then
+    match cPprintEnvGetStr env id with (env,id) then
       match printCDef env ty id (None ()) with (env,str) then
         (env, join ["typedef ", str, ";"])
       else never
     else never
 
   | CTDef { ty = ty, id = id, init = init } ->
-    match pprintEnvGetOptStr env id with (env,id) then
+    match cPprintEnvGetOptStr env id with (env,id) then
       match printCDef env ty id init with (env,str) then
         (env, join [str, ";"])
       else never
@@ -420,9 +420,9 @@ lang CTopPrettyPrint =
   | CTFun { ret = ret, id = id, params = params, body = body } ->
     let i = indent in
     let ii = pprintIncr indent in
-    match pprintEnvGetStr env id with (env,id) then
+    match cPprintEnvGetStr env id with (env,id) then
       let f = lam env. lam t: (CType,Name).
-        match pprintEnvGetStr env t.1 with (env,t1) then
+        match cPprintEnvGetStr env t.1 with (env,t1) then
           printCDef env t.0 t1 (None ())
         else never in
       match mapAccumL f env params with (env,params) then

--- a/stdlib/cuda/pprint.mc
+++ b/stdlib/cuda/pprint.mc
@@ -54,7 +54,7 @@ lang CudaPrettyPrint = CPrettyPrint + CudaAst
     let ops = int2string opsPerThread in
     (env, join ["CELoopKernel(", n, ", ", f, ")[opsPerThread=", ops, "]"])
   | CEKernelApp t ->
-    match pprintEnvGetStr env t.fun with (env, fun) in
+    match cPprintEnvGetStr env t.fun with (env, fun) in
     match mapAccumL printCExpr env t.args with (env, args) in
     match printCExpr env t.gridSize with (env, gridSize) in
     match printCExpr env t.blockSize with (env, blockSize) in

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -169,7 +169,7 @@ lang RecLetsCPS = CPS + RecLetsAst + LamAst
   | TmRecLets t ->
     let bindings = map (lam b: RecLetBinding. { b with body =
         match b.body with TmLam t then
-          if not (transform env b.ident) then
+          if not (or (transform env b.ident) (transform env t.ident)) then
             TmLam { t with body = exprCps env (None ()) t.body }
           else
             let kName = nameSym "k" in


### PR DESCRIPTION
Fixes C pprint errors in Miking DPPL resulting from recent changes in Miking.

Also adds a fix for TmRecLet in `cps.mc`.