### PR TITLE
Add micro benchmarks for `map` and `foldl` implemented in MCore

### DIFF
--- a/test/microbenchmark/benchmarkcommon.mc
+++ b/test/microbenchmark/benchmarkcommon.mc
@@ -2,12 +2,12 @@
 include "string.mc"
 
 recursive
-  let work = lam f. lam n.
+  let bc_work : all a. (() -> a) -> Int -> () = lam f. lam n.
     if eqi n 0 then
       ()
     else
       f();
-      work f (subi n 1)
+      bc_work f (subi n 1)
 end
 
-let repeat = lam f. work f (string2int (get argv 1))
+let bc_repeat = lam f. bc_work f (string2int (get argv 1))

--- a/test/microbenchmark/factorial.mc
+++ b/test/microbenchmark/factorial.mc
@@ -10,4 +10,4 @@ let fact = lam n.
     else muli n (fact (subi n 1))
 in
 
-repeat (lam. fact 100)
+bc_repeat (lam. fact 100)

--- a/test/microbenchmark/fold_list.mc
+++ b/test/microbenchmark/fold_list.mc
@@ -12,4 +12,4 @@ in
 
 -- printLn (int2string (foldf n));
 
-repeat (lam. foldf n)
+bc_repeat (lam. foldf n)

--- a/test/microbenchmark/fold_native_list.mc
+++ b/test/microbenchmark/fold_native_list.mc
@@ -1,0 +1,23 @@
+
+include "benchmarkcommon.mc"
+include "string.mc"
+include "common.mc"
+include "fold.ml"
+
+mexpr
+
+let foldl = lam f. lam acc. lam s.
+  recursive let rec = lam acc. lam s.
+    match s with [] then acc
+    else match s with [a] ++ ss then rec (f acc a) ss
+    else never
+  in rec acc s
+in
+
+let foldf = lam n.
+  foldl addi 0 (createList n (lam i. i))
+in
+
+-- printLn (int2string (foldf n));
+
+bc_repeat (lam. foldf n)

--- a/test/microbenchmark/fold_native_rope.mc
+++ b/test/microbenchmark/fold_native_rope.mc
@@ -1,0 +1,23 @@
+
+include "benchmarkcommon.mc"
+include "string.mc"
+include "common.mc"
+include "fold.ml"
+
+mexpr
+
+let foldl = lam f. lam acc. lam s.
+  recursive let rec = lam acc. lam s.
+    match s with [] then acc
+    else match s with [a] ++ ss then rec (f acc a) ss
+    else never
+  in rec acc s
+in
+
+let foldf = lam n.
+  foldl addi 0 (createRope n (lam i. i))
+in
+
+-- printLn (int2string (foldf n));
+
+bc_repeat (lam. foldf n)

--- a/test/microbenchmark/fold_rope.mc
+++ b/test/microbenchmark/fold_rope.mc
@@ -12,4 +12,4 @@ in
 
 -- printLn (int2string (foldf n));
 
-repeat (lam. foldf n)
+bc_repeat (lam. foldf n)

--- a/test/microbenchmark/iter_list.mc
+++ b/test/microbenchmark/iter_list.mc
@@ -8,4 +8,4 @@ let iterf = lam n.
   iter (lam. ()) (createList n (lam i. i))
 in
 
-repeat (lam. iterf n)
+bc_repeat (lam. iterf n)

--- a/test/microbenchmark/iter_rope.mc
+++ b/test/microbenchmark/iter_rope.mc
@@ -8,4 +8,4 @@ let iterf = lam n.
   iter (lam. ()) (createRope n (lam i. i))
 in
 
-repeat (lam. iterf n)
+bc_repeat (lam. iterf n)

--- a/test/microbenchmark/mapReverse_list.mc
+++ b/test/microbenchmark/mapReverse_list.mc
@@ -12,4 +12,4 @@ in
 
 -- iter (lam x. print (int2string x)) (mapf n);
 
-repeat (lam. mapf n)
+bc_repeat (lam. mapf n)

--- a/test/microbenchmark/map_list.mc
+++ b/test/microbenchmark/map_list.mc
@@ -6,14 +6,10 @@ include "map_n.ml"
 
 mexpr
 
-let workload = 30 in
-recursive let fibonacci = lam n.
-  if lti n 3 then 1
-  else addi (fibonacci (subi n 1)) (fibonacci (subi n 2))
-in
-
 let mapf = lam n.
-  map (lam. fibonacci workload) (createList n (lam i. i))
+  map (addi 1) (createList n (lam i. i))
 in
 
-repeat (lam. mapf n)
+-- iter (lam x. print (int2string x)) (mapf n);
+
+bc_repeat (lam. mapf n)

--- a/test/microbenchmark/map_native_list.mc
+++ b/test/microbenchmark/map_native_list.mc
@@ -1,0 +1,24 @@
+
+include "benchmarkcommon.mc"
+include "string.mc"
+include "common.mc"
+include "map_n.ml"
+
+mexpr
+
+let map = lam f. lam s.
+  recursive let rec = lam s.
+    match s with [] then []
+    else match s with [a] then [f a]
+    else match s with [a] ++ ss then cons (f a) (rec ss)
+    else never
+  in rec s
+in
+
+let mapf = lam n.
+  map (addi 1) (createList n (lam i. i))
+in
+
+-- iter (lam x. print (int2string x)) (mapf n);
+
+bc_repeat (lam. mapf n)

--- a/test/microbenchmark/map_native_rope.mc
+++ b/test/microbenchmark/map_native_rope.mc
@@ -1,0 +1,24 @@
+
+include "benchmarkcommon.mc"
+include "string.mc"
+include "common.mc"
+include "map_n.ml"
+
+mexpr
+
+let map = lam f. lam s.
+  recursive let rec = lam s.
+    match s with [] then []
+    else match s with [a] then [f a]
+    else match s with [a] ++ ss then cons (f a) (rec ss)
+    else never
+  in rec s
+in
+
+let mapf = lam n.
+  map (addi 1) (createRope n (lam i. i))
+in
+
+-- iter (lam x. print (int2string x)) (mapf n);
+
+bc_repeat (lam. mapf n)

--- a/test/microbenchmark/map_rope.mc
+++ b/test/microbenchmark/map_rope.mc
@@ -12,4 +12,4 @@ in
 
 -- iter (lam x. print (int2string x)) (mapf n);
 
-repeat (lam. mapf n)
+bc_repeat (lam. mapf n)

--- a/test/microbenchmark/pmap_list.mc
+++ b/test/microbenchmark/pmap_list.mc
@@ -22,7 +22,7 @@ let mapf = lam n.
   res
 in
 
-let res = repeat (lam. mapf n) in
+let res = bc_repeat (lam. mapf n) in
 
 threadPoolTearDown pool;
 

--- a/test/microbenchmark/pmap_list_sequential.mc
+++ b/test/microbenchmark/pmap_list_sequential.mc
@@ -22,7 +22,7 @@ let mapf = lam n.
   res
 in
 
-let res = repeat (lam. mapf n) in
+let res = bc_repeat (lam. mapf n) in
 
 threadPoolTearDown pool;
 

--- a/test/microbenchmark/pmap_rope.mc
+++ b/test/microbenchmark/pmap_rope.mc
@@ -22,7 +22,7 @@ let mapf = lam n.
   res
 in
 
-let res = repeat (lam. mapf n) in
+let res = bc_repeat (lam. mapf n) in
 
 threadPoolTearDown pool;
 

--- a/test/microbenchmark/pmap_rope_sequential.mc
+++ b/test/microbenchmark/pmap_rope_sequential.mc
@@ -22,7 +22,7 @@ let mapf = lam n.
   res
 in
 
-let res = repeat (lam. mapf n) in
+let res = bc_repeat (lam. mapf n) in
 
 threadPoolTearDown pool;
 

--- a/test/microbenchmark/rand_sample_gauss.mc
+++ b/test/microbenchmark/rand_sample_gauss.mc
@@ -36,5 +36,5 @@ let randFloatGaussBoxMuller: () -> Float = lam.
   get (randFloatGaussBoxMullerMany 1) 0
 
 mexpr
-repeat (lam. randFloatGaussBoxMullerMany n)
+bc_repeat (lam. randFloatGaussBoxMullerMany n)
 

--- a/test/microbenchmark/run.ml
+++ b/test/microbenchmark/run.ml
@@ -41,6 +41,11 @@ let generate_dune name =
     \         (modes byte exe))" name ;
   close_out oc
 
+let generate_dune_project () =
+  let oc = open_out "dune-project" in
+  Printf.fprintf oc "(lang dune 2.0)" ;
+  close_out oc
+
 let main =
   let len = Array.length Sys.argv in
   let name, iterations =
@@ -61,6 +66,7 @@ let main =
       ("rm -f " ^ name) ;
     if Sys.file_exists (name ^ ".ml") then (
       generate_dune name ;
+      generate_dune_project () ;
       measure excludes 4 "Ocaml byte code    "
         ("dune build --root ." ^ " " ^ name ^ ".bc")
         ("ocamlrun _build/default/" ^ name ^ ".bc" ^ " " ^ iterations)

--- a/test/microbenchmark/split_list.mc
+++ b/test/microbenchmark/split_list.mc
@@ -12,4 +12,4 @@ recursive let sum = lam acc. lam s.
 in
 
 let s = createList 1000 (lam i. i) in
-repeat (lam. sum 0 s)
+bc_repeat (lam. sum 0 s)

--- a/test/microbenchmark/split_rope.mc
+++ b/test/microbenchmark/split_rope.mc
@@ -12,4 +12,4 @@ recursive let sum = lam acc. lam s.
 in
 
 let s = create 1000 (lam i. i) in
-repeat (lam. sum 0 s)
+bc_repeat (lam. sum 0 s)

--- a/test/microbenchmark/tree.mc
+++ b/test/microbenchmark/tree.mc
@@ -20,4 +20,4 @@ in
 
 let tree = Node(Node(Leaf(3),Node(Leaf(2),Leaf(6))),Leaf(12)) in
 
-repeat (lam. count tree)
+bc_repeat (lam. count tree)


### PR DESCRIPTION
* Adds micro benchmarks for `map` and `foldl` implemented in pure MCore, that is, without using intrinsic functions. See results below.
* Prefixes functions in `benchmarkcommon.mc` with `bc_` to avoid collisions with stdlib functions.
* Generate a temporary `dune-project` file to avoid getting warnings about that.
* Streamlines the list map micro benchmark to be similar to the others (it was using a heavier workload than the others).

The following are some quick results over 100 runs, showing a significant slowdown of the native versions. The size of the sequences is 10^5. 

Update: something seems to be off with complexities; the below statement is not valid.
~According to some quick tests I did, the complexities of the native versions are correct (that is, they seem to scale linearly).~

## Ropes
About 3x slowdown for `foldl`
```
$ ./run fold_native_rope 100 124
3. Miking compiler:      3.387486s  0.338615s
-------------------------------------------------------------------------------------------------------------------
$ ./run fold_rope 100 124
3. Miking compiler:      0.199286s  0.103352s
5. OCaml native:         4.938560s  0.113232s
```
and about 33x slowdown for `map`
```
$ ./run map_native_rope 100 124
3. Miking compiler:      4.963697s  4.881615s
-------------------------------------------------------------------------------------------------------------------
$ ./run map_rope 100 124
3. Miking compiler:      0.246004s  0.150056s
5. OCaml native:         0.256971s  0.150433s
```

## Lists
About 1.5x slowdown for `foldl`
```
$ ./run fold_native_list 100 124
3. Miking compiler:      0.867523s  0.759224s
-------------------------------------------------------------------------------------------------------------------
$ ./run fold_list 100 124
3. Miking compiler:      0.660040s  0.489972s
5. OCaml native:         0.620571s  0.459079s
```
and about 7x slowdown for `map`
```
$ ./run map_native_list 100 124
3. Miking compiler:      8.291943s  5.220912s
-------------------------------------------------------------------------------------------------------------------
$ ./run map_list 100 124
3. Miking compiler:      0.840659s  0.740034s
5. OCaml native:         0.817393s  0.709123s
```