### PR TITLE
Pretty print improvments

### DIFF
--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -295,7 +295,7 @@ end
 
 
 -- TmLam --
-lang LamAst = Ast + VarAst + AppAst
+lang LamAst = Ast
   syn Expr =
   | TmLam {ident : Name,
            tyAnnot : Type,

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -155,7 +155,7 @@ lang AppEq = Eq + AppAst
     else None ()
 end
 
-lang LamEq = Eq + LamAst + VarEq + AppEq
+lang LamEq = Eq + LamAst
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmLam r ->
     match env with {varEnv = varEnv} then

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -2070,8 +2070,8 @@ lang MExprEval =
   + NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +
   IntPatEval + CharPatEval + BoolPatEval + AndPatEval + OrPatEval + NotPatEval
 
-  -- Pretty Printing of Identifiers
-  + MExprIdentifierPrettyPrint
+  -- Pretty Printing
+  + MExprPrettyPrint
 end
 
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -500,28 +500,39 @@ lang MatchPrettyPrint = PrettyPrint + MatchAst
   sem pprintCode (indent : Int) (env: PprintEnv) =
   | TmMatch t -> pprintTmMatchNormally indent env t
 
-  sem pprintTmMatchNormally (indent : Int) (env: PprintEnv) =
+ sem pprintTmMatchBegin (indent : Int) (env: PprintEnv) =
   | t ->
-    let t : { target : Expr
-            , pat : Pat
-            , thn : Expr
-            , els : Expr
-            , ty : Type
-            , info : Info } = t in
     let i = indent in
     let ii = pprintIncr indent in
     match pprintCode ii env t.target with (env,target) in
     match getPatStringCode ii env t.pat with (env,pat) in
+    (env,join ["match", pprintNewline ii, target, pprintNewline i,
+               "with", pprintNewline ii, pat, pprintNewline i])
+
+  sem pprintTmMatchNormally (indent : Int) (env: PprintEnv) =
+  | t ->
+    let i = indent in
+    let ii = pprintIncr indent in
+    match pprintTmMatchBegin i env t with (env,begin) in
     match pprintCode ii env t.thn with (env,thn) in
     match pprintCode ii env t.els with (env,els) in
-    (env,join ["match", pprintNewline ii, target, pprintNewline i,
-               "with", pprintNewline ii, pat, pprintNewline i,
+    (env,join [begin,
                "then", pprintNewline ii, thn, pprintNewline i,
                "else", pprintNewline ii, els])
+
+  sem pprintTmMatchIn (indent : Int) (env: PprintEnv) =
+  | t ->
+    let i = indent in
+    let ii = pprintIncr indent in
+    match pprintTmMatchBegin i env t with (env,begin) in
+    match pprintCode ii env t.thn with (env,thn) in
+    (env,join [begin, "in", pprintNewline i, thn])
 end
 
-lang RecordProjectionSyntaxSugarPrettyPrint = MExprIdentifierPrettyPrint + MatchPrettyPrint + RecordPat + NeverAst + NamedPat + VarAst
+lang RecordProjectionSyntaxSugarPrettyPrint = MExprIdentifierPrettyPrint +
+  MatchPrettyPrint + RecordPat + NeverAst + NamedPat + VarAst
   sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmMatch (t & {els = TmNever _}) -> pprintTmMatchIn indent env t
   | TmMatch (t &
     { pat = PatRecord
       { bindings = bindings
@@ -538,8 +549,8 @@ lang RecordProjectionSyntaxSugarPrettyPrint = MExprIdentifierPrettyPrint + Match
       then
         match printParen indent env expr with (env, expr) in
         (env, join [expr, ".", pprintProjString fieldLabel])
-      else pprintTmMatchNormally indent env t
-    else pprintTmMatchNormally indent env t
+      else pprintTmMatchIn indent env t
+    else pprintTmMatchIn indent env t
 end
 
 lang UtestPrettyPrint = PrettyPrint + UtestAst

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -530,7 +530,7 @@ end
 lang MExprSym =
 
   -- Default implementations (Terms)
-  RecordAst + ConstAst + UtestAst + SeqAst + NeverAst +
+  RecordAst + ConstAst + UtestAst + SeqAst + NeverAst + AppAst +
 
   -- Default implementations (Types)
   UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -325,7 +325,7 @@ lang OCamlAst =
   OCamlTopAst +
 
   -- Terms
-  LamAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
+  VarAst + LamAst + AppAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
   OCamlArray + OCamlData + OCamlRecord + OCamlRecordUpdate + OCamlLabel +
   OCamlLam +
 

--- a/stdlib/tuning/call-graph.mc
+++ b/stdlib/tuning/call-graph.mc
@@ -56,7 +56,7 @@ let _handleApps = use AppAst in use VarAst in
 -- node exactly once and each time potentially perform a graph union operation,
 -- which we assume has complexity O(|F|). V is the set of nodes in the AST and F
 -- is the set of nodes in the call graph (i.e. set of functions in the AST).
-lang HoleCallGraph = LetAst + LamAst + RecLetsAst
+lang HoleCallGraph = LetAst + AppAst + LamAst + RecLetsAst
   sem toCallGraph =
   | arg ->
     let gempty = digraphAddVertex callGraphTop


### PR DESCRIPTION
This PR:
- Changes the MExpr pretty printer to recognize the syntactic sugar `match t1 then t2 else never` = `match t1 in t2`;
- Adds pretty printing and equality checks of tensor values in MExpr `eval`;
- Prunes some dependencies from the `LamAst` langauge fragment.  