### PR TITLE
Minor fixes in the MExpr pretty-printer

### DIFF
--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -575,7 +575,7 @@ lang SeqPrettyPrint = PrettyPrint + SeqAst + ConstPrettyPrint + CharAst
     let extract_char = lam e.
       match e with TmConst t1 then
         match t1.val with CChar c then
-          Some (c.val)
+          Some c.val
         else None ()
       else None ()
     in
@@ -885,7 +885,7 @@ lam recur. lam indent. lam env. lam pats.
     match e with PatChar c then Some c.val
     else None () in
   match optionMapM extract_char pats with Some str then
-    (env, join ["\"", str, "\""])
+    (env, join ["\"", escapeString str, "\""])
   else match mapAccumL (recur (pprintIncr indent)) env pats
   with (env, pats) in
   let merged =

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -97,7 +97,9 @@ let _parserStr = lam str. lam prefix. lam cond.
 let _isValidLowerIdent = lam str.
   match str with [x]
   then isLowerAlpha x
-  else isLowerAlphaOrUnderscore (head str)
+  else if isLowerAlphaOrUnderscore (head str) then
+    forAll (lam c. or (isAlphanum c) (eqc c '_')) (tail str)
+  else false
 
 -- Variable string parser translation
 let pprintVarString = lam str.

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1152,6 +1152,9 @@ lang AppTypePrettyPrint = PrettyPrint + AppTypeAst
 end
 
 lang AliasTypePrettyPrint = PrettyPrint + AliasTypeAst
+  sem typePrecedence =
+  | TyAlias _ -> 1
+
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
   | TyAlias t -> getTypeStringCode indent env t.display
 end


### PR DESCRIPTION
This PR includes fixes for three minor bugs in the MExpr pretty-printer:
* Use escaping of "invalid" identifiers using `#var"..."` - the predicate determining whether to apply the escaping only looked at the first character of the string.
* Pattern strings with escape characters were not escaped correctly (e.g., `"\n" ++ _` would be pretty-printed as a newline character, rather than the escaped version).
* The pretty-printer precedence for type aliases, `TyAlias`, caused them to be wrongly parenthesized after type-checking (e.g., `Map Int (Set Int)` would be pretty-printed as `Map Int Set Int`, because `Set Int` becomes a `TyAlias` after type-checking).