### PR TITLE
Fix failing tests after latest merges

### DIFF
--- a/stdlib/list.mc
+++ b/stdlib/list.mc
@@ -53,12 +53,24 @@ let listMap : all a. all b. (a -> b) -> List a -> List b = lam f. lam li.
 
 let listToSeq : all a. List a -> [a] = listFoldl snoc []
 
+let listEq : all a. all b. (a -> b -> Bool) -> List a -> List b -> Bool =
+  lam eqElem.
+  recursive let work = lam l. lam r.
+    switch (l, r)
+    case (Cons (lh, lt), Cons (rh, rt)) then
+      if eqElem lh rh then work lt rt
+      else false
+    case (Nil _, Nil _) then true
+    case _ then false
+    end
+  in work
+
 mexpr
 
 let l1 = listEmpty in
 let l2 = listCons 3 l1 in
 let l3 = listCons 4 (listCons 3 l2) in
-utest l1 with Nil () in
+utest l1 with Nil () using listEq eqi in
 utest l2 with Cons (3, Nil ()) in
 utest l3 with Cons (4, Cons (3, Cons (3, Nil ()))) in
 

--- a/stdlib/mexpr/utest-generate.mc
+++ b/stdlib/mexpr/utest-generate.mc
@@ -1296,7 +1296,10 @@ let r = ref_ (int_ 0) in
 utest evalPrettyPrint env refTy r with str_ "<ref>" using eqExpr in
 
 let mapTy = tyapp_ (tyapp_ (tycon_ "Map") tyint_) tyint_ in
-let subExpr = ulam_ "x" (ulam_ "y" (subi_ (var_ "x") (var_ "y"))) in
+let subExpr =
+  let x = nameSym "x" in
+  let y = nameSym "y" in
+  nulam_ x (nulam_ y (subi_ (nvar_ x) (nvar_ y))) in
 let m1 = mapEmpty_ subExpr in
 let m2 = mapInsert_ (int_ 2) (int_ 3) m1 in
 let m3 = mapInsert_ (int_ 3) (int_ 4) m2 in


### PR DESCRIPTION
This PR fixes a couple of failing tests that showed up after merging #668:
1. A unit test in `stdlib/list.mc` compared lists of unknown argument type, for which we cannot generate equality functions (using the new utest approach introduced in #665). I fixed it by using an explicit equality function for lists.
2. A unit test in `stdlib/utest-generate.mc` used a comparison function for maps whose arguments were not symbolized. Due to the use of `nameEqSymUnsafe` introduced in #668 to improve performance, this results in both arguments always getting the same value (as they were both unsymbolized). The arguments are now defined with distinct symbols.