### PR TITLE
Unify partial applications in the interpreter

### DIFF
--- a/src/main/eval.mc
+++ b/src/main/eval.mc
@@ -72,6 +72,6 @@ let eval = lam files. lam options : Options. lam args.
     let ast = generateUtest options.runTests ast in
     if options.exitBefore then exit 0
     else
-      eval {env = evalEnvEmpty} (updateArgv args ast); ()
+      eval (evalCtxEmpty ()) (updateArgv args ast); ()
   in
   iter evalFile files

--- a/stdlib/mexpr/const-arity.mc
+++ b/stdlib/mexpr/const-arity.mc
@@ -1,16 +1,20 @@
 include "ast.mc"
 
-lang UnsafeCoerceArity = UnsafeCoerceAst
+lang ConstArity = ConstAst
+  sem constArity : Const -> Int
+end
+
+lang UnsafeCoerceArity = ConstArity + UnsafeCoerceAst
   sem constArity =
   | CUnsafeCoerce _ -> 1
 end
 
-lang IntArity = IntAst
+lang IntArity = ConstArity + IntAst
   sem constArity =
   | CInt _ -> 0
 end
 
-lang ArithIntArity = ArithIntAst
+lang ArithIntArity = ConstArity + ArithIntAst
   sem constArity =
   | CAddi _ -> 2
   | CSubi _ -> 2
@@ -20,19 +24,19 @@ lang ArithIntArity = ArithIntAst
   | CModi _ -> 2
 end
 
-lang ShiftIntArity = ShiftIntAst
+lang ShiftIntArity = ConstArity + ShiftIntAst
   sem constArity =
   | CSlli _ -> 2
   | CSrli _ -> 2
   | CSrai _ -> 2
 end
 
-lang FloatArity = FloatAst
+lang FloatArity = ConstArity + FloatAst
   sem constArity =
   | CFloat _ -> 0
 end
 
-lang ArithFloatArity = ArithFloatAst
+lang ArithFloatArity = ConstArity + ArithFloatAst
   sem constArity =
   | CAddf _ -> 2
   | CSubf _ -> 2
@@ -41,7 +45,7 @@ lang ArithFloatArity = ArithFloatAst
   | CNegf _ -> 1
 end
 
-lang FloatIntConversionArity = FloatIntConversionAst
+lang FloatIntConversionArity = ConstArity + FloatIntConversionAst
   sem constArity =
   | CFloorfi _ -> 1
   | CCeilfi _ -> 1
@@ -49,12 +53,12 @@ lang FloatIntConversionArity = FloatIntConversionAst
   | CInt2float _ -> 1
 end
 
-lang BoolArity = BoolAst
+lang BoolArity = ConstArity + BoolAst
   sem constArity =
   | CBool _ -> 0
 end
 
-lang CmpIntArity = CmpIntAst
+lang CmpIntArity = ConstArity + CmpIntAst
   sem constArity =
   | CEqi _ -> 2
   | CNeqi _ -> 2
@@ -64,7 +68,7 @@ lang CmpIntArity = CmpIntAst
   | CGeqi _ -> 2
 end
 
-lang CmpFloatArity = CmpFloatAst
+lang CmpFloatArity = ConstArity + CmpFloatAst
   sem constArity =
   | CEqf _ -> 2
   | CLtf _ -> 2
@@ -74,42 +78,42 @@ lang CmpFloatArity = CmpFloatAst
   | CNeqf _ -> 2
 end
 
-lang CharArity = CharAst
+lang CharArity = ConstArity + CharAst
   sem constArity =
   | CChar _ -> 0
 end
 
-lang CmpCharArity = CmpCharAst
+lang CmpCharArity = ConstArity + CmpCharAst
   sem constArity =
   | CEqc _ -> 2
 end
 
-lang IntCharConversionArity = IntCharConversionAst
+lang IntCharConversionArity = ConstArity + IntCharConversionAst
   sem constArity =
   | CInt2Char _ -> 1
   | CChar2Int _ -> 1
 end
 
-lang FloatStringConversionArity = FloatStringConversionAst
+lang FloatStringConversionArity = ConstArity+ FloatStringConversionAst
   sem constArity =
   | CStringIsFloat _ -> 1
   | CString2float _ -> 1
   | CFloat2string _ -> 1
 end
 
-lang SymbArity = SymbAst
+lang SymbArity = ConstArity + SymbAst
   sem constArity =
   | CSymb _ -> 0
   | CGensym _ -> 1
   | CSym2hash _ -> 1
 end
 
-lang CmpSymbArity = CmpSymbAst
+lang CmpSymbArity = ConstArity + CmpSymbAst
   sem constArity =
   | CEqsym _ -> 2
 end
 
-lang SeqOpArity = SeqOpAst
+lang SeqOpArity = ConstArity + SeqOpAst
   sem constArity =
   | CSet _ -> 3
   | CGet _ -> 2
@@ -136,7 +140,7 @@ lang SeqOpArity = SeqOpAst
   | CSubsequence _ -> 3
 end
 
-lang FileOpArity = FileOpAst
+lang FileOpArity = ConstArity + FileOpAst
   sem constArity =
   | CFileRead _ -> 1
   | CFileWrite _ -> 2
@@ -144,7 +148,7 @@ lang FileOpArity = FileOpAst
   | CFileDelete _ -> 1
 end
 
-lang IOArity = IOAst
+lang IOArity = ConstArity + IOAst
   sem constArity =
   | CPrint _ -> 1
   | CPrintError _ -> 1
@@ -155,13 +159,13 @@ lang IOArity = IOAst
   | CReadBytesAsString _ -> 1
 end
 
-lang RandomNumberGeneratorArity = RandomNumberGeneratorAst
+lang RandomNumberGeneratorArity = ConstArity + RandomNumberGeneratorAst
   sem constArity =
   | CRandIntU _ -> 2
   | CRandSetSeed _ -> 1
 end
 
-lang SysArity = SysAst
+lang SysArity = ConstArity + SysAst
   sem constArity =
   | CExit _ -> 1
   | CError _ -> 1
@@ -169,25 +173,25 @@ lang SysArity = SysAst
   | CCommand _ -> 1
 end
 
-lang TimeArity = TimeAst
+lang TimeArity = ConstArity + TimeAst
   sem constArity =
   | CWallTimeMs _ -> 1
   | CSleepMs _ -> 1
 end
 
-lang ConTagArity = ConTagAst
+lang ConTagArity = ConstArity + ConTagAst
   sem constArity =
   | CConstructorTag _ -> 1
 end
 
-lang RefOpArity = RefOpAst
+lang RefOpArity = ConstArity + RefOpAst
   sem constArity =
   | CRef _ -> 1
   | CModRef _ -> 2
   | CDeRef _ -> 1
 end
 
-lang MapArity = MapAst
+lang MapArity = ConstArity + MapAst
   sem constArity =
   | CMapEmpty _ -> 1
   | CMapInsert _ -> 3
@@ -209,7 +213,7 @@ lang MapArity = MapAst
   | CMapGetCmpFun _ -> 1
 end
 
-lang TensorOpArity = TensorOpAst
+lang TensorOpArity = ConstArity + TensorOpAst
   sem constArity =
   | CTensorCreateUninitInt _ -> 1
   | CTensorCreateUninitFloat _ -> 1
@@ -232,9 +236,9 @@ lang TensorOpArity = TensorOpAst
   | CTensorToString _ -> 2
 end
 
-lang BootParserArity = BootParserAst
+lang BootParserArity = ConstArity + BootParserAst
   sem constArity =
-  | CBootParserParseMExprString _ -> 2
+  | CBootParserParseMExprString _ -> 3
   | CBootParserParseMCoreFile _ -> 3
   | CBootParserGetId _ -> 1
   | CBootParserGetTerm _ -> 2

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -136,12 +136,16 @@ lang RecLetsEval =
     eval {ctx with env = envPrime ()} t.inexpr
 end
 
-lang ConstEval = Eval + ConstAst + SysAst + SeqAst + UnknownTypeAst + ConstArity
+lang ConstAppAst = ConstAst
   syn Expr =
   | TmConstApp {
     const : Const,
     args : [Expr]
   }
+end
+
+lang ConstEval =
+  Eval + ConstAppAst + SysAst + SeqAst + UnknownTypeAst + ConstArity
 
   sem delta : Info -> (Const, [Expr]) -> Expr
   sem delta info =

--- a/stdlib/mexpr/infix.mc
+++ b/stdlib/mexpr/infix.mc
@@ -74,7 +74,7 @@ end
 
 -- Evaluate an expression into a value expression
 let evalExpr : Expr -> Expr =
-  use MExprExt in lam t. eval {env = evalEnvEmpty} (symbolize t)
+  use MExprExt in lam t. eval (evalCtxEmpty ()) (symbolize t)
 
 -- Parse a string and then evaluate into a value expression
 let evalStr : String -> Expr =

--- a/stdlib/mexpr/mexpr.mc
+++ b/stdlib/mexpr/mexpr.mc
@@ -15,7 +15,7 @@ end
 
 -- Evaluate an expression into a value expression
 let evalExpr : Expr -> Expr =
-  use MExpr in lam t. eval {env = evalEnvEmpty} (symbolize t)
+  use MExpr in lam t. eval (evalCtxEmpty ()) (symbolize t)
 
 -- Parse a string and then evaluate into a value expression
 let evalStr : String -> Expr =

--- a/stdlib/mexpr/profiling.mc
+++ b/stdlib/mexpr/profiling.mc
@@ -278,7 +278,7 @@ let t = bindall_ [
   app_ (var_ "f") (int_ 4)
 ] in
 let t = instrumentProfiling t in
-eval {env = evalEnvEmpty} (symbolize t);
+eval (evalCtxEmpty ()) (symbolize t);
 utest fileExists profilingResultFileName with true in
 (if fileExists profilingResultFileName then
   let lines =

--- a/stdlib/mexpr/utest-generate.mc
+++ b/stdlib/mexpr/utest-generate.mc
@@ -1140,7 +1140,7 @@ let emptyEnv = utestEnvEmpty () in
 
 let eval = lam env. lam e.
   let e = mergeWithUtestHeader env e in
-  eval {env = evalEnvEmpty} e
+  eval (evalCtxEmpty ()) e
 in
 
 let evalEquality : UtestEnv -> Type -> Expr -> Expr -> Expr =

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -334,7 +334,7 @@ let test : Bool -> Expr -> [(String, [([String],Expr)])] -> String =
     in
     dumpTable lookupTable;
     use MExprEval in
-    let s = expr2str (eval { env = evalEnvEmpty } ast) in
+    let s = expr2str (eval (evalCtxEmpty ()) ast) in
 
     -- Clean up and return result
     res.cleanup ();

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -460,7 +460,7 @@ let test = lam debug. lam full: Bool. lam table : [((String,[String]),Expr)]. la
   let ast = typeCheck ast in
 
   -- Evaluate the program
-  eval { env = evalEnvEmpty } ast;
+  eval (evalCtxEmpty ()) ast;
 
   -- Read the profiled data
   let logStr = readFile res.fileName in

--- a/stdlib/tuning/tail-positions.mc
+++ b/stdlib/tuning/tail-positions.mc
@@ -157,7 +157,7 @@ let test = lam debug. lam t. lam acc. lam lacc. lam baseCase. lam tailCall. lam 
   match tailPositionsReclet baseCase tailCall letexpr lacc acc t with (acc, t) in
   debugPrint debug (expr2str t);
   debugPrint debug "-------------";
-  let res = eval {env = evalEnvEmpty} t in
+  let res = eval (evalCtxEmpty ()) t in
   debugPrint debug (expr2str res);
   (acc, expr2str res)
 in


### PR DESCRIPTION
This PR introduces a new constructor `TmConstApp {const : Const, args : [Expr]}` in the interpreter (`eval`) that represents partially applied constants. Before we had a constructor for each partially applied constant which amounted to a lot of code and a lot of constructors. With this PR we instead collect all arguments in the `args` field until a constant is fully applied. 

The downside of this is that we do not catch invalid applications as early as before but this is not relevant anymore since these invalid applications will be caught by the type checker. On the positive, apart from reduced code size, is that this PR should make it more convenient to work with partially evaluated code.

Additionally this PR: 
- fixes a bug in `const-arity.mc`; 
- moves the evaluation contexts/environment inside the `Eval` fragment;
- changes the signature of `apply` from `Info -> EvalCtx -> Expr -> Expr -> Exr` to  `Info -> EvalCtx -> (Expr, Expr) -> Exr` so that you apply `apply` as `apply info ctx (lhs, rhs)` instead of `apply info ctx rhs lhs`. 

This PR includes https://github.com/miking-lang/miking/pull/680.