### PR TITLE
Insert profiling before symbolize, so the resulting tree resolves aliases properly

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -55,8 +55,6 @@ let insertTunedOrDefaults = lam options : Options. lam ast. lam file.
 let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
   use MCoreCompile in
     let log = mkPhaseLogState options.debugPhases in
-    let ast = symbolize ast in
-    endPhaseStats log "symbolize" ast;
 
     -- If option --debug-profile, insert instrumented profiling expressions
     -- in AST
@@ -65,6 +63,9 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
       else ast
     in
     endPhaseStats log "instrument-profiling" ast;
+
+    let ast = symbolize ast in
+    endPhaseStats log "symbolize" ast;
 
     let ast = typeCheck ast in
     (if options.debugTypeCheck then


### PR DESCRIPTION
The `instrument-profiling` pass was broken by #667, since it inserted new code after `symbolize`, but the new code introduced a new type alias, which would then not be transformed into a `TyAlias`.

This lead to somewhat confusing errors where we got a type error, where `Ref [StackEntry]` was expected and `Ref [{...}]` was found, where `{...}` was precisely the record described by the `StackEntry` type alias.