### PR TITLE
Isolate `TyFlex` to `type-check.mc`

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -112,23 +112,6 @@ let tyalls_ =
   lam strs. lam ty.
   foldr tyall_ ty strs
 
-let tyFlexUnbound = use FlexTypeAst in
-  lam info. lam ident. lam level. lam sort. lam isWeak.
-  TyFlex {info = info,
-          contents = ref (Unbound {ident = ident,
-                                   level = level,
-                                   sort = sort,
-                                   isWeak = isWeak})}
-
-let tyflexunbound_ = use FlexTypeAst in
-  lam s.
-  tyFlexUnbound (NoInfo ()) (nameNoSym s) 0 (PolyVar ()) true
-
-let tyflexlink_ = use FlexTypeAst in
-  lam ty.
-  TyFlex {info = NoInfo (),
-          contents = ref (Link ty)}
-
 -- Tensor OP types
 let tytensorcreateuninitint_ =
   tyarrow_ (tyseq_ tyint_) (tytensor_ tyint_)

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1441,51 +1441,6 @@ lang VarSortAst
     match smapAccumL_VarSort_Type (lam a. lam x. (f a x, x)) acc s with (a, _) in a
 end
 
-type FlexVarRec = {ident  : Name,
-                   level  : Level,
-                   sort   : VarSort,
-                   isWeak : Bool}
-
-lang FlexTypeAst = VarSortAst + Ast
-  syn FlexVar =
-  | Unbound FlexVarRec
-  | Link Type
-
-  syn Type =
-  -- Flexible type variable
-  | TyFlex {info     : Info,
-            contents : Ref FlexVar}
-
-  -- Recursively follow links, producing something guaranteed not to be a link.
-  sem resolveLink =
-  | TyFlex t & ty ->
-    match deref t.contents with Link ty then
-      resolveLink ty
-    else
-      ty
-  | ty ->
-    ty
-
-  sem tyWithInfo (info : Info) =
-  | TyFlex t & ty ->
-    match deref t.contents with Unbound _ then
-      TyFlex {t with info = info}
-    else
-      tyWithInfo info (resolveLink ty)
-
-  sem infoTy =
-  | TyFlex {info = info} -> info
-
-  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
-  | TyFlex t & ty ->
-    match deref t.contents with Unbound r then
-      match smapAccumL_VarSort_Type f acc r.sort with (acc, sort) in
-      modref t.contents (Unbound {r with sort = sort});
-      (acc, ty)
-    else
-      smapAccumL_Type_Type f acc (resolveLink ty)
-end
-
 lang AllTypeAst = VarSortAst + Ast
   syn Type =
   | TyAll {info  : Info,
@@ -1560,5 +1515,5 @@ lang MExprAst =
   -- Types
   UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
   FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + ConTypeAst +
-  VarTypeAst + FlexTypeAst + AppTypeAst + TensorTypeAst + AllTypeAst
+  VarTypeAst + AppTypeAst + TensorTypeAst + AllTypeAst
 end

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -413,22 +413,6 @@ lang VarSortCmp = Cmp + VarSortAst
     subi (constructorTag lhs) (constructorTag rhs)
 end
 
-lang FlexTypeCmp = VarSortCmp + FlexTypeAst
-  sem cmpTypeH =
-  | (TyFlex _ & lhs, rhs)
-  | (lhs, TyFlex _ & rhs) ->
-    match (resolveLink lhs, resolveLink rhs) with (lhs, rhs) in
-    match (lhs, rhs) with (TyFlex t1, TyFlex t2) then
-      match (deref t1.contents, deref t2.contents) with (Unbound n1, Unbound n2) in
-      let identDiff = nameCmp n1.ident n2.ident in
-      if eqi identDiff 0 then
-        cmpVarSort (n1.sort, n2.sort)
-      else
-        identDiff
-    else match (lhs, rhs) with (! TyFlex _, ! TyFlex _) then cmpType lhs rhs
-    else subi (constructorTag lhs) (constructorTag rhs)
-end
-
 lang AllTypeCmp = VarSortCmp + AllTypeAst
   sem cmpTypeH =
   | (TyAll t1, TyAll t2) ->
@@ -469,7 +453,7 @@ lang MExprCmp =
   -- Types
   UnknownTypeCmp + BoolTypeCmp + IntTypeCmp + FloatTypeCmp + CharTypeCmp +
   FunTypeCmp + SeqTypeCmp + TensorTypeCmp + RecordTypeCmp + VariantTypeCmp +
-  ConTypeCmp + VarTypeCmp + FlexTypeCmp + AppTypeCmp + AllTypeCmp
+  ConTypeCmp + VarTypeCmp + AppTypeCmp + AllTypeCmp
 end
 
 -----------
@@ -855,10 +839,5 @@ utest cmpType (tyvar_ "a") (tyvar_ "b") with 0 using neqi in
 utest cmpType (tyall_ "a" tybool_) (tyall_ "a" tybool_) with 0 in
 utest cmpType (tyall_ "a" tybool_) (tyall_ "a" tyfloat_) with 0 using neqi in
 utest cmpType (tyall_ "a" tybool_) (tyall_ "b" tybool_) with 0 using neqi in
-
-utest cmpType (tyflexunbound_ "a") (tyflexunbound_ "a") with 0 in
-utest cmpType (tyflexunbound_ "a") (tyflexunbound_ "b") with 0 using neqi in
-utest cmpType (tyflexlink_ (tyvar_ "a")) (tyvar_ "a") with 0 in
-utest cmpType (tyflexlink_ (tyvar_ "a")) (tyvar_ "b") with 0 using neqi in
 
 ()

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1126,18 +1126,6 @@ lang VarSortPrettyPrint = RecordTypePrettyPrint + VarSortAst
   | _ -> (env, idstr)
 end
 
-lang FlexTypePrettyPrint = IdentifierPrettyPrint + VarSortPrettyPrint + FlexTypeAst
-  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
-  | TyFlex t & ty ->
-    match deref t.contents with Unbound t then
-      match pprintVarName env t.ident with (env, idstr) in
-      match getVarSortStringCode indent env idstr t.sort with (env, str) in
-      let weakPrefix = if t.isWeak then "_" else "" in
-      (env, concat weakPrefix str)
-    else
-      getTypeStringCode indent env (resolveLink ty)
-end
-
 lang AllTypePrettyPrint = IdentifierPrettyPrint + AllTypeAst + VarSortPrettyPrint
   sem typePrecedence =
   | TyAll _ -> 0
@@ -1199,7 +1187,7 @@ lang MExprPrettyPrint =
   UnknownTypePrettyPrint + BoolTypePrettyPrint + IntTypePrettyPrint +
   FloatTypePrettyPrint + CharTypePrettyPrint + FunTypePrettyPrint +
   SeqTypePrettyPrint + RecordTypePrettyPrint + VariantTypePrettyPrint +
-  ConTypePrettyPrint + VarTypePrettyPrint + FlexTypePrettyPrint +
+  ConTypePrettyPrint + VarTypePrettyPrint +
   AppTypePrettyPrint + TensorTypePrettyPrint + AllTypePrettyPrint
 
   -- Identifiers

--- a/stdlib/mexpr/shallow-patterns.mc
+++ b/stdlib/mexpr/shallow-patterns.mc
@@ -491,7 +491,7 @@ lang ShallowBool = ShallowBase + BoolPat
   | (SPatBool false, SPatBool false) -> 0
 end
 
-lang ShallowRecord = ShallowBase + RecordPat + RecordTypeAst + FlexTypeAst + PrettyPrint
+lang ShallowRecord = ShallowBase + RecordPat + RecordTypeAst + PrettyPrint
   syn SPat =
   | SPatRecord { bindings : Map SID Name, ty : Type }
 
@@ -505,8 +505,8 @@ lang ShallowRecord = ShallowBase + RecordPat + RecordTypeAst + FlexTypeAst + Pre
 
   sem collectShallows =
   | PatRecord px ->
-    -- TODO(vipa, 2022-05-26): This needs to resolve links and aliases :(
-    match resolveLink px.ty with TyRecord x then
+    -- TODO(vipa, 2022-05-26): This needs to resolve aliases :(
+    match px.ty with TyRecord x then
       _ssingleton (SPatRecord { bindings = mapMap (lam. nameSym "field") x.fields, ty = px.ty })
     else errorSingle [px.info]
       (join ["I can't immediately see the record type of this pattern, it's a ", type2str px.ty])

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -111,15 +111,6 @@ lang VarCompatibleType = CompatibleType + VarTypeAst + UnknownTypeAst
   | TyVar {info = i} -> TyUnknown {info = i}
 end
 
-lang FlexCompatibleType = CompatibleType + FlexTypeAst + UnknownTypeAst
-  sem reduceTyVar =
-  | TyFlex {info = i} & ty ->
-    match resolveLink ty with ! TyFlex _ & ty then
-      reduceTyVar ty
-    else
-      TyUnknown {info = i}
-end
-
 lang AllCompatibleType = CompatibleType + AllTypeAst
   sem reduceType (tyEnv : Map Name Type) =
   | TyAll t -> Some t.ty
@@ -708,7 +699,7 @@ lang MExprTypeAnnot =
   FunCompatibleType + SeqCompatibleType + TensorCompatibleType +
   RecordCompatibleType + VariantCompatibleType + AppCompatibleType +
   PropagateArrowLambda + PropagateLetType + VarCompatibleType +
-  FlexCompatibleType + AllCompatibleType +
+  AllCompatibleType +
 
   -- Terms
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -742,8 +742,7 @@ lang FlexDisableGeneralize = FlexTypeAst
       sfold_VarSort_Type (lam. lam ty. disableGeneralize ty) () r.sort
     else
       disableGeneralize (resolveLink ty)
-  | ty ->
-    sfold_Type_Type (lam. lam ty. disableGeneralize ty) () ty
+  | ty -> ()
 end
 
 lang RecordTypeCheck = TypeCheck + RecordAst + RecordTypeAst + FlexDisableGeneralize

--- a/stdlib/pmexpr/utils.mc
+++ b/stdlib/pmexpr/utils.mc
@@ -78,7 +78,7 @@ let typeCheckEnv = lam env : [(Name, Type)]. lam expr.
         match x with (id, ty) in
         _insertVar id ty env)
       _tcEnvEmpty env in
-  resolveLinksExpr (typeCheckExpr tcEnv expr)
+  removeFlexExpr (typeCheckExpr tcEnv expr)
 in
 
 let t = typeCheck (symbolize (lam_ "x" tyint_ (char_ 'c'))) in


### PR DESCRIPTION
This PR moves all definitions relating to `TyFlex` into `type-check.mc`, and furthermore makes `typeCheck` replace any lingering occurrences of `TyFlex` in the result with `TyUnknown`. This isolates the unification variables to the type checker so that surrounding code doesn't need to worry about them at all.

We may want to consider (at least in some cases) raising an error on a lingering `TyFlex`, as this means the program's type is ambiguous.

The PR also fixes a bug making `disableGeneralize` slightly too strict.

This PR contains #646.