### PR TITLE
Type checker improvements

### DIFF
--- a/stdlib/arg.mc
+++ b/stdlib/arg.mc
@@ -99,7 +99,8 @@ let argHelpOptions_general : all a.
 
 
 
-let argHelpOptions = argHelpOptions_general argHelpOptions_defaults
+let argHelpOptions = lam opConfig.
+  argHelpOptions_general argHelpOptions_defaults opConfig
 
 
 -- argument value conversion --

--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -163,25 +163,25 @@ mexpr
 let traits = {eq = eqi} in
 
 let length = assocLength in
-let lookup = assocLookup traits in
-let lookupOrElse = assocLookupOrElse traits in
+let lookup = lam x. assocLookup traits x in
+let lookupOrElse = lam x. assocLookupOrElse traits x in
 let lookupPred = assocLookupPred in
 let any = assocAny in
 let forAll = assocAll in
-let insert = assocInsert traits in
-let seq2assoc = seq2assoc traits in
-let assoc2seq = assoc2seq traits in
-let mem = assocMem traits in
-let remove = assocRemove traits in
-let keys = assocKeys traits in
-let values = assocValues traits in
-let map = assocMap traits in
-let mapWithKey = assocMapWithKey traits in
-let fold = assocFold traits in
-let foldOption = assocFoldlM traits in
-let mapAccum = assocMapAccum traits in
-let mergePreferLeft = assocMergePreferLeft traits in
-let mergePreferRight = assocMergePreferRight traits in
+let insert = lam x. assocInsert traits x in
+let seq2assoc = lam x. seq2assoc traits x in
+let assoc2seq = lam x. assoc2seq traits x in
+let mem = lam x. assocMem traits x in
+let remove = lam x. assocRemove traits x in
+let keys = lam x. assocKeys traits x in
+let values = lam x. assocValues traits x in
+let map = lam x. assocMap traits x in
+let mapWithKey = lam x. assocMapWithKey traits x in
+let fold = lam x. assocFold traits x in
+let foldOption = lam x. assocFoldlM traits x in
+let mapAccum = lam x. assocMapAccum traits x in
+let mergePreferLeft = lam x. assocMergePreferLeft traits x in
+let mergePreferRight = lam x. assocMergePreferRight traits x in
 
 let m = assocEmpty in
 let m = insert 1 '1' m in

--- a/stdlib/cuda/pmexpr-ast.mc
+++ b/stdlib/cuda/pmexpr-ast.mc
@@ -96,8 +96,8 @@ lang CudaPMExprAst = PMExprAst
     let s = typeCheckExpr env t.s in
     let inElemType = newvar env.currentLvl t.info in
     let outElemType = newvar env.currentLvl t.info in
-    unify [infoTm s, t.info] (tyTm s) (ityseq_ t.info inElemType);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info inElemType outElemType);
+    unify env [infoTm s, t.info] (tyTm s) (ityseq_ t.info inElemType);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info inElemType outElemType);
     TmSeqMap {{{t with f = f}
                   with s = s}
                   with ty = TySeq {ty = outElemType, info = t.info}}
@@ -106,8 +106,8 @@ lang CudaPMExprAst = PMExprAst
     let acc = typeCheckExpr env t.acc in
     let s = typeCheckExpr env t.s in
     let sElemTy = newvar env.currentLvl t.info in
-    unify [infoTm s, t.info] (tyTm s) (ityseq_ t.info sElemTy);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm acc)
+    unify env [infoTm s, t.info] (tyTm s) (ityseq_ t.info sElemTy);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm acc)
                                          (ityarrow_ t.info sElemTy (tyTm acc)));
     TmSeqFoldl {{{{t with f = f}
                      with acc = acc}
@@ -117,8 +117,8 @@ lang CudaPMExprAst = PMExprAst
     let tt = typeCheckExpr env t.t in
     let slice = typeCheckExpr env t.slice in
     let elemTy = newvar env.currentLvl t.info in
-    unify [infoTm tt, t.info] (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
-    unify [infoTm slice, t.info] (tyTm slice) (ityseq_ t.info (tyWithInfo t.info tyint_));
+    unify env [infoTm tt, t.info] (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
+    unify env [infoTm slice, t.info] (tyTm slice) (ityseq_ t.info (tyWithInfo t.info tyint_));
     TmTensorSliceExn {{{t with t = tt}
                           with slice = slice}
                           with ty = tyTm tt}
@@ -127,9 +127,9 @@ lang CudaPMExprAst = PMExprAst
     let ofs = typeCheckExpr env t.ofs in
     let len = typeCheckExpr env t.len in
     let elemTy = newvar env.currentLvl t.info in
-    unify [infoTm tt, t.info] (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
-    unify [infoTm ofs, t.info] (tyTm ofs) (tyWithInfo t.info tyint_);
-    unify [infoTm len, t.info] (tyTm len) (tyWithInfo t.info tyint_);
+    unify env [infoTm tt, t.info] (tyTm tt) (tyWithInfo t.info (tytensor_ elemTy));
+    unify env [infoTm ofs, t.info] (tyTm ofs) (tyWithInfo t.info tyint_);
+    unify env [infoTm len, t.info] (tyTm len) (tyWithInfo t.info tyint_);
     TmTensorSubExn {{{{t with t = tt}
                          with ofs = ofs}
                          with len = len}
@@ -139,8 +139,8 @@ lang CudaPMExprAst = PMExprAst
     let s = typeCheckExpr env t.s in
     let inElemType = newvar env.currentLvl t.info in
     let outElemType = newvar env.currentLvl t.info in
-    unify [infoTm s, t.info] (tyTm s) (ityseq_ t.info inElemType);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info inElemType outElemType);
+    unify env [infoTm s, t.info] (tyTm s) (ityseq_ t.info inElemType);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info inElemType outElemType);
     TmMapKernel {{{t with f = f}
                      with s = s}
                      with ty = TySeq {ty = outElemType, info = t.info}}
@@ -150,8 +150,8 @@ lang CudaPMExprAst = PMExprAst
     let s = typeCheckExpr env t.s in
     let seqElemTy = newvar env.currentLvl t.info in
     let neTy = tyTm ne in
-    unify [infoTm s, t.info] (tyTm s) (ityseq_ t.info neTy);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info neTy (ityarrow_ t.info neTy neTy));
+    unify env [infoTm s, t.info] (tyTm s) (ityseq_ t.info neTy);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info neTy (ityarrow_ t.info neTy neTy));
     TmReduceKernel {{{{t with f = f}
                          with ne = ne}
                          with s = s}
@@ -160,8 +160,8 @@ lang CudaPMExprAst = PMExprAst
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
+    unify env [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
     TmLoopKernel {{{t with n = n}
                       with f = f}
                       with ty = unitType}

--- a/stdlib/hashmap.mc
+++ b/stdlib/hashmap.mc
@@ -34,7 +34,8 @@ let _hashmapBucketIdx : all k. all v. Int -> HashMap k v -> Int =
   modi (absi hash) (length hm.buckets)
 
 -- 'hashmapEmpty' is an empty hashmap with a default number of buckets.
-let hashmapEmpty : all k. all v. HashMap k v =
+-- TODO(aathn, 2023-05-07): Relax value restriction
+let hashmapEmpty : all k. all v. () -> HashMap k v = lam.
   {buckets = make _hashmapDefaultBucketCount [],
    nelems = 0}
 
@@ -227,24 +228,24 @@ mexpr
 
 let empty = hashmapEmpty in
 let traits = hashmapStrTraits in
-let mem = hashmapMem traits in
-let any = hashmapAny traits in
-let forAll = hashmapAll traits in
-let map = hashmapMap traits in
-let filter = hashmapFilter traits in
-let filterKeys = hashmapFilterKeys traits in
-let filterValues = hashmapFilterValues traits in
-let lookupOrElse = hashmapLookupOrElse traits in
-let lookupOr = hashmapLookupOr traits in
-let lookup = hashmapLookup traits in
-let lookupPred = hashmapLookupPred traits in
-let count = hashmapCount traits in
-let insert = hashmapInsert traits in
-let remove = hashmapRemove traits in
-let keys = hashmapKeys traits in
-let values = hashmapValues traits in
+let mem = lam x. hashmapMem traits x in
+let any = lam x. hashmapAny traits x in
+let forAll = lam x. hashmapAll traits x in
+let map = lam x. hashmapMap traits x in
+let filter = lam x. hashmapFilter traits x in
+let filterKeys = lam x. hashmapFilterKeys traits x in
+let filterValues = lam x. hashmapFilterValues traits x in
+let lookupOrElse = lam x. hashmapLookupOrElse traits x in
+let lookupOr = lam x. hashmapLookupOr traits x in
+let lookup = lam x. hashmapLookup traits x in
+let lookupPred = lam x. hashmapLookupPred traits x in
+let count = lam x. hashmapCount traits x in
+let insert = lam x. hashmapInsert traits x in
+let remove = lam x. hashmapRemove traits x in
+let keys = lam x. hashmapKeys traits x in
+let values = lam x. hashmapValues traits x in
 
-let m = empty in
+let m = empty () in
 
 utest count m with 0 in
 utest mem "foo" m with false in
@@ -343,7 +344,7 @@ recursive let populate = lam hm. lam i.
     populate (insert key i hm)
              (addi i 1)
 in
-let m = populate (empty) 0 in
+let m = populate (empty ()) 0 in
 
 utest count m with n in
 

--- a/stdlib/list.mc
+++ b/stdlib/list.mc
@@ -24,12 +24,13 @@ let listFind : all a. (a -> Bool) -> List a -> Option a = lam p. lam li.
     end
   in find li
 
-let listFromSeq : all a. [a] -> List a =
+let listFromSeq : all a. [a] -> List a = lam l.
   recursive let build = lam acc. lam s.
     match s with mid ++ [last] then
       build (listCons last acc) mid
     else acc
-  in build listEmpty
+  in
+  build listEmpty l
 
 let listFoldl : all a. all b. (b -> a -> b) -> b -> List a -> b = lam f.
   recursive let fold = lam acc. lam li.
@@ -39,8 +40,8 @@ let listFoldl : all a. all b. (b -> a -> b) -> b -> List a -> b = lam f.
     end
   in fold
 
-let listReverse : all a. List a -> List a =
-  listFoldl (lam acc. lam x. listCons x acc) listEmpty
+let listReverse : all a. List a -> List a = lam l.
+  listFoldl (lam acc. lam x. listCons x acc) listEmpty l
 
 let listMap : all a. all b. (a -> b) -> List a -> List b = lam f. lam li.
   recursive let map = lam acc. lam li.
@@ -51,7 +52,7 @@ let listMap : all a. all b. (a -> b) -> List a -> List b = lam f. lam li.
   in
   listReverse (map listEmpty li)
 
-let listToSeq : all a. List a -> [a] = listFoldl snoc []
+let listToSeq : all a. List a -> [a] = lam l. listFoldl snoc [] l
 
 let listEq : all a. all b. (a -> b -> Bool) -> List a -> List b -> Bool =
   lam eqElem.

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -221,13 +221,22 @@ let mapUpdate : all k. all v. k -> (Option v -> Option v) -> Map k v -> Map k v
     case None _ then mapRemove k m
     end
 
+-- `mapGetMin m` returns the smallest key-value pair of `m`, or None ()
+-- if the map is empty.
+let mapGetMin : all k. all v. Map k v -> Option (k, v) =
+  lam m.
+    if mapIsEmpty m then None ()
+    else
+      use AVLTreeImpl in
+      match avlSplitFirst m.root with (k, v, _) in
+      Some (k, v)
+
 mexpr
 
 let m = mapEmpty subi in
 
-utest
-  match mapChoose m with None _ then true else false
-with true in
+utest mapChoose m with None () in
+utest mapGetMin m with None () in
 
 utest mapLookupOrElse (lam. 2) 1 m with 2 in
 utest mapLookupApplyOrElse (lam. 2) (lam. 3) 1 m with 3 in
@@ -355,5 +364,7 @@ utest
        m)
   with [(1, "1"), (2, "22"), (3, "3")]
 in
+
+utest mapGetMin m with Some (1, "1") in
 
 ()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -234,7 +234,9 @@ utest mapLookupApplyOrElse (lam. 2) (lam. 3) 1 m with 3 in
 utest mapLength m with 0 in
 utest mapIsEmpty m with true in
 
-utest mapLookup 1 m with None () using optionEq eqString in
+utest mapLookup 1 m with None () using optionEq eqi in
+
+let m = mapEmpty subi in
 
 let m = mapInsert 1 "1" m in
 let m = mapInsert 2 "2" m in

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -101,7 +101,7 @@ let tycon_ = lam s.
 
 let ntyvar_ = use VarTypeAst in
   lam n.
-  TyVar {ident = n, level = 0, info = NoInfo ()}
+  TyVar {ident = n, info = NoInfo ()}
 
 let tyvar_ =
   lam s.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1409,22 +1409,17 @@ lang ConTypeAst = Ast
   | TyCon r -> r.info
 end
 
--- A Level denotes the nesting level of the let that a type variable is introduced by
-type Level = Int
-
 lang VarTypeAst = Ast
   syn Type =
   -- Rigid type variable
   | TyVar  {info     : Info,
-            ident    : Name,
-            level    : Level}
+            ident    : Name}
 
   sem tyWithInfo (info : Info) =
   | TyVar t -> TyVar {t with info = info}
 
   sem infoTy =
   | TyVar t -> t.info
-
 end
 
 lang VarSortAst

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -270,8 +270,7 @@ lang BootParser = MExprAst + ConstTransformer
            ident = gname t 0}
   | 210 /-TyVar-/ ->
     TyVar {info = ginfo t 0,
-           ident = gname t 0,
-           level = 0}
+           ident = gname t 0}
   | 211 /-TyApp-/ ->
     TyApp {info = ginfo t 0,
            lhs = gtype t 0,

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -789,13 +789,16 @@ utest liftLambdas liftMatchEls with expected using eqExpr in
 let conAppLift = preprocess (bindall_ [
   type_ "Tree" [] (tyvariant_ []),
   condef_ "Leaf" (tyarrow_ tyint_ (tycon_ "Tree")),
-  conapp_ "Leaf" fapp
+  ulet_ "x" (conapp_ "Leaf" fapp),
+  unit_
 ]) in
 let expected = preprocess (bindall_ [
   type_ "Tree" [] (tyvariant_ []),
   condef_ "Leaf" (tyarrow_ tyint_ (tycon_ "Tree")),
   fdef,
-  conapp_ "Leaf" (app_ (var_ "f") (int_ 1))]) in
+  ulet_ "x" (conapp_ "Leaf" (app_ (var_ "f") (int_ 1))),
+  unit_
+]) in
 
 -- NOTE(larshum, 2022-09-15): Compare using eqString as equality of TmType has
 -- not been implemented.

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -510,7 +510,7 @@ lang LambdaLiftTyAlls = MExprAst
   sem eraseUnboundTypesType bound =
   | TyVar t ->
     match mapLookup t.ident bound with Some (_, info) then
-      TyVar {t with info = info, level = 1}
+      TyVar {t with info = info}
     else TyUnknown {info = t.info}
   | ty -> smap_Type_Type (eraseUnboundTypesType bound) ty
 

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -127,9 +127,9 @@ lang FlexTypePrettyPrint = IdentifierPrettyPrint + VarSortPrettyPrint + FlexType
     case Unbound t then
       match pprintVarName env t.ident with (env, idstr) in
       match getVarSortStringCode indent env idstr t.sort with (env, str) in
-      let flexPrefix =
-        match t.sort with !RecordVar _ then "_" else "" in
-      (env, concat flexPrefix str)
+      let monoPrefix =
+        match t.sort with MonoVar _ then "_" else "" in
+      (env, concat monoPrefix str)
     case Link ty then
       getTypeStringCode indent env ty
     end
@@ -483,7 +483,7 @@ lang FlexTypeGeneralize = Generalize + FlexTypeAst + VarTypeAst
   | TyFlex t ->
     switch deref t.contents
     case Unbound {ident = n, level = k, sort = s} then
-      if gti k lvl then
+      if lti lvl k then
         -- Var is free, generalize
         let f = lam vars. lam ty.
           concat vars (genBase lvl vs bound ty) in
@@ -648,7 +648,8 @@ lang FlexDisableGeneralize = Unify
     switch deref t.contents
     case Unbound r then
       sfold_VarSort_Type (lam. lam ty. weakenTyFlex lvl ty) () r.sort;
-      modref t.contents (Unbound {r with level = lvl})
+      let sort = match r.sort with PolyVar _ then MonoVar () else r.sort in
+      modref t.contents (Unbound {r with level = mini lvl r.level, sort = sort})
     case Link tyL then
       weakenTyFlex lvl tyL
     end

--- a/stdlib/mexpr/utest-generate.mc
+++ b/stdlib/mexpr/utest-generate.mc
@@ -86,7 +86,7 @@ let _conTy = lam id.
   TyCon {ident = id, info = _utestInfo}
 let _varTy = lam id.
   use MExprAst in
-  TyVar {ident = id, level = 1, info = _utestInfo}
+  TyVar {ident = id, info = _utestInfo}
 let _recordTy = lam fields.
   use MExprAst in
   let fields = map (lam f. match f with (s, ty) in (stringToSid s, ty)) fields in

--- a/stdlib/mexpr/value.mc
+++ b/stdlib/mexpr/value.mc
@@ -1,0 +1,131 @@
+-- Miking is licensed under the MIT license.
+-- Copyright (C) David Broman. See file LICENSE.txt
+--
+-- Functions for determining whether a term is a syntactic value.
+
+include "ast.mc"
+include "ast-builder.mc"
+
+-- We define values and "guarded" values, following the FreezeML
+-- paper (see type-check.mc).  Value terms are syntactic values and
+-- terms where no subterm contains a function application.
+-- "Guarded" values are value terms which have no frozen variable in
+-- tail position, i.e., whose type is guaranteed to have no leading
+-- quantifiers.
+type Guarded
+con Val  : () -> Guarded
+con GVal : () -> Guarded
+
+lang IsValue = Ast
+  sem isValue : Guarded -> Expr -> Bool
+  sem isValue (guarded : Guarded) =
+  | t ->
+    sfold_Expr_Expr (lam v. lam tm.
+      if v then isValue (Val ()) tm else false) true t
+end
+
+lang VarIsValue = VarAst
+  sem isValue (guarded : Guarded) =
+  | TmVar t ->
+    switch guarded
+    case Val () then true
+    case GVal () then not t.frozen
+    end
+end
+
+lang AppIsValue = AppAst
+  sem isValue (guarded : Guarded) =
+  | TmApp t -> false
+end
+
+lang LamIsValue = LamAst
+  sem isValue (guarded : Guarded) =
+  | TmLam t -> true
+end
+
+lang LetIsValue = LetAst
+  sem isValue (guarded : Guarded) =
+  | TmLet t ->
+    if isValue (Val ()) t.body then isValue guarded t.inexpr
+    else false
+end
+
+lang RecLetsIsValue = RecLetsAst
+  sem isValue (guarded : Guarded) =
+  | TmRecLets t ->
+    if forAll (lam b. isValue (Val ()) b.body) t.bindings then isValue guarded t.inexpr
+    else false
+end
+
+lang TypeIsValue = TypeAst
+  sem isValue (guarded : Guarded) =
+  | TmType t -> isValue guarded t.inexpr
+end
+
+lang DataIsValue = DataAst
+  sem isValue (guarded : Guarded) =
+  | TmConDef t -> isValue guarded t.inexpr
+end
+
+lang MatchIsValue = MatchAst
+  sem isValue (guarded : Guarded) =
+  | TmMatch t ->
+    if isValue (Val ()) t.target then
+      if isValue guarded t.thn then isValue guarded t.els
+      else false
+    else false
+end
+
+lang UtestIsValue = UtestAst
+  sem isValue (guarded : Guarded) =
+  | TmUtest t -> isValue guarded t.next
+end
+
+lang ExtIsValue = ExtAst
+  sem isValue (guarded : Guarded) =
+  | TmExt t -> isValue guarded t.inexpr
+end
+
+lang MExprIsValue =
+  MExprAst + IsValue +
+  VarIsValue + AppIsValue + LamIsValue + LetIsValue + RecLetsIsValue +
+  TypeIsValue + DataIsValue + MatchIsValue + UtestIsValue + ExtIsValue
+end
+
+mexpr
+
+use MExprIsValue in
+
+-- Variables
+utest isValue (Val ()) (var_ "a") with true in
+utest isValue (GVal ()) (var_ "a") with true in
+
+utest isValue (Val ()) (freeze_ (var_ "a")) with true in
+utest isValue (GVal ()) (freeze_ (var_ "a")) with false in
+
+-- Constants
+utest isValue (GVal ()) (int_ 0) with true in
+
+-- Application
+utest isValue (Val ()) (app_ (var_ "a") (var_ "b")) with false in
+
+-- Lambda
+utest isValue (GVal ()) (ulam_ "x" (app_ (var_ "x") (var_ "b"))) with true in
+
+-- Let
+utest isValue (Val ()) (bind_ (ulet_ "f" (ulam_ "x" (var_ "x")))
+                          (freeze_ (var_ "f"))) with true in
+utest isValue (GVal ()) (bind_ (ulet_ "f" (ulam_ "x" (var_ "x")))
+                          (freeze_ (var_ "f"))) with false in
+utest isValue (Val ()) (bind_ (ulet_ "f" (app_ (var_ "y") (var_ "x")))
+                          (var_ "f")) with false in
+
+-- Record
+utest isValue (GVal ()) (utuple_ [freeze_ (var_ "x"), int_ 0]) with true in
+utest isValue (Val ()) (utuple_ [app_ (var_ "y") (var_ "x"), int_ 0]) with false in
+
+-- Utest
+utest isValue (GVal ()) (utest_ (app_ (var_ "y") (var_ "x"))
+                           (int_ 0) (int_ 0)) with true in
+
+()

--- a/stdlib/parser-combinators.mc
+++ b/stdlib/parser-combinators.mc
@@ -66,7 +66,7 @@ let runParser : all a. Filename -> Parser a -> String -> ParseResult a =
   p (input, (initPos f))
 
 -- Run a parser without a current file.
-let testParser : all a. Parser a -> String -> ParseResult a = runParser ""
+let testParser : all a. Parser a -> String -> ParseResult a = lam p. runParser "" p
 
 -- Fail parsing with custom info
 let fail : all a. String -> String -> Parser a = lam found. lam expected. lam st.
@@ -143,7 +143,7 @@ let bind : all a. all b. Parser a -> (a -> Parser b) -> Parser b =
 -- Control combinators
 
 -- Run parser and ignore result
-let void : all a. Parser a -> Parser () = apl (pure ())
+let void : all a. Parser a -> Parser () = lam p. apl (pure ()) p
 
 -- Monadic conditional. `when b p` runs `p` (ignoring the
 -- result) if `b` is true.
@@ -534,7 +534,7 @@ let ws = void (many (alt lineComment spaces1)) in
 -- token : Parser a -> Parser a
 --
 -- `token p` parses `p` and any trailing whitespace or comments.
-let token = lexToken ws in
+let token = lam p. lexToken ws p in
 
 -- string : String -> Parser String
 --

--- a/stdlib/parser/breakable.mc
+++ b/stdlib/parser/breakable.mc
@@ -638,7 +638,8 @@ let _popFromQueue
         modref queue.lowestIndex (length (deref queue.values));
         None ()
     in work values
-let _cachedQueue = _newQueue ()
+-- TODO(aathn, 2023-05-09): Change the queue implementation and remove this unsafeCoerce
+let _cachedQueue : all self. BreakableQueue self = unsafeCoerce (_newQueue ())
 
 let _addLOpen
   : all self. all rstyle. Config self
@@ -965,7 +966,7 @@ let breakableReportAmbiguities
           let r = match _rightChildrenP p with Some children
             then resolveTopMany rIdxs (_includesRight parAllowed) children
             else [[]] in
-          let f = info.toTok selfImportant in
+          let f = lam x. info.toTok selfImportant x in
           let here = _callWithSelfP #frozen"f" p in
           seqLiftA2 (lam l. lam r. join [l, here, r]) l r
       let resolveTopMany : [Int] -> Bool -> [PermanentNode self] -> [[tokish]] =

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -130,6 +130,7 @@ lang ParserConcrete = ParserBase
   | TokParsed t -> TokSpec (tokToRepr t)
   | LitParsed x -> LitSpec {lit = x.lit}
 
+  sem parsedMatchesSpec : all state. all prodLabel. SpecSymbol Token TokenRepr state prodLabel -> ParsedSymbol Token -> Bool
   sem parsedMatchesSpec spec =
   | TokParsed t -> match spec with TokSpec repr then tokKindEq repr t else false
   | LitParsed x -> match spec with LitSpec s then eqString x.lit s.lit else false

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -130,7 +130,6 @@ lang ParserConcrete = ParserBase
   | TokParsed t -> TokSpec (tokToRepr t)
   | LitParsed x -> LitSpec {lit = x.lit}
 
-  sem parsedMatchesSpec : all state. all prodLabel. SpecSymbol Token TokenRepr state prodLabel -> ParsedSymbol Token -> Bool
   sem parsedMatchesSpec spec =
   | TokParsed t -> match spec with TokSpec repr then tokKindEq repr t else false
   | LitParsed x -> match spec with LitSpec s then eqString x.lit s.lit else false

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -201,7 +201,6 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
         result.ok (TyVar
           { ident = x.name.v
           , info = x.info
-          , level = 0
           })
       case RecordExpr (x & {fields = []}) then
         result.ok (tyWithInfo x.info tyunit_)

--- a/stdlib/pmexpr/ast.mc
+++ b/stdlib/pmexpr/ast.mc
@@ -144,7 +144,7 @@ lang PMExprAst =
   | TmFlatten t ->
     let e = typeCheckExpr env t.e in
     let elemTy = newvar env.currentLvl t.info in
-    unify [infoTm e, t.info] (tyTm e) (ityseq_ t.info (ityseq_ t.info elemTy));
+    unify env [infoTm e, t.info] (tyTm e) (ityseq_ t.info (ityseq_ t.info elemTy));
     TmFlatten {{t with e = e}
                   with ty = TySeq {ty = elemTy, info = t.info}}
   | TmMap2 t ->
@@ -154,9 +154,9 @@ lang PMExprAst =
     let aElemTy = newvar env.currentLvl t.info in
     let bElemTy = newvar env.currentLvl t.info in
     let outElemTy = newvar env.currentLvl t.info in
-    unify [infoTm as, t.info] (tyTm as) (ityseq_ t.info aElemTy);
-    unify [infoTm bs, t.info] (tyTm bs) (ityseq_ t.info bElemTy);
-    unify [infoTm f, t.info] (tyTm f)
+    unify env [infoTm as, t.info] (tyTm as) (ityseq_ t.info aElemTy);
+    unify env [infoTm bs, t.info] (tyTm bs) (ityseq_ t.info bElemTy);
+    unify env [infoTm f, t.info] (tyTm f)
       (ityarrow_ t.info aElemTy (ityarrow_ t.info bElemTy outElemTy));
     TmMap2 {{{{t with f = f}
                  with as = as}
@@ -167,8 +167,8 @@ lang PMExprAst =
     let ne = typeCheckExpr env t.ne in
     let as = typeCheckExpr env t.as in
     let accType = tyTm ne in
-    unify [infoTm as, t.info] (tyTm as) (ityseq_ t.info accType);
-    unify [infoTm f, t.info] (tyTm f)
+    unify env [infoTm as, t.info] (tyTm as) (ityseq_ t.info accType);
+    unify env [infoTm f, t.info] (tyTm f)
       (ityarrow_ t.info accType (ityarrow_ t.info accType accType));
     TmParallelReduce {{{{t with f = f}
                            with ne = ne}
@@ -178,8 +178,8 @@ lang PMExprAst =
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
+    unify env [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
     TmLoop {{{t with n = n}
                 with f = f}
                 with ty = unitType}
@@ -187,8 +187,8 @@ lang PMExprAst =
     let ne = typeCheckExpr env t.ne in
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
-    unify [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm ne)
+    unify env [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm ne)
                                          (ityarrow_ t.info (tyTm n) (tyTm ne)));
     TmLoopAcc {{{{t with ne = ne}
                     with n = n}
@@ -198,15 +198,15 @@ lang PMExprAst =
     let n = typeCheckExpr env t.n in
     let f = typeCheckExpr env t.f in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
-    unify [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
+    unify env [infoTm n, t.info] (tyTm n) (tyWithInfo t.info tyint_);
+    unify env [infoTm f, t.info] (tyTm f) (ityarrow_ t.info (tyTm n) unitType);
     TmParallelLoop {{{t with n = n}
                         with f = f}
                         with ty = unitType}
   | TmPrintFloat t ->
     let e = typeCheckExpr env t.e in
     let unitType = tyWithInfo t.info tyunit_ in
-    unify [infoTm e, t.info] (tyTm e) (tyWithInfo t.info tyfloat_);
+    unify env [infoTm e, t.info] (tyTm e) (tyWithInfo t.info tyfloat_);
     TmPrintFloat {{t with e = e} with ty = unitType}
   | TmParallelSizeCoercion t ->
     let e = typeCheckExpr env t.e in

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -192,7 +192,8 @@ let zipWithIndex : all a. all b. all c. (Int -> a -> b -> c) -> [a] -> [b] -> [c
 utest zipWithIndex (lam i. lam a. lam b. addi i (addi a b)) [100, 200, 300] [4000, 5000, 6000]
       with [4100, 5201, 6302] using eqSeq eqi
 
-let zip : all a. all b. [a] -> [b] -> [(a, b)] = zipWith (lam x. lam y. (x, y))
+let zip : all a. all b. [a] -> [b] -> [(a, b)] =
+  lam l1. lam l2. zipWith (lam x. lam y. (x, y)) l1 l2
 
 -- Accumulating maps
 let mapAccumL : all a. all b. all c. (a -> b -> (a, c)) -> a -> [b] -> (a, [c]) =
@@ -219,7 +220,7 @@ utest mapAccumR (lam acc. lam x. ((cons x acc), x)) [] [1,2,3]
 with ([1,2,3], [1,2,3])
 
 let unzip : all a. all b. [(a, b)] -> ([a], [b]) =
-  mapAccumL (lam l. lam p : (a, b). (snoc l p.0, p.1)) []
+  lam l. mapAccumL (lam l. lam p : (a, b). (snoc l p.0, p.1)) [] l
 
 -- `iter2 f seq1 seq1` iterativly applies `f` to the first
 -- min(`length seq1`, `length seq2`) elements in `seq1` and `seq2`.

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -58,10 +58,10 @@ let setToSeq : all a. Set a -> [a] = lam s. mapKeys s
 
 -- Two sets are equal, where equality is determined by the compare function.
 -- Both sets are assumed to have the same equality function.
-let setEq : all a. Set a -> Set a -> Bool = mapEq (lam. lam. true)
+let setEq : all a. Set a -> Set a -> Bool = lam m1. lam m2. mapEq (lam. lam. true) m1 m2
 
 -- `setCmp` provides comparison over sets.
-let setCmp : all a. Set a -> Set a -> Int = mapCmp (lam. lam. 0)
+let setCmp : all a. Set a -> Set a -> Int = lam m1. lam m2. mapCmp (lam. lam. 0) m1 m2
 
 -- `setChoose s` chooses one element from the set `s`, giving `None ()` if `s`
 -- is empty.

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -114,13 +114,13 @@ let sysRunCommandWithTimingTimeout : Option Float -> [String] -> String -> Strin
 
 utest sysRunCommandWithTimingTimeout (None ()) ["echo -n \"\""] "" "."; () with ()
 
-let sysRunCommandWithTimingFileIO : [String] -> String -> String -> (Float, ExecResult) =
+let sysRunCommandWithTimingFileIO : [String] -> String -> String -> String -> String -> (Float, ReturnCode) =
   sysRunCommandWithTimingTimeoutFileIO (None ())
 
 let sysRunCommandWithTiming : [String] -> String -> String -> (Float, ExecResult) =
     sysRunCommandWithTimingTimeout (None ())
 
-let sysRunCommandFileIO : [String] -> String -> String -> ExecResult =
+let sysRunCommandFileIO : [String] -> String -> String -> String -> String -> ReturnCode =
   lam cmd. lam stdinFile. lam stdoutFile. lam stderrFile. lam cwd.
     match sysRunCommandWithTimingFileIO cmd stdinFile stdoutFile stderrFile cwd
     with (_, res) then res else never

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -192,8 +192,8 @@ lam f. lam tcreate. lam shape. lam seq.
 
 let tensorOfSeqExn
   : all a. ([Int] -> ([Int] -> a) -> Tensor[a]) -> [Int] -> [a] -> Tensor[a] =
-  tensorOfSeqOrElse
-    (lam. error "Empty seq in tensorOfSeqExn")
+  lam x.
+  tensorOfSeqOrElse (lam. error "Empty seq in tensorOfSeqExn") x
 
 -- Construct a sequence from a rank 1 tensor `t`.
 let tensorToSeqOrElse : all a. (() -> [a]) -> Tensor[a] -> [a] =
@@ -205,8 +205,8 @@ lam f. lam t.
                then Some (tensorGetExn t [i], addi i 1) else None ())
             0
 
-let tensorToSeqExn : all a. Tensor[a] -> [a] =
-  tensorToSeqOrElse (lam. error "Not rank 1 tensor in tensorToSeqExn")
+let tensorToSeqExn : all a. Tensor[a] -> [a] = lam x.
+  tensorToSeqOrElse (lam. error "Not rank 1 tensor in tensorToSeqExn") x
 
 utest tensorToSeqExn (tensorOfSeqExn tensorCreateCArrayInt [0] [])
 with []
@@ -257,8 +257,8 @@ lam f. lam g. lam t1. lam t2.
       v1
   else f ()
 
-let tensorMapExn =
-  tensorMapOrElse (lam. error "Tensor shape mismatch in tensorMap")
+let tensorMapExn = lam x.
+  tensorMapOrElse (lam. error "Tensor shape mismatch in tensorMap") x
 
 utest
   let t1 = tensorCreateDense [0] (lam. []) in
@@ -337,8 +337,8 @@ lam f. lam g. lam t1. lam t2.
       v1
   else f ()
 
-let tensorMapiExn =
-  tensorMapiOrElse (lam. error "Tensor shape mismatch in tensorMap")
+let tensorMapiExn = lam x.
+  tensorMapiOrElse (lam. error "Tensor shape mismatch in tensorMap") x
 
 utest
   let t1 = tensorOfSeqExn tensorCreateDense [2, 2]

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -132,7 +132,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot + TypeCheck
   | TmHole t ->
     let default = typeCheckExpr env t.default in
     let ty = hty t.info t.inner in
-    unify [t.info] ty (tyTm default);
+    unify env [t.info] ty (tyTm default);
     TmHole {{t with default = default}
                with ty = ty}
 

--- a/test/mexpr/seq-test.mc
+++ b/test/mexpr/seq-test.mc
@@ -196,28 +196,28 @@ with [(0, 0), (1, 1), (2, 2)] in
 -- The rest of the file contains various test computions with sequences
 
 -- map
-let map = fix (lam map. lam f. lam seq.
+let map = lam l. fix (lam map. lam f. lam seq.
   if eqi (length seq) 0 then []
   else cons (f (head seq)) (map f (tail seq))
-) in
+) l in
 utest map (lam x. addi x 1) [3,4,8,9,20] with [4,5,9,10,21] in
 utest map (lam x. addi x 1) [] with [] using eqSeq eqi in
 
 -- foldl
-let foldl = fix (lam foldl. lam f. lam acc. lam seq.
+let foldl = lam l. fix (lam foldl. lam f. lam acc. lam seq.
     if eqi (length seq) 0 then acc
     else foldl f (f acc (head seq)) (tail seq)
-) in
+) l in
 utest foldl addi 0 [1,2,3,4,5] with 15 in
 utest foldl addi 0 [] with 0 in
 utest map (foldl addi 0) [[1,2,3], [], [1,3,5,7]] with [6, 0, 16] in
 
 -- zipwith
-let zipwith = fix (lam zipwith. lam f. lam seq1. lam seq2.
+let zipwith = lam l. fix (lam zipwith. lam f. lam seq1. lam seq2.
     if eqi (length seq1) 0 then []
     else if eqi (length seq2) 0 then []
     else cons (f (head seq1) (head seq2)) (zipwith f (tail seq1) (tail seq2))
-) in
+) l in
 utest zipwith addi [1,2,3,4,5] [5, 4, 3, 2, 1] with [6,6,6,6,6] in
 utest zipwith (zipwith addi) [[1,2], [], [10, 10, 10]] [[3,4,5], [1,2], [2, 3]]
       with [[4,6], [], [12, 13]] in


### PR DESCRIPTION
This PR makes a number of improvements to the type checker, fixing several bugs and previously known soundness problems.

- Fix a bug where bound type variables could escape their scope.
  The level-based approach to scope checking ensures type variables do not escape their lexical scope (i.e., their let binder), but there was no check ensuring that a unification does not bring a type variable out of its forall binder _within_ the type. For example, given the type `(all b. b -> %a) -> %a` (where `%a` denotes a unification variable), there was nothing stopping `%a` from being unified with `b`, giving the type `(all b. b -> b) -> b` where the last `b` is out of scope.  In fact, we never want to let flexible variables be unified with rigid variables whose binder is not outermost in the type.
- Fix a bug where type variables in recursive lets could escape to one of the parallel binders without being generalized.
  For example, in the program below, the signature of `none` would be inferred to `() -> Option a`, where `a` is out of scope.  This PR fixes the issue by making sure to quantify those variables as well (giving `none` type `all a. () -> Option a` as expected).
```haskell
recursive 
let f : all a. () -> Option a = none
let none = lam. None ()
end
```
- Fix a bug where annotations on polymorphic terms would not be checked correctly.
  The issue was that the type checker would always strip the `all` binders of the annotation before matching it with the inferred type.  Thus, when the inferred type had leading foralls, the check would always fail.  For instance, in the below code, we would try to unify `a -> a` with `all a. a -> a`, giving an error.
```haskell
let id = lam x. x
let f : all a. a -> a = #frozen"id"
```
- Implement the value restriction.
  The value restriction means that polymorphic types may only be inferred for terms with no visible side effects, and is typical of ML-like systems (including OCaml and Standard ML).  For example, in the program below, `x` would get the polymorphic type `all a. a ->  a` as usual, but `y`, which contains a function application, gets type `_a -> _a`, where `_a` is a _weak_ variable representing some fixed but as-of-yet unknown type.
```haskell
let x = lam x. x
let y = x x
```
The typical example where dropping the value restriction allows unsound behavior is the following program where a reference to an empty list is created.
```haskell
let r = ref [] in
modref r [true];
addi (head (deref r)) 1
```
Without the value restriction, `r` gets type `all a. Ref [a]`, meaning that we can treat its contents as having any type, allowing unsound operations like writing a bool and reading an int as in the example.  With the value restriction, `r` instead gets type `Ref [_a]`, where `_a` is determined to `Bool` at the call to `modref`, resulting in a consequent type error at the call to `addi`.
- Add scope check for type constructors.
  Previously, programs like
```haskell
let x =
  type Foo in
  con Foo : () -> Foo in
  Foo ()
```
or
```haskell
let y = ref []
type Foo
con Foo : () -> Foo
modref y (Foo ())
```
were possible.  In the first, a value of the local type `Foo` is returned, giving `x` the type `Foo` no longer in scope.  In the second, a value of type `Foo` is written into `y`, which was defined before the declaration of `Foo`, so that `Foo` again escapes its scope. This PR fixes the issue, using a level-based approach similar to how type variable scopes are handled.  We increment the current level whenever a type `X` is declared, , and check that unification variables are never unified with a type constructor of higher level.  We also check that no values of type `X` are returned from the `inexpr` of `X`.
In particular, this means that the following program is no longer valid:
```haskell
type Foo in
con Foo : () -> Foo in
Foo ()
```