### PR TITLE
Fix utest equality for maps in `boot`

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -629,6 +629,7 @@ module IO = struct
     in
     let rec work indent v =
       if Obj.is_int v then string_of_int (Obj.obj v) ^ "\n"
+      else if Obj.tag v = Obj.custom_tag then "<custom>\n"
       else if Obj.tag v = Obj.double_tag then
         string_of_float (Obj.obj v) ^ "\n"
       else if Obj.tag v = Obj.closure_tag then "<closure>\n"

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1754,6 +1754,8 @@ let rec val_equal v1 v2 =
       Mseq.Helpers.equal val_equal s1 s2
   | TmRecord (_, r1), TmRecord (_, r2) ->
       Record.equal (fun t1 t2 -> val_equal t1 t2) r1 r2
+  | TmConst (_, CMap (_, m1)), TmConst (_, CMap (_, m2)) ->
+      Mmap.eq val_equal m1 m2
   | TmConst (_, c1), TmConst (_, c2) ->
       c1 = c2
   | TmConApp (_, _, sym1, v1), TmConApp (_, _, sym2, v2) ->


### PR DESCRIPTION
This PR fixes a bug in the equality used for utests on maps in `boot`. The default equality would perform a structural comparison of the full map representation (as for all kinds of constants). As the map representation includes a comparison function, this did not work out well. Instead, I added special-case treatment for maps to use `Mmap.eq` to compare the underlying map representation only (not the comparison function).

Interestingly, this seems to have resulted in multiple different kinds of errors:
* The utest failing to match on maps that were clearly equal.
* `Fatal error: exception Invalid_argument("compare: functional value")` - when comparing empty maps.
* `Fatal error: exception Out of memory` - I don't know why this happens, my guess is that this is triggered by a cycle in the internal representation of the map.

EDIT: I'm also including a fix for dprint in `mi compile`, which would segfault for tensors of Bigarrays.