### PR TITLE
Add CFA of fold and map sequence intrinsics

### DIFF
--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -63,6 +63,19 @@ utest eqBool false true  with false
 utest eqBool true  false with false
 utest eqBool true  true  with true
 
+
+-- Boolean comparison
+let cmpBool: Bool -> Bool -> Int =
+  lam b1: Bool. lam b2: Bool.
+  if b1 then if b2 then 0 else 1
+  else if b2 then negi 1 else 0
+
+utest cmpBool false false with 0
+utest cmpBool false true  with negi 1
+utest cmpBool true  false with 1
+utest cmpBool true  true  with 0
+
+
 -- Boolean to string
 let bool2string: Bool -> String = lam b.
   if b then "true" else "false"

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -1052,7 +1052,6 @@ lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint + LamCFA
     | CTail _
     | CSubsequence _
     | CFoldl _
-    | CFoldr _
     | CMap _
     ) & const ->
     [

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -117,6 +117,37 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
     -- lhs \ {dhole : dhole ∈ rhs} ⊆ res
   | CstrHoleIndependent { lhs: IName, rhs: IName, res: IName }
 
+  sem cmpConstraintH =
+  | (CstrHoleDirectData l, CstrHoleDirectData r) ->
+    let d = subi l.lhs r.lhs in
+    if eqi d 0 then subi l.rhs r.rhs
+    else d
+  | (CstrHoleDirectExe l, CstrHoleDirectExe r) ->
+    let d = subi l.lhs r.lhs in
+    if eqi d 0 then subi l.rhs r.rhs
+    else d
+  | (CstrHoleApp l, CstrHoleApp r) ->
+    let d = subi l.res r.res in
+    if eqi d 0 then subi l.lhs r.lhs
+    else d
+  | (CstrHoleConstApp l, CstrHoleConstApp r) ->
+    let d = subi l.res r.res in
+    if eqi d 0 then
+      let d = subi l.lhs r.lhs in
+      if eqi d 0 then subi l.rhs r.rhs
+      else d
+    else d
+  | (CstrHoleMatch l, CstrHoleMatch r) ->
+    let d = subi l.res r.res in
+    if eqi d 0 then subi l.lhs r.lhs
+    else d
+  | (CstrHoleIndependent l, CstrHoleIndependent r) ->
+    let d = subi l.res r.res in
+    if eqi d 0 then
+      let d = subi l.lhs r.lhs in
+      if eqi d 0 then subi l.rhs r.rhs
+      else d
+    else d
 
   sem initConstraint (graph : CFAGraph) =
   | CstrHoleApp r & cstr -> initConstraintName r.lhs graph cstr


### PR DESCRIPTION
Changes in CFA framework:
* Changes the representation of edges from `[Constraint]` to `Set Constraint` to avoid duplication of constraints. All constraints now have to implement the function `cmpConstraintH`. This improved the runtime of CFA so there seem to have been duplicate constraints before I added constraints for fold and map.
* Adds analysis of `map`, `foldl` and `foldr` to 0-CFA and k-CFA. This considerably slows down the analysis of `mi-lite` (which is expected).

Changes to stdlib:
* Adds a `cmpBool` function.