### PR TITLE
Optimize the Miking interpreter

### DIFF
--- a/stdlib/list.mc
+++ b/stdlib/list.mc
@@ -1,0 +1,90 @@
+-- MExpr implementation of a cons list using explicit constructors.
+
+include "option.mc"
+include "map.mc"
+
+type List a
+con Cons : all a. (a, List a) -> List a
+con Nil : all a. () -> List a
+
+let listEmpty : all a. List a = Nil ()
+
+let listNil : all a. List a -> Bool = lam li.
+  match li with Nil _ then true else false
+
+let listCons : all a. a -> List a -> List a = lam e. lam li. Cons (e, li)
+
+let listFind : all a. (a -> Bool) -> List a -> Option a = lam p. lam li.
+  recursive let find = lam li.
+    switch li
+    case Cons (e, li) then
+      if p e then Some e
+      else find li
+    case Nil _ then None ()
+    end
+  in find li
+
+let listFromSeq : all a. [a] -> List a =
+  recursive let build = lam acc. lam s.
+    match s with mid ++ [last] then
+      build (listCons last acc) mid
+    else acc
+  in build listEmpty
+
+let listFoldl : all a. all b. (b -> a -> b) -> b -> List a -> b = lam f.
+  recursive let fold = lam acc. lam li.
+    switch li
+    case Cons (x, li) then fold (f acc x) li
+    case Nil _ then acc
+    end
+  in fold
+
+let listReverse : all a. List a -> List a =
+  listFoldl (lam acc. lam x. listCons x acc) listEmpty
+
+let listMap : all a. all b. (a -> b) -> List a -> List b = lam f. lam li.
+  recursive let map = lam acc. lam li.
+    switch li
+    case Cons (x, li) then map (Cons (f x, acc)) li
+    case Nil _ then acc
+    end
+  in
+  listReverse (map listEmpty li)
+
+let listToSeq : all a. List a -> [a] = listFoldl snoc []
+
+mexpr
+
+let l1 = listEmpty in
+let l2 = listCons 3 l1 in
+let l3 = listCons 4 (listCons 3 l2) in
+utest l1 with Nil () in
+utest l2 with Cons (3, Nil ()) in
+utest l3 with Cons (4, Cons (3, Cons (3, Nil ()))) in
+
+utest listNil l1 with true in
+utest listNil l2 with false in
+utest listNil l3 with false in
+
+let l4 = listFromSeq [2, 3, 4] in
+utest l4 with Cons (2, Cons (3, Cons (4, Nil ()))) in
+utest listToSeq l4 with [2, 3, 4] in
+
+let findInt = lam i. lam x.
+  match x with (y, _) in
+  eqi i y
+in
+let l5 = listFromSeq [(2, "2"), (3, "3"), (5, "5")] in
+utest listFind (findInt 0) l5 with None () in
+utest listFind (findInt 2) l5 with Some (2, "2") in
+utest listFind (findInt 3) l5 with Some (3, "3") in
+utest listFind (findInt 4) l5 with None () in
+
+utest listReverse l4 with Cons (4, Cons (3, Cons (2, Nil ()))) in
+
+let l6 = listMap (addi 1) l4 in
+utest l6 with Cons (3, Cons (4, Cons (5, Nil ()))) in
+utest listFoldl addi 0 l4 with 9 in
+utest listFoldl addi 0 l6 with 12 in
+
+()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -2,9 +2,8 @@
 
 include "string.mc"
 include "char.mc"
-include "assoc.mc"
 include "name.mc"
-include "map.mc"
+include "list.mc"
 
 include "info.mc"
 include "error.mc"
@@ -18,13 +17,15 @@ include "pprint.mc"
 -- EVALUATION ENVIRONMENT --
 ----------------------------
 
-type Env = [(Name, Expr)]
+type Env = List (Name, Expr)
 
-let evalEnvEmpty = createList 0 (lam. (nameNoSym "", unit_))
+let evalEnvEmpty = listEmpty
 
-let evalEnvLookup = lam id. lam env. assocSeqLookup {eq=nameEqSymUnsafe} id env
+let evalEnvLookup = lam id. lam env.
+  let p = lam entry. nameEqSymUnsafe id entry.0 in
+  match listFind p env with Some (_, e) then Some e else None ()
 
-let evalEnvInsert = lam id. lam e. lam env. assocSeqInsert id e env
+let evalEnvInsert = lam id. lam e. lam env. listCons (id, e) env
 
 ------------------------
 -- EVALUATION CONTEXT --

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -44,17 +44,6 @@ let evalCtxEmpty = { env = evalEnvEmpty }
 -------------
 -- HELPERS --
 -------------
--- Dynamic versions of recordproj_ and tupleproj_ in ast.mc. Usable on the fly
--- during evaluation (generates a fresh symbol for the internally matched
--- variable).
-
-let _evalDRecordProj = use MExprAst in
-  lam key. lam r.
-  nrecordproj_ (nameSym "x") key r
-
-let _evalDTupleProj = use MExprAst in
-  lam i. lam t.
-  _evalDRecordProj (int2string i) t
 
 -- Converts a sequence of characters to a string
 let _evalSeqOfCharsToString = use MExprAst in
@@ -76,19 +65,10 @@ lang Eval
   sem eval : EvalCtx -> Expr -> Expr
 end
 
--- Fixpoint operator is only needed for eval. Hence, it is not in ast.mc
-lang FixAst = LamAst
-  syn Expr =
-  | TmFix ()
-end
-
-lang VarEval = Eval + VarAst + FixAst + AppAst
+lang VarEval = Eval + VarAst + AppAst
   sem eval ctx =
   | TmVar r ->
-    match evalEnvLookup r.ident ctx.env with Some t then
-      match t with TmApp {lhs = TmFix _} then
-        eval ctx t
-      else t
+    match evalEnvLookup r.ident ctx.env with Some t then t
     else
       errorSingle [r.info] (concat "Unknown variable: " (pprintVarString (nameGetStr r.ident)))
 end
@@ -103,14 +83,16 @@ lang AppEval = Eval + AppAst
 end
 
 lang LamEval = Eval + LamAst + VarEval + AppEval
+  type Lazy a = () -> a
+
   syn Expr =
-  | TmClos {ident : Name, body : Expr, env : Env}
+  | TmClos {ident : Name, body : Expr, env : Lazy Env}
 
   sem apply ctx info arg =
-  | TmClos t -> eval {ctx with env = evalEnvInsert t.ident arg t.env} t.body
+  | TmClos t -> eval {ctx with env = evalEnvInsert t.ident arg (t.env ())} t.body
 
   sem eval ctx =
-  | TmLam t -> TmClos {ident = t.ident, body = t.body, env = ctx.env}
+  | TmLam t -> TmClos {ident = t.ident, body = t.body, env = lam. ctx.env}
   | TmClos t -> TmClos t
 end
 
@@ -120,25 +102,6 @@ lang LetEval = Eval + LetAst + VarEval
     eval {ctx with env = evalEnvInsert t.ident (eval ctx t.body) ctx.env}
       t.inexpr
 end
-
-lang FixEval = Eval + FixAst + LamEval + UnknownTypeAst
-  sem apply ctx info arg =
-  | TmFix _ ->
-    match arg with TmClos clos then
-      let ident = clos.ident in
-      let body = clos.body in
-      let env =
-        evalEnvInsert ident (TmApp {lhs = TmFix (),
-                                rhs = TmClos clos,
-                                ty = tyunknown_,
-                                info = NoInfo()}) clos.env in
-      eval {ctx with env = env} body
-    else
-      errorSingle [info] "Not fixing a function"
-
-  sem eval ctx =
-  | TmFix _ -> TmFix ()
- end
 
 lang RecordEval = Eval + RecordAst
   sem eval ctx =
@@ -155,68 +118,23 @@ lang RecordEval = Eval + RecordAst
 end
 
 lang RecLetsEval =
-  Eval + RecLetsAst + VarEval + FixAst + FixEval + RecordEval + LetEval +
+  Eval + RecLetsAst + VarEval + RecordEval + LetEval + LamEval +
   UnknownTypeAst
 
   sem eval ctx =
   | TmRecLets t ->
-    let foldli : all a. all acc. (Int -> acc -> a -> acc) -> acc -> [a] -> acc =
-      lam f. lam init. lam seq.
-      let foldres : (Int, acc) = foldl (lam acc : (Int, acc). lam x.
-                                         (addi acc.0 1, f acc.0 acc.1 x))
-                                       (0, init) seq in
-      foldres.1
+    recursive let envPrime : Lazy Env = lam.
+      let wraplambda = lam v.
+        match v with TmLam t then
+          TmClos {ident = t.ident, body = t.body, env = envPrime}
+        else errorSingle [infoTm v] "Right-hand side of recursive let must be a lambda"
+      in
+      foldl
+        (lam env. lam bind.
+          evalEnvInsert bind.ident (wraplambda bind.body) env)
+        ctx.env t.bindings
     in
-    utest foldli (lam i. lam acc. lam x. concat (concat acc (int2string i)) x)
-                 ""
-                 ["a", "b", "c"]
-    with "0a1b2c" in
-    let eta_name = nameSym "eta" in
-    let eta_var = TmVar {ident = eta_name,
-                         ty = tyunknown_,
-                         info = NoInfo(),
-                         frozen = false} in
-    let unpack_from = lam var. lam body.
-      foldli
-        (lam i. lam bodyacc. lam binding : RecLetBinding.
-          TmLet {ident = binding.ident,
-                 tyAnnot = tyunknown_,
-                 tyBody = tyunknown_,
-                 body = TmLam {ident = eta_name,
-                               body = TmApp {lhs = _evalDTupleProj i var,
-                                             rhs = eta_var,
-                                             ty = tyunknown_,
-                                             info = NoInfo()},
-                               tyAnnot = tyunknown_,
-                               tyIdent = tyunknown_,
-                               ty = tyunknown_,
-                               info = NoInfo()
-                               },
-                 inexpr = bodyacc,
-                 ty = tyunknown_,
-                 info = NoInfo()}
-        )
-        body
-        t.bindings in
-    let lst_name = nameSym "lst" in
-    let lst_var = TmVar {ident = lst_name,
-                         ty = tyunknown_,
-                         info = NoInfo(),
-                         frozen = false} in
-    let func_tuple = utuple_ (map (lam x : RecLetBinding. x.body) t.bindings) in
-    let unfixed_tuple = TmLam {ident = lst_name,
-                               body = unpack_from lst_var func_tuple,
-                               tyIdent = tyunknown_,
-                               tyAnnot = tyunknown_,
-                               ty = tyunknown_,
-                               info = NoInfo()} in
-    eval {ctx with env =
-            evalEnvInsert lst_name (TmApp {lhs = TmFix (),
-                                       rhs = unfixed_tuple,
-                                       ty = tyunknown_,
-                                       info = NoInfo()})
-            ctx.env}
-         (unpack_from lst_var t.inexpr)
+    eval {ctx with env = envPrime ()} t.inexpr
 end
 
 lang ConstEval = Eval + ConstAst + SysAst + SeqAst + UnknownTypeAst
@@ -2145,7 +2063,7 @@ end
 lang MExprEval =
 
   -- Terms
-  VarEval + AppEval + LamEval + FixEval + RecordEval + RecLetsEval +
+  VarEval + AppEval + LamEval + RecordEval + RecLetsEval +
   ConstEval + TypeEval + DataEval + MatchEval + UtestEval + SeqEval +
   NeverEval + RefEval + ExtEval
 

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -26,13 +26,6 @@ let evalEnvLookup = lam id. lam env. assocSeqLookup {eq=nameEqSymUnsafe} id env
 
 let evalEnvInsert = lam id. lam e. lam env. assocSeqInsert id e env
 
-let _evalEqNameWithInfo =
-  lam info. lam n1. lam n2.
-    if and (nameHasSym n1) (nameHasSym n2) then
-      nameEqSym n1 n2
-    else
-      errorSingle [info] "Found name without symbol in eval. Did you run symbolize?"
-
 ------------------------
 -- EVALUATION CONTEXT --
 ------------------------
@@ -1997,11 +1990,9 @@ lang DataPatEval = DataAst + DataPat
   sem tryMatch (env : Env) (t : Expr) =
   | PatCon {ident = ident, subpat = subpat, info = info} ->
     match t with TmConApp cn then
-      let constructor = cn.ident in
-      let subexpr = cn.body in
-      if _evalEqNameWithInfo info ident constructor
-        then tryMatch env subexpr subpat
-        else None ()
+      if nameEqSymUnsafe ident cn.ident then
+        tryMatch env cn.body subpat
+      else None ()
     else None ()
 end
 

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -22,7 +22,7 @@ type Env = [(Name, Expr)]
 
 let evalEnvEmpty = createList 0 (lam. (nameNoSym "", unit_))
 
-let evalEnvLookup = lam id. lam env. assocSeqLookup {eq=nameEq} id env
+let evalEnvLookup = lam id. lam env. assocSeqLookup {eq=nameEqSymUnsafe} id env
 
 let evalEnvInsert = lam id. lam e. lam env. assocSeqInsert id e env
 

--- a/stdlib/mexpr/profiling.mc
+++ b/stdlib/mexpr/profiling.mc
@@ -25,6 +25,7 @@
 include "mexpr/ast.mc"
 include "mexpr/boot-parser.mc"
 include "mexpr/eval.mc"
+include "mexpr/symbolize.mc"
 
 include "sys.mc"
 
@@ -256,7 +257,7 @@ lang MExprProfileInstrument = MExprAst + BootParser
       getProfilerReportCode ()]
 end
 
-lang TestLang = MExprProfileInstrument + MExprEval
+lang TestLang = MExprProfileInstrument + MExprSym + MExprEval
 end
 
 mexpr
@@ -277,7 +278,7 @@ let t = bindall_ [
   app_ (var_ "f") (int_ 4)
 ] in
 let t = instrumentProfiling t in
-eval {env = evalEnvEmpty} t;
+eval {env = evalEnvEmpty} (symbolize t);
 utest fileExists profilingResultFileName with true in
 (if fileExists profilingResultFileName then
   let lines =

--- a/stdlib/name.mc
+++ b/stdlib/name.mc
@@ -72,6 +72,14 @@ utest nameEqSym _t1 _t2 with false
 utest nameEqSym _t2 _t3 with false
 utest _t3 with _t3 using nameEqSym
 
+-- 'nameEqSymUnsafe' returns true if names 'n1' and 'n2' contain the same
+-- symbols, without checking whether they contain a symbol. This means two
+-- unsymbolized names will be considered equal.
+--
+-- This function is to be used in performance critical situations where we know
+-- both names have been symbolized.
+let nameEqSymUnsafe : Name -> Name -> Bool = lam n1. lam n2. eqsym n1.1 n2.1
+
 -- 'nameEq n1 n2' returns true if the symbols are equal, or if neither name has
 -- a symbol and their strings are equal. Otherwise, return false.
 let nameEq : Name -> Name -> Bool =

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -453,6 +453,7 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   debugPrintLn debug "";
 
   -- Transformations should produce an AST that type checks
+  let ast = symbolize ast in
   let ast = typeCheck ast in
 
   -- Evaluate the program


### PR DESCRIPTION
This PR vastly improves the performance of the Miking interpreter (`mi eval`), putting it close to the performance of the boot interpreter (`boot eval`) in the first bootstrapping stage, which I used for evaluation (see benchmarks below). The improvements are due to ~~two~~ (**EDIT**: three) key changes in the Miking interpreter:
* Optimized handling of recursive let-expressions, using a similar approach as in the boot interpreter.
* A more efficient equality function for the evaluation environment. The new equality function, `nameEqSymUnsafe`, skips unnecessary checks given that all names have a symbol (as is the case for the interpreter).
* A native implementation of cons lists in MExpr, which does not suffer from the performance overheads of "list sequences" (due to the extra indirection). These are used for the evaluation environment.

This PR fixes #378, as `mi eval` now vastly outperforms `boot eval` in the example presented for that PR (factorial), and the performance difference is minimal now. A major difference that I found from local testing is in the evaluation of patterns, which is significantly slower in the Miking interpreter (≈10s slower when running the first bootstrapping phase, roughly 5s compared to 15s spent interpreting patterns). This is, at least to some extent, due to the record patterns, where the boot interpreter uses an efficient map merge function. I haven't found a way to improve the approach in the Miking interpreter. The problems are that:
* We do not have access to the underlying map representation, so we cannot replicate the behavior of the merge function as efficiently as the OCaml function. Because of this, we need to use `mapBindings` to get a sequence we can operate on, which has a significant overhead compared to the "native" merge.
* Adding the [merge function](https://v2.ocaml.org/api/Map.S.html#VALmerge) as an intrinsic is problematic because it uses OCaml options. I tried implementing an intrinsic for the intersection of maps to improve this, but I did not find sufficient performance improvements to justify including it in this PR.

Discussion points:
* An alternative approach to the pattern evaluation problem could be to implement maps natively in MExpr, as that would let us implement things like merges more efficiently. I took a quick look at the [OCaml implementation of maps](https://github.com/ocaml/ocaml/blob/trunk/stdlib/map.ml), and I found it surprisingly brief (less than 500 LOC). A problem with doing this is that map operations would become much slower in `boot`.

<details id="benchmarks">
<summary>Benchmarks (EDITED)</summary>

I repeated the command three times for each of these "benchmarks"; the best result is shown below. The key takeaway should be massive performance improvements in the Miking interpreter. Take the difference between the new Miking interpreter and the boot interpreter with a grain of salt - they seem to vary significantly between runs.

Miking interpreter (`develop`):
```
$ time mi eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc
mi eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc  200.30s user 0.87s system 99% cpu 3:21.22 total
```

Miking interpreter (this PR):
```
$ time mi eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc
mi eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc  55.30s user 0.75s system 99% cpu 56.079 total
```

Boot interpreter:
```
$ time boot eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc
boot eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc  51.11s user 0.37s system 99% cpu 51.498 total
```
</details>