### PR TITLE
Add peval keyword

### DIFF
--- a/src/main/eval.mc
+++ b/src/main/eval.mc
@@ -18,13 +18,13 @@ include "mexpr/type-check.mc"
 include "mexpr/remove-ascription.mc"
 include "mexpr/type-lift.mc"
 include "mexpr/utest-generate.mc"
-
+include "peval/ast.mc"
 
 
 lang ExtMCore =
   BootParser + MExpr + MExprTypeCheck + MExprRemoveTypeAscription +
   MExprTypeCheck + MExprTypeLift + MExprUtestGenerate +
-  MExprProfileInstrument + MExprEval
+  MExprProfileInstrument + MExprEval + PEvalAst
 
   sem updateArgv : [String] -> Expr -> Expr
   sem updateArgv args =
@@ -45,7 +45,7 @@ let eval = lam files. lam options : Options. lam args.
   let evalFile = lam file.
     let ast = parseParseMCoreFile {
       keepUtests = options.runTests,
-      keywords = [],
+      keywords = pevalKeywords,
       pruneExternalUtests = not options.disablePruneExternalUtests,
       pruneExternalUtestsWarning = not options.disablePruneExternalUtestsWarning,
       findExternalsExclude = false, -- the interpreter does not support externals
@@ -54,6 +54,8 @@ let eval = lam files. lam options : Options. lam args.
 
     -- If option --debug-parse, then pretty print the AST
     (if options.debugParse then printLn (mexprToString ast) else ());
+
+    let ast = makeKeywords ast in
 
     let ast = symbolize ast in
 

--- a/stdlib/mexpr/keywords.mc
+++ b/stdlib/mexpr/keywords.mc
@@ -10,4 +10,6 @@ let accelerateKeywords = [
   "accelerate", "parallelMap", "flatten", "map2", "reduce", "seqLoop",
   "seqLoopAcc", "loop", "printFloat"]
 
-let mexprExtendedKeywords = concat holeKeywords accelerateKeywords
+let pevalKeywords = ["peval"]
+
+let mexprExtendedKeywords = concat pevalKeywords (concat holeKeywords accelerateKeywords)

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -61,11 +61,10 @@ lang PEvalAst = KeywordMaker + MExpr + MExprEq + Eval + PrettyPrint
   | TmPEval e -> 
   switch eval ctx e.e 
     case clos & TmClos {ident=i, body=b, env=envi} then
-        match peval clos with res then
+        match peval clos with res in
             match res with TmLam t then
                 eval ctx res -- TmClos ...
             else res
-        else never
     case x then x
   end 
 

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -99,8 +99,6 @@ utest makeKeywords expr with peval_ (addfn_) using eqExpr in
 let expr = app_ (var_ "peval") (app_ addfn_ (int_ 3)) in
 utest makeKeywords expr with peval_ (app_ addfn_ (int_ 3)) using eqExpr in
 
-let x = eval (evalCtxEmpty ()) (makeKeywords expr) in
-
 let arg = (appf2_ addfn_ (int_ 3) (int_ 4)) in
 let expr = app_ (var_ "peval") arg  in
 utest makeKeywords expr with peval_ arg using eqExpr in

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -53,20 +53,20 @@ lang PEvalAst = KeywordMaker + MExpr + MExprEq + Eval + PrettyPrint
   -- Equality of the new terms
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmPEval r ->
-      match lhs with TmPEval l then
-        eqExprH env free l.e r.e
-      else None ()
+    match lhs with TmPEval l then
+      eqExprH env free l.e r.e
+    else None ()
 
   sem eval (ctx : EvalCtx) = 
   | TmPEval e -> 
-  switch eval ctx e.e 
-    case clos & TmClos {ident=i, body=b, env=envi} then
-        match peval clos with res in
-            match res with TmLam t then
-                eval ctx res -- TmClos ...
-            else res
+    switch eval ctx e.e
+    case clos & TmClos _ then
+      let res = peval clos in
+        match res with TmLam _ then
+          eval (evalCtxEmpty ()) res -- TmClos ...
+        else res
     case x then x
-  end 
+    end
 
   sem isAtomic = 
   | TmPEval _ -> false
@@ -74,7 +74,7 @@ lang PEvalAst = KeywordMaker + MExpr + MExprEq + Eval + PrettyPrint
   sem pprintCode (indent : Int) (env : PprintEnv) =
   | TmPEval t ->
     match printParen indent env t.e with (env, e) in
-     (env, join ["peval", pprintNewline indent , e])
+    (env, join ["peval", pprintNewline indent , e])
 
 end
 

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -1,0 +1,112 @@
+include "mexpr/keyword-maker.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/type-check.mc"
+include "mexpr/type-annot.mc"
+include "mexpr/eval.mc"
+include "mexpr/info.mc"
+include "mexpr/eq.mc"
+
+include "peval/peval.mc"
+include "error.mc"
+include "list.mc"
+
+
+lang PEvalAst = KeywordMaker + MExpr + MExprEq + Eval + PrettyPrint
+                + MExprTypeCheck + LamEval + TypeAnnot + MExprPEval
+
+  syn Expr =
+  | TmPEval {e: Expr, info: Info}
+
+  -- States that the new terms are indeed mapping from keywords
+  sem isKeyword =
+  | TmPEval _ -> true
+
+  -- Defines the new mapping from keyword to new terms
+  sem matchKeywordString (info: Info) =
+  | "peval" -> Some (1, lam lst. TmPEval {e = get lst 0,
+                                          info = info})
+  sem tyTm = 
+  | TmPEval t -> tyTm t.e
+
+  sem infoTm =
+  | TmPEval t -> t.info
+
+  sem withType (ty : Type) =
+  | TmPEval t -> TmPEval {t with e = withType ty t.e}
+
+  sem typeCheckExpr (env : TCEnv) = 
+  | TmPEval t -> 
+    let e = typeCheckExpr env t.e in
+    TmPEval {t with e = e}
+
+  sem typeAnnotExpr (env : TypeEnv) = 
+  | TmPEval t -> 
+    let e = typeAnnotExpr env t.e in
+    TmPEval {t with e = e}
+
+  sem smapAccumL_Expr_Expr f acc =
+  | TmPEval t ->
+    match f acc t.e with (acc, e) in
+    (acc, TmPEval {t with e = e})
+
+  -- Equality of the new terms
+  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
+  | TmPEval r ->
+      match lhs with TmPEval l then
+        eqExprH env free l.e r.e
+      else None ()
+
+  sem eval (ctx : EvalCtx) = 
+  | TmPEval e -> 
+  switch eval ctx e.e 
+    case clos & TmClos {ident=i, body=b, env=envi} then
+        match peval clos with res then
+            match res with TmLam t then
+                eval ctx res -- TmClos ...
+            else res
+        else never
+    case x then x
+  end 
+
+  sem isAtomic = 
+  | TmPEval _ -> false
+
+  sem pprintCode (indent : Int) (env : PprintEnv) =
+  | TmPEval t ->
+    match printParen indent env t.e with (env, e) in
+     (env, join ["peval", pprintNewline indent , e])
+
+end
+
+let peval_ = lam e.
+  use PEvalAst in 
+  TmPEval {e = e, info = NoInfo ()}
+
+
+lang TestLang = PEvalAst + MExprEval
+end 
+
+mexpr 
+
+use TestLang in
+
+let addfn_ = ulam_ "acc" (ulam_ "i" (addi_ (var_ "acc") (var_ "i"))) in
+
+let expr = app_ (var_ "peval") addfn_ in
+utest makeKeywords expr with peval_ (addfn_) using eqExpr in 
+
+let expr = app_ (var_ "peval") (app_ addfn_ (int_ 3)) in
+utest makeKeywords expr with peval_ (app_ addfn_ (int_ 3)) using eqExpr in
+
+let x = eval (evalCtxEmpty ()) (makeKeywords expr) in
+
+let arg = (appf2_ addfn_ (int_ 3) (int_ 4)) in
+let expr = app_ (var_ "peval") arg  in
+utest makeKeywords expr with peval_ arg using eqExpr in
+
+let expr = app_ (var_ "peval") (int_ 3) in
+utest makeKeywords expr with peval_ (int_ 3) using eqExpr in
+
+
+()

--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -2,12 +2,12 @@ include "map.mc"
 include "set.mc"
 include "log.mc"
 
-include "ast.mc"
-include "ast-builder.mc"
-include "eval.mc"
-include "pprint.mc"
-include "boot-parser.mc"
-include "side-effect.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/eval.mc"
+include "mexpr/pprint.mc"
+include "mexpr/boot-parser.mc"
+include "mexpr/side-effect.mc"
 
 let astBuilder = lam info.
   use MExprAst in

--- a/test/examples/peval/pow.mc
+++ b/test/examples/peval/pow.mc
@@ -1,0 +1,23 @@
+include "common.mc"
+include "string.mc"
+
+mexpr
+
+recursive let pow = lam n. lam x. 
+    if eqi n 0 then 1
+    else 
+        if eqi (modi n 2) 0 then 
+            let r = pow (divi n 2) x in
+            muli r r
+        else 
+           let r = pow (subi n 1) x in
+           muli x r
+in 
+
+let x = pow 2 3 in 
+
+let pow2 = peval (pow 2) in 
+
+let z = pow2 3 in
+
+printLn (int2string z)


### PR DESCRIPTION
Adds the keyword 'peval' using the keyword-maker tool. Only works with the interpreter as of now. 
