### PR TITLE
Always apply pattern lowering

### DIFF
--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -8,6 +8,7 @@
 include "options.mc"
 include "parse.mc"
 include "mexpr/boot-parser.mc"
+include "mexpr/pprint.mc"
 include "mexpr/shallow-patterns.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/type-check.mc"
@@ -16,7 +17,7 @@ include "ocaml/mcore.mc"
 
 lang MCoreLiteCompile =
   BootParser + MExprSym + MExprTypeCheck + MExprUtestTrans + MCoreCompileLang +
-  MExprLowerNestedPatterns
+  MExprLowerNestedPatterns + MExprPrettyPrint
 end
 
 -- NOTE(larshum, 2021-03-22): This does not work for Windows file paths.
@@ -68,7 +69,6 @@ let compile : Options -> String -> () = lam options. lam file.
   let ast = symbolize ast in
   let ast = typeCheck ast in
   let ast = lowerAll ast in
-  printLn "After pattern lowering";
   let hooks = mkEmptyHooks (ocamlCompile options file) in
   compileMCore ast hooks;
   ()

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -68,7 +68,6 @@ let compile : Options -> String -> () = lam options. lam file.
   let ast = utestStrip ast in
   let ast = symbolize ast in
   let ast = typeCheck ast in
-  let ast = lowerAll ast in
   let hooks = mkEmptyHooks (ocamlCompile options file) in
   compileMCore ast hooks;
   ()

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -8,13 +8,15 @@
 include "options.mc"
 include "parse.mc"
 include "mexpr/boot-parser.mc"
+include "mexpr/shallow-patterns.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/type-check.mc"
 include "mexpr/utesttrans.mc"
 include "ocaml/mcore.mc"
 
 lang MCoreLiteCompile =
-  BootParser + MExprSym + MExprTypeCheck + MExprUtestTrans + MCoreCompileLang
+  BootParser + MExprSym + MExprTypeCheck + MExprUtestTrans + MCoreCompileLang +
+  MExprLowerNestedPatterns
 end
 
 -- NOTE(larshum, 2021-03-22): This does not work for Windows file paths.
@@ -65,6 +67,8 @@ let compile : Options -> String -> () = lam options. lam file.
   let ast = utestStrip ast in
   let ast = symbolize ast in
   let ast = typeCheck ast in
+  let ast = lowerAll ast in
+  printLn "After pattern lowering";
   let hooks = mkEmptyHooks (ocamlCompile options file) in
   compileMCore ast hooks;
   ()

--- a/stdlib/javascript/compile.mc
+++ b/stdlib/javascript/compile.mc
@@ -380,18 +380,15 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
       args = [body],
       curried = false
     })
-  | TmMatch { target = target, pat = pat, thn = thn, els = els } ->
-    match tryCompileOptimizedMatch ctx target pat thn els with Some (ctx, expr) then (ctx, expr) else
-    match compileMExpr ctx target with (ctx, target) in
-    match compileMExpr ctx thn with (ctx, thn) in
-    match compileMExpr ctx els with (ctx, els) in
-    match compileBindingPattern ctx target pat with (ctx2, pat) in
+  | TmMatch t ->
+    match compileMExpr ctx t.target with (ctx, target) in
+    match compileMExpr ctx t.thn with (ctx, thn) in
+    match compileMExpr ctx t.els with (ctx, els) in
+    match compilePattern ctx target t.pat with (ctx, cond) in
     let expr = JSETernary {
-      cond = pat,
+      cond = cond,
       thn = immediatelyInvokeBlock thn,
-      els = immediatelyInvokeBlock els
-    } in
-    let ctx = combineDeclarations ctx ctx2 in
+      els = immediatelyInvokeBlock els} in
     (ctx, if ctx.options.generalOptimizations then optimizeExpr3 expr else expr)
   | TmUtest _ & t -> errorSingle [infoTm t] "Unit test expressions cannot be handled in compileMExpr"
   | TmExt _ & t -> errorSingle [infoTm t] "External expressions cannot be handled in compileMExpr"

--- a/stdlib/javascript/compile.mc
+++ b/stdlib/javascript/compile.mc
@@ -330,10 +330,11 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
       match compileMExpr ctx e with (ctx2, e) in
       let ctx = combineDeclarations ctx1 ctx2 in
       match compileDeclarations ctx with (ctx, decs) in
-      (ctx, flattenBlock (JSEBlock {
-        exprs = [decs, JSEDef { id = ident, expr = body }],
-        ret = e
-      }))
+      let bindingExpr = JSEIIFE {
+        body = flattenBlock (JSEBlock {
+          exprs = [decs, JSEDef { id = ident, expr = body }],
+          ret = e})} in
+      (ctx, bindingExpr)
 
   | TmRecLets { bindings = bindings, inexpr = e, ty = ty } ->
     match compileMExpr ctx e with (ctx, e) in

--- a/stdlib/javascript/patterns.mc
+++ b/stdlib/javascript/patterns.mc
@@ -8,24 +8,13 @@ include "javascript/ast.mc"
 include "javascript/util.mc"
 
 
-lang PatJSCompileLang = JSProgAst + NamedPat + SeqTotPat + SeqEdgePat +
-                    RecordPat + DataPat + IntPat + OrPat +
-                    CharPat + BoolPat + AndPat + NotPat
-end
-
-let tmpIgnoreJS = use PatJSCompileLang in
-  JSEVar { id = nameSym "_" }
-
-let compilePatsLen = use PatJSCompileLang in
-  lam pats: [Pat]. lam target: JSExpr. lam checkExactInsteadOfAtLeast: Bool.
-  let op = (if checkExactInsteadOfAtLeast then (JSOEq {}) else (JSOGe {})) in
-  _binOp op [JSEMember { expr = target, id = "length" }, JSEInt { i = length pats }]
-
 ------------------------------------
 -- Pattern -> JavaScript FRAGMENT --
 ------------------------------------
 
-lang PatJSCompile = PatJSCompileLang
+lang PatJSCompile =
+  JSProgAst + NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat +
+  IntPat + OrPat + CharPat + BoolPat + AndPat + NotPat
 
   sem getPatNameVar : PatName -> JSExpr
   sem getPatNameVar =

--- a/stdlib/javascript/pprint.mc
+++ b/stdlib/javascript/pprint.mc
@@ -21,7 +21,6 @@ let pprintEnvGetStr = lam env. lam id: Name.
       match nameGetSym id with Some sym then int2string (sym2hash sym) else ""
     ])
   else
-    let id = nameSetStr id (nameGetStr id) in
     pprintEnvGetStr env id -- Note that this is not a recursive call!
 
 let joinAsStatements = lam indent. lam seq.
@@ -152,13 +151,12 @@ lang JSPrettyPrint = JSExprAst
     match mapAccumL (printJSExpr indent) env exprs with (env,exprs) in
     (env, join ["[", strJoin ", " exprs, "]"])
   | JSEObject { fields = fields } ->
-
-    let printPair = lam field.
+    let printPair = lam env. lam field.
       match field with (n, e) in
       match (printJSExpr 0) env e with (env,e) in
-      join [n, ": ", e]
+      (env, join [n, ": ", e])
     in
-    match map (printPair) fields with prs in
+    match mapAccumL printPair env fields with (env, prs) in
     (env, join ["{", strJoin ", " prs, "}"])
   | JSEBlock { exprs = exprs, ret = ret } ->
     let i = indent in

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -146,10 +146,10 @@ let record2tuple
 -----------
 
 lang IdentifierPrettyPrint
-  sem pprintVarName  (env : PprintEnv) =
-  sem pprintConName  (env : PprintEnv) =
-  sem pprintTypeName (env : PprintEnv) =
-  sem pprintLabelString =                -- Record label string parser translation
+  sem pprintVarName : PprintEnv -> Name -> (PprintEnv, String)
+  sem pprintConName : PprintEnv -> Name -> (PprintEnv, String)
+  sem pprintTypeName : PprintEnv -> Name -> (PprintEnv, String)
+  sem pprintLabelString : SID -> String
 
   -- Get a string for the given name. Returns both the string and a new
   -- environment.

--- a/stdlib/mexpr/shallow-patterns.mc
+++ b/stdlib/mexpr/shallow-patterns.mc
@@ -510,10 +510,7 @@ lang ShallowRecord = ShallowBase + RecordPat + RecordTypeAst + PrettyPrint + Fle
     -- TODO(vipa, 2022-05-26): This needs to resolve aliases :(
     match px.ty with TyRecord x then
       _ssingleton (SPatRecord { bindings = mapMap (lam. nameSym "field") x.fields, ty = px.ty })
-    else match resolveLink px.ty with TyFlex t then
-      dprintLn (deref t.contents);
-      errorSingle [px.info] "Why is there still a TyFlex here?"
-    else dprintLn px; errorSingle [px.info]
+    else errorSingle [px.info]
       (join ["I can't immediately see the record type of this pattern, it's a ", type2str px.ty])
 
   sem mkMatch scrutinee t e =

--- a/stdlib/mexpr/shallow-patterns.mc
+++ b/stdlib/mexpr/shallow-patterns.mc
@@ -1,7 +1,6 @@
 include "either.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/pprint.mc"
-include "mexpr/type-check.mc"
 /-
 
 NOTE(vipa, 2022-05-20): This file decomposes nested patterns into a
@@ -493,7 +492,7 @@ lang ShallowBool = ShallowBase + BoolPat
   | (SPatBool false, SPatBool false) -> 0
 end
 
-lang ShallowRecord = ShallowBase + RecordPat + RecordTypeAst + PrettyPrint + FlexTypeAst
+lang ShallowRecord = ShallowBase + RecordPat + RecordTypeAst + PrettyPrint
   syn SPat =
   | SPatRecord { bindings : Map SID Name, ty : Type }
 

--- a/stdlib/mexpr/shallow-patterns.mc
+++ b/stdlib/mexpr/shallow-patterns.mc
@@ -758,9 +758,11 @@ lang LowerNestedPatterns = CollectBranches + ShallowBase
     then
       match target with Left expr then
         let targetId = nameSym "_target" in
-        bind_
-          (nulet_ targetId (lowerAll expr))
-          (lowerToExpr targetId (map f branches) (lowerAll fallthrough))
+        let elseId = nameSym "_elsBranch" in
+        bindall_ [
+          nulet_ elseId (ulam_ "" (lowerAll fallthrough)),
+          nulet_ targetId (lowerAll expr),
+          lowerToExpr targetId (map f branches) (app_ (nvar_ elseId) uunit_)]
       else match target with Right name then
         lowerToExpr name (map f branches) (lowerAll fallthrough)
       else never

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -524,11 +524,15 @@ end
 -- TYPE CHECKING --
 -------------------
 
-lang RemoveFlex = FlexTypeAst + UnknownTypeAst
+lang RemoveFlex = FlexTypeAst + UnknownTypeAst + RecordTypeAst
   sem removeFlexType =
   | TyFlex t & ty ->
-    match deref t.contents with Unbound _ then TyUnknown { info = t.info }
-    else removeFlexType (resolveLink ty)
+    switch deref t.contents
+    case Unbound {sort = RecordVar x} then
+      TyRecord {info = t.info, fields = mapMap removeFlexType x.fields}
+    case Unbound _ then TyUnknown { info = t.info }
+    case _ then removeFlexType (resolveLink ty)
+    end
   | ty ->
     smap_Type_Type removeFlexType ty
 

--- a/stdlib/ocaml/mcore.mc
+++ b/stdlib/ocaml/mcore.mc
@@ -43,48 +43,9 @@ lang MCoreCompileLang =
       (setToSeq libs, setToSeq clibs)
     else never
 
-  sem isRegular : Pat -> Bool
-  sem isRegular =
-  | PatAnd _ | PatOr _ | PatNot _ -> true
-  | _ -> false
-
-  sem isPatNamed : Bool -> Pat -> Bool
-  sem isPatNamed acc =
-  | PatNamed _ -> acc
-  | _ -> false
-
-  sem isNested : Bool -> Pat -> Bool
-  sem isNested acc =
-  | PatNamed _ | PatInt _ | PatChar _ | PatBool _ -> false
-  | PatSeqTot t -> not (foldl isPatNamed true t.pats)
-  | PatSeqEdge t -> not (foldl isPatNamed true (concat t.prefix t.postfix))
-  | PatRecord t -> not (foldl isPatNamed true (mapValues t.bindings))
-  | PatCon t -> not (isPatNamed true t.subpat)
-
-  sem printNestedPatterns : () -> Expr -> ()
-  sem printNestedPatterns acc =
-  | TmMatch t ->
-    printNestedPatterns acc t.target;
-    (if isRegular t.pat then
-      printLn "Found regular pattern";
-      use MExprPrettyPrint in
-      match getPatStringCode 0 pprintEnvEmpty t.pat with (_, pstr) in
-      printLn (info2str (infoPat t.pat));
-      printLn pstr
-    else if isNested false t.pat then
-      use MExprPrettyPrint in
-      match getPatStringCode 0 pprintEnvEmpty t.pat with (_, pstr) in
-      printLn (info2str (infoPat t.pat));
-      printLn pstr
-    else ());
-    printNestedPatterns acc t.thn;
-    printNestedPatterns acc t.els
-  | t -> sfold_Expr_Expr printNestedPatterns acc t
-
   sem compileMCore : all a. Expr -> Hooks a -> a
   sem compileMCore ast =
   | hooks ->
-    printNestedPatterns () ast;
     let ast = typeAnnot ast in
     let ast = removeTypeAscription ast in
 

--- a/stdlib/ocaml/mcore.mc
+++ b/stdlib/ocaml/mcore.mc
@@ -67,9 +67,15 @@ lang MCoreCompileLang =
     printNestedPatterns acc t.target;
     (if isRegular t.pat then
       printLn "Found regular pattern";
-      dprintLn t.pat
+      use MExprPrettyPrint in
+      match getPatStringCode 0 pprintEnvEmpty t.pat with (_, pstr) in
+      printLn (info2str (infoPat t.pat));
+      printLn pstr
     else if isNested false t.pat then
-      dprintLn t.pat
+      use MExprPrettyPrint in
+      match getPatStringCode 0 pprintEnvEmpty t.pat with (_, pstr) in
+      printLn (info2str (infoPat t.pat));
+      printLn pstr
     else ());
     printNestedPatterns acc t.thn;
     printNestedPatterns acc t.els

--- a/stdlib/pmexpr/replace-accelerate.mc
+++ b/stdlib/pmexpr/replace-accelerate.mc
@@ -58,8 +58,8 @@ lang PMExprReplaceAccelerate =
             -- NOTE(larshum, 2022-03-17): We explicitly use the label escaping
             -- of the OCaml pretty-printer to ensure the labels of the fields
             -- match.
+            let asStr = pprintLabelString sid in
             let str = sidToString sid in
-            let asStr = pprintLabelString str in
             (acc, {label = asStr, asLabel = str, ty = ty}))
           acc (tyRecordOrderedLabels ty)
       with (acc, ocamlTypedFields) in

--- a/test/js/make.sh
+++ b/test/js/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-COMPILE_JS="./build/boot eval src/main/mi.mc -- compile --test --disable-prune-utests --to-js --js-target node"
+COMPILE_JS="./build/mi compile --test --disable-prune-utests --to-js --js-target node"
 RUN_JS="node"
 RUN_MI="./build/boot eval"
 TEST_MI="./build/mi run --test --disable-prune-warning"


### PR DESCRIPTION
This PR fixes an issue that caused the pattern lowering to not always be applied and resolves a performance issue introduced when always using pattern lowering. In addition, it includes a significant number of changes that were required to make the tests pass. After this PR has been merged, we can update the OCaml backend to use a simpler approach for pattern compilation, which should (hopefully) improve performance as we no longer need to generate matches using `option`s. As we now run pattern lowering in `mi-lite`, the first two stages of bootstrapping are slowed down. I hope this will be improved after updating the compilation of patterns to OCaml.

@elegios co-authored the main changes in the pattern lowering and the changes in the type checker.

Additional changes included in this PR to get tests to pass after the above updates:
* Updated the type checker to replace `RecordVar`s with a `TyRecord` instead of a `TyUnknown`.
* Fixed untyped patterns being generated in the utest translation.
* Added explicit types to the `pprintVarName`, `pprintConName`, `pprintTypeName`, and `pprintLabelString` functions and fixed resulting type errors.
* Includes `MExprPrettyPrint` in `mi-lite` so that type errors are correctly printed
  * The type checker uses `type2str` when generating a unification error, but it does not include the pretty-print fragments needed to print anything. Perhaps this is considered an issue in the type checker rather than in `mi-lite`?
* Update the JS backend to pass its tests after making the changes discussed here. These changes will likely degrade performance, but I found correctness more critical (passing all tests). Feel free to optimize what I did @WilliamRagstad.
  * Simplified the compilation of pattern matching by using the lowering guarantees. I removed all special-case handling, which may have resulted in worse execution times.
  * Fixed a bug in the pretty printing of JavaScript objects.
  * Updated the JS tests to use `mi compile` instead of interpreting the compiler via `boot`.

Edit: Here are the results from running the bootstrapping, including the changes in this PR vs. `develop`:
<details id="detail-summary-1">
<summary>Current</summary>

```
Bootstrapping the Miking compiler (1st round, might take a few minutes)
50.08user 0.39system 0:50.49elapsed 99%CPU (0avgtext+0avgdata 996640maxresident)k
0inputs+50920outputs (0major+351999minor)pagefaults 0swaps
Bootstrapping the Miking compiler (2nd round, might take some more time)
27.89user 0.95system 0:29.79elapsed 96%CPU (0avgtext+0avgdata 2210864maxresident)k
0inputs+264600outputs (0major+945011minor)pagefaults 0swaps
Bootstrapping the Miking compiler (3rd round, might take some more time)
30.65user 1.17system 0:32.18elapsed 98%CPU (0avgtext+0avgdata 2247800maxresident)k
0inputs+267376outputs (0major+1046978minor)pagefaults 0swaps
```
</details>
<details id="detail-summary-2">
<summary>After this PR</summary>

```
Bootstrapping the Miking compiler (1st round, might take a few minutes)
73.11user 0.41system 1:13.54elapsed 99%CPU (0avgtext+0avgdata 1219044maxresident)k
0inputs+59024outputs (0major+421327minor)pagefaults 0swaps
Bootstrapping the Miking compiler (2nd round, might take some more time)
31.87user 1.14system 0:33.17elapsed 99%CPU (0avgtext+0avgdata 2264392maxresident)k
0inputs+297104outputs (0major+1082602minor)pagefaults 0swaps
Bootstrapping the Miking compiler (3rd round, might take some more time)
32.48user 1.15system 0:33.82elapsed 99%CPU (0avgtext+0avgdata 2429080maxresident)k
0inputs+297104outputs (0major+1122116minor)pagefaults 0swaps
```
</details>