### PR TITLE
Recursive let generalization bugfix

### DIFF
--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -1045,6 +1045,17 @@ let tests = [
    ty = tyarrow_ tyint_ tybool_,
    env = []},
 
+  {name = "RecLets3",
+   tm = bindall_ [
+     ureclets_ [
+       ("f", ulam_ "x" (var_ "x")),
+       ("g", ulam_ "x" (app_ (var_ "f") (var_ "x")))
+     ],
+     app_ (var_ "g") (int_ 1)
+   ],
+   ty = tyint_,
+   env = []},
+
   {name = "Match1",
    tm = if_ true_ (int_ 1) (int_ 0),
    ty = tyint_,

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -402,6 +402,9 @@ lang Generalize = AllTypeAst + VarTypeSubstitute + ResolveAlias + FlexTypeAst
   sem gen (lvl : Level) =
   | ty ->
     match genBase lvl ty with (vars, genTy) in
+    -- OPT(aathn, 2022-06-29): It might be better to use a set for `vars`
+    -- to avoid having to check for duplicates here.
+    let vars = distinct (lam x. lam y. nameEq x.0 y.0) vars in
     let iteratee = lam v : (Name, VarSort). lam ty.
       let sort = match v.1 with MonoVar _ then PolyVar () else v.1 in
       TyAll {info = infoTy genTy, ident = v.0, ty = ty, sort = sort}
@@ -427,9 +430,7 @@ lang FlexTypeGeneralize = Generalize + FlexTypeAst + VarTypeAst
           (concat vars1 vars2, ty)
         in
         match smapAccumL_VarSort_Type f [] s with (vars, sort) in
-        let v = TyVar {info = t.info, ident = n, level = lvl} in
-        modref t.contents (Link v);
-        (snoc vars (n, sort), v)
+        (snoc vars (n, sort), TyVar {info = t.info, ident = n, level = lvl})
       else
         -- Var is bound in previous let, don't generalize
         ([], ty)


### PR DESCRIPTION
This PR fixes a bug introduced in #601 related to let-generalization in recursive lets.

As a minimal example, consider the following:
```haskell
mexpr
recursive
  let f = lam x. x
  let g = lam x. f x
in
g 1
```
This gives the error
```
ERROR: Type check failed: unification failure
LHS: a
RHS: Int
while unifying these:
LHS: a -> a
RHS: Int -> a
g 5
```
The reason for this is that #601 made it so that whenever a unification variable is generalized, it is also unified with the type variable it is generalized to. That is, whenever I find one variable to generalize, all other occurrences of that variable are replaced with the corresponding type variable at the same time. This saves some work and is correct in most cases, where a unification variable can only occur in the body of its surrounding let. However, for mutually recursive functions, this can cause the variable to escape its scope.

In the example above, `f` gets type `all a. a -> a` as expected, but `g` gets type `a -> a`, where `a` is the variable bound by `f`. Therefore, the type of `g` is not instantiated properly, causing the error above.

This PR reverts the change and adds a test case to prevent future regressions.