### PR TITLE
Update to use OCaml 5 (release candidate 1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install OCaml and opam for Miking
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.0.0~beta2
+          ocaml-compiler: ocaml-base-compiler.5.0.0~rc1
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
 
@@ -55,7 +55,7 @@ jobs:
       - name: Install OCaml and opam for Miking
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.0.0~beta2
+          ocaml-compiler: ocaml-base-compiler.5.0.0~rc1
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y liblapacke-dev libopenblas-dev
 
           # Install all opam packages used in make test-all
-          opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.20.1
+          opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.24.1
 
       - name: Build Miking
         timeout-minutes: 10
@@ -80,7 +80,7 @@ jobs:
           ln -s $(brew --prefix gcc)/lib/gcc/current/libquadmath.0.dylib $(brew --prefix openblas)/lib
 
           # Install all opam packages used in make test-all
-          opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.20.1
+          opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.24.1
 
       - name: Build Miking
         timeout-minutes: 10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,9 @@ jobs:
       - name: Install OCaml and opam for Miking
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: ocaml-variants.4.12.0+domains
+          ocaml-compiler: 5.0.0~beta2
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
-            multicore: https://github.com/ocaml-multicore/multicore-opam.git
 
       - name: Cache opam packages
         uses: actions/cache@v2
@@ -56,10 +55,9 @@ jobs:
       - name: Install OCaml and opam for Miking
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: ocaml-variants.4.12.0+domains
+          ocaml-compiler: 5.0.0~beta2
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
-            multicore: https://github.com/ocaml-multicore/multicore-opam.git
 
       - name: Cache opam packages
         uses: actions/cache@v2

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.20.1
+version=0.24.1
 profile=ocamlformat
 margin=79

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ After the installation, you need to install the OCaml compiler by
 running the following:
 ```
 opam update
-opam switch create miking-ocaml 5.0.0~beta2
+opam switch create miking-ocaml 5.0.0~rc1
 eval $(opam env)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1819,10 +1819,10 @@ automatically format ocaml source code.
 
 ###  Setup and use `ocamlformat`
 
-We are currently using this package at version `0.20.1`. To pin and/or install
+We are currently using this package at version `0.24.1`. To pin and/or install
 the package at this version using `opam` do
 ```
-opam pin ocamlformat 0.20.1
+opam pin ocamlformat 0.24.1
 ```
 Then you can then run `dune build @fmt` to see a
 diff between your code and the formatted code. To promote the changes run `dune

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Before you can use the Miking system, you need to install
 [OCaml](https://ocaml.org/) and the
 [OPAM](https://opam.ocaml.org/) package manager.
 
-After the installation, you need to install the OCaml multicore compiler by
+After the installation, you need to install the OCaml compiler by
 running the following:
 ```
 opam update
-opam switch create 4.12.0+domains --packages=ocaml-variants.4.12.0+domains --repositories=multicore=git+https://github.com/ocaml-multicore/multicore-opam.git,default
+opam switch create miking-ocaml 5.0.0~beta2
 eval $(opam env)
 ```
 
@@ -25,8 +25,8 @@ opam install dune linenoise
 ```
 
 Note that the `opam switch` command lets you have several OCaml installations on
-your system. When using the Miking system, you need to use the `4.12.0+domains`
-switch. Running `opam switch 4.12.0+domains` followed by `eval $(opam env)`
+your system. When using the Miking system, you need to use the `miking-ocaml`
+switch. Running `opam switch miking-ocaml` followed by `eval $(opam env)`
 always takes you back to the correct switch.
 
 To compile the project, go back to the Miking repository and execute:
@@ -1380,10 +1380,6 @@ The parallel programming primitives consist of atomic references and functions
 for creating and synchronizing threads. In addition to the examples below, more
 documentation can be found in the standard library at
 [stdlib/multicore](stdlib/multicore/).
-
-To use the parallel programming externals, ensure that you are on the
-`4.12.0+domains`
-[switch](https://github.com/ocaml-multicore/ocaml-multicore/tree/4.12+domains).
 
 #### Atomic References
 

--- a/src/boot/lib/patterns.ml
+++ b/src/boot/lib/patterns.ml
@@ -73,7 +73,8 @@ type snpat =
   | NPatChar of int
   | NPatBool of bool
   | NPatCon of ustring * npat
-  | NPatRecord of npat Record.t * UstringSet.t (* The set is disallowed labels *)
+  | NPatRecord of
+      npat Record.t * UstringSet.t (* The set is disallowed labels *)
   | NPatSeqTot of npat list
   | NPatSeqEdge of
       npat list * IntSet.t (* The set of disallowed lengths *) * npat list

--- a/stdlib/multicore/thread.ext-ocaml.mc
+++ b/stdlib/multicore/thread.ext-ocaml.mc
@@ -36,7 +36,7 @@ let threadExtMap =
 
     ("externalThreadCPURelax", [
       impl
-      { expr = "Domain.Sync.cpu_relax"
+      { expr = "Domain.cpu_relax"
       , ty = tyarrow_ otyunit_ otyunit_
       }])
   ]


### PR DESCRIPTION
This PR updates the repo to use the latest version of OCaml (5.0.0~rc1, as of writing). The changes are:
* Upgraded the `ocamlformat` version from `0.20.1` to `0.24.1` (we'll need to make another PR to update the git-refs as we did [last time](https://github.com/miking-lang/miking/pull/546)). This resulted in a minor change in `src/boot/lib/patterns.ml`.
* Updated `stdlib/multicore/thread.ext-ocaml.mc` because the API changed in the latest OCaml version.
* Rewrote the `README.md` to show how to install the new OCaml version (also naming the switch `miking-ocaml`, not sure if we want to do that).