### PR TITLE
Fix duplicate code elimination handling of TyAlias

### DIFF
--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1543,7 +1543,8 @@ lang AliasTypeAst = AllTypeAst
   sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyAlias t ->
     match f acc t.content with (acc, content) in
-    (acc, TyAlias {t with content = content})
+    match f acc t.display with (acc, display) in
+    (acc, TyAlias {t with content = content, display = display})
 
   sem rappAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TyAlias t -> f acc t.content

--- a/stdlib/mexpr/duplicate-code-elimination.mc
+++ b/stdlib/mexpr/duplicate-code-elimination.mc
@@ -173,10 +173,6 @@ lang MExprEliminateDuplicateCode = MExprAst
   | TyVar t ->
     match lookupReplacement env replaced t.ident with (replaced, ident) in
     (replaced, TyVar {t with ident = ident})
-  | TyAlias t ->
-    match eliminateDuplicateCodeType env replaced t.display with (replaced, display) in
-    match eliminateDuplicateCodeType env replaced t.content with (replaced, content) in
-    (replaced, TyAlias {t with display = display, content = content})
   | ty -> smapAccumL_Type_Type (eliminateDuplicateCodeType env) replaced ty
 
   sem eliminateDuplicateCodePat : DuplicateCodeEnv -> Map Name Name -> Pat -> (Map Name Name, Pat)


### PR DESCRIPTION
This PR fixes the duplicate code elimination so that it correctly handles `TyAlias` nodes. Previously, it would not update its `display` field, leading to errors when the `display` field contained an aliased type that should be updated.