### PR TITLE
Tweak CVODE

### DIFF
--- a/stdlib/sundials/cvode.ext-ocaml.mc
+++ b/stdlib/sundials/cvode.ext-ocaml.mc
@@ -77,20 +77,21 @@ begin
       | (tend, Cvode.RootsFound) -> (tend, (1, -1))
       | (tend, Cvode.StopTimeReached ) -> (tend, (2, -1))
     with
-    | Cvode.IllInput -> (tend, (3, 0))  
-    | Cvode.TooClose -> (tend, (3, 1)) 
-    | Cvode.TooMuchWork -> (tend, (3, 2)) 
-    | Cvode.TooMuchAccuracy -> (tend, (3, 3)) 
-    | Cvode.ErrFailure -> (tend, (3, 4)) 
-    | Cvode.ConvergenceFailure -> (tend, (3, 5)) 
+    | Cvode.IllInput -> (tend, (3, 0))
+    | Cvode.TooClose -> (tend, (3, 1))
+    | Cvode.TooMuchWork -> (tend, (3, 2))
+    | Cvode.TooMuchAccuracy -> (tend, (3, 3))
+    | Cvode.ErrFailure -> (tend, (3, 4))
+    | Cvode.ConvergenceFailure -> (tend, (3, 5))
     | Cvode.LinearInitFailure -> (tend, (3, 6))
-    | Cvode.LinearSetupFailure _ -> (tend, (3, 7)) 
-    | Cvode.LinearSolveFailure _ -> (tend, (3, 8)) 
-    | Cvode.RhsFuncFailure -> (tend, (3, 9)) 
-    | Cvode.FirstRhsFuncFailure -> (tend, (3, 10)) 
-    | Cvode.RepeatedRhsFuncFailure -> (tend, (3, 11)) 
-    | Cvode.UnrecoverableRhsFuncFailure -> (tend, (3, 12)) 
+    | Cvode.LinearSetupFailure _ -> (tend, (3, 7))
+    | Cvode.LinearSolveFailure _ -> (tend, (3, 8))
+    | Cvode.RhsFuncFailure -> (tend, (3, 9))
+    | Cvode.FirstRhsFuncFailure -> (tend, (3, 10))
+    | Cvode.RepeatedRhsFuncFailure -> (tend, (3, 11))
+    | Cvode.UnrecoverableRhsFuncFailure -> (tend, (3, 12))
     | Cvode.RootFuncFailure -> (tend, (3, 13))
+    | _ -> (tend, (3, 14))
   in solve
 end
 ",
@@ -100,6 +101,12 @@ end
                otyopaque_,
                otytuple_ [tyfloat_, otytuple_ [tyint_, tyint_]]
         ]
+      }
+    ]),
+    ("cvodeSetStopTime", [
+      impl {
+        expr = "Cvode.set_stop_time",
+        ty = tyarrows_ [otyopaque_, tyfloat_, otyunit_]
       }
     ])
   ]


### PR DESCRIPTION
This PR adds `set_stop_time`, which sets the final time of the interval to solve the ODE over, to the CVODE interface and makes the error handling more robust. 