### PR TITLE
Visualizing the generated AST

### DIFF
--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -385,7 +385,7 @@ open AstHelpers
 
 let translate_cases fi f target cases =
   let translate_case (pat, handler) inner =
-    TmMatch (pat_info pat, target, pat, handler, inner)
+    TmMatch (mkinfo (pat_info pat) (tm_info handler), target, pat, handler, inner)
   in
   let msg =
     Mseq.map
@@ -875,7 +875,7 @@ let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function
       (* translate "Inter"s into (info * ustring * tm) *)
       let inter_to_tm fname fi params cases =
         let target = us "__sem_target" in
-        let wrap_param (Param (fi, name, ty)) tm =
+        let wrap_param (Param (_, name, ty)) tm =
           TmLam (fi, name, Symb.Helpers.nosym, desugar_ty ns ty, tm)
         in
         TmLam

--- a/src/boot/lib/msg.ml
+++ b/src/boot/lib/msg.ml
@@ -86,3 +86,11 @@ let message2str (id, sev, info, _) =
 let raise_error fi msg = raise (Error (ERROR msg, ERROR, fi, []))
 
 let error fi msg = raise_error fi (msg |> Ustring.to_utf8)
+
+(** Create a new info, taking left and right part *)
+let mkinfo fi1 fi2 =
+  match (fi1,fi2) with
+    | (Info(fn,r1,c1,_,_), Info(_,_,_,r2,c2)) -> Info(fn,r1,c1,r2,c2)
+    | (Info(fn,r1,c1,r2,c2), NoInfo) -> Info(fn,r1,c1,r2,c2)
+    | (NoInfo, Info(fn,r1,c1,r2,c2)) -> Info(fn,r1,c1,r2,c2)
+    | (_,_) -> NoInfo

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -15,6 +15,7 @@ include "mexpr/shallow-patterns.mc"
 include "mexpr/symbolize.mc"
 include "mexpr/type-check.mc"
 include "mexpr/utest-generate.mc"
+include "mexpr/visualize-ast.mc"
 include "ocaml/ast.mc"
 include "ocaml/external-includes.mc"
 include "ocaml/mcore.mc"
@@ -36,6 +37,9 @@ lang MCoreCompile =
 end
 
 lang TyAnnotFull = MExprPrettyPrint + TyAnnot + HtmlAnnotator
+end
+
+lang AstAnnotFull = MExprPrettyPrint + AstAnnot + HtmlAnnotator
 end
 
 let insertTunedOrDefaults = lam options : Options. lam ast. lam file.
@@ -84,7 +88,7 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
     let ast = lowerAll ast in
     endPhaseStats log "pattern-lowering" ast;
     (if options.debugShallow then
-      printLn (expr2str ast) else ());
+      printLn (use AstAnnotFull in annotateMExpr ast) else ());
 
     let res =
       if options.toJVM then compileMCoreToJVM ast else

--- a/stdlib/mexpr/visualize-ast.mc
+++ b/stdlib/mexpr/visualize-ast.mc
@@ -1,0 +1,156 @@
+include "annotate.mc"
+
+-- NOTE(vipa, 2022-10-07): This can't use AnnotateMExprBase because it
+-- has to thread a pprint environment, which AnnotateMExprBase doesn't
+-- allow.
+lang AstAnnot = AnnotateSources + PrettyPrint + Ast + LetAst + RecLetsAst + TypeAst + DataAst + ExtAst
+  sem annotateMExpr : Expr -> Output
+  sem annotateMExpr = | tm ->
+    let env =
+      { pprintEnv = pprintEnvEmpty
+      , nextExpr = 0
+      , nextPat = 0
+      , nextType = 0
+      , annots = []
+      } in
+    annotateAndReadSources (_annotateTopExpr env tm).0 .annots
+
+  type VisAnnotEnv =
+    { pprintEnv : PprintEnv
+    , nextExpr : Int
+    , nextType : Int
+    , nextPat : Int
+    , annots : [(Info, Annotation)]
+    }
+
+  syn AstNodeSource =
+  | AstFromWithin Info
+  | AstFromElsewhere ()
+  sem _checkSource : Info -> Info -> (AstNodeSource, Info)
+  sem _checkSource infoAbove = | info ->
+    let source =
+      switch (infoAbove, info)
+      case (_, NoInfo _) then AstFromElsewhere ()
+      case (NoInfo _, _) then AstFromWithin info
+      case (Info above, Info here) then
+        if eqString above.filename here.filename then
+          let startEq = eqi above.row1 here.row1 in
+          let startsAfter = if startEq
+            then leqi above.col1 here.col1
+            else lti above.row1 here.row1 in
+          let endEq = eqi here.row2 above.row2 in
+          let endsBefore = if endEq
+            then leqi here.col2 above.col2
+            else lti here.row2 above.row2 in
+          if and startEq endEq then AstFromElsewhere ()
+          else if and startsAfter endsBefore then AstFromWithin info
+          else AstFromElsewhere ()
+        else AstFromElsewhere ()
+      end in
+    (source, match source with AstFromWithin _ then info else infoAbove)
+
+  sem _addExprAnnot : VisAnnotEnv -> Expr -> (VisAnnotEnv, Expr)
+  sem _addExprAnnot env = | tm ->
+    let info = infoTm tm in
+    let id = join ["expr", int2string env.nextExpr] in
+    match pprintCode 2 env.pprintEnv tm with (pprintEnv, tm) in
+    let annot = join [id, " => ", tm] in
+    let env =
+      { env
+      with nextExpr = addi 1 env.nextExpr
+      , annots = cons (info, annot) env.annots
+      , pprintEnv = pprintEnv
+      } in
+    (env, var_ id)
+
+  sem _annotateTopExpr : VisAnnotEnv -> Expr -> (VisAnnotEnv, Expr)
+  sem _annotateTopExpr env =
+  | TmLet x ->
+    match _annotateExpr x.info env x.body with (env, body) in
+    match _annotateType x.info env x.tyAnnot with (env, tyAnnot) in
+    match _annotateTopExpr env x.inexpr with (env, inexpr) in
+    let tm = TmLet {x with body = body, tyAnnot = tyAnnot, inexpr = inexpr} in
+    _addExprAnnot env tm
+  | TmRecLets x ->
+    let f = lam env. lam binding.
+      match _annotateExpr x.info env binding.body with (env, body) in
+      match _annotateType x.info env binding.tyAnnot with (env, tyAnnot) in
+      (env, {binding with body = body, tyAnnot = tyAnnot}) in
+    match mapAccumL f env x.bindings with (env, bindings) in
+    match _annotateTopExpr env x.inexpr with (env, inexpr) in
+    let tm = TmRecLets {x with bindings = bindings, inexpr = inexpr} in
+    _addExprAnnot env tm
+  | TmType x ->
+    match _annotateType x.info env x.tyIdent with (env, tyIdent) in
+    match _annotateTopExpr env x.inexpr with (env, inexpr) in
+    let tm = TmType {x with tyIdent = tyIdent, inexpr = inexpr} in
+    _addExprAnnot env tm
+  | TmConDef x ->
+    match _annotateType x.info env x.tyIdent with (env, tyIdent) in
+    match _annotateTopExpr env x.inexpr with (env, inexpr) in
+    let tm = TmConDef {x with tyIdent = tyIdent, inexpr = inexpr} in
+    _addExprAnnot env tm
+  | TmExt x ->
+    match _annotateType x.info env x.tyIdent with (env, tyIdent) in
+    match _annotateTopExpr env x.inexpr with (env, inexpr) in
+    let tm = TmExt {x with tyIdent = tyIdent, inexpr = inexpr} in
+    _addExprAnnot env tm
+  | tm -> _annotateExpr (NoInfo ()) env tm
+
+  sem _annotateExpr : Info -> VisAnnotEnv -> Expr -> (VisAnnotEnv, Expr)
+  sem _annotateExpr infoAbove env = | tm ->
+    match _checkSource infoAbove (infoTm tm) with (source, infoBelow) in
+
+    match smapAccumL_Expr_Expr (_annotateExpr infoBelow) env tm with (env, tm) in
+    match smapAccumL_Expr_Pat (_annotatePat infoBelow) env tm with (env, tm) in
+    match smapAccumL_Expr_Type (_annotateType infoBelow) env tm with (env, tm) in
+
+    switch source
+    case AstFromElsewhere _ then (env, tm)
+    case AstFromWithin _ then _addExprAnnot env tm
+    end
+
+  sem _annotatePat : Info -> VisAnnotEnv -> Pat -> (VisAnnotEnv, Pat)
+  sem _annotatePat infoAbove env = | pat ->
+    match _checkSource infoAbove (infoPat pat) with (source, infoBelow) in
+
+    match smapAccumL_Pat_Expr (_annotateExpr infoBelow) env pat with (env, pat) in
+    match smapAccumL_Pat_Pat (_annotatePat infoBelow) env pat with (env, pat) in
+    match smapAccumL_Pat_Type (_annotateType infoBelow) env pat with (env, pat) in
+
+    switch source
+    case AstFromElsewhere _ then (env, pat)
+    case AstFromWithin info then
+      let id = join ["pat", int2string env.nextPat] in
+      match getPatStringCode 2 env.pprintEnv pat with (pprintEnv, pat) in
+      let annot = join [id, " => ", pat] in
+      let env =
+        { env
+        with nextPat = addi 1 env.nextPat
+        , annots = cons (info, annot) env.annots
+        , pprintEnv = pprintEnv
+        } in
+      (env, pvar_ id)
+    end
+
+  sem _annotateType : Info -> VisAnnotEnv -> Type -> (VisAnnotEnv, Type)
+  sem _annotateType infoAbove env = | ty ->
+    match _checkSource infoAbove (infoTy ty) with (source, infoBelow) in
+
+    match smapAccumL_Type_Type (_annotateType infoBelow) env ty with (env, ty) in
+
+    switch source
+    case AstFromElsewhere _ then (env, ty)
+    case AstFromWithin info then
+      let id = join ["type", int2string env.nextType] in
+      match getTypeStringCode 2 env.pprintEnv ty with (pprintEnv, ty) in
+      let annot = join [id, " => ", ty] in
+      let env =
+        { env
+        with nextType = addi 1 env.nextType
+        , annots = cons (info, annot) env.annots
+        , pprintEnv = pprintEnv
+        } in
+      (env, tyvar_ id)
+    end
+end


### PR DESCRIPTION
This PR primarily adds a visualization based on my earlier `annotate.mc` to produce an html page that annotates the source code with the actual AST with that info field.

The approach is based on the following ideas:
- Each AST node will either have a corresponding annotation, or be included in the annotation of its parent.
- Those that have an annotation get a unique identifier in the beginning of their annotation, and their parent prints that identifier instead of the full AST for the child.
- An AST node gets its own annotation if:
  - It has an info field and it's fully contained within its parent and has a smaller range.
  - Or, it's a top-level definition, i.e., it's along the "spine" of the program.

This means that it should be possible to quickly find the AST for each part of the program, either directly in the annotation or as a different annotation within the already highlighted range.

At present there are some questions on where and how this should be incorporated; I needed it at a particular point in the program, but this could/should maybe be a replacement for all the parts where we previously just `pprint` the AST when a `--debug` flag is passed.

---

To support this I had to update how info fields are assigned in boot, since a large (but somewhat inconsistent) number of productions pick their info field from a subset of the right-hand side, as opposed to the entirety of the thing parsed.