### PR TITLE
Optimize `seqCmp`

### DIFF
--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -395,7 +395,7 @@ utest jsonParse "{\"mylist\" : [{},2,3e-2], \"mystr\" : \n\"foo\", \"mybool\" :\
 with Left myJsonObject using eitherEq jsonEq eqString in
 
 utest json2string myJsonObject
-with "{\"mystr\":\"foo\",\"mybool\":true,\"mylist\":[{},2,0.03],\"mynull\":null}" in
+with "{\"mybool\":true,\"mylist\":[{},2,0.03],\"mynull\":null,\"mystr\":\"foo\"}" in
 
 utest jsonParse (json2string myJsonObject) with Left myJsonObject using eitherEq jsonEq eqString in
 

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -474,13 +474,11 @@ let seqCmp : all a. (a -> a -> Int) -> [a] -> [a] -> Int = lam cmp. lam s1. lam 
       let c = cmp h1 h2 in
       if eqi c 0 then work t1 t2
       else c
+    else match (s1, s2) with (t1, []) then length t1
+    else match (s1, s2) with ([], t2) then negi (length t2)
     else 0
   in
-  let n1 = length s1 in
-  let n2 = length s2 in
-  let ndiff = subi n1 n2 in
-  if eqi ndiff 0 then work s1 s2
-  else ndiff
+  work s1 s2
 
 utest seqCmp subi [] [] with 0
 utest seqCmp subi [1,2,3] [1,2,3] with 0

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -86,7 +86,7 @@ utest
   with true
 utest
   -- Shortlex example
-  match lti (cmpString "aab" "aaaa") 0 with true then true else false
+  match gti (cmpString "aab" "aaaa") 0 with true then true else false
   with true
 
 let str2upper = lam s. map char2upper s


### PR DESCRIPTION
Optimize `seqCmp` for lists.
To discuss:
- How will this affect the performance of `seqCmp` for ropes?
- The optimization actually changes the semantics of `seqCmp` slightly (previously [shortlex order](https://en.wikipedia.org/wiki/Shortlex_order) and now [lexicographic order](https://en.wikipedia.org/wiki/Lexicographic_order)). Does this matter for anyone?