### PR TITLE
Add missing CPS support for record updates

### DIFF
--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -238,6 +238,8 @@ lang RecordCPS = CPS + RecordAst
   sem exprCps env k =
   | TmLet ({ body = TmRecord _ } & t) ->
     TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmLet ({ body = TmRecordUpdate _ } & t) ->
+    TmLet { t with inexpr = exprCps env k t.inexpr }
 end
 
 lang TypeCPS = CPS + TypeAst


### PR DESCRIPTION
This tiny PR adds a missing case for record updates in the partial CPS transformation.