### PR TITLE
Give TyFlex created by inst a better info field

### DIFF
--- a/stdlib/ocaml/compile.mc
+++ b/stdlib/ocaml/compile.mc
@@ -73,7 +73,7 @@ let ocamlCompileWithConfig : CompileOptions -> String -> CompileResult =
     run =
       lam stdin. lam args.
         let command =
-          concat ["dune", "exec", "./program.exe", "--"] args
+          concat ["dune", "exec", "--no-build", "./program.exe", "--"] args
         in
         sysRunCommand command stdin (tempfile ""),
     cleanup = lam. sysTempDirDelete td (); (),


### PR DESCRIPTION
I was getting surprising info fields when looking at some `TyFlex`es, so I figured I'd change it so that the info field is populated from the expression that causes the instantiation to happen (which is what creates the `TyFlex`es in the first place).

I imagine there might be conflicts with Anders' recent PRs, I'll look at that once they're merged.

I'm also experimenting with a new frontend for Git essentially, as might be visible from the autogenerated stuff below.

---

Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/elegios/miking/pull/648).
* __->__ #648
* #653

Give TyFlex created by inst a better info field

