### PR TITLE
Make the CFA framework more modular

### DIFF
--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -29,7 +29,7 @@ let dependencyAnalysis
     if options.tuneOptions.dependencyAnalysis then
       let ast = typeCheck ast in
       let ast = use HoleANFAll in normalizeTerm ast in
-      let cfaRes = cfaData (Some (graphDataInit env)) ast in
+      let cfaRes = holeCfa (graphDataInit env) ast in
       let cfaRes = analyzeNested env cfaRes ast in
       let dep = analyzeDependency env cfaRes ast in
       (if options.tuneOptions.debugDependencyAnalysis then

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -254,7 +254,13 @@ lang MatchCPS = CPS + MatchAst
   sem exprCps env k =
   | TmLet ({ ident = ident, body = TmMatch m, inexpr = inexpr } & b) & t ->
     if not (transform env ident) then
-      TmLet { b with inexpr = exprCps env k inexpr }
+      TmLet { b with
+        body = TmMatch { m with
+          thn = exprCps env (None ()) m.thn,
+          els = exprCps env (None ()) m.els
+        },
+        inexpr = exprCps env k inexpr
+      }
     else
       let opt = match k with Some k then tailCall t else false in
       if opt then

--- a/stdlib/tuning/dependency-analysis.mc
+++ b/stdlib/tuning/dependency-analysis.mc
@@ -259,7 +259,7 @@ let test : Bool -> Bool -> Expr -> (DependencyGraph, CallCtxEnv) =
       match pprintCode 0 pprintEnvEmpty tANF with (pprintEnv,tANFStr) in
       printLn "\n--- ANF ---";
       printLn tANFStr;
-      match cfaDebug (Some graphData) (Some pprintEnv) tANF with (Some pprintEnv,cfaRes) in
+      match holeCfaDebug graphData pprintEnv tANF with (pprintEnv,cfaRes) in
       match cfaGraphToString pprintEnv cfaRes with (_, resStr) in
       printLn "\n--- FINAL CFA GRAPH ---";
       printLn resStr;
@@ -277,7 +277,7 @@ let test : Bool -> Bool -> Expr -> (DependencyGraph, CallCtxEnv) =
 
     else
       -- Version without debug printouts
-      let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
+      let cfaRes : CFAGraph = holeCfa graphData tANF in
       let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
       match
         if full then assumeFullDependency env tANF

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -406,7 +406,7 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   debugPrintLn debug "";
 
   -- Perform CFA
-  let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
+  let cfaRes : CFAGraph = holeCfa graphData tANF in
 
   -- Analyze nested
   let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -376,7 +376,7 @@ let test: Bool -> Expr -> [String] -> [(String,[AbsVal],Map NameInfo (Map [NameI
       match pprintCode 0 pprintEnvEmpty tANF with (pprintEnv,tANFStr) in
       printLn "\n--- ANF ---";
       printLn tANFStr;
-      match cfaDebug (Some graphData) (Some pprintEnv) tANF with (Some pprintEnv,cfaRes) in
+      match holeCfaDebug graphData pprintEnv tANF with (pprintEnv,cfaRes) in
       match cfaGraphToString pprintEnv cfaRes with (_, resStr) in
       printLn "\n--- CFA GRAPH ---";
       printLn resStr;
@@ -397,7 +397,7 @@ let test: Bool -> Expr -> [String] -> [(String,[AbsVal],Map NameInfo (Map [NameI
 
     else
       -- Version without debug printouts
-      let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
+      let cfaRes : CFAGraph = holeCfa graphData tANF in
       let cfaRes : CFAGraph  = analyzeNested env cfaRes tANF in
       let avs : [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
         map (lam var: String.

--- a/stdlib/tuning/tune-stats.mc
+++ b/stdlib/tuning/tune-stats.mc
@@ -334,7 +334,7 @@ let test
     -- Perform dependency analysis
     match
       let graphData = graphDataInit env in
-      let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
+      let cfaRes : CFAGraph = holeCfa graphData tANF in
       let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
       (analyzeDependency env cfaRes tANF, tANF)
     with (dep, ast) in

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -596,7 +596,7 @@ let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchSta
       else
         -- Perform CFA
         let graphData = graphDataInit env in
-        let cfaRes : CFAGraph = cfaData (Some graphData) tANF in
+        let cfaRes : CFAGraph = holeCfa graphData tANF in
         let cfaRes : CFAGraph = analyzeNested env cfaRes tANF in
         (analyzeDependency env cfaRes tANF, tANF)
     with (dep, ast) in


### PR DESCRIPTION
This PR makes the CFA framework slightly more modular. Specifically, the PR removes the `initGraph` function, and the CFA analysis entrypoint is now `sem solveCfa: CFAGraph -> CFAGraph`. That is, analyses based on `cfa.mc` are themselves responsible for constructing the initial `CFAGraph`. This makes the framework more flexible, and in particular allows for incremental analyses building upon each other (as needed in, e.g., Miking DPPL).

Builds upon and contains https://github.com/miking-lang/miking/pull/608 and must therefore be rebased and merged after that PR is merged (this also messes up the GitHub diff quite a lot).

This PR also (temporarily) breaks the analysis in Miking DPPL (hence the draft status).
