### PR TITLE
Bugfix: reverse the parameter list to externals in ANF

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -285,7 +285,7 @@ lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst
             (from, to)
           else (TyUnknown {info = t.info}, tyIdent)
         with (argTy, innerTy) in
-        vars (cons (arg, argTy) acc, innerTy) (subi arity 1)
+        vars (snoc acc (arg, argTy), innerTy) (subi arity 1)
     in
     let varNameTypes : [(Name, Type)] = vars ([], t.tyIdent) arity in
 
@@ -567,13 +567,13 @@ utest _test lamseq with _parse "
 
 -- Externals
 let ext = _parse "
-  external e: Int -> Int -> Int in
+  external e: Int -> Float -> Int in
   e 1 2
 " in
 -- printLn (mexprToString (_test ext));
 utest _test ext with _parse "
-external e : Int -> Int -> Int in
-let e: Int -> Int -> Int = lam a1.  lam a2.  e a1 a2 in
+external e : Int -> Float -> Int in
+let e: Int -> Float -> Int = lam a1.  lam a2.  e a1 a2 in
 let t = 1 in
 let t1 = e t in
 let t2 = 2 in

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -568,7 +568,7 @@ utest _test lamseq with _parse "
 -- Externals
 let ext = _parse "
   external e: Int -> Float -> Int in
-  e 1 2
+  e 1 2.
 " in
 -- printLn (mexprToString (_test ext));
 utest _test ext with _parse "
@@ -576,7 +576,7 @@ external e : Int -> Float -> Int in
 let e: Int -> Float -> Int = lam a1.  lam a2.  e a1 a2 in
 let t = 1 in
 let t1 = e t in
-let t2 = 2 in
+let t2 = 2. in
 let t3 = t1 t2 in
 t3
 " using eqExpr in


### PR DESCRIPTION
Running ANF on an external function caused the parameter list to be reversed. This PR fixes that.