### PR TITLE
Mixed updates related to Miking DPPL

### DIFF
--- a/stdlib/ext/dist-ext.ext-ocaml.mc
+++ b/stdlib/ext/dist-ext.ext-ocaml.mc
@@ -118,5 +118,14 @@ let distExtMap =
         libraries = ["owl"],
         cLibraries = []
       }
+    ]),
+    ("externalSetSeed", [
+      impl { expr = "
+        fun seed -> (
+          Random.init seed;
+          Owl_stats_prng.sfmt_seed seed;
+          Owl_stats_prng.init seed
+        )",
+      ty = tyarrows_ [tyint_, otyunit_] }
     ])
   ]

--- a/stdlib/ext/dist-ext.ext-ocaml.mc
+++ b/stdlib/ext/dist-ext.ext-ocaml.mc
@@ -120,12 +120,15 @@ let distExtMap =
       }
     ]),
     ("externalSetSeed", [
-      impl { expr = "
+      { expr = "
         fun seed -> (
           Random.init seed;
           Owl_stats_prng.sfmt_seed seed;
           Owl_stats_prng.init seed
         )",
-      ty = tyarrows_ [tyint_, otyunit_] }
+        ty = tyarrows_ [tyint_, otyunit_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
     ])
   ]

--- a/stdlib/ext/dist-ext.mc
+++ b/stdlib/ext/dist-ext.mc
@@ -135,6 +135,10 @@ let exponentialLogPdf : Float -> Float -> Float = lam lambda. lam x.
 let exponentialPdf : Float -> Float -> Float = lam lambda. lam x.
   exp (exponentialLogPdf lambda x)
 
+-- Seed
+external externalSetSeed ! : Int -> ()
+let setSeed : Int -> () = lam seed. externalSetSeed seed
+
 mexpr
 
 
@@ -214,5 +218,8 @@ utest poissonSample 2.0 with 3 using intRange 0 100000 in
 utest exponentialSample 1.0 with 0. using floatRange 0. inf in
 utest exp (exponentialLogPdf 1.0 2.0) with 0.135335283237 using _eqf in
 utest exponentialPdf 2.0 2.0 with 0.0366312777775 using _eqf in
+
+-- Testing seed
+utest setSeed 0; uniformSample () with setSeed 0; uniformSample () in
 
 ()


### PR DESCRIPTION
- Add `externalSetSeed` intrinsic.
- Generalize partial CPS to accept a `Name -> Bool` function instead of a `Set Name`.

Updates by @larshum  (maybe @larshum can provide further details if needed)
- Fix to `NoInfo` in `duplicate-code-elimination.mc`.
- Update lambda lifting so that it gives lifted parameters new symbols.
