### PR TITLE
Be explicit about what 'info' field definition is used in tool.mc

### DIFF
--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -937,7 +937,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
           end
         in result.map (lam expr. (field, expr)) (result.map f exprs)
       in
-      let res = result.mapM mkField (mapBindings record) in
+      let res = result.mapM mkField (mapBindings (mapRemove "info" record)) in
       let res =
         match infos with Some infos then
           let infos = result.mapM identity infos in


### PR DESCRIPTION
The output of `mi syn` got accidentally broken by #697 when it changed `mapFromSeq` to prefer earlier bindings instead of later (in case of a conflict). My implementation in `tool.mc` depended on that order, and while we decided to change the behavior of `mapFromSeq` back to the earlier iteration it still seems a bit confusing to depend on it, so this PR makes things explicit.