### PR TITLE
LR(k) parser generator

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -79,6 +79,10 @@ let tyapp_ = use AppTypeAst in
   lam lhs. lam rhs.
   TyApp {lhs = lhs, rhs = rhs, info = NoInfo ()}
 
+let tyapps_ = use AppTypeAst in
+  lam lhs. lam args.
+  foldl tyapp_ lhs args
+
 let tyalias_ = use AliasTypeAst in
   lam display. lam content.
   TyAlias {display = display, content = content}

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -1,4 +1,4 @@
-include "./bool.mc"
+include "bool.mc"
 
 type Option a
 con Some : all a. a -> Option a

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -1,4 +1,4 @@
-include "bool.mc"
+include "./bool.mc"
 
 type Option a
 con Some : all a. a -> Option a
@@ -132,15 +132,6 @@ let optionGetOr: all a. a -> Option a -> a = lam d.
 
 utest optionGetOr 3 (Some 1) with 1
 utest optionGetOr 3 (None ()) with 3
-
--- Retrieve all contained values that are not None in the sequence
-let optionGetAll: all a. [Option a] -> [a] = lam s.
-  reverse (foldl (lam acc. lam e. match e with Some v then cons v acc else acc) [] s)
-
-utest optionGetAll [] with []
-utest optionGetAll [None (), None ()] with []
-utest optionGetAll [Some 1, Some 10, Some 100] with [1, 10, 100]
-utest optionGetAll [Some 1, None (), None (), Some 10, None ()] with [1, 10]
 
 -- Applies a function to the contained value (if any),
 -- or computes a default (if not).

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -133,6 +133,15 @@ let optionGetOr: all a. a -> Option a -> a = lam d.
 utest optionGetOr 3 (Some 1) with 1
 utest optionGetOr 3 (None ()) with 3
 
+-- Retrieve all contained values that are not None in the sequence
+let optionGetAll: all a. [Option a] -> [a] = lam s.
+  reverse (foldl (lam acc. lam e. match e with Some v then cons v acc else acc) [] s)
+
+utest optionGetAll [] with []
+utest optionGetAll [None (), None ()] with []
+utest optionGetAll [Some 1, Some 10, Some 100] with [1, 10, 100]
+utest optionGetAll [Some 1, None (), None (), Some 10, None ()] with [1, 10]
+
 -- Applies a function to the contained value (if any),
 -- or computes a default (if not).
 let optionMapOrElse: all a. all b. (() -> b) -> (a -> b) -> Option a -> b =

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -32,8 +32,14 @@ lang TokenParser = WSACParser
   sem tokKindEq (tokRepr : TokenRepr) /- : Token -> Bool -/ =
   sem tokInfo /- : Token -> Info -/ =
   sem tokToStr /- : Token -> String -/ =
-  sem tokReprCompare /- : (TokenRepr, TokenRepr) -> Int -/ =
+  sem tokReprCompare2 : (TokenRepr, TokenRepr) -> Int
+  sem tokReprCompare2 /- : (TokenRepr, TokenRepr) -> Int -/ =
   | (l, r) -> subi (constructorTag l) (constructorTag r)
+  sem tokReprCompare l =
+  | r -> tokReprCompare2 (l, r)
+  sem tokReprEq : TokenRepr -> TokenRepr -> Bool
+  sem tokReprEq l /- : TokenRepr -> TokenRepr -> Bool -/ =
+  | r -> eqi 0 (tokReprCompare l r)
   sem tokReprToStr /- : TokenRepr -> String -/ =
   sem tokToRepr /- : Token -> TokenRepr -/ =
 end
@@ -673,7 +679,7 @@ lang HashStringTokenParser = TokenParser
   sem tokToStr =
   | HashStringTok tok -> join ["<Hash:", tok.hash, ">", tok.val]
 
-  sem tokReprCompare =
+  sem tokReprCompare2 =
   | (HashStringRepr l, HashStringRepr r) -> cmpString l.hash r.hash
 
   sem tokToRepr =

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -71,7 +71,7 @@ lang ParserBase = TokenParser + EOFTokenParser
   | r -> _compareSpecSymbol (l, r)
   sem _compareSpecSymbol : all state. all prodLabel. (SpecSymbol Token TokenRepr state prodLabel, SpecSymbol Token TokenRepr state prodLabel) -> Int
   sem _compareSpecSymbol =
-  | (TokSpec l, TokSpec r) -> tokReprCompare (l, r)
+  | (TokSpec l, TokSpec r) -> tokReprCompare l r
   | (LitSpec l, LitSpec r) -> cmpString l.lit r.lit
   | (NtSpec l, NtSpec r) -> nameCmp l r
   | (l, r) -> subi (constructorTag l) (constructorTag r)

--- a/stdlib/parser/lrk.mc
+++ b/stdlib/parser/lrk.mc
@@ -342,7 +342,7 @@ lang LRParser = LRTokens + MExprAst + MExprCmp
             else None ()
         end
       ) rule.terms argtypes in
-      match optionGetAll maybeErrs with ([_] ++ _) & actualErrs then
+      match filterOption maybeErrs with ([_] ++ _) & actualErrs then
         snoc errs (strJoin "\n - " (
           cons (join ["Argument type mismatch for rule ", int2string ruleIdx, ":"])
                actualErrs

--- a/stdlib/parser/lrk.mc
+++ b/stdlib/parser/lrk.mc
@@ -905,20 +905,18 @@ lang LRParser = EOFTokenParser + MExprAst + MExprCmp
                       -- extract all values from the stacks and pop that value from the stack
                       -- and create the new production
                       bindall_ (snoc
-                        (mapi (lam i. lam lbl.
+                        -- Stack semantics, so we pop in reverse order
+                        (reverse (mapi (lam i. lam lbl.
                         bindall_ [
                           ulet_ (join ["tokenValue", int2string i]) (head_ (var_ (concat "var" lbl))),
                           ulet_ (concat "var" lbl) (tail_ (var_ (concat "var" lbl)))
                         ]
-                        ) stackLabels)
+                        ) stackLabels))
                         (ulet_ "newProduce" (appSeq_ rule.action (cons (nvar_ varActionState) (mapi (lam i. lam. var_ (join ["tokenValue", int2string i])) stackLabels))))
                       ),
                       --printLn "     If we reduce on the entrypoint rule, then we return...";
                       -- If we reduce on the entrypoint rule, then we return. Otherwise push to the stack and run the GOTO action
                       if eqi reduction.ruleIdx table.entrypointRuleIdx then (
-                        printLn (join ["TADA! reduction.ruleIdx: ", int2string reduction.ruleIdx,
-                                       ", table.entrypointRuleIdx: ", int2string table.entrypointRuleIdx,
-                                       ", stateIdx: ", int2string i]);
                         #var"global: result.ok" (var_ "newProduce")
                       ) else (bindall_ [
                         ulet_ (concat "var" returnLabel) (cons_ (var_ "newProduce") (var_ (concat "var" returnLabel))),

--- a/stdlib/parser/lrk.mc
+++ b/stdlib/parser/lrk.mc
@@ -144,7 +144,7 @@ lang LRParser = LRTokens + MExprAst + MExprCmp
     setInsert [] (setEmpty (seqCmp tokenCmp))
 
 
-  -- FIRST_k(S) is the set of sequences of all non-terminals that can appear
+  -- FIRST_k(S) is the set of sequences of all terminals that can appear
   -- for a term S, truncated to the first k symbols.
   sem lrFirst : Int -> LRSyntaxDef -> Map LRTerm (Set [LRToken])
   sem lrFirst k =

--- a/stdlib/parser/lrk.mc
+++ b/stdlib/parser/lrk.mc
@@ -1,0 +1,728 @@
+-- LR(k >= 1)
+
+include "bool.mc"
+include "common.mc"
+include "map.mc"
+include "name.mc"
+include "option.mc"
+include "seq.mc"
+include "set.mc"
+
+
+lang LRTokens
+  syn LRToken =
+  | LRTokenEOF ()
+
+  sem token2string : LRToken -> String
+  sem token2string =
+  | LRTokenEOF _ -> "EOF"
+
+  sem tokenId : LRToken -> Int
+  sem tokenId =
+  | LRTokenEOF _ -> negi 100
+
+  sem tokenCmp : LRToken -> LRToken -> Int
+  sem tokenCmp other =
+  | t -> subi (tokenId other) (tokenId t)
+
+  sem tokenEq : LRToken -> LRToken -> Bool
+  sem tokenEq other =
+  | t -> eqi (tokenCmp other t) 0
+end
+
+lang LRBase = LRTokens
+  syn LRTerm =
+  | Terminal LRToken
+  | NonTerminal Name
+
+  type LRRule = {
+    name: Name,
+    terms: [LRTerm]
+  }
+
+  type LRSyntaxDef = {
+    entrypoint: Name,
+    rules: [LRRule]
+  }
+
+  type LRStateItem = {
+    name: Name,
+    terms: [LRTerm],
+    stackPointer: Int,
+    lookahead: [LRToken],
+    ruleIdx: Int -- index of the rule that this item originates from
+  }
+
+  type LRParseTable = {
+    k_lookahead: Int,
+    entrypointIdx: Int,
+    _debugStates: [Set LRStateItem],
+    nStates: Int,
+    syntaxDef: LRSyntaxDef,
+    shifts: Map Int [{lookahead: [LRToken], toIdx: Int}],
+    gotos: Map Int [{name: Name, lookahead: [LRToken], toIdx: Int}],
+    reductions: Map Int [{lookahead: [LRToken], ruleIdx: Int}]
+  }
+
+
+  sem lrTerm2string : LRTerm -> String
+  sem lrTerm2string =
+  | Terminal t -> join (["Term(", token2string t, ")"])
+  | NonTerminal n -> join (["NonTerminal(", nameGetStr n, ")"])
+
+
+  sem lrTermCmp2 : (LRTerm, LRTerm) -> Int
+  sem lrTermCmp2 =
+  | (Terminal t1, Terminal t2) -> tokenCmp t1 t2
+  | (NonTerminal n1, NonTerminal n2) -> nameCmp n1 n2
+  | (Terminal _, NonTerminal _) -> negi 1
+  | (NonTerminal _, Terminal _) -> 1
+
+
+  sem lrTermCmp : LRTerm -> LRTerm -> Int
+  sem lrTermCmp other =
+  | t -> lrTermCmp2 (other, t)
+
+
+  sem lrtermEq : LRTerm -> LRTerm -> Bool
+  sem lrtermEq other =
+  | t -> eqi (lrTermCmp other t) 0
+
+
+  sem lrStateItemCmp2 : (LRStateItem, LRStateItem) -> Int
+  sem lrStateItemCmp2 =
+  | (lhs, rhs) ->
+    let cName = nameCmp lhs.name rhs.name in
+    if neqi cName 0 then cName else
+    let cTerms = seqCmp lrTermCmp lhs.terms rhs.terms in
+    if neqi cTerms 0 then cTerms else
+    let cStackPointer = subi lhs.stackPointer rhs.stackPointer in
+    if neqi cStackPointer 0 then cStackPointer else
+    let cLookahead = seqCmp tokenCmp lhs.lookahead rhs.lookahead in
+    if neqi cLookahead 0 then cLookahead else
+    let cRuleIdx = subi lhs.ruleIdx rhs.ruleIdx in
+    cRuleIdx
+
+
+  sem lrStateItemCmp : LRStateItem -> LRStateItem -> Int
+  sem lrStateItemCmp lhs =
+  | rhs -> lrStateItemCmp2 (lhs, rhs)
+
+
+  -- The ComposeFirst function
+  --   if seq = [Y_1]:
+  --     -- take the FIRST_n available
+  --     return {[t_1,...,t_n] | [t_1,t_2,t_3,t_4,...] in FIRST_k(Y_1)}
+  --   else if seq = [Y_1] ++ rest:
+  --     ret <- {}
+  --     for [t_1,..t_i] in FIRST_k(Y_1):
+  --       if i >= n:
+  --         ret <- ret U {[t_1,...,t_n]}
+  --       else:
+  --         for [t_{i+1},...t_j] in ComposeFirst(n - i, rest):
+  --           ret <- ret U {[t_1,..t_i,t_{i+1},...t_j]}
+  --     return ret
+  sem lrComposeFirst: Int -> Map LRTerm (Set [LRToken]) -> [LRTerm] -> Set [LRToken]
+  sem lrComposeFirst k firstMap =
+  | [y1] ->
+    -- Return first k from the firstMap
+    setFold (lam acc: Set [LRToken]. lam y1_tokens: [LRToken].
+      setInsert (subsequence y1_tokens 0 k) acc
+    ) (setEmpty (seqCmp tokenCmp)) (mapLookupOrElse (lam. setEmpty (seqCmp tokenCmp)) y1 firstMap)
+  | [y1, y2] ++ rest ->
+    setFold (lam acc: Set [LRToken]. lam y1_tokens: [LRToken].
+      if geqi (length y1_tokens) k then
+        setInsert (subsequence y1_tokens 0 k) acc
+      else
+        setFold (lam acc: Set [LRToken]. lam rest_tokens: [LRToken].
+          setInsert (concat y1_tokens rest_tokens) acc
+        ) acc (lrComposeFirst (subi k (length y1_tokens)) firstMap (cons y2 rest))
+    ) (setEmpty (seqCmp tokenCmp)) (mapLookupOrElse (lam. setEmpty (seqCmp tokenCmp)) y1 firstMap)
+  | [] ->
+    setInsert [] (setEmpty (seqCmp tokenCmp))
+
+
+  -- FIRST_k(S) is the set of sequences of all non-terminals that can appear
+  -- for a term S, truncated to the first k symbols.
+  sem lrFirst : Int -> LRSyntaxDef -> Map LRTerm (Set [LRToken])
+  sem lrFirst k =
+  | syntaxDef ->
+    -- Compile a set of all terms in the syntax definition
+    let allTerms: Set LRTerm = foldl (lam acc: Set LRTerm. lam rule: LRRule.
+      let acc = setInsert (NonTerminal rule.name) acc in
+      foldl (lam acc: Set LRTerm. lam term: LRTerm. setInsert term acc) acc rule.terms
+    ) (setEmpty lrTermCmp) syntaxDef.rules in
+
+    -- Initialize FIRST_k:
+    --   for all terminals t:
+    --     FIRSK_k(t) = {[t]}
+    --   for all non-terminals S:
+    --     FIRST_k(S) = {}
+    let firstK: Map LRTerm (Set [LRToken]) = setFold (lam acc: Map LRTerm (Set [LRToken]). lam term: LRTerm.
+      switch term
+      case Terminal t then mapInsert term (setInsert [t] (setEmpty (seqCmp tokenCmp))) acc
+      case NonTerminal _ then mapInsert term (setEmpty (seqCmp tokenCmp)) acc
+      end
+    ) (mapEmpty lrTermCmp) allTerms in
+
+    -- Convenience functions for insertions
+    let firstInsert: LRTerm -> Set [LRToken] -> Map LRTerm (Set [LRToken]) -> Map LRTerm (Set [LRToken]) = lam term. lam tokenSet. lam firstMap.
+      mapInsert term
+                (setUnion tokenSet
+                          (mapLookupOrElse (lam. setEmpty (seqCmp tokenCmp))
+                                           term
+                                           firstMap))
+                firstMap
+    in
+
+    -- loop until convergence:
+    --   for each production S -> Y_1 Y_2 ... Y_n do:
+    --     if n = 0:
+    --       FIRST_k(S) <- FIRST_k(S) U {[]}  -- empty production
+    --     else if for all Y_i, FIRST_k(Y_i) != ø:
+    --       FIRST_k(S) <- FIRST_k(S) U ComposeFirst(k, [Y_1,Y_2,...,Y_n])
+    recursive let iterate = lam firstMap: Map LRTerm (Set [LRToken]).
+      let resultMap = foldl (lam firstMap: Map LRTerm (Set [LRToken]). lam rule: LRRule.
+        if eqi (length rule.terms) 0 then
+          firstInsert (NonTerminal rule.name) (setInsert [] (setEmpty (seqCmp tokenCmp))) firstMap
+        else if any (lam term: LRTerm. setIsEmpty (mapLookupOrElse (lam. setEmpty (seqCmp tokenCmp)) term firstMap)) rule.terms then
+          firstMap -- one of symbols for these rules lack an instance of firskK, skip this for now
+        else
+          firstInsert (NonTerminal rule.name) (lrComposeFirst k firstMap rule.terms) firstMap
+      ) firstMap (syntaxDef.rules) in
+      if mapEq setEq resultMap firstMap then
+        resultMap
+      else
+        iterate resultMap
+    in
+    iterate firstK
+
+
+  -- Computes the closure for the input set as
+  -- Closure(I) =
+  --   repeat
+  --     for any item (A -> a.Xb, L) in I
+  --       for any production X -> y
+  --         for any W in FIRST_k (bL)
+  --           I <- I U {(X -> .y, W)}
+  --   until I does not change
+  --   return I
+  sem lrClosure: Int -> LRSyntaxDef -> Map LRTerm (Set [LRToken]) -> Set LRStateItem -> Set LRStateItem
+  sem lrClosure k syntaxDef firstMap =
+  | inSet ->
+    -- OPT(johnwikman, 2023-01-14): This performs a bunch of unnecessary checks
+    -- on new iterations, as it only needs to check the latest items that were
+    -- added to the set. But to keep things simple initially, I didn't bother
+    -- to implement this optimization.
+    recursive let iterate = lam inSet: Set LRStateItem.
+      let resultSet = setFold (lam accSet: Set LRStateItem. lam item: LRStateItem.
+        match subsequence item.terms item.stackPointer (length item.terms)
+        with [NonTerminal x] ++ b then
+          let bL: [LRTerm] = concat b (map (lam t. Terminal t) item.lookahead) in
+          let firstK_bL: Set [LRToken] = lrComposeFirst k firstMap bL in
+          foldli (lam accSet: Set LRStateItem. lam ruleIdx: Int. lam rule: LRRule.
+            if nameEq x rule.name then
+              -- Process this rule
+              setFold (lam accSet: Set LRStateItem. lam w: [LRToken].
+                let newItem: LRStateItem = {
+                  name = x,
+                  terms = rule.terms,
+                  stackPointer = 0,
+                  lookahead = w,
+                  ruleIdx = ruleIdx
+                } in
+                setInsert newItem accSet
+              ) accSet firstK_bL
+            else
+              accSet
+          ) accSet syntaxDef.rules
+        else
+          accSet
+      ) inSet inSet in
+      if setEq resultSet inSet then
+        resultSet
+      else
+        iterate resultSet
+    in
+    iterate inSet
+
+
+  -- GOTO(I, X) =
+  --   J <- {}
+  --   for any item (A -> a.Xb, L) in I
+  --     add (A -> aX.b, L) to J
+  --   return Closure(J)
+  sem lrGoto: Int -> LRSyntaxDef -> Map LRTerm (Set [LRToken]) -> Set LRStateItem -> LRTerm -> Set LRStateItem
+  sem lrGoto k syntaxDef firstMap inSet =
+  | x ->
+    let j = setFold (lam jAcc: Set LRStateItem. lam item: LRStateItem.
+      if lti item.stackPointer (length item.terms) then
+        if lrtermEq x (get item.terms item.stackPointer) then
+          setInsert {item with stackPointer = addi item.stackPointer 1} jAcc
+        else
+          jAcc
+      else
+        jAcc
+    ) (setEmpty lrStateItemCmp) inSet in
+    lrClosure k syntaxDef firstMap j
+
+
+  -- Initialize T to {Closure(({S' -> .S$}, $))}
+  -- Initialize E to empty
+  -- repeat
+  --  for each state I in T
+  --    for each item (A -> a.Xb, z) in I
+  --      let J be GOTO(I, X)
+  --      T <- T U {J}
+  --      E <- E U {I --X-> J}
+  -- until E and T did not change in this iteration
+  -- R <- {}
+  -- for each state I in T
+  --   for each item (A -> a., z) in I
+  --     R <- R U {(I, z, A -> a)}
+  sem lrCreateParseTable: Int -> LRSyntaxDef -> LRParseTable
+  sem lrCreateParseTable k =
+  | syntaxDef ->
+    let initRule: LRRule = {
+      name = nameSym "_entrypoint_",
+      terms = [NonTerminal syntaxDef.entrypoint, Terminal (LRTokenEOF ())]
+    } in
+    let syntaxDef = {syntaxDef with rules = snoc syntaxDef.rules initRule} in
+    let firstK = lrFirst k syntaxDef in
+    let initState: Set LRStateItem = setInsert {
+      name = initRule.name,
+      terms = initRule.terms,
+      stackPointer = 0,
+      lookahead = [],
+      ruleIdx = subi (length syntaxDef.rules) 1 -- We inserted the initial rule at the back
+    } (setEmpty lrStateItemCmp) in
+    let initState: Set LRStateItem = lrClosure k syntaxDef firstK initState in
+    let table: LRParseTable = {
+      k_lookahead = k,
+      entrypointIdx = 0,
+      _debugStates = [initState],
+      nStates = 1,
+      syntaxDef = syntaxDef,
+      shifts = mapEmpty subi,
+      gotos = mapEmpty subi,
+      reductions = mapEmpty subi
+    } in
+
+    -- Iterate to create all states and transitions
+    recursive let iterate = lam table: LRParseTable. lam stateIdxLookup: Map (Set LRStateItem) Int. lam nextStateIdx: Int.
+      if geqi nextStateIdx table.nStates then
+        table
+      else --continue
+      let state = get table._debugStates nextStateIdx in
+
+      let cmpShift = lam lhs. lam rhs.
+        let cLookahead = seqCmp tokenCmp lhs.lookahead rhs.lookahead in
+        if neqi cLookahead 0 then cLookahead
+        else subi lhs.toIdx rhs.toIdx
+      in
+      let cmpGoto = lam lhs. lam rhs.
+        let cName = nameCmp lhs.name rhs.name in
+        let cLookahead = seqCmp tokenCmp lhs.lookahead rhs.lookahead in
+        if neqi cName 0 then cName
+        else if neqi cLookahead 0 then cLookahead
+        else subi lhs.toIdx rhs.toIdx
+      in
+
+      let result = setFold (lam acc: (LRParseTable, Map (Set LRStateItem) Int, Set {lookahead: [LRToken], toIdx: Int}, Set {name: Name, lookahead: [LRToken], toIdx: Int}). lam item: LRStateItem.
+        match acc with (table, stateIdxLookup, stateShifts, stateGotos) in
+        match subsequence item.terms item.stackPointer (length item.terms)
+        with ([x] ++ b) & postStackTerms then
+          let j = lrGoto k syntaxDef firstK state x in
+
+          let jInsertResult =
+            match mapLookup j stateIdxLookup with Some jIdx then
+              (table, stateIdxLookup, jIdx)
+            else
+              -- the state j is new, add it to the table
+              let jIdx = length table._debugStates in
+              let table = {table with _debugStates = snoc table._debugStates j, nStates = addi table.nStates 1} in
+              let stateIdxLookup = mapInsert j jIdx stateIdxLookup in
+              (table, stateIdxLookup, jIdx)
+          in
+          match jInsertResult with (table, stateIdxLookup, jIdx) in
+
+          switch x
+          case Terminal t then
+            -- This is a shift action
+            let possibleLookaheads = lrComposeFirst k firstK (concat postStackTerms (map (lam t2. Terminal t2) item.lookahead)) in
+            let stateShifts = setFold (lam acc. lam lh. setInsert {lookahead = lh, toIdx = jIdx} acc) stateShifts possibleLookaheads in
+            (table, stateIdxLookup, stateShifts, stateGotos)
+          case NonTerminal n then
+            -- This is a Goto action
+            let possibleLookaheads = lrComposeFirst k firstK (concat b (map (lam t2. Terminal t2) item.lookahead)) in
+            let stateGotos = setFold (lam acc. lam lh. setInsert {name = n, lookahead = lh, toIdx = jIdx} acc) stateGotos possibleLookaheads in
+            (table, stateIdxLookup, stateShifts, stateGotos)
+          end
+        else
+          acc
+      ) (table, stateIdxLookup, setEmpty cmpShift, setEmpty cmpGoto) state in
+      match result with (table, stateIdxLookup, stateShifts, stateGotos) in
+
+      -- Only keep track of unique state transitions
+      let stateShifts = setToSeq stateShifts in
+      let stateGotos = setToSeq stateGotos in
+      let table = {table with shifts = mapInsert nextStateIdx stateShifts table.shifts,
+                              gotos = mapInsert nextStateIdx stateGotos table.gotos} in
+      iterate table stateIdxLookup (addi nextStateIdx 1)
+    in
+    let table = iterate table (mapInsert initState 0 (mapEmpty setCmp)) 0 in
+
+    -- Construct the reductions
+    let table = foldli (lam tableAcc: LRParseTable. lam stateIdx: Int. lam state: Set LRStateItem.
+      let stateReductions = setFold (lam redAcc: [{lookahead: [LRToken], ruleIdx: Int}]. lam item: LRStateItem.
+        if eqi item.stackPointer (length item.terms) then
+          snoc redAcc {lookahead = item.lookahead, ruleIdx = item.ruleIdx}
+        else
+          redAcc
+      ) [] state in
+      {tableAcc with reductions = mapInsert stateIdx stateReductions tableAcc.reductions}
+    ) table table._debugStates in
+
+    -- Table is now constructed
+    table
+end
+
+lang LRBaseTest = LRBase
+  syn LRToken =
+  | LRTokenIdentifier String
+  | LRTokenLParen {}
+  | LRTokenRParen {}
+  | LRTokenComma {}
+  | LRTokenStar {}
+  | LRTokenEquals {}
+
+  sem token2string =
+  | LRTokenIdentifier s -> join ["Ident\"", s, "\""]
+  | LRTokenLParen {} -> "("
+  | LRTokenRParen {} -> ")"
+  | LRTokenComma {} -> ","
+  | LRTokenStar {} -> "*"
+  | LRTokenEquals {} -> "="
+
+  sem tokenId =
+  | LRTokenIdentifier _ -> 1
+  | LRTokenLParen {} -> 2
+  | LRTokenRParen {} -> 3
+  | LRTokenComma {} -> 4
+  | LRTokenStar {} -> 5
+  | LRTokenEquals {} -> 6
+end
+
+
+mexpr
+use LRBaseTest in
+
+
+type LRTestCase = {
+  name: String,
+  syntaxDef: LRSyntaxDef,
+  first1: Map LRTerm (Set [LRToken]),
+  first2: Map LRTerm (Set [LRToken]),
+  first3: Map LRTerm (Set [LRToken])
+} in
+
+
+let testcases = [
+  -- LR1 example from the book by Appel
+  let _S = nameSym "S" in
+  let _E = nameSym "E" in
+  let _V = nameSym "V" in
+  {
+    name = "LR1 Example",
+    syntaxDef = {
+      entrypoint = _S,
+      rules = [
+        {name = _S, terms = [NonTerminal _V, Terminal (LRTokenEquals ()), NonTerminal _E]},
+        {name = _S, terms = [NonTerminal _E]},
+        {name = _E, terms = [NonTerminal _V]},
+        {name = _V, terms = [Terminal (LRTokenIdentifier "")]},
+        {name = _V, terms = [Terminal (LRTokenStar ()), NonTerminal _E]}
+      ]
+    },
+    first1 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""], [LRTokenStar ()]
+       ]),
+      (NonTerminal _E, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""], [LRTokenStar ()]
+       ]),
+      (NonTerminal _V, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""], [LRTokenStar ()]
+       ])
+    ],
+    first2 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""],
+        [LRTokenIdentifier "", LRTokenEquals ()],
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar ()]
+       ]),
+      (NonTerminal _E, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar ()]
+       ]),
+      (NonTerminal _V, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar ()]
+       ])
+    ],
+    first3 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""],
+        [LRTokenIdentifier "", LRTokenEquals (), LRTokenStar ()],
+        [LRTokenIdentifier "", LRTokenEquals (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier "", LRTokenEquals ()],
+        [LRTokenStar (), LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar (), LRTokenStar ()]
+       ]),
+      (NonTerminal _E, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar (), LRTokenStar ()]
+       ]),
+      (NonTerminal _V, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenStar (), LRTokenStar ()]
+       ])
+    ]
+  },
+  -- LR2 example from https://stackoverflow.com/questions/62075086/what-is-an-lr2-parser-how-does-it-differ-from-an-lr1-parser
+  let _S = nameSym "S" in
+  let _R = nameSym "R" in
+  let _T = nameSym "T" in
+  {
+    name = "LR2 Example",
+    syntaxDef = 
+    {
+      entrypoint = _S,
+      rules = [
+        {name = _S, terms = [NonTerminal _R, NonTerminal _S]},
+        {name = _S, terms = [NonTerminal _R]},
+        {name = _R, terms = [Terminal (LRTokenStar ()), Terminal (LRTokenIdentifier ""), NonTerminal _T]},
+        {name = _T, terms = [Terminal (LRTokenStar ())]},
+        {name = _T, terms = [Terminal (LRTokenEquals ())]},
+        {name = _T, terms = []}
+      ]
+    },
+    first1 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar ()]
+       ]),
+      (NonTerminal _R, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar ()]
+       ]),
+      (NonTerminal _T, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenEquals ()], [LRTokenStar ()], []
+       ])
+    ],
+    first2 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenIdentifier ""]
+       ]),
+      (NonTerminal _R, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenIdentifier ""]
+       ]),
+      (NonTerminal _T, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenEquals ()], [LRTokenStar ()], []
+       ])
+    ],
+    first3 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier "", LRTokenStar ()],
+        [LRTokenStar (), LRTokenIdentifier "", LRTokenEquals ()]
+       ]),
+      (NonTerminal _R, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenIdentifier ""],
+        [LRTokenStar (), LRTokenIdentifier "", LRTokenStar ()],
+        [LRTokenStar (), LRTokenIdentifier "", LRTokenEquals ()]
+       ]),
+      (NonTerminal _T, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenEquals ()], [LRTokenStar ()], []
+       ])
+    ]
+  },
+  -- Custom example showing GOTO lookaheads
+  let _S = nameSym "S" in
+  let _R = nameSym "R" in
+  let _T = nameSym "T" in
+  {
+    name = "GOTO Example",
+    syntaxDef = 
+    {
+      entrypoint = _S,
+      rules = [
+        {name = _S, terms = [Terminal (LRTokenStar ()), NonTerminal _R, NonTerminal _S, Terminal (LRTokenEquals ()), Terminal (LRTokenStar ())]},
+        {name = _S, terms = [Terminal (LRTokenStar ()), NonTerminal _R, NonTerminal _T, Terminal (LRTokenStar ()), Terminal (LRTokenEquals ())]},
+        {name = _R, terms = [Terminal (LRTokenStar ()), Terminal (LRTokenIdentifier ""), Terminal (LRTokenEquals ())]},
+        {name = _T, terms = [Terminal (LRTokenStar ()), Terminal (LRTokenEquals ())]},
+        {name = _T, terms = [Terminal (LRTokenStar ()), Terminal (LRTokenIdentifier "")]}
+      ]
+    },
+    first1 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar ()]
+       ]),
+      (NonTerminal _R, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar ()]
+       ]),
+      (NonTerminal _T, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar ()]
+       ])
+    ],
+    first2 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenStar ()]
+       ]),
+      (NonTerminal _R, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenIdentifier ""]
+       ]),
+      (NonTerminal _T, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (),  LRTokenIdentifier ""], [LRTokenStar (),  LRTokenEquals ()]
+       ])
+    ],
+    first3 = mapFromSeq lrTermCmp [
+      (Terminal (LRTokenEquals ()), setOfSeq (seqCmp tokenCmp) [[LRTokenEquals ()]]),
+      (Terminal (LRTokenIdentifier ""), setOfSeq (seqCmp tokenCmp) [[LRTokenIdentifier ""]]),
+      (Terminal (LRTokenStar ()), setOfSeq (seqCmp tokenCmp) [[LRTokenStar ()]]),
+      (NonTerminal _S, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenStar (), LRTokenIdentifier ""]
+       ]),
+      (NonTerminal _R, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (), LRTokenIdentifier "", LRTokenEquals ()]
+       ]),
+      (NonTerminal _T, setOfSeq (seqCmp tokenCmp) [
+        [LRTokenStar (),  LRTokenIdentifier ""], [LRTokenStar (),  LRTokenEquals ()]
+       ])
+    ]
+  }
+] in
+
+
+let printFirst: Int -> Map LRTerm (Set [LRToken]) -> () = lam k. lam firstMap.
+  mapFoldWithKey (lam. lam term: LRTerm. lam first1: Set [LRToken].
+    match term with NonTerminal _ then
+      printLn (join ["First_", int2string k, "(", lrTerm2string term, "):"]);
+      setFold (lam. lam tokens: [LRToken].
+        printLn (join ["  [", strJoin ", " (map token2string tokens), "]"])
+      ) () first1
+    else
+      ()
+  ) () firstMap
+in
+
+
+let printStates: [Set LRStateItem] -> () = lam states.
+  printLn "  States:";
+  foldli (lam. lam stateIdx: Int. lam state: Set LRStateItem.
+    printLn (join ["    State ", int2string stateIdx, ":"]);
+    let stateStrs = setFold (lam acc: [(String, String)]. lam item: LRStateItem.
+      let prefix = ["      ", nameGetStr item.name, " ->"] in
+      let prefix = foldli (lam pfxacc. lam termIdx: Int. lam term: LRTerm.
+        if eqi item.stackPointer termIdx then
+          concat pfxacc [" [STACK]", " ", lrTerm2string term]
+        else
+          concat pfxacc [" ", lrTerm2string term]
+      ) prefix item.terms in
+      let prefix = if eqi item.stackPointer (length item.terms) then snoc prefix " [STACK]" else prefix in
+      let suffix = join [
+        " | (rule ", int2string item.ruleIdx, ")",
+        " | (lookahead [", strJoin ", " (map token2string item.lookahead), "])"
+      ] in
+      snoc acc (join prefix, suffix)
+    ) [] state in
+    let maxLen = foldl (lam cand. lam s. match s with (prefix, _) in maxi cand (length prefix)) 0 stateStrs in
+    foldl (lam. lam pfxsfx: (String, String).
+      match pfxsfx with (prefix, suffix) in
+      print prefix;
+      print (make (subi maxLen (length prefix)) ' ');
+      printLn suffix
+    ) () stateStrs
+  ) () states
+in
+
+
+let printShifts: Map Int [{lookahead: [LRToken], toIdx: Int}] -> () = lam shifts.
+  printLn "  Shifts:";
+  mapFoldWithKey (lam. lam stateIdx: Int. lam stateShifts: [{lookahead: [LRToken], toIdx: Int}].
+    foldl (lam. lam shift: {lookahead: [LRToken], toIdx: Int}.
+      printLn (join ["    ", int2string stateIdx, " --[", strJoin "," (map token2string shift.lookahead), "]--> ", int2string shift.toIdx])
+    ) () stateShifts
+  ) () shifts
+in
+
+
+let printGotos: Map Int [{name: Name, lookahead: [LRToken], toIdx: Int}] -> () = lam gotos.
+  printLn "  Gotos:";
+  mapFoldWithKey (lam. lam stateIdx: Int. lam stateGotos: [{name: Name, lookahead: [LRToken], toIdx: Int}].
+    foldl (lam. lam goto: {name: Name, lookahead: [LRToken], toIdx: Int}.
+      printLn (join ["    ", int2string stateIdx, " --(", nameGetStr goto.name, ")--[", strJoin "," (map token2string goto.lookahead), "]--> ", int2string goto.toIdx])
+    ) () stateGotos
+  ) () gotos
+in
+
+
+let printReductions: Map Int [{lookahead: [LRToken], ruleIdx: Int}] -> () = lam reductions.
+  printLn "  Reductions:";
+  mapFoldWithKey (lam. lam stateIdx: Int. lam stateReductions: [{lookahead: [LRToken], ruleIdx: Int}].
+    foldl (lam. lam red: {lookahead: [LRToken], ruleIdx: Int}.
+      printLn (join [
+        "    in state ", int2string stateIdx,
+        ", reduce by rule ", int2string red.ruleIdx,
+        " on lookahead [", strJoin ", " (map token2string red.lookahead), "]"])
+    ) () stateReductions
+  ) () reductions
+in
+
+
+
+-- Run tests
+foldl (lam. lam tc: LRTestCase.
+  print (join ["Running testcase ", tc.name, " "]);
+  utest lrFirst 1 tc.syntaxDef with tc.first1 using mapEq setEq in
+  utest lrFirst 2 tc.syntaxDef with tc.first2 using mapEq setEq in
+  utest lrFirst 3 tc.syntaxDef with tc.first3 using mapEq setEq in
+  printLn "";
+  let lrtable = lrCreateParseTable 2 tc.syntaxDef in
+  printStates lrtable._debugStates;
+  printShifts lrtable.shifts;
+  printGotos lrtable.gotos;
+  printReductions lrtable.reductions;
+  printLn "\n\n";
+  ()
+) () testcases

--- a/stdlib/parser/lrk.mc
+++ b/stdlib/parser/lrk.mc
@@ -1424,10 +1424,13 @@ let printFirst: Int -> Map LRTerm (Set [TokenRepr]) -> () = lam k. lam firstMap.
 in
 
 
+let printLRInfo = false in
 
 -- Run tests
 foldl (lam. lam tc: LRTestCase.
-  print (join ["Running testcase ", tc.name, " "]);
+  (if printLRInfo then (
+    print (join ["Running testcase ", tc.name, " "])
+  ) else ());
   utest lrFirst 1 tc.syntaxDef with tc.first1 using mapEq setEq in
   utest lrFirst 2 tc.syntaxDef with tc.first2 using mapEq setEq in
   utest lrFirst 3 tc.syntaxDef with tc.first3 using mapEq setEq in
@@ -1435,12 +1438,14 @@ foldl (lam. lam tc: LRTestCase.
   let isLR1_table = match lrCreateParseTable 1 tc.tokenConTypes tc.syntaxDef with ResultOk _ then true else false in
   utest isLR1_table with tc.isLR1 in
 
-  printLn "";
-  switch lrCreateParseTable 2 tc.tokenConTypes tc.syntaxDef
-  case ResultOk {value = lrtable} then
-    printLn (lrtable2string 2 lrtable);
-    printLn "\n\n"
-  case ResultErr {errors = errors} then
-    errorSingle [] (join (mapValues errors))
-  end
+  (if printLRInfo then (
+    printLn "";
+    switch lrCreateParseTable 2 tc.tokenConTypes tc.syntaxDef
+    case ResultOk {value = lrtable} then
+      printLn (lrtable2string 2 lrtable);
+      printLn "\n\n"
+    case ResultErr {errors = errors} then
+      errorSingle [] (join (mapValues errors))
+    end
+  ) else ())
 ) () testcases

--- a/stdlib/parser/lrk.mc
+++ b/stdlib/parser/lrk.mc
@@ -570,6 +570,75 @@ lang LRParser = LRTokens + MExprAst + MExprCmp
     ) lines lrtable.reductions in
 
     strJoin "\n" lines
+
+
+  -- Generates AST-code for an LR parser corresponding to the provided parse
+  -- table. The generated code will follow this structure:
+  -- let myLRParser: all a. (a -> (a, Option LRToken)) -> a -> Either (a, <EntrypointReturnType>) [ErrorSection] =
+  --   lam nextToken. lam lexerState.
+  --   let stack_LRToken: [<LRTokenType>] = createList () in
+  --   let stack_NType0: [<NonTerminalType0>] = createList () in
+  --   let stack_NType1: [<NonTerminalType1>] = createList () in
+  --   ...
+  --   let stack_NType(k-1): [<NonTerminalType(k-1)>] = createList () in
+  --   let stacks = {
+  --     stack_LRToken = stack_LRToken,
+  --     stack_NType0 = stack_NType0,
+  --     stack_NType1 = stack_NType1,
+  --     ...
+  --     stack_NType(k-1) = stack_NType(k-1)
+  --   } in
+  --   let gotos_ON_NonTerminal0: [Int] = asRope [..., ..., ..., ...] in
+  --   let gotos_ON_NonTerminal1: [Int] = asRope [..., ..., ..., ...] in
+  --   ...
+  --   recursive let runLRParser =
+  --     lam stacks: {...}.
+  --     lam trace: [Int].
+  --     lam lookahead: [LRToken].
+  --     ...
+  --     let currentState: Int = head trace in
+  --     switch currentState
+  --     case 0 then
+  --       switch lookahead
+  --       case [..., ...] then
+  --         <perform action on this lookahead and tail-recurse on runLRParser>
+  --       case [..., ...] then
+  --         -- let's pretend this is a reduce action
+  --         let stack_NTypeX = stacks.stack.NTypeX in
+  --         let stack_NTypeY = stacks.stack.NTypeY in
+  --         let stack_NTypeZ = stacks.stack.NTypeZ in
+  --         let stack_NTypeW = stacks.stack.NTypeW in
+  --         let a3 = head stack_NTypeX in
+  --         let stack_NTypeX = tail stack_NTypeX in
+  --         let a2 = head stack_NTypeY in
+  --         let stack_NTypeY = tail stack_NTypeY in
+  --         let a1 = head stack_NTypeZ in
+  --         let stack_NTypeZ = tail stack_NTypeZ in
+  --         let prodresult = prodfun a1 a2 a3 in
+  --         let stack_NTypeW = cons prodresult stack_NTypeW in
+  --         let stacks = {stacks with stack_NTypeX = stack_NTypeX,
+  --                                   stack_NTypeY = stack_NTypeY,
+  --                                   stack_NTypeZ = stack_NTypeZ,
+  --                                   stack_NTypeW = stack_NTypeW} in
+  --         let trace = subsequence trace 3 (length trace) in
+  --         let currentState = head trace in
+  --         let nextState = get gotos_ON_NonTerminal0 currentState in
+  --         let trace = cons nextState trace in
+  --         -- NOTE: lookahead is unchanged by a reduce action
+  --         runLRParser stacks trace lookahead ...
+  --       ...
+  --       case _ then
+  --         <parse error, expected>
+  --       end
+  --     ...
+  --     end
+  --   in
+  /-
+  sem lrGenerateParser: Name -> LRParseTable -> Expr
+  sem lrGenerateParser functionName =
+  | table ->
+    TODO ()
+  -/
 end
 
 
@@ -708,8 +777,7 @@ let testcases: [LRTestCase] = [
   let _T = nameSym "T" in
   {
     name = "LR2 Example",
-    syntaxDef = 
-    {
+    syntaxDef = {
       entrypoint = _S,
       rules = [
         {name = _S, terms = [NonTerminal _R, NonTerminal _S],
@@ -780,8 +848,7 @@ let testcases: [LRTestCase] = [
   let _T = nameSym "T" in
   {
     name = "GOTO Example",
-    syntaxDef = 
-    {
+    syntaxDef = {
       entrypoint = _S,
       rules = [
         {name = _S, terms = [Terminal tokStar, NonTerminal _R, NonTerminal _T, Terminal tokEquals, Terminal tokStar],

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -19,7 +19,7 @@ lang PreToken = TokenParser
   sem tokReprToStr =
   | PreRepr x -> join ["<", nameGetStr x.constructorName, ">"]
 
-  sem tokReprCompare =
+  sem tokReprCompare2 =
   | (PreRepr l, PreRepr r) -> nameCmp l.constructorName r.constructorName
 end
 
@@ -36,7 +36,7 @@ lang PreLitToken = TokenParser
   sem tokReprToStr =
   | PreLitRepr x -> snoc (cons '\'' x.lit) '\''
 
-  sem tokReprCompare =
+  sem tokReprCompare2 =
   | (PreLitRepr l, PreLitRepr r) -> cmpString l.lit r.lit
 end
 

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -165,6 +165,23 @@ utest zipWith (zipWith addi) [[1,2], [], [10, 10, 10]] [[3,4,5], [1,2], [2, 3]]
       with [[4,6], [], [12, 13]] using eqSeq (eqSeq eqi)
 utest zipWith addi [] [] with [] using eqSeq eqi
 
+let zipWithIndex : all a. all b. all c. (Int -> a -> b -> c) -> [a] -> [b] -> [c] =
+  lam f. lam a1. lam a2.
+  recursive let work = lam acc. lam i. lam seq1. lam seq2.
+    match seq1 with [e1] ++ seq1tail then
+      match seq2 with [e2] ++ seq2tail then
+        work (cons (f i e1 e2) acc)
+             (addi i 1)
+             seq1tail
+             seq2tail
+      else reverse acc
+    else reverse acc
+  in
+  work (toList []) 0 a1 a2
+
+utest zipWithIndex (lam i. lam a. lam b. addi i (addi a b)) [100, 200, 300] [4000, 5000, 6000]
+      with [4100, 5201, 6302] using eqSeq eqi
+
 let zip : all a. all b. [a] -> [b] -> [(a, b)] = zipWith (lam x. lam y. (x, y))
 
 -- Accumulating maps

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -149,7 +149,7 @@ let foldli: all a. all b. (a -> Int -> b -> a) -> a -> [b] -> a =
   in
   work initAcc 0 seq
 
-utest foldli (lam acc. lam i. lam e. snoc acc (i, e)) [] []
+utest foldli (lam acc. lam i. lam e: Float. snoc acc (i, e)) [] []
 with []
 utest foldli (lam acc. lam i. lam e. snoc acc (i, e)) [] [5.0]
 with [(0, 5.0)]

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -137,6 +137,25 @@ with [(1, 4), (2, 5)]
 utest foldl2 (lam a. lam x1. lam x2. snoc a (x1, x2)) [] [1, 2, 3] [4, 5]
 with [(1, 4), (2, 5)]
 
+-- `foldli f acc seq` folds over a sequence together with the index of element
+-- in the sequence. (Similar to `mapi`)
+let foldli: all a. all b. (a -> Int -> b -> a) -> a -> [b] -> a =
+  lam fn. lam initAcc. lam seq.
+  recursive let work = lam acc. lam i. lam s.
+    match s with [e] ++ rest then
+      work (fn acc i e) (addi i 1) rest
+    else
+      acc
+  in
+  work initAcc 0 seq
+
+utest foldli (lam acc. lam i. lam e. snoc acc (i, e)) [] []
+with []
+utest foldli (lam acc. lam i. lam e. snoc acc (i, e)) [] [5.0]
+with [(0, 5.0)]
+utest foldli (lam acc. lam i. lam e. snoc acc (i, e)) [] ["foo", "bar", "babar"]
+with [(0, "foo"), (1, "bar"), (2, "babar")]
+
 -- zips
 let zipWith : all a. all b. all c. (a -> b -> c) -> [a] -> [b] -> [c] =
   lam f. foldl2 (lam acc. lam x1. lam x2. snoc acc (f x1 x2)) []

--- a/test/examples/parser/build-lrk.sh
+++ b/test/examples/parser/build-lrk.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+#mi compile /mnt/test/examples/parser/lrk-lr2.mc && ./lrk-lr2 && mi compile lrk-lr2-gen.mc
+
+DIR="$(dirname "$0")"
+
+set -e
+
+for f in $(ls "$DIR"/lrk-*.mc); do
+    bn=$(basename $f)
+    binname=${bn%.mc}
+    mi compile "$f" && ./$binname
+done

--- a/test/examples/parser/lrk-calclang.mc
+++ b/test/examples/parser/lrk-calclang.mc
@@ -1,0 +1,190 @@
+include "common.mc"
+include "ext/file-ext.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/pprint.mc"
+include "parser/lrk.mc"
+
+
+lang LRParser_CalcLang = LRParser
+                       + BracketTokenParser
+                       + UIntTokenParser
+                       + MExprPrettyPrint
+  syn Token =
+  | PlusTok {info : Info}
+  | TimesTok {info : Info}
+  syn TokenRepr =
+  | PlusRepr ()
+  | TimesRepr ()
+
+  sem parseToken (pos : Pos) =
+  | "+" ++ str ->
+    let pos2 = advanceCol pos 1 in
+    let info = makeInfo pos pos2 in
+    {token = PlusTok {info = info}, lit = "+", info = info, stream = {pos = pos2, str = str}}
+  | "*" ++ str ->
+    let pos2 = advanceCol pos 1 in
+    let info = makeInfo pos pos2 in
+    {token = TimesTok {info = info}, lit = "+", info = info, stream = {pos = pos2, str = str}}
+
+  sem tokKindEq (tokRepr : TokenRepr) =
+  | PlusTok _ -> match tokRepr with PlusRepr _ then true else false
+  | TimesTok _ -> match tokRepr with TimesRepr _ then true else false
+
+  sem tokInfo =
+  | PlusTok {info = info} -> info
+  | TimesTok {info = info} -> info
+
+  sem tokToStr =
+  | PlusTok _ -> "<Plus>"
+  | TimesTok _ -> "<Times>"
+
+  sem tokReprToStr =
+  | PlusRepr _ -> "<Plus>"
+  | TimesRepr _ -> "<Times>"
+
+  sem tokToRepr =
+  | PlusTok _ -> PlusRepr ()
+  | TimesTok _ -> TimesRepr ()
+end
+
+mexpr
+
+use LRParser_CalcLang in
+
+let _Expr = nameSym "Expr" in
+let _Term = nameSym "Term" in
+let _Factor = nameSym "Factor" in
+
+let tokTy = tyrecord_ [("info", tycon_ "Info")] in
+let tokUIntTy = tyrecord_ [("info", tycon_ "Info"), ("val", tyint_)] in
+
+let tokenConTypes = mapFromSeq tokReprCompare [
+  (EOFRepr {}, {conIdent = nameNoSym "EOFTok", conArg = tokTy}),
+  (LParenRepr {}, {conIdent = nameNoSym "LParenTok", conArg = tokTy}),
+  (RParenRepr {}, {conIdent = nameNoSym "RParenTok", conArg = tokTy}),
+  (PlusRepr {}, {conIdent = nameNoSym "PlusTok", conArg = tokTy}),
+  (TimesRepr {}, {conIdent = nameNoSym "TimesTok", conArg = tokTy}),
+  (IntRepr {}, {conIdent = nameNoSym "IntTok", conArg = tokUIntTy})
+] in
+
+let syntaxdef: LRSyntaxDef = {
+  entrypoint = _Expr,
+  rules = [
+    {name = _Expr, terms = [LRNonTerminal _Expr, LRTerminal (PlusRepr {}), LRNonTerminal _Term],
+     action = withType (tyarrows_ [tyunit_, tystr_, tokTy, tystr_, tystr_])
+                       (ulams_ ["actionState", "lexpr", "plusTok", "rterm"]
+                               (appf1_ (var_ "join") (seq_ [
+                                  str_ "PLUS(", var_ "lexpr", str_ ", ", var_ "rterm", str_ ")"
+                                ])))},
+    {name = _Expr, terms = [LRNonTerminal _Term],
+     action = withType (tyarrows_ [tyunit_, tystr_, tystr_])
+                       (ulams_ ["actionState", "term"] (var_ "term"))},
+    {name = _Term, terms = [LRNonTerminal _Term, LRTerminal (TimesRepr {}), LRNonTerminal _Factor],
+     action = withType (tyarrows_ [tyunit_, tystr_, tokTy, tystr_, tystr_])
+                       (ulams_ ["actionState", "lterm", "plusTok", "rfactor"]
+                               (appf1_ (var_ "join") (seq_ [
+                                  str_ "TIMES(", var_ "lterm", str_ ", ", var_ "rfactor", str_ ")"
+                                ])))},
+    {name = _Term, terms = [LRNonTerminal _Factor],
+     action = withType (tyarrows_ [tyunit_, tystr_, tystr_])
+                       (ulams_ ["actionState", "factor"] (var_ "factor"))},
+    {name = _Factor, terms = [LRTerminal (LParenRepr {}), LRNonTerminal _Expr, LRTerminal (RParenRepr {})],
+     action = withType (tyarrows_ [tyunit_, tokTy, tystr_, tokTy, tystr_])
+                       (ulams_ ["actionState", "lparen", "midexpr", "rparen"] (var_ "midexpr"))},
+    {name = _Factor, terms = [LRTerminal (IntRepr {})],
+     action = withType (tyarrows_ [tyunit_, tokUIntTy, tystr_])
+                       (ulams_ ["actionState", "uint"]
+                               (appf1_ (var_ "join") (seq_ [
+                                  str_ "INT(", appf1_ (var_ "int2string") (recordproj_ "val" (var_ "uint")), str_ ")"
+                                ])))}
+  ],
+  initActionState = unit_
+} in
+
+switch lrCreateParseTable 1 tokenConTypes syntaxdef
+case ResultErr {errors = errors} then
+  errorSingle [] (join (mapValues errors))
+case ResultOk {value = lrtable} then
+  printLn (lrtable2string 2 lrtable);
+  printLn "";
+  let parser = lrGenerateParser lrtable in
+  let program: String = strJoin "\n" [
+    "include \"map.mc\"",
+    "include \"result.mc\"",
+    "include \"seq.mc\"",
+    "include \"string.mc\"",
+    "include \"parser/lexer.mc\"",
+"
+lang PMLexer = Lexer
+  syn Token =
+  | PlusTok {info : Info}
+  | TimesTok {info : Info}
+  syn TokenRepr =
+  | PlusRepr ()
+  | TimesRepr ()
+
+  sem parseToken (pos : Pos) =
+  | \"+\" ++ str ->
+    let pos2 = advanceCol pos 1 in
+    let info = makeInfo pos pos2 in
+    {token = PlusTok {info = info}, lit = \"+\", info = info, stream = {pos = pos2, str = str}}
+  | \"*\" ++ str ->
+    let pos2 = advanceCol pos 1 in
+    let info = makeInfo pos pos2 in
+    {token = TimesTok {info = info}, lit = \"+\", info = info, stream = {pos = pos2, str = str}}
+
+  sem tokKindEq (tokRepr : TokenRepr) =
+  | PlusTok _ -> match tokRepr with PlusRepr _ then true else false
+  | TimesTok _ -> match tokRepr with TimesRepr _ then true else false
+
+  sem tokInfo =
+  | PlusTok {info = info} -> info
+  | TimesTok {info = info} -> info
+
+  sem tokToStr =
+  | PlusTok _ -> \"<Plus>\"
+  | TimesTok _ -> \"<Times>\"
+
+  sem tokReprToStr =
+  | PlusRepr _ -> \"<Plus>\"
+  | TimesRepr _ -> \"<Times>\"
+
+  sem tokToRepr =
+  | PlusTok _ -> PlusRepr ()
+  | TimesTok _ -> TimesRepr ()
+end
+",
+    "mexpr",
+    "use PMLexer in",
+    "let wrappedNextToken = lam s. result.ok (nextToken s) in",
+    expr2str (bindall_ [
+      let_ "parse" (tyTm parser) parser,
+      let_ "lexerState" (tycon_ "Stream")
+                        (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
+                                   ("str", get_ (var_ "argv") (int_ 1))]),
+      ulet_ "parse_result" (appf2_ (var_ "parse")
+                                   (var_ "lexerState")
+                                   (var_ "wrappedNextToken")),
+      matchall_ [
+        matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
+          appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
+            str_ "success: \"", var_ "result", str_ "\""
+          ]))
+        ),
+        matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
+          appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
+                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                                (appf1_ (var_ "mapValues") (var_ "errors"))))
+        )
+      ]
+    ]),
+    ""
+  ] in
+  let fname = "lrk-calclang-gen.mc" in
+  match writeOpen fname with Some wc then
+    writeString wc program;
+    printLn (join ["Generated parser as \"", fname, "\""])
+  else
+    printLn (join ["Could not open the file \"", fname, "\""])
+end

--- a/test/examples/parser/lrk-lr2.mc
+++ b/test/examples/parser/lrk-lr2.mc
@@ -1,0 +1,126 @@
+-- A grammar that is not LR(1)
+--   S -> R S | R
+--   R -> , <name> T
+--   T -> , | <uint> |
+
+-- example of something that is not LL-parsable
+-- L = { (^m )^n | forall n >= 0, forall m >= n}
+
+include "common.mc"
+include "ext/file-ext.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/pprint.mc"
+include "parser/lrk.mc"
+
+lang LRParser_NonLL = LRParser
+                    + LIdentTokenParser
+                    + UIntTokenParser
+                    + CommaTokenParser
+                    + MExprPrettyPrint
+end
+
+mexpr
+
+use LRParser_NonLL in
+
+let _S = nameSym "S" in
+let _R = nameSym "R" in
+let _T = nameSym "T" in
+
+let tokTy = tyrecord_ [("info", tycon_ "Info")] in
+let inttokTy = tyrecord_ [("info", tycon_ "Info"), ("val", tycon_ "Int")] in
+let identtokTy = tyrecord_ [("info", tycon_ "Info"), ("val", tycon_ "String")] in
+
+let tokenConTypes = mapFromSeq tokReprCompare [
+  (EOFRepr {}, {conIdent = nameNoSym "EOFTok", conArg = tokTy}),
+  (CommaRepr {}, {conIdent = nameNoSym "CommaTok", conArg = tokTy}),
+  (IntRepr {}, {conIdent = nameNoSym "IntTok", conArg = inttokTy}),
+  (LIdentRepr {}, {conIdent = nameNoSym "LIdentTok", conArg = identtokTy})
+] in
+
+let syntaxdef: LRSyntaxDef = {
+  entrypoint = _S,
+  rules = [
+    {name = _S, terms = [LRNonTerminal _R, LRNonTerminal _S],
+     action = withType (tyarrows_ [tyunit_, tystr_, tyseq_ tystr_, tyseq_ tystr_])
+                       (ulams_ ["actionState", "a1_R", "a2_S"]
+                               (cons_ (var_ "a1_R") (var_ "a2_S")))},
+    {name = _S, terms = [LRNonTerminal _R],
+     action = withType (tyarrows_ [tyunit_, tystr_, tyseq_ tystr_])
+                       (ulams_ ["actionState", "a1_R"]
+                               (seq_ [var_ "a1_R"]))},
+    {name = _R, terms = [LRTerminal (CommaRepr {}), LRTerminal (LIdentRepr {}), LRNonTerminal _T],
+     action = withType (tyarrows_ [tyunit_, tokTy, identtokTy, tyint_, tystr_])
+                       (ulams_ ["actionState", "a1_Comma", "a2_Ident", "a3_T"]
+                               (appf1_ (var_ "join") (seq_ [
+                                  recordproj_ "val" (var_ "a2_Ident"),
+                                  str_ ": ",
+                                  appf1_ (var_ "int2string") (var_ "a3_T")
+                                ])))},
+    {name = _T, terms = [LRTerminal (CommaRepr {})],
+     action = withType (tyarrows_ [tyunit_, tokTy, tyint_])
+                       (ulams_ ["actionState", "a1_Comma"]
+                               (negi_ (int_ 2)))},
+    {name = _T, terms = [LRTerminal (IntRepr {})],
+     action = withType (tyarrows_ [tyunit_, inttokTy, tyint_])
+                       (ulams_ ["actionState", "a1_Int"]
+                               (recordproj_ "val" (var_ "a1_Int")))},
+    {name = _T, terms = [],
+     action = withType (tyarrows_ [tyunit_, tyint_])
+                       (ulams_ ["actionState"]
+                               (negi_ (int_ 1)))}
+  ],
+  initActionState = unit_
+} in
+
+switch lrCreateParseTable 2 tokenConTypes syntaxdef
+case ResultErr {errors = errors} then
+  errorSingle [] (join (mapValues errors))
+case ResultOk {value = lrtable} then
+  printLn (lrtable2string 2 lrtable);
+  printLn "";
+  let parser = lrGenerateParser lrtable in
+  let program: String = strJoin "\n" [
+    "include \"map.mc\"",
+    "include \"result.mc\"",
+    "include \"seq.mc\"",
+    "include \"string.mc\"",
+    "include \"parser/lexer.mc\"",
+    "let seq2string = lam s: [String]. snoc (cons '[' (strJoin \", \" s)) ']'",
+    "mexpr",
+    "use Lexer in",
+    "let wrappedNextToken = lam s. result.ok (nextToken s) in",
+    expr2str (bindall_ [
+      let_ "parse" (tyTm parser) parser,
+      let_ "lexerState" (tycon_ "Stream")
+                        (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
+                                   ("str", get_ (var_ "argv") (int_ 1))]),
+      ulet_ "parse_result" (appf2_ (var_ "parse")
+                                   (var_ "lexerState")
+                                   (var_ "wrappedNextToken")),
+      matchall_ [
+        matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
+          appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
+            str_ "success: ", appf1_ (var_ "seq2string") (var_ "result")
+          ]))
+        ),
+        matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
+          appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
+                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                                (appf1_ (var_ "mapValues") (var_ "errors"))))
+        )
+      ]
+    ]),
+    ""
+  ] in
+  let fname = "lrk-lr2-gen.mc" in
+  match writeOpen fname with Some wc then
+    writeString wc program;
+    printLn (join ["Generated parser as \"", fname, "\""])
+  else
+    printLn (join ["Could not open the file \"", fname, "\""])
+end
+
+
+

--- a/test/examples/parser/lrk-lr2.mc
+++ b/test/examples/parser/lrk-lr2.mc
@@ -3,9 +3,6 @@
 --   R -> , <name> T
 --   T -> , | <uint> |
 
--- example of something that is not LL-parsable
--- L = { (^m )^n | forall n >= 0, forall m >= n}
-
 include "common.mc"
 include "ext/file-ext.mc"
 include "mexpr/ast.mc"

--- a/test/examples/parser/lrk-nonll.mc
+++ b/test/examples/parser/lrk-nonll.mc
@@ -1,0 +1,102 @@
+-- example of something that is not LL-parsable
+-- L = { (^m )^n | forall n >= 0, forall m >= n}
+
+include "common.mc"
+include "ext/file-ext.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/pprint.mc"
+include "parser/lrk.mc"
+
+lang LRParser_NonLL = LRParser
+                    + BracketTokenParser
+                    + MExprPrettyPrint
+end
+
+mexpr
+
+use LRParser_NonLL in
+
+let _LeftRight = nameSym "LeftRight" in
+let _LeftOnly = nameSym "LeftOnly" in
+
+let tokTy = tyrecord_ [("info", tycon_ "Info")] in
+
+let tokenConTypes = mapFromSeq tokReprCompare [
+  (EOFRepr {}, {conIdent = nameNoSym "EOFTok", conArg = tokTy}),
+  (LParenRepr {}, {conIdent = nameNoSym "LParenTok", conArg = tokTy}),
+  (RParenRepr {}, {conIdent = nameNoSym "RParenTok", conArg = tokTy})
+] in
+
+let syntaxdef: LRSyntaxDef = {
+  entrypoint = _LeftOnly,
+  rules = [
+    {name = _LeftOnly, terms = [LRTerminal (LParenRepr {}), LRNonTerminal _LeftOnly],
+     action = withType (tyarrows_ [tyunit_, tokTy, tystr_, tystr_])
+                       (ulams_ ["actionState", "lparen", "lprod"]
+                               (cons_ (char_ '(') (var_ "lprod")))},
+    {name = _LeftOnly, terms = [LRNonTerminal _LeftRight],
+     action = withType (tyarrows_ [tyunit_, tystr_, tystr_])
+                       (ulams_ ["actionState", "lrprod"]
+                               (cons_ (char_ '|') (var_ "lrprod")))},
+    {name = _LeftRight, terms = [LRTerminal (LParenRepr {}), LRNonTerminal _LeftRight, LRTerminal (RParenRepr {})],
+     action = withType (tyarrows_ [tyunit_, tokTy, tystr_, tokTy, tystr_])
+                       (ulams_ ["actionState", "lparen", "middle", "rparen"]
+                               (cons_ (char_ '(') (snoc_ (var_ "middle") (char_ ')'))))},
+    {name = _LeftRight, terms = [],
+     action = withType (tyarrows_ [tyunit_, tystr_])
+                       (ulams_ ["actionState"]
+                               (str_ "e"))}
+  ],
+  initActionState = unit_
+} in
+
+switch lrCreateParseTable 1 tokenConTypes syntaxdef
+case ResultErr {errors = errors} then
+  errorSingle [] (join (mapValues errors))
+case ResultOk {value = lrtable} then
+  printLn (lrtable2string 2 lrtable);
+  printLn "";
+  let parser = lrGenerateParser lrtable in
+  let program: String = strJoin "\n" [
+    "include \"map.mc\"",
+    "include \"result.mc\"",
+    "include \"seq.mc\"",
+    "include \"string.mc\"",
+    "include \"parser/lexer.mc\"",
+    "mexpr",
+    "use Lexer in",
+    "let wrappedNextToken = lam s. result.ok (nextToken s) in",
+    expr2str (bindall_ [
+      let_ "parse" (tyTm parser) parser,
+      let_ "lexerState" (tycon_ "Stream")
+                        (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
+                                   ("str", get_ (var_ "argv") (int_ 1))]),
+      ulet_ "parse_result" (appf2_ (var_ "parse")
+                                   (var_ "lexerState")
+                                   (var_ "wrappedNextToken")),
+      matchall_ [
+        matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
+          appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
+            str_ "success: \"", var_ "result", str_ "\""
+          ]))
+        ),
+        matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
+          appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
+                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                                (appf1_ (var_ "mapValues") (var_ "errors"))))
+        )
+      ]
+    ]),
+    ""
+  ] in
+  let fname = "lrk-nonll-gen.mc" in
+  match writeOpen fname with Some wc then
+    writeString wc program;
+    printLn (join ["Generated parser as \"", fname, "\""])
+  else
+    printLn (join ["Could not open the file \"", fname, "\""])
+end
+
+
+

--- a/test/examples/parser/lrk-parenlang.mc
+++ b/test/examples/parser/lrk-parenlang.mc
@@ -1,0 +1,49 @@
+include "common.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/pprint.mc"
+include "parser/lrk.mc"
+
+
+lang LRParser_ParenLang = LRParser
+                        + BracketTokenParser
+                        + MExprPrettyPrint
+end
+
+mexpr
+
+use LRParser_ParenLang in
+
+let _Parens = nameSym "Parens" in
+
+let tokenConTypes = mapFromSeq tokReprCompare [
+  (EOFRepr {}, {conIdent = nameNoSym "EOFTok", conArg = tyunit_}),
+  (LParenRepr {}, {conIdent = nameNoSym "LParenTok", conArg = tyunit_}),
+  (RParenRepr {}, {conIdent = nameNoSym "RParenTok", conArg = tyunit_})
+] in
+
+let syntaxdef: LRSyntaxDef = {
+  entrypoint = _Parens,
+  rules = [
+    {name = _Parens, terms = [LRTerminal (LParenRepr {}), LRNonTerminal _Parens, LRTerminal (RParenRepr {})],
+     action = withType (tyarrows_ [tyunknown_, tyunit_, tystr_, tyunit_, tystr_])
+                       (ulams_ ["actionState", "lparen", "middle", "rparen"]
+                               (cons_ (char_ '(') (snoc_ (var_ "middle") (char_ ')'))))},
+    {name = _Parens, terms = [],
+     action = withType (tyarrows_ [tyunknown_, tystr_])
+                       (ulams_ ["actionState"]
+                               (str_ "e"))}
+  ],
+  initActionState = unit_
+} in
+
+switch lrCreateParseTable 1 tokenConTypes syntaxdef
+case ResultErr {errors = errors} then
+  errorSingle [] (join (mapValues errors))
+case ResultOk {value = lrtable} then
+  printLn (lrtable2string 2 lrtable);
+  printLn "\n\n";
+  let parser = lrGenerateParser lrtable in
+  printLn (expr2str parser);
+  printLn "\n\n"
+end

--- a/test/examples/parser/lrk-parenlang.mc
+++ b/test/examples/parser/lrk-parenlang.mc
@@ -1,4 +1,5 @@
 include "common.mc"
+include "ext/file-ext.mc"
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/pprint.mc"
@@ -16,21 +17,23 @@ use LRParser_ParenLang in
 
 let _Parens = nameSym "Parens" in
 
+let tokTy = tyrecord_ [("info", tycon_ "Info")] in
+
 let tokenConTypes = mapFromSeq tokReprCompare [
-  (EOFRepr {}, {conIdent = nameNoSym "EOFTok", conArg = tyunit_}),
-  (LParenRepr {}, {conIdent = nameNoSym "LParenTok", conArg = tyunit_}),
-  (RParenRepr {}, {conIdent = nameNoSym "RParenTok", conArg = tyunit_})
+  (EOFRepr {}, {conIdent = nameNoSym "EOFTok", conArg = tokTy}),
+  (LParenRepr {}, {conIdent = nameNoSym "LParenTok", conArg = tokTy}),
+  (RParenRepr {}, {conIdent = nameNoSym "RParenTok", conArg = tokTy})
 ] in
 
 let syntaxdef: LRSyntaxDef = {
   entrypoint = _Parens,
   rules = [
     {name = _Parens, terms = [LRTerminal (LParenRepr {}), LRNonTerminal _Parens, LRTerminal (RParenRepr {})],
-     action = withType (tyarrows_ [tyunknown_, tyunit_, tystr_, tyunit_, tystr_])
+     action = withType (tyarrows_ [tyunit_, tokTy, tystr_, tokTy, tystr_])
                        (ulams_ ["actionState", "lparen", "middle", "rparen"]
                                (cons_ (char_ '(') (snoc_ (var_ "middle") (char_ ')'))))},
     {name = _Parens, terms = [],
-     action = withType (tyarrows_ [tyunknown_, tystr_])
+     action = withType (tyarrows_ [tyunit_, tystr_])
                        (ulams_ ["actionState"]
                                (str_ "e"))}
   ],
@@ -42,8 +45,44 @@ case ResultErr {errors = errors} then
   errorSingle [] (join (mapValues errors))
 case ResultOk {value = lrtable} then
   printLn (lrtable2string 2 lrtable);
-  printLn "\n\n";
+  printLn "";
   let parser = lrGenerateParser lrtable in
-  printLn (expr2str parser);
-  printLn "\n\n"
+  let program: String = strJoin "\n" [
+    "include \"map.mc\"",
+    "include \"result.mc\"",
+    "include \"seq.mc\"",
+    "include \"string.mc\"",
+    "include \"parser/lexer.mc\"",
+    "mexpr",
+    "use Lexer in",
+    "let wrappedNextToken = lam s. result.ok (nextToken s) in",
+    expr2str (bindall_ [
+      let_ "parse" (tyTm parser) parser,
+      let_ "lexerState" (tycon_ "Stream")
+                        (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
+                                   ("str", get_ (var_ "argv") (int_ 1))]),
+      ulet_ "parse_result" (appf2_ (var_ "parse")
+                                   (var_ "lexerState")
+                                   (var_ "wrappedNextToken")),
+      matchall_ [
+        matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
+          appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
+            str_ "success: \"", var_ "result", str_ "\""
+          ]))
+        ),
+        matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
+          appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
+                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                                (appf1_ (var_ "mapValues") (var_ "errors"))))
+        )
+      ]
+    ]),
+    ""
+  ] in
+  let fname = "lrk-parenlang-gen.mc" in
+  match writeOpen fname with Some wc then
+    writeString wc program;
+    printLn (join ["Generated parser as \"", fname, "\""])
+  else
+    printLn (join ["Could not open the file \"", fname, "\""])
 end


### PR DESCRIPTION
This adds a LR(k) parser generator that hooks in to the existing parser/lexer.mc library. The parser generator is still in pretty rough shape with plenty of low-hanging fruits for improvement. But seeing as it at least is in a working state I suggest that it can be merged in so that other parts of the bootstrapping process that depends on this can start being worked on.

See the files under test/examples/parser for practical examples of how the parser generator can be used.