### PR TITLE
Expressing and solving constraint optimization models

### DIFF
--- a/stdlib/cp/ast.mc
+++ b/stdlib/cp/ast.mc
@@ -62,10 +62,22 @@ lang COPConstraintTableAst = COPConstraintDeclAst
   | COPConstraintTable { vars: COPExpr, tuples: COPExpr }
 end
 
+-- Reified table constraint: table('vars', 'tuples') <=> 'b'
+lang COPConstraintTableReifAst = COPConstraintDeclAst
+  syn COPConstraint =
+  | COPConstraintTableReif { vars: COPExpr, tuples: COPExpr, b: COPExpr }
+end
+
 -- Constrain 'lhs' to be smaller or equal to 'rhs'
 lang COPConstraintLEAst = COPConstraintDeclAst
   syn COPConstraint =
   | COPConstraintLE { lhs: COPExpr, rhs: COPExpr }
+end
+
+-- Constrain 'lhs' to be smaller than 'rhs'
+lang COPConstraintLTAst = COPConstraintDeclAst
+  syn COPConstraint =
+  | COPConstraintLT { lhs: COPExpr, rhs: COPExpr }
 end
 
 ----------------
@@ -127,7 +139,8 @@ lang COP =
   -- Variables --
   COPVarDeclAst + COPVarArrayDeclAst +
   -- Constraints --
-  COPConstraintDeclAst + COPConstraintTableAst + COPConstraintLEAst +
+  COPConstraintDeclAst + COPConstraintTableAst + COPConstraintTableReifAst +
+  COPConstraintLEAst + COPConstraintLTAst +
   -- Objectives --
   COPObjectiveDeclAst + COPObjectiveMinimizeAst +
   -- Expressions --

--- a/stdlib/cp/ast.mc
+++ b/stdlib/cp/ast.mc
@@ -1,8 +1,6 @@
 -- AST representation of a constraint optimization or satisfaction problem
 -- (COP/CSP).
 
--- NOTE(Linnea, 2023-02-08): Arrays are indexed from 1.
-
 include "name.mc"
 
 ----------------------------

--- a/stdlib/cp/ast.mc
+++ b/stdlib/cp/ast.mc
@@ -1,0 +1,138 @@
+-- AST representation of a constraint optimization or satisfaction problem
+-- (COP/CSP).
+
+-- NOTE(Linnea, 2023-02-08): Arrays are indexed from 1.
+
+include "name.mc"
+
+----------------------------
+-- BASE LANGUAGE FRAGMENT --
+----------------------------
+
+lang COPAst
+  type COPModel = [COPDecl]
+
+  syn COPDecl =
+  syn COPDomain =
+  syn COPExpr =
+end
+
+-------------
+-- DOMAINS --
+-------------
+
+lang COPDomainIntRangeAst = COPAst
+  syn COPDomain =
+  | COPDomainIntRange { min: COPExpr, max: COPExpr }
+end
+
+lang COPDomainBooleanAst = COPAst
+  syn COPDomain =
+  | COPDomainBoolean {}
+end
+
+---------------
+-- VARIABLES --
+---------------
+
+lang COPVarDeclAst = COPAst
+  syn COPDecl =
+  | COPVarDecl { id: Name,
+                 domain: COPDomain }
+end
+
+lang COPVarArrayDeclAst = COPAst
+  syn COPDecl =
+  | COPVarArrayDecl { id: Name,
+                      domain: COPDomain,
+                      length: COPExpr }
+end
+
+-----------------
+-- CONSTRAINTS --
+-----------------
+
+lang COPConstraintDeclAst = COPAst
+  syn COPConstraint =
+  syn COPDecl =
+  | COPConstraintDecl { constraint: COPConstraint }
+end
+
+-- Table constraint
+lang COPConstraintTableAst = COPConstraintDeclAst
+  syn COPConstraint =
+  | COPConstraintTable { vars: COPExpr, tuples: COPExpr }
+end
+
+-- Constrain 'lhs' to be smaller or equal to 'rhs'
+lang COPConstraintLEAst = COPConstraintDeclAst
+  syn COPConstraint =
+  | COPConstraintLE { lhs: COPExpr, rhs: COPExpr }
+end
+
+----------------
+-- OBJECTIVES --
+----------------
+
+lang COPObjectiveDeclAst = COPAst
+  syn COPObjective =
+  syn COPDecl =
+  | COPObjectiveDecl { objective: COPObjective }
+end
+
+lang COPObjectiveMinimizeAst = COPObjectiveDeclAst
+  syn COPObjective =
+  | COPObjectiveMinimize { expr: COPExpr }
+end
+
+-----------------
+-- EXPRESSIONS --
+-----------------
+
+lang COPExprSumAst = COPAst
+  syn COPExpr =
+  | COPExprSum { expr: COPExpr }
+end
+
+lang COPExprVarAst = COPAst
+  syn COPExpr =
+  | COPExprVar { id: Name }
+end
+
+lang COPExprVarAccessAst = COPAst
+  syn COPExpr =
+  | COPExprVarAccess { id: Name, index: COPExpr }
+end
+
+lang COPExprIntAst = COPAst
+  syn COPExpr =
+  | COPExprInt { value: Int }
+end
+
+lang COPExprArrayAst = COPAst
+  syn COPExpr =
+  | COPExprArray { array: [COPExpr] }
+end
+
+lang COPExprArray2dAst = COPAst
+  syn COPExpr =
+  | COPExprArray2d { array: [[COPExpr]] }
+end
+
+----------------------
+-- COP AST FRAGMENT --
+----------------------
+
+lang COP =
+  -- Domains --
+  COPDomainIntRangeAst + COPDomainBooleanAst +
+  -- Variables --
+  COPVarDeclAst + COPVarArrayDeclAst +
+  -- Constraints --
+  COPConstraintDeclAst + COPConstraintTableAst + COPConstraintLEAst +
+  -- Objectives --
+  COPObjectiveDeclAst + COPObjectiveMinimizeAst +
+  -- Expressions --
+  COPExprSumAst + COPExprVarAst + COPExprVarAccessAst + COPExprIntAst +
+  COPExprArrayAst + COPExprArray2dAst
+end

--- a/stdlib/cp/pprint.mc
+++ b/stdlib/cp/pprint.mc
@@ -1,0 +1,262 @@
+-- Pretty printing of a COP/CSP as a MiniZinc model.
+
+include "ast.mc"
+include "common.mc"
+include "mexpr/pprint.mc"
+
+lang COPPrettyPrintBase = COPAst + IdentifierPrettyPrint
+  sem pprintCOPModel: COPModel -> (PprintEnv, String)
+  sem pprintCOPModel =
+  | decls ->
+    match mapAccumL (lam env. lam d. pprintCOPDecl env d) pprintEnvEmpty decls
+    with (env, decls) in
+    (env, strJoin "\n" decls)
+
+  sem pprintCOPDecl: PprintEnv -> COPDecl -> (PprintEnv, String)
+  sem pprintCOPDomain: PprintEnv -> COPDomain -> (PprintEnv, String)
+  sem pprintCOPExpr: PprintEnv -> COPExpr -> (PprintEnv, String)
+
+  -- NOTE(Linnea, 2023-02-08): Assumes that the base string of the name is a
+  -- valid MiniZinc identifier (not a MiniZinc keyword, etc.).
+  sem pprintVarName : PprintEnv -> Name -> (PprintEnv, String)
+  sem pprintVarName env =
+  | name ->
+    pprintEnvGetStr env name
+end
+
+-------------
+-- DOMAINS --
+-------------
+
+lang COPDomainIntRangePrettyPrint = COPPrettyPrintBase + COPDomainIntRangeAst
+  sem pprintCOPDomain env =
+  | COPDomainIntRange {min = min, max = max} ->
+    match pprintCOPExpr env min with (env, min) in
+    match pprintCOPExpr env max with (env, max) in
+    (env, join [min, "..", max])
+end
+
+lang COPDomainBooleanPrettyPrint = COPPrettyPrintBase + COPDomainBooleanAst
+  sem pprintCOPDomain env =
+  | COPDomainBoolean {} -> (env, "bool")
+end
+
+---------------
+-- VARIABLES --
+---------------
+
+lang COPVarDeclPrettyPrint = COPPrettyPrintBase + COPVarDeclAst
+  sem pprintCOPDecl env =
+  | COPVarDecl {id = id, domain = domain } ->
+    match pprintVarName env id with (env, id) in
+    match pprintCOPDomain env domain with (env, domain) in
+    (env, join ["var ", domain, ": ", id, ";"])
+end
+
+lang COPVarArrayDeclPrettyPrint = COPPrettyPrintBase + COPVarArrayDeclAst
+  sem pprintCOPDecl env =
+  | COPVarArrayDecl {id = id, domain = domain, length = length} ->
+    match pprintVarName env id with (env, id) in
+    match pprintCOPExpr env length with (env, length) in
+    match pprintCOPDomain env domain with (env, domain) in
+    (env, join ["array [1..", length, "] of var ", domain, ": ", id, ";"])
+end
+
+-----------------
+-- CONSTRAINTS --
+-----------------
+
+lang COPConstraintDeclPrettyPrint = COPPrettyPrintBase + COPConstraintDeclAst
+  sem pprintCOPConstraint: PprintEnv -> COPConstraint ->
+                           (PprintEnv, Option String, String)
+  sem pprintCOPDecl env =
+  | COPConstraintDecl { constraint = constraint } ->
+    match pprintCOPConstraint env constraint with (env, incl, str) in
+    ( env, join [optionMapOr "" (lam i. join ["include \"", i, "\";\n"]) incl,
+                 "constraint ", str, ";"])
+end
+
+lang COPConstraintTablePrettyPrint = COPConstraintDeclPrettyPrint + COPConstraintTableAst
+  sem pprintCOPConstraint env =
+  | COPConstraintTable { vars = vars, tuples = tuples } ->
+    match pprintCOPExpr env vars with (env, vars) in
+    match pprintCOPExpr env tuples with (env, tuples) in
+    ( env, Some "table.mzn", join ["table(", vars, ",", tuples, ")"] )
+end
+
+lang COPConstraintLEPrettyPrint = COPConstraintDeclPrettyPrint + COPConstraintLEAst
+  sem pprintCOPConstraint env =
+  | COPConstraintLE { lhs = lhs, rhs = rhs } ->
+    match pprintCOPExpr env lhs with (env, lhs) in
+    match pprintCOPExpr env rhs with (env, rhs) in
+    ( env, None (), join [lhs, " <= ", rhs] )
+end
+
+----------------
+-- OBJECTIVES --
+----------------
+
+lang COPObjectiveDeclPrettyPrint = COPPrettyPrintBase + COPObjectiveDeclAst
+  sem pprintCOPObjective: PprintEnv -> COPObjective -> (PprintEnv, String)
+  sem pprintCOPDecl env =
+  | COPObjectiveDecl { objective = objective } ->
+    match pprintCOPObjective env objective with (env, obj) in
+    (env, join ["solve ", obj, ";"])
+end
+
+lang COPObjectiveMinimizePrettyPrint = COPPrettyPrintBase + COPObjectiveMinimizeAst
+  sem pprintCOPObjective env =
+  | COPObjectiveMinimize { expr = expr } ->
+    match pprintCOPExpr env expr with (env, expr) in
+    (env, concat "minimize " expr)
+end
+
+-----------------
+-- EXPRESSIONS --
+-----------------
+
+lang COPExprSumPrettyPrint = COPPrettyPrintBase + COPExprSumAst
+  sem pprintCOPExpr env =
+  | COPExprSum { expr = expr } ->
+    match pprintCOPExpr env expr with (env, expr) in
+    (env, join ["sum(", expr, ")"])
+end
+
+lang COPExprVarPrettyPrint = COPPrettyPrintBase + COPExprVarAst
+  sem pprintCOPExpr env =
+  | COPExprVar { id = id } -> pprintVarName env id
+end
+
+lang COPExprVarAccessPrettyPrint = COPPrettyPrintBase + COPExprVarAccessAst
+  sem pprintCOPExpr env =
+  | COPExprVarAccess { id = id, index = index } ->
+    match pprintVarName env id with (env, id) in
+    match pprintCOPExpr env index with (env, index) in
+    (env, join [id, "[", index, "]"])
+end
+
+lang COPExprIntPrettyPrint = COPPrettyPrintBase + COPExprIntAst
+  sem pprintCOPExpr env =
+  | COPExprInt { value = value } -> (env, int2string value)
+end
+
+lang COPExprArrayPrettyPrint = COPPrettyPrintBase + COPExprArrayAst
+  sem pprintCOPExpr env =
+  | COPExprArray { array = array } ->
+    match mapAccumL (lam env. lam e. pprintCOPExpr env e) env array
+    with (env, array) in
+    (env, join ["[", strJoin "," array, "]"])
+end
+
+lang COPExprArray2dPrettyPrint = COPPrettyPrintBase + COPExprArray2dAst
+  sem pprintCOPExpr env =
+  | COPExprArray2d { array = array } ->
+    match mapAccumL (lam env. lam inner.
+        match mapAccumL (lam env. lam e. pprintCOPExpr env e) env inner
+        with (env, inner) in
+        (env, strJoin "," inner)
+      ) env array
+    with (env, array) in
+    (env, join ["[|", strJoin "|" array, "|]"])
+end
+
+
+-------------------------------
+-- COP PRETTY PRINT FRAGMENT --
+-------------------------------
+
+lang COPPrettyPrint =
+  -- Domains --
+  COPDomainIntRangePrettyPrint + COPDomainBooleanPrettyPrint +
+  -- Variables --
+  COPVarDeclPrettyPrint + COPVarArrayDeclPrettyPrint +
+  -- Constraints --
+  COPConstraintDeclPrettyPrint + COPConstraintTablePrettyPrint +
+  COPConstraintLEPrettyPrint +
+  -- Objectives --
+  COPObjectiveDeclPrettyPrint + COPObjectiveMinimizePrettyPrint +
+  -- Expressions --
+  COPExprSumPrettyPrint + COPExprVarPrettyPrint + COPExprVarAccessPrettyPrint +
+  COPExprIntPrettyPrint + COPExprArrayPrettyPrint + COPExprArray2dPrettyPrint
+end
+
+mexpr
+
+use COPPrettyPrint in
+
+-- Enable debug printing
+let debug = false in
+
+let cpInt_ = lam i. COPExprInt {value = i} in
+
+let eqTest = lam lhs: COPModel. lam rhs: String.
+  match pprintCOPModel lhs with (_, lhs) in
+  let lhs = strTrim lhs in
+  let rhs = strTrim rhs in
+  (if debug then
+     printLn "\n*** LHS ***";
+     printLn lhs;
+     printLn "\n*** RHS ***";
+     printLn rhs
+   else ());
+  eqString lhs rhs
+in
+
+
+utest
+  let x = nameSym "x" in
+  let y = nameSym "y" in
+  [COPVarArrayDecl {
+      id = x,
+      domain = COPDomainIntRange {min = cpInt_ 1, max = cpInt_ 10},
+      length = cpInt_ 5
+   },
+   COPVarDecl {id = y, domain = COPDomainBoolean {}},
+   COPConstraintDecl {constraint = COPConstraintLE {
+     lhs = COPExprVarAccess {id = x, index = cpInt_ 1},
+     rhs = COPExprVarAccess {id = x, index = cpInt_ 2}}},
+   COPObjectiveDecl {
+     objective = COPObjectiveMinimize {
+       expr = COPExprSum {expr = COPExprArray {
+         array = [COPExprVarAccess {id = x, index = cpInt_ 1},
+                  COPExprVarAccess {id = x, index = cpInt_ 2},
+                  COPExprVar {id = y}]}}}
+   }
+  ]
+with
+"
+array [1..5] of var 1..10: x;
+var bool: y;
+constraint x[1] <= x[2];
+solve minimize sum([x[1],x[2],y]);
+"
+using eqTest in
+
+utest
+  let x = nameSym "x" in
+  let zero = cpInt_ 0 in
+  let one = cpInt_ 1 in
+  [COPVarArrayDecl {
+     id = x,
+     domain = COPDomainIntRange {min = cpInt_ 0, max = cpInt_ 1},
+     length = cpInt_ 3},
+   COPConstraintDecl {constraint = COPConstraintTable {
+     vars = COPExprVar {id = x},
+     tuples = COPExprArray2d {array = [[zero,zero,one],[one,zero,one],[zero,zero,zero]]}
+   }},
+   COPObjectiveDecl {
+     objective = COPObjectiveMinimize {
+       expr = COPExprSum {expr = COPExprVar {id = x}}
+     }
+   }
+]
+with
+"
+array [1..3] of var 0..1: x;
+include \"table.mzn\";
+constraint table(x,[|0,0,1|1,0,1|0,0,0|]);
+solve minimize sum(x);
+"
+using eqTest in
+
+()

--- a/stdlib/cp/solve.mc
+++ b/stdlib/cp/solve.mc
@@ -178,8 +178,10 @@ let eqCOPSolverResult = lam s1. lam s2.
 in
 
 let eqTest = lam lhs: COPModel. lam rhs: COPSolverResult.
-  let lhs = solve lhs in
-  eqCOPSolverResult lhs rhs
+  if sysCommandExists "minizinc" then
+    let lhs = solve lhs in
+    eqCOPSolverResult lhs rhs
+  else true
 in
 
 let x = nameSym "x" in

--- a/stdlib/cp/solve.mc
+++ b/stdlib/cp/solve.mc
@@ -1,0 +1,217 @@
+-- Solves a COP using MiniZinc as backend and returns the solution.
+
+include "ast.mc"
+include "pprint.mc"
+include "sys.mc"
+include "json.mc"
+
+lang COPSolve = COP + COPPrettyPrint
+  syn COPVarValue =
+  | COPInt {val: Int}
+  | COPBool {val: Bool}
+  | COPArray {vals: [COPVarValue]}
+
+  syn COPSolverResult =
+  | COPSolution {
+      solution: Map Name COPVarValue,
+      objective: Option COPVarValue
+    }
+  | COPError {msg: String}
+
+  sem solve: COPModel -> COPSolverResult
+  sem solve =
+  | model ->
+    match pprintCOPModel model with (env, model) in
+    -- Output the model to a temporary file
+    let tempDir = sysTempDirMake () in
+    let modelFile = sysJoinPath tempDir "model.mzn" in
+    let outputFile = sysJoinPath tempDir "result.json" in
+    writeFile modelFile model;
+    -- Solve the model
+    match sysRunCommandWithTiming [
+      "minizinc",
+        "--output-mode", "json",
+        "-o", outputFile,
+        "--output-objective",
+        "--solver", "gecode",
+        modelFile
+      ] "" ""
+    with (elapsed, {stdout = stdout, stderr = stderr, returncode = returncode}) in
+    let errorStr = lam.
+      strJoin "\n"
+        [ "> Output file",
+          if fileExists outputFile then readFile outputFile else "-- No output file --",
+          "\n> Model", readFile modelFile,
+          "\n> Stdout", stdout,
+          "\n> Stderr", stderr,
+          "\n> Returncode", int2string returncode ]
+    in
+    -- Read the result back
+    let res =
+      match _parseResult outputFile with Some resMap then
+        -- Build a map with relevant variables
+        let m: Option (Map Name COPVarValue) =
+          mapFoldWithKey (lam acc. lam n. lam s.
+            match acc with Some m then
+              match mapLookup s resMap with Some v then
+                Some (mapInsert n v m)
+              else None ()
+            else None ()
+          ) (Some (mapEmpty nameCmp)) env.nameMap in
+        match m with Some m then
+          COPSolution {
+            solution = m,
+            -- Objective value stored as key "_objective"
+            objective = mapLookup "_objective" resMap
+          }
+        else COPError { msg = strJoin "\n"
+          ["Some variables were not found", errorStr ()]}
+      else
+        COPError { msg = strJoin "\n" ["Could not parse solution:", errorStr ()]}
+    in
+    -- Remove temporary directory and return
+    sysTempDirDelete tempDir ();
+    res
+
+  sem _json2COPVarValue: JsonValue -> Option COPVarValue
+  sem _json2COPVarValue =
+  | v ->
+    switch v
+    case JsonInt i then Some (COPInt {val = i})
+    case JsonBool b then Some (COPBool {val = b})
+    case JsonArray a then
+      let vals =
+        foldl (lam acc. lam x.
+          match acc with Some vals then
+            match _json2COPVarValue x with Some val then Some (snoc vals val)
+            else None ()
+          else None ()
+        ) (Some []) a
+      in
+      match vals with Some vals then
+        Some (COPArray {vals = vals})
+      else None ()
+    end
+
+  sem _parseResult: String -> Option (Map String COPVarValue)
+  sem _parseResult =
+  | jsonFile ->
+    -- Cut out the last outputed solution
+    let lastSolution: String -> Option String = lam str.
+      let split = strSplit "----------" str in
+      switch length split
+      case 1 then None ()
+      case n then
+        Some (strTrim (get split (subi n 2)))
+      end
+    in
+    utest lastSolution "
+    one
+    ----------
+    " with Some "one" in
+    utest lastSolution "
+    one
+    ----------
+    two
+    ----------
+    " with Some "two" in
+    utest lastSolution "
+    optimal
+    ----------
+    ==========
+    " with Some "optimal" in
+    utest lastSolution "" with None () in
+
+    -- Parse a solution in json format
+    let parseSolution: String -> Option (Map String COPVarValue) = lam str.
+      switch jsonParse str
+      case Left (JsonObject m) then
+        mapFoldWithKey (lam acc. lam k. lam v.
+            match acc with Some m then
+              match _json2COPVarValue v with Some v2 then
+                Some (mapInsert k v2 m)
+              else None ()
+            else None ()
+          ) (Some (mapEmpty cmpString)) m
+      case _ then
+        -- Incorrectly formatted solution
+        None ()
+      end
+    in
+
+    if fileExists jsonFile then
+      match lastSolution (readFile jsonFile) with Some sol then
+        parseSolution sol
+      else None ()
+    else None ()
+
+end
+
+mexpr
+
+use COPSolve in
+
+let cpInt_ = lam i. COPExprInt {value = i} in
+
+utest _json2COPVarValue (JsonInt 2) with Some (COPInt {val = 2}) in
+utest _json2COPVarValue (JsonArray [JsonBool true])
+with Some (COPArray {vals = [COPBool {val = true}]}) in
+
+recursive let eqCOPVarValue = lam v1. lam v2.
+  switch (v1, v2)
+  case (COPInt v1, COPInt v2) then eqi v1.val v2.val
+  case (COPBool v1, COPBool v2) then eqBool v1.val v2.val
+  case (COPArray v1, COPArray v2) then
+    forAll (lam x. x) (zipWith eqCOPVarValue v1.vals v2.vals)
+  end
+in
+
+let eqCOPSolverResult = lam s1. lam s2.
+  switch (s1, s2)
+  case (COPSolution s1, COPSolution s2) then
+    if mapEq eqCOPVarValue s1.solution s2.solution then
+      optionEq eqCOPVarValue s1.objective s2.objective
+    else false
+  case (COPError _, COPError _) then true
+  case _ then false
+  end
+in
+
+let eqTest = lam lhs: COPModel. lam rhs: COPSolverResult.
+  let lhs = solve lhs in
+  eqCOPSolverResult lhs rhs
+in
+
+let x = nameSym "x" in
+
+utest
+  let zero = cpInt_ 0 in
+  let one = cpInt_ 1 in
+  [COPVarArrayDecl {
+     id = x,
+     domain = COPDomainIntRange {min = cpInt_ 0, max = cpInt_ 1},
+     length = cpInt_ 3},
+   COPConstraintDecl {constraint = COPConstraintTable {
+     vars = COPExprVar {id = x},
+     tuples = COPExprArray2d {array = [[zero,zero,one],[one,zero,one],[zero,zero,zero]]}}},
+   COPObjectiveDecl {
+     objective = COPObjectiveMinimize {
+       expr = COPExprSum {expr = COPExprVar {id = x}}
+     }
+   }
+  ]
+with
+  COPSolution {
+    solution = mapFromSeq nameCmp [
+      (x, COPArray {vals=[COPInt{val=0},COPInt{val=0},COPInt{val=0}]})],
+    objective = Some (COPInt {val = 0})}
+using eqTest in
+
+utest
+  [COPObjectiveDecl {
+    objective = COPObjectiveMinimize {expr = COPExprVar {id = x}}}]
+with COPError {msg = ""}
+using eqTest in
+
+()
+

--- a/stdlib/cp/solve.mc
+++ b/stdlib/cp/solve.mc
@@ -11,6 +11,8 @@ lang COPSolve = COP + COPPrettyPrint
   | COPBool {val: Bool}
   | COPArray {vals: [COPVarValue]}
 
+  -- TODO(Linnea, 2023-03-16): Include other possible results (unsatisfiable,
+  -- unknown, unbounded, optimal, all solutions).
   syn COPSolverResult =
   | COPSolution {
       solution: Map Name COPVarValue,
@@ -216,4 +218,3 @@ with COPError {msg = ""}
 using eqTest in
 
 ()
-


### PR DESCRIPTION
This PR adds functionality for expressing and solving constraint optimization models. It defines:
* An AST that represents a constraint optimization or satisfaction problem (COP or CSP). It's rather limited as a first step.
* A pretty printer that outputs the model in MiniZinc.
* A basic solve functionality that solves the model by calling `minizinc` via the command line.

I'm not sure how to handle dependencies on MiniZinc, so right now some tests are not run if MiniZinc is not installed (so that `make test-all` will not fail).