### PR TITLE
Better type errors

### DIFF
--- a/stdlib/mexpr/info.mc
+++ b/stdlib/mexpr/info.mc
@@ -51,20 +51,20 @@ let infoVal : String -> Int -> Int -> Int -> Int -> Info =
 
 -- Generate a string from an info
 let info2str : Info -> String = lam fi.
-  match fi with NoInfo () then "[No file info] " else
+  match fi with NoInfo () then "<No file info>" else
   match fi with Info (r & {row1 = 0}) then
-    join ["FILE \"", r.filename, "\" "]
+    join ["<", r.filename, ">"]
   else match fi with Info r then
-    join ["FILE \"", r.filename, "\" ", int2string r.row1, ":", int2string r.col1,
-    "-", int2string r.row2, ":", int2string r.col2, " "]
+    join ["<", r.filename, " ", int2string r.row1, ":", int2string r.col1,
+    "-", int2string r.row2, ":", int2string r.col2, ">"]
   else never
 
 -- Generate an info error string
 let infoErrorString : Info -> String -> String = lam fi. lam str.
-    join [info2str fi, "ERROR: ", str]
+    join ["ERROR ", info2str fi, ":\n", str]
 
 let infoWarningString : Info -> String -> String = lam fi. lam str.
-    join [info2str fi, "WARNING: ", str]
+    join ["WARNING ", info2str fi, ":\n", str]
 
 -- Print an error with info struct info and exit (error code 1)
 let infoErrorExit : Info -> String -> Unknown = lam fi. lam str.

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1122,7 +1122,7 @@ lang VarSortPrettyPrint = PrettyPrint + RecordTypeAst + VarSortAst
   | RecordVar r ->
     let recty = TyRecord {info = NoInfo (), fields = r.fields} in
     match getTypeStringCode indent env recty with (env, recstr) in
-    (env, concat (init recstr) " ... }")
+    (env, join [init recstr, " ... ", [last recstr]])
   | _ -> (env, idstr)
 end
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1122,7 +1122,7 @@ lang VarSortPrettyPrint = PrettyPrint + RecordTypeAst + VarSortAst
   | RecordVar r ->
     let recty = TyRecord {info = NoInfo (), fields = r.fields} in
     match getTypeStringCode indent env recty with (env, recstr) in
-    (env, join [idstr, "<:", recstr])
+    (env, concat (init recstr) " ... }")
   | _ -> (env, idstr)
 end
 

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -181,7 +181,8 @@ lang FlexTypePrettyPrint = IdentifierPrettyPrint + VarSortPrettyPrint + FlexType
     match deref t.contents with Unbound t then
       match pprintVarName env t.ident with (env, idstr) in
       match getVarSortStringCode indent env idstr t.sort with (env, str) in
-      let weakPrefix = if t.isWeak then "_" else "" in
+      let weakPrefix =
+        match (t.isWeak, t.sort) with (true, !RecordVar _) then "_" else "" in
       (env, concat weakPrefix str)
     else
       getTypeStringCode indent env (resolveLink ty)


### PR DESCRIPTION
This pull request improves the error messages given by the type checker.  This consists primarily in
- Changing unification errors to present one type as 'expected' and the other as 'found'
- Updating the type checking of function applications to give better errors
- ~Making unification preserve aliases as long as possible~
- Presenting the errors in a nicer way

The pull request also changes the printing of unknown record types to be more helpful: `_a<:{x:_a1}` is now printed as `{x:_a1 ... }` instead.

Finally, the PR updates how errors with info fields are printed, from 
```
FILE "/path/to/file.mc" l1:c1-l2:c2 ERROR: ...
``` 
to
```
ERROR </path/to/file.mc l1:c1-l2:c2>:
...
```
I think this style is easier to read, but I know it's a controversial change which might warrant more discussion.  In that case, I can drop it from this PR.

To demonstrate the new style of type errors, consider the example I had in my workshop presentation, where we modify the `TmLet` case in `eval.mc` to not pass the `ctx` parameter in the recursive call.
```haskell
  sem eval ctx =
  | TmLet t ->
    eval {ctx with env = evalEnvInsert t.ident (eval t.body) ctx.env}
      t.inexpr
```
Previously, we would get the error
```
FILE "/home/aathn/Documents/projects/miking/miking/stdlib/mexpr/eval.mc" 120:48-120:52 ERROR: Type check failed: unification failure
LHS: {env: Env}
RHS: Expr
while unifying these:
LHS: EvalCtx -> Expr -> Expr
RHS: Expr -> a
    eval {ctx with env = evalEnvInsert t.ident (*eval* t.body) ctx.env}
```
whereas after this PR, we get
```
ERROR </home/aathn/Documents/projects/miking/miking/stdlib/mexpr/eval.mc 120:53-120:59>:
* Expected an expression of type: {env: Env}
* Found an expression of type: Expr
* When type checking the expression
    eval {ctx with env = evalEnvInsert t.ident (eval *t.body*) ctx.env}
```
(here, I indicate highlighting with asterisks, although color is used in the actual output).

EDIT: I'll move the change to preserve aliases to a separate PR, as it requires a bit more work (see discussion below).