### PR TITLE
Update transformations to handle `tyAnnot` correctly

### DIFF
--- a/stdlib/mexpr/duplicate-code-elimination.mc
+++ b/stdlib/mexpr/duplicate-code-elimination.mc
@@ -97,12 +97,13 @@ lang MExprEliminateDuplicateCode = MExprAst
     lookupDefinition
       env replaced t.ident t.info t.inexpr
       (lam env.
+        match eliminateDuplicateCodeType env replaced t.tyAnnot with (replaced, tyAnnot) in
         match eliminateDuplicateCodeType env replaced t.tyBody with (replaced, tyBody) in
         match eliminateDuplicateCodeExpr env replaced t.body with (replaced, body) in
         match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
         match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
         ( replaced
-        , TmLet {t with body = body, tyBody = tyBody, inexpr = inexpr, ty = ty} ))
+        , TmLet {t with body = body, tyAnnot = tyAnnot, tyBody = tyBody, inexpr = inexpr, ty = ty} ))
   | TmType t ->
     lookupDefinition
       env replaced t.ident t.info t.inexpr
@@ -143,9 +144,10 @@ lang MExprEliminateDuplicateCode = MExprAst
         ((replaced, env), Some binding)
     in
     let eliminateDuplicateBody = lam env. lam replaced. lam binding.
+      match eliminateDuplicateCodeType env replaced binding.tyAnnot with (replaced, tyAnnot) in
       match eliminateDuplicateCodeType env replaced binding.tyBody with (replaced, tyBody) in
       match eliminateDuplicateCodeExpr env replaced binding.body with (replaced, body) in
-      (replaced, {binding with body = body, tyBody = tyBody})
+      (replaced, {binding with body = body, tyAnnot = tyAnnot, tyBody = tyBody})
     in
     match mapAccumL eliminateDuplicateBinding (replaced, env) (reverse t.bindings)
     with ((replaced, env), optBindings) in
@@ -158,6 +160,7 @@ lang MExprEliminateDuplicateCode = MExprAst
   | t ->
     match smapAccumL_Expr_Expr (eliminateDuplicateCodeExpr env) replaced t with (replaced, t) in
     match smapAccumL_Expr_Type (eliminateDuplicateCodeType env) replaced t with (replaced, t) in
+    match smapAccumL_Expr_TypeLabel (eliminateDuplicateCodeType env) replaced t with (replaced, t) in
     match smapAccumL_Expr_Pat (eliminateDuplicateCodePat env) replaced t with (replaced, t) in
     match eliminateDuplicateCodeType env replaced (tyTm t) with (replaced, tmTy) in
     (replaced, withType tmTy t)

--- a/stdlib/mexpr/utils.mc
+++ b/stdlib/mexpr/utils.mc
@@ -26,12 +26,14 @@ lang MExprSubstitute = MExprAst
                      ty = substituteIdentifiersType replacements t.ty}
   | TmLet t ->
     TmLet {t with ident = subIdent replacements t.ident,
+                  tyAnnot = substituteIdentifiersType replacements t.tyAnnot,
                   tyBody = substituteIdentifiersType replacements t.tyBody,
                   body = substituteIdentifiersExpr replacements t.body,
                   inexpr = substituteIdentifiersExpr replacements t.inexpr,
                   ty = substituteIdentifiersType replacements t.ty}
   | TmLam t ->
     TmLam {t with ident = subIdent replacements t.ident,
+                  tyAnnot = substituteIdentifiersType replacements t.tyAnnot,
                   tyIdent = substituteIdentifiersType replacements t.tyIdent,
                   body = substituteIdentifiersExpr replacements t.body,
                   ty = substituteIdentifiersType replacements t.ty}
@@ -54,6 +56,7 @@ lang MExprSubstitute = MExprAst
     let subBinding = lam bind.
       {bind with ident = subIdent replacements bind.ident,
                  body = substituteIdentifiersExpr replacements bind.body,
+                 tyAnnot = substituteIdentifiersType replacements bind.tyAnnot,
                  tyBody = substituteIdentifiersType replacements bind.tyBody}
     in
     TmRecLets {t with bindings = map subBinding t.bindings,
@@ -62,6 +65,7 @@ lang MExprSubstitute = MExprAst
   | ast ->
     let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
     let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
     withType (substituteIdentifiersType replacements (tyTm ast)) ast
 


### PR DESCRIPTION
This PR fixes two problems that arose in Miking DPPL after merging #646.

The first problem was due to a workaround in the lambda lifting. As it does not handle captured type variables correctly, bindings with unbound variables had their type set to `TyUnknown`. However, now that we added a `tyAnnot` field, this does not work, as the type-checker will look at the annotated type instead, which could be wrong after capturing free variables. To fix this, the `tyAnnot` field is cleared for any bindings where we capture free variables.

The second problem was that transformations involving identifiers (duplicate code elimination, symbolization, and identifier substitution) were not applied to all type fields. In the case of symbolize, we did not apply it to `tyIdent`. This is fine in the main compiler because we always symbolize before type-checking (so `tyIdent` is always `TyUnknown`), but in Miking DPPL, we run the type-checking multiple times, so this does not hold. Regardless, we want identifiers to be updated in both annotated and inferred types, and this is what was added here.

This PR should be merged **simultaneously** with https://github.com/miking-lang/miking-dppl/pull/120.