### PR TITLE
Include info into the LR(k) parse errors

### DIFF
--- a/stdlib/parser/lrk.mc
+++ b/stdlib/parser/lrk.mc
@@ -674,7 +674,9 @@ lang LRParser = EOFTokenParser + MExprAst + MExprCmp
     /---- Assumed to exist "public" identifiers ----/
     let #var"global: result.err" = lam v. appf1_ (recordproj_ "err" (var_ "result")) v in
     let #var"global: result.ok" = lam v. appf1_ (recordproj_ "ok" (var_ "result")) v in
-    let resExprErrNoInfo = lam e: Expr.  #var"global: result.err" (utuple_ [conapp_ "NoInfo" unit_, e]) in
+    let resExprErr = lam i: Expr. lam e: Expr.  #var"global: result.err" (utuple_ [i, e]) in
+    let resErr = lam i. lam s. resExprErr (str_ s) i in
+    let resExprErrNoInfo = lam e: Expr. resExprErr (conapp_ "NoInfo" unit_) e in
     let resErrNoInfo = lam s: String. resExprErrNoInfo (str_ s) in
 
     /---- Set up the types ----/
@@ -950,15 +952,25 @@ lang LRParser = EOFTokenParser + MExprAst + MExprCmp
                     join [head t, " followed by ", strJoin ", " (tail t)]
                 ) allLookaheads in
                 let lookaheadFailCase =
-                  resErrNoInfo (join [
-                    "unexpected ",
-                    if eqi 1 table.k_lookahead then "token" else "tokens",
-                    " at position <??>. Expected ",
-                    if eqi 1 (length allLookaheads) then
-                      head allLookaheadStrings
-                    else
-                      strJoin "\n - " (cons "one of" allLookaheadStrings)
-                  ])
+                  resExprErr (appf2_ (var_ "mergeInfo")
+                                     (appf1_ (var_ "tokInfo") (head_ (nvar_ lamLookahead)))
+                                     (appf1_ (var_ "tokInfo") (head_ (reverse_ (nvar_ lamLookahead)))))
+                             (appf1_ (var_ "join") (seq_ [
+                    str_ (join [
+                      "Unexpected ",
+                      if eqi 1 table.k_lookahead then "token" else "tokens"
+                    ]),
+                    str_ " ",
+                    appf2_ (var_ "strJoin") (str_ ", ")
+                           (map_ (var_ "tokToStr") (nvar_ lamLookahead)),
+                    str_ ". Expected ",
+                    str_ (
+                      if eqi 1 (length allLookaheads) then
+                        head allLookaheadStrings
+                      else
+                        strJoin "\n - " (cons "one of" allLookaheadStrings)
+                    )
+                  ]))
                 in
 
                 matchall_ (join [shiftMatches, reductionMatches, [lookaheadFailCase]])
@@ -1045,7 +1057,7 @@ lang LRParser = EOFTokenParser + MExprAst + MExprCmp
                   ]
                 ),
                 matchex_ (var_ "r") (pcon_ "ResultErr" (prec_ [("errors", pvar_ "errors"), ("warnings", pvar_ "warnings")])) (
-          conapp_ "ResultErr" (urecord_ [("errors", var_ "errors"), ("warnings", var_ "warnings")])
+                  conapp_ "ResultErr" (urecord_ [("errors", var_ "errors"), ("warnings", var_ "warnings")])
                 )
               ]
             ])

--- a/test/examples/parser/lrk-calclang.mc
+++ b/test/examples/parser/lrk-calclang.mc
@@ -114,6 +114,7 @@ case ResultOk {value = lrtable} then
     "include \"result.mc\"",
     "include \"seq.mc\"",
     "include \"string.mc\"",
+    "include \"mexpr/info.mc\"",
     "include \"parser/lexer.mc\"",
 "
 lang PMLexer = Lexer
@@ -174,7 +175,14 @@ end
         ),
         matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
           appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
-                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                          (map_ (ulam_ "v" (
+                                                  appf1_ (var_ "join") (seq_ [
+                                                    str_ "Parse error at ",
+                                                    appf1_ (var_ "info2str") (tupleproj_ 0 (var_ "v")),
+                                                    str_ ": ",
+                                                    tupleproj_ 1 (var_ "v")
+                                                  ])
+                                                ))
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]

--- a/test/examples/parser/lrk-lr2.mc
+++ b/test/examples/parser/lrk-lr2.mc
@@ -83,6 +83,7 @@ case ResultOk {value = lrtable} then
     "include \"result.mc\"",
     "include \"seq.mc\"",
     "include \"string.mc\"",
+    "include \"mexpr/info.mc\"",
     "include \"parser/lexer.mc\"",
     "let seq2string = lam s: [String]. snoc (cons '[' (strJoin \", \" s)) ']'",
     "mexpr",
@@ -104,7 +105,14 @@ case ResultOk {value = lrtable} then
         ),
         matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
           appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
-                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                          (map_ (ulam_ "v" (
+                                                  appf1_ (var_ "join") (seq_ [
+                                                    str_ "Parse error at ",
+                                                    appf1_ (var_ "info2str") (tupleproj_ 0 (var_ "v")),
+                                                    str_ ": ",
+                                                    tupleproj_ 1 (var_ "v")
+                                                  ])
+                                                ))
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]

--- a/test/examples/parser/lrk-nonll.mc
+++ b/test/examples/parser/lrk-nonll.mc
@@ -63,6 +63,7 @@ case ResultOk {value = lrtable} then
     "include \"result.mc\"",
     "include \"seq.mc\"",
     "include \"string.mc\"",
+    "include \"mexpr/info.mc\"",
     "include \"parser/lexer.mc\"",
     "mexpr",
     "use Lexer in",
@@ -83,7 +84,14 @@ case ResultOk {value = lrtable} then
         ),
         matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
           appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
-                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                          (map_ (ulam_ "v" (
+                                                  appf1_ (var_ "join") (seq_ [
+                                                    str_ "Parse error at ",
+                                                    appf1_ (var_ "info2str") (tupleproj_ 0 (var_ "v")),
+                                                    str_ ": ",
+                                                    tupleproj_ 1 (var_ "v")
+                                                  ])
+                                                ))
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]

--- a/test/examples/parser/lrk-parenlang.mc
+++ b/test/examples/parser/lrk-parenlang.mc
@@ -52,6 +52,7 @@ case ResultOk {value = lrtable} then
     "include \"result.mc\"",
     "include \"seq.mc\"",
     "include \"string.mc\"",
+    "include \"mexpr/info.mc\"",
     "include \"parser/lexer.mc\"",
     "mexpr",
     "use Lexer in",
@@ -72,7 +73,14 @@ case ResultOk {value = lrtable} then
         ),
         matchex_ (var_ "parse_result") (pcon_ "ResultErr" (prec_ [("errors", (pvar_ "errors"))])) (
           appf1_ (var_ "printLn") (appf2_ (var_ "strJoin") (str_ "\n")
-                                          (map_ (ulam_ "v" (tupleproj_ 1 (var_ "v")))
+                                          (map_ (ulam_ "v" (
+                                                  appf1_ (var_ "join") (seq_ [
+                                                    str_ "Parse error at ",
+                                                    appf1_ (var_ "info2str") (tupleproj_ 0 (var_ "v")),
+                                                    str_ ": ",
+                                                    tupleproj_ 1 (var_ "v")
+                                                  ])
+                                                ))
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]


### PR DESCRIPTION
Compared to before, this at least provides _some_ info. This is to be improved in the future, but adding this as a stepping stone to good parse errors.