### PR TITLE
Include as an MLang expression

### DIFF
--- a/stdlib/mlang/ast-builder.mc
+++ b/stdlib/mlang/ast-builder.mc
@@ -12,6 +12,8 @@ recursive let mlang_bindF_ = use MLangAst in
   bindF_ (lam letexpr. lam expr.
     match letexpr with TmUse t then
       TmUse {t with inexpr = mlang_bindF_ f t.inexpr expr}
+    else match letexpr with TmInclude t then
+      TmInclude {t with inexpr = mlang_bindF_ f t.inexpr expr}
     else
       f letexpr expr -- Insert at the end of the chain
   ) letexpr expr
@@ -33,6 +35,10 @@ let nuse_ = use UseAst in
 let use_ = use UseAst in
   lam s.
   nuse_ (nameNoSym s)
+
+let include_ = use IncludeAst in
+  lam p.
+  TmInclude {path = p, inexpr = uunit_, ty = tyunknown_, info = NoInfo {}}
 
 
 -- Declarations --

--- a/stdlib/mlang/ast.mc
+++ b/stdlib/mlang/ast.mc
@@ -35,6 +35,32 @@ lang UseAst = Ast
     (acc, TmUse {t with inexpr = inexpr})
 end
 
+--- TmInclude --
+lang IncludeAst = Ast
+  syn Expr =
+  | TmInclude {path : String,
+               inexpr : Expr,
+               ty : Type,
+               info : Info}
+
+  sem infoTm =
+  | TmInclude t -> t.info
+
+  sem tyTm =
+  | TmInclude t -> t.ty
+
+  sem withInfo (info : Info) =
+  | TmInclude t -> TmInclude {t with info = info}
+
+  sem withType (ty : Type) =
+  | TmInclude t -> TmInclude {t with ty = ty}
+
+  sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
+  | TmInclude t ->
+    match f acc t.inexpr with (acc, inexpr) in
+    (acc, TmInclude {t with inexpr = inexpr})
+end
+
 -- Base fragment for MLang declarations --
 lang DeclAst = Ast
   syn Decl = -- intentionally left blank
@@ -142,7 +168,7 @@ lang MLangAst =
   MLangTopLevel
 
   -- Additional expressions
-  + UseAst
+  + UseAst + IncludeAst
 
   -- Declarations
   + LangDeclAst + SynDeclAst + SemDeclAst + LetDeclAst + TypeDeclAst

--- a/stdlib/mlang/pprint.mc
+++ b/stdlib/mlang/pprint.mc
@@ -20,6 +20,18 @@ lang MLangIdentifierPrettyPrint = IdentifierPrettyPrint
     (env, s)
 end
 
+lang IncludePrettyPrint = PrettyPrint + IncludeAst
+  sem isAtomic =
+  | TmInclude _ -> false
+
+  sem pprintCode (indent : Int) (env: PprintEnv) =
+  | TmInclude t ->
+    match pprintCode indent env t.inexpr with (env,inexpr) in
+    (env, join ["include \"", escapeString t.path, "\"", pprintNewline indent,
+                "in", pprintNewline indent,
+                inexpr])
+end
+
 
 lang UsePrettyPrint = PrettyPrint + UseAst + MLangIdentifierPrettyPrint
   sem isAtomic =
@@ -207,7 +219,7 @@ end
 lang MLangPrettyPrint = MExprPrettyPrint +
 
   -- Extended expressions
-  UsePrettyPrint +
+  UsePrettyPrint + IncludePrettyPrint +
 
   -- Declarations
   DeclPrettyPrint + LangDeclPrettyPrint + SynDeclPrettyPrint +
@@ -244,6 +256,7 @@ let prog: MLangProgram = {
         (pcon_ "Pear" (pvar_ "fs"),
          bindall_ [
            ulet_ "strJoin" (unit_),
+           include_ "string.mc",
            appf2_ (var_ "strJoin")
                   (var_ "x")
                   (appf2_ (var_ "map") (var_ "float2string") (var_ "fs"))


### PR DESCRIPTION
This is the bit of code that was lifted out from PR #694 (MLang AST in MCore). The idea of having an include statement ties in with how include handling will be done in the bootstrapping stage.

Instead of include being a copy-paste of code (a la C style), the included file would be parsed and symbolized separately, and the symbolized identifiers would be added to the scope of where the include is being done. This would slightly impact the include semantics, such that this following program with 2 includes that is currently valid would now be invalid:
```
-- testA.mc
let strA = "I am string A..."
mexpr ()
```

```
-- testB.mc
let strB = concat strA " and I am string B"
mexpr ()
```

```
-- test.mc
include "testA.mc"
include "testB.mc"
mexpr
print strB; print "\n"
```

This currently works with the boot parser since it simply concatenates the includes, whereas in the bootstrapped parser the includes would be parsed independently, and give the error for testB.mc that `strA` is an unknown variable.

The reason for having an include as an expression would be to control in generated code that the unsymbolized identifiers will refer to the intended functions/types/constructors in some library. E.g. if I want to access the `result` identifier from result.mc, I could simply do `include "result.mc" in` at the start of the generated code and not have to worry about where my generated expression is being placed.

Current use case for this kind of feature would be in the code generated for the LR(k) parser (see `lrGenerateParser` in parser/lrk.mc), where there are unsymbolized to `ResultErr`, `ResultOk`, `int2string`, `mergeInfo`, `join`, etc. all over the place. There is currently nothing guaranteeing that these will be symbolized to the intended definitions, instead the generated expressions just assumes that nothing else will bind to these identifiers.