### PR TITLE
Fix bug in symbolization

### DIFF
--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -411,7 +411,7 @@ lang ConAppTypeSym = ConTypeAst + AppTypeAst + AliasTypeAst + VariantTypeAst +
             appTy
         else
           if env.strictTypeVars then
-            if env.allowFree then ty
+            if env.allowFree then smap_Type_Type (symbolizeType env) ty
             else errorSingle [t.info] (join [
               "* Encountered an unknown type constructor: ", str, "\n",
               "* When symbolizing the type"

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -411,7 +411,7 @@ lang ConAppTypeSym = ConTypeAst + AppTypeAst + AliasTypeAst + VariantTypeAst +
             appTy
         else
           if env.strictTypeVars then
-            if env.allowFree then smap_Type_Type (symbolizeType env) ty
+            if env.allowFree then mkAppTy (TyCon t) args
             else errorSingle [t.info] (join [
               "* Encountered an unknown type constructor: ", str, "\n",
               "* When symbolizing the type"

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -411,7 +411,7 @@ lang ConAppTypeSym = ConTypeAst + AppTypeAst + AliasTypeAst + VariantTypeAst +
             appTy
         else
           if env.strictTypeVars then
-            if env.allowFree then TyCon t
+            if env.allowFree then ty
             else errorSingle [t.info] (join [
               "* Encountered an unknown type constructor: ", str, "\n",
               "* When symbolizing the type"


### PR DESCRIPTION
This PR fixes a nasty bug in the symbolization, which led to the type parameters of a free type variable would be removed. The bug shows up in Miking DPPL, where the `allowFree` flag is set to allow symbolizing types defined in the runtime (the `Dist` type).

I don't think we use this option elsewhere, and currently, there are no tests in `symbolize.mc`, which is why this bug managed to sneak through.