### PR TITLE
Add `tyAnnot` field to lambdas and lets

### DIFF
--- a/src/main/eval.mc
+++ b/src/main/eval.mc
@@ -32,6 +32,9 @@ lang ExtMCore =
 
 end
 
+lang TyAnnotFull = MExprPrettyPrint + TyAnnot + HtmlAnnotator
+end
+
 let generateTests = lam ast. lam testsEnabled.
   use ExtMCore in
   if testsEnabled then
@@ -70,7 +73,7 @@ let eval = lam files. lam options : Options. lam args.
 
     let ast = typeCheck ast in
     (if options.debugTypeCheck then
-       printLn (join [mexprToString ast, "\n : ", type2str (tyTm ast)]) else ());
+       printLn (use TyAnnotFull in annotateMExpr ast) else ());
 
     -- If option --test, then generate utest runner calls. Otherwise strip away
     -- all utest nodes from the AST.

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -38,6 +38,7 @@ lang ANF = LetAst + VarAst + UnknownTypeAst
     } in
     let inexpr = k var in
     TmLet {ident = ident,
+           tyAnnot = tyTm n,
            tyBody = tyTm n,
            body = n,
            inexpr = inexpr,
@@ -319,13 +320,13 @@ lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst
         (lam v. lam acc.
           match v with (id, ty) in
           TmLam {
-            ident = id, tyIdent = ty, body = acc,
+            ident = id, tyAnnot = ty, tyIdent = ty, body = acc,
             ty = TyArrow {from = ty, to = tyTm acc, info = t.info},
             info = t.info})
         inner varNameTypes in
     TmExt { t with
       inexpr = TmLet {
-        ident = t.ident, tyBody = t.tyIdent, body = etaExpansion,
+        ident = t.ident, tyAnnot = t.tyIdent, tyBody = t.tyIdent, body = etaExpansion,
         inexpr = normalize k t.inexpr, ty = tyTm t.inexpr, info = t.info} }
 
 end

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -350,7 +350,7 @@ let unit_ = use MExprAst in
 
 let nlet_ = use MExprAst in
   lam n. lam ty. lam body.
-  TmLet {ident = n, tyBody = ty, body = body,
+  TmLet {ident = n, tyAnnot = ty, tyBody = ty, body = body,
   inexpr = uunit_, ty = tyunknown_, info = NoInfo ()}
 
 let let_ = use MExprAst in
@@ -386,6 +386,7 @@ let nreclets_ = use MExprAst in
   lam bs.
   let bindingMapFunc = lam t : (Name, Type, Expr).
     { ident = t.0
+    , tyAnnot = t.1
     , tyBody = t.1
     , body = t.2
     , info = NoInfo ()
@@ -429,7 +430,7 @@ let reclets_empty = use MExprAst in
 let nreclets_add = use MExprAst in
   lam n. lam ty. lam body. lam reclets.
   match reclets with TmRecLets t then
-    let newbind = {ident = n, tyBody = ty, body = body, info = NoInfo ()} in
+    let newbind = {ident = n, tyAnnot = ty, tyBody = ty, body = body, info = NoInfo ()} in
     TmRecLets {t with bindings = cons newbind t.bindings}
   else
     errorSingle [infoTm reclets] "reclets is not a TmRecLets construct"
@@ -494,11 +495,12 @@ let tmLam = use MExprAst in
   lam info : Info.
   lam ty : Type.
   lam ident : Name.
-  lam tyIdent : Type.
+  lam tyAnnot : Type.
   lam body : Expr.
   TmLam {
     ident = ident,
-    tyIdent = tyIdent,
+    tyAnnot = tyAnnot,
+    tyIdent = tyAnnot,
     ty = ty,
     body = body,
     info = info

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -139,13 +139,15 @@ lang BootParser = MExprAst + ConstTransformer
            info = ginfo t 0}
   | 102 /-TmLam-/ ->
     TmLam {ident = gname t 0,
-           tyIdent = gtype t 0,
+           tyAnnot = gtype t 0,
+           tyIdent = TyUnknown { info = ginfo t 0 },
            ty = TyUnknown { info = ginfo t 0 },
            info = ginfo t 0,
            body = gterm t 0}
   | 103 /-TmLet-/ ->
     TmLet {ident = gname t 0,
-           tyBody = gtype t 0,
+           tyAnnot = gtype t 0,
+           tyBody = TyUnknown { info = ginfo t 0 },
            body = gterm t 0,
            inexpr = gterm t 1,
            ty = TyUnknown { info = ginfo t 0 },
@@ -154,7 +156,8 @@ lang BootParser = MExprAst + ConstTransformer
     TmRecLets {bindings =
                create (glistlen t 0)
                       (lam n. {ident = gname t n,
-                               tyBody = gtype t n,
+                               tyAnnot = gtype t n,
+                               tyBody = TyUnknown { info = ginfo t (addi n 1)},
                                body = gterm t n,
                                info = ginfo t (addi n 1)}),
                inexpr = gterm t (glistlen t 0),
@@ -626,47 +629,47 @@ utest l_infoClosed "   \n  external y! : Int in 1" with r_info 2 2 2 24 in
 -- TyUnknown
 let s = "let y:Unknown = lam x.x in y" in
 utest lsideClosed s with rside "let y = lam x.x in y" in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 13 in
 let s = "lam x:Int. lam y:Char. x" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] " \n lam x:Int. lam y:Char. x" with TmLam l then infoTy l.tyIdent else NoInfo ()
+utest match parseMExprStringKeywords [] " \n lam x:Int. lam y:Char. x" with TmLam l then infoTy l.tyAnnot else NoInfo ()
 with r_info 2 7 2 10 in
 
 -- TyInt
 let s = "let y:Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 9 in
 
 -- TyFloat
 let s = "let y:Float = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 11 in
 
 -- TyChar
 let s = "let y:Char = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 10 in
 
 -- TyArrow
 let s = "let y:Int->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 14 in
 
 -- Nested TyArrow
 let s = "let y:[Float]->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 18 in
 
 -- TySeq
 let s = "let y:[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 11 in
 
 -- Nested TySeq
@@ -682,13 +685,13 @@ let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
 utest parseMExprStringKeywords [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 56 in
 
 -- TyTensor
 let s = "let y:Tensor[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 17 in
 
 -- Nested TyTensor
@@ -702,14 +705,14 @@ let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
 utest parseMExprStringKeywords [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 30 in
 
 -- TyRecord
 let s = "let y:{a:Int,b:[Char]} = lam x.x in y" in
 let recTy = tyrecord_ [("a", tyint_), ("b", tystr_)] in
 utest parseMExprStringKeywords [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 22 in
 
 -- Nested TyRecord
@@ -722,50 +725,50 @@ let recTy = tyrecord_ [
     ("b_1", tystr_),
     ("b_2", tyfloat_)])] in
 utest parseMExprStringKeywords [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 54 in
 
 -- TyVariant
 let s = "let y:<> = lam x.x in y" in
 -- NOTE(caylak,2021-03-17): Parsing of TyVariant is not supported yet
 --utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 8 in
 
 -- TyVar
 let s = "let y:_asd = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 10 in
 
 -- TyAll
 let s = "let y:all x.x = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 13 in
 
 -- Nested TyAll
 let s = "let y:all x.(all y.all z.z)->all w.w = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 36 in
 
 -- TyCon
 let s = "let y:Foo = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 9 in
 
 -- TyApp
 let s = "let y:(Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 7 1 19 in
 
 -- Nested TyApp
 let s = "let y:((Int->Int)Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyBody else NoInfo ()
+utest match parseMExprStringKeywords [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 8 1 29 in
 
 -- Allow free variables

--- a/stdlib/mexpr/cse.mc
+++ b/stdlib/mexpr/cse.mc
@@ -56,8 +56,8 @@ lang CSE = MExprCmp
           foldl
             (lam acc. lam namedExpr : (Name, Expr).
               match namedExpr with (id, e) then
-                TmLet {ident = id, tyBody = tyTm e, body = e, inexpr = acc,
-                       ty = tyTm acc, info = infoTm e}
+                TmLet {ident = id, tyAnnot = tyTm e, tyBody = tyTm e,
+                       body = e, inexpr = acc, ty = tyTm acc, info = infoTm e}
               else never)
             t
             exprs)

--- a/stdlib/mexpr/duplicate-code-elimination.mc
+++ b/stdlib/mexpr/duplicate-code-elimination.mc
@@ -255,7 +255,7 @@ utest expr2str (eliminateDuplicateCode t) with expr2str expected using eqString 
 -- Tests that it applies to bindings in recursive let-expressions
 let ireclets = lam bindings.
   let bindFn = lam idx. lam entry : (String, Expr).
-    {ident = nameNoSym entry.0, tyBody = tyunknown_, body = entry.1, info = i idx} in
+    {ident = nameNoSym entry.0, tyAnnot = tyunknown_, tyBody = tyunknown_, body = entry.1, info = i idx} in
   TmRecLets { bindings = mapi bindFn bindings, inexpr = uunit_,
               ty = tyunknown_, info = NoInfo () } in
 let baseBindings = [

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -180,12 +180,14 @@ lang RecLetsEval =
       foldli
         (lam i. lam bodyacc. lam binding : RecLetBinding.
           TmLet {ident = binding.ident,
+                 tyAnnot = tyunknown_,
                  tyBody = tyunknown_,
                  body = TmLam {ident = eta_name,
                                body = TmApp {lhs = _evalDTupleProj i var,
                                              rhs = eta_var,
                                              ty = tyunknown_,
                                              info = NoInfo()},
+                               tyAnnot = tyunknown_,
                                tyIdent = tyunknown_,
                                ty = tyunknown_,
                                info = NoInfo()
@@ -205,6 +207,7 @@ lang RecLetsEval =
     let unfixed_tuple = TmLam {ident = lst_name,
                                body = unpack_from lst_var func_tuple,
                                tyIdent = tyunknown_,
+                               tyAnnot = tyunknown_,
                                ty = tyunknown_,
                                info = NoInfo()} in
     eval {ctx with env =

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -49,7 +49,7 @@ lang LambdaLiftNameAnonymous = MExprAst
     in
     let lambdaName = nameSym "t" in
     let letBody = TmLam {t with body = recurseInLambdaBody t.body} in
-    TmLet {ident = lambdaName, tyBody = t.ty, body = letBody,
+    TmLet {ident = lambdaName, tyAnnot = t.ty, tyBody = t.ty, body = letBody,
            inexpr = TmVar {ident = lambdaName, ty = t.ty, info = t.info, frozen = false},
            ty = t.ty, info = t.info}
   | TmLet t ->
@@ -210,7 +210,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
       let body =
         foldr
           (lam freeVar : (Name, Type). lam body.
-            TmLam {ident = freeVar.0, tyIdent = freeVar.1,
+            TmLam {ident = freeVar.0, tyAnnot = freeVar.1, tyIdent = freeVar.1,
                    body = body, info = info,
                    ty = TyUnknown {info = info}})
           t.body
@@ -254,7 +254,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
           foldr
             (lam freeVar : (Name, Type). lam body.
               let info = infoTm body in
-              TmLam {ident = freeVar.0, tyIdent = freeVar.1,
+              TmLam {ident = freeVar.0, tyAnnot = freeVar.1, tyIdent = freeVar.1,
                      body = body, info = info,
                      ty = TyUnknown {info = info}})
             bind.body fv in
@@ -285,7 +285,7 @@ lang LambdaLiftLiftGlobal = MExprAst
     match liftRecursiveBindingH bindings t.body with (bindings, body) in
     match t.body with TmLam _ then
       let bind : RecLetBinding =
-        {ident = t.ident, tyBody = t.tyBody, body = body, info = t.info} in
+        {ident = t.ident, tyAnnot = t.tyAnnot, tyBody = t.tyBody, body = body, info = t.info} in
       let bindings = snoc bindings bind in
       liftRecursiveBindingH bindings t.inexpr
     else match liftRecursiveBindingH bindings t.inexpr with (bindings, inexpr) in

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -403,7 +403,7 @@ lang FunParser =
     let r3 : StrPos = matchKeyword "." r2.pos r2.str in
     let e : ParseResult Expr = parseExprMain r3.pos 0 r3.str in
     {val = TmLam {ident = nameNoSym r2.val, ty = tyunknown_,
-                  tyIdent = tyunknown_, body = e.val,
+                  tyAnnot = tyunknown_, tyIdent = tyunknown_, body = e.val,
                   info = makeInfo p e.pos},
      pos = e.pos, str = e.str}
 end
@@ -420,7 +420,7 @@ lang LetParser =
     let e1 : ParseResult Expr = parseExprMain r3.pos 0 r3.str in
     let r4 : StrPos = matchKeyword "in" e1.pos e1.str in
     let e2 : ParseResult Expr = parseExprMain r4.pos 0 r4.str in
-    {val = TmLet {ident = nameNoSym r2.val, tyBody = tyunknown_,
+    {val = TmLet {ident = nameNoSym r2.val, tyAnnot = tyunknown_, tyBody = tyunknown_,
                   body = e1.val, inexpr = e2.val, ty = tyunknown_,
                   info = makeInfo p e2.pos},
      pos = e2.pos, str = e2.str}

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -316,7 +316,7 @@ lang LamPrettyPrint = PrettyPrint + LamAst + UnknownTypeAst
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmLam t ->
     match pprintVarName env t.ident with (env,str) in
-    match getTypeStringCode indent env t.tyIdent with (env, ty) in
+    match getTypeStringCode indent env t.tyAnnot with (env, ty) in
     let ty = if eqString ty "Unknown" then "" else concat ": " ty in
     match pprintCode (pprintIncr indent) env t.body with (env,body) in
     (env,
@@ -380,8 +380,8 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
       in (env, join [body, pprintNewline indent, "; ", inexpr])
     else
       match
-        match t.tyBody with TyUnknown _ then (env,"") else
-        match getTypeStringCode indent env t.tyBody with (env, ty) in
+        match t.tyAnnot with TyUnknown _ then (env,"") else
+        match getTypeStringCode indent env t.tyAnnot with (env, ty) in
         (env, concat ": " ty)
       with (env, ty) in
       match pprintCode (pprintIncr indent) env t.body with (env,body) in
@@ -446,7 +446,7 @@ lang RecLetsPrettyPrint = PrettyPrint + RecLetsAst + UnknownTypeAst
     let f = lam env. lam bind : RecLetBinding.
       match pprintVarName env bind.ident with (env,str) in
       match pprintCode iii env bind.body with (env,body) in
-      match getTypeStringCode indent env bind.tyBody with (env, ty) in
+      match getTypeStringCode indent env bind.tyAnnot with (env, ty) in
         let ty = if eqString ty "Unknown" then "" else concat ": " ty in
         (env, join ["let ", str, ty, " =", pprintNewline iii, body])
     in

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -123,9 +123,9 @@ lang LamSym = Sym + LamAst + VarSym
   | TmLam t ->
     match env with {varEnv = varEnv} then
       let ty = symbolizeType env t.ty in
-      let tyIdent = symbolizeType env t.tyIdent in
+      let tyAnnot = symbolizeType env t.tyAnnot in
       if nameHasSym t.ident then
-        TmLam {{{t with tyIdent = tyIdent}
+        TmLam {{{t with tyAnnot = tyAnnot}
                    with body = symbolizeExpr env t.body}
                    with ty = ty}
       else
@@ -134,7 +134,7 @@ lang LamSym = Sym + LamAst + VarSym
         let varEnv = mapInsert str ident varEnv in
         let env = {env with varEnv = varEnv} in
         TmLam {{{{t with ident = ident}
-                    with tyIdent = tyIdent}
+                    with tyAnnot = tyAnnot}
                     with body = symbolizeExpr env t.body}
                     with ty = ty}
     else never
@@ -144,10 +144,10 @@ lang LetSym = Sym + LetAst + AllTypeAst
   sem symbolizeExpr (env : SymEnv) =
   | TmLet t ->
     match env with {varEnv = varEnv} then
-      let tyBody = symbolizeType env t.tyBody in
+      let tyAnnot = symbolizeType env t.tyAnnot in
       let ty = symbolizeType env t.ty in
       let body =
-        match stripTyAll tyBody with (vars, _) in
+        match stripTyAll tyAnnot with (vars, _) in
         let tyVarEnv =
           foldr (lam v: (Name, VarSort).
               mapInsert (nameGetStr v.0) (v.0, env.currentLvl))
@@ -156,7 +156,7 @@ lang LetSym = Sym + LetAst + AllTypeAst
                             with currentLvl = addi 1 env.currentLvl} t.body
       in
       if nameHasSym t.ident then
-        TmLet {{{{t with tyBody = tyBody}
+        TmLet {{{{t with tyAnnot = tyAnnot}
                     with body = body}
                     with inexpr = symbolizeExpr env t.inexpr}
                     with ty = ty}
@@ -166,7 +166,7 @@ lang LetSym = Sym + LetAst + AllTypeAst
         let varEnv = mapInsert str ident varEnv in
         let env = {env with varEnv = varEnv} in
         TmLet {{{{{t with ident = ident}
-                     with tyBody = tyBody}
+                     with tyAnnot = tyAnnot}
                      with body = body}
                      with inexpr = symbolizeExpr env t.inexpr}
                      with ty = ty}
@@ -261,8 +261,8 @@ lang RecLetsSym = Sym + RecLetsAst + AllTypeAst
     -- Symbolize all bodies with the new environment
     let bindings =
       map (lam bind : RecLetBinding.
-        let tyBody = symbolizeType env bind.tyBody in
-        match stripTyAll tyBody with (vars, _) in
+        let tyAnnot = symbolizeType env bind.tyAnnot in
+        match stripTyAll tyAnnot with (vars, _) in
         let tyVarEnv =
           foldr (lam v: (Name, VarSort).
               mapInsert (nameGetStr v.0) (v.0, env.currentLvl))
@@ -270,7 +270,7 @@ lang RecLetsSym = Sym + RecLetsAst + AllTypeAst
         {{bind with body = symbolizeExpr
                              {{env with tyVarEnv = tyVarEnv}
                                    with currentLvl = addi 1 env.currentLvl} bind.body}
-               with tyBody = tyBody})
+               with tyAnnot = tyAnnot})
         bindings in
 
     TmRecLets {{t with bindings = bindings}

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -274,9 +274,9 @@ lang LamTypeAnnot = TypeAnnot + LamAst + FunTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmLam t ->
     match env with {varEnv = varEnv} then
-      let env = {env with varEnv = mapInsert t.ident t.tyIdent varEnv} in
+      let env = {env with varEnv = mapInsert t.ident t.tyAnnot varEnv} in
       let body = typeAnnotExpr env t.body in
-      let ty = ityarrow_ t.info t.tyIdent (tyTm body) in
+      let ty = ityarrow_ t.info t.tyAnnot (tyTm body) in
       TmLam {{t with body = body}
                 with ty = ty}
     else never
@@ -291,22 +291,23 @@ lang LetTypeAnnot = TypeAnnot + TypePropagation + LetAst +  UnknownTypeAst + All
   sem typeAnnotExpr (env : TypeEnv) =
   | TmLet t ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
-      let body = match t.tyBody with TyUnknown _ then t.body else
-        match stripTyAll t.tyBody with (_, tyBody) in
-        propagateExpectedType tyEnv (tyBody, t.body) in
+      let body = match t.tyAnnot with TyUnknown _ then t.body else
+        match stripTyAll t.tyAnnot with (_, tyAnnot) in
+        propagateExpectedType tyEnv (tyAnnot, t.body) in
       let body = typeAnnotExpr env body in
-      match compatibleType tyEnv t.tyBody (tyTm body) with Some tyBody then
+      match compatibleType tyEnv t.tyAnnot (tyTm body) with Some tyBody then
         let env = {env with varEnv = mapInsert t.ident tyBody varEnv} in
         let inexpr = typeAnnotExpr env t.inexpr in
-        TmLet {{{{t with tyBody = tyBody}
-                    with body = withType tyBody body}
-                    with inexpr = inexpr}
-                    with ty = tyTm inexpr}
+        TmLet {t with tyAnnot = tyBody,
+                      tyBody = tyBody,
+                      body = withType tyBody body,
+                      inexpr = inexpr,
+                      ty = tyTm inexpr}
       else
         let msg = join [
           "Inconsistent type annotation of let-expression\n",
           "Expected type: ", _pprintType (tyTm body), "\n",
-          "Annotated type: ", _pprintType t.tyBody
+          "Annotated type: ", _pprintType t.tyAnnot
         ] in
         errorSingle [t.info] msg
     else never
@@ -325,14 +326,15 @@ end
 lang PropagateArrowLambda = TypePropagation + FunTypeAst + LamAst
   sem propagateExpectedType (tyEnv : Map Name Type) =
   | (TyArrow {from = from, to = to}, TmLam t) ->
-    match compatibleType tyEnv from t.tyIdent with Some ty then
-      TmLam {{t with tyIdent = ty}
-                with body = propagateExpectedType tyEnv (to, t.body)}
+    match compatibleType tyEnv from t.tyAnnot with Some ty then
+      TmLam {t with tyAnnot = ty,
+                    tyIdent = ty,
+                    body = propagateExpectedType tyEnv (to, t.body)}
     else
       let msg = join [
         "Inconsistent type annotation of let-expression and lambda\n",
         "Type from let: ", _pprintType from, "\n",
-        "Type from lambda: ", _pprintType t.tyIdent
+        "Type from lambda: ", _pprintType t.tyAnnot
       ] in
       errorSingle [t.info] msg
 end
@@ -355,31 +357,32 @@ lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsAst + LamAst + Unkn
     -- annotations of the bindings. This is to make annotations work for
     -- mutually recursive functions, given correct type annotations.
     let foldBindingInit = lam acc. lam binding : RecLetBinding.
-      mapInsert binding.ident binding.tyBody acc
+      mapInsert binding.ident binding.tyAnnot acc
     in
     -- Add mapping from binding identifier to the inferred type.
     let foldBindingAfter = lam acc. lam binding : RecLetBinding.
-      mapInsert binding.ident binding.tyBody acc
+      mapInsert binding.ident binding.tyAnnot acc
     in
     let annotBinding = lam env : TypeEnv. lam binding : RecLetBinding.
-      let body = match binding.tyBody with TyUnknown _ then binding.body else
-        match stripTyAll binding.tyBody with (_, tyBody) in
-        propagateExpectedType env.tyEnv (tyBody, binding.body) in
+      let body = match binding.tyAnnot with TyUnknown _ then binding.body else
+        match stripTyAll binding.tyAnnot with (_, tyAnnot) in
+        propagateExpectedType env.tyEnv (tyAnnot, binding.body) in
       let body = typeAnnotExpr env body in
       match env with {tyEnv = tyEnv} then
         let tyBody =
-          match compatibleType tyEnv binding.tyBody (tyTm body) with Some tyBody then
+          match compatibleType tyEnv binding.tyAnnot (tyTm body) with Some tyBody then
             tyBody
           else
             let msg = join [
               "Inconsistent type annotation of recursive let-expression\n",
               "Expected type: ", _pprintType (tyTm body), "\n",
-              "Annotated type: ", _pprintType binding.tyBody
+              "Annotated type: ", _pprintType binding.tyAnnot
             ] in
             errorSingle [t.info] msg
         in
-        {{binding with body = body}
-                  with tyBody = tyBody}
+        {binding with body = body,
+                      tyAnnot = tyBody,
+                      tyBody = tyBody}
       else never
     in
     match env with {varEnv = varEnv} then

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -144,15 +144,11 @@ lang TypeLift = TypeLiftBase + Cmp
   sem typeLiftExpr (env : TypeLiftEnv) =
   | t ->
     -- Lift all sub-expressions
-    match smapAccumL_Expr_Expr typeLiftExpr env t with (env, t) then
-      -- Lift the contained types
-      match smapAccumL_Expr_Type typeLiftType env t with (env, t) then
-        -- Lift the annotated type
-        match typeLiftType env (tyTm t) with (env, ty) then
-          (env, withType ty t)
-        else never
-      else never
-    else never
+    match smapAccumL_Expr_Expr typeLiftExpr env t with (env, t) in
+    -- Lift the contained types
+    match smapAccumL_Expr_Type typeLiftType env t with (env, t) in
+    -- Lift the annotated types
+    smapAccumL_Expr_TypeLabel typeLiftType env t
 
   sem typeLiftType (env : TypeLiftEnv) =
   | t -> smapAccumL_Type_Type typeLiftType env t

--- a/stdlib/mexpr/utesttrans.mc
+++ b/stdlib/mexpr/utesttrans.mc
@@ -825,7 +825,7 @@ lang MExprUtestTrans = MExprAst
       target = testsFailedCond,
       pat = PatBool {val = true, info = info, ty = TyBool {info = info}},
       thn = TmLet {
-        ident = nameSym "", tyBody = tyTm t, body = t,
+        ident = nameSym "", tyAnnot = tyTm t, tyBody = tyTm t, body = t,
         inexpr = TmApp {
           lhs = TmConst {
             val = CExit (), info = info,

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -151,6 +151,7 @@ lang OCamlDataConversionHelpers =
                   rhs =
                     TmLam {
                       ident = ident,
+                      tyAnnot = TyUnknown { info = info },
                       tyIdent = TyUnknown { info = info },
                       body = body,
                       ty = TyUnknown { info = info },

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -428,6 +428,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
     let inexpr = generate env inexpr in
     TmLet {
       ident = ident,
+      tyAnnot = tyIdent,
       tyBody = tyIdent,
       body = body,
       inexpr = inexpr,

--- a/stdlib/ocaml/wrap-in-try-with.mc
+++ b/stdlib/ocaml/wrap-in-try-with.mc
@@ -15,12 +15,12 @@ lang OCamlTryWithWrap = MExprAst + OCamlAst
     (acc.0, snoc acc.1 t)
   | OTopLet t ->
     let letExpr = TmLet {
-      ident = t.ident, tyBody = t.tyBody, body = t.body, inexpr = unit_,
-      ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
+      ident = t.ident, tyAnnot = t.tyBody, tyBody = t.tyBody, body = t.body,
+      inexpr = unit_, ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
     (bind_ acc.0 letExpr, acc.1)
   | OTopRecLets t ->
     let toRecLetBinding = lam bind : OCamlTopBinding.
-      { ident = bind.ident, tyBody = bind.tyBody
+      { ident = bind.ident, tyAnnot = bind.tyBody, tyBody = bind.tyBody
       ,  body = bind.body, info = NoInfo ()} in
     let recLetExpr = TmRecLets {
       bindings = map toRecLetBinding t.bindings, inexpr = unit_,

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -203,6 +203,7 @@ let _typeToString = use MExprPrettyPrint in lam ty. (getTypeStringCode 0 pprintE
 let _nulet_ = lam n. lam body. lam inexpr. use LetAst in TmLet
   { ident = n
   , body = body
+  , tyAnnot = tyunknown_
   , tyBody = tyunknown_
   , inexpr = inexpr
   , info = NoInfo ()

--- a/stdlib/parser/gen-op-ast.mc
+++ b/stdlib/parser/gen-op-ast.mc
@@ -66,7 +66,7 @@ let _mergeInfos_ : [Expr] -> Expr = lam exprs. switch exprs
 let _nletin_ : Name -> Type -> Expr -> Expr -> Expr
   = lam name. lam ty. lam val. lam body.
     use MExprAst in
-    TmLet {ident = name, tyBody = ty, body = val, inexpr = body, ty = tyunknown_, info = NoInfo ()}
+    TmLet {ident = name, tyAnnot = ty, tyBody = tyunknown_, body = val, inexpr = body, ty = tyunknown_, info = NoInfo ()}
 
 let _letin_ : String -> Type -> Expr -> Expr -> Expr
   = lam name. lam ty. lam val. lam body.

--- a/stdlib/pmexpr/demote.mc
+++ b/stdlib/pmexpr/demote.mc
@@ -55,10 +55,10 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
     let iid = nameSym "i" in
     let xid = nameSym "x" in
     let aExpr = TmLet {
-      ident = aid, tyBody = tyTm t.as, body = demoteParallel t.as,
+      ident = aid, tyAnnot = tyTm t.as, tyBody = tyTm t.as, body = demoteParallel t.as,
       inexpr = unit_, ty = tyresult, info = infoTm t.as} in
     let bExpr = TmLet {
-      ident = bid, tyBody = tyTm t.bs, body = demoteParallel t.bs,
+      ident = bid, tyAnnot = tyTm t.bs, tyBody = tyTm t.bs, body = demoteParallel t.bs,
       inexpr = unit_, ty = tyresult, info = infoTm t.bs} in
     let access = lam seqId. lam seqTy. lam elemTy.
       TmApp {
@@ -70,7 +70,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
                      frozen = false},
         ty = elemTy, info = t.info} in
     let tExpr = TmLet {
-      ident = tid, tyBody = tyseqtuple,
+      ident = tid, tyAnnot = tyseqtuple, tyBody = tyseqtuple,
       body = TmApp {
         lhs = TmApp {
           lhs = TmConst {val = CCreate (), ty = tyuk, info = t.info},
@@ -81,7 +81,8 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
             ty = TyInt {info = t.info}, info = t.info},
           ty = tyuk, info = t.info},
         rhs = TmLam {
-          ident = iid, tyIdent = TyInt {info = t.info},
+          ident = iid,
+          tyAnnot = TyInt {info = t.info}, tyIdent = TyInt {info = t.info},
           body = TmRecord {
             bindings = mapFromSeq cmpSID [
               (stringToSid "0", access aid (tyTm t.as) lty),
@@ -106,7 +107,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
       lhs = TmApp {
         lhs = TmConst {val = CMap (), ty = tyuk, info = t.info},
         rhs = TmLam {
-          ident = xid, tyIdent = tytuple,
+          ident = xid, tyAnnot = tytuple, tyIdent = tytuple,
           body = TmApp {
             lhs = TmApp {
               lhs = demoteParallel t.f,
@@ -142,7 +143,7 @@ lang PMExprDemoteLoop = PMExprAst
     let unitTy = TyRecord {fields = mapEmpty cmpSID, info = t.info} in
     let acc = TmRecord {bindings = mapEmpty cmpSID, ty = unitTy, info = t.info} in
     let f = TmLam {
-      ident = nameNoSym "", tyIdent = unitTy, body = t.f,
+      ident = nameNoSym "", tyAnnot = unitTy, tyIdent = unitTy, body = t.f,
       ty = TyArrow {from = unitTy, to = tyTm t.f, info = t.info},
       info = t.info} in
     let accLoop = TmLoopAcc {
@@ -189,6 +190,7 @@ lang PMExprDemoteLoop = PMExprAst
     let tVar = TmVar {ident = tIdent, ty = accTy, info = t.info, frozen = false} in
     let thnExpr = TmLet {
       ident = tIdent,
+      tyAnnot = accTy,
       tyBody = accTy,
       body = TmApp {
         lhs = TmApp {
@@ -202,11 +204,12 @@ lang PMExprDemoteLoop = PMExprAst
         ty = accTy, info = t.info},
       ty = accTy, info = t.info} in
     let loopBindingDef = {
-      ident = loopId, tyBody = loopTy, info = t.info,
+      ident = loopId, tyAnnot = loopTy, tyBody = loopTy, info = t.info,
       body = TmLam {
-        ident = accIdent, tyIdent = accTy,
+        ident = accIdent, tyAnnot = accTy, tyIdent = accTy,
         body = TmLam {
-          ident = iIdent, tyIdent = TyInt {info = t.info},
+          ident = iIdent,
+          tyAnnot = TyInt {info = t.info}, tyIdent = TyInt {info = t.info},
           body = TmMatch {
             target = loopCompareExpr,
             pat = PatBool {val = true, ty = TyBool {info = t.info}, info = t.info},

--- a/stdlib/pmexpr/extract.mc
+++ b/stdlib/pmexpr/extract.mc
@@ -118,9 +118,10 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
     let accelerateLet =
       TmLet {
         ident = accelerateIdent,
+        tyAnnot = funcType,
         tyBody = funcType,
         body = TmLam {
-          ident = paramId, tyIdent = paramTy, body = t.e,
+          ident = paramId, tyAnnot = paramTy, tyIdent = paramTy, body = t.e,
           ty = TyArrow {from = paramTy, to = retType, info = info},
           info = info},
         inexpr = TmApp {
@@ -196,6 +197,7 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
           with (tyBody, body) in
           TmLet {
             ident = bind.ident,
+            tyAnnot = tyBody,
             tyBody = tyBody,
             body = body,
             inexpr = acc,

--- a/stdlib/pmexpr/parallel-patterns.mc
+++ b/stdlib/pmexpr/parallel-patterns.mc
@@ -230,7 +230,7 @@ let mapPattern : () -> Pattern =
           lhs = TmApp {
             lhs = TmConst {val = CMap (), ty = mapTy, info = info},
             rhs = TmLam {
-              ident = x, tyIdent = tyTm headExpr, body = els,
+              ident = x, tyAnnot = tyTm headExpr, tyIdent = tyTm headExpr, body = els,
               ty = fType, info = infoTm els},
             ty = innerAppType, info = info},
           rhs = sExpr,
@@ -311,9 +311,9 @@ let map2Pattern : () -> Pattern =
         let els = eliminateUnusedLetExpressions (bind_ els fResultVar) in
         TmMap2 {
           f = TmLam {
-            ident = x, tyIdent = tyTm headFstExpr,
+            ident = x, tyAnnot = tyTm headFstExpr, tyIdent = tyTm headFstExpr,
             body = TmLam {
-              ident = y, tyIdent = tyTm headSndExpr, body = els,
+              ident = y, tyAnnot = tyTm headSndExpr, tyIdent = tyTm headSndExpr, body = els,
               ty = TyArrow {from = tyTm headSndExpr, to = tyTm els, info = info},
               info = infoTm els},
             ty = TyArrow {
@@ -422,9 +422,9 @@ let reducePattern : () -> Pattern =
       let elemTy = tyTm headExpr in
       let accTy = tyTm accExpr in
       let f = TmLam {
-        ident = x, tyIdent = accTy,
+        ident = x, tyAnnot = accTy, tyIdent = accTy,
         body = TmLam {
-          ident = y, tyIdent = elemTy, body = els,
+          ident = y, tyAnnot = elemTy, tyIdent = elemTy, body = els,
           ty = TyArrow {from = elemTy, to = accTy,
                         info = infoTm els},
           info = info},

--- a/stdlib/pmexpr/parallel-rewrite.mc
+++ b/stdlib/pmexpr/parallel-rewrite.mc
@@ -93,6 +93,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
                   -- types, which are known.
                   TmLam {
                     ident = name,
+                    tyAnnot = TyUnknown {info = info},
                     tyIdent = TyUnknown {info = info},
                     body = e,
                     ty = tyTm e,

--- a/stdlib/pmexpr/recursion-elimination.mc
+++ b/stdlib/pmexpr/recursion-elimination.mc
@@ -78,7 +78,7 @@ lang PMExprRecursionElimination = PMExprAst
   sem eliminateRecursion =
   | TmRecLets t ->
     let toLetBinding : Expr -> RecLetBinding -> Expr = lam inexpr. lam binding.
-      TmLet {ident = binding.ident, tyBody = binding.tyBody,
+      TmLet {ident = binding.ident, tyAnnot = binding.tyAnnot, tyBody = binding.tyBody,
              body = binding.body, inexpr = inexpr,
              ty = tyTm inexpr, info = binding.info}
     in

--- a/stdlib/pmexpr/tailrecursion.mc
+++ b/stdlib/pmexpr/tailrecursion.mc
@@ -229,6 +229,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
       let functionBody = replaceFunctionBody binding.body body in
       let bodyWithAcc = TmLam {
         ident = accIdent,
+        tyAnnot = accType,
         tyIdent = accType,
         body = functionBody,
         ty = TyArrow {from = accType, to = binding.tyBody, info = binding.info},

--- a/stdlib/pmexpr/utest-size-constraint.mc
+++ b/stdlib/pmexpr/utest-size-constraint.mc
@@ -31,7 +31,7 @@ lang PMExprUtestSizeConstraint = PMExprAst
           let inexpr = replaceUtestsWithSizeConstraintH params t.next in
           let eq = TmParallelSizeEquality {x1 = x1, d1 = d1, x2 = x2, d2 = d2,
                                            ty = ty, info = t.info} in
-          Some (TmLet {ident = nameNoSym "", tyBody = ty, body = eq,
+          Some (TmLet {ident = nameNoSym "", tyAnnot = ty, tyBody = ty, body = eq,
                        inexpr = inexpr, ty = t.ty, info = t.info})
         else None ()
       else None () in
@@ -40,7 +40,7 @@ lang PMExprUtestSizeConstraint = PMExprAst
       let coercion =
         TmParallelSizeCoercion {e = s, size = sizeId,
                                 ty = tyTm s, info = infoTm s} in
-      TmLet {ident = id, tyBody = tyTm s, body = coercion,
+      TmLet {ident = id, tyAnnot = tyTm s, tyBody = tyTm s, body = coercion,
              inexpr = inexpr, ty = t.ty, info = t.info} in
     let result =
       match t.tusing with None _ | Some (TmConst {val = CEqi _}) then


### PR DESCRIPTION
When type checking a let binding `let x : T = t in ...`, the type checker currently overwrites the programmer-given annotation `T` with whatever type it infers for the body `t` (after ensuring the two match).

This is not exactly a problem in practice, but it means we cannot reproduce the original annotations after typechecking. Separating the programmer's annotations from the compiler's inferred types seems more principled conceptually.

This PR adds a new `tyAnnot` field to lets and lambdas to hold the programmer annotation, while the `tyBody`/`tyIdent` fields hold the type checker's inferred types. There are also some other minor changes, like adding a function `smapAccumL_Expr_TypeLabel` to map over the inferred type fields, and making the `--debug-type-check` flag emit HTML when running `mi eval` (previously it only did for `mi compile`).

The PR contains the changes of #644.