### PR TITLE
Print aliases as well

### DIFF
--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -42,7 +42,7 @@ lang Cmp = Ast
     else res
 
   sem cmpType (lhs: Type) =
-  | rhs /- : Type -/ -> cmpTypeH (lhs, rhs)
+  | rhs /- : Type -/ -> cmpTypeH (unwrapType lhs, unwrapType rhs)
 
   sem cmpTypeH =
   -- Default case when types are not the same

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -106,6 +106,15 @@ lang FlexTypeAst = VarSortAst + Ast
     else (acc, ty)
 end
 
+lang FlexTypeCmp = Cmp + FlexTypeAst
+  sem cmpTypeH =
+  | (TyFlex l, TyFlex r) ->
+    -- NOTE(vipa, 2023-04-19): Any non-link TyFlex should have been
+    -- unwrapped already, thus we can assume `Unbound` here.
+    match (deref l.contents, deref r.contents) with (Unbound l, Unbound r) in
+    nameCmp l.ident r.ident
+end
+
 lang FlexTypePrettyPrint = IdentifierPrettyPrint + VarSortPrettyPrint + FlexTypeAst
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
   | TyFlex t ->


### PR DESCRIPTION
This PR changes the error message on unification error in the type checker to print the definitions of all aliases, to provide more relevant information. Additionally, the unification error now also `pprint`s consistently, in case multiple `Name`s are involved with the same `String` but different `Symbol`s.

![image](https://user-images.githubusercontent.com/810210/232749232-e5d64965-d7cd-44f3-96e7-663bd7edfbda.png)

Edit: found and fixed a bug because `TyFlex` was not supported in `cmp.mc`. Note that because a `TyFlex` is essentially mutable it's a bit unsafe to depend on `cmpType a b` to remain constant for all types `a` and `b`, but the use here is safe because we never call `unify` after `cmpType`.
