### PR TITLE
Interactive `--debug-type-check`

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -34,6 +34,10 @@ let pprintMcore = lam ast.
   use MExprPrettyPrint in
   expr2str ast
 
+let pprintMcoreHtmlWithTy = lam ast.
+  use DebugTypeHtml in
+  mexprToString ast
+
 let pprintType = lam ty.
   use MExprPrettyPrint in
   type2str ty
@@ -73,8 +77,9 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
     in
 
     let ast = typeCheck ast in
-    (if options.debugTypeCheck then
-       printLn (join [pprintMcore ast, "\n : ", pprintType (tyTm ast)]) else ());
+    (if options.debugTypeCheck
+     then printLn (pprintMcoreHtmlWithTy ast)
+     else ());
 
     -- If --runtime-checks is set, runtime safety checks are instrumented in
     -- the AST. This includes for example bounds checking on sequence

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -216,12 +216,10 @@ lang PrettyPrint = IdentifierPrettyPrint
   sem typePrecedence =
   | ty -> 100000
 
-  sem pprintCode (indent : Int) (env: PprintEnv) =
-  -- Intentionally left blank
-  sem getPatStringCode (indent : Int) (env: PprintEnv) =
-  -- Intentionally left blank
-  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
-  -- Intentionally left blank
+  -- The first argument is the indentation-level to be used
+  sem pprintCode : Int -> PprintEnv -> Expr -> String
+  sem getPatStringCode : Int -> PprintEnv -> Pat -> String
+  sem getTypeStringCode : Int -> PprintEnv -> Expr -> String
 
   sem exprToString (env: PprintEnv) =
   | expr ->

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -852,6 +852,12 @@ lang MExprTypeCheck =
 
 end
 
+lang DebugTypeHtml = MExprPrettyPrintAnnotatedHtml
+  sem exprAnnotation env = | e -> typeToString env (tyTm e)
+  sem patAnnotation env = | p -> typeToString env (tyPat p)
+  sem typeAnnotation env = | _ -> ""
+end
+
 lang TestLang = MExprTypeCheck + MExprEq end
 
 mexpr

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -670,6 +670,10 @@ lang OCamlPrettyPrint =
     match mapAccumL (getPatStringCode indent) env args with (env, args) then
       (env, join [ident, " (", strJoin ", " args, ")"])
     else never
+
+  sem postprocessExpr env str = | _ -> str
+  sem postprocessPat env str = | _ -> str
+  sem postprocessType env str = | _ -> str
 end
 
 lang TestLang = OCamlPrettyPrint + OCamlSym


### PR DESCRIPTION
This PR adds a first version of a nice debugging tool when pprinting programs with lots of annotations: generating an html file where the annotations can be examined by hovering over the relevant piece of code, showing all enclosing annotations as well in a list. I'll demo it during the meeting, it's rather easier to show than describe textually.

I'm not entirely certain we want to merge this in it's current form, but it's good enough for what I need, so I figured I'd raise the discussion point.
- We'd like to be able to extend `sem`s with functions to run before/after current branches, rather than just either-or, which is what we have right now. Since we lack such a feature this implementation is very invasive, every implementation of the `pprint` `sem`s for `Expr`, `Pat`, and `Type` need to call a new function called `postprocessExpr` (etc.) before returning.
- Because we don't have the ability to completely override previous branches we also can't provide a default to `postprocessExpr` that does nothing, since that will overlap with most general annotation schemes. This means that languages that don't use `MExprPrettyPrint` explicitly, rather some subset of the smaller fragments, won't get a default implementation for these functions, whereby they'll currently crash since there's no implementation available at all. For example, I had to add such implementations to `ocaml/pprint.mc`, even though this kind of shouldn't affect that code at all.
- Down the road we also want a version of this that puts the annotations over the original file, rather than the `pprint`ed ast. I've implemented this before in Haskell, so I don't think it should be too hard to port, but I didn't need it yet. Regardless, this suggests that we might want to extract the html template and annotation functions, since that code would also want to use them.