### PR TITLE
Don't use `nameNoSym` in `ast-builder.mc` when the generated name is invisible from the outside.

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -610,7 +610,7 @@ let nrecordproj_ = use MExprAst in
 
 let recordproj_ = use MExprAst in
   lam key. lam r.
-  nrecordproj_ (nameNoSym "x") key r
+  nrecordproj_ (nameSym "x") key r
 
 let ntupleproj_ = use MExprAst in
   lam name. lam i. lam t.


### PR DESCRIPTION
During discussion in a previous meeting we talked about maintaining the symbolized property (i.e., every `Name` is defined in exactly one location across a program) during transformations, and that `ast-builder.mc` did not do this for tuple projection.

I did some minor benchmarking (see below) which suggests that there's no real penalty to use `nameSym` instead in this case. Note that I haven't changed any other functions, e.g., `let_` still exists alongside `nlet_` et. al. It's possible we want to deprecate the non-`n` versions, but it's not obvious, given that we at least semi-frequently generate parts of ASTs that will be symbolized later anyway, in which case it may be easier to use the `nameNoSym` versions.

As an aside, I'd like it if we added a (phantom) type parameter to `Name` denoting whether it is symbolized or not, then perhaps thread it through the AST, thereby getting some type safety around it, but it's not entirely certain that the gains outweigh the drawbacks.

```
❯ hyperfine --prepare "make clean && stg goto mcore.syn" "echo 'pre' && make install" --prepare "make clean && stg goto gensym-ast-builder" "echo 'post' && make install"
Benchmark 1: echo 'pre' && make install
  Time (mean ± σ):     187.409 s ±  1.762 s    [User: 185.291 s, System: 5.670 s]
  Range (min … max):   185.622 s … 189.600 s    10 runs
 
Benchmark 2: echo 'post' && make install
  Time (mean ± σ):     186.482 s ±  1.383 s    [User: 184.088 s, System: 5.690 s]
  Range (min … max):   184.886 s … 188.989 s    10 runs
 
Summary
  'echo 'post' && make install' ran
    1.00 ± 0.01 times faster than 'echo 'pre' && make install'
```