### PR TITLE
Tup build system

### DIFF
--- a/Tupdefault.lua
+++ b/Tupdefault.lua
@@ -1,0 +1,5 @@
+local sources = tup.glob('*.mc')
+
+for _, source in ipairs(sources) do
+  testsFor(source)
+end

--- a/Tupfile.lua
+++ b/Tupfile.lua
@@ -1,0 +1,81 @@
+-- Bootstrapping, build boot.
+do
+
+  -- NOTE(vipa, 2023-01-30): Dune copies the *entire* repo into its
+  -- build directory (_build by default), which means two things:
+  -- 1. Tup thinks the command depends on *every* file in the repo.
+  -- 2. Some of the files copied (Tupfile.lua, Tuprules.lua, etc.)
+  --    will trigger more builds in these directories next time we
+  --    run tup.
+
+  -- We work around point 2 by using a temporary bulid directory
+  -- somewhere else, that's `mktemp -d` below. We must make sure to
+  -- remove this directory after, whether the build succeeded or not.
+
+  local display = "^ dune build^"
+  local mkdir = 'tmp=`mktemp -d`'
+  local dune = '&& if dune build --build-dir $tmp'
+  local cp = '; then cp $tmp/install/default/bin/boot build/boot'
+  local rm = '; rm -rf $tmp; else rm -rf $tmp; fi'
+
+  -- As for point 1, we can circumvent Tups dependency detection by
+  -- telling it to ignore some files. Unfortunately, this must be as
+  -- one (or more) regexes that match paths to ignore, and what we
+  -- *want* to do is list things to track.
+
+  -- We expect these files to potentially be relevant:
+  local keep = {
+    -- Negative look-behind pattern; tup uses PCRE
+    'src/boot/.+(?<!/.gitignore)$',
+    'boot.opam$',
+    'dune-project$',
+    -- The output is also relevant
+    'build/boot$',
+  }
+  -- We can now 'or' these regexes together and put them in a negative
+  -- look-ahead pattern, to match a path that matches none of the
+  -- paths above.
+  local ignore = '(?!'..table.concat(keep, '|')..')'
+
+  -- Unfortunately, a regex like '(?!foo)' *does* match 'foo', just
+  -- not at the beginning. Ideally we could just require that the
+  -- match is at the beginning of the path (with '^'), but Tup matches
+  -- against the complete, absolute path, for some reason (I assume to
+  -- have the same behavior when full-deps tracking is turned on). The
+  -- only path we have access to is tup.getdirectory(), which is just
+  -- the name of the current directory. Presently this is ok, there is
+  -- no subdirectory anywhere in the repo named 'miking' (which is the
+  -- default name of the repo itself), thus we can just prepend
+  -- '/miking/' to the regex and get something that does what we want
+  -- it to.
+  ignore = '/'..tup.getdirectory()..'/'..ignore
+
+  -- Finally, we put the command together, and put a '^' at the
+  -- beginning of the regex, since that signals to Tup that this is a
+  -- regex for paths to ignore.
+  tup.rule({}, display..mkdir..dune..cp..rm, {'build/boot', extra_outputs = {'^'..ignore}})
+end
+
+-- Bootstrapping, interpret mi-lite on itself
+do
+  local compile = 'build/boot eval %f -- 0 %f %o'
+  local display = '^o '..compile..'^ '
+  local inputs = {'src/main/mi-lite.mc', extra_inputs={'build/boot'}}
+  tup.rule(inputs, display..setStdlib..compile, 'build/mi-lite')
+end
+
+-- Bootstrapping, use compiled mi-lite to build mi
+do
+  local compile = 'build/mi-lite 1 %f %o'
+  local display = '^o '..compile..'^ '
+  local inputs = {'src/main/mi.mc', extra_inputs = {'build/mi-lite'}}
+  tup.rule(inputs, display..setStdlib..compile, 'build/mi1')
+end
+
+-- Bootstrapping, use compiled mi to compile itself
+do
+  local compile = 'build/mi1 compile %f --output %o'
+  local display = '^o '..compile..'^ '
+  local inputs = {'src/main/mi.mc', extra_inputs = {'build/mi1'}}
+  tup.rule(inputs, display..setStdlib..compile, {'build/mi', miGroup})
+end

--- a/Tuprules.lua
+++ b/Tuprules.lua
@@ -1,0 +1,279 @@
+if #tup.glob('.gitignore') == 0 then
+  -- Only automatically generate a .gitignore if there isn't one in
+  -- the cwd already. We assume that a pre-existing .gitignore already
+  -- covers what tup would generate. This is to avoid spurious edits
+  -- to .gitignores.
+  tup.creategitignore()
+end
+
+if root then
+  -- root is already defined, this means that we're in a copy of this
+  -- file, presumably created by a previous 'dune build'
+  -- command. When this happens we just stub out 'definerule', which
+  -- means that no build rules are generated in directories below the
+  -- current one
+  tup.definerule = function() end
+end
+
+tup.export("OPAM_SWITCH_PREFIX")
+tup.export("CAML_LD_LIBRARY_PATH")
+tup.export("OCAML_TOPLEVEL_PATH")
+
+root = tup.getcwd()
+mi = root..'/build/mi '
+miGroup = root..'/<mi>'
+local cwd = tup.getrelativedir(root)
+
+setStdlib = 'MCORE_STDLIB='..root..'/stdlib '
+
+-- Set up exception lists
+local compileShouldFail = {}
+local runShouldFail = {}
+local evalShouldFail = {}
+local noRun = {}
+local noEval = {}
+
+function populateTable(table, items)
+  for _, v in ipairs(items) do
+    table[v] = true
+  end
+end
+
+populateTable(compileShouldFail, {
+  -- Missing include
+  'test/js/web/document.mc',
+
+  -- Old, parse error now
+  'test/examples/lang-sem.mc',
+  'test/examples/lang-syn.mc',
+
+  -- Old, type-error now
+  'stdlib/parser/breakable-helper.mc',
+  'test/mlang/nestedpatterns.mc',
+
+  -- Old, uses Dyn
+  'test/mlang/mlang.mc',
+  'test/mlang/catchall.mc',
+
+  -- Old, fails symbolize in types
+  'test/mexpr/nestedpatterns.mc',
+  'test/examples/external/ext-list-concat-map.mc',
+  'test/examples/external/ext-list-map.mc',
+
+  -- Uses python
+  'stdlib/python/python.mc',
+  'test/py/python.mc',
+
+  -- Intentional error
+  'test/examples/external/multiple-ext-parse-error.mc',
+  'test/examples/external/ext-not-applied-parse-error.mc',
+  'test/examples/external/ext-not-fully-applied-parse-error.mc',
+  -- NOTE(vipa, 2023-01-09): I'm not sure this is actually intentionally failing
+  'test/examples/external/ext-removal.mc',
+
+  -- Missing external
+  'test/examples/external/ext-parse.mc',
+
+  -- Uses 'Domain', which is fine on 5.0, thus they're commented out here
+  -- 'test/microbenchmark/pmap_list.mc',
+  -- 'test/microbenchmark/pmap_list_sequential.mc',
+  -- 'test/microbenchmark/pmap_rope.mc',
+  -- 'test/microbenchmark/pmap_rope_sequential.mc',
+  -- 'stdlib/multicore/thread-pool.mc',
+  -- 'stdlib/multicore/thread.mc',
+  -- 'stdlib/multicore/cond.mc',
+  -- 'stdlib/multicore/mutex.mc',
+  -- 'stdlib/multicore/channel.mc',
+  -- 'stdlib/multicore/pseq.mc',
+})
+
+populateTable(runShouldFail, {
+  -- Utest failures (this is weird)
+  'test/examples/test-prune-utests.mc',
+
+  -- Seems to non-deterministically fail?
+  'test/examples/accelerate/mixed.mc',
+
+  -- Out of bounds in microbenchmarks
+  'test/microbenchmark/factorial.mc',
+  'test/microbenchmark/fold_list.mc',
+  'test/microbenchmark/fold_native_list.mc',
+  'test/microbenchmark/fold_native_rope.mc',
+  'test/microbenchmark/fold_rope.mc',
+  'test/microbenchmark/iter_list.mc',
+  'test/microbenchmark/iter_rope.mc',
+  'test/microbenchmark/mapReverse_list.mc',
+  'test/microbenchmark/map_list.mc',
+  'test/microbenchmark/map_native_list.mc',
+  'test/microbenchmark/map_native_rope.mc',
+  'test/microbenchmark/map_rope.mc',
+  'test/microbenchmark/rand_sample_gauss.mc',
+  'test/microbenchmark/split_list.mc',
+  'test/microbenchmark/split_rope.mc',
+  'test/microbenchmark/tree.mc',
+  'test/microbenchmark/pmap_rope.mc',
+  'test/microbenchmark/pmap_rope_sequential.mc',
+  'test/microbenchmark/pmap_list_sequential.mc',
+  'test/microbenchmark/pmap_list.mc',
+
+  -- Needs a command-line argument when run
+  'test/js/benchmarks/factorial.mc',
+  'test/js/benchmarks/factorial_fast.mc',
+  'test/js/benchmarks/fold_list.mc',
+  'test/js/benchmarks/tree.mc',
+
+  -- Intentional error, but maybe wrong error (stack overflow)?
+  'test/examples/accelerate/errors/illformed-futhark.mc',
+
+  -- Intentionally fails utests
+  'test/examples/utest.mc',
+
+  -- Out of bounds in json benchmark
+  'test/examples/json/perftest-mc.mc',
+})
+
+populateTable(noRun, {
+  -- Doesn't terminate, maybe just slow?
+  'test/examples/async/tick.mc',
+})
+
+populateTable(evalShouldFail, {
+  -- Unknown variable in accelerate
+  -- NOTE(vipa, 2023-01-09): expected, interpreter doesn't support accelerate
+  'test/examples/accelerate/foldl.mc',
+  'test/examples/accelerate/cond.mc',
+  'test/examples/accelerate/external.mc',
+  'test/examples/accelerate/map.mc',
+  'test/examples/accelerate/indirect-map.mc',
+  'test/examples/accelerate/futhark-ext.mc',
+  'test/examples/accelerate/first.mc',
+  'test/examples/accelerate/fold-tensors.mc',
+  'test/examples/accelerate/fold-capture.mc',
+  'test/examples/accelerate/mixed.mc',
+  'test/examples/accelerate/mutual-reclet.mc',
+  'test/examples/accelerate/rec-tensor.mc',
+  'test/examples/accelerate/matmul.mc',
+  'test/examples/accelerate/reclet.mc',
+  'test/examples/accelerate/print-float.mc',
+  'test/examples/accelerate/sequences.mc',
+  'test/examples/accelerate/tensor-aliasing.mc',
+  'test/examples/accelerate/seq-tensor.mc',
+  'test/examples/accelerate/records.mc',
+  'test/examples/accelerate/tensor-add.mc',
+  'test/examples/accelerate/errors/function-arg.mc',
+  'test/examples/accelerate/wrap-records.mc',
+  'test/examples/accelerate/tensor-loop.mc',
+  'test/examples/accelerate/zip.mc',
+  'test/examples/accelerate/errors/illformed-cuda.mc',
+  'test/examples/accelerate/errors/irregular-seq.mc',
+  'test/examples/accelerate/errors/indirect-nesting.mc',
+  'test/examples/accelerate/errors/reclet-nested-accelerate.mc',
+  'test/examples/accelerate/errors/illformed-futhark.mc',
+  'test/examples/accelerate/errors/let-nested-accelerate.mc',
+  'test/examples/accelerate/errors/seq-nested-accelerate.mc',
+
+  -- Unknown variable
+  -- NOTE(vipa, 2023-01-09): expected, missing asyncPrint
+  'test/examples/async/tick.mc',
+
+  -- Unknown variable in tuning
+  -- NOTE(vipa, 2023-01-09): expected, interpreter doesn't support holes
+  'test/examples/tuning/tune-context.mc',
+  'test/examples/tuning/tune-sleep.mc',
+
+  -- Uses multicore
+  'test/microbenchmark/pmap_rope.mc',
+  'test/microbenchmark/pmap_rope_sequential.mc',
+  'test/microbenchmark/pmap_list_sequential.mc',
+  'test/microbenchmark/pmap_list.mc',
+})
+
+populateTable(noEval, {
+  -- Seems annoyingly slow, but should work
+  'stdlib/tuning/tune.mc',
+})
+
+-- Functions that work on individual commands, things that are passed to sh
+
+function expectFail(cmd, msg)
+  local cond = 'if '..cmd..' 1>/dev/null 2>&1'
+  local success = '; then echo "'..msg..'"; return 1'
+  local failure = '; else return 0'
+  local fi = '; fi'
+  return cond..success..failure..fi
+end
+
+function formatFailOutput(cmd, head, tail)
+  local tmp = 'ooof=`mktemp`'
+  local cond = '; if '..cmd..' >$ooof 2>&1'
+  local rm = 'rm -f $ooof'
+  head = head or 6
+  tail = (tail or 6) - 1
+  local awk = '\'FNR <= '..head..' || FNR >= \'`wc -l < $ooof`\'-'..tail..' {print FNR ":\t" $0; next} !el {print "...elided..."; el=1}\''
+  local onSuccess = '; then '..rm..'; return 0'
+  local onFailure = '; else ooofrv=$?; awk '..awk..' $ooof; '..rm..'; return $ooofrv'
+  local fi = '; fi'
+  return tmp..cond..onSuccess..onFailure..fi
+end
+
+
+-- Functions that produce Tup rules, i.e., the actual point of this file
+
+-- Compile a given .mc file to an executable
+function miCompile(source, destination, options)
+  local inputs = {source, extra_inputs = {miGroup}}
+  local transient = options.transient and '^t ' or '^ '
+  local test = options.test and ' --test' or ''
+  local display = transient..'COMPILE'..test..' %f > %o^ '
+  local compile = setStdlib..mi..'compile %f --output %o'..test
+  return tup.rule(inputs, display..formatFailOutput(compile, 10, 10), destination)
+end
+
+function miCompileExpectFail(source)
+  local inputs = {source, extra_inputs = {miGroup}}
+  local display = '^ COMPILE-EXPECT-FAIL --test %f^ '
+  local compile = setStdlib..mi..'compile --test %f --output /dev/null'
+  local msg = 'Expected compilation to fail, but it succeeded.'
+  return tup.rule(inputs, display..expectFail(compile, msg), {})
+end
+
+function runExec(executable, expectSuccess)
+  local display = '^ RUN'..(expectSuccess and '' or '-EXPECT-FAIL')..' %f^ '
+  local msg = 'Expected running to fail, but it succeeded.'
+  local run = setStdlib..'./%f'
+  local run = expectSuccess and formatFailOutput(run) or expectFail(run, msg)
+  return tup.rule(executable, display..run, {})
+end
+
+function miEvalTest(source, expectSuccess)
+  local display = '^ EVAL'..(expectSuccess and '' or '-EXPECT-FAIL')..' --test %f^ '
+  local msg = 'Expected evaluating to fail, but it succeeded.'
+  local run = setStdlib..mi..'eval --test %f'
+  run = expectSuccess and formatFailOutput(run) or expectFail(run, msg)
+  local inputs = {source, extra_inputs = {miGroup}}
+  return tup.rule(inputs, display..run, {})
+end
+
+-- Wrap a command, save the return value in $rv, print an elided
+-- version of the output if it doesn't conform to expectations
+
+function testsFor(source)
+  local realSource = cwd..'/'..source
+  if compileShouldFail[realSource] then
+    miCompileExpectFail(source)
+  else
+    local executable = miCompile(source, '%B-test.exe', {test = true, transient = true})
+
+    if noRun[realSource] then
+      return
+    end
+
+    runExec(executable, not runShouldFail[realSource])
+
+    if noEval[realSource] then
+      return
+    end
+
+    miEvalTest(source, not (runShouldFail[realSource] or evalShouldFail[realSource]))
+  end
+end

--- a/make.sh
+++ b/make.sh
@@ -53,9 +53,9 @@ build() {
         echo "Bootstrapped compiler already exists. Run 'make clean' before to recompile. "
     else
         echo "Bootstrapping the Miking compiler (1st round, might take a few minutes)"
-        time build/$BOOT_NAME eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc
+        time build/$BOOT_NAME eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc ./$MI_LITE_NAME
         echo "Bootstrapping the Miking compiler (2nd round, might take some more time)"
-        time ./$MI_LITE_NAME 1 src/main/mi.mc
+        time ./$MI_LITE_NAME 1 src/main/mi.mc ./$MI_NAME
         echo "Bootstrapping the Miking compiler (3rd round, might take some more time)"
         time ./$MI_NAME compile src/main/mi.mc
         mv -f $MI_NAME build/$MI_NAME

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -82,13 +82,14 @@ let compile : Options -> String -> () = lam options. lam file.
 
 mexpr
 
-let printMenu = lam. print "Usage: mi-lite [0|1] file" in
+let printMenu = lam. print "Usage: mi-lite [0|1] file outfile" in
 
-if neqi (length argv) 3 then
+if neqi (length argv) 4 then
   printMenu ()
 else match get argv 1 with "0" then
-  let options = {optionsDefault with disableOptimizations = true} in
+  let options = {optionsDefault with disableOptimizations = true, output = Some (get argv 3)} in
   compile options (get argv 2)
 else match get argv 1 with "1" then
-  compile optionsDefault (get argv 2)
+  let options = {optionsDefault with output = Some (get argv 3)} in
+  compile options (get argv 2)
 else printMenu ()


### PR DESCRIPTION
Tup build system

Create configuration to build and test everything using Tup. Most of the interesting stuff happens in `Tuprules.lua`, which defines how to build, run, and test normal `.mc` files, as well as a list of exceptions, files that shouldn't be built/evaled. Bootstrapping is handled by the root `Tupfile`.

Much like the make-based build system there is a list of files we don't expect to compile/run/etc. However, we make sure to *try* compiling/running/etc. anyway; we just check that the exit code is non-zero. This means that we can have negative tests, and that the lists have to be up-to-date.

We're also discovering *all* `.mc` files in the repo, as opposed to only those in folders we've explicitly marked for inclusion. For files where the tests are too slow to run regularly there are two lists that avoid running/evaling altogether: `noRun` and `noEval`.

Worth looking into, maybe for later updates:
- Non-standard compilation tests (tuning, accelerate, other backends, etc.)
- Cleverness regarding installed dependencies, it's currently set according to what succeeds on my machine.
- I tried listing *why* things failed in the exclusion lists, and some of the failures seem strange.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/miking-lang/miking/pull/674).
* __->__ #674 (2 commits)
