### PR TITLE
Various improvements

### DIFF
--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -55,16 +55,15 @@ let _collapse_array (s : 'a t) : 'a array =
       let a = Array.sub v off len in
       s := Leaf a ;
       a
-  | Concat {lhs; rhs; len;} ->
+  | Concat {lhs; rhs; len} ->
       (* NOTE(larshum, 2021-02-12): the implementation guarantees that Concat
        * nodes are non-empty. *)
       let dst = Array.make len (get_array s 0) in
-
       (* Collapse the rope using an explicit stack to avoid stack overflow. *)
       let st = Stack.create () in
       let i = ref 0 in
-      Stack.push rhs st;
-      Stack.push lhs st;
+      Stack.push rhs st ;
+      Stack.push lhs st ;
       while Stack.length st > 0 do
         let s = Stack.pop st in
         match s with
@@ -76,10 +75,8 @@ let _collapse_array (s : 'a t) : 'a array =
             Array.blit v off dst !i len ;
             i := !i + len
         | Concat {lhs; rhs; _} ->
-            Stack.push rhs st;
-            Stack.push lhs st
-      done;
-
+            Stack.push rhs st ; Stack.push lhs st
+      done ;
       s := Leaf dst ;
       dst
 

--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -48,6 +48,16 @@ let rec _get_array (s : 'a u) (i : int) : 'a =
 let get_array (s : 'a t) (i : int) : 'a = _get_array !s i
 
 let _collapse_array (s : 'a t) : 'a array =
+  let rec collapse dst s i =
+    match s with
+    | Leaf a ->
+        let n = Array.length a in
+        Array.blit a 0 dst i n ; i + n
+    | Slice {v; off; len} ->
+        Array.blit v off dst i len ; i + len
+    | Concat {lhs; rhs; _} ->
+        collapse dst rhs (collapse dst lhs i)
+  in
   match !s with
   | Leaf a ->
       a
@@ -55,28 +65,11 @@ let _collapse_array (s : 'a t) : 'a array =
       let a = Array.sub v off len in
       s := Leaf a ;
       a
-  | Concat {lhs; rhs; len} ->
+  | Concat {len; _} ->
       (* NOTE(larshum, 2021-02-12): the implementation guarantees that Concat
        * nodes are non-empty. *)
       let dst = Array.make len (get_array s 0) in
-      (* Collapse the rope using an explicit stack to avoid stack overflow. *)
-      let st = Stack.create () in
-      let i = ref 0 in
-      Stack.push rhs st ;
-      Stack.push lhs st ;
-      while Stack.length st > 0 do
-        let s = Stack.pop st in
-        match s with
-        | Leaf a ->
-            let n = Array.length a in
-            Array.blit a 0 dst !i n ;
-            i := !i + n
-        | Slice {v; off; len} ->
-            Array.blit v off dst !i len ;
-            i := !i + len
-        | Concat {lhs; rhs; _} ->
-            Stack.push rhs st ; Stack.push lhs st
-      done ;
+      let _ = collapse dst !s 0 in
       s := Leaf dst ;
       dst
 

--- a/stdlib/log.mc
+++ b/stdlib/log.mc
@@ -30,10 +30,10 @@ let _logLevelToString = lam lvl : LogLevel.
 let logSetLogLevel = lam lvl : LogLevel. modref _logLevel lvl
 
 -- `log lvl msg` logs the message `msg` at the log level `lvl`.
-let logMsg = lam lvl : LogLevel. lam msg : String.
+let logMsg = lam lvl : LogLevel. lam msg : () -> String.
   if eqi lvl logLevel.off then ()
   else if leqi lvl (deref _logLevel) then
-    printError (join ["LOG ", _logLevelToString lvl, ":\t", msg, "\n"]);
+    printError (join ["LOG ", _logLevelToString lvl, ":\t", msg (), "\n"]);
     flushStderr ()
   else ()
 

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -1,10 +1,23 @@
 include "map.mc"
 include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/const-types.mc"
 
 -- Returns the arity of a function type
 recursive let arityFunType = use MExprAst in lam ty.
   match ty with TyArrow t then addi 1 (arityFunType t.to) else 0
 end
+
+let isHigherOrderFunType = use MExprAst in lam ty.
+  recursive let rec = lam under: Bool. lam acc. lam ty.
+    match ty with TyArrow { from = from, to = to } then
+      if under then true else
+        let acc = rec true acc from in
+        if acc then acc else rec false acc to
+    else
+      sfold_Type_Type (rec under) acc ty
+  in
+  rec false false ty
 
 -- Unwraps type alias `ty` from `aliases`.
 recursive let typeUnwrapAlias = use MExprAst in
@@ -15,3 +28,15 @@ recursive let typeUnwrapAlias = use MExprAst in
     else ty
   else ty
 end
+
+lang Test = MExprAst + MExprConstType end
+
+mexpr
+use Test in
+
+utest isHigherOrderFunType (tyConst (CInt { val = 1 })) with false in
+utest isHigherOrderFunType (tyConst (CGet ())) with false in
+utest isHigherOrderFunType (tyConst (CAddi ())) with false in
+utest isHigherOrderFunType (tyConst (CMap ())) with true in
+utest isHigherOrderFunType (tyConst (CIter ())) with true in
+()

--- a/stdlib/seq-native.mc
+++ b/stdlib/seq-native.mc
@@ -1,0 +1,57 @@
+-- MExpr-native alternative implementations of higher-order functions over
+-- sequences. The below versions are slower than their intrisic counterparts.
+
+let map = lam f. lam s.
+  recursive let rec = lam s.
+    match s with [] then []
+    else match s with [a] then [f a]
+    else match s with [a] ++ ss then cons (f a) (rec ss)
+    else never
+  in rec s
+
+utest map (lam x. addi x 1) [3,4,8,9,20] with [4,5,9,10,21]
+utest map (lam x. addi x 1) [] with []
+
+let mapi = lam f. lam s.
+  recursive let rec = lam i. lam s.
+    match s with [] then []
+    else match s with [a] then [f i a]
+    else match s with [a] ++ ss then cons (f i a) (rec (addi i 1) ss)
+    else never
+  in rec 0 s
+
+utest mapi (lam i. lam x. i) [3,4,8,9,20] with [0,1,2,3,4]
+utest mapi (lam i. lam x. i) [] with []
+
+let foldl = lam f. lam acc. lam s.
+  recursive let rec = lam acc. lam s.
+    match s with [] then acc
+    else match s with [a] ++ ss then rec (f acc a) ss
+    else never
+  in rec acc s
+
+utest foldl addi 0 [1,2,3,4,5] with 15
+utest foldl addi 0 [] with 0
+utest map (foldl addi 0) [[1,2,3], [], [1,3,5,7]] with [6, 0, 16]
+
+let foldr = lam f. lam acc. lam s.
+  recursive let rec = lam acc. lam s.
+    match s with [] then acc
+    else match s with [a] ++ ss then f a (rec acc ss)
+    else never
+  in rec acc s
+
+utest foldr (lam x. lam acc. x) 0 [1,2] with 1
+utest foldr (lam acc. lam x. x) 0 [] with 0
+utest foldr cons [] [1,2,3] with [1,2,3]
+
+let create = lam l. lam f.
+  recursive let rec = lam i. lam acc.
+    if geqi i 0 then rec (subi i 1) (cons (f i) acc)
+    else acc
+  in rec (subi l 1) []
+
+utest create 3 (lam. 10) with [10,10,10]
+utest create 8 (lam. 'a') with ['a','a','a','a','a','a','a','a']
+utest create 4 (lam i. muli 2 i) with [0,2,4,6]
+utest create 0 (lam i. i) with []

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -75,15 +75,17 @@ with [true, false]
 let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> String -> (Float, ExecResult) =
   lam timeoutSec. lam cmd. lam stdin. lam cwd.
     let tempDir = sysTempDirMake () in
+    let tempStdin = sysJoinPath tempDir "stdin.txt" in
+    writeFile tempStdin stdin;
     let tempStdout = sysJoinPath tempDir "stdout.txt" in
     let tempStderr = sysJoinPath tempDir "stderr.txt" in
 
     let fullCmd =
     [ "cd", cwd, ";"
-    , "echo", stdin, "|"
     , strJoin " " cmd
     , ">", tempStdout
     , "2>", tempStderr
+    , "<", tempStdin
     , ";"
     ] in
     let fullCmd =

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -1,6 +1,7 @@
 include "string.mc"
 
-type ExecResult = {stdout: String, stderr: String, returncode: Int}
+type ReturnCode = Int
+type ExecResult = {stdout: String, stderr: String, returncode: ReturnCode}
 
 let _pathSep = "/"
 let _tempBase = "/tmp"
@@ -72,20 +73,17 @@ utest
   [exists, sysFileExists (sysTempDirName d)]
 with [true, false]
 
-let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> String -> (Float, ExecResult) =
-  lam timeoutSec. lam cmd. lam stdin. lam cwd.
-    let tempDir = sysTempDirMake () in
-    let tempStdin = sysJoinPath tempDir "stdin.txt" in
-    writeFile tempStdin stdin;
-    let tempStdout = sysJoinPath tempDir "stdout.txt" in
-    let tempStderr = sysJoinPath tempDir "stderr.txt" in
-
+let sysRunCommandWithTimingTimeoutFileIO
+    : Option Float -> [String] -> String -> String -> String -> String
+      -> (Float, ReturnCode) =
+  lam timeoutSec. lam cmd. lam stdinFile.
+  lam stdoutFile. lam stderrFile. lam cwd.
     let fullCmd =
     [ "cd", cwd, ";"
     , strJoin " " cmd
-    , ">", tempStdout
-    , "2>", tempStderr
-    , "<", tempStdin
+    , ">", stdoutFile
+    , "2>", stderrFile
+    , "<", stdinFile
     , ";"
     ] in
     let fullCmd =
@@ -94,22 +92,38 @@ let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> Strin
       else fullCmd
     in
     match _commandListTime fullCmd with (ms, retCode) then
-
-      -- NOTE(Linnea, 2021-04-14): Workaround for readFile bug #145
-      _commandList ["echo", "", ">>", tempStdout];
-      _commandList ["echo", "", ">>", tempStderr];
-      let stdout = init (readFile tempStdout) in
-      let stderr = init (readFile tempStderr) in
-
-      sysTempDirDelete tempDir ();
-      (ms, {stdout = stdout, stderr = stderr, returncode = retCode})
+      (ms, retCode)
     else never
+
+let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> String -> (Float, ExecResult) =
+  lam timeoutSec. lam cmd. lam stdin. lam cwd.
+    let tempDir = sysTempDirMake () in
+    let tempStdin = sysJoinPath tempDir "stdin.txt" in
+    writeFile tempStdin stdin;
+    let tempStdout = sysJoinPath tempDir "stdout.txt" in
+    let tempStderr = sysJoinPath tempDir "stderr.txt" in
+    let res = sysRunCommandWithTimingTimeoutFileIO
+                timeoutSec cmd tempStdin tempStdout tempStderr cwd in
+    -- NOTE(Linnea, 2021-04-14): Workaround for readFile bug #145
+    _commandList ["echo", "", ">>", tempStdout];
+    _commandList ["echo", "", ">>", tempStderr];
+    let stdout = init (readFile tempStdout) in
+    let stderr = init (readFile tempStderr) in
+    sysTempDirDelete tempDir ();
+    (res.0, {stdout = stdout, stderr = stderr, returncode = res.1})
 
 utest sysRunCommandWithTimingTimeout (None ()) ["echo -n \"\""] "" "."; () with ()
 
+let sysRunCommandWithTimingFileIO : [String] -> String -> String -> (Float, ExecResult) =
+  sysRunCommandWithTimingTimeoutFileIO (None ())
+
 let sysRunCommandWithTiming : [String] -> String -> String -> (Float, ExecResult) =
-  lam cmd. lam stdin. lam cwd.
-    sysRunCommandWithTimingTimeout (None ()) cmd stdin cwd
+    sysRunCommandWithTimingTimeout (None ())
+
+let sysRunCommandFileIO : [String] -> String -> String -> ExecResult =
+  lam cmd. lam stdinFile. lam stdoutFile. lam stderrFile. lam cwd.
+    match sysRunCommandWithTimingFileIO cmd stdinFile stdoutFile stderrFile cwd
+    with (_, res) then res else never
 
 let sysRunCommand : [String] -> String -> String -> ExecResult =
   lam cmd. lam stdin. lam cwd.
@@ -126,3 +140,11 @@ let sysGetEnv : String -> Option String = lam env.
   else Some res
 
 utest sysCommandExists "ls" with true
+
+let sysAppendFile : String -> String -> ReturnCode =
+  lam filename. lam str.
+  let f = sysTempFileMake () in
+  writeFile f str;
+  let r = _commandList ["cat", f, ">>", filename] in
+  sysDeleteFile f;
+  r


### PR DESCRIPTION
- Do not give "also exists in standard library" error when using, e.g.,`include "./common.mc"`. `include "common.mc"` still gives the error. The implementation makes use of `Filename.is_implicit` in OCaml.
- Change the signature of `logMsg` from `LogLevel -> String -> ()` to `LogLevel -> (() -> String) -> ()`. Useful when the log message should only be computed when printing the log message.
- CPS transformation now gives an error message when encountering higher-order intrinsics (cannot be transformed to CPS).
- Add `isHigherOrderFunType: Type -> Bool` to `mexpr/type.mc`.
- Add `seq-native.mc` containing MExpr implementations of some higher-order sequence constants (e.g., `map`, `foldl`).
- Improve scalability of exec functions in `sys.mc`.
  1. In `sysRunCommandWithTimingTimeout`, print the stdin string to a temporary file `f`, and then send it to the command via `< f`. Previously, the stdin string was sent directly on the command line via `echo <stdin string> |` (doesn't work for large stdin strings).
  2. Add a function `sysRunCommandWithTimingTimeoutFileIO` that runs a command with only files used for stdin, stdout, and stderr. That is, no reading/writing strings from/to Miking. Important memory optimization when dealing with large IO strings.
- Add `sysAppendFile: String -> String -> ReturnCode` to `sys.mc`. Could be implemented with `writeFile` instead, but `sysAppendFile` avoids reading in the original file as an MExpr string before appending.
