### PR TITLE
CPS and CFA fixes

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -264,13 +264,16 @@ lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst
 
   sem normalize (k : Expr -> Expr) =
   | TmExt ({inexpr = inexpr} & t) ->
-    -- TmExt {t with inexpr = normalize k t.inexpr}
-
-    -- NOTE(dlunde,2022-06-14): Externals must always be fully applied (otherwise the parser throws an
-    -- erro). To make this compatible with ANF, we eta expand definitions of
-    -- externals.
+    -- NOTE(dlunde,2022-06-14): Externals must always be fully applied
+    -- (otherwise the parser throws an error). To make this compatible with
+    -- ANF, we eta expand definitions of externals. In this way, the only
+    -- application of the external is in the body of the eta expansion (where
+    -- it is always fully applied).
+    --
     let arity = arityFunType t.tyIdent in
     let i = withInfo t.info in
+
+    -- Introduce variable names for each external parameter
     recursive let vars = lam acc. lam arity.
       match acc with (acc, tyIdent) in
       if lti arity 1 then acc
@@ -284,9 +287,14 @@ lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst
         vars (cons (arg, argTy) acc, innerTy) (subi arity 1)
     in
     let varNameTypes : [(Name, Type)] = vars ([], t.tyIdent) arity in
+
+    -- Variable for the external itself
     let extId = TmVar {
       ident = t.ident, ty = t.tyIdent,
-      info = t.info, frozen = false} in
+      info = t.info, frozen = false}
+    in
+
+    -- The body of the eta expansion
     match
       foldl
         (lam acc. lam v.
@@ -305,6 +313,7 @@ lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst
         (extId, t.tyIdent)
         varNameTypes
     with (inner, _) in
+
     let etaExpansion =
       foldr
         (lam v. lam acc.

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -882,7 +882,7 @@ lang ExtCFA = CFA + ExtAst
   sem collectConstraints cgfs acc =
   | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } & t ->
     let acc = foldl (lam acc. lam f. concat (f t) acc) acc cgfs in
-    sfold_Expr_Expr (collectConstraints cgfs) acc inexpr
+    collectConstraints cgfs acc inexpr
 
   sem generateConstraints im =
   | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
@@ -894,7 +894,8 @@ lang ExtCFA = CFA + ExtAst
     []
 
   sem exprName =
-  | TmExt t -> exprName t.inexpr
+  -- Skip the eta expanded let added by ANF,
+  | TmExt { inexpr = TmLet { inexpr = inexpr }} -> exprName inexpr
 
 end
 
@@ -2633,7 +2634,7 @@ lang ExtKCFA = KCFA + ExtAst
         match f ctx env t with (env, fcstrs) in
         (env, concat fcstrs cstrs)
       ) acc cgfs in
-    sfold_Expr_Expr (collectConstraints ctx cgfs) acc inexpr
+    collectConstraints ctx cgfs acc inexpr
 
   sem generateConstraints im ctx env =
   | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
@@ -2645,7 +2646,8 @@ lang ExtKCFA = KCFA + ExtAst
     (env,[])
 
   sem exprName =
-  | TmExt t -> exprName t.inexpr
+  -- Skip the eta expanded let added by ANF,
+  | TmExt { inexpr = TmLet { inexpr = inexpr }} -> exprName inexpr
 
 end
 


### PR DESCRIPTION
This PR includes two small fixes:
- Fixes a problem with `TyAll` types for `TmConDef` in `cps.mc`.
- Fixes a problem with `TmExt` in `cfa.mc`.