### PR TITLE
Reserve built-in names in default environment of expr2str

### DIFF
--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -242,7 +242,16 @@ lang PrettyPrint = IdentifierPrettyPrint
     match getTypeStringCode 0 env ty with (_,str) in str
 
   sem expr2str =
-  | expr -> exprToString pprintEnvEmpty expr
+  | expr ->
+    -- Reserve the names of the built-in constants when pretty-printing.
+    let env =
+      foldl
+        (lam env. lam e.
+          match e with (str, _) in
+          let n = nameSym str in
+          pprintEnvAdd n str 1 env)
+        pprintEnvEmpty builtin in
+    exprToString env expr
 
   sem type2str =
   | ty -> typeToString pprintEnvEmpty ty


### PR DESCRIPTION
This PR reserves the names of built-ins in the environment used by `expr2str`, to ensure that they are pretty-printed differently from any bindings that use the same name.

Fixes #631