### PR TITLE
Record type inference fixes

### DIFF
--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -249,16 +249,8 @@ end
 lang FlexTypeUnify = UnifyFields + FlexTypeAst
   sem addSorts (env : UnifyEnv) =
   | (RecordVar r1, RecordVar r2) ->
-    let f = lam acc. lam b : (SID, Type).
-      match b with (k, ty2) in
-      match mapLookup k r1.fields with Some ty1 then
-        unifyTypes env (ty1, ty2);
-        acc
-      else
-        mapInsert k ty2 acc
-    in
-    let fields = foldl f r1.fields (mapBindings r2.fields) in
-    RecordVar {r1 with fields = fields}
+    let f = lam ty1. lam ty2. unifyTypes env (ty1, ty2); ty1 in
+    RecordVar {r1 with fields = mapUnionWith f r1.fields r2.fields}
   | (RecordVar _ & rv, ! RecordVar _ & tv)
   | (! RecordVar _ & tv, RecordVar _ & rv) ->
     rv
@@ -270,6 +262,7 @@ lang FlexTypeUnify = UnifyFields + FlexTypeAst
     match (deref t1.contents, deref t2.contents) with (Unbound r1, Unbound r2) in
     if not (nameEq r1.ident r2.ident) then
       unifyCheck env.info r1 ty2;
+      unifyCheck env.info r2 ty1;
       let updated =
         Unbound {r1 with level = mini r1.level r2.level
                 , sort = addSorts env (r1.sort, r2.sort)
@@ -606,7 +599,26 @@ lang AppTypeCheck = TypeCheck + AppAst
     TmApp {t with lhs = lhs, rhs = rhs, ty = tyRes}
 end
 
-lang LetTypeCheck = TypeCheck + LetAst + SubstituteUnknown
+lang FlexDisableGeneralize = Unify
+  sem disableRecordGeneralize (info : [Info]) (lvl : Level) =
+  | TyFlex t & ty ->
+    switch deref t.contents
+    case Unbound {sort = RecordVar _} then
+      let tv = {ident = nameSym "a",
+                level = lvl,
+                sort = PolyVar (),
+                isWeak = true}
+      in
+      unifyCheck info tv ty
+    case Unbound _ then ()
+    case Link tyL then
+      disableRecordGeneralize info lvl tyL
+    end
+  | ty ->
+    sfold_Type_Type (lam. lam ty. disableRecordGeneralize info lvl ty) () ty
+end
+
+lang LetTypeCheck = TypeCheck + LetAst + SubstituteUnknown + FlexDisableGeneralize
   sem typeCheckExpr env =
   | TmLet t ->
     let lvl = env.currentLvl in
@@ -617,6 +629,8 @@ lang LetTypeCheck = TypeCheck + LetAst + SubstituteUnknown
     -- Unify the annotated type with the inferred one and generalize
     match stripTyAll tyBody with (_, stripped) in
     unify [infoTy t.tyAnnot, infoTm body] stripped (tyTm body);
+    (if env.disableRecordPolymorphism then
+      disableRecordGeneralize [infoTm body] lvl tyBody else ());
     let tyBody = gen lvl tyBody in
     let inexpr = typeCheckExpr (_insertVar t.ident tyBody env) t.inexpr in
     TmLet {t with body = body
@@ -633,7 +647,7 @@ lang LetTypeCheck = TypeCheck + LetAst + SubstituteUnknown
   | (tm, ty) -> tm
 end
 
-lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck
+lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck + FlexDisableGeneralize
   sem typeCheckExpr env =
   | TmRecLets t ->
     let lvl = env.currentLvl in
@@ -659,6 +673,8 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck
 
     -- Third: Produce a new environment with generalized types
     let envIteratee = lam acc. lam b : RecLetBinding.
+      (if env.disableRecordPolymorphism then
+        disableRecordGeneralize [infoTm b.body] lvl b.tyBody else ());
       let tyBody = gen lvl b.tyBody in
       (_insertVar b.ident tyBody acc, {b with tyBody = tyBody})
     in
@@ -701,20 +717,7 @@ lang SeqTypeCheck = TypeCheck + SeqAst
     TmSeq {t with tms = tms, ty = ityseq_ t.info elemTy}
 end
 
-lang FlexDisableGeneralize = FlexTypeAst
-  sem disableGeneralize =
-  | TyFlex t ->
-    switch deref t.contents
-    case Unbound r then
-      modref t.contents (Unbound {r with isWeak = true});
-      sfold_VarSort_Type (lam. lam ty. disableGeneralize ty) () r.sort
-    case Link ty then
-      disableGeneralize ty
-    end
-  | ty -> ()
-end
-
-lang RecordTypeCheck = TypeCheck + RecordAst + RecordTypeAst + FlexDisableGeneralize
+lang RecordTypeCheck = TypeCheck + RecordAst + RecordTypeAst
   sem typeCheckExpr env =
   | TmRecord t ->
     let bindings = mapMap (typeCheckExpr env) t.bindings in
@@ -726,7 +729,6 @@ lang RecordTypeCheck = TypeCheck + RecordAst + RecordTypeAst + FlexDisableGenera
     let value = typeCheckExpr env t.value in
     let fields = mapInsert t.key (tyTm value) (mapEmpty cmpSID) in
     unify [infoTm rec] (newrecvar fields env.currentLvl (infoTm rec)) (tyTm rec);
-    (if env.disableRecordPolymorphism then disableGeneralize (tyTm rec) else ());
     TmRecordUpdate {t with rec = rec, value = value, ty = tyTm rec}
 end
 
@@ -836,13 +838,12 @@ lang SeqEdgePatTypeCheck = PatTypeCheck + SeqEdgePat
     (patEnv, PatSeqEdge {t with prefix = prefix, postfix = postfix, ty = seqTy})
 end
 
-lang RecordPatTypeCheck = PatTypeCheck + RecordPat + FlexDisableGeneralize
+lang RecordPatTypeCheck = PatTypeCheck + RecordPat
   sem typeCheckPat env patEnv =
   | PatRecord t ->
     let typeCheckBinding = lam patEnv. lam. lam pat. typeCheckPat env patEnv pat in
     match mapMapAccum typeCheckBinding patEnv t.bindings with (patEnv, bindings) in
     let ty = newrecvar (mapMap tyPat bindings) env.currentLvl t.info in
-    (if env.disableRecordPolymorphism then disableGeneralize ty else ());
     (patEnv, PatRecord {t with bindings = bindings, ty = ty})
 end
 

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -141,7 +141,7 @@ end
 -- TYPE UNIFICATION --
 ----------------------
 
-lang Unify = MExprAst + FlexTypeAst + PrettyPrint
+lang Unify = FlexTypeAst + PrettyPrint
   -- Unify the types `ty1' and `ty2', where
   -- `ty1' is the expected type of an expression, and
   -- `ty2' is the inferred type of the expression.
@@ -246,7 +246,7 @@ lang VarTypeUnify = Unify + VarTypeAst
     else ()
 end
 
-lang FlexTypeUnify = UnifyFields + FlexTypeAst
+lang FlexTypeUnify = UnifyFields + FlexTypeAst + RecordTypeAst
   sem addSorts (env : UnifyEnv) =
   | (RecordVar r1, RecordVar r2) ->
     let f = lam ty1. lam ty2. unifyTypes env (ty1, ty2); ty1 in
@@ -618,7 +618,8 @@ lang FlexDisableGeneralize = Unify
     sfold_Type_Type (lam. lam ty. disableRecordGeneralize info lvl ty) () ty
 end
 
-lang LetTypeCheck = TypeCheck + LetAst + SubstituteUnknown + FlexDisableGeneralize
+lang LetTypeCheck =
+  TypeCheck + LetAst + LamAst + FunTypeAst + SubstituteUnknown + FlexDisableGeneralize
   sem typeCheckExpr env =
   | TmLet t ->
     let lvl = env.currentLvl in
@@ -740,7 +741,7 @@ lang TypeTypeCheck = TypeCheck + TypeAst + SubstituteUnknown
     TmType {t with inexpr = inexpr, ty = tyTm inexpr}
 end
 
-lang DataTypeCheck = TypeCheck + DataAst + SubstituteUnknown
+lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + SubstituteUnknown
   sem typeCheckExpr env =
   | TmConDef t ->
     checkUnknown t.info t.tyIdent;
@@ -847,7 +848,7 @@ lang RecordPatTypeCheck = PatTypeCheck + RecordPat
     (patEnv, PatRecord {t with bindings = bindings, ty = ty})
 end
 
-lang DataPatTypeCheck = TypeCheck + PatTypeCheck + DataPat
+lang DataPatTypeCheck = PatTypeCheck + DataPat + FunTypeAst + Generalize
   sem typeCheckPat env patEnv =
   | PatCon t ->
     match mapLookup t.ident env.conEnv with Some ty then
@@ -864,17 +865,17 @@ lang DataPatTypeCheck = TypeCheck + PatTypeCheck + DataPat
       errorSingle [t.info] msg
 end
 
-lang IntPatTypeCheck = PatTypeCheck + IntPat
+lang IntPatTypeCheck = PatTypeCheck + IntPat + IntTypeAst
   sem typeCheckPat env patEnv =
   | PatInt t -> (patEnv, PatInt {t with ty = TyInt {info = t.info}})
 end
 
-lang CharPatTypeCheck = PatTypeCheck + CharPat
+lang CharPatTypeCheck = PatTypeCheck + CharPat + CharTypeAst
   sem typeCheckPat env patEnv =
   | PatChar t -> (patEnv, PatChar {t with ty = TyChar {info = t.info}})
 end
 
-lang BoolPatTypeCheck = PatTypeCheck + BoolPat
+lang BoolPatTypeCheck = PatTypeCheck + BoolPat + BoolTypeAst
   sem typeCheckPat env patEnv =
   | PatBool t -> (patEnv, PatBool {t with ty = TyBool {info = t.info}})
 end

--- a/stdlib/nfa.mc
+++ b/stdlib/nfa.mc
@@ -109,17 +109,16 @@ let nfaNextStates : all v. all l. v -> Digraph v l -> l -> [v] =
   error "No transition was found"
   else neighboringStates
 
--- takes a path and returns whether it's accepted or not.
-let pathIsAccepted = lam path.
-  if null path then false
-  else (eqsetEqual eqChar (last path).status "accepted")
-
 -- goes through the nfa, one state of the input at a time. Returns a list of {state, status, input}
 -- where status is either accepted,stuck,not accepted or neutral ("")
 recursive
 let nfaMakeInputPath : all v. all l.
   Int -> v -> [l] -> NFA v l -> [{state : v, index : Int, status : String}] =
   lam i. lam currentState. lam input. lam nfa.
+  let pathIsAccepted = lam path.
+    if null path then false
+    else (eqsetEqual eqChar (last path).status "accepted")
+  in
   if (eqi (length input) 0) then
     if (nfaIsAcceptedState currentState nfa) then [{state = currentState,index = i, status = "accepted"}]
     else [{state = currentState, index = i, status = "not accepted"}]


### PR DESCRIPTION
This PR fixes a number of subtle bugs related to the inference of record types, and also improves the inference to handle more cases than previously.

As a short recap, while the type checker infers the types of records, it often does not have precise information due to the way our record matches work.  For instance, if we write
```haskell
let g = lam r. r.x
```
we know that `r` is a record with a field `x`, but we do not know its precise structure.  Accordingly, the type checker will infer a signature
```haskell
g : {x : _a ... } -> _a
```
meaning that `g` takes a record containing at least the field `x` of some type `_a`.  Importantly, this parameter type is _not polymorphic_, but represents some fixed but as-of-yet undetermined record type.  For this reason, `_a` also must not be treated polymorphically.  The current type checker tries to enforce this by marking variables as 'weak' and refusing to generalize those variables, but there were a number of bugs in the implementation.

* Weak variables could be unified with type variables from a later let binding at the same 'level'.
```haskell
let g = lam r. r.x
let h : all a. {x : a} -> a = g -- This makes 'a' escape its scope into the type of 'g' 
```

* The contents of records could sometimes be unified with type variables unsoundly.
```haskell
let f : all a. a -> Unknown = lam x. lam r. {r with s = x} -- This places 'a' inside an unknown record type
```

* The occurs check would sometimes succeed prematurely for unknown records.
```haskell
let g = lam a. lam r.
  let h : all a. a -> a -> a = lam x. lam y. y in
  ({a with x = r}, h a r) -- This makes an infinite record type
```

In addition, the type checker was quite eager to mark variables as 'weak', meaning that sometimes it would fail to produce a general type even in cases when it was completely safe.  For instance, given
```haskell
recursive let work = lam eq. lam s1. lam s2.
  match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) then
    if eq h1 h2 then work eq t1 t2
    else false
  else true
end
```
it would infer `work : (_a -> _a1 -> Bool) -> [_a] -> [_a1] -> Bool` instead of the most general type `work : all a. all a1. (a -> a1 -> Bool) -> [a] -> [a1] -> Bool`.  This is now fixed, by waiting until just before generalization to mark variables inside unknown records as weak.