### PR TITLE
Continuation passing style map

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -13,6 +13,7 @@ include "symbolize.mc"
 include "eq.mc"
 include "info.mc"
 include "error.mc"
+include "map.mc"
 
 lang ANF = LetAst + VarAst + UnknownTypeAst
 
@@ -117,16 +118,10 @@ lang RecordANF = ANF + RecordAst
 
   sem normalize (k : Expr -> Expr) =
   | TmRecord t ->
-    let acc = lam bs. k (TmRecord {t with bindings = bs}) in
-    let f =
-      (lam acc. lam k. lam e.
-         (lam bs.
-            normalizeName
-              (lam v. acc (mapInsert k v bs))
-              e))
-    in
-    let tmp = mapFoldWithKey f acc t.bindings in
-    tmp (mapEmpty (mapGetCmpFun t.bindings))
+    mapMapK
+      (lam e. lam k. normalizeName k e)
+      t.bindings
+      (lam bs. k (TmRecord {t with bindings = bs}))
 
   | TmRecordUpdate t ->
     normalizeName
@@ -242,15 +237,7 @@ lang SeqANF = ANF + SeqAst
 
   sem normalize (k : Expr -> Expr) =
   | TmSeq t ->
-    let acc = lam ts. k (TmSeq {t with tms = ts}) in
-    let f =
-      (lam acc. lam e.
-         (lam ts.
-            normalizeName
-              (lam v. acc (cons v ts))
-              e))
-    in
-    (foldl f acc t.tms) []
+    mapK (lam e. lam k. normalizeName k e) t.tms (lam ts. k (TmSeq {t with tms = ts}))
 
 end
 

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -80,6 +80,16 @@ let mapReverse = lam f. lam lst.
 
 utest toRope (mapReverse (lam x. addi x 1) [10,20,30]) with [31,21,11]
 
+-- `mapK f seq k` maps the continuation passing function `f` over the sequence
+-- `seq`, passing the result of the mapping to the continuation `k`.
+let mapK : all a. all b. all c. (a -> (b -> c) -> c) -> [a] -> ([b] -> c) -> c =
+  lam f. lam seq. lam k.
+    foldl (lam k. lam x. (lam xs. f x (lam x. k (cons x xs)))) k seq []
+
+utest mapK (lam x. lam k. k (addi x 1)) [] (lam seq. reverse seq) with []
+utest mapK (lam x. lam k. k (addi x 1)) [1,2,3] (lam seq. reverse seq) with [4,3,2]
+utest mapK (lam x. lam k. k (addi x 1)) [1,2,3] (lam seq. foldl addi 0 seq) with 9
+
 -- Folds
 let foldl1 = lam f. lam l. foldl f (head l) (tail l)
 


### PR DESCRIPTION
This PR adds library functions `mapK`, `mapMapK`, and `mapMapWithKeysK` which are continuation passing versions of `map`, `mapMap`, and `mapMapWithKeys`, respectively. The implementation is a generalization of @dlunde's implementation in `anf.mc`.   