### PR TITLE
Removes the -y diff flag from make test-js

### DIFF
--- a/test/js/make.sh
+++ b/test/js/make.sh
@@ -33,7 +33,7 @@ run_test() {
 	filename=${file%.*}
 	echo $($RUN_JS "$filename.js" 2>&1) > "$filename.node.out"
 	echo $($RUN_MI "$filename.mc" 2>&1) > "$filename.mi.out"
-	diff_output=$(diff -y "$filename.node.out" "$filename.mi.out" 2>&1)
+	diff_output=$(diff "$filename.node.out" "$filename.mi.out" 2>&1)
   	exit_code=$?
 	clean_out
 	set -e


### PR DESCRIPTION
`make test-all` fails when building the Miking docker image since the -y flag used for diff in the JS tests is not supported on the BusyBox implementation of diff, which Alpine Linux uses. The purpose of the -y flag is only to print diff side by side instead of interspersed, so this should not break anything functionally.