### PR TITLE
More general types for some map functions

### DIFF
--- a/stdlib/avl.mc
+++ b/stdlib/avl.mc
@@ -351,8 +351,8 @@ lang AVLTreeImpl
         avlJoin rt.key value lhs rhs
       else error "avlUnionWith: empty right tree"
 
-  sem avlIntersectWith : all k. all v.
-    (k -> k -> Int) -> (v -> v -> v) -> AVL k v -> AVL k v -> AVL k v
+  sem avlIntersectWith : all k. all a. all b. all c.
+    (k -> k -> Int) -> (a -> b -> c) -> AVL k a -> AVL k b -> AVL k c
   sem avlIntersectWith cmp f l =
   | r ->
     match l with Leaf _ then Leaf ()
@@ -378,7 +378,7 @@ lang AVLTreeImpl
           avlJoin2 lhs rhs
       else error "avlIntersectWith: empty right tree"
 
-  sem avlDifference : all k. all v. (k -> k -> Int) -> AVL k v -> AVL k v -> AVL k v
+  sem avlDifference : all k. all a. all b. (k -> k -> Int) -> AVL k a -> AVL k b -> AVL k a
   sem avlDifference cmp l =
   | r ->
     match l with Leaf _ then Leaf ()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -139,12 +139,12 @@ let mapUnionWith : all k. all v. (v -> v -> v) -> Map k v -> Map k v -> Map k v 
   use AVLTreeImpl in
   {l with root = avlUnionWith l.cmp f l.root r.root}
 
-let mapIntersectWith : all k. all v. (v -> v -> v) -> Map k v -> Map k v -> Map k v =
+let mapIntersectWith : all k. all a. all b. all c. (a -> b -> c) -> Map k a -> Map k b -> Map k c =
   lam f. lam l. lam r.
   use AVLTreeImpl in
-  {l with root = avlIntersectWith l.cmp f l.root r.root}
+  {cmp = l.cmp, root = avlIntersectWith l.cmp f l.root r.root}
 
-let mapDifference : all k. all v. Map k v -> Map k v -> Map k v =
+let mapDifference : all k. all v. all v2. Map k v -> Map k v2 -> Map k v =
   lam l. lam r.
   use AVLTreeImpl in
   {l with root = avlDifference l.cmp l.root r.root}


### PR DESCRIPTION
This PR gives some functions in `map.mc` (and the underlying `avl.mc`) more general types, since the currently specified ones are unnecessarily strict.