### PR TITLE
Fix MacOS build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,11 @@ jobs:
           brew install openblas
 
           # Export environment variable needed by openblas
-          export PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig
+          export PKG_CONFIG_PATH=$(brew --prefix openblas)/lib/pkgconfig
+
+          # Hack to fix installation of owl
+          ln -s $(brew --prefix gcc)/lib/gcc/current/libgcc_s.1.1.dylib $(brew --prefix openblas)/lib
+          ln -s $(brew --prefix gcc)/lib/gcc/current/libquadmath.0.dylib $(brew --prefix openblas)/lib
 
           # Install all opam packages used in make test-all
           opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.20.1


### PR DESCRIPTION
This PR introduces a workaround to fix the build error for the `owl` package in the default workflow. This workaround was inspired by [a discussion on a slightly related problem](https://github.com/owlbarn/owl/issues/611#issuecomment-1120238578).