### PR TITLE
Fix TyFlex pretty printing bug

### DIFF
--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1117,7 +1117,7 @@ lang VarTypePrettyPrint = IdentifierPrettyPrint + VarTypeAst
     pprintVarName env t.ident
 end
 
-lang VarSortPrettyPrint = RecordTypePrettyPrint + VarSortAst
+lang VarSortPrettyPrint = PrettyPrint + RecordTypeAst + VarSortAst
   sem getVarSortStringCode (indent : Int) (env : PprintEnv) (idstr : String) =
   | RecordVar r ->
     let recty = TyRecord {info = NoInfo (), fields = r.fields} in

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -942,8 +942,10 @@ lang MExprTypeCheck =
   -- Patterns
   NamedPatTypeCheck + SeqTotPatTypeCheck + SeqEdgePatTypeCheck +
   RecordPatTypeCheck + DataPatTypeCheck + IntPatTypeCheck + CharPatTypeCheck +
-  BoolPatTypeCheck + AndPatTypeCheck + OrPatTypeCheck + NotPatTypeCheck
+  BoolPatTypeCheck + AndPatTypeCheck + OrPatTypeCheck + NotPatTypeCheck +
 
+  -- Pretty Printing
+  FlexTypePrettyPrint
 end
 
 -- NOTE(vipa, 2022-10-07): This can't use AnnotateMExprBase because it


### PR DESCRIPTION
Previously the type-checker crashed when it encountered a `TyFlex` when constructing a type-error message string. This happened because there was no rule for pretty printing a `TyFlex` in the compiler. On the other hand it was impossible to include the `FlexTypePrettyPrint` language fragment due to pattern a overlap in `ocaml/pprint.mc`.

This PR changes `VarSortPrettyPrint` so that it only includes `RecordTypeAst` instead of the `RecordTypePrettyPrint`, which removes the above mentioned pattern overlap, and allows us to include the `FlexTypePrettyPrint` fragment in the compiler.