### PR TITLE
Pattern typechecking updates

### DIFF
--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -1625,16 +1625,16 @@ lang TensorOpEval =
       errorSingle [info] "Tensor and value type does not match in CTensorLinearSetExn"
   | CTensorRank _ ->
     match arg with TmTensor { val = t } then
-      match t with TInt t | TFloat t | TExpr t then
-        let val = tensorRank t in
-        int_ val
+      match t with TInt t then int_ (tensorRank t)
+      else match t with TFloat t then int_ (tensorRank t)
+      else match t with TExpr t then int_ (tensorRank t)
       else never
     else errorSingle [info] "First argument to CTensorRank not a tensor"
   | CTensorShape _ ->
     match arg with TmTensor { val = t } then
-      match t with TInt t | TFloat t | TExpr t then
-        let shape = tensorShape t in
-        _toTmSeq shape
+      match t with TInt t then _toTmSeq (tensorShape t)
+      else match t with TFloat t then _toTmSeq (tensorShape t)
+      else match t with TExpr t then _toTmSeq (tensorShape t)
       else never
     else errorSingle [info] "First argument to CTensorRank not a tensor"
   | CTensorReshapeExn _ ->


### PR DESCRIPTION
Previously, there was no check that a variable had the same type across a pattern. For instance, we could write a type-incorrect program using or-patterns in the following way:
```haskell
mexpr
type Foo in
con C1 : Int    -> Foo in
con C2 : [Char] -> Foo in

let f = lam x. match x with C1 a | C2 a in head a in
f (C1 1)
```
This would pass the type checker, even though `a` occurs with different types in the pattern `C1 a | C2 a`. This PR fixes the issue, and also makes some improvements to the pattern type checking code.

Note that the type checker now requires that multiple occurrences of a variable in a non-or-pattern have the same type as well, so that for instance, the pattern `a ++ [a]` would be disallowed. I don't believe this change should do any harm; this sort of pattern seems dubious anyways as it's ambiguous which `a` will be bound in the body.