### PR TITLE
Initial Partial Evaluation and Constant Folding

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -13,6 +13,9 @@ include "map.mc"
 let tyint_ = use IntTypeAst in
   TyInt {info = NoInfo ()}
 
+let ityfloat_ = use FloatTypeAst in
+  lam i. TyFloat {info = i}
+
 let tyfloat_ = use FloatTypeAst in
   TyFloat {info = NoInfo ()}
 
@@ -55,13 +58,15 @@ let tyarrows_ = use FunTypeAst in
   lam tys.
   foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
 
-let tyrecord_ : [(String, Type)] -> Type = use RecordTypeAst in
-  lam fields.
+let tyRecord : Info -> [(String, Type)] -> Type = use RecordTypeAst in
+  lam info. lam fields.
   let fieldMapFunc = lam b : (String, Type). (stringToSid b.0, b.1) in
   TyRecord {
     fields = mapFromSeq cmpSID (map fieldMapFunc fields),
-    info = NoInfo ()
+    info = info
   }
+
+let tyrecord_ = tyRecord (NoInfo ())
 
 let tytuple_ = lam tys.
   tyrecord_ (mapi (lam i. lam ty. (int2string i, ty)) tys)

--- a/stdlib/mexpr/constant-fold.mc
+++ b/stdlib/mexpr/constant-fold.mc
@@ -1,0 +1,538 @@
+include "log.mc"
+
+include "ast.mc"
+include "eval.mc"
+include "pprint.mc"
+include "boot-parser.mc"
+include "side-effect.mc"
+
+lang ConstantFoldCtx = Ast + SideEffect
+  type VarCount = Map Name Int
+  type ConstantFoldCtx = {
+    _vars : VarCount,
+    _env : Map Name Expr,
+    sideEffectEnv : SideEffectEnv
+  }
+
+  sem constantfoldCtxEmpty : () -> ConstantFoldCtx
+  sem constantfoldCtxEmpty =| _ ->
+    {
+      _vars = mapEmpty nameCmp,
+      _env = mapEmpty nameCmp,
+      sideEffectEnv = sideEffectEnvEmpty ()
+    }
+
+  sem constantfoldCtxReset : ConstantFoldCtx -> ConstantFoldCtx
+  sem constantfoldCtxReset =| ctx ->
+    { ctx with _vars = mapEmpty nameCmp, _env = mapEmpty nameCmp }
+
+  sem constantfoldVarCount : Name -> ConstantFoldCtx -> Int
+  sem constantfoldVarCount id =| ctx ->
+    match mapLookup id ctx._vars with Some n then n else 0
+
+  sem constantfoldVarCountIncr : Name -> ConstantFoldCtx -> ConstantFoldCtx
+  sem constantfoldVarCountIncr id =| ctx ->
+    let _vars =
+      if mapMem id ctx._vars then
+        mapInsert id (addi (mapFindExn id ctx._vars) 1) ctx._vars
+      else mapInsert id 1 ctx._vars
+    in
+    { ctx with _vars = _vars }
+
+  sem constantfoldVarCountDecr : Name -> ConstantFoldCtx -> ConstantFoldCtx
+  sem constantfoldVarCountDecr id =| ctx ->
+    let _vars =
+      switch mapLookup id ctx._vars
+      case Some 1 then mapRemove id ctx._vars
+      case Some n then mapInsert id (subi n 1) ctx._vars
+      case None _ then ctx._vars
+      end
+    in
+    { ctx with _vars = _vars }
+
+  sem constantfoldEnvInsert : Name -> Expr -> ConstantFoldCtx -> ConstantFoldCtx
+  sem constantfoldEnvInsert id t =| ctx ->
+    { ctx with _env = mapInsert id t ctx._env }
+
+  sem constantfoldEnvLookup : Name -> ConstantFoldCtx -> Option Expr
+  sem constantfoldEnvLookup id =| ctx -> mapLookup id ctx._env
+
+  sem constantfoldEnvIsEmpty : ConstantFoldCtx -> Bool
+  sem constantfoldEnvIsEmpty =| ctx -> mapIsEmpty ctx._env
+end
+
+lang ConstantFold = ConstantFoldCtx + MExprSideEffect
+  sem _constantfoldExpr : ConstantFoldCtx -> Expr -> Expr
+  sem _constantfoldExpr ctx =| t ->
+    let t = innermost (optimizeOnce ctx) t in
+    let ctx = updateCtx (constantfoldCtxReset ctx) t in
+    if constantfoldEnvIsEmpty ctx then t
+    else _constantfoldExpr ctx t
+
+  sem constantfoldExpr : ConstantFoldCtx -> Expr -> Expr
+  sem constantfoldExpr ctx =| t ->
+    let ctx = { ctx with sideEffectEnv = constructSideEffectEnv t } in
+    let ctx = updateCtx (constantfoldCtxReset ctx) t in
+    _constantfoldExpr ctx t
+
+  sem constantfold : Expr -> Expr
+  sem constantfold =| t -> constantfoldExpr (constantfoldCtxEmpty ()) t
+
+  sem updateCtx : ConstantFoldCtx -> Expr -> ConstantFoldCtx
+  sem updateCtx ctx =
+  | t -> sfold_Expr_Expr updateCtx ctx t
+
+  sem innermost : (Expr -> Option Expr) -> Expr -> Expr
+  sem innermost f =| t1 ->
+    let t2 = smap_Expr_Expr (innermost f) t1 in
+    switch f t2
+    case Some t3 then innermost f t3
+    case None _ then t2
+    end
+
+  sem optimizeOnce : ConstantFoldCtx -> Expr -> Option Expr
+  sem optimizeOnce ctx =| _ -> None ()
+end
+
+lang VarConstantFold = ConstantFold + VarAst
+  sem optimizeOnce ctx =
+  | TmVar r -> optionMap (lam x. x) (constantfoldEnvLookup r.ident ctx)
+
+  sem updateCtx ctx =
+  | TmVar r -> constantfoldVarCountIncr r.ident ctx
+end
+
+lang LamAppConstantFold = ConstantFold + LamAst + AppAst + VarAst + LetAst
+  sem optimizeOnce ctx =
+  -- | TmLam (lamr & ({body = TmApp {lhs = lhs, rhs = TmVar varr}})) ->
+  --   if and
+  --        (nameEqSymUnsafe lamr.ident varr.ident)
+  --        (eqi (constantfoldVarCount lamr.ident ctx) 1)
+  --   then Some lhs
+  --   else None ()
+  | TmApp (appr & {lhs = TmLam lamr}) ->
+    let tyBody = tyTm appr.rhs in
+    Some (TmLet {
+      ident = lamr.ident,
+      tyAnnot = tyBody,
+      tyBody = tyBody,
+      body = appr.rhs,
+      inexpr = lamr.body,
+      ty = appr.ty,
+      info = appr.info
+    })
+end
+
+lang LetConstantFold = ConstantFold + LetAst + ConstAst + LamAst
+  sem optimizeOnce ctx =
+  | TmLet r ->
+    if optionIsSome (constantfoldEnvLookup r.ident ctx) then Some r.inexpr
+    else None ()
+
+  sem updateCtx ctx =
+  | TmLet r ->
+    let ctx = updateCtx (updateCtx ctx r.body) r.inexpr in
+    switch r.body
+    case TmVar _ then constantfoldEnvInsert r.ident r.body ctx
+    case TmConst c | TmLam {body = TmConst c} then
+      if exprHasSideEffect ctx.sideEffectEnv r.body then ctx
+      else constantfoldEnvInsert r.ident r.body ctx
+    case body then
+      if and
+           (not (exprHasSideEffect ctx.sideEffectEnv body))
+           (lti (constantfoldVarCount r.ident ctx) 2)
+      then constantfoldEnvInsert r.ident body ctx
+      else ctx
+    end
+end
+
+lang ArithFloatConstantFold = ConstantFold + ArithFloatEval + AppAst
+  sem optimizeOnce ctx =
+  | TmApp {
+    lhs = TmApp {
+      lhs = TmConst {val = c & CAddf _},
+      rhs = a},
+    rhs = b,
+    info = info
+  } ->
+    switch (a, b)
+    case (TmConst {val = CFloat f1}, TmConst {val = CFloat f2}) then
+      Some (delta info (c, [a, b]))
+    case (TmConst {val = CFloat f}, b) | (b, TmConst {val = CFloat f}) then
+      if eqf f.val 0. then Some b else None ()
+    case (_, _) then None ()
+    end
+  | TmApp {
+    lhs = TmApp {
+      lhs = TmConst {val = c & CMulf _},
+      rhs = a},
+    rhs = b,
+    info = info
+  } ->
+    switch (a, b)
+    case (TmConst {val = CFloat f1}, TmConst {val = CFloat f2}) then
+      Some (delta info (c, [a, b]))
+    case
+      (a & TmConst {val = CFloat f}, b) | (b, a & TmConst {val = CFloat f})
+    then
+      if eqf f.val 1. then Some b
+      else if and (eqf f.val 0.) (not (hasSideEffect b)) then Some a
+      else None ()
+    case (_, _) then None ()
+    end
+  | TmApp {
+    lhs = TmApp (appr & {
+      lhs = TmConst (constr & {val = c & CSubf _}),
+      rhs = a}),
+    rhs = b,
+    info = info
+  } ->
+    switch (a, b)
+    case (TmConst {val = CFloat f1}, TmConst {val = CFloat f2}) then
+      Some (delta info (c, [a, b]))
+    case (TmConst {val = CFloat f}, b) then
+      if eqf f.val 0. then
+        Some (TmApp {
+          appr with lhs = TmConst { constr with val = CNegf () },
+          rhs = b
+        })
+      else None ()
+    case (a, TmConst {val = CFloat f}) then
+      if eqf f.val 0. then Some a
+      else None ()
+    case (_, _) then None ()
+    end
+  | TmApp {
+    lhs = TmApp {
+      lhs = TmConst {val = c & CDivf _},
+      rhs = a},
+    rhs = b,
+    info = info
+  } ->
+    switch (a, b)
+    case (TmConst {val = CFloat f1}, TmConst {val = CFloat f2}) then
+      Some (delta info (c, [a, b]))
+    case (TmConst {val = CFloat f}, b) then
+      if and (eqf f.val 0.) (not (hasSideEffect b)) then Some a
+      else None ()
+    case (a, TmConst {val = CFloat f}) then
+      if eqf f.val 0. then
+        errorSingle [info] "Division by zero"
+      else if eqf f.val 1. then Some a
+      else None ()
+    case (_, _) then None ()
+    end
+  | TmApp {
+    lhs = TmConst {val = CNegf _},
+    rhs = TmApp {
+      lhs = TmConst {val = CNegf _},
+      rhs = a},
+    info = info
+  } -> Some a
+  | TmApp {
+    lhs = TmConst {val = c & CNegf _},
+    rhs = (a & TmConst {val = CFloat _}),
+    info = info} ->
+    Some (delta info (c, [a]))
+end
+
+lang MExprConstantFold =
+  -- Terms
+  VarConstantFold + LamAppConstantFold + LetConstantFold +
+
+  -- Constants
+  ArithFloatConstantFold
+end
+
+lang TestLang = MExprConstantFold + MExprPrettyPrint + MExprEq + BootParser end
+
+mexpr
+
+use TestLang in
+
+let _test = lam expr.
+  logMsg logLevel.debug (lam.
+    strJoin "\n" [
+      "Before constantfold",
+      expr2str expr
+    ]);
+  let expr = symbolizeAllowFree expr in
+  match constantfold expr with expr in
+  logMsg logLevel.debug (lam.
+    strJoin "\n" [
+      "After constantfold",
+      expr2str expr
+    ]);
+  expr
+in
+
+let _parse =
+  parseMExprString
+    { _defaultBootParserParseMExprStringArg () with allowFree = true }
+in
+
+-----------------------
+-- Test Let-bindings --
+-----------------------
+
+let prog = _parse "let x = y in x" in
+utest _test prog with _parse "y" using eqExpr in
+
+let prog = _parse "let x = y y in x x" in
+utest _test prog with _parse "let x = y y in x x" using eqExpr in
+
+let prog = _parse "let x = let z = y in z in x" in
+utest _test prog with _parse "y" using eqExpr in
+
+let prog = _parse "let x = let z = y in z in x" in
+utest _test prog with _parse "y" using eqExpr in
+
+let prog = _parse "let x = y in x x" in
+utest _test prog with _parse "y y" using eqExpr in
+
+let prog = _parse "let x = let y = z in y in x x" in
+utest _test prog with _parse "z z" using eqExpr in
+
+let prog = _parse "let x = 1 in x x" in
+utest _test prog with _parse "1 1" using eqExpr in
+
+let prog = _parse "let f = lam. 1 in (f x) (f x)" in
+utest _test prog with _parse "1 1" using eqExpr in
+
+let prog = _parse "let f = print \"hello world\" in f" in
+utest _test prog with _parse "
+let f =
+  print
+    \"hello world\"
+in
+f
+  "
+  using eqExpr
+in
+
+let prog = _parse "let f = print \"hello world\" in let g = f in g" in
+utest _test prog with _parse "
+let f =
+  print
+    \"hello world\"
+in
+f
+  "
+  using eqExpr
+in
+
+------------------
+-- Test Lam App --
+------------------
+
+let prog = _parse "(lam x. x x z) y" in
+utest _test prog with _parse "
+y
+  y
+  z
+  "
+  using eqExpr
+in
+
+let prog = _parse "(lam. x x z) y" in
+utest _test prog with _parse "
+x
+  x
+  z
+  "
+  using eqExpr
+in
+
+let prog = _parse "(lam x. x x z) (lam x. x z)" in
+utest _test prog with _parse "
+let x =
+  lam x1.
+    x1
+      z
+in
+x
+  x
+  z
+  "
+  using eqExpr
+in
+
+--------------
+-- Test Lam --
+--------------
+
+let prog = _parse "lam x. x" in
+utest _test prog with _parse "lam x. x" using eqExpr in
+
+let prog = _parse "lam x. let y = x in y" in
+utest _test prog with _parse "lam x. x" using eqExpr in
+
+let prog = _parse "(lam x. x) y" in
+utest _test prog with _parse "y" using eqExpr in
+
+-------------------------------
+-- Test Remove Eta-Expansion --
+-------------------------------
+
+let prog = _parse "lam x. y x" in
+utest _test prog with _parse "y" using eqExpr in
+
+let prog = _parse "let g = lam x. addf (subf x 1.) x in g" in
+utest _test prog with _parse "lam x. addf (subf x 1.) x" using eqExpr in
+
+-- logSetLogLevel logLevel.debug;
+
+-- let prog = _parse "
+--   let h = lam x. addf x x in
+--   let g = lam x. mulf x (subf x 1.) in
+--   lam x. addf (h x) (g x)
+--   "
+-- in
+-- utest _test prog with _parse "lam x. addf (subf x 1.) x" using eqExpr in
+
+---------------------------
+-- Test Float Arithmetic --
+---------------------------
+
+let prog = _parse "
+let x = negf (subf (divf (mulf (addf 1. 2.) 2.) 2.) 4.) in
+x
+  " in
+utest _test prog with _parse "1." using eqExpr in
+
+let prog = _parse "addf x 0." in
+utest _test prog with _parse "x" using eqExpr in
+
+let prog = _parse "addf 0. x" in
+utest _test prog with _parse "x" using eqExpr in
+
+let prog = _parse "subf x 0." in
+utest _test prog with _parse "x" using eqExpr in
+
+let prog = _parse "subf 0. x" in
+utest _test prog with _parse "negf x" using eqExpr in
+
+let prog = _parse "mulf x 0." in
+utest _test prog with _parse "0." using eqExpr in
+
+let prog = _parse "mulf 0. x" in
+utest _test prog with _parse "0." using eqExpr in
+
+let prog = _parse "mulf (print \"hello\"; y) 0." in
+utest _test prog with _parse "
+mulf
+  (print \"hello\"; y)
+  0.
+  "
+  using eqExpr
+in
+
+let prog = _parse "mulf 0. (print \"hello\"; y)" in
+utest _test prog with _parse "
+mulf
+  0.
+  (print \"hello\"; y)
+  "
+  using eqExpr
+in
+
+
+let prog = _parse "mulf x 1." in
+utest _test prog with _parse "x" using eqExpr in
+
+let prog = _parse "mulf 1. x" in
+utest _test prog with _parse "x" using eqExpr in
+
+let prog = _parse "divf x 1." in
+utest _test prog with _parse "x" using eqExpr in
+
+let prog = _parse "divf 0. x" in
+utest _test prog with _parse "0." using eqExpr in
+
+-- logSetLogLevel logLevel.debug;
+
+let prog = _parse "divf 0. (print \"hello\"; x)" in
+utest _test prog with _parse "
+divf
+  0.
+  (print \"hello\"; x)
+  "
+  using eqExpr
+in
+
+let prog = _parse "negf (negf x)" in
+utest _test prog with _parse "x" using eqExpr in
+
+-- logSetLogLevel logLevel.debug;
+
+let prog = _parse "
+let h =
+  lam x6.
+    subf
+      x6
+      2.
+in
+let dh =
+  lam x5.
+    1.
+in
+let g =
+  lam x4.
+    mulf
+      x4
+      (subf
+         x4
+         1.)
+in
+let dg =
+  lam x3.
+    addf
+      (subf
+         x3
+         1.)
+      x3
+in
+let f =
+  lam x2.
+    addf
+      (addf
+         (g
+            x2)
+         (h
+            x2))
+      (h
+         (mulf
+            2.
+            x2))
+in
+let df =
+  lam x1.
+    addf
+      (addf
+         (dg
+            x1)
+         (dh
+            x1))
+      (mulf
+         2.
+         (dh
+            (mulf
+               2.
+               x1)))
+in
+let df =
+  lam x.
+    df
+      x
+in
+df
+  1.
+  " in
+
+utest _test prog with _parse "
+4.
+  "
+  using eqExpr
+in
+
+()

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -61,7 +61,7 @@ end
 -- TERMS --
 -----------
 
-lang VarEval = Eval + VarAst + AppAst
+lang VarEval = Eval + VarAst
   sem eval ctx =
   | TmVar r ->
     match evalEnvLookup r.ident ctx.env with Some t then t
@@ -79,12 +79,28 @@ lang AppEval = Eval + AppAst
   | TmApp r -> apply ctx r.info (eval ctx r.lhs, eval ctx r.rhs)
 end
 
-lang LamEval = Eval + LamAst + VarEval + AppEval
+lang ClosAst = Ast + Eval + PrettyPrint
   type Lazy a = () -> a
 
   syn Expr =
   | TmClos {ident : Name, body : Expr, env : Lazy EvalEnv}
 
+  sem isAtomic =
+  | TmClos _ -> true
+
+  sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmClos r ->
+    match pprintVarName env r.ident with (env,ident) in
+    match pprintCode (pprintIncr indent) env r.body with (env,body) in
+   (env,
+    join [
+      "Clos{lam ", ident, ".",
+      pprintNewline (pprintIncr indent), body,
+      "}"
+    ])
+end
+
+lang LamEval = Eval + LamAst + ClosAst + AppEval
   sem apply ctx info =
   | (TmClos t, arg) ->
     eval {ctx with env = evalEnvInsert t.ident arg (t.env ())} t.body
@@ -94,7 +110,7 @@ lang LamEval = Eval + LamAst + VarEval + AppEval
   | TmClos t -> TmClos t
 end
 
-lang LetEval = Eval + LetAst + VarEval
+lang LetEval = Eval + LetAst
   sem eval ctx =
   | TmLet t ->
     eval {ctx with env = evalEnvInsert t.ident (eval ctx t.body) ctx.env}
@@ -143,17 +159,29 @@ lang ConstAppAst = ConstAst
     const : Const,
     args : [Expr]
   }
+
+  sem isAtomic =
+  | TmConstApp _ -> true
+
+  sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmConstApp r ->
+    pprintCode indent env (appSeq_ (uconst_ r.const) r.args)
 end
 
 lang ConstEval =
-  Eval + ConstAppAst + SysAst + SeqAst + UnknownTypeAst + ConstArity
+  Eval + ConstAppAst + SysAst + SeqAst + UnknownTypeAst + ConstArity +
+  PrettyPrint
 
   sem delta : Info -> (Const, [Expr]) -> Expr
   sem delta info =
   | (const, args) ->
     if lti (length args) (constArity const) then
       TmConstApp {const = const, args = args}
-    else errorSingle [info] "Invalid application"
+    else errorSingle [info]
+           (join [
+             "Invalid application\n",
+             expr2str (TmConstApp {const = const, args = args})
+           ])
 
   sem apply ctx info =
   | (TmConst r, arg) -> delta info (r.val, [arg])

--- a/stdlib/mexpr/peval.mc
+++ b/stdlib/mexpr/peval.mc
@@ -1,0 +1,697 @@
+include "map.mc"
+include "log.mc"
+
+include "ast.mc"
+include "ast-builder.mc"
+include "eval.mc"
+include "pprint.mc"
+include "boot-parser.mc"
+
+lang PEvalCtx = Eval
+  type PEvalCtx = { env : EvalEnv }
+
+  sem pevalCtxEmpty : () -> PEvalCtx
+  sem pevalCtxEmpty =| _ ->
+    { env = evalEnvEmpty () }
+end
+
+lang PEval = PEvalCtx + Eval + PrettyPrint
+  sem peval : Expr -> Expr
+  sem peval =| t -> pevalReadback (pevalBind (pevalCtxEmpty ()) (lam x. x) t)
+
+  sem pevalIsValue : Expr -> Bool
+  sem pevalIsValue =
+  | t ->
+    errorSingle [infoTm t] (join ["pevalIsValue: undefined for:\n", expr2str t])
+
+  sem pevalBind : PEvalCtx -> (Expr -> Expr) -> Expr -> Expr
+  sem pevalBind ctx k =| t ->
+    pevalEval ctx
+      (lam t.
+        if pevalIsValue t then k t
+        else
+          let ident = nameSym "t" in
+          bind_ (nulet_ ident t) (k (nvar_ ident)))
+      t
+
+  sem pevalEval : PEvalCtx -> (Expr -> Expr) -> Expr -> Expr
+  sem pevalEval ctx k =
+  | t -> errorSingle [infoTm t] (join ["peval: undefined for:\n", expr2str t])
+
+  sem pevalReadback : Expr -> Expr
+  sem pevalReadback =| t -> smap_Expr_Expr pevalReadback t
+end
+
+lang AppPEval = PEval + AppAst
+  sem pevalIsValue =
+  | TmApp _ -> false
+
+  sem pevalApply : Info -> PEvalCtx -> (Expr -> Expr) -> (Expr, Expr) -> Expr
+  sem pevalApply info ctx k =
+  | (f, arg) ->
+    errorSingle [info]
+      (join [
+        "Bad application between:\n",
+        expr2str f,
+        "\nand:\n",
+        expr2str arg
+      ])
+
+  sem pevalEval ctx k =
+  | TmApp r ->
+    pevalBind ctx
+      (lam lhs.
+        pevalBind ctx
+          (lam rhs. pevalApply r.info ctx k (lhs, rhs))
+          r.rhs)
+      r.lhs
+end
+
+lang VarPEval = PEval + VarAst + AppPEval
+  sem pevalIsValue =
+  | TmVar _ -> true
+
+  sem pevalApply info ctx k =
+  | (f & TmVar _, arg) -> k (app_ f arg)
+
+  sem pevalEval ctx k =
+  | t & TmVar r ->
+    match evalEnvLookup r.ident ctx.env with Some t then k t
+    else k t
+end
+
+lang LamPEval = PEval + LamAst + ClosAst + AppEval
+  sem pevalIsValue =
+  | TmClos _ -> true
+
+  sem pevalApply info ctx k =
+  | (TmClos r, arg) ->
+    pevalEval { ctx with env = evalEnvInsert r.ident arg (r.env ()) } k r.body
+
+  sem pevalEval ctx k =
+  | TmLam t -> k (TmClos { ident = t.ident, body = t.body, env = lam. ctx.env })
+  | TmClos t -> k (TmClos t)
+
+  sem pevalReadback =
+  | TmClos r ->
+    let body =
+      pevalReadback
+        (pevalBind { (pevalCtxEmpty ()) with env = r.env () } (lam x. x) r.body)
+    in
+    nulam_ r.ident body
+end
+
+lang LetPEval = PEval + LetAst
+  sem pevalIsValue =
+  | TmLet _ -> false
+
+  sem pevalEval ctx k =
+  | TmLet r ->
+    pevalBind ctx
+      (lam body.
+        if pevalIsValue body then
+          pevalBind
+            { ctx with env = evalEnvInsert r.ident body ctx.env } k r.inexpr
+        else
+          TmLet { r with body = body, inexpr = pevalBind ctx k r.inexpr })
+      r.body
+end
+
+lang RecordPEval = PEval + RecordAst + VarAst
+  sem pevalIsValue =
+  -- NOTE(oerikss, 2022-02-15): We do not have to check inside the record as the
+  -- bindings vill always bind to values after the PEval transformation.
+  | TmRecord _ -> true
+  | TmRecordUpdate _ -> false
+
+  sem pevalEval ctx k =
+  | TmRecord r ->
+    mapMapK
+      (lam t. lam k. pevalBind ctx k t)
+      r.bindings
+      (lam bs. k (TmRecord { r with bindings = bs }))
+  | TmRecordUpdate r1 ->
+    pevalBind ctx
+      (lam rec.
+        pevalBind ctx
+          (lam value.
+            switch rec
+            case TmRecord r2 then
+              let r2 =
+                { r2 with bindings = mapInsert r1.key value r2.bindings }
+              in
+              k (TmRecord r2)
+            case TmVar _ then
+              k (TmRecordUpdate { r1 with rec = rec, value = value })
+            end)
+          r1.value)
+      r1.rec
+end
+
+lang ConstPEval = PEval + ConstEval
+  sem pevalReadback =
+  | TmConstApp r ->
+    let args = map pevalReadback r.args in
+    appSeq_ (uconst_ r.const) args
+
+  sem pevalIsValue =
+  | TmConst _ -> true
+  | TmConstApp _ -> true
+  -- NOTE(oerikss, 2022-02-15): We treat partially applied constants as
+  -- values. We then have to make sure to transform these to normal TmApp's to
+  -- avoid re-computations when we see that we cannot statically evaluate the
+  -- constant.
+
+  sem pevalEval ctx k =
+  | t & (TmConst _ | TmConstApp _) -> k t
+
+  sem pevalApply info ctx k =
+  | (TmConst r, arg) -> k (delta info (r.val, [arg]))
+  | (TmConstApp r, arg) -> k (delta info (r.const, snoc r.args arg))
+end
+
+lang MatchPEval = PEval + MatchEval + NeverAst + VarAst
+  sem pevalIsValue =
+  | TmMatch _ -> false
+
+  sem pevalEval ctx k =
+  | TmMatch r ->
+    pevalBind ctx
+      (lam target.
+        switch target
+        case TmVar _ then
+          k (TmMatch {r with
+                      target = target,
+                      thn = pevalBind ctx (lam x. x) r.thn,
+                      els = pevalBind ctx (lam x. x) r.els
+          })
+        case t & TmNever _ then k t
+        case _ then
+          match tryMatch ctx.env target r.pat with Some env then
+            pevalBind { ctx with env = env } k r.thn
+          else pevalBind ctx k r.els
+        end)
+      r.target
+end
+
+lang NeverPEval = PEval + NeverAst
+  sem pevalIsValue =
+  | TmNever _ -> true
+
+  sem pevalEval ctx k =
+  | t & TmNever _ -> k t
+
+  sem pevalApply info ctx k =
+  | (t & TmNever _, _) -> k t
+end
+
+lang ArithIntPEval = ArithIntEval + VarAst
+  sem delta info =
+  | (c & (CAddi _ | CMuli _), args & [TmVar _, TmConst _]) ->
+    -- NOTE(oerikss, 2022-02-15): We move constants to the lhs for associative
+    -- operators to make later simplifications easier.
+    delta info (c, reverse args)
+  | (c & CAddi _, args & [TmConst {val = CInt a}, b & TmVar _]) ->
+    if eqi a.val 0 then b else appSeq_ (uconst_ c) args
+  | (c & CAddi _, [a & TmVar r1, b & TmVar r2]) ->
+    if nameEqSymUnsafe r1.ident r2.ident then muli_ (int_ 2) b
+    else appSeq_ (uconst_ c) [a, b]
+  | (c & CMuli _, args & [TmConst {val = CInt a}, b & TmVar _]) ->
+    switch a.val
+    case 0 then int_ 0
+    case 1 then b
+    case _ then appSeq_ (uconst_ c) args
+    end
+  | (c & CSubi _, args & [TmConst {val = CInt a}, b & TmVar _]) ->
+    if eqi a.val 0 then negi_ b else appSeq_ (uconst_ c) args
+  | (c & CSubi _, args & [a & TmVar _, TmConst {val = CInt b}]) ->
+    if eqi b.val 0 then a else appSeq_ (uconst_ c) args
+  | (c & CSubi _, [a & TmVar r1, b & TmVar r2]) ->
+    if nameEqSymUnsafe r1.ident r2.ident then int_ 0
+    else appSeq_ (uconst_ c) [a, b]
+  | (c & (CDivi _), args & [TmConst {val = CInt a}, b & TmVar _]) ->
+    if eqi a.val 0 then int_ 0 else appSeq_ (uconst_ c) args
+  | (c & (CDivi _), args & [a, TmConst {val = CInt b}]) ->
+    switch b.val
+    case 0 then errorSingle [info] "Division by zero"
+    case 1 then a
+    case _ then appSeq_ (uconst_ c) args
+    end
+  | (c & (CModi _), args & [TmConst _, b & TmVar _]) ->
+    appSeq_ (uconst_ c) args
+  | (c & (CAddi _ | CMuli _ | CSubi _ | CDivi _ | CModi _),
+     args & [TmVar _, TmVar _]) ->
+    appSeq_ (uconst_ c) args
+  | (c & CNegi _, [a & TmVar _]) -> app_ (uconst_ c) a
+end
+
+lang ArithFloatPEval = ArithFloatEval + VarAst
+  sem delta info =
+  | (c & (CAddf _ | CMulf _), args & [TmVar _, TmConst _]) ->
+    -- NOTE(oerikss, 2022-02-15): We move constants to the lhs for associative
+    -- operators to make later simplifications easier.
+    delta info (c, reverse args)
+  | (c & CAddf _, args & [TmConst {val = CFloat a}, b & TmVar _]) ->
+    if eqf a.val 0. then b else appSeq_ (uconst_ c) args
+  | (c & CAddf _, [a & TmVar r1, b & TmVar r2]) ->
+    if nameEqSymUnsafe r1.ident r2.ident then mulf_ (float_ 2.) b
+    else appSeq_ (uconst_ c) [a, b]
+  | (c & CMulf _, args & [TmConst {val = CFloat a}, b & TmVar _]) ->
+    if eqf a.val 0. then float_ 0.
+    else if eqf a.val 1. then b
+    else appSeq_ (uconst_ c) args
+  | (c & CSubf _, args & [TmConst {val = CFloat a}, b & TmVar _]) ->
+    if eqf a.val 0. then negf_ b else appSeq_ (uconst_ c) args
+  | (c & CSubf _, args & [a & TmVar _, TmConst {val = CFloat b}]) ->
+    if eqf b.val 0. then a else appSeq_ (uconst_ c) args
+  | (c & CSubf _, [a & TmVar r1, b & TmVar r2]) ->
+    if nameEqSymUnsafe r1.ident r2.ident then float_ 0.
+    else appSeq_ (uconst_ c) [a, b]
+  | (c & (CDivf _), args & [TmConst {val = CFloat a}, b & TmVar _]) ->
+    if eqf a.val 0. then float_ 0. else appSeq_ (uconst_ c) args
+  | (c & (CDivf _), args & [a, TmConst {val = CFloat b}]) ->
+    if eqf b.val 0. then errorSingle [info] "Division by zero"
+    else if eqf b.val 1. then a
+    else appSeq_ (uconst_ c) args
+  | (c & (CAddf _ | CMulf _ | CSubf _ | CDivf _),
+     args & [TmVar _, TmVar _]) ->
+    appSeq_ (uconst_ c) args
+  | (c & CNegf _, [a & TmVar _]) -> app_ (uconst_ c) a
+end
+
+lang CmpFloatPEval = CmpFloatEval + VarAst
+  sem delta info =
+  | (c & (CEqf _ | CLtf _ | CLeqf _ | CGtf _ | CGeqf _ | CNeqf _),
+     args & ([TmVar _, TmVar _] | [!TmVar _, TmVar _] | [TmVar _, !TmVar _])) ->
+    appSeq_ (uconst_ c) args
+end
+
+lang MExprPEval =
+  -- Terms
+  VarPEval + LamPEval + AppPEval + RecordPEval + ConstPEval + LetPEval +
+  MatchPEval + NeverPEval +
+
+  -- Constants
+  ArithIntPEval + ArithFloatPEval + CmpFloatPEval +
+
+  -- Patterns
+  NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +
+  IntPatEval + CharPatEval + BoolPatEval + AndPatEval + OrPatEval + NotPatEval
+end
+
+lang TestLang = MExprPEval + MExprPrettyPrint + MExprEq + BootParser end
+
+mexpr
+
+use TestLang in
+
+let _test = lam expr.
+  logMsg logLevel.debug (lam.
+    strJoin "\n" [
+      "Before peval",
+      expr2str expr
+    ]);
+  let expr = symbolizeAllowFree expr in
+  match peval expr with expr in
+  logMsg logLevel.debug (lam.
+    strJoin "\n" [
+      "After peval",
+      expr2str expr
+    ]);
+  expr
+in
+
+let _parse =
+  parseMExprString
+    { _defaultBootParserParseMExprStringArg () with allowFree = true }
+in
+
+
+------------------------------
+-- Test closure application --
+------------------------------
+
+let prog = _parse "lam x. x" in
+utest _test prog with _parse "lam x. x" using eqExpr in
+
+let prog = _parse "(lam x. x) (lam z. z)" in
+utest _test prog with _parse "lam z. z" using eqExpr in
+
+let prog = _parse "(lam x. x y) (lam z. z)" in
+utest _test prog with _parse "y" using eqExpr in
+
+let prog = _parse "(lam x. y y x) (lam z. z)" in
+utest _test prog with _parse "
+let t =
+  y
+    y
+in
+let t1 =
+  t
+    (lam z.
+       z)
+in
+t1
+  "
+  using eqExpr
+in
+
+-----------------------------
+-- Test integer arithmetic --
+-----------------------------
+
+let prog = _parse "lam x. addi x 0" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. addi x 1" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    addi
+      1
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. addi 0 x" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. addi 1 x" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    addi
+      1
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. addi x x" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    muli
+      2
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. muli x 0" in
+utest _test prog with _parse "lam x. 0"
+  using eqExpr
+in
+
+let prog = _parse "lam x. muli 0 x" in
+utest _test prog with _parse "lam x. 0"
+  using eqExpr
+in
+
+let prog = _parse "lam x. muli 1 x" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. muli x 1" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. muli 2 x" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    muli
+      2
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. muli x 2" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    muli
+      2
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. divi x 1" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. divi 0 x" in
+utest _test prog with _parse "lam x. 0"
+  using eqExpr
+in
+
+
+------------------------------------
+-- Test floating point arithmetic --
+------------------------------------
+
+let prog = _parse "lam x. addf x 0." in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. addf x 1." in
+utest _test prog with _parse "
+lam x.
+  let t =
+    addf
+      1.
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. addf 0. x" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. addf 1. x" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    addf
+      1.
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. addf x x" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    mulf
+      2.
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. mulf x 0." in
+utest _test prog with _parse "lam x. 0."
+  using eqExpr
+in
+
+let prog = _parse "lam x. mulf 0. x" in
+utest _test prog with _parse "lam x. 0."
+  using eqExpr
+in
+
+let prog = _parse "lam x. mulf 1. x" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. mulf x 1." in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. mulf 2. x" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    mulf
+      2.
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. mulf x 2." in
+utest _test prog with _parse "
+lam x.
+  let t =
+    mulf
+      2.
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam x. divf x 1." in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "lam x. divf 0. x" in
+utest _test prog with _parse "lam x. 0."
+  using eqExpr
+in
+
+
+-------------------------------------------
+-- Test Composite Arithmetic Expressions --
+-------------------------------------------
+
+let prog = _parse "lam x. mulf (addf 1. x) 1." in
+utest _test prog with _parse "
+lam x.
+  let t =
+    addf
+      1.
+      x
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "lam y. (lam x. mulf x x) (mulf (mulf 2. y) y)" in
+utest _test prog with _parse "
+lam y.
+  let t =
+    mulf
+      2.
+      y
+  in
+  let t1 =
+    mulf
+      t
+      y
+  in
+  let t2 =
+    mulf
+      t1
+      t1
+  in
+  t2
+  "
+  using eqExpr
+in
+
+----------------------------------------
+-- Test Record Updates and Projection --
+----------------------------------------
+
+let prog = _parse "{ a = 1, b = 2}.b" in
+utest _test prog with _parse "2"
+  using eqExpr
+in
+
+let prog = _parse "{ a = 1, b = 2}.a" in
+utest _test prog with _parse "1"
+  using eqExpr
+in
+
+let prog = _parse "lam x. x.a" in
+utest _test prog with _parse "
+lam x.
+  let t =
+    x.a
+  in
+  t
+  "
+  using eqExpr
+in
+
+let prog = _parse "{{ a = 1, b = 2} with a = 3}.a" in
+utest _test prog with _parse "3"
+  using eqExpr
+in
+
+-- logSetLogLevel logLevel.debug;
+
+let prog = _parse "{x with a = 3}.a" in
+utest _test prog with _parse "
+let t =
+  { x
+    with
+    a =
+      3 }
+in
+let t1 =
+  t.a
+in
+t1
+  "
+  using eqExpr
+in
+
+---------------------------
+-- Test Pattern Matching --
+---------------------------
+
+let prog = _parse "lam x. match (lam z. (1, z)) x with (u, v) in v" in
+utest _test prog with _parse "lam x. x"
+  using eqExpr
+in
+
+let prog = _parse "
+lam x. match x with (f, g) then (lam x. x) (f, g) else (lam x. x) (lam z. z)
+  " in
+utest _test prog with _parse "
+lam x.
+  let t =
+    match
+      x
+    with
+      (f, g)
+    then
+      (f, g)
+    else
+      lam z.
+        z
+  in
+  t
+  "
+  using eqExpr
+in
+
+()

--- a/stdlib/mexpr/side-effect.mc
+++ b/stdlib/mexpr/side-effect.mc
@@ -150,12 +150,11 @@ lang MExprSideEffect =
         (map (lam bind : RecLetBinding. (bind.ident, bind)) t.bindings) in
     let sideEffectsScc = lam env : SideEffectEnv. lam scc : [Name].
       let sccBindings : [RecLetBinding] =
-        map
-          (lam id : Name.
-            optionGetOrElse
-              (lam. never)
-              (mapLookup id bindMap))
-          scc in
+        foldl
+          (lam acc. lam id. optionMapOr acc (snoc acc) (mapLookup id bindMap))
+          []
+          scc
+      in
       -- Determine whether the body of any binding within this strongly
       -- connected component contains side-effects. If we find any side-effect,
       -- we know they must all contain a side-effect as they can be called from

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -115,7 +115,8 @@ lang VarSym = Sym + VarAst
         let ident =
           match mapLookup str varEnv with Some ident then ident
           else if env.allowFree then t.ident
-          else errorSingle [t.info] (concat "Unknown variable in symbolizeExpr: " str)
+          else
+            errorSingle [t.info] (concat "Unknown variable in symbolizeExpr: " str)
         in
         TmVar {{t with ident = ident}
                   with ty = symbolizeType env t.ty}


### PR DESCRIPTION
This draft PR contains:

**An initial implementation of constant folding**

This might be useful to everyone. It is good to discuss what should be contained in this transformation and what is sound. I though about it but I might have added stuff that should not be there. I based it on @elegios sketch here https://github.com/miking-lang/miking/wiki/Recursion-Cookbook#constant-folding. In addition I added:
- Substitution of let-bindings when the bound variable: only occurs at most once, is an alias, or constant/constant function. I also make sure not to substitute bindings with side-effects (using the analysis from `side-effects.mc`.
-  Simplification rules for floating-point arithmetic, with side-effects checking. However, I only considered one operation at a time and not, e.g., factoring like `a * b + a * c = a * (b + c)`.
- Removal of eta-expansions (do you want to always do this?)
- `(lam x. body) arg` is treated as `let x = arg in body` in the transformation which means that for example applications of identity functions are removed.

**An Initial Implementation of PEval**
This is reference implementation of a partial evaluator I define in my paper (which uses an eval/readback approach but with added let-bound dynamic computations). It currently only covers a small subset of pure mexpr. I doubt that this one should be merged into the main miking branch in its current state but It could perhaps serve as a starting point or a point of reference for Johan, depending on what approach he intends to take.

Features includes:
- Agressive evaluation of colsure applications. I use this because I want to specialize code down to elementary floating point operations in selected parts of the program. You probably do not want this in a general partial evaluator.
- Let-bidning of shared computations. Dynamic computations are let-bound to avoid expression swell. In fact the output from this partial evaluator is in administrative normal form (ANF).
- A consequence of the above is that you should apply the constant folding after applying the peval function to get rid of dead-code and superfluous let-bindings. I suppose the backend should handle this otherwise, but the code quickly becomes quite unreadable if you don't do this.  
 