### PR TITLE
New flag: --debug-phases

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -12,6 +12,7 @@ include "mexpr/type-check.mc"
 include "mexpr/remove-ascription.mc"
 include "mexpr/utesttrans.mc"
 include "mexpr/shallow-patterns.mc"
+include "mexpr/phase-stats.mc"
 include "tuning/context-expansion.mc"
 include "tuning/tune-file.mc"
 include "ocaml/ast.mc"
@@ -30,7 +31,7 @@ lang MCoreCompile =
   MExprUtestTrans + MExprRuntimeCheck + MExprProfileInstrument +
   MExprPrettyPrint +
   MExprLowerNestedPatterns +
-  OCamlTryWithWrap + MCoreCompileLang
+  OCamlTryWithWrap + MCoreCompileLang + PhaseStats
 end
 
 lang TyAnnotFull = MExprPrettyPrint + TyAnnot + HtmlAnnotator
@@ -61,7 +62,9 @@ let insertTunedOrDefaults = lam options : Options. lam ast. lam file.
 
 let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
   use MCoreCompile in
+    let log = mkPhaseLogState options.debugPhases in
     let ast = symbolize ast in
+    endPhaseStats log "symbolize" ast;
 
     -- If option --debug-profile, insert instrumented profiling expressions
     -- in AST
@@ -69,40 +72,50 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
       if options.debugProfile then instrumentProfiling ast
       else ast
     in
+    endPhaseStats log "instrument-profiling" ast;
 
     let ast = typeCheck ast in
     (if options.debugTypeCheck then
        printLn (use TyAnnotFull in annotateMExpr ast) else ());
+    endPhaseStats log "typecheck" ast;
 
     -- If --runtime-checks is set, runtime safety checks are instrumented in
     -- the AST. This includes for example bounds checking on sequence
     -- operations.
     let ast = if options.runtimeChecks then injectRuntimeChecks ast else ast in
 
+    endPhaseStats log "runtime-checks" ast;
+
     -- If option --test, then generate utest runner calls. Otherwise strip away
     -- all utest nodes from the AST.
     match generateTests ast options.runTests with (symEnv, ast) in
+    endPhaseStats log "generate-tests" ast;
 
     -- Re-symbolize the MExpr AST and re-annotate it with types
     let ast = symbolizeExpr symEnv ast in
+    endPhaseStats log "symbolize2" ast;
 
     let ast = lowerAll ast in
+    endPhaseStats log "pattern-lowering" ast;
     (if options.debugShallow then
       printLn (expr2str ast) else ());
 
-    if options.toJavaScript then compileMCoreToJS {
-        compileJSOptionsEmpty with
-        targetPlatform = parseJSTarget options.jsTarget,
-        generalOptimizations = not options.disableJsGeneralOptimizations,
-        tailCallOptimizations = not options.disableJsTCO
-      } ast sourcePath
-    else compileMCore ast
-      { debugTypeAnnot = lam ast. if options.debugTypeAnnot then printLn (expr2str ast) else ()
-      , debugGenerate = lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ()
-      , exitBefore = lam. if options.exitBefore then exit 0 else ()
-      , postprocessOcamlTops = lam tops. if options.runtimeChecks then wrapInTryWith tops else tops
-      , compileOcaml = ocamlCompile options sourcePath
-      }
+    let res =
+      if options.toJavaScript then compileMCoreToJS
+        { compileJSOptionsEmpty with
+          targetPlatform = parseJSTarget options.jsTarget
+        , generalOptimizations = not options.disableJsGeneralOptimizations
+        , tailCallOptimizations = not options.disableJsTCO
+        } ast sourcePath
+      else compileMCore ast
+        { debugTypeAnnot = lam ast. if options.debugTypeAnnot then printLn (expr2str ast) else ()
+        , debugGenerate = lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ()
+        , exitBefore = lam. if options.exitBefore then exit 0 else ()
+        , postprocessOcamlTops = lam tops. if options.runtimeChecks then wrapInTryWith tops else tops
+        , compileOcaml = ocamlCompile options sourcePath
+        } in
+    endPhaseStats log "backend" ast;
+    res
 
 -- Main function for compiling a program
 -- files: a list of files
@@ -111,6 +124,7 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
 let compile = lam files. lam options : Options. lam args.
   use MCoreCompile in
   let compileFile = lam file.
+    let log = mkPhaseLogState options.debugPhases in
     let ast = parseParseMCoreFile {
       keepUtests = options.runTests,
       pruneExternalUtests = not options.disablePruneExternalUtests,
@@ -119,7 +133,9 @@ let compile = lam files. lam options : Options. lam args.
       eliminateDeadCode = not options.keepDeadCode,
       keywords = mexprExtendedKeywords
     } file in
+    endPhaseStats log "parsing" ast;
     let ast = makeKeywords ast in
+    endPhaseStats log "make-keywords" ast;
 
     -- Applies static and dynamic checks on the accelerated expressions, to
     -- verify that the code within them are supported by the accelerate
@@ -134,9 +150,11 @@ let compile = lam files. lam options : Options. lam args.
         match checkWellFormedness options ast with (ast, _, _) in
         demoteParallel ast
       else demoteParallel ast in
+    endPhaseStats log "accelerate" ast;
 
     -- Insert tuned values, or use default values if no .tune file present
     let ast = insertTunedOrDefaults options ast file in
+    endPhaseStats log "tuning" ast;
 
     -- If option --debug-parse, then pretty print the AST
     (if options.debugParse then printLn (expr2str ast) else ());

--- a/src/main/options-config.mc
+++ b/src/main/options-config.mc
@@ -27,6 +27,10 @@ let optionsConfig : ParseConfig Options = [
     "Print the AST after lowering nested patterns to shallow ones",
     lam p: ArgPart Options.
       let o: Options = p.options in {o with debugShallow = true}),
+  ([("--debug-phases", "", "")],
+    "Show debug and profiling information about each pass",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with debugPhases = true}),
   ([("--exit-before", "", "")],
     "Exit before evaluation or compilation",
     lam p: ArgPart Options.

--- a/src/main/options-type.mc
+++ b/src/main/options-type.mc
@@ -8,6 +8,7 @@ type Options = {
   debugTypeCheck : Bool,
   debugProfile : Bool,
   debugShallow : Bool,
+  debugPhases : Bool,
   exitBefore : Bool,
   disablePruneExternalUtests : Bool,
   disablePruneExternalUtestsWarning : Bool,

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -11,6 +11,7 @@ let optionsDefault : Options = {
   debugTypeCheck = false,
   debugProfile = false,
   debugShallow = false,
+  debugPhases = false,
   exitBefore = false,
   disablePruneExternalUtests = false,
   disablePruneExternalUtestsWarning = false,

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -205,6 +205,24 @@ lang Ast
   | p ->
     match smapAccumL_Pat_Type (lam acc. lam a. (f acc a, a)) acc p
     with (acc, _) in acc
+
+  sem countExprNodes count = | t ->
+    let count = addi count 1 in
+    let count = sfold_Expr_Expr countExprNodes count t in
+    let count = sfold_Expr_Type countTypeNodes count t in
+    let count = sfold_Expr_TypeLabel countTypeNodes count t in
+    let count = sfold_Expr_Pat countPatNodes count t in
+    count
+  sem countTypeNodes count = | t ->
+    let count = addi count 1 in
+    let count = sfold_Type_Type countTypeNodes count t in
+    count
+  sem countPatNodes count = | t ->
+    let count = addi count 1 in
+    let count = sfold_Pat_Pat countPatNodes count t in
+    let count = sfold_Pat_Expr countExprNodes count t in
+    let count = sfold_Pat_Type countTypeNodes count t in
+    count
 end
 
 -- TmVar --

--- a/stdlib/mexpr/phase-stats.mc
+++ b/stdlib/mexpr/phase-stats.mc
@@ -1,0 +1,27 @@
+include "common.mc"
+include "ast.mc"
+
+lang PhaseStats = Ast
+  type StatState =
+    { lastPhaseEnd : Ref Float
+    , log : Bool
+    }
+
+  sem endPhaseStats : StatState -> String -> Expr -> ()
+  sem endPhaseStats state phaseLabel = | e ->
+    if state.log then
+      let before = deref state.lastPhaseEnd in
+      let now = wallTimeMs () in
+      printLn phaseLabel;
+      let preTraverse = wallTimeMs () in
+      let size = countExprNodes 0 e in
+      let postTraverse = wallTimeMs () in
+      printLn (join ["  Ast size: ", int2string size, " (Traversal takes ~", float2string (subf postTraverse preTraverse), "ms)"]);
+      printLn (concat "  Phase duration: " (float2string (subf now before)));
+      let newNow = wallTimeMs () in
+      modref state.lastPhaseEnd newNow
+    else ()
+
+  sem mkPhaseLogState : Bool -> StatState
+  sem mkPhaseLogState = | log -> { lastPhaseEnd = ref (wallTimeMs ()), log = log }
+end


### PR DESCRIPTION
Introduce a new debug-flag for keeping track of some numbers related to phases, to make basic performance sanity checks easier.

Example output:

```
❯ MCORE_STDLIB=(pwd)/stdlib mi compile --debug-phases src/main/mi.mc
parsing
  Ast size: 1038556
  Phase duration: 14252.1191406
make-keywords
  Ast size: 1038556
  Phase duration: 343.031982422
accelerate
  Ast size: 1038556
  Phase duration: 137.394042969
tuning
  Ast size: 1038556
  Phase duration: 240.879150391
symbolize
  Ast size: 1038556
  Phase duration: 581.970947266
instrument-profiling
  Ast size: 1038556
  Phase duration: 0.
typecheck
  Ast size: 2723232
  Phase duration: 2389.10522461
runtime-checks
  Ast size: 2723232
  Phase duration: 0.001220703125
generate-tests
  Ast size: 2723232
  Phase duration: 144.854736328
symbolize2
  Ast size: 2723232
  Phase duration: 620.866943359
pattern-lowering
  Ast size: 2923683
  Phase duration: 1026.57299805
backend
  Ast size: 2923683
  Phase duration: 35104.894043
```

