### PR TITLE
Refactor freeVars and add case for Match

### DIFF
--- a/stdlib/mexpr/free-vars.mc
+++ b/stdlib/mexpr/free-vars.mc
@@ -1,0 +1,123 @@
+-- This file contains language fragments and functions related to free
+-- variables.
+
+include "set.mc"
+include "name.mc"
+
+include "mexpr/ast.mc"
+include "mexpr/symbolize.mc"
+include "mexpr/boot-parser.mc"
+
+lang FreeVars = Ast
+  -- Returns the set of free variables for a given expression. Assumes that the
+  -- expression is symbolized.
+  sem freeVars : Expr -> Set Name
+  sem freeVars =| t -> freeVarsExpr (setEmpty nameCmp) t
+
+  sem freeVarsExpr : Set Name -> Expr -> Set Name
+  sem freeVarsExpr acc =
+  | t -> sfold_Expr_Expr freeVarsExpr acc t
+end
+
+lang VarFreeVars = FreeVars + VarAst
+  sem freeVarsExpr acc =
+  | TmVar r -> setInsert r.ident acc
+end
+
+lang LamFreeVars = FreeVars + LamAst
+  sem freeVarsExpr acc =
+  | TmLam r ->
+    setRemove r.ident (freeVarsExpr acc r.body)
+end
+
+lang LetFreeVars = FreeVars + LetAst
+  sem freeVarsExpr acc =
+  | TmLet r ->
+    setRemove r.ident (freeVarsExpr (freeVarsExpr acc r.body) r.inexpr)
+end
+
+lang RecLetsFreeVars = FreeVars + RecLetsAst
+  sem freeVarsExpr acc =
+  | TmRecLets r ->
+    let acc = foldl (lam acc. lam b.
+      freeVarsExpr acc b.body) (freeVarsExpr acc r.inexpr) r.bindings in
+    foldl (lam acc. lam b. setRemove b.ident acc) acc r.bindings
+end
+
+lang MatchFreeVars = FreeVars + MatchAst + NamedPat
+  sem freeVarsExpr acc =
+  | TmMatch r ->
+    freeVarsExpr
+      (freeVarsExpr
+         (bindVarsPat
+            (freeVarsExpr acc r.thn)
+            r.pat)
+         r.els)
+      r.target
+
+  sem bindVarsPat : Set Name -> Pat -> Set Name
+  sem bindVarsPat acc =
+  | PatNamed {ident = PName ident} -> setRemove ident acc
+  | pat -> sfold_Pat_Pat bindVarsPat acc pat
+end
+
+lang MExprFreeVars =
+  VarFreeVars + LamFreeVars + LetFreeVars + RecLetsFreeVars + MatchFreeVars
+end
+
+lang TestLang = MExprFreeVars + MExprSym + BootParser end
+
+mexpr
+
+use TestLang in
+
+let parseProgram : String -> Expr =
+  lam str.
+    let parseArgs =
+      {defaultBootParserParseMExprStringArg with allowFree = true}
+    in
+    let ast = parseMExprString parseArgs str in
+    symbolizeExpr {symEnvEmpty with allowFree = true} ast
+in
+
+-------------------
+-- Test freeVars --
+-------------------
+
+let testFreeVars = lam prog.
+  let fv = freeVars prog in
+  sort cmpString (map nameGetStr (setToSeq fv))
+in
+
+let prog = parseProgram "
+  lam x. x x y y y
+  "
+in
+
+utest testFreeVars prog with ["y"] in
+
+let prog = parseProgram "
+  let x = z in x x y y y
+  "
+in
+
+utest testFreeVars prog with ["y", "z"] in
+
+let prog = parseProgram "
+  recursive let f = lam x. w f (f x) in
+  recursive let g = lam y. z f (g y) in
+  w z (f (g u))
+  "
+in
+
+utest testFreeVars prog with ["u", "w", "z"] in
+
+let prog = parseProgram "
+  match u with (x, (y, z)) in
+  x y y z z z u w w
+  "
+in
+
+utest testFreeVars prog with ["u", "w"] in
+
+()


### PR DESCRIPTION
This PR refactors `freeVars` from `cfa.mc` into a separate file `free-vars.mc`. It also slightly modifies its signature to default to the common case where the initial call contains an empty set.  Moreover, it adds a missing case for matches and adds tests.