### PR TITLE
Mixed updates

### DIFF
--- a/stdlib/common.mc
+++ b/stdlib/common.mc
@@ -28,6 +28,12 @@ let repeat : (() -> ()) -> Int -> () = lam f. lam n.
     if leqi n 0 then () else (f (); rec (subi n 1))
   in rec n
 
+-- Function repetition (for side-effects)
+let repeati : (Int -> ()) -> Int -> () = lam f. lam n.
+  recursive let rec = lam i.
+    if geqi i n then () else (f i; rec (addi i 1))
+  in rec 0
+
 -- Fixpoint computation for mutual recursion. Thanks Oleg Kiselyov!
 -- (http://okmij.org/ftp/Computation/fixed-point-combinators.html)
 let fixMutual : all a. all b. [[a -> b] -> a -> b] -> [a -> b] =

--- a/stdlib/log.mc
+++ b/stdlib/log.mc
@@ -29,7 +29,7 @@ let _logLevelToString = lam lvl : LogLevel.
 -- Sets the log level
 let logSetLogLevel = lam lvl : LogLevel. modref _logLevel lvl
 
--- Checks if given level is printed the current log level
+-- Checks if given level is printed under the current log level
 let logLevelPrinted = lam lvl. leqi lvl (deref _logLevel)
 
 -- `log lvl msg` logs the message `msg` at the log level `lvl`.

--- a/stdlib/log.mc
+++ b/stdlib/log.mc
@@ -29,10 +29,13 @@ let _logLevelToString = lam lvl : LogLevel.
 -- Sets the log level
 let logSetLogLevel = lam lvl : LogLevel. modref _logLevel lvl
 
+-- Checks if given level is printed the current log level
+let logLevelPrinted = lam lvl. leqi lvl (deref _logLevel)
+
 -- `log lvl msg` logs the message `msg` at the log level `lvl`.
 let logMsg = lam lvl : LogLevel. lam msg : () -> String.
   if eqi lvl logLevel.off then ()
-  else if leqi lvl (deref _logLevel) then
+  else if logLevelPrinted lvl then
     printError (join ["LOG ", _logLevelToString lvl, ":\t", msg (), "\n"]);
     flushStderr ()
   else ()

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -332,6 +332,8 @@ recursive let bindF_ = use MExprAst in
     TmType {t with inexpr = bindF_ f t.inexpr expr}
   else match letexpr with TmExt t then
     TmExt {t with inexpr = bindF_ f t.inexpr expr}
+  else match letexpr with TmUtest t then
+    TmUtest {t with next = bindF_ f t.next expr}
   else
     f letexpr expr -- Insert at the end of the chain
 end

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -332,8 +332,6 @@ recursive let bindF_ = use MExprAst in
     TmType {t with inexpr = bindF_ f t.inexpr expr}
   else match letexpr with TmExt t then
     TmExt {t with inexpr = bindF_ f t.inexpr expr}
-  else match letexpr with TmUtest t then
-    TmUtest {t with next = bindF_ f t.next expr}
   else
     f letexpr expr -- Insert at the end of the chain
 end

--- a/stdlib/seq-native.mc
+++ b/stdlib/seq-native.mc
@@ -9,6 +9,8 @@ let map = lam f. lam s.
     else never
   in rec s
 
+let iter = lam f. lam s.  map f s; ()
+
 utest map (lam x. addi x 1) [3,4,8,9,20] with [4,5,9,10,21]
 utest map (lam x. addi x 1) [] with []
 
@@ -19,6 +21,8 @@ let mapi = lam f. lam s.
     else match s with [a] ++ ss then cons (f i a) (rec (addi i 1) ss)
     else never
   in rec 0 s
+
+let iteri = lam f. lam s. mapi f s; ()
 
 utest mapi (lam i. lam x. i) [3,4,8,9,20] with [0,1,2,3,4]
 utest mapi (lam i. lam x. i) [] with []


### PR DESCRIPTION
- Add `repeati : (Int -> ()) -> Int -> ()` function to `common.mc`
- Add `logLevelPrinted` function to `log.mc`
- ~Add missing `TmUtest` case in `bindF_` in `mexpr/ast-builder.mc`~. Reverted after discussion with @elegios, `bindF_` is only for terms that bind something. We could also rename it to something other than `bindF_` and include `TmUtest`, but I'll leave it for now.
- Add missing `iter` and `iteri` functions to `seq-native.mc`
