### PR TITLE
Mlang ast for tool

### DIFF
--- a/stdlib/mlang/ast-builder.mc
+++ b/stdlib/mlang/ast-builder.mc
@@ -69,6 +69,7 @@ let decl_nsynn_ = use MLangAst in
   lam n. lam ndefs: [(Name, Type)].
   DeclSyn {ident = n,
            defs = map (lam t. {ident = t.0, tyIdent = t.1}) ndefs,
+           params = [],
            info = NoInfo {}}
 
 let decl_nsyn_ = use MLangAst in

--- a/stdlib/mlang/ast.mc
+++ b/stdlib/mlang/ast.mc
@@ -53,6 +53,7 @@ end
 lang SynDeclAst = DeclAst
   syn Decl =
   | DeclSyn {ident : Name,
+             params : [Name],
              defs : [{ident : Name, tyIdent : Type}],
              info : Info}
 end

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -1,3 +1,4 @@
+include "mlang/ast.mc"
 include "mexpr/eq.mc"
 include "common.mc"
 
@@ -159,47 +160,58 @@ file uses local and temporary definitions of language fragments. These
 are not intended to be public, and should be replaced once we do
 bootstrap MLang.
 
+-- TODO(vipa, 2023-03-09): The previous note is mostly handled at this
+point, but I'm leaving it in place since there are some open questions
+on Info fields and similar things. Search for "NoInfo ()" or
+"nameNoSym" for a large number of places that should probably be
+changed.
+
 -/
 
 type Constructor =
   { name : Name
+  , fragment : Name
   , synType : Name
   , carried : CarriedType
   }
 
-type SemanticFunction =
-  { name : String
-  , ty : Option Type
-  , preCaseArgs : [(Name, Option Type)]
-  , cases : [(Pat, Expr)]
+type SFuncRequest =
+  { synName : Name
+  , target : Type
+  , names :
+    { smapAccumL : Name
+    , smap : Name
+    , sfold : Name
+    }
   }
 
-type LanguageFragment =
-  { name : String
-  , extends : [String]
-  , aliases : [(Name, Type)]
-  , synTypes : Map Name ([Name], [Constructor])
-  , semanticFunctions : [SemanticFunction]
+type FieldAccessorRequest =
+  { synName : Name
+  , field : String
+  , resTy : Type
+  , names :
+    { get : Name
+    , set : Name
+    , mapAccum : Name
+    , map : Name
+    }
   }
 
 type GenInput =
-  { baseName : String
-  , composedName : Option String
-  , fragmentName : Name -> String
+  { baseName : Name
+  , composedName : Option Name
   , constructors : [Constructor]
-  , requestedSFunctions : [(Name, Type)]
-  , fieldAccessors : [(Name, String, Type)]
+  , sfunctions : [SFuncRequest]
+  , fieldAccessors : [FieldAccessorRequest]
   }
 
 lang CarriedTypeBase
   syn CarriedType =
 
-  sem carriedRepr /- : CarriedType -> Type -/ =
-  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) /- : CarriedType -> Option (Name -> Name -> Expr) -/ =
+  sem carriedRepr : CarriedType -> Type
+  sem carriedSMapAccumL : (Expr -> Expr -> Expr) -> Type -> CarriedType -> Option (Name -> Name -> Expr)
 end
 
-let _equalTypes = use MExprEq in eqType
-let _typeToString = use MExprPrettyPrint in lam ty. (getTypeStringCode 0 pprintEnvEmpty ty).1
 let _nulet_ = lam n. lam body. lam inexpr. use LetAst in TmLet
   { ident = n
   , body = body
@@ -210,298 +222,235 @@ let _nulet_ = lam n. lam body. lam inexpr. use LetAst in TmLet
   , ty = tyunknown_
   }
 
-let _pprintSemanticFunction
-  : SemanticFunction
-  -> String
-  = lam func. use MExprPrettyPrint in
-    match func with {name = name, preCaseArgs = preCaseArgs, cases = cases, ty = ty} then
-      let pprintArg = lam env. lam arg.
-        match arg with (name, ty) then
-          match pprintVarName env name with (env, str) then
-            match ty with Some ty then
-              match getTypeStringCode 2 env ty with (env, ty) in
-              (env, join [" (", str, " : ", ty, ")"])
-            else (env, cons ' ' str)
-          else never
-        else never in
-      let pprintCase = lam env. lam aCase.
-        match aCase with (pat, expr) then
-          match getPatStringCode 4 env pat with (env, pat) then
-            match pprintCode 4 env expr with (env, expr) then
-              (env, join ["  | ", pat, " ->\n    ", expr, "\n"])
-            else never
-          else never
-        else never in
-      let env = pprintEnvEmpty in
-      let temp =
-        match ty with Some ty then
-          match getTypeStringCode 2 env ty with (env, ty) in
-          (env, join ["  sem ", name, " : ", ty, "\n"])
-        else (env, "") in
-      match temp with (env, sig) in
-      let temp =
-        match cases with ![] then
-          match mapAccumL pprintArg env preCaseArgs with (env, args) in
-          match mapAccumL pprintCase env cases with (env, cases) in
-          let str = join
-            [ "  sem ", name
-            , join args
-            , " =\n"
-            , join cases
-            ] in
-          (env, str)
-        else (env, "") in
-      match temp with (env, impl) in
-      -- NOTE(vipa, 2022-03-31): In an actual later implementation
-      -- we'd presumably pass on the environment here as well, but for
-      -- now we just return the string
-      concat sig impl
-    else never
-
-lang CarriedTypeHelpers = CarriedTypeBase
-  sem _pprintLanguageFragment =
-  | x ->
-    match let x: LanguageFragment = x in x with
-      { name = name
-      , extends = extends
-      , aliases = aliases
-      , synTypes = synTypes
-      , semanticFunctions = semanticFunctions
-      }
-    then
-      let extends = match extends
-        with [] then ""
-        else concat " = " (strJoin " + " extends) in
-      let pprintConstructor = lam constructor: Constructor.
-        match constructor with {name = name, carried = carried} then
-          join ["\n  | ", nameGetStr name, " ", _typeToString (carriedRepr carried)]
-        else never in
-      let aliases = map
-        (lam binding. match binding with (name, ty) in
-          join [ "  type ", nameGetStr name, " = ", _typeToString ty, "\n"])
-        aliases in
-      let synDefns = map
-        (lam binding.
-          match binding with (synType, (params, constructors)) then
-            join
-              [ "  syn ", nameGetStr synType, join (map (lam x. cons ' ' (nameGetStr x)) params), " ="
-              , join (map pprintConstructor constructors)
-              , "\n"
-              ]
-          else never)
-        (mapBindings synTypes) in
-      join
-        [ "lang ", name, extends , "\n"
-        , join aliases
-        , "\n"
-        , join synDefns
-        , "\n"
-        , strJoin "\n" (map _pprintSemanticFunction semanticFunctions)
-        , "\nend"
-        ]
-    else never
-
-  sem _mkSmapAccumL (synType : Name) (targetTy : Type) =
+lang CarriedTypeHelpers = CarriedTypeBase + SemDeclAst + PrettyPrint
+  sem _mkSmapAccumL : SFuncRequest -> Constructor -> Option Decl
+  sem _mkSmapAccumL request =
   | constructor ->
-    let constructor: Constructor = constructor in
-    if nameEq synType constructor.synType then
-      let fName = nameSym "f" in
-      match carriedSMapAccumL (appf2_ (nvar_ fName)) targetTy constructor.carried with Some mkNew then
-        let accName = nameSym "acc" in
-        let valName = nameSym "x" in
-        Some
-          { name = join ["smapAccumL_", nameGetStr synType, "_", _typeToString targetTy]
-          , ty = None ()
-          , preCaseArgs =
-            [ (fName, None ())
-            , (accName, None ())
-            ]
+    if nameEq request.synName constructor.synType then
+      let fName = nameNoSym "f" in
+      match carriedSMapAccumL (appf2_ (nvar_ fName)) request.target constructor.carried with Some mkNew then
+        let accName = nameNoSym "acc" in
+        let valName = nameNoSym "x" in
+        let decl = DeclSem
+          { ident = request.names.smapAccumL
+          , tyAnnot = tyunknown_
+          , tyBody = tyunknown_  -- TODO(vipa, 2023-03-09): Provide a proper type here
+          , args = [{ident = fName, tyAnnot = tyunknown_}, {ident = accName, tyAnnot = tyunknown_}]
           , cases =
-            [ ( npcon_ constructor.name (npvar_ valName)
-              , match_
+            [ { pat = npcon_ constructor.name (npvar_ valName)
+              , thn = match_
                 (mkNew accName valName)
                 (ptuple_ [npvar_ accName, npvar_ valName])
                 (utuple_ [nvar_ accName, nconapp_ constructor.name (nvar_ valName)])
                 never_
-              )
+              }
             ]
-          }
+          , info = NoInfo ()  -- TODO(vipa, 2023-03-09): Info
+          } in
+        Some decl
       else None ()
     else None ()
 
-  sem _mkAccess : Name -> String -> Constructor -> [SemanticFunction]
-  sem _mkAccess synType field =
+  sem _mkAccess : FieldAccessorRequest -> Constructor -> [Decl]
+  -- sem _mkAccess synType field =
+  sem _mkAccess request =
   | constructor ->
-    if nameEq constructor.synType synType then
+    if nameEq constructor.synType request.synName then
       let targetName = nameSym "target" in
-      let valName = nameSym "val" in
-      let getf =
-        { name = join ["get_", nameGetStr synType, "_", field]
-        , ty = None ()
-        , preCaseArgs = []
+      let valName = nameNoSym "val" in
+      let getf = DeclSem
+        { ident = request.names.get
+        , tyAnnot = tyunknown_
+        , tyBody = tyunknown_  -- TODO(vipa, 2023-03-09): provide a proper type here
+        , args = []
         , cases =
-          [ ( npcon_ constructor.name (npvar_ targetName)
-            , recordproj_ field (nvar_ targetName)
-            )
+          [ { pat = npcon_ constructor.name (npvar_ targetName)
+            , thn = recordproj_ request.field (nvar_ targetName)
+            }
           ]
+        , info = NoInfo () -- TODO(vipa, 2023-03-09): Info
         } in
-      let setf =
-        { name = join ["set_", nameGetStr synType, "_", field]
-        , ty = None ()
-        , preCaseArgs = [(valName, None ())]
+      let setf = DeclSem
+        { ident = request.names.set
+        , tyAnnot = tyunknown_
+        , tyBody = tyunknown_  -- TODO(vipa, 2023-03-09): provide a proper type here
+        , args = [{ident = valName, tyAnnot = tyunknown_}]
         , cases =
-          [ ( npcon_ constructor.name (npvar_ targetName)
-            , nconapp_ constructor.name (recordupdate_ (nvar_ targetName) field (nvar_ valName))
-            )
+          [ { pat = npcon_ constructor.name (npvar_ targetName)
+            , thn = nconapp_ constructor.name (recordupdate_ (nvar_ targetName) request.field (nvar_ valName))
+            }
           ]
+        , info = NoInfo () -- TODO(vipa, 2023-03-09): Info
         } in
       [getf, setf]
     else []
-end
 
-let _mkSFuncStubs
-  : Name
-  -> Type
-  -> [SemanticFunction]
-  = lam synType. lam targetTy.
-    let synTy = ntycon_ synType in
-    let suffix = join ["_", nameGetStr synType, "_", _typeToString targetTy] in
-    let fName = nameSym "f" in
-    let accName = nameSym "acc" in
+  sem _mkSFuncStubs : SFuncRequest -> [Decl]
+  sem _mkSFuncStubs = | request ->
+    let synTy = ntycon_ request.synName in
+    let fName = nameNoSym "f" in
+    let accName = nameNoSym "acc" in
     let valName = nameSym "x" in
-    let smapAccumL_ = appf3_ (var_ (concat "smapAccumL" suffix)) in
+    let smapAccumL_ = appf3_ (nvar_ request.names.smapAccumL) in
     let smapAccumL =
-      { name = concat "smapAccumL" suffix
-      , ty = Some (tyall_ "a" (tyarrows_
-        [ tyarrows_ [tyvar_ "a", targetTy, tytuple_ [tyvar_ "a", targetTy]]
+      let ty = tyall_ "a" (tyarrows_
+        [ tyarrows_ [tyvar_ "a", request.target, tytuple_ [tyvar_ "a", request.target]]
         , tyvar_ "a"
         , synTy
         , tytuple_ [tyvar_ "a", synTy]
-        ]))
-      , preCaseArgs =
-        [ (fName, None ())
-        , (accName, None ())
+        ])
+      in DeclSem
+      { ident = request.names.smapAccumL
+      , tyAnnot = ty
+      , tyBody = ty
+      , args =
+        [ {ident = fName, tyAnnot = tyunknown_}
+        , {ident = accName, tyAnnot = tyunknown_}
         ]
       , cases =
-        [ (npvar_ valName, utuple_ [nvar_ accName, nvar_ valName])
+        [ {pat = npvar_ valName, thn = utuple_ [nvar_ accName, nvar_ valName]}
         ]
+      , info = NoInfo ()
       } in
     let smap =
-      { name = concat "smap" suffix
-      , ty = Some (tyarrows_
-        [ tyarrow_ targetTy targetTy
+      let ty = tyarrows_
+        [ tyarrow_ request.target request.target
         , synTy
         , synTy
-        ])
-      , preCaseArgs =
-        [ (fName, None ())
+        ]
+      in DeclSem
+      { ident = request.names.smap
+      , tyAnnot = ty
+      , tyBody = ty
+      , args =
+        [ {ident = fName, tyAnnot = tyunknown_}
         ]
       , cases =
-        [ ( npvar_ valName
-          , tupleproj_ 1
+        [ { pat = npvar_ valName
+          , thn = tupleproj_ 1
             (smapAccumL_
               (ulam_ "" (nulam_ valName (utuple_ [uunit_, appf1_ (nvar_ fName) (nvar_ valName)])))
               uunit_
               (nvar_ valName))
-          )
+          }
         ]
+      , info = NoInfo ()
       } in
     let sfold =
-      { name = concat "sfold" suffix
-      , ty = Some (tyall_ "a" (tyarrows_
-        [ tyarrows_ [tyvar_ "a", targetTy, tyvar_ "a"]
+      let ty = tyall_ "a" (tyarrows_
+        [ tyarrows_ [tyvar_ "a", request.target, tyvar_ "a"]
         , tyvar_ "a"
         , synTy
         , tyvar_ "a"
-        ]))
-      , preCaseArgs =
-        [ (fName, None ())
-        , (accName, None ())
+        ])
+      in DeclSem
+      { ident = request.names.sfold
+      , tyAnnot = ty
+      , tyBody = ty
+      , args =
+        [ {ident = fName, tyAnnot = tyunknown_}
+        , {ident = accName, tyAnnot = tyunknown_}
         ]
       , cases =
-        [ ( npvar_ valName
-          , tupleproj_ 0
+        [ { pat = npvar_ valName
+          , thn = tupleproj_ 0
             (smapAccumL_
               (nulam_ accName (nulam_ valName (utuple_ [appf2_ (nvar_ fName) (nvar_ accName) (nvar_ valName), nvar_ valName])))
               (nvar_ accName)
               (nvar_ valName))
-          )
+          }
         ]
+      , info = NoInfo ()
       } in
     [smapAccumL, smap, sfold]
+end
 
 let _mkFieldStubs
-  : Name
-  -> String
-  -> Type
-  -> [SemanticFunction]
-  = lam synType. lam field. lam ty.
-    let synTy = ntycon_ synType in
-    let suffix = join ["_", nameGetStr synType, "_", field] in
-    let fName = nameSym "f" in
-    let accName = nameSym "acc" in
-    let valName = nameSym "val" in
+  : FieldAccessorRequest -> [Decl]
+  = lam request.
+    use SemDeclAst in
+    let synTy = ntycon_ request.synName in
+    let ty = request.resTy in
+    let fName = nameNoSym "f" in
+    let accName = nameNoSym "acc" in
+    let valName = nameNoSym "val" in
     let targetName = nameSym "target" in
     let getf =
-      { name = concat "get" suffix
-      , ty = Some (tyarrow_ synTy ty)
-      , preCaseArgs = []
+      let ty = tyarrow_ synTy ty
+      in DeclSem
+      { ident = request.names.get
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = []
       , cases = []
+      , info = NoInfo ()
       } in
-    let getf_ = appf1_ (var_ (concat "get" suffix)) in
+    let getf_ = appf1_ (nvar_ request.names.get) in
     let setf =
-      { name = concat "set" suffix
-      , ty = Some (tyarrows_ [ty, synTy, synTy])
-      , preCaseArgs = [(valName, None ())]
+      let ty = tyarrows_ [ty, synTy, synTy]
+      in DeclSem
+      { ident = request.names.set
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = [{ident = valName, tyAnnot = tyunknown_}]
       , cases = []
+      , info = NoInfo ()
       } in
-    let setf_ = appf2_ (var_ (concat "set" suffix)) in
+    let setf_ = appf2_ (nvar_ request.names.set) in
     let mapAccumf =
-      { name = concat "mapAccum" suffix
-      , ty = Some (tyall_ "a" (tyarrows_
+      let ty = tyall_ "a" (tyarrows_
         [ tyarrows_ [tyvar_ "a", ty, tytuple_ [tyvar_ "a", ty]]
         , tyvar_ "a"
         , synTy
         , tytuple_ [tyvar_ "a", synTy]
-        ]))
-      , preCaseArgs = [(fName, None ()), (accName, None ())]
+        ])
+      in DeclSem
+      { ident = request.names.mapAccum
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = [{ident = fName, tyAnnot = tyunknown_}, {ident = accName, tyAnnot = tyunknown_}]
       , cases =
-        [ ( npvar_ targetName
-          , match_
+        [ { pat = npvar_ targetName
+          , thn = match_
             (appf2_ (nvar_ fName) (nvar_ accName) (getf_ (nvar_ targetName)))
             (ptuple_ [npvar_ accName, npvar_ valName])
             (utuple_ [nvar_ accName, setf_ (nvar_ valName) (nvar_ targetName)])
             never_
-          )
+          }
         ]
+      , info = NoInfo ()
       } in
     let mapf =
-      { name = concat "map" suffix
-      , ty = Some (tyarrows_
+      let ty = tyarrows_
         [ tyarrow_ ty ty
         , synTy
         , synTy
-        ])
-      , preCaseArgs = [(fName, None ())]
-      , cases =
-        [ ( npvar_ targetName
-          , setf_ (appf1_ (nvar_ fName) (getf_ (nvar_ targetName))) (nvar_ targetName)
-          )
         ]
+      in DeclSem
+      { ident = request.names.map
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = [{ident = fName, tyAnnot = tyunknown_}]
+      , cases =
+        [ { pat = npvar_ targetName
+          , thn = setf_ (appf1_ (nvar_ fName) (getf_ (nvar_ targetName))) (nvar_ targetName)
+          }
+        ]
+      , info = NoInfo ()
       } in
     [getf, setf, mapAccumf, mapf]
 
-lang CarriedTarget = CarriedTypeBase
+lang CarriedTarget = CarriedTypeBase + Eq
   syn CarriedType =
   | TargetType {targetable : Bool, ty : Type}
 
   sem carriedRepr =
   | TargetType {ty = ty} -> ty
 
-  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) =
+  sem carriedSMapAccumL f targetTy =
   | TargetType {targetable = false} -> None ()
   | TargetType {targetable = true, ty = ty} ->
-    if _equalTypes ty targetTy
+    if eqType ty targetTy
     then Some (lam accName. lam valName. f (nvar_ accName) (nvar_ valName))
     else None ()
 end
@@ -513,7 +462,7 @@ lang CarriedSeq = CarriedTypeBase
   sem carriedRepr =
   | SeqType ty -> tyseq_ (carriedRepr ty)
 
-  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) =
+  sem carriedSMapAccumL f targetTy =
   | SeqType ty ->
     match carriedSMapAccumL f targetTy ty with Some mkNew then Some
       (lam accName. lam valName.
@@ -564,7 +513,7 @@ lang CarriedRecord = CarriedTypeBase
       (lam x. (x.0, carriedRepr x.1))
       tys)
 
-  sem carriedSMapAccumL (f : Expr -> Expr -> Expr) (targetTy : Type) =
+  sem carriedSMapAccumL f targetTy =
   | RecordType fields ->
     let mappingFields = mapOption
       (lam x. optionMap (lam y. (x.0, y)) (carriedSMapAccumL f targetTy x.1))
@@ -635,39 +584,54 @@ let tupleType
   -> CarriedType
   = lam fields. recordType (mapi (lam i. lam field. (int2string i, field)) fields)
 
-lang CarriedTypeGenerate = CarriedTypeHelpers
-  sem mkLanguages : GenInput -> String
+lang CarriedTypeGenerate = CarriedTypeHelpers + LangDeclAst + TypeDeclAst + SynDeclAst
+  sem mkLanguages : GenInput -> [Decl]
   sem mkLanguages =
   | input ->
     let synTypes = foldl
-      (lam acc. lam c: Constructor. mapInsert c.synType ([], []) acc)
-      (mapEmpty nameCmp)
+      (lam acc. lam c: Constructor. setInsert c.synType acc)
+      (setEmpty nameCmp)
       input.constructors in
-    let baseLang =
-      let sfunctions = join
-        (map (lam request: (Unknown, Unknown). _mkSFuncStubs request.0 request.1) input.requestedSFunctions) in
-      let accessors = join
-        (map (lam x. match x with (synty, field, ty) in _mkFieldStubs synty field ty) input.fieldAccessors) in
-      { name = input.baseName
-      , extends = []
-      , aliases = []
-      , synTypes = synTypes
-      , semanticFunctions = concat sfunctions accessors
+    let synTypes = setFold
+      (lam acc. lam synType. cons (DeclSyn {ident = synType, defs = [], info = NoInfo ()}) acc)
+      []
+      synTypes in
+    type DeclLangRec =
+      { ident : Name
+      , includes : [Name]
+      , decls : [Decl]
+      , info : Info
       } in
-    let mkConstructorLang = lam constructor: Constructor.
+    let baseLang: DeclLangRec =
+      let sfunctions = join
+        (map _mkSFuncStubs input.sfunctions) in
+      let accessors = join
+        (map _mkFieldStubs input.fieldAccessors) in
+      { ident = input.baseName
+      , includes = []
+      , decls = join [synTypes, sfunctions, accessors]
+      , info = NoInfo () -- TODO(vipa, 2023-03-09): info?
+      } in
+    let mkConstructorLang : Constructor -> DeclLangRec = lam constructor.
       match constructor with {name = name, synType = synType, carried = carried} then
         let recordTyName = nameNoSym (concat (nameGetStr name) "Record") in
         let sfunctions = mapOption
-          (lam request: (Unknown, Unknown). _mkSmapAccumL request.0 request.1 constructor)
-          input.requestedSFunctions in
+          (lam request. _mkSmapAccumL request constructor)
+          input.sfunctions in
         let accessors = map
-          (lam request. match request with (name, field, _) in _mkAccess name field constructor)
+          (lam request. _mkAccess request constructor)
           input.fieldAccessors in
-        { name = input.fragmentName name
-        , extends = [input.baseName]
-        , aliases = [(recordTyName, carriedRepr carried)]
-        , synTypes = mapInsert synType ([], [{constructor with carried = untargetableType (ntycon_ recordTyName)}]) (mapEmpty nameCmp)
-        , semanticFunctions = concat sfunctions (join accessors)
+        { ident = constructor.fragment
+        , includes = [input.baseName]
+        , decls =
+          join
+            [ [ DeclType {ident = recordTyName, params = [], tyIdent = carriedRepr carried, info = NoInfo ()}
+              , DeclSyn {ident = synType, defs = [{ident = name, tyIdent = ntycon_ recordTyName}], info = NoInfo ()}
+              ]
+            , sfunctions
+            , join accessors
+            ]
+        , info = NoInfo ()
         }
       else never in
     let constructorLangs = map mkConstructorLang input.constructors in
@@ -675,22 +639,24 @@ lang CarriedTypeGenerate = CarriedTypeHelpers
       match input.composedName with Some name then
         snoc
           constructorLangs
-          { name = name
-          , extends = map (lam x: LanguageFragment. x.name) constructorLangs
-          , aliases = []
-          , synTypes = mapEmpty nameCmp
-          , semanticFunctions = []
+          { ident = name
+          , includes = map (lam x. x.ident) constructorLangs
+          , decls = []
+          , info = NoInfo ()
           }
       else constructorLangs in
-    strJoin "\n\n" (map _pprintLanguageFragment (cons baseLang constructorLangs))
+  map (lam x. DeclLang x) (cons baseLang constructorLangs)
 end
 
 lang CarriedBasic = CarriedTypeGenerate + CarriedTarget + CarriedSeq + CarriedRecord + CarriedOption
 end
 
+lang TestLang = CarriedBasic + MExprEq + MExprPrettyPrint
+end
+
 mexpr
 
-use CarriedBasic in
+use TestLang in
 
 let tyInfo = targetableType (tycon_ "Info") in
 let tyName = targetableType (tycon_ "Name") in
@@ -707,12 +673,14 @@ let tyRecord = recordType
 
 let recordConstructor =
   { name = nameSym "TmRecord"
+  , fragment = nameSym "TmRecordAst"
   , synType = nameNoSym "Expr"
   , carried = tyRecord
   } in
 
 let varConstructor =
   { name = nameSym "TmVar"
+  , fragment = nameSym "TmVarAst"
   , synType = nameNoSym "Expr"
   , carried = recordType
     [ ("info", tyInfo)
@@ -723,6 +691,7 @@ let varConstructor =
 
 let seqConstructor =
   { name = nameSym "TmSeq"
+  , fragment = nameSym "TmSeqAst"
   , synType = nameNoSym "Expr"
   , carried = recordType
     [ ("info", tyInfo)
@@ -732,15 +701,14 @@ let seqConstructor =
   } in
 
 let input =
-  { baseName = "MExprBase"
-  , fragmentName = lam s. concat (nameGetStr s) "Ast"
+  { baseName = nameNoSym "MExprBase"
   , constructors = [recordConstructor, varConstructor, seqConstructor]
-  , requestedSFunctions =
-    [ (nameNoSym "Expr", tycon_ "Info")
-    , (nameNoSym "Expr", tycon_ "Expr")
-    , (nameNoSym "Expr", tycon_ "Type")
+  , sfunctions =
+    [ {synName = nameNoSym "Expr", target = tycon_ "Info", names = {smapAccumL = nameNoSym "smapAccumL_EI", smap = nameNoSym "smap_EI", sfold = nameNoSym "sfold_EI"}}
+    , {synName = nameNoSym "Expr", target = tycon_ "Expr", names = {smapAccumL = nameNoSym "smapAccumL_EI", smap = nameNoSym "smap_EI", sfold = nameNoSym "sfold_EI"}}
+    , {synName = nameNoSym "Expr", target = tycon_ "Type", names = {smapAccumL = nameNoSym "smapAccumL_EI", smap = nameNoSym "smap_EI", sfold = nameNoSym "sfold_EI"}}
     ]
-  , composedName = Some "Composed"
+  , composedName = Some (nameNoSym "Composed")
   , fieldAccessors = []
   } in
 
@@ -749,6 +717,7 @@ let res = mkLanguages input in
 
 let recordConstructor =
   { name = nameSym "TmRecord"
+  , fragment = nameSym "TmRecordAst"
   , synType = nameNoSym "Expr"
   , carried = recordType
     [ ("info", untargetableType (tycon_ "Info"))
@@ -762,13 +731,12 @@ let recordConstructor =
     ]
   } in
 let res = mkLanguages
-  { baseName = "MExprBase"
-  , fragmentName = lam s. concat (nameGetStr s) "Ast"
+  { baseName = nameNoSym "MExprBase"
   , constructors = [recordConstructor]
-  , requestedSFunctions =
-    [ (nameNoSym "Expr", tycon_ "Expr")
+  , sfunctions =
+    [ {synName = nameNoSym "Expr", target = tycon_ "Expr", names = {smapAccumL = nameNoSym "smapAccumL_EE", smap = nameNoSym "smap_EE", sfold = nameNoSym "sfold_EE"}}
     ]
-  , composedName = Some "Composed"
+  , composedName = Some (nameNoSym "Composed")
   , fieldAccessors = []
   } in
 -- printLn res;

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -593,7 +593,7 @@ lang CarriedTypeGenerate = CarriedTypeHelpers + LangDeclAst + TypeDeclAst + SynD
       (setEmpty nameCmp)
       input.constructors in
     let synTypes = setFold
-      (lam acc. lam synType. cons (DeclSyn {ident = synType, defs = [], info = NoInfo ()}) acc)
+      (lam acc. lam synType. cons (DeclSyn {ident = synType, params = [], defs = [], info = NoInfo ()}) acc)
       []
       synTypes in
     type DeclLangRec =
@@ -626,7 +626,7 @@ lang CarriedTypeGenerate = CarriedTypeHelpers + LangDeclAst + TypeDeclAst + SynD
         , decls =
           join
             [ [ DeclType {ident = recordTyName, params = [], tyIdent = carriedRepr carried, info = NoInfo ()}
-              , DeclSyn {ident = synType, defs = [{ident = name, tyIdent = ntycon_ recordTyName}], info = NoInfo ()}
+              , DeclSyn {ident = synType, params = [], defs = [{ident = name, tyIdent = ntycon_ recordTyName}], info = NoInfo ()}
               ]
             , sfunctions
             , join accessors

--- a/stdlib/parser/gen-op-ast.mc
+++ b/stdlib/parser/gen-op-ast.mc
@@ -27,50 +27,121 @@ con LAssoc : () -> Assoc
 con RAssoc : () -> Assoc
 
 type GenOperator =
-  { baseConstructorName : Option Name
+  { requiredFragments : [Name]
   , opConstructorName : Name
+  , precedenceKey : Option Name
   , baseTypeName : Name
   , carried : Type
   , mkUnsplit : OperatorUnsplitter
   , assoc : Assoc
   }
+/-
+NOTE(vipa, 2023-05-08): There are a bunch of names in
+`GenOpInput.syns`, so for ease of understanding here are some
+examples, using the current naming scheme for `Expr` in a language
+`Lang` and a key-value pair `(k, v)`:
+
+- `k = Expr`
+- `v.baseFragmentName = LangBaseAst`
+- `v.bad.conName = BadExpr`, which is defined in `v.bad.langName = BadExprAst`
+-/
+type SynDesc =
+  { bad : {conName : Name, langName : Name} -- The constructor created upon parse failure in this syn
+  , grouping : Option (String, String)
+  , precedence : Map (Name, Name) Ordering
+  , baseFragmentName : Name -- The fragment declaring the normal `syn`
+  }
+type FieldLabels =
+  { info : String, terms : String }
 type GenOpInput =
-  { infoFieldLabel : String
-  , termsFieldLabel : String
-  , syns : Map Name {bad : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering}
-  , mkSynName : Name -> String
-  , mkSynAstBaseName : Name -> String
-  , mkConAstName : Name -> String
-  , mkBaseName : String -> String
-  , composedName : String
+  { fieldLabels : FieldLabels
+  , syns : Map Name SynDesc
+  , namingScheme :
+    { synName : String -> String -- e.g., `Expr` -> `ExprOp`
+    , opBaseLangName : String -> String -- e.g., `ExprOp` -> `ExprOpBase`
+    }
+  -- , mkSynName : String -> String -- namingScheme.synName
+  -- , mkSynAstBaseName : String -> String -- This should be provided as a `Name` directly instead
+  -- , mkConAstName : String -> String -- This should be provided as a `Name` directly instead
+  -- , mkBaseName : String -> String -- namingScheme.opBaseLangName
+  , composedName : Name
   , operators : [GenOperator]
-  , extraFragments : [String]
+  , extraFragments : [Name]
+  }
+type InternalSynDesc =
+  { bad : {conName : Name, langName : Name} -- The constructor created upon parse failure in this syn
+  , grouping : Option (String, String)
+  , precedence : Map (Name, Name) Ordering
+  , baseFragmentName : Name -- The fragment declaring the normal `syn`
+  -- The names below are newly generated and not used outside of gen-op-ast (except indirectly).
+  , synName : Name -- The `Name` of the type that contains all operators for this syn
+  , baseOpFragmentName : Name -- The base fragment declaring the `syn` for the operators
+  , functions :
+    { topAllowed : Name
+    , leftAllowed : Name
+    , rightAllowed : Name
+    , groupingsAllowed : Name
+    , parenAllowed : Name
+    , getInfo : Name
+    , getTerms : Name
+    , unsplit : Name
+    }
   }
 
-let _allowedDirectionTy = ntycon_ (nameSym "AllowedDirection")
-let _gneither = nconapp_ (nameSym "GNeither") unit_
-let _gleft = nconapp_ (nameSym "GLeft") unit_
-let _gright = nconapp_ (nameSym "GRight") unit_
-let _geither = nconapp_ (nameSym "GEither") unit_
-let _infoTy = ntycon_ (nameSym "Info")
-let _permanentNodeName = nameSym "PermanentNode"
-let _permanentNode_ = lam ty. tyapp_ (ntycon_ _permanentNodeName) ty
+let _incNames =
+  { v =
+    { allowedDirectionTy = nameNoSym "AllowedDirection"
+    , mergeInfo = nameNoSym "mergeInfo"
+    , foldl = nameNoSym "foldl"
+    , optionMap = nameNoSym "optionMap"
+    , optionBind = nameNoSym "optionBind"
+    , breakableFinalizeParse = nameNoSym "breakableFinalizeParse"
+    , breakableDefaultHighlight = nameNoSym "breakableDefaultHighlight"
+    , optionGetOr = nameNoSym "optionGetOr"
+    , breakableAddAtom = nameNoSym "breakableAddAtom"
+    , breakableAddInfix = nameNoSym "breakableAddInfix"
+    , breakableAddPrefix = nameNoSym "breakableAddPrefix"
+    , breakableAddPostfix = nameNoSym "breakableAddPostfix"
+    }
+  , c =
+    { gneither = nameNoSym "GNeither"
+    , gleft = nameNoSym "GLeft"
+    , gright = nameNoSym "GRight"
+    , geither = nameNoSym "GEither"
+    , noInfo = nameNoSym "NoInfo"
+    , info = nameNoSym "Info"
+    , none = nameNoSym "None"
+    , some = nameNoSym "Some"
+    , atomP = nameNoSym "AtomP"
+    , prefixP = nameNoSym "PrefixP"
+    , postfixP = nameNoSym "PostfixP"
+    , infixP = nameNoSym "InfixP"
+    }
+  , t =
+    { infoTy = nameNoSym "Info"
+    , permanentNode = nameNoSym "PermanentNode"
+    }
+  }
+
+let _allowedDirectionTy = ntycon_ _incNames.v.allowedDirectionTy
+let _gneither = nconapp_ _incNames.c.gneither unit_
+let _gleft = nconapp_ _incNames.c.gleft unit_
+let _gright = nconapp_ _incNames.c.gright unit_
+let _geither = nconapp_ _incNames.c.geither unit_
+let _infoTy = ntycon_ _incNames.t.infoTy
+let _permanentNode_ = lam ty. tyapp_ (ntycon_ _incNames.t.permanentNode) ty
 
 let _mergeInfos_ : [Expr] -> Expr = lam exprs. switch exprs
-  case [] then conapp_ "NoInfo" unit_
+  case [] then nconapp_ _incNames.c.noInfo unit_
   case [x] then x
-  case [a, b] then appf2_ (var_ "mergeInfo") a b
-  case [first] ++ exprs then appf3_ (var_ "foldl") (var_ "mergeInfo") first (seq_ exprs)
+  case [a, b] then appf2_ (nvar_ _incNames.v.mergeInfo) a b
+  case [first] ++ exprs then appf3_ (nvar_ _incNames.v.foldl) (nvar_ _incNames.v.mergeInfo) first (seq_ exprs)
   end
 
 let _nletin_ : Name -> Type -> Expr -> Expr -> Expr
   = lam name. lam ty. lam val. lam body.
     use MExprAst in
     TmLet {ident = name, tyAnnot = ty, tyBody = tyunknown_, body = val, inexpr = body, ty = tyunknown_, info = NoInfo ()}
-
-let _letin_ : String -> Type -> Expr -> Expr -> Expr
-  = lam name. lam ty. lam val. lam body.
-    _nletin_ (nameNoSym name) ty val body
 
 let _nuletin_ : Name -> Expr -> Expr -> Expr
   = lam name. lam val. lam body.
@@ -81,286 +152,342 @@ let _uletin_ : String -> Expr -> Expr -> Expr
     _nletin_ (nameNoSym name) tyunknown_ val body
 
 let _mkBaseFragment
-  : GenOpInput -> (Name, {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering}) -> LanguageFragment
-  = lam config. lam names.
-    let originalName = names.0 in
-    let synName = names.1 .op in
+  : (Name, InternalSynDesc) -> Decl
+  = lam names.
+    use SemDeclAst in
+    use SynDeclAst in
+    use LangDeclAst in
+    match names with (originalName, desc) in
+    let synName = desc.synName in
     let synTy_ = lam l. lam r. tyapp_ (tyapp_ (ntycon_ synName) l) r in
     let synTy = synTy_ (tyvar_ "lstyle") (tyvar_ "rstyle") in
-    let suffix = concat "_" (nameGetStr synName) in
 
     let topAllowed =
-      { name = concat "topAllowed" suffix
-      , ty = Some (tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy tybool_))
-      , preCaseArgs = []
-      , cases = [(pvarw_, true_)]
+      let ty = tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy tybool_)
+      in DeclSem
+      { ident = desc.functions.topAllowed
+      , tyBody = ty
+      , tyAnnot = ty
+      , args = []
+      , cases = [{pat = pvarw_, thn = true_}]
+      , info = NoInfo ()
       }
     in
     let leftAllowed =
-      { name = concat "leftAllowed" suffix
-      , ty = Some (tyalls_ ["lstyle", "style", "rstyle"] (tyarrow_
+      let ty = tyalls_ ["lstyle", "style", "rstyle"] (tyarrow_
         (tyrecord_ [("parent", synTy_ (tycon_ "LOpen") (tyvar_ "style")), ("child", synTy)])
-        tybool_))
-      , preCaseArgs = []
-      , cases = [(pvarw_, true_)]
+        tybool_)
+      in DeclSem
+      { ident = desc.functions.leftAllowed
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = []
+      , cases = [{pat = pvarw_, thn = true_}]
+      , info = NoInfo ()
       }
     in
     let rightAllowed =
-      { name = concat "rightAllowed" suffix
-      , ty = Some (tyalls_ ["style", "lstyle", "rstyle"] (tyarrow_
+      let ty = tyalls_ ["style", "lstyle", "rstyle"] (tyarrow_
         (tyrecord_ [("parent", synTy_ (tyvar_ "style") (tycon_ "ROpen")), ("child", synTy)])
-        tybool_))
-      , preCaseArgs = []
-      , cases = [(pvarw_, true_)]
+        tybool_)
+      in DeclSem
+      { ident = desc.functions.rightAllowed
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = []
+      , cases = [{pat = pvarw_, thn = true_}]
+      , info = NoInfo ()
       }
     in
     let groupingsAllowed =
-      { name = concat "groupingsAllowed" suffix
-      , ty = Some (tyalls_ ["lstyle", "rstyle"] (tyarrow_ (tytuple_ [synTy_ (tyvar_ "lstyle") (tycon_ "ROpen"), synTy_ (tycon_ "LOpen") (tyvar_ "rstyle")]) _allowedDirectionTy))
-      , preCaseArgs = []
-      , cases = [(pvarw_, _geither)]
+      let ty = tyalls_ ["lstyle", "rstyle"] (tyarrow_ (tytuple_ [synTy_ (tyvar_ "lstyle") (tycon_ "ROpen"), synTy_ (tycon_ "LOpen") (tyvar_ "rstyle")]) _allowedDirectionTy)
+      in DeclSem
+      { ident = desc.functions.groupingsAllowed
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = []
+      , cases = [{pat = pvarw_, thn = _geither}]
+      , info = NoInfo ()
       }
     in
     let parenAllowed =
-      { name = concat "parenAllowed" suffix
-      , ty = Some (tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy _allowedDirectionTy))
-      , preCaseArgs = []
-      , cases = [(pvarw_, _geither)]
+      let ty = tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy _allowedDirectionTy)
+      in DeclSem
+      { ident = desc.functions.parenAllowed
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = []
+      , cases = [{pat = pvarw_, thn = _geither}]
+      , info = NoInfo ()
       }
     in
     let getInfo =
-      { name = join ["get", suffix, "_info"]
-      , ty = Some (tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy _infoTy))
-      , preCaseArgs = []
+      let ty = tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy _infoTy)
+      in DeclSem
+      { ident = desc.functions.getInfo
+      , tyAnnot = ty
+      , tyBody = ty
       , cases = []
+      , args = []
+      , info = NoInfo ()
       }
     in
     let getTerms =
-      { name = join ["get", suffix, "_terms"]
-      , ty = Some (tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy (tyseq_ _infoTy)))
-      , preCaseArgs = []
+      let ty = tyalls_ ["lstyle", "rstyle"] (tyarrow_ synTy (tyseq_ _infoTy))
+      in DeclSem
+      { ident = desc.functions.getTerms
+      , tyAnnot = ty
+      , tyBody = ty
       , cases = []
+      , args = []
+      , info = NoInfo ()
       }
     in
     let unsplit =
-      { name = concat "unsplit" suffix
-      , ty = Some (tyarrow_ (_permanentNode_ (ntycon_ synName)) (tytuple_ [_infoTy, ntycon_ originalName]))
-      , preCaseArgs = []
+      let ty = tyarrow_ (_permanentNode_ (ntycon_ synName)) (tytuple_ [_infoTy, ntycon_ originalName])
+      in DeclSem
+      { ident = desc.functions.unsplit
+      , tyAnnot = ty
+      , tyBody = ty
+      , args = []
       , cases = []
+      , info = NoInfo ()
       }
     in
-
-    { name = config.mkBaseName (nameGetStr synName)
-    , extends = [config.mkSynAstBaseName originalName]
-    , aliases = []
-    , synTypes = mapInsert synName ([nameNoSym "lstyle", nameNoSym "rstyle"], []) (mapEmpty nameCmp)
-    , semanticFunctions =
-      [ topAllowed, leftAllowed, rightAllowed, groupingsAllowed
+    DeclLang
+    { ident = desc.baseOpFragmentName
+    , includes = [desc.baseFragmentName]
+    , decls =
+      [ DeclSyn {ident = synName, params = [nameNoSym "lstyle", nameNoSym "rstyle"], defs = [], info = NoInfo ()}
+      , topAllowed, leftAllowed, rightAllowed, groupingsAllowed
       , parenAllowed, getInfo, getTerms, unsplit
       ]
+    , info = NoInfo ()
     }
 
-let _mkConstructorFragment
-  : GenOpInput -> Map Name {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering} -> GenOperator -> LanguageFragment
-  = lam config. lam synNames. lam op.
-    let synName =
-      let tmp : {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering} = mapFindExn op.baseTypeName synNames in
-      tmp.op in
+lang GenOpAstLang = SynDeclAst + SemDeclAst + LangDeclAst
+  sem _mkConstructorFragment
+  : FieldLabels
+  -> Map Name InternalSynDesc
+  -> GenOperator
+  -> Decl
+  sem _mkConstructorFragment labels synNames = | op ->
+    let desc = mapFindExn op.baseTypeName synNames in
+    let synName = desc.synName in
     let conName = op.opConstructorName in
-    let suffix = concat "_" (nameGetStr synName) in
 
     let getInfo =
       let x = nameSym "x" in
-      { name = join ["get", suffix, "_info"]
-      , ty = None ()
-      , preCaseArgs = []
-      , cases = [(npcon_ conName (npvar_ x), recordproj_ config.infoFieldLabel (nvar_ x))]
+      DeclSem
+      { ident = desc.functions.getInfo
+      , tyAnnot = tyunknown_
+      , tyBody = tyunknown_
+      , args = []
+      , cases = [{pat = npcon_ conName (npvar_ x), thn = recordproj_ labels.info (nvar_ x)}]
+      , info = NoInfo ()
       } in
     let getTerms =
       let x = nameSym "x" in
-      { name = join ["get", suffix, "_terms"]
-      , ty = None ()
-      , preCaseArgs = []
-      , cases = [(npcon_ conName (npvar_ x), recordproj_ config.termsFieldLabel (nvar_ x))]
+      DeclSem
+      { ident = desc.functions.getTerms
+      , tyAnnot = tyunknown_
+      , tyBody = tyunknown_
+      , args = []
+      , cases = [{pat = npcon_ conName (npvar_ x), thn = recordproj_ labels.terms (nvar_ x)}]
+      , info = NoInfo ()
       } in
     let unsplit =
-      let unsplitStr = concat "unsplit" suffix in
-      let unsplit_ = lam r. app_ (var_ unsplitStr) r in
+      let unsplit_ = lam r. app_ (nvar_ desc.functions.unsplit) r in
       let x = nameSym "x" in
       let arm = switch op.mkUnsplit
         case AtomUnsplit f then
-          ( pcon_ "AtomP" (prec_ [("self", npcon_ conName (npvar_ x))])
-          , utuple_
-            [ recordproj_ config.infoFieldLabel (nvar_ x)
-            , f {record = nvar_ x, info = recordproj_ config.infoFieldLabel (nvar_ x)}
+          { pat = npcon_ _incNames.c.atomP (prec_ [("self", npcon_ conName (npvar_ x))])
+          , thn = utuple_
+            [ recordproj_ labels.info (nvar_ x)
+            , f {record = nvar_ x, info = recordproj_ labels.info (nvar_ x)}
             ]
-          )
+          }
         case PrefixUnsplit f then
           let info = nameSym "info" in
           let r = nameSym "r" in
           let rinfo = nameSym "rinfo" in
-          ( pcon_ "PrefixP"
+          { pat = npcon_ _incNames.c.prefixP
             (prec_
               [ ("self", npcon_ conName (npvar_ x))
               , ("rightChildAlts", pseqedgew_ [npvar_ r] [])
               ]
             )
-          , match_
+          , thn = match_
             (unsplit_ (nvar_ r))
             (ptuple_ [npvar_ rinfo, npvar_ r])
-            (_nuletin_ info (_mergeInfos_ [recordproj_ config.infoFieldLabel (nvar_ x), nvar_ rinfo])
+            (_nuletin_ info (_mergeInfos_ [recordproj_ labels.info (nvar_ x), nvar_ rinfo])
               (utuple_
                 [ nvar_ info
                 , f { record = nvar_ x , right = nvar_ r , info = nvar_ info}
                 ]))
             never_
-          )
+          }
         case PostfixUnsplit f then
           let info = nameSym "info" in
           let l = nameSym "l" in
           let linfo = nameSym "linfo" in
-          ( pcon_ "PostfixP"
+          { pat = npcon_ _incNames.c.postfixP
             (prec_
               [ ("self", npcon_ conName (npvar_ x))
               , ("leftChildAlts", pseqedgew_ [npvar_ l] [])
               ]
             )
-          , match_
+          , thn = match_
             (unsplit_ (nvar_ l))
             (ptuple_ [npvar_ linfo, npvar_ l])
-            (_nuletin_ info (_mergeInfos_ [nvar_ linfo, recordproj_ config.infoFieldLabel (nvar_ x)])
+            (_nuletin_ info (_mergeInfos_ [nvar_ linfo, recordproj_ labels.info (nvar_ x)])
               (utuple_
                 [ nvar_ info
                 , f { record = nvar_ x , left = nvar_ l , info = nvar_ info}
                 ]))
             never_
-          )
+          }
         case InfixUnsplit f then
           let info = nameSym "info" in
           let l = nameSym "l" in
           let linfo = nameSym "linfo" in
           let r = nameSym "r" in
           let rinfo = nameSym "rinfo" in
-          ( pcon_ "InfixP"
+          { pat = npcon_ _incNames.c.infixP
             (prec_
               [ ("self", npcon_ conName (npvar_ x))
               , ("leftChildAlts", pseqedgew_ [npvar_ l] [])
               , ("rightChildAlts", pseqedgew_ [npvar_ r] [])
               ]
             )
-          , match_
+          , thn = match_
             (utuple_ [unsplit_ (nvar_ l), unsplit_ (nvar_ r)])
             (ptuple_
               [ ptuple_ [npvar_ linfo, npvar_ l]
               , ptuple_ [npvar_ rinfo, npvar_ r]
               ])
-            (_nuletin_ info (_mergeInfos_ [nvar_ linfo, recordproj_ config.infoFieldLabel (nvar_ x), nvar_ rinfo])
+            (_nuletin_ info (_mergeInfos_ [nvar_ linfo, recordproj_ labels.info (nvar_ x), nvar_ rinfo])
               (utuple_
                 [ nvar_ info
                 , f { record = nvar_ x , left = nvar_ l, right = nvar_ r , info = nvar_ info}
                 ]))
             never_
-          )
+          }
         end
-      in
-      { name = concat "unsplit" suffix
-      , ty = None ()
-      , preCaseArgs = []
+      in DeclSem
+      { ident = desc.functions.unsplit
+      , tyAnnot = tyunknown_
+      , tyBody = tyunknown_
+      , args = []
       , cases = [arm]
+      , info = NoInfo ()
       } in
     let grouping = match (op.mkUnsplit, op.assoc) with (InfixUnsplit _, !NAssoc _)
-      then [
-        { name = concat "groupingsAllowed" suffix
-        , ty = None ()
-        , preCaseArgs = []
+      then [ DeclSem
+        { ident = desc.functions.groupingsAllowed
+        , tyAnnot = tyunknown_
+        , tyBody = tyunknown_
+        , args = []
         , cases =
-          [ ( ptuple_ [npcon_ op.opConstructorName pvarw_, npcon_ op.opConstructorName pvarw_]
-            , match op.assoc with LAssoc _ then conapp_ "GLeft" unit_ else conapp_ "GRight" unit_
-            )
+          [ { pat = ptuple_ [npcon_ op.opConstructorName pvarw_, npcon_ op.opConstructorName pvarw_]
+            , thn = match op.assoc with LAssoc _ then nconapp_ _incNames.c.gleft unit_ else nconapp_ _incNames.c.gright unit_
+            }
           ]
+        , info = NoInfo ()
         }]
       else [] in
-    { name = nameGetStr conName
-    , extends = cons
-      (config.mkBaseName (nameGetStr synName))
-      (match op.baseConstructorName with Some n then [config.mkConAstName n] else [])
-    , aliases = []
-    , synTypes = mapInsert synName ([nameNoSym "lstyle", nameNoSym "rstyle"], [{name = conName, synType = synName, carried = untargetableType op.carried}]) (mapEmpty nameCmp)
-    , semanticFunctions = concat [getInfo, getTerms, unsplit] grouping
+    DeclLang
+    { ident = conName  -- TODO(vipa, 2023-05-08): This reuses a `Name`, though in a different kind of scope. Might be worth creating a new name and syncing, but it's too much work right now
+    , includes = cons desc.baseOpFragmentName op.requiredFragments
+    , decls = concat
+      grouping
+      [ DeclSyn
+        { ident = synName
+        , params = [nameNoSym "lstyle", nameNoSym "rstyle"]
+        , defs = [{ident = conName, tyIdent = op.carried}]
+        , info = NoInfo ()
+        }
+      , getInfo
+      , getTerms
+      , unsplit
+      ]
+    , info = NoInfo ()
     }
+end
 
 let _mkGroupingSem
-  : GenOpInput
-  -> Map Name {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
-  -> (Name, {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering})
-  -> SemanticFunction
-  = lam config. lam opMap. lam binding.
-    let suffix = concat "_" (nameGetStr binding.1 .op) in
+  : Map Name {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
+  -> InternalSynDesc
+  -> Decl
+  = lam opMap. lam desc.
+    use SemDeclAst in
     let mkCase
       : Ordering
       -> {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
       -> {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
-      -> Option (Pat, Expr)
+      -> Option {pat : Pat, thn : Expr}
       = lam ordering. lam l. lam r.
         if and l.canBeLeft r.canBeRight then
           let dir = switch ordering
-            case LT _ then Some "GRight"
-            case GT _ then Some "GLeft"
+            case LT _ then Some _incNames.c.gright
+            case GT _ then Some _incNames.c.gleft
             case EQ _ then
               switch (l.assoc, r.assoc)
-              case (LAssoc _, LAssoc _) then Some "GLeft"
-              case (RAssoc _, RAssoc _) then Some "GRight"
+              case (LAssoc _, LAssoc _) then Some _incNames.c.gleft
+              case (RAssoc _, RAssoc _) then Some _incNames.c.gright
               case _ then None ()
               end
             end
           in match dir with Some dir then
-            Some (ptuple_ [npcon_ l.conName pvarw_, npcon_ r.conName pvarw_], conapp_ dir unit_)
+            Some {pat = ptuple_ [npcon_ l.conName pvarw_, npcon_ r.conName pvarw_], thn = nconapp_ dir unit_}
           else None ()
         else None () in
-    let mkCases : ((Name, Name), Ordering) -> [(Pat, Expr)] = lam pair.
+    let mkCases : ((Name, Name), Ordering) -> [{pat : Pat, thn : Expr}] = lam pair.
       let linfo : {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
         = mapFindExn pair.0 .0 opMap in
       let rinfo : {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
         = mapFindExn pair.0 .1 opMap in
       mapOption identity
         [ mkCase pair.1 linfo rinfo, mkCase (flipOrdering pair.1) rinfo linfo ]
-    in
-    { name = concat "groupingsAllowed" suffix
-    , ty = None ()
-    , preCaseArgs = []
-    , cases = join (map mkCases (mapBindings binding.1 .precedence))
+    in DeclSem
+    { ident = desc.functions.groupingsAllowed
+    , tyAnnot = tyunknown_
+    , tyBody = tyunknown_
+    , args = []
+    , cases = join (map mkCases (mapBindings desc.precedence))
+    , info = NoInfo ()
     }
 
 let _mkComposedFragment
-  : GenOpInput -> Map Name {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering} -> [LanguageFragment] -> LanguageFragment
-  = lam config. lam opTypeNames. lam fragments.
-    let opFragments : [String] = map
-      (lam frag: LanguageFragment. frag.name)
+  : GenOpInput -> Map Name InternalSynDesc -> [Decl] -> Decl
+  = lam config. lam synDescs. lam fragments.
+    use LangDeclAst in
+    let opFragments : [Name] = mapOption
+      (lam decl. match decl with DeclLang x then Some x.ident else None ())
       fragments in
-    let badFragments : [String] = map
-      (lam name: {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering}. config.mkConAstName name.bad)
-      (mapValues opTypeNames) in
+    let badFragments : [Name] = map
+      (lam desc. desc.bad.langName)
+      (mapValues synDescs) in
     let opMap : Map Name {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name} = mapFromSeq nameCmp
       (mapOption
-        (lam op: GenOperator. match op.baseConstructorName with Some name then
+        (lam op: GenOperator. match op.precedenceKey with Some key then
           switch op.mkUnsplit
-          case AtomUnsplit _ then Some (name, {canBeLeft = false, canBeRight = false, assoc = op.assoc, conName = op.opConstructorName})
-          case PrefixUnsplit _ then Some (name, {canBeLeft = true, canBeRight = false, assoc = op.assoc, conName = op.opConstructorName})
-          case InfixUnsplit _ then Some (name, {canBeLeft = true, canBeRight = true, assoc = op.assoc, conName = op.opConstructorName})
-          case PostfixUnsplit _ then Some (name, {canBeLeft = false, canBeRight = true, assoc = op.assoc, conName = op.opConstructorName})
+          case AtomUnsplit _ then Some (key, {canBeLeft = false, canBeRight = false, assoc = op.assoc, conName = op.opConstructorName})
+          case PrefixUnsplit _ then Some (key, {canBeLeft = true, canBeRight = false, assoc = op.assoc, conName = op.opConstructorName})
+          case InfixUnsplit _ then Some (key, {canBeLeft = true, canBeRight = true, assoc = op.assoc, conName = op.opConstructorName})
+          case PostfixUnsplit _ then Some (key, {canBeLeft = false, canBeRight = true, assoc = op.assoc, conName = op.opConstructorName})
           end else None ())
         config.operators) in
-    let groupingSems = map (_mkGroupingSem config opMap) (mapBindings opTypeNames) in
-    { name = config.composedName
-    , extends = join
+    let groupingSems = map (_mkGroupingSem opMap) (mapValues synDescs) in
+    DeclLang
+    { ident = config.composedName
+    , includes = join
       [ opFragments
       , badFragments
-      , ["LL1Parser"]
       , config.extraFragments
       ]
-    , aliases = []
-    , synTypes = mapEmpty nameCmp
-    , semanticFunctions = groupingSems
+    , decls = groupingSems
+    , info = NoInfo ()
     }
 
 type WrapperInfo =
@@ -373,96 +500,95 @@ type WrapperInfo =
   }
 
 let _mkBrWrappersFor
-  : GenOpInput -> {original: Name, op: Name, bad: Name, grouping: Option (String, String), precedence : Map (Name, Name) Ordering} -> WrapperInfo
-  = lam config. lam name.
+  : Name -> InternalSynDesc -> WrapperInfo
+  = lam original. lam desc.
     let stateTy = tyrecord_
       [ ("errors", tyapp_ (tycon_ "Ref") (tyseq_ (tytuple_ [tycon_ "Info", tystr_])))
       , ("content", tycon_ "String")
       ] in
-    match match name.grouping with Some x then x else ("(", ")") with (lparStr, rparStr) in
-    let suffix = concat "_" (nameGetStr name.op) in
+    match match desc.grouping with Some x then x else ("(", ")") with (lparStr, rparStr) in
     let configName = nameSym "config" in
     let reportConfigName = nameSym "reportConfig" in
-    let addAtomName = nameSym (join ["add", nameGetStr name.op, "Atom"]) in
-    let addInfixName = nameSym (join ["add", nameGetStr name.op, "Infix"]) in
-    let addPrefixName = nameSym (join ["add", nameGetStr name.op, "Prefix"]) in
-    let addPostfixName = nameSym (join ["add", nameGetStr name.op, "Postfix"]) in
-    let finalizeName = nameSym (concat "finalize" (nameGetStr name.op)) in
+    let addAtomName = nameSym (join ["add", nameGetStr desc.synName, "Atom"]) in
+    let addInfixName = nameSym (join ["add", nameGetStr desc.synName, "Infix"]) in
+    let addPrefixName = nameSym (join ["add", nameGetStr desc.synName, "Prefix"]) in
+    let addPostfixName = nameSym (join ["add", nameGetStr desc.synName, "Postfix"]) in
+    let finalizeName = nameSym (concat "finalize" (nameGetStr desc.synName)) in
     let mkTotalFunc = lam callee: Name.
       (ulam_ "" (ulam_ "x" (ulam_ "st"
-        (appf2_ (var_ "optionMap")
+        (appf2_ (nvar_ _incNames.v.optionMap)
           (appf2_ (nvar_ callee) (nvar_ configName) (var_ "x"))
           (var_ "st"))))) in
     let mkPartialFunc = lam callee: Name.
       (lam_ "p" stateTy (ulam_ "x" (ulam_ "st"
-        (match_ (var_ "st") (pcon_ "Some" (pvar_ "st"))
+        (match_ (var_ "st") (npcon_ _incNames.c.some (pvar_ "st"))
           (_uletin_ "st"
             (appf3_ (nvar_ callee) (nvar_ configName) (var_ "x") (var_ "st"))
             (semi_
-              (match_ (var_ "st") (pcon_ "None" pvarw_)
+              (match_ (var_ "st") (npcon_ _incNames.c.none pvarw_)
                 (modref_ (recordproj_ "errors" (var_ "p"))
                   (snoc_ (deref_ (recordproj_ "errors" (var_ "p")))
                     (utuple_
-                      [ app_ (var_ (join ["get", suffix, "_info"])) (var_ "x")
+                      [ app_ (nvar_ desc.functions.getInfo) (var_ "x")
                       , str_ "Invalid input"
                       ])))
                 (unit_))
               (var_ "st")))
-          (conapp_ "None" unit_))))) in
+          (nconapp_ _incNames.c.none unit_))))) in
     let definitions =
       [ nulet_ configName
         (urecord_
-          [ ("topAllowed", freeze_ (var_ (concat "topAllowed" suffix)))
-          , ("leftAllowed", freeze_ (var_ (concat "leftAllowed" suffix)))
-          , ("rightAllowed", freeze_ (var_ (concat "rightAllowed" suffix)))
-          , ("parenAllowed", freeze_ (var_ (concat "parenAllowed" suffix)))
-          , ("groupingsAllowed", freeze_ (var_ (concat "groupingsAllowed" suffix)))
+          [ ("topAllowed", freeze_ (nvar_ desc.functions.topAllowed))
+          , ("leftAllowed", freeze_ (nvar_ desc.functions.leftAllowed))
+          , ("rightAllowed", freeze_ (nvar_ desc.functions.rightAllowed))
+          , ("parenAllowed", freeze_ (nvar_ desc.functions.parenAllowed))
+          , ("groupingsAllowed", freeze_ (nvar_ desc.functions.groupingsAllowed))
           ])
       , nulet_ reportConfigName
         (urecord_
-          [ ("parenAllowed", freeze_ (var_ (concat "parenAllowed" suffix)))
-          , ("topAllowed", freeze_ (var_ (concat "topAllowed" suffix)))
-          , ("terminalInfos", freeze_ (var_ (join ["get", suffix, "_terms"])))
-          , ("getInfo", freeze_ (var_ (join ["get", suffix, "_info"])))
+          [ ("parenAllowed", freeze_ (nvar_ desc.functions.parenAllowed))
+          , ("topAllowed", freeze_ (nvar_ desc.functions.topAllowed))
+          , ("terminalInfos", freeze_ (nvar_ desc.functions.getTerms))
+          , ("getInfo", freeze_ (nvar_ desc.functions.getInfo))
           , ("lpar", str_ lparStr)
           , ("rpar", str_ rparStr)
           ])
-      , nulet_ addAtomName (mkTotalFunc (nameNoSym "breakableAddAtom"))
-      , nulet_ addInfixName (mkPartialFunc (nameNoSym "breakableAddInfix"))
-      , nulet_ addPrefixName (mkTotalFunc (nameNoSym "breakableAddPrefix"))
-      , nulet_ addPostfixName (mkPartialFunc (nameNoSym "breakableAddPostfix"))
+      , nulet_ addAtomName (mkTotalFunc (_incNames.v.breakableAddAtom))
+      , nulet_ addInfixName (mkPartialFunc (_incNames.v.breakableAddInfix))
+      , nulet_ addPrefixName (mkTotalFunc (_incNames.v.breakableAddPrefix))
+      , nulet_ addPostfixName (mkPartialFunc (_incNames.v.breakableAddPostfix))
       , nulet_ finalizeName
         (lam_ "p" stateTy (ulam_ "st"
           (_uletin_ "res"
-            (appf2_ (var_ "optionBind") (var_ "st")
+            (appf2_ (nvar_ _incNames.v.optionBind) (var_ "st")
               (ulam_ "st"
                 (match_
-                  (appf2_ (var_ "breakableFinalizeParse") (nvar_ configName) (var_ "st"))
-                  (pcon_ "Some" (pand_ (pvar_ "tops") (pseqedgew_ [pvar_ "top"] [])))
+                  (appf2_ (nvar_ _incNames.v.breakableFinalizeParse) (nvar_ configName) (var_ "st"))
+                  (npcon_ _incNames.c.some (pand_ (pvar_ "tops") (pseqedgew_ [pvar_ "top"] [])))
                   (_uletin_ "errs"
-                    (appf3_ (var_ "breakableDefaultHighlight") (nvar_ reportConfigName) (recordproj_ "content" (var_ "p")) (var_ "tops"))
-                    (_letin_ "res" (tytuple_ [tycon_ "Info", ntycon_ name.original])
-                      (app_ (var_ (concat "unsplit" suffix)) (var_ "top"))
+                    (appf3_ (nvar_ _incNames.v.breakableDefaultHighlight) (nvar_ reportConfigName) (recordproj_ "content" (var_ "p")) (var_ "tops"))
+                    (_uletin_ "res"
+                      (app_ (nvar_ desc.functions.unsplit) (var_ "top"))
                       (if_ (null_ (var_ "errs"))
-                        (conapp_ "Some" (var_ "res"))
+                        (nconapp_ _incNames.c.some (var_ "res"))
                         (semi_
                           (modref_ (recordproj_ "errors" (var_ "p"))
                             (concat_ (deref_ (recordproj_ "errors" (var_ "p"))) (var_ "errs")))
-                            (conapp_ "Some"
+                            (nconapp_ _incNames.c.some
                               (utuple_
                                 [ tupleproj_ 0 (var_ "res")
-                                , nconapp_ name.bad (urecord_ [("info", tupleproj_ 0 (var_ "res"))])
+                                , nconapp_ desc.bad.conName (urecord_ [("info", tupleproj_ 0 (var_ "res"))])
                                 ]))))))
                   (semi_
                     (modref_ (recordproj_ "errors" (var_ "p"))
                       (snoc_
                         (deref_ (recordproj_ "errors" (var_ "p")))
-                        (utuple_ [conapp_ "NoInfo" unit_, str_ (concat "Unfinished " (nameGetStr name.original))])))
-                    (conapp_ "None" unit_)))))
-            (appf2_ (var_ "optionGetOr")
+                        (utuple_ [nconapp_ _incNames.c.noInfo unit_, str_ (concat "Unfinished " (nameGetStr original))])))
+                    (nconapp_ _incNames.c.none unit_)))))
+            (appf2_ (nvar_ _incNames.v.optionGetOr)
               (utuple_
-                [ conapp_ "NoInfo" unit_
-                , nconapp_ name.bad (urecord_ [("info", conapp_ "NoInfo" unit_)])
+                [ nconapp_ _incNames.c.noInfo unit_
+                , nconapp_ desc.bad.conName (urecord_ [("info", nconapp_ _incNames.c.noInfo unit_)])
                 ])
               (var_ "res")))
         ))
@@ -476,7 +602,7 @@ let _mkBrWrappersFor
     }
 
 type GenOpResult =
-  { fragments : String
+  { fragments : [Decl]
   -- NOTE(vipa, 2022-04-12): This function wraps an expression such
   -- that the remaining functions (`addAtomFor`, etc.) can be used.
   , wrapProductions : Expr -> Expr
@@ -497,12 +623,9 @@ type GenOpResult =
   }
 
 let _mkBrWrappers
-  : GenOpInput -> Map Name {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering} -> GenOpResult
-  = lam config. lam synNames.
-    let wrappers = mapMapWithKey
-      (lam original. lam names : {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering}.
-        _mkBrWrappersFor config {original = original, op = names.op, bad = names.bad, grouping = names.grouping, precedence = names.precedence})
-      synNames in
+  : Map Name InternalSynDesc -> GenOpResult
+  = lam synDescs.
+    let wrappers = mapMapWithKey _mkBrWrappersFor synDescs in
     let getWrapper : Name -> WrapperInfo = lam name.
       mapFindExn name wrappers in
     { fragments = ""
@@ -519,21 +642,40 @@ let _mkBrWrappers
       bindall_ (snoc definitions expr)
     }
 
-let mkOpLanguages
+
+lang MkOpLanguages = GenOpAstLang
+  sem mkOpLanguages
   : GenOpInput -> GenOpResult
-  = lam config.
-    use CarriedBasic in
-    let opTypeNames : Map Name {bad : Name, op : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering} = mapMapWithKey
-      (lam original. lam names : {bad : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering}.
-        {bad = names.bad, op = nameSym (config.mkSynName original), grouping = names.grouping, precedence = names.precedence})
+  sem mkOpLanguages = | config ->
+    let synDescs : Map Name InternalSynDesc = mapMapWithKey
+      (lam original. lam desc.
+        let synStr = config.namingScheme.synName (nameGetStr original) in
+        { bad = desc.bad
+        , grouping = desc.grouping
+        , precedence = desc.precedence
+        , baseFragmentName = desc.baseFragmentName
+        , synName = nameSym synStr
+        , baseOpFragmentName = nameSym (config.namingScheme.opBaseLangName (nameGetStr original))
+        , functions =
+          { topAllowed = nameSym (concat "topAllowed_" synStr)
+          , leftAllowed = nameSym (concat "leftAllowed_" synStr)
+          , rightAllowed = nameSym (concat "rightAllowed_" synStr)
+          , groupingsAllowed = nameSym (concat "groupingsAllowed_" synStr)
+          , parenAllowed = nameSym (concat "parenAllowed_" synStr)
+          , getInfo = nameSym (concat "getInfo_" synStr)
+          , getTerms = nameSym (concat "getTerms_" synStr)
+          , unsplit = nameSym (concat "unsplit_" synStr)
+          }
+        })
       config.syns in
-    let baseFragments = map (_mkBaseFragment config) (mapBindings opTypeNames) in
-    let constructorFragments = map (_mkConstructorFragment config opTypeNames) config.operators in
-    let composedFragment = _mkComposedFragment config opTypeNames constructorFragments in
+    let baseFragments = map _mkBaseFragment (mapBindings synDescs) in
+    let constructorFragments = map (_mkConstructorFragment config.fieldLabels synDescs) config.operators in
+    let composedFragment = _mkComposedFragment config synDescs constructorFragments in
     let fragments = join
       [ baseFragments
       , constructorFragments
       , [composedFragment]
       ] in
-    let res : GenOpResult = _mkBrWrappers config opTypeNames in
-    {res with fragments = strJoin "\n\n" (snoc (map _pprintLanguageFragment fragments) res.fragments)}
+    let res : GenOpResult = _mkBrWrappers synDescs in
+    {res with fragments = concat fragments res.fragments}
+end

--- a/stdlib/parser/selfhost-gen.mc
+++ b/stdlib/parser/selfhost-gen.mc
@@ -1,23 +1,17 @@
 include "seq.mc"
-
 include "parser/ll1.mc"
-
 include "parser/breakable.mc"
-
 lang SelfhostBaseAst
-
-  syn File =
-  syn Decl =
-  syn Regex =
   syn Expr =
-
-  sem smapAccumL_File_File : all a. ((a) -> ((File) -> ((a, File)))) -> ((a) -> ((File) -> ((a, File))))
-  sem smapAccumL_File_File f acc =
+  syn Regex =
+  syn Decl =
+  syn File =
+  sem smapAccumL_File_File : all a. (a -> File -> (a, File)) -> a -> File -> (a, File)
+sem smapAccumL_File_File f acc =
   | x ->
     (acc, x)
-
-  sem smap_File_File : ((File) -> (File)) -> ((File) -> (File))
-  sem smap_File_File f =
+  sem smap_File_File : (File -> File) -> File -> File
+sem smap_File_File f =
   | x ->
     (smapAccumL_File_File
        (lam #var"".
@@ -25,10 +19,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_File_File : all a. ((a) -> ((File) -> (a))) -> ((a) -> ((File) -> (a)))
-  sem sfold_File_File f acc =
+       x).1
+  sem sfold_File_File : all a. (a -> File -> a) -> a -> File -> a
+sem sfold_File_File f acc =
   | x ->
     (smapAccumL_File_File
        (lam acc.
@@ -37,15 +30,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_File_Decl : all a. ((a) -> ((Decl) -> ((a, Decl)))) -> ((a) -> ((File) -> ((a, File))))
-  sem smapAccumL_File_Decl f acc =
+       x).0
+  sem smapAccumL_File_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> File -> (a, File)
+sem smapAccumL_File_Decl f acc =
   | x ->
     (acc, x)
-
-  sem smap_File_Decl : ((Decl) -> (Decl)) -> ((File) -> (File))
-  sem smap_File_Decl f =
+  sem smap_File_Decl : (Decl -> Decl) -> File -> File
+sem smap_File_Decl f =
   | x ->
     (smapAccumL_File_Decl
        (lam #var"".
@@ -53,10 +44,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_File_Decl : all a. ((a) -> ((Decl) -> (a))) -> ((a) -> ((File) -> (a)))
-  sem sfold_File_Decl f acc =
+       x).1
+  sem sfold_File_Decl : all a. (a -> Decl -> a) -> a -> File -> a
+sem sfold_File_Decl f acc =
   | x ->
     (smapAccumL_File_Decl
        (lam acc.
@@ -65,15 +55,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_File_Regex : all a. ((a) -> ((Regex) -> ((a, Regex)))) -> ((a) -> ((File) -> ((a, File))))
-  sem smapAccumL_File_Regex f acc =
+       x).0
+  sem smapAccumL_File_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> File -> (a, File)
+sem smapAccumL_File_Regex f acc =
   | x ->
     (acc, x)
-
-  sem smap_File_Regex : ((Regex) -> (Regex)) -> ((File) -> (File))
-  sem smap_File_Regex f =
+  sem smap_File_Regex : (Regex -> Regex) -> File -> File
+sem smap_File_Regex f =
   | x ->
     (smapAccumL_File_Regex
        (lam #var"".
@@ -81,10 +69,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_File_Regex : all a. ((a) -> ((Regex) -> (a))) -> ((a) -> ((File) -> (a)))
-  sem sfold_File_Regex f acc =
+       x).1
+  sem sfold_File_Regex : all a. (a -> Regex -> a) -> a -> File -> a
+sem sfold_File_Regex f acc =
   | x ->
     (smapAccumL_File_Regex
        (lam acc.
@@ -93,15 +80,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_File_Expr : all a. ((a) -> ((Expr) -> ((a, Expr)))) -> ((a) -> ((File) -> ((a, File))))
-  sem smapAccumL_File_Expr f acc =
+       x).0
+  sem smapAccumL_File_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> File -> (a, File)
+sem smapAccumL_File_Expr f acc =
   | x ->
     (acc, x)
-
-  sem smap_File_Expr : ((Expr) -> (Expr)) -> ((File) -> (File))
-  sem smap_File_Expr f =
+  sem smap_File_Expr : (Expr -> Expr) -> File -> File
+sem smap_File_Expr f =
   | x ->
     (smapAccumL_File_Expr
        (lam #var"".
@@ -109,10 +94,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_File_Expr : all a. ((a) -> ((Expr) -> (a))) -> ((a) -> ((File) -> (a)))
-  sem sfold_File_Expr f acc =
+       x).1
+  sem sfold_File_Expr : all a. (a -> Expr -> a) -> a -> File -> a
+sem sfold_File_Expr f acc =
   | x ->
     (smapAccumL_File_Expr
        (lam acc.
@@ -121,15 +105,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Decl_File : all a. ((a) -> ((File) -> ((a, File)))) -> ((a) -> ((Decl) -> ((a, Decl))))
-  sem smapAccumL_Decl_File f acc =
+       x).0
+  sem smapAccumL_Decl_File : all a. (a -> File -> (a, File)) -> a -> Decl -> (a, Decl)
+sem smapAccumL_Decl_File f acc =
   | x ->
     (acc, x)
-
-  sem smap_Decl_File : ((File) -> (File)) -> ((Decl) -> (Decl))
-  sem smap_Decl_File f =
+  sem smap_Decl_File : (File -> File) -> Decl -> Decl
+sem smap_Decl_File f =
   | x ->
     (smapAccumL_Decl_File
        (lam #var"".
@@ -137,10 +119,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Decl_File : all a. ((a) -> ((File) -> (a))) -> ((a) -> ((Decl) -> (a)))
-  sem sfold_Decl_File f acc =
+       x).1
+  sem sfold_Decl_File : all a. (a -> File -> a) -> a -> Decl -> a
+sem sfold_Decl_File f acc =
   | x ->
     (smapAccumL_Decl_File
        (lam acc.
@@ -149,15 +130,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Decl_Decl : all a. ((a) -> ((Decl) -> ((a, Decl)))) -> ((a) -> ((Decl) -> ((a, Decl))))
-  sem smapAccumL_Decl_Decl f acc =
+       x).0
+  sem smapAccumL_Decl_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> Decl -> (a, Decl)
+sem smapAccumL_Decl_Decl f acc =
   | x ->
     (acc, x)
-
-  sem smap_Decl_Decl : ((Decl) -> (Decl)) -> ((Decl) -> (Decl))
-  sem smap_Decl_Decl f =
+  sem smap_Decl_Decl : (Decl -> Decl) -> Decl -> Decl
+sem smap_Decl_Decl f =
   | x ->
     (smapAccumL_Decl_Decl
        (lam #var"".
@@ -165,10 +144,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Decl_Decl : all a. ((a) -> ((Decl) -> (a))) -> ((a) -> ((Decl) -> (a)))
-  sem sfold_Decl_Decl f acc =
+       x).1
+  sem sfold_Decl_Decl : all a. (a -> Decl -> a) -> a -> Decl -> a
+sem sfold_Decl_Decl f acc =
   | x ->
     (smapAccumL_Decl_Decl
        (lam acc.
@@ -177,15 +155,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Decl_Regex : all a. ((a) -> ((Regex) -> ((a, Regex)))) -> ((a) -> ((Decl) -> ((a, Decl))))
-  sem smapAccumL_Decl_Regex f acc =
+       x).0
+  sem smapAccumL_Decl_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> Decl -> (a, Decl)
+sem smapAccumL_Decl_Regex f acc =
   | x ->
     (acc, x)
-
-  sem smap_Decl_Regex : ((Regex) -> (Regex)) -> ((Decl) -> (Decl))
-  sem smap_Decl_Regex f =
+  sem smap_Decl_Regex : (Regex -> Regex) -> Decl -> Decl
+sem smap_Decl_Regex f =
   | x ->
     (smapAccumL_Decl_Regex
        (lam #var"".
@@ -193,10 +169,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Decl_Regex : all a. ((a) -> ((Regex) -> (a))) -> ((a) -> ((Decl) -> (a)))
-  sem sfold_Decl_Regex f acc =
+       x).1
+  sem sfold_Decl_Regex : all a. (a -> Regex -> a) -> a -> Decl -> a
+sem sfold_Decl_Regex f acc =
   | x ->
     (smapAccumL_Decl_Regex
        (lam acc.
@@ -205,15 +180,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Decl_Expr : all a. ((a) -> ((Expr) -> ((a, Expr)))) -> ((a) -> ((Decl) -> ((a, Decl))))
-  sem smapAccumL_Decl_Expr f acc =
+       x).0
+  sem smapAccumL_Decl_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> Decl -> (a, Decl)
+sem smapAccumL_Decl_Expr f acc =
   | x ->
     (acc, x)
-
-  sem smap_Decl_Expr : ((Expr) -> (Expr)) -> ((Decl) -> (Decl))
-  sem smap_Decl_Expr f =
+  sem smap_Decl_Expr : (Expr -> Expr) -> Decl -> Decl
+sem smap_Decl_Expr f =
   | x ->
     (smapAccumL_Decl_Expr
        (lam #var"".
@@ -221,10 +194,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Decl_Expr : all a. ((a) -> ((Expr) -> (a))) -> ((a) -> ((Decl) -> (a)))
-  sem sfold_Decl_Expr f acc =
+       x).1
+  sem sfold_Decl_Expr : all a. (a -> Expr -> a) -> a -> Decl -> a
+sem sfold_Decl_Expr f acc =
   | x ->
     (smapAccumL_Decl_Expr
        (lam acc.
@@ -233,15 +205,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Regex_File : all a. ((a) -> ((File) -> ((a, File)))) -> ((a) -> ((Regex) -> ((a, Regex))))
-  sem smapAccumL_Regex_File f acc =
+       x).0
+  sem smapAccumL_Regex_File : all a. (a -> File -> (a, File)) -> a -> Regex -> (a, Regex)
+sem smapAccumL_Regex_File f acc =
   | x ->
     (acc, x)
-
-  sem smap_Regex_File : ((File) -> (File)) -> ((Regex) -> (Regex))
-  sem smap_Regex_File f =
+  sem smap_Regex_File : (File -> File) -> Regex -> Regex
+sem smap_Regex_File f =
   | x ->
     (smapAccumL_Regex_File
        (lam #var"".
@@ -249,10 +219,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Regex_File : all a. ((a) -> ((File) -> (a))) -> ((a) -> ((Regex) -> (a)))
-  sem sfold_Regex_File f acc =
+       x).1
+  sem sfold_Regex_File : all a. (a -> File -> a) -> a -> Regex -> a
+sem sfold_Regex_File f acc =
   | x ->
     (smapAccumL_Regex_File
        (lam acc.
@@ -261,15 +230,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Regex_Decl : all a. ((a) -> ((Decl) -> ((a, Decl)))) -> ((a) -> ((Regex) -> ((a, Regex))))
-  sem smapAccumL_Regex_Decl f acc =
+       x).0
+  sem smapAccumL_Regex_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> Regex -> (a, Regex)
+sem smapAccumL_Regex_Decl f acc =
   | x ->
     (acc, x)
-
-  sem smap_Regex_Decl : ((Decl) -> (Decl)) -> ((Regex) -> (Regex))
-  sem smap_Regex_Decl f =
+  sem smap_Regex_Decl : (Decl -> Decl) -> Regex -> Regex
+sem smap_Regex_Decl f =
   | x ->
     (smapAccumL_Regex_Decl
        (lam #var"".
@@ -277,10 +244,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Regex_Decl : all a. ((a) -> ((Decl) -> (a))) -> ((a) -> ((Regex) -> (a)))
-  sem sfold_Regex_Decl f acc =
+       x).1
+  sem sfold_Regex_Decl : all a. (a -> Decl -> a) -> a -> Regex -> a
+sem sfold_Regex_Decl f acc =
   | x ->
     (smapAccumL_Regex_Decl
        (lam acc.
@@ -289,15 +255,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Regex_Regex : all a. ((a) -> ((Regex) -> ((a, Regex)))) -> ((a) -> ((Regex) -> ((a, Regex))))
-  sem smapAccumL_Regex_Regex f acc =
+       x).0
+  sem smapAccumL_Regex_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> Regex -> (a, Regex)
+sem smapAccumL_Regex_Regex f acc =
   | x ->
     (acc, x)
-
-  sem smap_Regex_Regex : ((Regex) -> (Regex)) -> ((Regex) -> (Regex))
-  sem smap_Regex_Regex f =
+  sem smap_Regex_Regex : (Regex -> Regex) -> Regex -> Regex
+sem smap_Regex_Regex f =
   | x ->
     (smapAccumL_Regex_Regex
        (lam #var"".
@@ -305,10 +269,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Regex_Regex : all a. ((a) -> ((Regex) -> (a))) -> ((a) -> ((Regex) -> (a)))
-  sem sfold_Regex_Regex f acc =
+       x).1
+  sem sfold_Regex_Regex : all a. (a -> Regex -> a) -> a -> Regex -> a
+sem sfold_Regex_Regex f acc =
   | x ->
     (smapAccumL_Regex_Regex
        (lam acc.
@@ -317,15 +280,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Regex_Expr : all a. ((a) -> ((Expr) -> ((a, Expr)))) -> ((a) -> ((Regex) -> ((a, Regex))))
-  sem smapAccumL_Regex_Expr f acc =
+       x).0
+  sem smapAccumL_Regex_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> Regex -> (a, Regex)
+sem smapAccumL_Regex_Expr f acc =
   | x ->
     (acc, x)
-
-  sem smap_Regex_Expr : ((Expr) -> (Expr)) -> ((Regex) -> (Regex))
-  sem smap_Regex_Expr f =
+  sem smap_Regex_Expr : (Expr -> Expr) -> Regex -> Regex
+sem smap_Regex_Expr f =
   | x ->
     (smapAccumL_Regex_Expr
        (lam #var"".
@@ -333,10 +294,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Regex_Expr : all a. ((a) -> ((Expr) -> (a))) -> ((a) -> ((Regex) -> (a)))
-  sem sfold_Regex_Expr f acc =
+       x).1
+  sem sfold_Regex_Expr : all a. (a -> Expr -> a) -> a -> Regex -> a
+sem sfold_Regex_Expr f acc =
   | x ->
     (smapAccumL_Regex_Expr
        (lam acc.
@@ -345,15 +305,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Expr_File : all a. ((a) -> ((File) -> ((a, File)))) -> ((a) -> ((Expr) -> ((a, Expr))))
-  sem smapAccumL_Expr_File f acc =
+       x).0
+  sem smapAccumL_Expr_File : all a. (a -> File -> (a, File)) -> a -> Expr -> (a, Expr)
+sem smapAccumL_Expr_File f acc =
   | x ->
     (acc, x)
-
-  sem smap_Expr_File : ((File) -> (File)) -> ((Expr) -> (Expr))
-  sem smap_Expr_File f =
+  sem smap_Expr_File : (File -> File) -> Expr -> Expr
+sem smap_Expr_File f =
   | x ->
     (smapAccumL_Expr_File
        (lam #var"".
@@ -361,10 +319,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Expr_File : all a. ((a) -> ((File) -> (a))) -> ((a) -> ((Expr) -> (a)))
-  sem sfold_Expr_File f acc =
+       x).1
+  sem sfold_Expr_File : all a. (a -> File -> a) -> a -> Expr -> a
+sem sfold_Expr_File f acc =
   | x ->
     (smapAccumL_Expr_File
        (lam acc.
@@ -373,15 +330,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Expr_Decl : all a. ((a) -> ((Decl) -> ((a, Decl)))) -> ((a) -> ((Expr) -> ((a, Expr))))
-  sem smapAccumL_Expr_Decl f acc =
+       x).0
+  sem smapAccumL_Expr_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> Expr -> (a, Expr)
+sem smapAccumL_Expr_Decl f acc =
   | x ->
     (acc, x)
-
-  sem smap_Expr_Decl : ((Decl) -> (Decl)) -> ((Expr) -> (Expr))
-  sem smap_Expr_Decl f =
+  sem smap_Expr_Decl : (Decl -> Decl) -> Expr -> Expr
+sem smap_Expr_Decl f =
   | x ->
     (smapAccumL_Expr_Decl
        (lam #var"".
@@ -389,10 +344,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Expr_Decl : all a. ((a) -> ((Decl) -> (a))) -> ((a) -> ((Expr) -> (a)))
-  sem sfold_Expr_Decl f acc =
+       x).1
+  sem sfold_Expr_Decl : all a. (a -> Decl -> a) -> a -> Expr -> a
+sem sfold_Expr_Decl f acc =
   | x ->
     (smapAccumL_Expr_Decl
        (lam acc.
@@ -401,15 +355,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Expr_Regex : all a. ((a) -> ((Regex) -> ((a, Regex)))) -> ((a) -> ((Expr) -> ((a, Expr))))
-  sem smapAccumL_Expr_Regex f acc =
+       x).0
+  sem smapAccumL_Expr_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> Expr -> (a, Expr)
+sem smapAccumL_Expr_Regex f acc =
   | x ->
     (acc, x)
-
-  sem smap_Expr_Regex : ((Regex) -> (Regex)) -> ((Expr) -> (Expr))
-  sem smap_Expr_Regex f =
+  sem smap_Expr_Regex : (Regex -> Regex) -> Expr -> Expr
+sem smap_Expr_Regex f =
   | x ->
     (smapAccumL_Expr_Regex
        (lam #var"".
@@ -417,10 +369,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Expr_Regex : all a. ((a) -> ((Regex) -> (a))) -> ((a) -> ((Expr) -> (a)))
-  sem sfold_Expr_Regex f acc =
+       x).1
+  sem sfold_Expr_Regex : all a. (a -> Regex -> a) -> a -> Expr -> a
+sem sfold_Expr_Regex f acc =
   | x ->
     (smapAccumL_Expr_Regex
        (lam acc.
@@ -429,15 +380,13 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem smapAccumL_Expr_Expr : all a. ((a) -> ((Expr) -> ((a, Expr)))) -> ((a) -> ((Expr) -> ((a, Expr))))
-  sem smapAccumL_Expr_Expr f acc =
+       x).0
+  sem smapAccumL_Expr_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> Expr -> (a, Expr)
+sem smapAccumL_Expr_Expr f acc =
   | x ->
     (acc, x)
-
-  sem smap_Expr_Expr : ((Expr) -> (Expr)) -> ((Expr) -> (Expr))
-  sem smap_Expr_Expr f =
+  sem smap_Expr_Expr : (Expr -> Expr) -> Expr -> Expr
+sem smap_Expr_Expr f =
   | x ->
     (smapAccumL_Expr_Expr
        (lam #var"".
@@ -445,10 +394,9 @@ lang SelfhostBaseAst
             ({}, f
               x))
        {}
-       x).#label"1"
-
-  sem sfold_Expr_Expr : all a. ((a) -> ((Expr) -> (a))) -> ((a) -> ((Expr) -> (a)))
-  sem sfold_Expr_Expr f acc =
+       x).1
+  sem sfold_Expr_Expr : all a. (a -> Expr -> a) -> a -> Expr -> a
+sem sfold_Expr_Expr f acc =
   | x ->
     (smapAccumL_Expr_Expr
        (lam acc.
@@ -457,14 +405,12 @@ lang SelfhostBaseAst
               acc
               x, x))
        acc
-       x).#label"0"
-
-  sem get_File_info : (File) -> (Info)
-
-  sem set_File_info : (Info) -> ((File) -> (File))
-
-  sem mapAccum_File_info : all a. ((a) -> ((Info) -> ((a, Info)))) -> ((a) -> ((File) -> ((a, File))))
-  sem mapAccum_File_info f acc =
+       x).0
+  sem get_File_info : File -> Info
+  sem set_File_info : Info -> File -> File
+sem set_File_info val =
+  sem mapAccum_File_info : all a. (a -> Info -> (a, Info)) -> a -> File -> (a, File)
+sem mapAccum_File_info f acc =
   | target ->
     match
       f
@@ -473,28 +419,23 @@ lang SelfhostBaseAst
            target)
     with
       (acc, val)
-    then
-      (acc, set_File_info
+    in
+    (acc, set_File_info
         val
         target)
-    else
-      never
-
-  sem map_File_info : ((Info) -> (Info)) -> ((File) -> (File))
-  sem map_File_info f =
+  sem map_File_info : (Info -> Info) -> File -> File
+sem map_File_info f =
   | target ->
     set_File_info
       (f
          (get_File_info
             target))
       target
-
-  sem get_Decl_info : (Decl) -> (Info)
-
-  sem set_Decl_info : (Info) -> ((Decl) -> (Decl))
-
-  sem mapAccum_Decl_info : all a. ((a) -> ((Info) -> ((a, Info)))) -> ((a) -> ((Decl) -> ((a, Decl))))
-  sem mapAccum_Decl_info f acc =
+  sem get_Decl_info : Decl -> Info
+  sem set_Decl_info : Info -> Decl -> Decl
+sem set_Decl_info val =
+  sem mapAccum_Decl_info : all a. (a -> Info -> (a, Info)) -> a -> Decl -> (a, Decl)
+sem mapAccum_Decl_info f acc =
   | target ->
     match
       f
@@ -503,28 +444,23 @@ lang SelfhostBaseAst
            target)
     with
       (acc, val)
-    then
-      (acc, set_Decl_info
+    in
+    (acc, set_Decl_info
         val
         target)
-    else
-      never
-
-  sem map_Decl_info : ((Info) -> (Info)) -> ((Decl) -> (Decl))
-  sem map_Decl_info f =
+  sem map_Decl_info : (Info -> Info) -> Decl -> Decl
+sem map_Decl_info f =
   | target ->
     set_Decl_info
       (f
          (get_Decl_info
             target))
       target
-
-  sem get_Regex_info : (Regex) -> (Info)
-
-  sem set_Regex_info : (Info) -> ((Regex) -> (Regex))
-
-  sem mapAccum_Regex_info : all a. ((a) -> ((Info) -> ((a, Info)))) -> ((a) -> ((Regex) -> ((a, Regex))))
-  sem mapAccum_Regex_info f acc =
+  sem get_Regex_info : Regex -> Info
+  sem set_Regex_info : Info -> Regex -> Regex
+sem set_Regex_info val =
+  sem mapAccum_Regex_info : all a. (a -> Info -> (a, Info)) -> a -> Regex -> (a, Regex)
+sem mapAccum_Regex_info f acc =
   | target ->
     match
       f
@@ -533,28 +469,23 @@ lang SelfhostBaseAst
            target)
     with
       (acc, val)
-    then
-      (acc, set_Regex_info
+    in
+    (acc, set_Regex_info
         val
         target)
-    else
-      never
-
-  sem map_Regex_info : ((Info) -> (Info)) -> ((Regex) -> (Regex))
-  sem map_Regex_info f =
+  sem map_Regex_info : (Info -> Info) -> Regex -> Regex
+sem map_Regex_info f =
   | target ->
     set_Regex_info
       (f
          (get_Regex_info
             target))
       target
-
-  sem get_Expr_info : (Expr) -> (Info)
-
-  sem set_Expr_info : (Info) -> ((Expr) -> (Expr))
-
-  sem mapAccum_Expr_info : all a. ((a) -> ((Info) -> ((a, Info)))) -> ((a) -> ((Expr) -> ((a, Expr))))
-  sem mapAccum_Expr_info f acc =
+  sem get_Expr_info : Expr -> Info
+  sem set_Expr_info : Info -> Expr -> Expr
+sem set_Expr_info val =
+  sem mapAccum_Expr_info : all a. (a -> Info -> (a, Info)) -> a -> Expr -> (a, Expr)
+sem mapAccum_Expr_info f acc =
   | target ->
     match
       f
@@ -563,32 +494,27 @@ lang SelfhostBaseAst
            target)
     with
       (acc, val)
-    then
-      (acc, set_Expr_info
+    in
+    (acc, set_Expr_info
         val
         target)
-    else
-      never
-
-  sem map_Expr_info : ((Info) -> (Info)) -> ((Expr) -> (Expr))
-  sem map_Expr_info f =
+  sem map_Expr_info : (Info -> Info) -> Expr -> Expr
+sem map_Expr_info f =
   | target ->
     set_Expr_info
       (f
          (get_Expr_info
             target))
       target
-
 end
-
-lang FileAst = SelfhostBaseAst
-  type FileRecord = {info: Info, name: {i: Info, v: String}, decls: [Decl]}
-
+lang LangFileAst =
+  SelfhostBaseAst
+  type LangFileRecord =
+    {info: Info, name: {i: Info, v: String}, decls: [Decl]}
   syn File =
-  | File FileRecord
-
+  | LangFile LangFileRecord
   sem smapAccumL_File_Decl f acc =
-  | File x ->
+  | LangFile x ->
     match
       match
         let decls =
@@ -604,45 +530,36 @@ lang FileAst = SelfhostBaseAst
           decls
       with
         (acc, decls)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           decls =
             decls })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, File
+    in
+    (acc, LangFile
         x)
-    else
-      never
-
   sem get_File_info =
-  | File target ->
+  | LangFile target ->
     target.info
-
   sem set_File_info val =
-  | File target ->
-    File
+  | LangFile target ->
+    LangFile
       { target
         with
         info =
           val }
-
 end
-
-lang StartDeclAst = SelfhostBaseAst
-  type StartDeclRecord = {info: Info, name: {i: Info, v: Name}}
-
+lang StartDeclAst =
+  SelfhostBaseAst
+  type StartDeclRecord =
+    {info: Info, name: {i: Info, v: Name}}
   syn Decl =
   | StartDecl StartDeclRecord
-
   sem get_Decl_info =
   | StartDecl target ->
     target.info
-
   sem set_Decl_info val =
   | StartDecl target ->
     StartDecl
@@ -650,19 +567,16 @@ lang StartDeclAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang IncludeDeclAst = SelfhostBaseAst
-  type IncludeDeclRecord = {info: Info, path: {i: Info, v: String}}
-
+lang IncludeDeclAst =
+  SelfhostBaseAst
+  type IncludeDeclRecord =
+    {info: Info, path: {i: Info, v: String}}
   syn Decl =
   | IncludeDecl IncludeDeclRecord
-
   sem get_Decl_info =
   | IncludeDecl target ->
     target.info
-
   sem set_Decl_info val =
   | IncludeDecl target ->
     IncludeDecl
@@ -670,15 +584,13 @@ lang IncludeDeclAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang TypeDeclAst = SelfhostBaseAst
-  type TypeDeclRecord = {info: Info, name: {i: Info, v: Name}, properties: [{val: Expr, name: {i: Info, v: String}}]}
-
+lang TypeDeclAst =
+  SelfhostBaseAst
+  type TypeDeclRecord =
+    {info: Info, name: {i: Info, v: Name}, properties: [{val: Expr, name: {i: Info, v: String}}]}
   syn Decl =
   | TypeDecl TypeDeclRecord
-
   sem smapAccumL_Decl_Expr f acc =
   | TypeDecl x ->
     match
@@ -690,44 +602,36 @@ lang TypeDeclAst = SelfhostBaseAst
           (lam acc1.
              lam x1: {val: Expr, name: {i: Info, v: String}}.
                match
-                 let val =
+                 let val1 =
                    x1.val
                  in
                  f
                    acc1
-                   val
+                   val1
                with
-                 (acc1, val)
-               then
-                 (acc1, { x1
+                 (acc1, val1)
+               in
+               (acc1, { x1
                    with
                    val =
-                     val })
-               else
-                 never)
+                     val1 }))
           acc
           properties
       with
         (acc, properties)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           properties =
             properties })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, TypeDecl
+    in
+    (acc, TypeDecl
         x)
-    else
-      never
-
   sem get_Decl_info =
   | TypeDecl target ->
     target.info
-
   sem set_Decl_info val =
   | TypeDecl target ->
     TypeDecl
@@ -735,15 +639,13 @@ lang TypeDeclAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang TokenDeclAst = SelfhostBaseAst
-  type TokenDeclRecord = {info: Info, name: (Option) ({i: Info, v: Name}), properties: [{val: Expr, name: {i: Info, v: String}}]}
-
+lang TokenDeclAst =
+  SelfhostBaseAst
+  type TokenDeclRecord =
+    {info: Info, name: Option {i: Info, v: Name}, properties: [{val: Expr, name: {i: Info, v: String}}]}
   syn Decl =
   | TokenDecl TokenDeclRecord
-
   sem smapAccumL_Decl_Expr f acc =
   | TokenDecl x ->
     match
@@ -755,44 +657,36 @@ lang TokenDeclAst = SelfhostBaseAst
           (lam acc1.
              lam x1: {val: Expr, name: {i: Info, v: String}}.
                match
-                 let val =
+                 let val1 =
                    x1.val
                  in
                  f
                    acc1
-                   val
+                   val1
                with
-                 (acc1, val)
-               then
-                 (acc1, { x1
+                 (acc1, val1)
+               in
+               (acc1, { x1
                    with
                    val =
-                     val })
-               else
-                 never)
+                     val1 }))
           acc
           properties
       with
         (acc, properties)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           properties =
             properties })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, TokenDecl
+    in
+    (acc, TokenDecl
         x)
-    else
-      never
-
   sem get_Decl_info =
   | TokenDecl target ->
     target.info
-
   sem set_Decl_info val =
   | TokenDecl target ->
     TokenDecl
@@ -800,19 +694,16 @@ lang TokenDeclAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang PrecedenceTableDeclAst = SelfhostBaseAst
-  type PrecedenceTableDeclRecord = {info: Info, levels: [{noeq: (Option) (Info), operators: [{i: Info, v: Name}]}], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]}
-
+lang PrecedenceTableDeclAst =
+  SelfhostBaseAst
+  type PrecedenceTableDeclRecord =
+    {info: Info, levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]}
   syn Decl =
   | PrecedenceTableDecl PrecedenceTableDeclRecord
-
   sem get_Decl_info =
   | PrecedenceTableDecl target ->
     target.info
-
   sem set_Decl_info val =
   | PrecedenceTableDecl target ->
     PrecedenceTableDecl
@@ -820,15 +711,13 @@ lang PrecedenceTableDeclAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang ProductionDeclAst = SelfhostBaseAst
-  type ProductionDeclRecord = {nt: {i: Info, v: Name}, info: Info, kinf: (Option) (Info), name: {i: Info, v: Name}, assoc: (Option) ({i: Info, v: String}), kpref: (Option) (Info), kprod: (Option) (Info), regex: Regex, kpostf: (Option) (Info)}
-
+lang ProductionDeclAst =
+  SelfhostBaseAst
+  type ProductionDeclRecord =
+    {nt: {i: Info, v: Name}, info: Info, kinf: Option Info, name: {i: Info, v: Name}, assoc: Option {i: Info, v: String}, kpref: Option Info, kprod: Option Info, regex: Regex, kpostf: Option Info}
   syn Decl =
   | ProductionDecl ProductionDeclRecord
-
   sem smapAccumL_Decl_Regex f acc =
   | ProductionDecl x ->
     match
@@ -841,25 +730,19 @@ lang ProductionDeclAst = SelfhostBaseAst
           regex
       with
         (acc, regex)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           regex =
             regex })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, ProductionDecl
+    in
+    (acc, ProductionDecl
         x)
-    else
-      never
-
   sem get_Decl_info =
   | ProductionDecl target ->
     target.info
-
   sem set_Decl_info val =
   | ProductionDecl target ->
     ProductionDecl
@@ -867,15 +750,13 @@ lang ProductionDeclAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang RecordRegexAst = SelfhostBaseAst
-  type RecordRegexRecord = {info: Info, regex: Regex}
-
+lang RecordRegexAst =
+  SelfhostBaseAst
+  type RecordRegexRecord =
+    {info: Info, regex: Regex}
   syn Regex =
   | RecordRegex RecordRegexRecord
-
   sem smapAccumL_Regex_Regex f acc =
   | RecordRegex x ->
     match
@@ -888,25 +769,19 @@ lang RecordRegexAst = SelfhostBaseAst
           regex
       with
         (acc, regex)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           regex =
             regex })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, RecordRegex
+    in
+    (acc, RecordRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | RecordRegex target ->
     target.info
-
   sem set_Regex_info val =
   | RecordRegex target ->
     RecordRegex
@@ -914,19 +789,16 @@ lang RecordRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang EmptyRegexAst = SelfhostBaseAst
-  type EmptyRegexRecord = {info: Info}
-
+lang EmptyRegexAst =
+  SelfhostBaseAst
+  type EmptyRegexRecord =
+    {info: Info}
   syn Regex =
   | EmptyRegex EmptyRegexRecord
-
   sem get_Regex_info =
   | EmptyRegex target ->
     target.info
-
   sem set_Regex_info val =
   | EmptyRegex target ->
     EmptyRegex
@@ -934,19 +806,16 @@ lang EmptyRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang LiteralRegexAst = SelfhostBaseAst
-  type LiteralRegexRecord = {val: {i: Info, v: String}, info: Info}
-
+lang LiteralRegexAst =
+  SelfhostBaseAst
+  type LiteralRegexRecord =
+    {val: {i: Info, v: String}, info: Info}
   syn Regex =
   | LiteralRegex LiteralRegexRecord
-
   sem get_Regex_info =
   | LiteralRegex target ->
     target.info
-
   sem set_Regex_info val =
   | LiteralRegex target ->
     LiteralRegex
@@ -954,15 +823,13 @@ lang LiteralRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang TokenRegexAst = SelfhostBaseAst
-  type TokenRegexRecord = {arg: (Option) (Expr), info: Info, name: {i: Info, v: Name}}
-
+lang TokenRegexAst =
+  SelfhostBaseAst
+  type TokenRegexRecord =
+    {arg: Option Expr, info: Info, name: {i: Info, v: Name}}
   syn Regex =
   | TokenRegex TokenRegexRecord
-
   sem smapAccumL_Regex_Expr f acc =
   | TokenRegex x ->
     match
@@ -980,25 +847,19 @@ lang TokenRegexAst = SelfhostBaseAst
           arg
       with
         (acc, arg)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           arg =
             arg })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, TokenRegex
+    in
+    (acc, TokenRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | TokenRegex target ->
     target.info
-
   sem set_Regex_info val =
   | TokenRegex target ->
     TokenRegex
@@ -1006,15 +867,13 @@ lang TokenRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang RepeatPlusRegexAst = SelfhostBaseAst
-  type RepeatPlusRegexRecord = {info: Info, left: Regex}
-
+lang RepeatPlusRegexAst =
+  SelfhostBaseAst
+  type RepeatPlusRegexRecord =
+    {info: Info, left: Regex}
   syn Regex =
   | RepeatPlusRegex RepeatPlusRegexRecord
-
   sem smapAccumL_Regex_Regex f acc =
   | RepeatPlusRegex x ->
     match
@@ -1027,25 +886,19 @@ lang RepeatPlusRegexAst = SelfhostBaseAst
           left
       with
         (acc, left)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           left =
             left })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, RepeatPlusRegex
+    in
+    (acc, RepeatPlusRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | RepeatPlusRegex target ->
     target.info
-
   sem set_Regex_info val =
   | RepeatPlusRegex target ->
     RepeatPlusRegex
@@ -1053,15 +906,13 @@ lang RepeatPlusRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang RepeatStarRegexAst = SelfhostBaseAst
-  type RepeatStarRegexRecord = {info: Info, left: Regex}
-
+lang RepeatStarRegexAst =
+  SelfhostBaseAst
+  type RepeatStarRegexRecord =
+    {info: Info, left: Regex}
   syn Regex =
   | RepeatStarRegex RepeatStarRegexRecord
-
   sem smapAccumL_Regex_Regex f acc =
   | RepeatStarRegex x ->
     match
@@ -1074,25 +925,19 @@ lang RepeatStarRegexAst = SelfhostBaseAst
           left
       with
         (acc, left)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           left =
             left })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, RepeatStarRegex
+    in
+    (acc, RepeatStarRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | RepeatStarRegex target ->
     target.info
-
   sem set_Regex_info val =
   | RepeatStarRegex target ->
     RepeatStarRegex
@@ -1100,15 +945,13 @@ lang RepeatStarRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang RepeatQuestionRegexAst = SelfhostBaseAst
-  type RepeatQuestionRegexRecord = {info: Info, left: Regex}
-
+lang RepeatQuestionRegexAst =
+  SelfhostBaseAst
+  type RepeatQuestionRegexRecord =
+    {info: Info, left: Regex}
   syn Regex =
   | RepeatQuestionRegex RepeatQuestionRegexRecord
-
   sem smapAccumL_Regex_Regex f acc =
   | RepeatQuestionRegex x ->
     match
@@ -1121,25 +964,19 @@ lang RepeatQuestionRegexAst = SelfhostBaseAst
           left
       with
         (acc, left)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           left =
             left })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, RepeatQuestionRegex
+    in
+    (acc, RepeatQuestionRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | RepeatQuestionRegex target ->
     target.info
-
   sem set_Regex_info val =
   | RepeatQuestionRegex target ->
     RepeatQuestionRegex
@@ -1147,15 +984,13 @@ lang RepeatQuestionRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang NamedRegexAst = SelfhostBaseAst
-  type NamedRegexRecord = {info: Info, name: {i: Info, v: String}, right: Regex}
-
+lang NamedRegexAst =
+  SelfhostBaseAst
+  type NamedRegexRecord =
+    {info: Info, name: {i: Info, v: String}, right: Regex}
   syn Regex =
   | NamedRegex NamedRegexRecord
-
   sem smapAccumL_Regex_Regex f acc =
   | NamedRegex x ->
     match
@@ -1168,25 +1003,19 @@ lang NamedRegexAst = SelfhostBaseAst
           right
       with
         (acc, right)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           right =
             right })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, NamedRegex
+    in
+    (acc, NamedRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | NamedRegex target ->
     target.info
-
   sem set_Regex_info val =
   | NamedRegex target ->
     NamedRegex
@@ -1194,15 +1023,13 @@ lang NamedRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang AlternativeRegexAst = SelfhostBaseAst
-  type AlternativeRegexRecord = {info: Info, left: Regex, right: Regex}
-
+lang AlternativeRegexAst =
+  SelfhostBaseAst
+  type AlternativeRegexRecord =
+    {info: Info, left: Regex, right: Regex}
   syn Regex =
   | AlternativeRegex AlternativeRegexRecord
-
   sem smapAccumL_Regex_Regex f acc =
   | AlternativeRegex x ->
     match
@@ -1215,8 +1042,8 @@ lang AlternativeRegexAst = SelfhostBaseAst
           left
       with
         (acc, left)
-      then
-        match
+      in
+      match
           let right =
             x.right
           in
@@ -1225,30 +1052,22 @@ lang AlternativeRegexAst = SelfhostBaseAst
             right
         with
           (acc, right)
-        then
-          (acc, { { x
+        in
+        (acc, { { x
               with
               left =
                 left }
             with
             right =
               right })
-        else
-          never
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, AlternativeRegex
+    in
+    (acc, AlternativeRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | AlternativeRegex target ->
     target.info
-
   sem set_Regex_info val =
   | AlternativeRegex target ->
     AlternativeRegex
@@ -1256,15 +1075,13 @@ lang AlternativeRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang ConcatRegexAst = SelfhostBaseAst
-  type ConcatRegexRecord = {info: Info, left: Regex, right: Regex}
-
+lang ConcatRegexAst =
+  SelfhostBaseAst
+  type ConcatRegexRecord =
+    {info: Info, left: Regex, right: Regex}
   syn Regex =
   | ConcatRegex ConcatRegexRecord
-
   sem smapAccumL_Regex_Regex f acc =
   | ConcatRegex x ->
     match
@@ -1277,8 +1094,8 @@ lang ConcatRegexAst = SelfhostBaseAst
           left
       with
         (acc, left)
-      then
-        match
+      in
+      match
           let right =
             x.right
           in
@@ -1287,30 +1104,22 @@ lang ConcatRegexAst = SelfhostBaseAst
             right
         with
           (acc, right)
-        then
-          (acc, { { x
+        in
+        (acc, { { x
               with
               left =
                 left }
             with
             right =
               right })
-        else
-          never
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, ConcatRegex
+    in
+    (acc, ConcatRegex
         x)
-    else
-      never
-
   sem get_Regex_info =
   | ConcatRegex target ->
     target.info
-
   sem set_Regex_info val =
   | ConcatRegex target ->
     ConcatRegex
@@ -1318,15 +1127,13 @@ lang ConcatRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang AppExprAst = SelfhostBaseAst
-  type AppExprRecord = {info: Info, left: Expr, right: Expr}
-
+lang AppExprAst =
+  SelfhostBaseAst
+  type AppExprRecord =
+    {info: Info, left: Expr, right: Expr}
   syn Expr =
   | AppExpr AppExprRecord
-
   sem smapAccumL_Expr_Expr f acc =
   | AppExpr x ->
     match
@@ -1339,8 +1146,8 @@ lang AppExprAst = SelfhostBaseAst
           left
       with
         (acc, left)
-      then
-        match
+      in
+      match
           let right =
             x.right
           in
@@ -1349,30 +1156,22 @@ lang AppExprAst = SelfhostBaseAst
             right
         with
           (acc, right)
-        then
-          (acc, { { x
+        in
+        (acc, { { x
               with
               left =
                 left }
             with
             right =
               right })
-        else
-          never
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, AppExpr
+    in
+    (acc, AppExpr
         x)
-    else
-      never
-
   sem get_Expr_info =
   | AppExpr target ->
     target.info
-
   sem set_Expr_info val =
   | AppExpr target ->
     AppExpr
@@ -1380,19 +1179,16 @@ lang AppExprAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang ConExprAst = SelfhostBaseAst
-  type ConExprRecord = {info: Info, name: {i: Info, v: Name}}
-
+lang ConExprAst =
+  SelfhostBaseAst
+  type ConExprRecord =
+    {info: Info, name: {i: Info, v: Name}}
   syn Expr =
   | ConExpr ConExprRecord
-
   sem get_Expr_info =
   | ConExpr target ->
     target.info
-
   sem set_Expr_info val =
   | ConExpr target ->
     ConExpr
@@ -1400,19 +1196,16 @@ lang ConExprAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang StringExprAst = SelfhostBaseAst
-  type StringExprRecord = {val: {i: Info, v: String}, info: Info}
-
+lang StringExprAst =
+  SelfhostBaseAst
+  type StringExprRecord =
+    {val: {i: Info, v: String}, info: Info}
   syn Expr =
   | StringExpr StringExprRecord
-
   sem get_Expr_info =
   | StringExpr target ->
     target.info
-
   sem set_Expr_info val =
   | StringExpr target ->
     StringExpr
@@ -1420,19 +1213,16 @@ lang StringExprAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang VariableExprAst = SelfhostBaseAst
-  type VariableExprRecord = {info: Info, name: {i: Info, v: Name}}
-
+lang VariableExprAst =
+  SelfhostBaseAst
+  type VariableExprRecord =
+    {info: Info, name: {i: Info, v: Name}}
   syn Expr =
   | VariableExpr VariableExprRecord
-
   sem get_Expr_info =
   | VariableExpr target ->
     target.info
-
   sem set_Expr_info val =
   | VariableExpr target ->
     VariableExpr
@@ -1440,15 +1230,13 @@ lang VariableExprAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang RecordExprAst = SelfhostBaseAst
-  type RecordExprRecord = {info: Info, fields: [{val: Expr, name: {i: Info, v: String}}]}
-
+lang RecordExprAst =
+  SelfhostBaseAst
+  type RecordExprRecord =
+    {info: Info, fields: [{val: Expr, name: {i: Info, v: String}}]}
   syn Expr =
   | RecordExpr RecordExprRecord
-
   sem smapAccumL_Expr_Expr f acc =
   | RecordExpr x ->
     match
@@ -1460,44 +1248,36 @@ lang RecordExprAst = SelfhostBaseAst
           (lam acc1.
              lam x1: {val: Expr, name: {i: Info, v: String}}.
                match
-                 let val =
+                 let val1 =
                    x1.val
                  in
                  f
                    acc1
-                   val
+                   val1
                with
-                 (acc1, val)
-               then
-                 (acc1, { x1
+                 (acc1, val1)
+               in
+               (acc1, { x1
                    with
                    val =
-                     val })
-               else
-                 never)
+                     val1 }))
           acc
           fields
       with
         (acc, fields)
-      then
-        (acc, { x
+      in
+      (acc, { x
           with
           fields =
             fields })
-      else
-        never
     with
       (acc, x)
-    then
-      (acc, RecordExpr
+    in
+    (acc, RecordExpr
         x)
-    else
-      never
-
   sem get_Expr_info =
   | RecordExpr target ->
     target.info
-
   sem set_Expr_info val =
   | RecordExpr target ->
     RecordExpr
@@ -1505,19 +1285,16 @@ lang RecordExprAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang BadFileAst = SelfhostBaseAst
-  type BadFileRecord = {info: Info}
-
+lang BadFileAst =
+  SelfhostBaseAst
+  type BadFileRecord =
+    {info: Info}
   syn File =
   | BadFile BadFileRecord
-
   sem get_File_info =
   | BadFile target ->
     target.info
-
   sem set_File_info val =
   | BadFile target ->
     BadFile
@@ -1525,19 +1302,16 @@ lang BadFileAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang BadDeclAst = SelfhostBaseAst
-  type BadDeclRecord = {info: Info}
-
+lang BadDeclAst =
+  SelfhostBaseAst
+  type BadDeclRecord =
+    {info: Info}
   syn Decl =
   | BadDecl BadDeclRecord
-
   sem get_Decl_info =
   | BadDecl target ->
     target.info
-
   sem set_Decl_info val =
   | BadDecl target ->
     BadDecl
@@ -1545,19 +1319,16 @@ lang BadDeclAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang BadRegexAst = SelfhostBaseAst
-  type BadRegexRecord = {info: Info}
-
+lang BadRegexAst =
+  SelfhostBaseAst
+  type BadRegexRecord =
+    {info: Info}
   syn Regex =
   | BadRegex BadRegexRecord
-
   sem get_Regex_info =
   | BadRegex target ->
     target.info
-
   sem set_Regex_info val =
   | BadRegex target ->
     BadRegex
@@ -1565,19 +1336,16 @@ lang BadRegexAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang BadExprAst = SelfhostBaseAst
-  type BadExprRecord = {info: Info}
-
+lang BadExprAst =
+  SelfhostBaseAst
+  type BadExprRecord =
+    {info: Info}
   syn Expr =
   | BadExpr BadExprRecord
-
   sem get_Expr_info =
   | BadExpr target ->
     target.info
-
   sem set_Expr_info val =
   | BadExpr target ->
     BadExpr
@@ -1585,187 +1353,165 @@ lang BadExprAst = SelfhostBaseAst
         with
         info =
           val }
-
 end
-
-lang SelfhostAst = FileAst + StartDeclAst + IncludeDeclAst + TypeDeclAst + TokenDeclAst + PrecedenceTableDeclAst + ProductionDeclAst + RecordRegexAst + EmptyRegexAst + LiteralRegexAst + TokenRegexAst + RepeatPlusRegexAst + RepeatStarRegexAst + RepeatQuestionRegexAst + NamedRegexAst + AlternativeRegexAst + ConcatRegexAst + AppExprAst + ConExprAst + StringExprAst + VariableExprAst + RecordExprAst + BadFileAst + BadDeclAst + BadRegexAst + BadExprAst
-
-
-
+lang SelfhostAst =
+  LangFileAst
+  + StartDeclAst
+  + IncludeDeclAst
+  + TypeDeclAst
+  + TokenDeclAst
+  + PrecedenceTableDeclAst
+  + ProductionDeclAst
+  + RecordRegexAst
+  + EmptyRegexAst
+  + LiteralRegexAst
+  + TokenRegexAst
+  + RepeatPlusRegexAst
+  + RepeatStarRegexAst
+  + RepeatQuestionRegexAst
+  + NamedRegexAst
+  + AlternativeRegexAst
+  + ConcatRegexAst
+  + AppExprAst
+  + ConExprAst
+  + StringExprAst
+  + VariableExprAst
+  + RecordExprAst
+  + BadFileAst
+  + BadDeclAst
+  + BadRegexAst
+  + BadExprAst
 end
-
-lang FileOpBase = SelfhostBaseAst
-
+lang FileOpBase =
+  SelfhostAst
   syn FileOp lstyle rstyle =
-
-  sem topAllowed_FileOp : all lstyle. all rstyle. (((FileOp) (lstyle)) (rstyle)) -> (Bool)
-  sem topAllowed_FileOp =
+  sem topAllowed_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> Bool
+sem topAllowed_FileOp =
   | _ ->
     true
-
-  sem leftAllowed_FileOp : all lstyle. all style. all rstyle. ({child: ((FileOp) (lstyle)) (rstyle), parent: ((FileOp) (LOpen)) (style)}) -> (Bool)
-  sem leftAllowed_FileOp =
+  sem leftAllowed_FileOp : all lstyle. all style. all rstyle. {child: FileOp lstyle rstyle, parent: FileOp LOpen style} -> Bool
+sem leftAllowed_FileOp =
   | _ ->
     true
-
-  sem rightAllowed_FileOp : all style. all lstyle. all rstyle. ({child: ((FileOp) (lstyle)) (rstyle), parent: ((FileOp) (style)) (ROpen)}) -> (Bool)
-  sem rightAllowed_FileOp =
+  sem rightAllowed_FileOp : all style. all lstyle. all rstyle. {child: FileOp lstyle rstyle, parent: FileOp style ROpen} -> Bool
+sem rightAllowed_FileOp =
   | _ ->
     true
-
-  sem groupingsAllowed_FileOp : all lstyle. all rstyle. ((((FileOp) (lstyle)) (ROpen), ((FileOp) (LOpen)) (rstyle))) -> (AllowedDirection)
-  sem groupingsAllowed_FileOp =
+  sem groupingsAllowed_FileOp : all lstyle. all rstyle. (FileOp lstyle ROpen, FileOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_FileOp =
   | _ ->
     GEither
       {}
-
-  sem parenAllowed_FileOp : all lstyle. all rstyle. (((FileOp) (lstyle)) (rstyle)) -> (AllowedDirection)
-  sem parenAllowed_FileOp =
+  sem parenAllowed_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_FileOp =
   | _ ->
     GEither
       {}
-
-  sem get_FileOp_info : all lstyle. all rstyle. (((FileOp) (lstyle)) (rstyle)) -> (Info)
-
-  sem get_FileOp_terms : all lstyle. all rstyle. (((FileOp) (lstyle)) (rstyle)) -> ([Info])
-
-  sem unsplit_FileOp : ((PermanentNode) (FileOp)) -> ((Info, File))
-
+  sem getInfo_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> Info
+  sem getTerms_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> [Info]
+  sem unsplit_FileOp : PermanentNode FileOp -> (Info, File)
 end
-
-lang DeclOpBase = SelfhostBaseAst
-
+lang DeclOpBase =
+  SelfhostAst
   syn DeclOp lstyle rstyle =
-
-  sem topAllowed_DeclOp : all lstyle. all rstyle. (((DeclOp) (lstyle)) (rstyle)) -> (Bool)
-  sem topAllowed_DeclOp =
+  sem topAllowed_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> Bool
+sem topAllowed_DeclOp =
   | _ ->
     true
-
-  sem leftAllowed_DeclOp : all lstyle. all style. all rstyle. ({child: ((DeclOp) (lstyle)) (rstyle), parent: ((DeclOp) (LOpen)) (style)}) -> (Bool)
-  sem leftAllowed_DeclOp =
+  sem leftAllowed_DeclOp : all lstyle. all style. all rstyle. {child: DeclOp lstyle rstyle, parent: DeclOp LOpen style} -> Bool
+sem leftAllowed_DeclOp =
   | _ ->
     true
-
-  sem rightAllowed_DeclOp : all style. all lstyle. all rstyle. ({child: ((DeclOp) (lstyle)) (rstyle), parent: ((DeclOp) (style)) (ROpen)}) -> (Bool)
-  sem rightAllowed_DeclOp =
+  sem rightAllowed_DeclOp : all style. all lstyle. all rstyle. {child: DeclOp lstyle rstyle, parent: DeclOp style ROpen} -> Bool
+sem rightAllowed_DeclOp =
   | _ ->
     true
-
-  sem groupingsAllowed_DeclOp : all lstyle. all rstyle. ((((DeclOp) (lstyle)) (ROpen), ((DeclOp) (LOpen)) (rstyle))) -> (AllowedDirection)
-  sem groupingsAllowed_DeclOp =
+  sem groupingsAllowed_DeclOp : all lstyle. all rstyle. (DeclOp lstyle ROpen, DeclOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_DeclOp =
   | _ ->
     GEither
       {}
-
-  sem parenAllowed_DeclOp : all lstyle. all rstyle. (((DeclOp) (lstyle)) (rstyle)) -> (AllowedDirection)
-  sem parenAllowed_DeclOp =
+  sem parenAllowed_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_DeclOp =
   | _ ->
     GEither
       {}
-
-  sem get_DeclOp_info : all lstyle. all rstyle. (((DeclOp) (lstyle)) (rstyle)) -> (Info)
-
-  sem get_DeclOp_terms : all lstyle. all rstyle. (((DeclOp) (lstyle)) (rstyle)) -> ([Info])
-
-  sem unsplit_DeclOp : ((PermanentNode) (DeclOp)) -> ((Info, Decl))
-
+  sem getInfo_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> Info
+  sem getTerms_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> [Info]
+  sem unsplit_DeclOp : PermanentNode DeclOp -> (Info, Decl)
 end
-
-lang RegexOpBase = SelfhostBaseAst
-
+lang RegexOpBase =
+  SelfhostAst
   syn RegexOp lstyle rstyle =
-
-  sem topAllowed_RegexOp : all lstyle. all rstyle. (((RegexOp) (lstyle)) (rstyle)) -> (Bool)
-  sem topAllowed_RegexOp =
+  sem topAllowed_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> Bool
+sem topAllowed_RegexOp =
   | _ ->
     true
-
-  sem leftAllowed_RegexOp : all lstyle. all style. all rstyle. ({child: ((RegexOp) (lstyle)) (rstyle), parent: ((RegexOp) (LOpen)) (style)}) -> (Bool)
-  sem leftAllowed_RegexOp =
+  sem leftAllowed_RegexOp : all lstyle. all style. all rstyle. {child: RegexOp lstyle rstyle, parent: RegexOp LOpen style} -> Bool
+sem leftAllowed_RegexOp =
   | _ ->
     true
-
-  sem rightAllowed_RegexOp : all style. all lstyle. all rstyle. ({child: ((RegexOp) (lstyle)) (rstyle), parent: ((RegexOp) (style)) (ROpen)}) -> (Bool)
-  sem rightAllowed_RegexOp =
+  sem rightAllowed_RegexOp : all style. all lstyle. all rstyle. {child: RegexOp lstyle rstyle, parent: RegexOp style ROpen} -> Bool
+sem rightAllowed_RegexOp =
   | _ ->
     true
-
-  sem groupingsAllowed_RegexOp : all lstyle. all rstyle. ((((RegexOp) (lstyle)) (ROpen), ((RegexOp) (LOpen)) (rstyle))) -> (AllowedDirection)
-  sem groupingsAllowed_RegexOp =
+  sem groupingsAllowed_RegexOp : all lstyle. all rstyle. (RegexOp lstyle ROpen, RegexOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_RegexOp =
   | _ ->
     GEither
       {}
-
-  sem parenAllowed_RegexOp : all lstyle. all rstyle. (((RegexOp) (lstyle)) (rstyle)) -> (AllowedDirection)
-  sem parenAllowed_RegexOp =
+  sem parenAllowed_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_RegexOp =
   | _ ->
     GEither
       {}
-
-  sem get_RegexOp_info : all lstyle. all rstyle. (((RegexOp) (lstyle)) (rstyle)) -> (Info)
-
-  sem get_RegexOp_terms : all lstyle. all rstyle. (((RegexOp) (lstyle)) (rstyle)) -> ([Info])
-
-  sem unsplit_RegexOp : ((PermanentNode) (RegexOp)) -> ((Info, Regex))
-
+  sem getInfo_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> Info
+  sem getTerms_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> [Info]
+  sem unsplit_RegexOp : PermanentNode RegexOp -> (Info, Regex)
 end
-
-lang ExprOpBase = SelfhostBaseAst
-
+lang ExprOpBase =
+  SelfhostAst
   syn ExprOp lstyle rstyle =
-
-  sem topAllowed_ExprOp : all lstyle. all rstyle. (((ExprOp) (lstyle)) (rstyle)) -> (Bool)
-  sem topAllowed_ExprOp =
+  sem topAllowed_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> Bool
+sem topAllowed_ExprOp =
   | _ ->
     true
-
-  sem leftAllowed_ExprOp : all lstyle. all style. all rstyle. ({child: ((ExprOp) (lstyle)) (rstyle), parent: ((ExprOp) (LOpen)) (style)}) -> (Bool)
-  sem leftAllowed_ExprOp =
+  sem leftAllowed_ExprOp : all lstyle. all style. all rstyle. {child: ExprOp lstyle rstyle, parent: ExprOp LOpen style} -> Bool
+sem leftAllowed_ExprOp =
   | _ ->
     true
-
-  sem rightAllowed_ExprOp : all style. all lstyle. all rstyle. ({child: ((ExprOp) (lstyle)) (rstyle), parent: ((ExprOp) (style)) (ROpen)}) -> (Bool)
-  sem rightAllowed_ExprOp =
+  sem rightAllowed_ExprOp : all style. all lstyle. all rstyle. {child: ExprOp lstyle rstyle, parent: ExprOp style ROpen} -> Bool
+sem rightAllowed_ExprOp =
   | _ ->
     true
-
-  sem groupingsAllowed_ExprOp : all lstyle. all rstyle. ((((ExprOp) (lstyle)) (ROpen), ((ExprOp) (LOpen)) (rstyle))) -> (AllowedDirection)
-  sem groupingsAllowed_ExprOp =
+  sem groupingsAllowed_ExprOp : all lstyle. all rstyle. (ExprOp lstyle ROpen, ExprOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_ExprOp =
   | _ ->
     GEither
       {}
-
-  sem parenAllowed_ExprOp : all lstyle. all rstyle. (((ExprOp) (lstyle)) (rstyle)) -> (AllowedDirection)
-  sem parenAllowed_ExprOp =
+  sem parenAllowed_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_ExprOp =
   | _ ->
     GEither
       {}
-
-  sem get_ExprOp_info : all lstyle. all rstyle. (((ExprOp) (lstyle)) (rstyle)) -> (Info)
-
-  sem get_ExprOp_terms : all lstyle. all rstyle. (((ExprOp) (lstyle)) (rstyle)) -> ([Info])
-
-  sem unsplit_ExprOp : ((PermanentNode) (ExprOp)) -> ((Info, Expr))
-
+  sem getInfo_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> Info
+  sem getTerms_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> [Info]
+  sem unsplit_ExprOp : PermanentNode ExprOp -> (Info, Expr)
 end
-
-lang FileOp = FileOpBase + FileAst
-
+lang LangFileOp =
+  FileOpBase
+  + LangFileAst
   syn FileOp lstyle rstyle =
-  | FileOp {name: [{i: Info, v: String}], decls: [Decl], __br_info: Info, __br_terms: [Info]}
-
-  sem get_FileOp_info =
-  | FileOp x ->
+  | LangFileOp {name: [{i: Info, v: String}], decls: [Decl], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_FileOp =
+  | LangFileOp x ->
     x.__br_info
-
-  sem get_FileOp_terms =
-  | FileOp x ->
+  sem getTerms_FileOp =
+  | LangFileOp x ->
     x.__br_terms
-
   sem unsplit_FileOp =
-  | AtomP {self = FileOp x} ->
-    (x.__br_info, File
+  | AtomP {self = LangFileOp x} ->
+    (x.__br_info, LangFile
       { info =
           x.__br_info,
         decls =
@@ -1775,26 +1521,20 @@ lang FileOp = FileOpBase + FileAst
             x.name
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang StartDeclOp = DeclOpBase + StartDeclAst
-
+lang StartDeclOp =
+  DeclOpBase
+  + StartDeclAst
   syn DeclOp lstyle rstyle =
   | StartDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_DeclOp_info =
+  sem getInfo_DeclOp =
   | StartDeclOp x ->
     x.__br_info
-
-  sem get_DeclOp_terms =
+  sem getTerms_DeclOp =
   | StartDeclOp x ->
     x.__br_terms
-
   sem unsplit_DeclOp =
   | AtomP {self = StartDeclOp x} ->
     (x.__br_info, StartDecl
@@ -1805,26 +1545,20 @@ lang StartDeclOp = DeclOpBase + StartDeclAst
             x.name
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang IncludeDeclOp = DeclOpBase + IncludeDeclAst
-
+lang IncludeDeclOp =
+  DeclOpBase
+  + IncludeDeclAst
   syn DeclOp lstyle rstyle =
   | IncludeDeclOp {path: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_DeclOp_info =
+  sem getInfo_DeclOp =
   | IncludeDeclOp x ->
     x.__br_info
-
-  sem get_DeclOp_terms =
+  sem getTerms_DeclOp =
   | IncludeDeclOp x ->
     x.__br_terms
-
   sem unsplit_DeclOp =
   | AtomP {self = IncludeDeclOp x} ->
     (x.__br_info, IncludeDecl
@@ -1835,26 +1569,20 @@ lang IncludeDeclOp = DeclOpBase + IncludeDeclAst
             x.path
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang TypeDeclOp = DeclOpBase + TypeDeclAst
-
+lang TypeDeclOp =
+  DeclOpBase
+  + TypeDeclAst
   syn DeclOp lstyle rstyle =
   | TypeDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]}
-
-  sem get_DeclOp_info =
+  sem getInfo_DeclOp =
   | TypeDeclOp x ->
     x.__br_info
-
-  sem get_DeclOp_terms =
+  sem getTerms_DeclOp =
   | TypeDeclOp x ->
     x.__br_terms
-
   sem unsplit_DeclOp =
   | AtomP {self = TypeDeclOp x} ->
     (x.__br_info, TypeDecl
@@ -1865,28 +1593,22 @@ lang TypeDeclOp = DeclOpBase + TypeDeclAst
             x.name
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never,
+          in
+          x1,
         properties =
           x.properties })
-
 end
-
-lang TokenDeclOp = DeclOpBase + TokenDeclAst
-
+lang TokenDeclOp =
+  DeclOpBase
+  + TokenDeclAst
   syn DeclOp lstyle rstyle =
   | TokenDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]}
-
-  sem get_DeclOp_info =
+  sem getInfo_DeclOp =
   | TokenDeclOp x ->
     x.__br_info
-
-  sem get_DeclOp_terms =
+  sem getTerms_DeclOp =
   | TokenDeclOp x ->
     x.__br_terms
-
   sem unsplit_DeclOp =
   | AtomP {self = TokenDeclOp x} ->
     (x.__br_info, TokenDecl
@@ -1905,22 +1627,18 @@ lang TokenDeclOp = DeclOpBase + TokenDeclAst
               {},
         properties =
           x.properties })
-
 end
-
-lang PrecedenceTableDeclOp = DeclOpBase + PrecedenceTableDeclAst
-
+lang PrecedenceTableDeclOp =
+  DeclOpBase
+  + PrecedenceTableDeclAst
   syn DeclOp lstyle rstyle =
-  | PrecedenceTableDeclOp {levels: [{noeq: (Option) (Info), operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]}
-
-  sem get_DeclOp_info =
+  | PrecedenceTableDeclOp {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]}
+  sem getInfo_DeclOp =
   | PrecedenceTableDeclOp x ->
     x.__br_info
-
-  sem get_DeclOp_terms =
+  sem getTerms_DeclOp =
   | PrecedenceTableDeclOp x ->
     x.__br_terms
-
   sem unsplit_DeclOp =
   | AtomP {self = PrecedenceTableDeclOp x} ->
     (x.__br_info, PrecedenceTableDecl
@@ -1930,22 +1648,18 @@ lang PrecedenceTableDeclOp = DeclOpBase + PrecedenceTableDeclAst
           x.levels,
         exceptions =
           x.exceptions })
-
 end
-
-lang ProductionDeclOp = DeclOpBase + ProductionDeclAst
-
+lang ProductionDeclOp =
+  DeclOpBase
+  + ProductionDeclAst
   syn DeclOp lstyle rstyle =
   | ProductionDeclOp {nt: [{i: Info, v: Name}], kinf: [Info], name: [{i: Info, v: Name}], assoc: [{i: Info, v: String}], kpref: [Info], kprod: [Info], regex: [Regex], kpostf: [Info], __br_info: Info, __br_terms: [Info]}
-
-  sem get_DeclOp_info =
+  sem getInfo_DeclOp =
   | ProductionDeclOp x ->
     x.__br_info
-
-  sem get_DeclOp_terms =
+  sem getTerms_DeclOp =
   | ProductionDeclOp x ->
     x.__br_terms
-
   sem unsplit_DeclOp =
   | AtomP {self = ProductionDeclOp x} ->
     (x.__br_info, ProductionDecl
@@ -1956,19 +1670,15 @@ lang ProductionDeclOp = DeclOpBase + ProductionDeclAst
             x.nt
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never,
+          in
+          x1,
         name =
           match
             x.name
           with
             [ x2 ] ++ _ ++ ""
-          then
-            x2
-          else
-            never,
+          in
+          x2,
         kinf =
           match
             x.kinf
@@ -2029,26 +1739,20 @@ lang ProductionDeclOp = DeclOpBase + ProductionDeclAst
             x.regex
           with
             [ x8 ] ++ _ ++ ""
-          then
-            x8
-          else
-            never })
-
+          in
+          x8 })
 end
-
-lang RecordRegexOp = RegexOpBase + RecordRegexAst
-
+lang RecordRegexOp =
+  RegexOpBase
+  + RecordRegexAst
   syn RegexOp lstyle rstyle =
   | RecordRegexOp {regex: [Regex], __br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | RecordRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | RecordRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | AtomP {self = RecordRegexOp x} ->
     (x.__br_info, RecordRegex
@@ -2059,47 +1763,37 @@ lang RecordRegexOp = RegexOpBase + RecordRegexAst
             x.regex
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang EmptyRegexOp = RegexOpBase + EmptyRegexAst
-
+lang EmptyRegexOp =
+  RegexOpBase
+  + EmptyRegexAst
   syn RegexOp lstyle rstyle =
   | EmptyRegexOp {__br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | EmptyRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | EmptyRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | AtomP {self = EmptyRegexOp x} ->
     (x.__br_info, EmptyRegex
       { info =
           x.__br_info })
-
 end
-
-lang LiteralRegexOp = RegexOpBase + LiteralRegexAst
-
+lang LiteralRegexOp =
+  RegexOpBase
+  + LiteralRegexAst
   syn RegexOp lstyle rstyle =
   | LiteralRegexOp {val: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | LiteralRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | LiteralRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | AtomP {self = LiteralRegexOp x} ->
     (x.__br_info, LiteralRegex
@@ -2110,26 +1804,20 @@ lang LiteralRegexOp = RegexOpBase + LiteralRegexAst
             x.val
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang TokenRegexOp = RegexOpBase + TokenRegexAst
-
+lang TokenRegexOp =
+  RegexOpBase
+  + TokenRegexAst
   syn RegexOp lstyle rstyle =
   | TokenRegexOp {arg: [Expr], name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | TokenRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | TokenRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | AtomP {self = TokenRegexOp x} ->
     (x.__br_info, TokenRegex
@@ -2140,10 +1828,8 @@ lang TokenRegexOp = RegexOpBase + TokenRegexAst
             x.name
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never,
+          in
+          x1,
         arg =
           match
             x.arg
@@ -2155,22 +1841,18 @@ lang TokenRegexOp = RegexOpBase + TokenRegexAst
           else
             None
               {} })
-
 end
-
-lang RepeatPlusRegexOp = RegexOpBase + RepeatPlusRegexAst
-
+lang RepeatPlusRegexOp =
+  RegexOpBase
+  + RepeatPlusRegexAst
   syn RegexOp lstyle rstyle =
   | RepeatPlusRegexOp {__br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | RepeatPlusRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | RepeatPlusRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | PostfixP {self = RepeatPlusRegexOp x, leftChildAlts = [ l ] ++ _ ++ ""} ->
     match
@@ -2178,8 +1860,8 @@ lang RepeatPlusRegexOp = RegexOpBase + RepeatPlusRegexAst
         l
     with
       (linfo, l)
-    then
-      let info =
+    in
+    let info =
         mergeInfo
           linfo
           (x.__br_info)
@@ -2192,28 +1874,20 @@ lang RepeatPlusRegexOp = RegexOpBase + RepeatPlusRegexAst
               [ l ]
             with
               [ x1 ] ++ _ ++ ""
-            then
-              x1
-            else
-              never })
-    else
-      never
-
+            in
+            x1 })
 end
-
-lang RepeatStarRegexOp = RegexOpBase + RepeatStarRegexAst
-
+lang RepeatStarRegexOp =
+  RegexOpBase
+  + RepeatStarRegexAst
   syn RegexOp lstyle rstyle =
   | RepeatStarRegexOp {__br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | RepeatStarRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | RepeatStarRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | PostfixP {self = RepeatStarRegexOp x, leftChildAlts = [ l ] ++ _ ++ ""} ->
     match
@@ -2221,8 +1895,8 @@ lang RepeatStarRegexOp = RegexOpBase + RepeatStarRegexAst
         l
     with
       (linfo, l)
-    then
-      let info =
+    in
+    let info =
         mergeInfo
           linfo
           (x.__br_info)
@@ -2235,28 +1909,20 @@ lang RepeatStarRegexOp = RegexOpBase + RepeatStarRegexAst
               [ l ]
             with
               [ x1 ] ++ _ ++ ""
-            then
-              x1
-            else
-              never })
-    else
-      never
-
+            in
+            x1 })
 end
-
-lang RepeatQuestionRegexOp = RegexOpBase + RepeatQuestionRegexAst
-
+lang RepeatQuestionRegexOp =
+  RegexOpBase
+  + RepeatQuestionRegexAst
   syn RegexOp lstyle rstyle =
   | RepeatQuestionRegexOp {__br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | RepeatQuestionRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | RepeatQuestionRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | PostfixP {self = RepeatQuestionRegexOp x, leftChildAlts = [ l ] ++ _ ++ ""} ->
     match
@@ -2264,8 +1930,8 @@ lang RepeatQuestionRegexOp = RegexOpBase + RepeatQuestionRegexAst
         l
     with
       (linfo, l)
-    then
-      let info =
+    in
+    let info =
         mergeInfo
           linfo
           (x.__br_info)
@@ -2278,28 +1944,20 @@ lang RepeatQuestionRegexOp = RegexOpBase + RepeatQuestionRegexAst
               [ l ]
             with
               [ x1 ] ++ _ ++ ""
-            then
-              x1
-            else
-              never })
-    else
-      never
-
+            in
+            x1 })
 end
-
-lang NamedRegexOp = RegexOpBase + NamedRegexAst
-
+lang NamedRegexOp =
+  RegexOpBase
+  + NamedRegexAst
   syn RegexOp lstyle rstyle =
   | NamedRegexOp {name: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | NamedRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | NamedRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | PrefixP {self = NamedRegexOp x, rightChildAlts = [ r ] ++ _ ++ ""} ->
     match
@@ -2307,8 +1965,8 @@ lang NamedRegexOp = RegexOpBase + NamedRegexAst
         r
     with
       (rinfo, r)
-    then
-      let info =
+    in
+    let info =
         mergeInfo
           (x.__br_info)
           rinfo
@@ -2321,37 +1979,31 @@ lang NamedRegexOp = RegexOpBase + NamedRegexAst
               x.name
             with
               [ x1 ] ++ _ ++ ""
-            then
-              x1
-            else
-              never,
+            in
+            x1,
           right =
             match
               [ r ]
             with
               [ x2 ] ++ _ ++ ""
-            then
-              x2
-            else
-              never })
-    else
-      never
-
+            in
+            x2 })
 end
-
-lang AlternativeRegexOp = RegexOpBase + AlternativeRegexAst
-
+lang AlternativeRegexOp =
+  RegexOpBase
+  + AlternativeRegexAst
+  sem groupingsAllowed_RegexOp =
+  | (AlternativeRegexOp _, AlternativeRegexOp _) ->
+    GLeft
+      {}
   syn RegexOp lstyle rstyle =
   | AlternativeRegexOp {__br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | AlternativeRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | AlternativeRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | InfixP {self = AlternativeRegexOp x, leftChildAlts = [ l ] ++ _ ++ "", rightChildAlts = [ r ] ++ _ ++ ""} ->
     match
@@ -2360,8 +2012,8 @@ lang AlternativeRegexOp = RegexOpBase + AlternativeRegexAst
         r)
     with
       ((linfo, l), (rinfo, r))
-    then
-      let info =
+    in
+    let info =
         foldl
           mergeInfo
           linfo
@@ -2376,42 +2028,31 @@ lang AlternativeRegexOp = RegexOpBase + AlternativeRegexAst
               [ l ]
             with
               [ x1 ] ++ _ ++ ""
-            then
-              x1
-            else
-              never,
+            in
+            x1,
           right =
             match
               [ r ]
             with
               [ x2 ] ++ _ ++ ""
-            then
-              x2
-            else
-              never })
-    else
-      never
-
+            in
+            x2 })
+end
+lang ConcatRegexOp =
+  RegexOpBase
+  + ConcatRegexAst
   sem groupingsAllowed_RegexOp =
-  | (AlternativeRegexOp _, AlternativeRegexOp _) ->
+  | (ConcatRegexOp _, ConcatRegexOp _) ->
     GLeft
       {}
-
-end
-
-lang ConcatRegexOp = RegexOpBase + ConcatRegexAst
-
   syn RegexOp lstyle rstyle =
   | ConcatRegexOp {__br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | ConcatRegexOp x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | ConcatRegexOp x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | InfixP {self = ConcatRegexOp x, leftChildAlts = [ l ] ++ _ ++ "", rightChildAlts = [ r ] ++ _ ++ ""} ->
     match
@@ -2420,8 +2061,8 @@ lang ConcatRegexOp = RegexOpBase + ConcatRegexAst
         r)
     with
       ((linfo, l), (rinfo, r))
-    then
-      let info =
+    in
+    let info =
         foldl
           mergeInfo
           linfo
@@ -2436,42 +2077,31 @@ lang ConcatRegexOp = RegexOpBase + ConcatRegexAst
               [ l ]
             with
               [ x1 ] ++ _ ++ ""
-            then
-              x1
-            else
-              never,
+            in
+            x1,
           right =
             match
               [ r ]
             with
               [ x2 ] ++ _ ++ ""
-            then
-              x2
-            else
-              never })
-    else
-      never
-
-  sem groupingsAllowed_RegexOp =
-  | (ConcatRegexOp _, ConcatRegexOp _) ->
+            in
+            x2 })
+end
+lang AppExprOp =
+  ExprOpBase
+  + AppExprAst
+  sem groupingsAllowed_ExprOp =
+  | (AppExprOp _, AppExprOp _) ->
     GLeft
       {}
-
-end
-
-lang AppExprOp = ExprOpBase + AppExprAst
-
   syn ExprOp lstyle rstyle =
   | AppExprOp {__br_info: Info, __br_terms: [Info]}
-
-  sem get_ExprOp_info =
+  sem getInfo_ExprOp =
   | AppExprOp x ->
     x.__br_info
-
-  sem get_ExprOp_terms =
+  sem getTerms_ExprOp =
   | AppExprOp x ->
     x.__br_terms
-
   sem unsplit_ExprOp =
   | InfixP {self = AppExprOp x, leftChildAlts = [ l ] ++ _ ++ "", rightChildAlts = [ r ] ++ _ ++ ""} ->
     match
@@ -2480,8 +2110,8 @@ lang AppExprOp = ExprOpBase + AppExprAst
         r)
     with
       ((linfo, l), (rinfo, r))
-    then
-      let info =
+    in
+    let info =
         foldl
           mergeInfo
           linfo
@@ -2496,42 +2126,27 @@ lang AppExprOp = ExprOpBase + AppExprAst
               [ l ]
             with
               [ x1 ] ++ _ ++ ""
-            then
-              x1
-            else
-              never,
+            in
+            x1,
           right =
             match
               [ r ]
             with
               [ x2 ] ++ _ ++ ""
-            then
-              x2
-            else
-              never })
-    else
-      never
-
-  sem groupingsAllowed_ExprOp =
-  | (AppExprOp _, AppExprOp _) ->
-    GLeft
-      {}
-
+            in
+            x2 })
 end
-
-lang ConExprOp = ExprOpBase + ConExprAst
-
+lang ConExprOp =
+  ExprOpBase
+  + ConExprAst
   syn ExprOp lstyle rstyle =
   | ConExprOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_ExprOp_info =
+  sem getInfo_ExprOp =
   | ConExprOp x ->
     x.__br_info
-
-  sem get_ExprOp_terms =
+  sem getTerms_ExprOp =
   | ConExprOp x ->
     x.__br_terms
-
   sem unsplit_ExprOp =
   | AtomP {self = ConExprOp x} ->
     (x.__br_info, ConExpr
@@ -2542,26 +2157,20 @@ lang ConExprOp = ExprOpBase + ConExprAst
             x.name
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang StringExprOp = ExprOpBase + StringExprAst
-
+lang StringExprOp =
+  ExprOpBase
+  + StringExprAst
   syn ExprOp lstyle rstyle =
   | StringExprOp {val: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_ExprOp_info =
+  sem getInfo_ExprOp =
   | StringExprOp x ->
     x.__br_info
-
-  sem get_ExprOp_terms =
+  sem getTerms_ExprOp =
   | StringExprOp x ->
     x.__br_terms
-
   sem unsplit_ExprOp =
   | AtomP {self = StringExprOp x} ->
     (x.__br_info, StringExpr
@@ -2572,26 +2181,20 @@ lang StringExprOp = ExprOpBase + StringExprAst
             x.val
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang VariableExprOp = ExprOpBase + VariableExprAst
-
+lang VariableExprOp =
+  ExprOpBase
+  + VariableExprAst
   syn ExprOp lstyle rstyle =
   | VariableExprOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_ExprOp_info =
+  sem getInfo_ExprOp =
   | VariableExprOp x ->
     x.__br_info
-
-  sem get_ExprOp_terms =
+  sem getTerms_ExprOp =
   | VariableExprOp x ->
     x.__br_terms
-
   sem unsplit_ExprOp =
   | AtomP {self = VariableExprOp x} ->
     (x.__br_info, VariableExpr
@@ -2602,26 +2205,20 @@ lang VariableExprOp = ExprOpBase + VariableExprAst
             x.name
           with
             [ x1 ] ++ _ ++ ""
-          then
-            x1
-          else
-            never })
-
+          in
+          x1 })
 end
-
-lang RecordExprOp = ExprOpBase + RecordExprAst
-
+lang RecordExprOp =
+  ExprOpBase
+  + RecordExprAst
   syn ExprOp lstyle rstyle =
   | RecordExprOp {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]}
-
-  sem get_ExprOp_info =
+  sem getInfo_ExprOp =
   | RecordExprOp x ->
     x.__br_info
-
-  sem get_ExprOp_terms =
+  sem getTerms_ExprOp =
   | RecordExprOp x ->
     x.__br_terms
-
   sem unsplit_ExprOp =
   | AtomP {self = RecordExprOp x} ->
     (x.__br_info, RecordExpr
@@ -2629,52 +2226,77 @@ lang RecordExprOp = ExprOpBase + RecordExprAst
           x.__br_info,
         fields =
           x.fields })
-
 end
-
-lang RegexGrouping = RegexOpBase
-
+lang RegexGrouping =
+  RegexOpBase
   syn RegexOp lstyle rstyle =
   | RegexGrouping {inner: Regex, __br_info: Info, __br_terms: [Info]}
-
-  sem get_RegexOp_info =
+  sem getInfo_RegexOp =
   | RegexGrouping x ->
     x.__br_info
-
-  sem get_RegexOp_terms =
+  sem getTerms_RegexOp =
   | RegexGrouping x ->
     x.__br_terms
-
   sem unsplit_RegexOp =
   | AtomP {self = RegexGrouping x} ->
     (x.__br_info, x.inner)
-
 end
-
-lang ExprGrouping = ExprOpBase
-
+lang ExprGrouping =
+  ExprOpBase
   syn ExprOp lstyle rstyle =
   | ExprGrouping {inner: Expr, __br_info: Info, __br_terms: [Info]}
-
-  sem get_ExprOp_info =
+  sem getInfo_ExprOp =
   | ExprGrouping x ->
     x.__br_info
-
-  sem get_ExprOp_terms =
+  sem getTerms_ExprOp =
   | ExprGrouping x ->
     x.__br_terms
-
   sem unsplit_ExprOp =
   | AtomP {self = ExprGrouping x} ->
     (x.__br_info, x.inner)
-
 end
-
-lang ParseSelfhost = FileOp + StartDeclOp + IncludeDeclOp + TypeDeclOp + TokenDeclOp + PrecedenceTableDeclOp + ProductionDeclOp + RecordRegexOp + EmptyRegexOp + LiteralRegexOp + TokenRegexOp + RepeatPlusRegexOp + RepeatStarRegexOp + RepeatQuestionRegexOp + NamedRegexOp + AlternativeRegexOp + ConcatRegexOp + AppExprOp + ConExprOp + StringExprOp + VariableExprOp + RecordExprOp + RegexGrouping + ExprGrouping + BadFileAst + BadDeclAst + BadRegexAst + BadExprAst + LL1Parser + SemiTokenParser + CommaTokenParser + WhitespaceParser + LIdentTokenParser + LineCommentParser + StringTokenParser + UIdentTokenParser + BracketTokenParser + OperatorTokenParser + MultilineCommentParser
-
-
-
-
+lang ParseSelfhost =
+  LangFileOp
+  + StartDeclOp
+  + IncludeDeclOp
+  + TypeDeclOp
+  + TokenDeclOp
+  + PrecedenceTableDeclOp
+  + ProductionDeclOp
+  + RecordRegexOp
+  + EmptyRegexOp
+  + LiteralRegexOp
+  + TokenRegexOp
+  + RepeatPlusRegexOp
+  + RepeatStarRegexOp
+  + RepeatQuestionRegexOp
+  + NamedRegexOp
+  + AlternativeRegexOp
+  + ConcatRegexOp
+  + AppExprOp
+  + ConExprOp
+  + StringExprOp
+  + VariableExprOp
+  + RecordExprOp
+  + RegexGrouping
+  + ExprGrouping
+  + BadFileAst
+  + BadDeclAst
+  + BadRegexAst
+  + BadExprAst
+  + LL1Parser
+  + SemiTokenParser
+  + CommaTokenParser
+  + WhitespaceParser
+  + LIdentTokenParser
+  + LineCommentParser
+  + StringTokenParser
+  + UIdentTokenParser
+  + BracketTokenParser
+  + OperatorTokenParser
+  + MultilineCommentParser
+  
+  
   sem groupingsAllowed_RegexOp =
   | (NamedRegexOp _, RepeatPlusRegexOp _) ->
     GLeft
@@ -2715,3872 +2337,3755 @@ lang ParseSelfhost = FileOp + StartDeclOp + IncludeDeclOp + TypeDeclOp + TokenDe
   | (ConcatRegexOp _, AlternativeRegexOp _) ->
     GLeft
       {}
-
-
+  
 end
-
-
-
-let _table = use ParseSelfhost in let target =
-  genParsingTable
-    (let #var"File" =
-       nameSym
-         "File"
-     in
-     let #var"Decl" =
-       nameSym
-         "Decl"
-     in
-     let #var"Regex" =
-       nameSym
-         "Regex"
-     in
-     let #var"Expr" =
-       nameSym
-         "Expr"
-     in
-     let #var"FileAtom" =
-       nameSym
-         "FileAtom"
-     in
-     let #var"FileInfix" =
-       nameSym
-         "FileInfix"
-     in
-     let #var"FilePrefix" =
-       nameSym
-         "FilePrefix"
-     in
-     let #var"FilePostfix" =
-       nameSym
-         "FilePostfix"
-     in
-     let #var"DeclAtom" =
-       nameSym
-         "DeclAtom"
-     in
-     let #var"DeclInfix" =
-       nameSym
-         "DeclInfix"
-     in
-     let #var"DeclPrefix" =
-       nameSym
-         "DeclPrefix"
-     in
-     let #var"DeclPostfix" =
-       nameSym
-         "DeclPostfix"
-     in
-     let #var"RegexAtom" =
-       nameSym
-         "RegexAtom"
-     in
-     let #var"RegexInfix" =
-       nameSym
-         "RegexInfix"
-     in
-     let #var"RegexPrefix" =
-       nameSym
-         "RegexPrefix"
-     in
-     let #var"RegexPostfix" =
-       nameSym
-         "RegexPostfix"
-     in
-     let #var"ExprAtom" =
-       nameSym
-         "ExprAtom"
-     in
-     let #var"ExprInfix" =
-       nameSym
-         "ExprInfix"
-     in
-     let #var"ExprPrefix" =
-       nameSym
-         "ExprPrefix"
-     in
-     let #var"ExprPostfix" =
-       nameSym
-         "ExprPostfix"
-     in
-     let kleene =
-       nameSym
-         "kleene"
-     in
-     let kleene1 =
-       nameSym
-         "kleene"
-     in
-     let alt =
-       nameSym
-         "alt"
-     in
-     let alt1 =
-       nameSym
-         "alt"
-     in
-     let kleene2 =
-       nameSym
-         "kleene"
-     in
-     let alt2 =
-       nameSym
-         "alt"
-     in
-     let alt3 =
-       nameSym
-         "alt"
-     in
-     let kleene3 =
-       nameSym
-         "kleene"
-     in
-     let kleene4 =
-       nameSym
-         "kleene"
-     in
-     let kleene5 =
-       nameSym
-         "kleene"
-     in
-     let kleene6 =
-       nameSym
-         "kleene"
-     in
-     let kleene7 =
-       nameSym
-         "kleene"
-     in
-     let alt4 =
-       nameSym
-         "alt"
-     in
-     let alt5 =
-       nameSym
-         "alt"
-     in
-     let alt6 =
-       nameSym
-         "alt"
-     in
-     let alt7 =
-       nameSym
-         "alt"
-     in
-     let kleene8 =
-       nameSym
-         "kleene"
-     in
-     let alt8 =
-       nameSym
-         "alt"
-     in
-     let #var"File_lclosed" =
-       nameSym
-         "File_lclosed"
-     in
-     let #var"File_lopen" =
-       nameSym
-         "File_lopen"
-     in
-     let #var"Decl_lclosed" =
-       nameSym
-         "Decl_lclosed"
-     in
-     let #var"Decl_lopen" =
-       nameSym
-         "Decl_lopen"
-     in
-     let #var"Regex_lclosed" =
-       nameSym
-         "Regex_lclosed"
-     in
-     let #var"Regex_lopen" =
-       nameSym
-         "Regex_lopen"
-     in
-     let #var"Expr_lclosed" =
-       nameSym
-         "Expr_lclosed"
-     in
-     let #var"Expr_lopen" =
-       nameSym
-         "Expr_lopen"
-     in
-     { start =
-         #var"File",
-       productions =
-         let config =
-           { topAllowed =
-               #frozen"topAllowed_FileOp",
-             leftAllowed =
-               #frozen"leftAllowed_FileOp",
-             rightAllowed =
-               #frozen"rightAllowed_FileOp",
-             parenAllowed =
-               #frozen"parenAllowed_FileOp",
-             groupingsAllowed =
-               #frozen"groupingsAllowed_FileOp" }
-         in
-         let reportConfig =
-           { topAllowed =
-               #frozen"topAllowed_FileOp",
-             parenAllowed =
-               #frozen"parenAllowed_FileOp",
-             terminalInfos =
-               #frozen"get_FileOp_terms",
-             getInfo =
-               #frozen"get_FileOp_info",
-             lpar =
-               "(",
-             rpar =
-               ")" }
-         in
-         let addFileOpAtom =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddAtom
-                      config
-                      x33)
-                   st
-         in
-         let addFileOpInfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddInfix
-                       config
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_FileOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let addFileOpPrefix =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddPrefix
-                      config
-                      x33)
-                   st
-         in
-         let addFileOpPostfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddPostfix
-                       config
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_FileOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let finalizeFileOp =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam st.
-               let res60 =
-                 optionBind
-                   st
-                   (lam st.
-                      match
-                        breakableFinalizeParse
-                          config
-                          st
-                      with
-                        Some (tops & ([ top ] ++ _ ++ ""))
-                      then
-                        let errs =
-                          breakableDefaultHighlight
-                            reportConfig
-                            (p.content)
-                            tops
-                        in
-                        let res60: (Info, File) =
-                          unsplit_FileOp
-                            top
-                        in
-                        match
-                          null
-                            errs
-                        with
-                          true
-                        then
-                          Some
-                            res60
-                        else
-                          (modref
-                               (p.errors)
-                               (concat
-                                  (deref
-                                     (p.errors))
-                                  errs))
-                          ;Some
-                            (res60.#label"0", BadFile
-                              { info =
-                                  res60.#label"0" })
-                      else
-                        (modref
-                             (p.errors)
-                             (snoc
-                                (deref
-                                   (p.errors))
-                                (NoInfo
-                                  {}, "Unfinished File")))
-                        ;None
-                          {})
-               in
-               optionGetOr
-                 (NoInfo
-                   {}, BadFile
-                   { info =
-                       NoInfo
-                         {} })
-                 res60
-         in
-         let config1 =
-           { topAllowed =
-               #frozen"topAllowed_DeclOp",
-             leftAllowed =
-               #frozen"leftAllowed_DeclOp",
-             rightAllowed =
-               #frozen"rightAllowed_DeclOp",
-             parenAllowed =
-               #frozen"parenAllowed_DeclOp",
-             groupingsAllowed =
-               #frozen"groupingsAllowed_DeclOp" }
-         in
-         let reportConfig1 =
-           { topAllowed =
-               #frozen"topAllowed_DeclOp",
-             parenAllowed =
-               #frozen"parenAllowed_DeclOp",
-             terminalInfos =
-               #frozen"get_DeclOp_terms",
-             getInfo =
-               #frozen"get_DeclOp_info",
-             lpar =
-               "(",
-             rpar =
-               ")" }
-         in
-         let addDeclOpAtom =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddAtom
-                      config1
-                      x33)
-                   st
-         in
-         let addDeclOpInfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddInfix
-                       config1
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_DeclOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let addDeclOpPrefix =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddPrefix
-                      config1
-                      x33)
-                   st
-         in
-         let addDeclOpPostfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddPostfix
-                       config1
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_DeclOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let finalizeDeclOp =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam st.
-               let res60 =
-                 optionBind
-                   st
-                   (lam st.
-                      match
-                        breakableFinalizeParse
-                          config1
-                          st
-                      with
-                        Some (tops & ([ top ] ++ _ ++ ""))
-                      then
-                        let errs =
-                          breakableDefaultHighlight
-                            reportConfig1
-                            (p.content)
-                            tops
-                        in
-                        let res60: (Info, Decl) =
-                          unsplit_DeclOp
-                            top
-                        in
-                        match
-                          null
-                            errs
-                        with
-                          true
-                        then
-                          Some
-                            res60
-                        else
-                          (modref
-                               (p.errors)
-                               (concat
-                                  (deref
-                                     (p.errors))
-                                  errs))
-                          ;Some
-                            (res60.#label"0", BadDecl
-                              { info =
-                                  res60.#label"0" })
-                      else
-                        (modref
-                             (p.errors)
-                             (snoc
-                                (deref
-                                   (p.errors))
-                                (NoInfo
-                                  {}, "Unfinished Decl")))
-                        ;None
-                          {})
-               in
-               optionGetOr
-                 (NoInfo
-                   {}, BadDecl
-                   { info =
-                       NoInfo
-                         {} })
-                 res60
-         in
-         let config2 =
-           { topAllowed =
-               #frozen"topAllowed_RegexOp",
-             leftAllowed =
-               #frozen"leftAllowed_RegexOp",
-             rightAllowed =
-               #frozen"rightAllowed_RegexOp",
-             parenAllowed =
-               #frozen"parenAllowed_RegexOp",
-             groupingsAllowed =
-               #frozen"groupingsAllowed_RegexOp" }
-         in
-         let reportConfig2 =
-           { topAllowed =
-               #frozen"topAllowed_RegexOp",
-             parenAllowed =
-               #frozen"parenAllowed_RegexOp",
-             terminalInfos =
-               #frozen"get_RegexOp_terms",
-             getInfo =
-               #frozen"get_RegexOp_info",
-             lpar =
-               "(",
-             rpar =
-               ")" }
-         in
-         let addRegexOpAtom =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddAtom
-                      config2
-                      x33)
-                   st
-         in
-         let addRegexOpInfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddInfix
-                       config2
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_RegexOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let addRegexOpPrefix =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddPrefix
-                      config2
-                      x33)
-                   st
-         in
-         let addRegexOpPostfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddPostfix
-                       config2
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_RegexOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let finalizeRegexOp =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam st.
-               let res60 =
-                 optionBind
-                   st
-                   (lam st.
-                      match
-                        breakableFinalizeParse
-                          config2
-                          st
-                      with
-                        Some (tops & ([ top ] ++ _ ++ ""))
-                      then
-                        let errs =
-                          breakableDefaultHighlight
-                            reportConfig2
-                            (p.content)
-                            tops
-                        in
-                        let res60: (Info, Regex) =
-                          unsplit_RegexOp
-                            top
-                        in
-                        match
-                          null
-                            errs
-                        with
-                          true
-                        then
-                          Some
-                            res60
-                        else
-                          (modref
-                               (p.errors)
-                               (concat
-                                  (deref
-                                     (p.errors))
-                                  errs))
-                          ;Some
-                            (res60.#label"0", BadRegex
-                              { info =
-                                  res60.#label"0" })
-                      else
-                        (modref
-                             (p.errors)
-                             (snoc
-                                (deref
-                                   (p.errors))
-                                (NoInfo
-                                  {}, "Unfinished Regex")))
-                        ;None
-                          {})
-               in
-               optionGetOr
-                 (NoInfo
-                   {}, BadRegex
-                   { info =
-                       NoInfo
-                         {} })
-                 res60
-         in
-         let config3 =
-           { topAllowed =
-               #frozen"topAllowed_ExprOp",
-             leftAllowed =
-               #frozen"leftAllowed_ExprOp",
-             rightAllowed =
-               #frozen"rightAllowed_ExprOp",
-             parenAllowed =
-               #frozen"parenAllowed_ExprOp",
-             groupingsAllowed =
-               #frozen"groupingsAllowed_ExprOp" }
-         in
-         let reportConfig3 =
-           { topAllowed =
-               #frozen"topAllowed_ExprOp",
-             parenAllowed =
-               #frozen"parenAllowed_ExprOp",
-             terminalInfos =
-               #frozen"get_ExprOp_terms",
-             getInfo =
-               #frozen"get_ExprOp_info",
-             lpar =
-               "(",
-             rpar =
-               ")" }
-         in
-         let addExprOpAtom =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddAtom
-                      config3
-                      x33)
-                   st
-         in
-         let addExprOpInfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddInfix
-                       config3
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_ExprOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let addExprOpPrefix =
-           lam #var"".
-             lam x33.
-               lam st.
-                 optionMap
-                   (breakableAddPrefix
-                      config3
-                      x33)
-                   st
-         in
-         let addExprOpPostfix =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam x33.
-               lam st.
-                 match
-                   st
-                 with
-                   Some st
-                 then
-                   let st =
-                     breakableAddPostfix
-                       config3
-                       x33
-                       st
-                   in
-                   (match
-                        st
-                      with
-                        None _
-                      then
-                        modref
-                          (p.errors)
-                          (snoc
-                             (deref
-                                (p.errors))
-                             (get_ExprOp_info
-                               x33, "Invalid input"))
-                      else
-                        {})
-                   ;st
-                 else
-                   None
-                     {}
-         in
-         let finalizeExprOp =
-           lam p: {errors: (Ref) ([(Info, [Char])]), content: String}.
-             lam st.
-               let res60 =
-                 optionBind
-                   st
-                   (lam st.
-                      match
-                        breakableFinalizeParse
-                          config3
-                          st
-                      with
-                        Some (tops & ([ top ] ++ _ ++ ""))
-                      then
-                        let errs =
-                          breakableDefaultHighlight
-                            reportConfig3
-                            (p.content)
-                            tops
-                        in
-                        let res60: (Info, Expr) =
-                          unsplit_ExprOp
-                            top
-                        in
-                        match
-                          null
-                            errs
-                        with
-                          true
-                        then
-                          Some
-                            res60
-                        else
-                          (modref
-                               (p.errors)
-                               (concat
-                                  (deref
-                                     (p.errors))
-                                  errs))
-                          ;Some
-                            (res60.#label"0", BadExpr
-                              { info =
-                                  res60.#label"0" })
-                      else
-                        (modref
-                             (p.errors)
-                             (snoc
-                                (deref
-                                   (p.errors))
-                                (NoInfo
-                                  {}, "Unfinished Expr")))
-                        ;None
-                          {})
-               in
-               optionGetOr
-                 (NoInfo
-                   {}, BadExpr
-                   { info =
-                       NoInfo
-                         {} })
-                 res60
-         in
-         [ { nt =
-               kleene,
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"Decl",
-                 ntSym
-                   kleene ],
-             action =
-               lam state: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res.
+let _table =
+  use ParseSelfhost
+  in
+  let target =
+    genParsingTable
+      (let #var"File" =
+         nameSym
+           "File"
+       in
+       let #var"Decl" =
+         nameSym
+           "Decl"
+       in
+       let #var"Regex" =
+         nameSym
+           "Regex"
+       in
+       let #var"Expr" =
+         nameSym
+           "Expr"
+       in
+       let #var"FilePostfix" =
+         nameSym
+           "FilePostfix"
+       in
+       let #var"FileAtom" =
+         nameSym
+           "FileAtom"
+       in
+       let #var"FileInfix" =
+         nameSym
+           "FileInfix"
+       in
+       let #var"FilePrefix" =
+         nameSym
+           "FilePrefix"
+       in
+       let #var"DeclPostfix" =
+         nameSym
+           "DeclPostfix"
+       in
+       let #var"DeclAtom" =
+         nameSym
+           "DeclAtom"
+       in
+       let #var"DeclInfix" =
+         nameSym
+           "DeclInfix"
+       in
+       let #var"DeclPrefix" =
+         nameSym
+           "DeclPrefix"
+       in
+       let #var"RegexPostfix" =
+         nameSym
+           "RegexPostfix"
+       in
+       let #var"RegexAtom" =
+         nameSym
+           "RegexAtom"
+       in
+       let #var"RegexInfix" =
+         nameSym
+           "RegexInfix"
+       in
+       let #var"RegexPrefix" =
+         nameSym
+           "RegexPrefix"
+       in
+       let #var"ExprPostfix" =
+         nameSym
+           "ExprPostfix"
+       in
+       let #var"ExprAtom" =
+         nameSym
+           "ExprAtom"
+       in
+       let #var"ExprInfix" =
+         nameSym
+           "ExprInfix"
+       in
+       let #var"ExprPrefix" =
+         nameSym
+           "ExprPrefix"
+       in
+       let kleene =
+         nameSym
+           "kleene"
+       in
+       let kleene1 =
+         nameSym
+           "kleene"
+       in
+       let alt =
+         nameSym
+           "alt"
+       in
+       let alt1 =
+         nameSym
+           "alt"
+       in
+       let kleene2 =
+         nameSym
+           "kleene"
+       in
+       let alt2 =
+         nameSym
+           "alt"
+       in
+       let alt3 =
+         nameSym
+           "alt"
+       in
+       let kleene3 =
+         nameSym
+           "kleene"
+       in
+       let kleene4 =
+         nameSym
+           "kleene"
+       in
+       let kleene5 =
+         nameSym
+           "kleene"
+       in
+       let kleene6 =
+         nameSym
+           "kleene"
+       in
+       let kleene7 =
+         nameSym
+           "kleene"
+       in
+       let alt4 =
+         nameSym
+           "alt"
+       in
+       let alt5 =
+         nameSym
+           "alt"
+       in
+       let alt6 =
+         nameSym
+           "alt"
+       in
+       let alt7 =
+         nameSym
+           "alt"
+       in
+       let kleene8 =
+         nameSym
+           "kleene"
+       in
+       let alt8 =
+         nameSym
+           "alt"
+       in
+       let #var"File_lclosed" =
+         nameSym
+           "File_lclosed"
+       in
+       let #var"File_lopen" =
+         nameSym
+           "File_lopen"
+       in
+       let #var"Decl_lclosed" =
+         nameSym
+           "Decl_lclosed"
+       in
+       let #var"Decl_lopen" =
+         nameSym
+           "Decl_lopen"
+       in
+       let #var"Regex_lclosed" =
+         nameSym
+           "Regex_lclosed"
+       in
+       let #var"Regex_lopen" =
+         nameSym
+           "Regex_lopen"
+       in
+       let #var"Expr_lclosed" =
+         nameSym
+           "Expr_lclosed"
+       in
+       let #var"Expr_lopen" =
+         nameSym
+           "Expr_lopen"
+       in
+       { start =
+           #var"File",
+         productions =
+           let config =
+             { topAllowed =
+                 #frozen"topAllowed_FileOp",
+               leftAllowed =
+                 #frozen"leftAllowed_FileOp",
+               rightAllowed =
+                 #frozen"rightAllowed_FileOp",
+               parenAllowed =
+                 #frozen"parenAllowed_FileOp",
+               groupingsAllowed =
+                 #frozen"groupingsAllowed_FileOp" }
+           in
+           let reportConfig =
+             { topAllowed =
+                 #frozen"topAllowed_FileOp",
+               parenAllowed =
+                 #frozen"parenAllowed_FileOp",
+               terminalInfos =
+                 #frozen"getTerms_FileOp",
+               getInfo =
+                 #frozen"getInfo_FileOp",
+               lpar =
+                 "(",
+               rpar =
+                 ")" }
+           in
+           let addFileOpAtom =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddAtom
+                        config
+                        x33)
+                     st
+           in
+           let addFileOpInfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
                    match
-                     res
+                     st
                    with
-                     [ UserSym ntVal,
-                       UserSym val ]
+                     Some st
                    then
+                     let st =
+                       breakableAddInfix
+                         config
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_FileOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let addFileOpPrefix =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddPrefix
+                        config
+                        x33)
+                     st
+           in
+           let addFileOpPostfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
+                   match
+                     st
+                   with
+                     Some st
+                   then
+                     let st =
+                       breakableAddPostfix
+                         config
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_FileOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let finalizeFileOp =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam st.
+                 let res60 =
+                   optionBind
+                     st
+                     (lam st.
+                        match
+                          breakableFinalizeParse
+                            config
+                            st
+                        with
+                          Some (tops & ([ top ] ++ _ ++ ""))
+                        then
+                          let errs =
+                            breakableDefaultHighlight
+                              reportConfig
+                              (p.content)
+                              tops
+                          in
+                          let res60 =
+                            unsplit_FileOp
+                              top
+                          in
+                          match
+                            null
+                              errs
+                          with
+                            true
+                          then
+                            Some
+                              res60
+                          else
+                            (modref
+                                 (p.errors)
+                                 (concat
+                                    (deref
+                                       (p.errors))
+                                    errs))
+                            ; Some
+                              (res60.0, BadFile
+                                { info =
+                                    res60.0 })
+                        else
+                          (modref
+                               (p.errors)
+                               (snoc
+                                  (deref
+                                     (p.errors))
+                                  (NoInfo
+                                    {}, "Unfinished File")))
+                          ; None
+                            {})
+                 in
+                 optionGetOr
+                   (NoInfo
+                     {}, BadFile
+                     { info =
+                         NoInfo
+                           {} })
+                   res60
+           in
+           let config1 =
+             { topAllowed =
+                 #frozen"topAllowed_DeclOp",
+               leftAllowed =
+                 #frozen"leftAllowed_DeclOp",
+               rightAllowed =
+                 #frozen"rightAllowed_DeclOp",
+               parenAllowed =
+                 #frozen"parenAllowed_DeclOp",
+               groupingsAllowed =
+                 #frozen"groupingsAllowed_DeclOp" }
+           in
+           let reportConfig1 =
+             { topAllowed =
+                 #frozen"topAllowed_DeclOp",
+               parenAllowed =
+                 #frozen"parenAllowed_DeclOp",
+               terminalInfos =
+                 #frozen"getTerms_DeclOp",
+               getInfo =
+                 #frozen"getInfo_DeclOp",
+               lpar =
+                 "(",
+               rpar =
+                 ")" }
+           in
+           let addDeclOpAtom =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddAtom
+                        config1
+                        x33)
+                     st
+           in
+           let addDeclOpInfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
+                   match
+                     st
+                   with
+                     Some st
+                   then
+                     let st =
+                       breakableAddInfix
+                         config1
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_DeclOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let addDeclOpPrefix =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddPrefix
+                        config1
+                        x33)
+                     st
+           in
+           let addDeclOpPostfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
+                   match
+                     st
+                   with
+                     Some st
+                   then
+                     let st =
+                       breakableAddPostfix
+                         config1
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_DeclOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let finalizeDeclOp =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam st.
+                 let res60 =
+                   optionBind
+                     st
+                     (lam st.
+                        match
+                          breakableFinalizeParse
+                            config1
+                            st
+                        with
+                          Some (tops & ([ top ] ++ _ ++ ""))
+                        then
+                          let errs =
+                            breakableDefaultHighlight
+                              reportConfig1
+                              (p.content)
+                              tops
+                          in
+                          let res60 =
+                            unsplit_DeclOp
+                              top
+                          in
+                          match
+                            null
+                              errs
+                          with
+                            true
+                          then
+                            Some
+                              res60
+                          else
+                            (modref
+                                 (p.errors)
+                                 (concat
+                                    (deref
+                                       (p.errors))
+                                    errs))
+                            ; Some
+                              (res60.0, BadDecl
+                                { info =
+                                    res60.0 })
+                        else
+                          (modref
+                               (p.errors)
+                               (snoc
+                                  (deref
+                                     (p.errors))
+                                  (NoInfo
+                                    {}, "Unfinished Decl")))
+                          ; None
+                            {})
+                 in
+                 optionGetOr
+                   (NoInfo
+                     {}, BadDecl
+                     { info =
+                         NoInfo
+                           {} })
+                   res60
+           in
+           let config2 =
+             { topAllowed =
+                 #frozen"topAllowed_RegexOp",
+               leftAllowed =
+                 #frozen"leftAllowed_RegexOp",
+               rightAllowed =
+                 #frozen"rightAllowed_RegexOp",
+               parenAllowed =
+                 #frozen"parenAllowed_RegexOp",
+               groupingsAllowed =
+                 #frozen"groupingsAllowed_RegexOp" }
+           in
+           let reportConfig2 =
+             { topAllowed =
+                 #frozen"topAllowed_RegexOp",
+               parenAllowed =
+                 #frozen"parenAllowed_RegexOp",
+               terminalInfos =
+                 #frozen"getTerms_RegexOp",
+               getInfo =
+                 #frozen"getInfo_RegexOp",
+               lpar =
+                 "(",
+               rpar =
+                 ")" }
+           in
+           let addRegexOpAtom =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddAtom
+                        config2
+                        x33)
+                     st
+           in
+           let addRegexOpInfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
+                   match
+                     st
+                   with
+                     Some st
+                   then
+                     let st =
+                       breakableAddInfix
+                         config2
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_RegexOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let addRegexOpPrefix =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddPrefix
+                        config2
+                        x33)
+                     st
+           in
+           let addRegexOpPostfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
+                   match
+                     st
+                   with
+                     Some st
+                   then
+                     let st =
+                       breakableAddPostfix
+                         config2
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_RegexOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let finalizeRegexOp =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam st.
+                 let res60 =
+                   optionBind
+                     st
+                     (lam st.
+                        match
+                          breakableFinalizeParse
+                            config2
+                            st
+                        with
+                          Some (tops & ([ top ] ++ _ ++ ""))
+                        then
+                          let errs =
+                            breakableDefaultHighlight
+                              reportConfig2
+                              (p.content)
+                              tops
+                          in
+                          let res60 =
+                            unsplit_RegexOp
+                              top
+                          in
+                          match
+                            null
+                              errs
+                          with
+                            true
+                          then
+                            Some
+                              res60
+                          else
+                            (modref
+                                 (p.errors)
+                                 (concat
+                                    (deref
+                                       (p.errors))
+                                    errs))
+                            ; Some
+                              (res60.0, BadRegex
+                                { info =
+                                    res60.0 })
+                        else
+                          (modref
+                               (p.errors)
+                               (snoc
+                                  (deref
+                                     (p.errors))
+                                  (NoInfo
+                                    {}, "Unfinished Regex")))
+                          ; None
+                            {})
+                 in
+                 optionGetOr
+                   (NoInfo
+                     {}, BadRegex
+                     { info =
+                         NoInfo
+                           {} })
+                   res60
+           in
+           let config3 =
+             { topAllowed =
+                 #frozen"topAllowed_ExprOp",
+               leftAllowed =
+                 #frozen"leftAllowed_ExprOp",
+               rightAllowed =
+                 #frozen"rightAllowed_ExprOp",
+               parenAllowed =
+                 #frozen"parenAllowed_ExprOp",
+               groupingsAllowed =
+                 #frozen"groupingsAllowed_ExprOp" }
+           in
+           let reportConfig3 =
+             { topAllowed =
+                 #frozen"topAllowed_ExprOp",
+               parenAllowed =
+                 #frozen"parenAllowed_ExprOp",
+               terminalInfos =
+                 #frozen"getTerms_ExprOp",
+               getInfo =
+                 #frozen"getInfo_ExprOp",
+               lpar =
+                 "(",
+               rpar =
+                 ")" }
+           in
+           let addExprOpAtom =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddAtom
+                        config3
+                        x33)
+                     st
+           in
+           let addExprOpInfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
+                   match
+                     st
+                   with
+                     Some st
+                   then
+                     let st =
+                       breakableAddInfix
+                         config3
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_ExprOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let addExprOpPrefix =
+             lam #var"".
+               lam x33.
+                 lam st.
+                   optionMap
+                     (breakableAddPrefix
+                        config3
+                        x33)
+                     st
+           in
+           let addExprOpPostfix =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam x33.
+                 lam st.
+                   match
+                     st
+                   with
+                     Some st
+                   then
+                     let st =
+                       breakableAddPostfix
+                         config3
+                         x33
+                         st
+                     in
+                     (match
+                          st
+                        with
+                          None _
+                        then
+                          modref
+                            (p.errors)
+                            (snoc
+                               (deref
+                                  (p.errors))
+                               (getInfo_ExprOp
+                                 x33, "Invalid input"))
+                        else
+                          {})
+                     ; st
+                   else
+                     None
+                       {}
+           in
+           let finalizeExprOp =
+             lam p: {errors: Ref [(Info, [Char])], content: String}.
+               lam st.
+                 let res60 =
+                   optionBind
+                     st
+                     (lam st.
+                        match
+                          breakableFinalizeParse
+                            config3
+                            st
+                        with
+                          Some (tops & ([ top ] ++ _ ++ ""))
+                        then
+                          let errs =
+                            breakableDefaultHighlight
+                              reportConfig3
+                              (p.content)
+                              tops
+                          in
+                          let res60 =
+                            unsplit_ExprOp
+                              top
+                          in
+                          match
+                            null
+                              errs
+                          with
+                            true
+                          then
+                            Some
+                              res60
+                          else
+                            (modref
+                                 (p.errors)
+                                 (concat
+                                    (deref
+                                       (p.errors))
+                                    errs))
+                            ; Some
+                              (res60.0, BadExpr
+                                { info =
+                                    res60.0 })
+                        else
+                          (modref
+                               (p.errors)
+                               (snoc
+                                  (deref
+                                     (p.errors))
+                                  (NoInfo
+                                    {}, "Unfinished Expr")))
+                          ; None
+                            {})
+                 in
+                 optionGetOr
+                   (NoInfo
+                     {}, BadExpr
+                     { info =
+                         NoInfo
+                           {} })
+                   res60
+           in
+           [ { nt =
+                 kleene,
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"Decl",
+                   ntSym
+                     kleene ],
+               action =
+                 lam state: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res.
+                     match
+                       res
+                     with
+                       [ UserSym ntVal,
+                         UserSym val1 ]
+                     in
                      let ntVal: (Info, Decl) =
-                       fromDyn
-                         ntVal
-                     in
-                     let val: {decls: [Decl], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val
+                         fromDyn
+                           ntVal
+                       in
+                       let val1: {decls: [Decl], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val1
+                       in
+                       asDyn
+                         { __br_terms =
+                             val1.__br_terms,
+                           __br_info =
+                             mergeInfo
+                               (ntVal.0)
+                               (val1.__br_info),
+                           decls =
+                             concat
+                               [ ntVal.1 ]
+                               (val1.decls) } },
+             { nt =
+                 kleene,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state1: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res1.
+                     match
+                       res1
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           val.__br_terms,
-                         decls =
-                           concat
-                             [ ntVal.#label"1" ]
-                             (val.decls),
-                         __br_info =
-                           mergeInfo
-                             (ntVal.#label"0")
-                             (val.__br_info) }
-                   else
-                     never },
-           { nt =
-               kleene,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state1: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res1.
-                   match
-                     res1
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         decls =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {} }
-                   else
-                     never },
-           { nt =
-               #var"FileAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "language",
-                 tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   #var"Decl",
-                 ntSym
-                   kleene ],
-             action =
-               lam state2: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res2.
-                   match
-                     res2
-                   with
-                     [ LitParsed l,
-                       TokParsed (UIdentTok x),
-                       UserSym ntVal1,
-                       UserSym val ]
-                   then
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           decls =
+                             "" } },
+             { nt =
+                 #var"FileAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "language",
+                   tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     #var"Decl",
+                   ntSym
+                     kleene ],
+               action =
+                 lam state2: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res2.
+                     match
+                       res2
+                     with
+                       [ LitParsed l,
+                         TokParsed (UIdentTok x),
+                         UserSym ntVal1,
+                         UserSym val1 ]
+                     in
                      let ntVal1: (Info, Decl) =
-                       fromDyn
-                         ntVal1
-                     in
-                     let val: {decls: [Decl], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val
+                         fromDyn
+                           ntVal1
+                       in
+                       let val1: {decls: [Decl], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val1
+                       in
+                       asDyn
+                         (LangFileOp
+                            { __br_terms =
+                                join
+                                  [ [ l.info ],
+                                    [ x.info ],
+                                    val1.__br_terms ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l.info)
+                                  [ x.info,
+                                    ntVal1.0,
+                                    val1.__br_info ],
+                              decls =
+                                concat
+                                  [ ntVal1.1 ]
+                                  (val1.decls),
+                              name =
+                                [ { v =
+                                      x.val,
+                                    i =
+                                      x.info } ] }) },
+             { nt =
+                 #var"DeclAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "start",
+                   tokSym
+                     (UIdentRepr
+                        {}) ],
+               action =
+                 lam state3: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res3.
+                     match
+                       res3
+                     with
+                       [ LitParsed l1,
+                         TokParsed (UIdentTok x1) ]
                      in
                      asDyn
-                       (FileOp
-                          { __br_terms =
-                              join
-                                [ [ l.info ],
-                                  [ x.info ],
-                                  val.__br_terms ],
-                            decls =
-                              concat
-                                [ ntVal1.#label"1" ]
-                                (val.decls),
-                            __br_info =
-                              foldl
+                         (StartDeclOp
+                            { __br_terms =
+                                concat
+                                  [ l1.info ]
+                                  [ x1.info ],
+                              __br_info =
                                 mergeInfo
-                                (l.info)
-                                [ x.info,
-                                  ntVal1.#label"0",
-                                  val.__br_info ],
-                            name =
-                              [ { v =
-                                    x.val,
-                                  i =
-                                    x.info } ] })
-                   else
-                     never },
-           { nt =
-               #var"DeclAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "start",
-                 tokSym
-                   (UIdentRepr
-                      {}) ],
-             action =
-               lam state3: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res3.
-                   match
-                     res3
-                   with
-                     [ LitParsed l1,
-                       TokParsed (UIdentTok x1) ]
-                   then
+                                  (l1.info)
+                                  (x1.info),
+                              name =
+                                [ { v =
+                                      nameNoSym
+                                        (x1.val),
+                                    i =
+                                      x1.info } ] }) },
+             { nt =
+                 #var"DeclAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "include",
+                   tokSym
+                     (StringRepr
+                        {}) ],
+               action =
+                 lam state4: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res4.
+                     match
+                       res4
+                     with
+                       [ LitParsed l2,
+                         TokParsed (StringTok x2) ]
+                     in
                      asDyn
-                       (StartDeclOp
-                          { __br_terms =
-                              concat
-                                [ l1.info ]
-                                [ x1.info ],
-                            __br_info =
-                              mergeInfo
-                                (l1.info)
-                                (x1.info),
-                            name =
-                              [ { v =
-                                    nameNoSym
-                                      (x1.val),
-                                  i =
-                                    x1.info } ] })
-                   else
-                     never },
-           { nt =
-               #var"DeclAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "include",
-                 tokSym
-                   (StringRepr
-                      {}) ],
-             action =
-               lam state4: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res4.
-                   match
-                     res4
-                   with
-                     [ LitParsed l2,
-                       TokParsed (StringTok x2) ]
-                   then
-                     asDyn
-                       (IncludeDeclOp
-                          { __br_terms =
-                              concat
-                                [ l2.info ]
-                                [ x2.info ],
-                            __br_info =
-                              mergeInfo
-                                (l2.info)
-                                (x2.info),
-                            path =
-                              [ { v =
-                                    x2.val,
-                                  i =
-                                    x2.info } ] })
-                   else
-                     never },
-           { nt =
-               kleene1,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (LIdentRepr
-                      {}),
-                 litSym
-                   "=",
-                 ntSym
-                   #var"Expr",
-                 litSym
-                   ",",
-                 ntSym
-                   kleene1 ],
-             action =
-               lam state5: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res5.
-                   match
-                     res5
-                   with
-                     [ TokParsed (LIdentTok x3),
-                       LitParsed l3,
-                       UserSym ntVal2,
-                       LitParsed l4,
-                       UserSym val1 ]
-                   then
+                         (IncludeDeclOp
+                            { __br_terms =
+                                concat
+                                  [ l2.info ]
+                                  [ x2.info ],
+                              __br_info =
+                                mergeInfo
+                                  (l2.info)
+                                  (x2.info),
+                              path =
+                                [ { v =
+                                      x2.val,
+                                    i =
+                                      x2.info } ] }) },
+             { nt =
+                 kleene1,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (LIdentRepr
+                        {}),
+                   litSym
+                     "=",
+                   ntSym
+                     #var"Expr",
+                   litSym
+                     ",",
+                   ntSym
+                     kleene1 ],
+               action =
+                 lam state5: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res5.
+                     match
+                       res5
+                     with
+                       [ TokParsed (LIdentTok x3),
+                         LitParsed l3,
+                         UserSym ntVal2,
+                         LitParsed l4,
+                         UserSym val2 ]
+                     in
                      let ntVal2: (Info, Expr) =
-                       fromDyn
-                         ntVal2
-                     in
-                     let val1: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                       fromDyn
-                         val1
-                     in
-                     asDyn
-                       { __br_terms =
-                           join
-                             [ [ x3.info ],
-                               [ l3.info ],
-                               [ l4.info ],
-                               val1.__br_terms ],
-                         __br_info =
-                           foldl
-                             mergeInfo
-                             (x3.info)
-                             [ l3.info,
-                               ntVal2.#label"0",
-                               l4.info,
-                               val1.__br_info ],
-                         properties =
-                           concat
-                             [ { val =
-                                   match
-                                     [ ntVal2.#label"1" ]
-                                   with
-                                     [ x4 ] ++ _ ++ ""
-                                   then
-                                     x4
-                                   else
-                                     never,
-                                 name =
-                                   match
-                                     [ { v =
-                                           x3.val,
-                                         i =
-                                           x3.info } ]
-                                   with
-                                     [ x5 ] ++ _ ++ ""
-                                   then
-                                     x5
-                                   else
-                                     never } ]
-                             (val1.properties) }
-                   else
-                     never },
-           { nt =
-               kleene1,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state6: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res6.
-                   match
-                     res6
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         properties =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state7: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res7.
-                   match
-                     res7
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         properties =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "{",
-                 ntSym
-                   kleene1,
-                 litSym
-                   "}" ],
-             action =
-               lam state8: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res8.
-                   match
-                     res8
-                   with
-                     [ LitParsed l5,
-                       UserSym val1,
-                       LitParsed l6 ]
-                   then
-                     let val1: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                       fromDyn
-                         val1
+                         fromDyn
+                           ntVal2
+                       in
+                       let val2: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
+                         fromDyn
+                           val2
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ x3.info ],
+                                 [ l3.info ],
+                                 [ l4.info ],
+                                 val2.__br_terms ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (x3.info)
+                               [ l3.info,
+                                 ntVal2.0,
+                                 l4.info,
+                                 val2.__br_info ],
+                           properties =
+                             concat
+                               [ { val =
+                                     match
+                                       [ ntVal2.1 ]
+                                     with
+                                       [ x4 ] ++ _ ++ ""
+                                     in
+                                     x4,
+                                   name =
+                                     match
+                                       [ { v =
+                                             x3.val,
+                                           i =
+                                             x3.info } ]
+                                     with
+                                       [ x5 ] ++ _ ++ ""
+                                     in
+                                     x5 } ]
+                               (val2.properties) } },
+             { nt =
+                 kleene1,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state6: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res6.
+                     match
+                       res6
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           join
-                             [ [ l5.info ],
-                               val1.__br_terms,
-                               [ l6.info ] ],
-                         __br_info =
-                           foldl
-                             mergeInfo
-                             (l5.info)
-                             [ val1.__br_info,
-                               l6.info ],
-                         properties =
-                           val1.properties }
-                   else
-                     never },
-           { nt =
-               #var"DeclAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "type",
-                 tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   alt ],
-             action =
-               lam state9: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res9.
-                   match
-                     res9
-                   with
-                     [ LitParsed l7,
-                       TokParsed (UIdentTok x6),
-                       UserSym val2 ]
-                   then
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           properties =
+                             "" } },
+             { nt =
+                 alt,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state7: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res7.
+                     match
+                       res7
+                     with
+                       ""
+                     in
+                     asDyn
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           properties =
+                             "" } },
+             { nt =
+                 alt,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "{",
+                   ntSym
+                     kleene1,
+                   litSym
+                     "}" ],
+               action =
+                 lam state8: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res8.
+                     match
+                       res8
+                     with
+                       [ LitParsed l5,
+                         UserSym val2,
+                         LitParsed l6 ]
+                     in
                      let val2: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                       fromDyn
-                         val2
+                         fromDyn
+                           val2
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ l5.info ],
+                                 val2.__br_terms,
+                                 [ l6.info ] ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (l5.info)
+                               [ val2.__br_info,
+                                 l6.info ],
+                           properties =
+                             val2.properties } },
+             { nt =
+                 #var"DeclAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "type",
+                   tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     alt ],
+               action =
+                 lam state9: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res9.
+                     match
+                       res9
+                     with
+                       [ LitParsed l7,
+                         TokParsed (UIdentTok x6),
+                         UserSym val3 ]
+                     in
+                     let val3: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
+                         fromDyn
+                           val3
+                       in
+                       asDyn
+                         (TypeDeclOp
+                            { __br_terms =
+                                join
+                                  [ [ l7.info ],
+                                    [ x6.info ],
+                                    val3.__br_terms ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l7.info)
+                                  [ x6.info,
+                                    val3.__br_info ],
+                              name =
+                                [ { v =
+                                      nameNoSym
+                                        (x6.val),
+                                    i =
+                                      x6.info } ],
+                              properties =
+                                val3.properties }) },
+             { nt =
+                 alt1,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state10: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res10.
+                     match
+                       res10
+                     with
+                       ""
                      in
                      asDyn
-                       (TypeDeclOp
-                          { __br_terms =
-                              join
-                                [ [ l7.info ],
-                                  [ x6.info ],
-                                  val2.__br_terms ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (l7.info)
-                                [ x6.info,
-                                  val2.__br_info ],
-                            name =
-                              [ { v =
-                                    nameNoSym
-                                      (x6.val),
-                                  i =
-                                    x6.info } ],
-                            properties =
-                              val2.properties })
-                   else
-                     never },
-           { nt =
-               alt1,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state10: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res10.
-                   match
-                     res10
-                   with
-                     ""
-                   then
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           name =
+                             "" } },
+             { nt =
+                 alt1,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (UIdentRepr
+                        {}) ],
+               action =
+                 lam state11: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res11.
+                     match
+                       res11
+                     with
+                       [ TokParsed (UIdentTok x7) ]
+                     in
                      asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         name =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt1,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (UIdentRepr
-                      {}) ],
-             action =
-               lam state11: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res11.
-                   match
-                     res11
-                   with
-                     [ TokParsed (UIdentTok x7) ]
-                   then
-                     asDyn
-                       { __br_terms =
-                           [ x7.info ],
-                         __br_info =
-                           x7.info,
-                         name =
-                           [ { v =
-                                 nameNoSym
-                                   (x7.val),
-                               i =
-                                 x7.info } ] }
-                   else
-                     never },
-           { nt =
-               kleene2,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (LIdentRepr
-                      {}),
-                 litSym
-                   "=",
-                 ntSym
-                   #var"Expr",
-                 litSym
-                   ",",
-                 ntSym
-                   kleene2 ],
-             action =
-               lam state12: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res12.
-                   match
-                     res12
-                   with
-                     [ TokParsed (LIdentTok x8),
-                       LitParsed l8,
-                       UserSym ntVal3,
-                       LitParsed l9,
-                       UserSym val3 ]
-                   then
+                         { __br_terms =
+                             [ x7.info ],
+                           __br_info =
+                             x7.info,
+                           name =
+                             [ { v =
+                                   nameNoSym
+                                     (x7.val),
+                                 i =
+                                   x7.info } ] } },
+             { nt =
+                 kleene2,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (LIdentRepr
+                        {}),
+                   litSym
+                     "=",
+                   ntSym
+                     #var"Expr",
+                   litSym
+                     ",",
+                   ntSym
+                     kleene2 ],
+               action =
+                 lam state12: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res12.
+                     match
+                       res12
+                     with
+                       [ TokParsed (LIdentTok x8),
+                         LitParsed l8,
+                         UserSym ntVal3,
+                         LitParsed l9,
+                         UserSym val4 ]
+                     in
                      let ntVal3: (Info, Expr) =
-                       fromDyn
-                         ntVal3
-                     in
-                     let val3: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                       fromDyn
-                         val3
+                         fromDyn
+                           ntVal3
+                       in
+                       let val4: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
+                         fromDyn
+                           val4
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ x8.info ],
+                                 [ l8.info ],
+                                 [ l9.info ],
+                                 val4.__br_terms ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (x8.info)
+                               [ l8.info,
+                                 ntVal3.0,
+                                 l9.info,
+                                 val4.__br_info ],
+                           properties =
+                             concat
+                               [ { val =
+                                     match
+                                       [ ntVal3.1 ]
+                                     with
+                                       [ x9 ] ++ _ ++ ""
+                                     in
+                                     x9,
+                                   name =
+                                     match
+                                       [ { v =
+                                             x8.val,
+                                           i =
+                                             x8.info } ]
+                                     with
+                                       [ x10 ] ++ _ ++ ""
+                                     in
+                                     x10 } ]
+                               (val4.properties) } },
+             { nt =
+                 kleene2,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state13: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res13.
+                     match
+                       res13
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           join
-                             [ [ x8.info ],
-                               [ l8.info ],
-                               [ l9.info ],
-                               val3.__br_terms ],
-                         __br_info =
-                           foldl
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           properties =
+                             "" } },
+             { nt =
+                 alt2,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state14: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res14.
+                     match
+                       res14
+                     with
+                       ""
+                     in
+                     asDyn
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           properties =
+                             "" } },
+             { nt =
+                 alt2,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "{",
+                   ntSym
+                     kleene2,
+                   litSym
+                     "}" ],
+               action =
+                 lam state15: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res15.
+                     match
+                       res15
+                     with
+                       [ LitParsed l10,
+                         UserSym val4,
+                         LitParsed l11 ]
+                     in
+                     let val4: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
+                         fromDyn
+                           val4
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ l10.info ],
+                                 val4.__br_terms,
+                                 [ l11.info ] ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (l10.info)
+                               [ val4.__br_info,
+                                 l11.info ],
+                           properties =
+                             val4.properties } },
+             { nt =
+                 #var"DeclAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "token",
+                   ntSym
+                     alt1,
+                   ntSym
+                     alt2 ],
+               action =
+                 lam state16: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res16.
+                     match
+                       res16
+                     with
+                       [ LitParsed l12,
+                         UserSym val5,
+                         UserSym val6 ]
+                     in
+                     let val5: {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val5
+                       in
+                       let val6: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
+                         fromDyn
+                           val6
+                       in
+                       asDyn
+                         (TokenDeclOp
+                            { __br_terms =
+                                join
+                                  [ [ l12.info ],
+                                    val5.__br_terms,
+                                    val6.__br_terms ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l12.info)
+                                  [ val5.__br_info,
+                                    val6.__br_info ],
+                              name =
+                                val5.name,
+                              properties =
+                                val6.properties }) },
+             { nt =
+                 alt3,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state17: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res17.
+                     match
+                       res17
+                     with
+                       ""
+                     in
+                     asDyn
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           noeq =
+                             "" } },
+             { nt =
+                 alt3,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "~" ],
+               action =
+                 lam state18: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res18.
+                     match
+                       res18
+                     with
+                       [ LitParsed l13 ]
+                     in
+                     asDyn
+                         { __br_terms =
+                             [ l13.info ],
+                           __br_info =
+                             l13.info,
+                           noeq =
+                             [ l13.info ] } },
+             { nt =
+                 kleene3,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     kleene3 ],
+               action =
+                 lam state19: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res19.
+                     match
+                       res19
+                     with
+                       [ TokParsed (UIdentTok x11),
+                         UserSym val7 ]
+                     in
+                     let val7: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} =
+                         fromDyn
+                           val7
+                       in
+                       asDyn
+                         { __br_terms =
+                             concat
+                               [ x11.info ]
+                               (val7.__br_terms),
+                           __br_info =
                              mergeInfo
-                             (x8.info)
-                             [ l8.info,
-                               ntVal3.#label"0",
-                               l9.info,
-                               val3.__br_info ],
-                         properties =
-                           concat
-                             [ { val =
-                                   match
-                                     [ ntVal3.#label"1" ]
-                                   with
-                                     [ x9 ] ++ _ ++ ""
-                                   then
-                                     x9
-                                   else
-                                     never,
-                                 name =
-                                   match
-                                     [ { v =
-                                           x8.val,
-                                         i =
-                                           x8.info } ]
-                                   with
-                                     [ x10 ] ++ _ ++ ""
-                                   then
-                                     x10
-                                   else
-                                     never } ]
-                             (val3.properties) }
-                   else
-                     never },
-           { nt =
-               kleene2,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state13: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res13.
-                   match
-                     res13
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         properties =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt2,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state14: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res14.
-                   match
-                     res14
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         properties =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt2,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "{",
-                 ntSym
-                   kleene2,
-                 litSym
-                   "}" ],
-             action =
-               lam state15: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res15.
-                   match
-                     res15
-                   with
-                     [ LitParsed l10,
-                       UserSym val3,
-                       LitParsed l11 ]
-                   then
-                     let val3: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                       fromDyn
-                         val3
+                               (x11.info)
+                               (val7.__br_info),
+                           operators =
+                             concat
+                               [ { v =
+                                     nameNoSym
+                                       (x11.val),
+                                   i =
+                                     x11.info } ]
+                               (val7.operators) } },
+             { nt =
+                 kleene3,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state20: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res20.
+                     match
+                       res20
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           join
-                             [ [ l10.info ],
-                               val3.__br_terms,
-                               [ l11.info ] ],
-                         __br_info =
-                           foldl
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           operators =
+                             "" } },
+             { nt =
+                 kleene4,
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     alt3,
+                   tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     kleene3,
+                   litSym
+                     ";",
+                   ntSym
+                     kleene4 ],
+               action =
+                 lam state21: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res21.
+                     match
+                       res21
+                     with
+                       [ UserSym val8,
+                         TokParsed (UIdentTok x12),
+                         UserSym val7,
+                         LitParsed l14,
+                         UserSym val9 ]
+                     in
+                     let val8: {noeq: [Info], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val8
+                       in
+                       let val7: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} =
+                         fromDyn
+                           val7
+                       in
+                       let val9: {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val9
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ val8.__br_terms,
+                                 [ x12.info ],
+                                 val7.__br_terms,
+                                 [ l14.info ],
+                                 val9.__br_terms ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (val8.__br_info)
+                               [ x12.info,
+                                 val7.__br_info,
+                                 l14.info,
+                                 val9.__br_info ],
+                           levels =
+                             concat
+                               [ { noeq =
+                                     match
+                                       val8.noeq
+                                     with
+                                       [ x13 ] ++ _ ++ ""
+                                     then
+                                       Some
+                                         x13
+                                     else
+                                       None
+                                         {},
+                                   operators =
+                                     concat
+                                       [ { v =
+                                             nameNoSym
+                                               (x12.val),
+                                           i =
+                                             x12.info } ]
+                                       (val7.operators) } ]
+                               (val9.levels) } },
+             { nt =
+                 kleene4,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state22: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res22.
+                     match
+                       res22
+                     with
+                       ""
+                     in
+                     asDyn
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           levels =
+                             "" } },
+             { nt =
+                 kleene5,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     kleene5 ],
+               action =
+                 lam state23: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res23.
+                     match
+                       res23
+                     with
+                       [ TokParsed (UIdentTok x14),
+                         UserSym val10 ]
+                     in
+                     let val10: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val10
+                       in
+                       asDyn
+                         { __br_terms =
+                             concat
+                               [ x14.info ]
+                               (val10.__br_terms),
+                           __br_info =
                              mergeInfo
-                             (l10.info)
-                             [ val3.__br_info,
-                               l11.info ],
-                         properties =
-                           val3.properties }
-                   else
-                     never },
-           { nt =
-               #var"DeclAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "token",
-                 ntSym
-                   alt1,
-                 ntSym
-                   alt2 ],
-             action =
-               lam state16: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res16.
-                   match
-                     res16
-                   with
-                     [ LitParsed l12,
-                       UserSym val4,
-                       UserSym val5 ]
-                   then
-                     let val4: {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val4
-                     in
-                     let val5: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                       fromDyn
-                         val5
+                               (x14.info)
+                               (val10.__br_info),
+                           lefts =
+                             concat
+                               [ { v =
+                                     nameNoSym
+                                       (x14.val),
+                                   i =
+                                     x14.info } ]
+                               (val10.lefts) } },
+             { nt =
+                 kleene5,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state24: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res24.
+                     match
+                       res24
+                     with
+                       ""
                      in
                      asDyn
-                       (TokenDeclOp
-                          { __br_terms =
-                              join
-                                [ [ l12.info ],
-                                  val4.__br_terms,
-                                  val5.__br_terms ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (l12.info)
-                                [ val4.__br_info,
-                                  val5.__br_info ],
-                            name =
-                              val4.name,
-                            properties =
-                              val5.properties })
-                   else
-                     never },
-           { nt =
-               alt3,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state17: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res17.
-                   match
-                     res17
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         noeq =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt3,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "~" ],
-             action =
-               lam state18: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res18.
-                   match
-                     res18
-                   with
-                     [ LitParsed l13 ]
-                   then
-                     asDyn
-                       { __br_terms =
-                           [ l13.info ],
-                         __br_info =
-                           l13.info,
-                         noeq =
-                           [ l13.info ] }
-                   else
-                     never },
-           { nt =
-               kleene3,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   kleene3 ],
-             action =
-               lam state19: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res19.
-                   match
-                     res19
-                   with
-                     [ TokParsed (UIdentTok x11),
-                       UserSym val6 ]
-                   then
-                     let val6: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} =
-                       fromDyn
-                         val6
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           lefts =
+                             "" } },
+             { nt =
+                 kleene6,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     kleene6 ],
+               action =
+                 lam state25: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res25.
+                     match
+                       res25
+                     with
+                       [ TokParsed (UIdentTok x15),
+                         UserSym val11 ]
                      in
-                     asDyn
-                       { __br_terms =
-                           concat
-                             [ x11.info ]
-                             (val6.__br_terms),
-                         __br_info =
-                           mergeInfo
-                             (x11.info)
-                             (val6.__br_info),
-                         operators =
-                           concat
-                             [ { v =
-                                   nameNoSym
-                                     (x11.val),
-                                 i =
-                                   x11.info } ]
-                             (val6.operators) }
-                   else
-                     never },
-           { nt =
-               kleene3,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state20: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res20.
-                   match
-                     res20
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         operators =
-                           "" }
-                   else
-                     never },
-           { nt =
-               kleene4,
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   alt3,
-                 tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   kleene3,
-                 litSym
-                   ";",
-                 ntSym
-                   kleene4 ],
-             action =
-               lam state21: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res21.
-                   match
-                     res21
-                   with
-                     [ UserSym val7,
-                       TokParsed (UIdentTok x12),
-                       UserSym val6,
-                       LitParsed l14,
-                       UserSym val8 ]
-                   then
-                     let val7: {noeq: [Info], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val7
-                     in
-                     let val6: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} =
-                       fromDyn
-                         val6
-                     in
-                     let val8: {levels: [{noeq: (Option) (Info), operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val8
-                     in
-                     asDyn
-                       { __br_terms =
-                           join
-                             [ val7.__br_terms,
-                               [ x12.info ],
-                               val6.__br_terms,
-                               [ l14.info ],
-                               val8.__br_terms ],
-                         __br_info =
-                           foldl
+                     let val11: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val11
+                       in
+                       asDyn
+                         { __br_terms =
+                             concat
+                               [ x15.info ]
+                               (val11.__br_terms),
+                           __br_info =
                              mergeInfo
-                             (val7.__br_info)
-                             [ x12.info,
-                               val6.__br_info,
-                               l14.info,
-                               val8.__br_info ],
-                         levels =
-                           concat
-                             [ { noeq =
-                                   match
-                                     val7.noeq
-                                   with
-                                     [ x13 ] ++ _ ++ ""
-                                   then
-                                     Some
-                                       x13
-                                   else
-                                     None
-                                       {},
-                                 operators =
-                                   concat
-                                     [ { v =
-                                           nameNoSym
-                                             (x12.val),
-                                         i =
-                                           x12.info } ]
-                                     (val6.operators) } ]
-                             (val8.levels) }
-                   else
-                     never },
-           { nt =
-               kleene4,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state22: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res22.
-                   match
-                     res22
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         levels =
-                           "" }
-                   else
-                     never },
-           { nt =
-               kleene5,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   kleene5 ],
-             action =
-               lam state23: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res23.
-                   match
-                     res23
-                   with
-                     [ TokParsed (UIdentTok x14),
-                       UserSym val9 ]
-                   then
-                     let val9: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val9
+                               (x15.info)
+                               (val11.__br_info),
+                           rights =
+                             concat
+                               [ { v =
+                                     nameNoSym
+                                       (x15.val),
+                                   i =
+                                     x15.info } ]
+                               (val11.rights) } },
+             { nt =
+                 kleene6,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state26: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res26.
+                     match
+                       res26
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           concat
-                             [ x14.info ]
-                             (val9.__br_terms),
-                         __br_info =
-                           mergeInfo
-                             (x14.info)
-                             (val9.__br_info),
-                         lefts =
-                           concat
-                             [ { v =
-                                   nameNoSym
-                                     (x14.val),
-                                 i =
-                                   x14.info } ]
-                             (val9.lefts) }
-                   else
-                     never },
-           { nt =
-               kleene5,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state24: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res24.
-                   match
-                     res24
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         lefts =
-                           "" }
-                   else
-                     never },
-           { nt =
-               kleene6,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   kleene6 ],
-             action =
-               lam state25: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res25.
-                   match
-                     res25
-                   with
-                     [ TokParsed (UIdentTok x15),
-                       UserSym val10 ]
-                   then
-                     let val10: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val10
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           rights =
+                             "" } },
+             { nt =
+                 kleene7,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     kleene5,
+                   litSym
+                     "?",
+                   tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     kleene6,
+                   litSym
+                     ";",
+                   ntSym
+                     kleene7 ],
+               action =
+                 lam state27: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res27.
+                     match
+                       res27
+                     with
+                       [ TokParsed (UIdentTok x16),
+                         UserSym val10,
+                         LitParsed l15,
+                         TokParsed (UIdentTok x17),
+                         UserSym val11,
+                         LitParsed l16,
+                         UserSym val12 ]
+                     in
+                     let val10: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val10
+                       in
+                       let val11: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val11
+                       in
+                       let val12: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
+                         fromDyn
+                           val12
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ x16.info ],
+                                 val10.__br_terms,
+                                 [ l15.info ],
+                                 [ x17.info ],
+                                 val11.__br_terms,
+                                 [ l16.info ],
+                                 val12.__br_terms ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (x16.info)
+                               [ val10.__br_info,
+                                 l15.info,
+                                 x17.info,
+                                 val11.__br_info,
+                                 l16.info,
+                                 val12.__br_info ],
+                           exceptions =
+                             concat
+                               [ { lefts =
+                                     concat
+                                       [ { v =
+                                             nameNoSym
+                                               (x16.val),
+                                           i =
+                                             x16.info } ]
+                                       (val10.lefts),
+                                   rights =
+                                     concat
+                                       [ { v =
+                                             nameNoSym
+                                               (x17.val),
+                                           i =
+                                             x17.info } ]
+                                       (val11.rights) } ]
+                               (val12.exceptions) } },
+             { nt =
+                 kleene7,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state28: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res28.
+                     match
+                       res28
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           concat
-                             [ x15.info ]
-                             (val10.__br_terms),
-                         __br_info =
-                           mergeInfo
-                             (x15.info)
-                             (val10.__br_info),
-                         rights =
-                           concat
-                             [ { v =
-                                   nameNoSym
-                                     (x15.val),
-                                 i =
-                                   x15.info } ]
-                             (val10.rights) }
-                   else
-                     never },
-           { nt =
-               kleene6,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state26: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res26.
-                   match
-                     res26
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         rights =
-                           "" }
-                   else
-                     never },
-           { nt =
-               kleene7,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   kleene5,
-                 litSym
-                   "?",
-                 tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   kleene6,
-                 litSym
-                   ";",
-                 ntSym
-                   kleene7 ],
-             action =
-               lam state27: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res27.
-                   match
-                     res27
-                   with
-                     [ TokParsed (UIdentTok x16),
-                       UserSym val9,
-                       LitParsed l15,
-                       TokParsed (UIdentTok x17),
-                       UserSym val10,
-                       LitParsed l16,
-                       UserSym val11 ]
-                   then
-                     let val9: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val9
-                     in
-                     let val10: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val10
-                     in
-                     let val11: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
-                       fromDyn
-                         val11
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           exceptions =
+                             "" } },
+             { nt =
+                 alt4,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state29: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res29.
+                     match
+                       res29
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           join
-                             [ [ x16.info ],
-                               val9.__br_terms,
-                               [ l15.info ],
-                               [ x17.info ],
-                               val10.__br_terms,
-                               [ l16.info ],
-                               val11.__br_terms ],
-                         __br_info =
-                           foldl
-                             mergeInfo
-                             (x16.info)
-                             [ val9.__br_info,
-                               l15.info,
-                               x17.info,
-                               val10.__br_info,
-                               l16.info,
-                               val11.__br_info ],
-                         exceptions =
-                           concat
-                             [ { lefts =
-                                   concat
-                                     [ { v =
-                                           nameNoSym
-                                             (x16.val),
-                                         i =
-                                           x16.info } ]
-                                     (val9.lefts),
-                                 rights =
-                                   concat
-                                     [ { v =
-                                           nameNoSym
-                                             (x17.val),
-                                         i =
-                                           x17.info } ]
-                                     (val10.rights) } ]
-                             (val11.exceptions) }
-                   else
-                     never },
-           { nt =
-               kleene7,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state28: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res28.
-                   match
-                     res28
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         exceptions =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt4,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state29: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res29.
-                   match
-                     res29
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         exceptions =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt4,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "except",
-                 litSym
-                   "{",
-                 ntSym
-                   kleene7,
-                 litSym
-                   "}" ],
-             action =
-               lam state30: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res30.
-                   match
-                     res30
-                   with
-                     [ LitParsed l17,
-                       LitParsed l18,
-                       UserSym val11,
-                       LitParsed l19 ]
-                   then
-                     let val11: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
-                       fromDyn
-                         val11
-                     in
-                     asDyn
-                       { __br_terms =
-                           join
-                             [ [ l17.info ],
-                               [ l18.info ],
-                               val11.__br_terms,
-                               [ l19.info ] ],
-                         __br_info =
-                           foldl
-                             mergeInfo
-                             (l17.info)
-                             [ l18.info,
-                               val11.__br_info,
-                               l19.info ],
-                         exceptions =
-                           val11.exceptions }
-                   else
-                     never },
-           { nt =
-               #var"DeclAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "precedence",
-                 litSym
-                   "{",
-                 ntSym
-                   kleene4,
-                 litSym
-                   "}",
-                 ntSym
-                   alt4 ],
-             action =
-               lam state31: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res31.
-                   match
-                     res31
-                   with
-                     [ LitParsed l20,
-                       LitParsed l21,
-                       UserSym val8,
-                       LitParsed l22,
-                       UserSym val12 ]
-                   then
-                     let val8: {levels: [{noeq: (Option) (Info), operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val8
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           exceptions =
+                             "" } },
+             { nt =
+                 alt4,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "except",
+                   litSym
+                     "{",
+                   ntSym
+                     kleene7,
+                   litSym
+                     "}" ],
+               action =
+                 lam state30: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res30.
+                     match
+                       res30
+                     with
+                       [ LitParsed l17,
+                         LitParsed l18,
+                         UserSym val12,
+                         LitParsed l19 ]
                      in
                      let val12: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
-                       fromDyn
-                         val12
+                         fromDyn
+                           val12
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ l17.info ],
+                                 [ l18.info ],
+                                 val12.__br_terms,
+                                 [ l19.info ] ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (l17.info)
+                               [ l18.info,
+                                 val12.__br_info,
+                                 l19.info ],
+                           exceptions =
+                             val12.exceptions } },
+             { nt =
+                 #var"DeclAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "precedence",
+                   litSym
+                     "{",
+                   ntSym
+                     kleene4,
+                   litSym
+                     "}",
+                   ntSym
+                     alt4 ],
+               action =
+                 lam state31: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res31.
+                     match
+                       res31
+                     with
+                       [ LitParsed l20,
+                         LitParsed l21,
+                         UserSym val9,
+                         LitParsed l22,
+                         UserSym val13 ]
+                     in
+                     let val9: {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val9
+                       in
+                       let val13: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
+                         fromDyn
+                           val13
+                       in
+                       asDyn
+                         (PrecedenceTableDeclOp
+                            { __br_terms =
+                                join
+                                  [ [ l20.info ],
+                                    [ l21.info ],
+                                    val9.__br_terms,
+                                    [ l22.info ],
+                                    val13.__br_terms ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l20.info)
+                                  [ l21.info,
+                                    val9.__br_info,
+                                    l22.info,
+                                    val13.__br_info ],
+                              levels =
+                                val9.levels,
+                              exceptions =
+                                val13.exceptions }) },
+             { nt =
+                 alt5,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "prod" ],
+               action =
+                 lam state32: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res32.
+                     match
+                       res32
+                     with
+                       [ LitParsed l23 ]
                      in
                      asDyn
-                       (PrecedenceTableDeclOp
-                          { __br_terms =
-                              join
-                                [ [ l20.info ],
-                                  [ l21.info ],
-                                  val8.__br_terms,
-                                  [ l22.info ],
-                                  val12.__br_terms ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (l20.info)
-                                [ l21.info,
-                                  val8.__br_info,
-                                  l22.info,
-                                  val12.__br_info ],
-                            levels =
-                              val8.levels,
-                            exceptions =
-                              val12.exceptions })
-                   else
-                     never },
-           { nt =
-               alt5,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "prod" ],
-             action =
-               lam state32: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res32.
-                   match
-                     res32
-                   with
-                     [ LitParsed l23 ]
-                   then
-                     asDyn
-                       { __br_terms =
-                           [ l23.info ],
-                         __br_info =
-                           l23.info,
-                         kinf =
-                           "",
-                         kpref =
-                           "",
-                         kprod =
-                           [ l23.info ],
-                         kpostf =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt5,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "infix" ],
-             action =
-               lam state33: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res33.
-                   match
-                     res33
-                   with
-                     [ LitParsed l24 ]
-                   then
-                     asDyn
-                       { __br_terms =
-                           [ l24.info ],
-                         __br_info =
-                           l24.info,
-                         kinf =
-                           [ l24.info ],
-                         kpref =
-                           "",
-                         kprod =
-                           "",
-                         kpostf =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt5,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "prefix" ],
-             action =
-               lam state34: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res34.
-                   match
-                     res34
-                   with
-                     [ LitParsed l25 ]
-                   then
-                     asDyn
-                       { __br_terms =
-                           [ l25.info ],
-                         __br_info =
-                           l25.info,
-                         kinf =
-                           "",
-                         kpref =
-                           [ l25.info ],
-                         kprod =
-                           "",
-                         kpostf =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt5,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "postfix" ],
-             action =
-               lam state35: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res35.
-                   match
-                     res35
-                   with
-                     [ LitParsed l26 ]
-                   then
-                     asDyn
-                       { __br_terms =
-                           [ l26.info ],
-                         __br_info =
-                           l26.info,
-                         kinf =
-                           "",
-                         kpref =
-                           "",
-                         kprod =
-                           "",
-                         kpostf =
-                           [ l26.info ] }
-                   else
-                     never },
-           { nt =
-               alt6,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state36: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res36.
-                   match
-                     res36
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         assoc =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt6,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (LIdentRepr
-                      {}) ],
-             action =
-               lam state37: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res37.
-                   match
-                     res37
-                   with
-                     [ TokParsed (LIdentTok x18) ]
-                   then
-                     asDyn
-                       { __br_terms =
-                           [ x18.info ],
-                         __br_info =
-                           x18.info,
-                         assoc =
-                           [ { v =
-                                 x18.val,
-                               i =
-                                 x18.info } ] }
-                   else
-                     never },
-           { nt =
-               #var"DeclAtom",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   alt5,
-                 ntSym
-                   alt6,
-                 tokSym
-                   (UIdentRepr
-                      {}),
-                 litSym
-                   ":",
-                 tokSym
-                   (UIdentRepr
-                      {}),
-                 litSym
-                   "=",
-                 ntSym
-                   #var"Regex" ],
-             action =
-               lam state38: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res38.
-                   match
-                     res38
-                   with
-                     [ UserSym val13,
-                       UserSym val14,
-                       TokParsed (UIdentTok x19),
-                       LitParsed l27,
-                       TokParsed (UIdentTok x20),
-                       LitParsed l28,
-                       UserSym ntVal4 ]
-                   then
-                     let val13: {kinf: [Info], kpref: [Info], kprod: [Info], kpostf: [Info], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val13
-                     in
-                     let val14: {assoc: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val14
-                     in
-                     let ntVal4: (Info, Regex) =
-                       fromDyn
-                         ntVal4
+                         { __br_terms =
+                             [ l23.info ],
+                           __br_info =
+                             l23.info,
+                           kinf =
+                             "",
+                           kpref =
+                             "",
+                           kprod =
+                             [ l23.info ],
+                           kpostf =
+                             "" } },
+             { nt =
+                 alt5,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "infix" ],
+               action =
+                 lam state33: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res33.
+                     match
+                       res33
+                     with
+                       [ LitParsed l24 ]
                      in
                      asDyn
-                       (ProductionDeclOp
-                          { __br_terms =
-                              join
-                                [ val13.__br_terms,
-                                  val14.__br_terms,
-                                  [ x19.info ],
-                                  [ l27.info ],
-                                  [ x20.info ],
-                                  [ l28.info ] ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (val13.__br_info)
-                                [ val14.__br_info,
-                                  x19.info,
-                                  l27.info,
-                                  x20.info,
-                                  l28.info,
-                                  ntVal4.#label"0" ],
-                            nt =
-                              [ { v =
-                                    nameNoSym
-                                      (x20.val),
-                                  i =
-                                    x20.info } ],
-                            name =
-                              [ { v =
-                                    nameNoSym
-                                      (x19.val),
-                                  i =
-                                    x19.info } ],
-                            kinf =
-                              val13.kinf,
-                            kpref =
-                              val13.kpref,
-                            kprod =
-                              val13.kprod,
-                            kpostf =
-                              val13.kpostf,
-                            assoc =
-                              val14.assoc,
-                            regex =
-                              [ ntVal4.#label"1" ] })
-                   else
-                     never },
-           { nt =
-               #var"RegexAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "{",
-                 ntSym
-                   #var"Regex",
-                 litSym
-                   "}" ],
-             action =
-               lam state39: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res39.
-                   match
-                     res39
-                   with
-                     [ LitParsed l29,
-                       UserSym ntVal5,
-                       LitParsed l30 ]
-                   then
+                         { __br_terms =
+                             [ l24.info ],
+                           __br_info =
+                             l24.info,
+                           kinf =
+                             [ l24.info ],
+                           kpref =
+                             "",
+                           kprod =
+                             "",
+                           kpostf =
+                             "" } },
+             { nt =
+                 alt5,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "prefix" ],
+               action =
+                 lam state34: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res34.
+                     match
+                       res34
+                     with
+                       [ LitParsed l25 ]
+                     in
+                     asDyn
+                         { __br_terms =
+                             [ l25.info ],
+                           __br_info =
+                             l25.info,
+                           kinf =
+                             "",
+                           kpref =
+                             [ l25.info ],
+                           kprod =
+                             "",
+                           kpostf =
+                             "" } },
+             { nt =
+                 alt5,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "postfix" ],
+               action =
+                 lam state35: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res35.
+                     match
+                       res35
+                     with
+                       [ LitParsed l26 ]
+                     in
+                     asDyn
+                         { __br_terms =
+                             [ l26.info ],
+                           __br_info =
+                             l26.info,
+                           kinf =
+                             "",
+                           kpref =
+                             "",
+                           kprod =
+                             "",
+                           kpostf =
+                             [ l26.info ] } },
+             { nt =
+                 alt6,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state36: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res36.
+                     match
+                       res36
+                     with
+                       ""
+                     in
+                     asDyn
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           assoc =
+                             "" } },
+             { nt =
+                 alt6,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (LIdentRepr
+                        {}) ],
+               action =
+                 lam state37: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res37.
+                     match
+                       res37
+                     with
+                       [ TokParsed (LIdentTok x18) ]
+                     in
+                     asDyn
+                         { __br_terms =
+                             [ x18.info ],
+                           __br_info =
+                             x18.info,
+                           assoc =
+                             [ { v =
+                                   x18.val,
+                                 i =
+                                   x18.info } ] } },
+             { nt =
+                 #var"DeclAtom",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     alt5,
+                   ntSym
+                     alt6,
+                   tokSym
+                     (UIdentRepr
+                        {}),
+                   litSym
+                     ":",
+                   tokSym
+                     (UIdentRepr
+                        {}),
+                   litSym
+                     "=",
+                   ntSym
+                     #var"Regex" ],
+               action =
+                 lam state38: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res38.
+                     match
+                       res38
+                     with
+                       [ UserSym val14,
+                         UserSym val15,
+                         TokParsed (UIdentTok x19),
+                         LitParsed l27,
+                         TokParsed (UIdentTok x20),
+                         LitParsed l28,
+                         UserSym ntVal4 ]
+                     in
+                     let val14: {kinf: [Info], kpref: [Info], kprod: [Info], kpostf: [Info], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val14
+                       in
+                       let val15: {assoc: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val15
+                       in
+                       let ntVal4: (Info, Regex) =
+                         fromDyn
+                           ntVal4
+                       in
+                       asDyn
+                         (ProductionDeclOp
+                            { __br_terms =
+                                join
+                                  [ val14.__br_terms,
+                                    val15.__br_terms,
+                                    [ x19.info ],
+                                    [ l27.info ],
+                                    [ x20.info ],
+                                    [ l28.info ] ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (val14.__br_info)
+                                  [ val15.__br_info,
+                                    x19.info,
+                                    l27.info,
+                                    x20.info,
+                                    l28.info,
+                                    ntVal4.0 ],
+                              nt =
+                                [ { v =
+                                      nameNoSym
+                                        (x20.val),
+                                    i =
+                                      x20.info } ],
+                              name =
+                                [ { v =
+                                      nameNoSym
+                                        (x19.val),
+                                    i =
+                                      x19.info } ],
+                              kinf =
+                                val14.kinf,
+                              kpref =
+                                val14.kpref,
+                              kprod =
+                                val14.kprod,
+                              kpostf =
+                                val14.kpostf,
+                              assoc =
+                                val15.assoc,
+                              regex =
+                                [ ntVal4.1 ] }) },
+             { nt =
+                 #var"RegexAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "{",
+                   ntSym
+                     #var"Regex",
+                   litSym
+                     "}" ],
+               action =
+                 lam state39: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res39.
+                     match
+                       res39
+                     with
+                       [ LitParsed l29,
+                         UserSym ntVal5,
+                         LitParsed l30 ]
+                     in
                      let ntVal5: (Info, Regex) =
-                       fromDyn
-                         ntVal5
+                         fromDyn
+                           ntVal5
+                       in
+                       asDyn
+                         (RecordRegexOp
+                            { __br_terms =
+                                concat
+                                  [ l29.info ]
+                                  [ l30.info ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l29.info)
+                                  [ ntVal5.0,
+                                    l30.info ],
+                              regex =
+                                [ ntVal5.1 ] }) },
+             { nt =
+                 #var"RegexAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "empty" ],
+               action =
+                 lam state40: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res40.
+                     match
+                       res40
+                     with
+                       [ LitParsed l31 ]
                      in
                      asDyn
-                       (RecordRegexOp
-                          { __br_terms =
-                              concat
-                                [ l29.info ]
-                                [ l30.info ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (l29.info)
-                                [ ntVal5.#label"0",
-                                  l30.info ],
-                            regex =
-                              [ ntVal5.#label"1" ] })
-                   else
-                     never },
-           { nt =
-               #var"RegexAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "empty" ],
-             action =
-               lam state40: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res40.
-                   match
-                     res40
-                   with
-                     [ LitParsed l31 ]
-                   then
+                         (EmptyRegexOp
+                            { __br_terms =
+                                [ l31.info ],
+                              __br_info =
+                                l31.info }) },
+             { nt =
+                 #var"RegexAtom",
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (StringRepr
+                        {}) ],
+               action =
+                 lam state41: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res41.
+                     match
+                       res41
+                     with
+                       [ TokParsed (StringTok x21) ]
+                     in
                      asDyn
-                       (EmptyRegexOp
-                          { __br_terms =
-                              [ l31.info ],
-                            __br_info =
-                              l31.info })
-                   else
-                     never },
-           { nt =
-               #var"RegexAtom",
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (StringRepr
-                      {}) ],
-             action =
-               lam state41: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res41.
-                   match
-                     res41
-                   with
-                     [ TokParsed (StringTok x21) ]
-                   then
+                         (LiteralRegexOp
+                            { val =
+                                [ { v =
+                                      x21.val,
+                                    i =
+                                      x21.info } ],
+                              __br_terms =
+                                [ x21.info ],
+                              __br_info =
+                                x21.info }) },
+             { nt =
+                 alt7,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state42: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res42.
+                     match
+                       res42
+                     with
+                       ""
+                     in
                      asDyn
-                       (LiteralRegexOp
-                          { val =
-                              [ { v =
-                                    x21.val,
-                                  i =
-                                    x21.info } ],
-                            __br_terms =
-                              [ x21.info ],
-                            __br_info =
-                              x21.info })
-                   else
-                     never },
-           { nt =
-               alt7,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state42: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res42.
-                   match
-                     res42
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         arg =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt7,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "[",
-                 ntSym
-                   #var"Expr",
-                 litSym
-                   "]" ],
-             action =
-               lam state43: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res43.
-                   match
-                     res43
-                   with
-                     [ LitParsed l32,
-                       UserSym ntVal6,
-                       LitParsed l33 ]
-                   then
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           arg =
+                             "" } },
+             { nt =
+                 alt7,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "[",
+                   ntSym
+                     #var"Expr",
+                   litSym
+                     "]" ],
+               action =
+                 lam state43: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res43.
+                     match
+                       res43
+                     with
+                       [ LitParsed l32,
+                         UserSym ntVal6,
+                         LitParsed l33 ]
+                     in
                      let ntVal6: (Info, Expr) =
-                       fromDyn
-                         ntVal6
+                         fromDyn
+                           ntVal6
+                       in
+                       asDyn
+                         { __br_terms =
+                             concat
+                               [ l32.info ]
+                               [ l33.info ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (l32.info)
+                               [ ntVal6.0,
+                                 l33.info ],
+                           arg =
+                             [ ntVal6.1 ] } },
+             { nt =
+                 #var"RegexAtom",
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (UIdentRepr
+                        {}),
+                   ntSym
+                     alt7 ],
+               action =
+                 lam state44: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res44.
+                     match
+                       res44
+                     with
+                       [ TokParsed (UIdentTok x22),
+                         UserSym val16 ]
+                     in
+                     let val16: {arg: [Expr], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val16
+                       in
+                       asDyn
+                         (TokenRegexOp
+                            { __br_terms =
+                                concat
+                                  [ x22.info ]
+                                  (val16.__br_terms),
+                              __br_info =
+                                mergeInfo
+                                  (x22.info)
+                                  (val16.__br_info),
+                              name =
+                                [ { v =
+                                      nameNoSym
+                                        (x22.val),
+                                    i =
+                                      x22.info } ],
+                              arg =
+                                val16.arg }) },
+             { nt =
+                 #var"RegexPostfix",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "+" ],
+               action =
+                 lam state45: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res45.
+                     match
+                       res45
+                     with
+                       [ LitParsed l34 ]
                      in
                      asDyn
-                       { __br_terms =
-                           concat
-                             [ l32.info ]
-                             [ l33.info ],
-                         __br_info =
-                           foldl
-                             mergeInfo
-                             (l32.info)
-                             [ ntVal6.#label"0",
-                               l33.info ],
-                         arg =
-                           [ ntVal6.#label"1" ] }
-                   else
-                     never },
-           { nt =
-               #var"RegexAtom",
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (UIdentRepr
-                      {}),
-                 ntSym
-                   alt7 ],
-             action =
-               lam state44: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res44.
-                   match
-                     res44
-                   with
-                     [ TokParsed (UIdentTok x22),
-                       UserSym val15 ]
-                   then
-                     let val15: {arg: [Expr], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val15
+                         (RepeatPlusRegexOp
+                            { __br_terms =
+                                [ l34.info ],
+                              __br_info =
+                                l34.info }) },
+             { nt =
+                 #var"RegexPostfix",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "*" ],
+               action =
+                 lam state46: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res46.
+                     match
+                       res46
+                     with
+                       [ LitParsed l35 ]
                      in
                      asDyn
-                       (TokenRegexOp
-                          { __br_terms =
-                              concat
-                                [ x22.info ]
-                                (val15.__br_terms),
-                            __br_info =
-                              mergeInfo
-                                (x22.info)
-                                (val15.__br_info),
-                            name =
-                              [ { v =
-                                    nameNoSym
-                                      (x22.val),
-                                  i =
-                                    x22.info } ],
-                            arg =
-                              val15.arg })
-                   else
-                     never },
-           { nt =
-               #var"RegexPostfix",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "+" ],
-             action =
-               lam state45: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res45.
-                   match
-                     res45
-                   with
-                     [ LitParsed l34 ]
-                   then
+                         (RepeatStarRegexOp
+                            { __br_terms =
+                                [ l35.info ],
+                              __br_info =
+                                l35.info }) },
+             { nt =
+                 #var"RegexPostfix",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "?" ],
+               action =
+                 lam state47: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res47.
+                     match
+                       res47
+                     with
+                       [ LitParsed l36 ]
+                     in
                      asDyn
-                       (RepeatPlusRegexOp
-                          { __br_terms =
-                              [ l34.info ],
-                            __br_info =
-                              l34.info })
-                   else
-                     never },
-           { nt =
-               #var"RegexPostfix",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "*" ],
-             action =
-               lam state46: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res46.
-                   match
-                     res46
-                   with
-                     [ LitParsed l35 ]
-                   then
+                         (RepeatQuestionRegexOp
+                            { __br_terms =
+                                [ l36.info ],
+                              __br_info =
+                                l36.info }) },
+             { nt =
+                 #var"RegexPrefix",
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (LIdentRepr
+                        {}),
+                   litSym
+                     ":" ],
+               action =
+                 lam state48: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res48.
+                     match
+                       res48
+                     with
+                       [ TokParsed (LIdentTok x23),
+                         LitParsed l37 ]
+                     in
                      asDyn
-                       (RepeatStarRegexOp
-                          { __br_terms =
-                              [ l35.info ],
-                            __br_info =
-                              l35.info })
-                   else
-                     never },
-           { nt =
-               #var"RegexPostfix",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "?" ],
-             action =
-               lam state47: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res47.
-                   match
-                     res47
-                   with
-                     [ LitParsed l36 ]
-                   then
+                         (NamedRegexOp
+                            { __br_terms =
+                                concat
+                                  [ x23.info ]
+                                  [ l37.info ],
+                              __br_info =
+                                mergeInfo
+                                  (x23.info)
+                                  (l37.info),
+                              name =
+                                [ { v =
+                                      x23.val,
+                                    i =
+                                      x23.info } ] }) },
+             { nt =
+                 #var"RegexInfix",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "|" ],
+               action =
+                 lam state49: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res49.
+                     match
+                       res49
+                     with
+                       [ LitParsed l38 ]
+                     in
                      asDyn
-                       (RepeatQuestionRegexOp
-                          { __br_terms =
-                              [ l36.info ],
-                            __br_info =
-                              l36.info })
-                   else
-                     never },
-           { nt =
-               #var"RegexPrefix",
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (LIdentRepr
-                      {}),
-                 litSym
-                   ":" ],
-             action =
-               lam state48: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res48.
-                   match
-                     res48
-                   with
-                     [ TokParsed (LIdentTok x23),
-                       LitParsed l37 ]
-                   then
+                         (AlternativeRegexOp
+                            { __br_terms =
+                                [ l38.info ],
+                              __br_info =
+                                l38.info }) },
+             { nt =
+                 #var"RegexInfix",
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state50: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res50.
+                     match
+                       res50
+                     with
+                       ""
+                     in
                      asDyn
-                       (NamedRegexOp
-                          { __br_terms =
-                              concat
-                                [ x23.info ]
-                                [ l37.info ],
-                            __br_info =
-                              mergeInfo
-                                (x23.info)
-                                (l37.info),
-                            name =
-                              [ { v =
-                                    x23.val,
-                                  i =
-                                    x23.info } ] })
-                   else
-                     never },
-           { nt =
-               #var"RegexInfix",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "|" ],
-             action =
-               lam state49: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res49.
-                   match
-                     res49
-                   with
-                     [ LitParsed l38 ]
-                   then
+                         (ConcatRegexOp
+                            { __br_terms =
+                                "",
+                              __br_info =
+                                NoInfo
+                                  {} }) },
+             { nt =
+                 #var"ExprInfix",
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state51: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res51.
+                     match
+                       res51
+                     with
+                       ""
+                     in
                      asDyn
-                       (AlternativeRegexOp
-                          { __br_terms =
-                              [ l38.info ],
-                            __br_info =
-                              l38.info })
-                   else
-                     never },
-           { nt =
-               #var"RegexInfix",
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state50: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res50.
-                   match
-                     res50
-                   with
-                     ""
-                   then
+                         (AppExprOp
+                            { __br_terms =
+                                "",
+                              __br_info =
+                                NoInfo
+                                  {} }) },
+             { nt =
+                 #var"ExprAtom",
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (UIdentRepr
+                        {}) ],
+               action =
+                 lam state52: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res52.
+                     match
+                       res52
+                     with
+                       [ TokParsed (UIdentTok x24) ]
+                     in
                      asDyn
-                       (ConcatRegexOp
-                          { __br_terms =
-                              "",
-                            __br_info =
-                              NoInfo
-                                {} })
-                   else
-                     never },
-           { nt =
-               #var"ExprInfix",
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state51: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res51.
-                   match
-                     res51
-                   with
-                     ""
-                   then
+                         (ConExprOp
+                            { __br_terms =
+                                [ x24.info ],
+                              __br_info =
+                                x24.info,
+                              name =
+                                [ { v =
+                                      nameNoSym
+                                        (x24.val),
+                                    i =
+                                      x24.info } ] }) },
+             { nt =
+                 #var"ExprAtom",
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (StringRepr
+                        {}) ],
+               action =
+                 lam state53: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res53.
+                     match
+                       res53
+                     with
+                       [ TokParsed (StringTok x25) ]
+                     in
                      asDyn
-                       (AppExprOp
-                          { __br_terms =
-                              "",
-                            __br_info =
-                              NoInfo
-                                {} })
-                   else
-                     never },
-           { nt =
-               #var"ExprAtom",
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (UIdentRepr
-                      {}) ],
-             action =
-               lam state52: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res52.
-                   match
-                     res52
-                   with
-                     [ TokParsed (UIdentTok x24) ]
-                   then
+                         (StringExprOp
+                            { val =
+                                [ { v =
+                                      x25.val,
+                                    i =
+                                      x25.info } ],
+                              __br_terms =
+                                [ x25.info ],
+                              __br_info =
+                                x25.info }) },
+             { nt =
+                 #var"ExprAtom",
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (LIdentRepr
+                        {}) ],
+               action =
+                 lam state54: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res54.
+                     match
+                       res54
+                     with
+                       [ TokParsed (LIdentTok x26) ]
+                     in
                      asDyn
-                       (ConExprOp
-                          { __br_terms =
-                              [ x24.info ],
-                            __br_info =
-                              x24.info,
-                            name =
-                              [ { v =
-                                    nameNoSym
-                                      (x24.val),
-                                  i =
-                                    x24.info } ] })
-                   else
-                     never },
-           { nt =
-               #var"ExprAtom",
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (StringRepr
-                      {}) ],
-             action =
-               lam state53: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res53.
-                   match
-                     res53
-                   with
-                     [ TokParsed (StringTok x25) ]
-                   then
-                     asDyn
-                       (StringExprOp
-                          { val =
-                              [ { v =
-                                    x25.val,
-                                  i =
-                                    x25.info } ],
-                            __br_terms =
-                              [ x25.info ],
-                            __br_info =
-                              x25.info })
-                   else
-                     never },
-           { nt =
-               #var"ExprAtom",
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (LIdentRepr
-                      {}) ],
-             action =
-               lam state54: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res54.
-                   match
-                     res54
-                   with
-                     [ TokParsed (LIdentTok x26) ]
-                   then
-                     asDyn
-                       (VariableExprOp
-                          { __br_terms =
-                              [ x26.info ],
-                            __br_info =
-                              x26.info,
-                            name =
-                              [ { v =
-                                    nameNoSym
-                                      (x26.val),
-                                  i =
-                                    x26.info } ] })
-                   else
-                     never },
-           { nt =
-               kleene8,
-             label =
-               {},
-             rhs =
-               [ litSym
-                   ",",
-                 tokSym
-                   (LIdentRepr
-                      {}),
-                 litSym
-                   "=",
-                 ntSym
-                   #var"Expr",
-                 ntSym
-                   kleene8 ],
-             action =
-               lam state55: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res55.
-                   match
-                     res55
-                   with
-                     [ LitParsed l39,
-                       TokParsed (LIdentTok x27),
-                       LitParsed l40,
-                       UserSym ntVal7,
-                       UserSym val16 ]
-                   then
+                         (VariableExprOp
+                            { __br_terms =
+                                [ x26.info ],
+                              __br_info =
+                                x26.info,
+                              name =
+                                [ { v =
+                                      nameNoSym
+                                        (x26.val),
+                                    i =
+                                      x26.info } ] }) },
+             { nt =
+                 kleene8,
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     ",",
+                   tokSym
+                     (LIdentRepr
+                        {}),
+                   litSym
+                     "=",
+                   ntSym
+                     #var"Expr",
+                   ntSym
+                     kleene8 ],
+               action =
+                 lam state55: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res55.
+                     match
+                       res55
+                     with
+                       [ LitParsed l39,
+                         TokParsed (LIdentTok x27),
+                         LitParsed l40,
+                         UserSym ntVal7,
+                         UserSym val17 ]
+                     in
                      let ntVal7: (Info, Expr) =
-                       fromDyn
-                         ntVal7
+                         fromDyn
+                           ntVal7
+                       in
+                       let val17: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val17
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ l39.info ],
+                                 [ x27.info ],
+                                 [ l40.info ],
+                                 val17.__br_terms ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (l39.info)
+                               [ x27.info,
+                                 l40.info,
+                                 ntVal7.0,
+                                 val17.__br_info ],
+                           fields =
+                             concat
+                               [ { val =
+                                     match
+                                       [ ntVal7.1 ]
+                                     with
+                                       [ x28 ] ++ _ ++ ""
+                                     in
+                                     x28,
+                                   name =
+                                     match
+                                       [ { v =
+                                             x27.val,
+                                           i =
+                                             x27.info } ]
+                                     with
+                                       [ x29 ] ++ _ ++ ""
+                                     in
+                                     x29 } ]
+                               (val17.fields) } },
+             { nt =
+                 kleene8,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state56: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res56.
+                     match
+                       res56
+                     with
+                       ""
                      in
-                     let val16: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val16
+                     asDyn
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           fields =
+                             "" } },
+             { nt =
+                 alt8,
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam state57: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res57.
+                     match
+                       res57
+                     with
+                       ""
                      in
                      asDyn
-                       { __br_terms =
-                           join
-                             [ [ l39.info ],
-                               [ x27.info ],
-                               [ l40.info ],
-                               val16.__br_terms ],
-                         __br_info =
-                           foldl
-                             mergeInfo
-                             (l39.info)
-                             [ x27.info,
-                               l40.info,
-                               ntVal7.#label"0",
-                               val16.__br_info ],
-                         fields =
-                           concat
-                             [ { val =
-                                   match
-                                     [ ntVal7.#label"1" ]
-                                   with
-                                     [ x28 ] ++ _ ++ ""
-                                   then
-                                     x28
-                                   else
-                                     never,
-                                 name =
-                                   match
-                                     [ { v =
-                                           x27.val,
-                                         i =
-                                           x27.info } ]
-                                   with
-                                     [ x29 ] ++ _ ++ ""
-                                   then
-                                     x29
-                                   else
-                                     never } ]
-                             (val16.fields) }
-                   else
-                     never },
-           { nt =
-               kleene8,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state56: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res56.
-                   match
-                     res56
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         fields =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt8,
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam state57: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res57.
-                   match
-                     res57
-                   with
-                     ""
-                   then
-                     asDyn
-                       { __br_terms =
-                           "",
-                         __br_info =
-                           NoInfo
-                             {},
-                         fields =
-                           "" }
-                   else
-                     never },
-           { nt =
-               alt8,
-             label =
-               {},
-             rhs =
-               [ tokSym
-                   (LIdentRepr
-                      {}),
-                 litSym
-                   "=",
-                 ntSym
-                   #var"Expr",
-                 ntSym
-                   kleene8 ],
-             action =
-               lam state58: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res58.
-                   match
-                     res58
-                   with
-                     [ TokParsed (LIdentTok x30),
-                       LitParsed l41,
-                       UserSym ntVal8,
-                       UserSym val16 ]
-                   then
+                         { __br_terms =
+                             "",
+                           __br_info =
+                             NoInfo
+                               {},
+                           fields =
+                             "" } },
+             { nt =
+                 alt8,
+               label =
+                 {},
+               rhs =
+                 [ tokSym
+                     (LIdentRepr
+                        {}),
+                   litSym
+                     "=",
+                   ntSym
+                     #var"Expr",
+                   ntSym
+                     kleene8 ],
+               action =
+                 lam state58: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res58.
+                     match
+                       res58
+                     with
+                       [ TokParsed (LIdentTok x30),
+                         LitParsed l41,
+                         UserSym ntVal8,
+                         UserSym val17 ]
+                     in
                      let ntVal8: (Info, Expr) =
-                       fromDyn
-                         ntVal8
+                         fromDyn
+                           ntVal8
+                       in
+                       let val17: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val17
+                       in
+                       asDyn
+                         { __br_terms =
+                             join
+                               [ [ x30.info ],
+                                 [ l41.info ],
+                                 val17.__br_terms ],
+                           __br_info =
+                             foldl
+                               mergeInfo
+                               (x30.info)
+                               [ l41.info,
+                                 ntVal8.0,
+                                 val17.__br_info ],
+                           fields =
+                             concat
+                               [ { val =
+                                     match
+                                       [ ntVal8.1 ]
+                                     with
+                                       [ x31 ] ++ _ ++ ""
+                                     in
+                                     x31,
+                                   name =
+                                     match
+                                       [ { v =
+                                             x30.val,
+                                           i =
+                                             x30.info } ]
+                                     with
+                                       [ x32 ] ++ _ ++ ""
+                                     in
+                                     x32 } ]
+                               (val17.fields) } },
+             { nt =
+                 #var"ExprAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "{",
+                   ntSym
+                     alt8,
+                   litSym
+                     "}" ],
+               action =
+                 lam state59: {errors: Ref [(Info, [Char])], content: String}.
+                   lam res59.
+                     match
+                       res59
+                     with
+                       [ LitParsed l42,
+                         UserSym val18,
+                         LitParsed l43 ]
                      in
-                     let val16: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val16
+                     let val18: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
+                         fromDyn
+                           val18
+                       in
+                       asDyn
+                         (RecordExprOp
+                            { __br_terms =
+                                join
+                                  [ [ l42.info ],
+                                    val18.__br_terms,
+                                    [ l43.info ] ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l42.info)
+                                  [ val18.__br_info,
+                                    l43.info ],
+                              fields =
+                                val18.fields }) },
+             { nt =
+                 #var"RegexAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "(",
+                   ntSym
+                     #var"Regex",
+                   litSym
+                     ")" ],
+               action =
+                 lam #var"".
+                   lam seq.
+                     match
+                       seq
+                     with
+                       [ LitParsed l44,
+                         UserSym ntVal9,
+                         LitParsed l45 ]
                      in
-                     asDyn
-                       { __br_terms =
-                           join
-                             [ [ x30.info ],
-                               [ l41.info ],
-                               val16.__br_terms ],
-                         __br_info =
-                           foldl
-                             mergeInfo
-                             (x30.info)
-                             [ l41.info,
-                               ntVal8.#label"0",
-                               val16.__br_info ],
-                         fields =
-                           concat
-                             [ { val =
-                                   match
-                                     [ ntVal8.#label"1" ]
-                                   with
-                                     [ x31 ] ++ _ ++ ""
-                                   then
-                                     x31
-                                   else
-                                     never,
-                                 name =
-                                   match
-                                     [ { v =
-                                           x30.val,
-                                         i =
-                                           x30.info } ]
-                                   with
-                                     [ x32 ] ++ _ ++ ""
-                                   then
-                                     x32
-                                   else
-                                     never } ]
-                             (val16.fields) }
-                   else
-                     never },
-           { nt =
-               #var"ExprAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "{",
-                 ntSym
-                   alt8,
-                 litSym
-                   "}" ],
-             action =
-               lam state59: {errors: (Ref) ([(Info, [Char])]), content: String}.
-                 lam res59.
-                   match
-                     res59
-                   with
-                     [ LitParsed l42,
-                       UserSym val17,
-                       LitParsed l43 ]
-                   then
-                     let val17: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
-                       fromDyn
-                         val17
-                     in
-                     asDyn
-                       (RecordExprOp
-                          { __br_terms =
-                              join
-                                [ [ l42.info ],
-                                  val17.__br_terms,
-                                  [ l43.info ] ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (l42.info)
-                                [ val17.__br_info,
-                                  l43.info ],
-                            fields =
-                              val17.fields })
-                   else
-                     never },
-           { nt =
-               #var"RegexAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "(",
-                 ntSym
-                   #var"Regex",
-                 litSym
-                   ")" ],
-             action =
-               lam #var"".
-                 lam seq.
-                   match
-                     seq
-                   with
-                     [ LitParsed l44,
-                       UserSym ntVal9,
-                       LitParsed l45 ]
-                   then
                      let ntVal9: (Info, Regex) =
-                       fromDyn
-                         ntVal9
-                     in
-                     asDyn
-                       (RegexGrouping
-                          { __br_terms =
-                              [ l44.info,
-                                l45.info ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (l44.info)
-                                [ ntVal9.#label"0",
+                         fromDyn
+                           ntVal9
+                       in
+                       asDyn
+                         (RegexGrouping
+                            { __br_terms =
+                                [ l44.info,
                                   l45.info ],
-                            inner =
-                              match
-                                [ ntVal9.#label"1" ]
-                              with
-                                [ x33 ]
-                              then
-                                x33
-                              else
-                                never })
-                   else
-                     never },
-           { nt =
-               #var"ExprAtom",
-             label =
-               {},
-             rhs =
-               [ litSym
-                   "(",
-                 ntSym
-                   #var"Expr",
-                 litSym
-                   ")" ],
-             action =
-               lam #var"".
-                 lam seq1.
-                   match
-                     seq1
-                   with
-                     [ LitParsed l46,
-                       UserSym ntVal10,
-                       LitParsed l47 ]
-                   then
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l44.info)
+                                  [ ntVal9.0,
+                                    l45.info ],
+                              inner =
+                                match
+                                  [ ntVal9.1 ]
+                                with
+                                  [ x33 ]
+                                in
+                                x33 }) },
+             { nt =
+                 #var"ExprAtom",
+               label =
+                 {},
+               rhs =
+                 [ litSym
+                     "(",
+                   ntSym
+                     #var"Expr",
+                   litSym
+                     ")" ],
+               action =
+                 lam #var"".
+                   lam seq1.
+                     match
+                       seq1
+                     with
+                       [ LitParsed l46,
+                         UserSym ntVal10,
+                         LitParsed l47 ]
+                     in
                      let ntVal10: (Info, Expr) =
-                       fromDyn
-                         ntVal10
+                         fromDyn
+                           ntVal10
+                       in
+                       asDyn
+                         (ExprGrouping
+                            { __br_terms =
+                                [ l46.info,
+                                  l47.info ],
+                              __br_info =
+                                foldl
+                                  mergeInfo
+                                  (l46.info)
+                                  [ ntVal10.0,
+                                    l47.info ],
+                              inner =
+                                match
+                                  [ ntVal10.1 ]
+                                with
+                                  [ x33 ]
+                                in
+                                x33 }) },
+             { nt =
+                 #var"File",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"File_lclosed" ],
+               action =
+                 lam #var"".
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym cont ]
+                     in
+                     fromDyn
+                         cont
+                         (Some
+                            (breakableInitState
+                               {})) },
+             { nt =
+                 #var"File_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"FileAtom",
+                   ntSym
+                     #var"File_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
                      in
                      asDyn
-                       (ExprGrouping
-                          { __br_terms =
-                              [ l46.info,
-                                l47.info ],
-                            __br_info =
-                              foldl
-                                mergeInfo
-                                (l46.info)
-                                [ ntVal10.#label"0",
-                                  l47.info ],
-                            inner =
-                              match
-                                [ ntVal10.#label"1" ]
-                              with
-                                [ x33 ]
-                              then
-                                x33
-                              else
-                                never })
-                   else
-                     never },
-           { nt =
-               #var"File",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"File_lclosed" ],
-             action =
-               lam #var"".
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym cont ]
-                   then
-                     fromDyn
-                       cont
-                       (Some
-                          (breakableInitState
-                             {}))
-                   else
-                     never },
-           { nt =
-               #var"File_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"FileAtom",
-                 ntSym
-                   #var"File_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addFileOpAtom
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"File_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"FileInfix",
+                   ntSym
+                     #var"File_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addFileOpInfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"File_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"FilePrefix",
+                   ntSym
+                     #var"File_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addFileOpPrefix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"File_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"FilePostfix",
+                   ntSym
+                     #var"File_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addFileOpPostfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"File_lopen",
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam p.
+                   lam #var"".
                      asDyn
                        (lam st.
-                          fromDyn
-                            cont
-                            (addFileOpAtom
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"File_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"FileInfix",
-                 ntSym
-                   #var"File_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addFileOpInfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"File_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"FilePrefix",
-                 ntSym
-                   #var"File_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addFileOpPrefix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"File_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"FilePostfix",
-                 ntSym
-                   #var"File_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addFileOpPostfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"File_lopen",
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam p.
+                          finalizeFileOp
+                            p
+                            st) },
+             { nt =
+                 #var"Decl",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"Decl_lclosed" ],
+               action =
                  lam #var"".
-                   asDyn
-                     (lam st.
-                        finalizeFileOp
-                          p
-                          st) },
-           { nt =
-               #var"Decl",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"Decl_lclosed" ],
-             action =
-               lam #var"".
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym cont ]
-                   then
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym cont ]
+                     in
                      fromDyn
-                       cont
-                       (Some
-                          (breakableInitState
-                             {}))
-                   else
-                     never },
-           { nt =
-               #var"Decl_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"DeclAtom",
-                 ntSym
-                   #var"Decl_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
+                         cont
+                         (Some
+                            (breakableInitState
+                               {})) },
+             { nt =
+                 #var"Decl_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"DeclAtom",
+                   ntSym
+                     #var"Decl_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addDeclOpAtom
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Decl_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"DeclInfix",
+                   ntSym
+                     #var"Decl_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addDeclOpInfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Decl_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"DeclPrefix",
+                   ntSym
+                     #var"Decl_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addDeclOpPrefix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Decl_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"DeclPostfix",
+                   ntSym
+                     #var"Decl_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addDeclOpPostfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Decl_lopen",
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam p.
+                   lam #var"".
                      asDyn
                        (lam st.
-                          fromDyn
-                            cont
-                            (addDeclOpAtom
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Decl_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"DeclInfix",
-                 ntSym
-                   #var"Decl_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addDeclOpInfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Decl_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"DeclPrefix",
-                 ntSym
-                   #var"Decl_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addDeclOpPrefix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Decl_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"DeclPostfix",
-                 ntSym
-                   #var"Decl_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addDeclOpPostfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Decl_lopen",
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam p.
+                          finalizeDeclOp
+                            p
+                            st) },
+             { nt =
+                 #var"Regex",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"Regex_lclosed" ],
+               action =
                  lam #var"".
-                   asDyn
-                     (lam st.
-                        finalizeDeclOp
-                          p
-                          st) },
-           { nt =
-               #var"Regex",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"Regex_lclosed" ],
-             action =
-               lam #var"".
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym cont ]
-                   then
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym cont ]
+                     in
                      fromDyn
-                       cont
-                       (Some
-                          (breakableInitState
-                             {}))
-                   else
-                     never },
-           { nt =
-               #var"Regex_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"RegexAtom",
-                 ntSym
-                   #var"Regex_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
+                         cont
+                         (Some
+                            (breakableInitState
+                               {})) },
+             { nt =
+                 #var"Regex_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"RegexAtom",
+                   ntSym
+                     #var"Regex_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addRegexOpAtom
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Regex_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"RegexInfix",
+                   ntSym
+                     #var"Regex_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addRegexOpInfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Regex_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"RegexPrefix",
+                   ntSym
+                     #var"Regex_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addRegexOpPrefix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Regex_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"RegexPostfix",
+                   ntSym
+                     #var"Regex_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addRegexOpPostfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Regex_lopen",
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam p.
+                   lam #var"".
                      asDyn
                        (lam st.
-                          fromDyn
-                            cont
-                            (addRegexOpAtom
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Regex_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"RegexInfix",
-                 ntSym
-                   #var"Regex_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addRegexOpInfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Regex_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"RegexPrefix",
-                 ntSym
-                   #var"Regex_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addRegexOpPrefix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Regex_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"RegexPostfix",
-                 ntSym
-                   #var"Regex_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addRegexOpPostfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Regex_lopen",
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam p.
+                          finalizeRegexOp
+                            p
+                            st) },
+             { nt =
+                 #var"Expr",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"Expr_lclosed" ],
+               action =
                  lam #var"".
-                   asDyn
-                     (lam st.
-                        finalizeRegexOp
-                          p
-                          st) },
-           { nt =
-               #var"Expr",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"Expr_lclosed" ],
-             action =
-               lam #var"".
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym cont ]
-                   then
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym cont ]
+                     in
                      fromDyn
-                       cont
-                       (Some
-                          (breakableInitState
-                             {}))
-                   else
-                     never },
-           { nt =
-               #var"Expr_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"ExprAtom",
-                 ntSym
-                   #var"Expr_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
+                         cont
+                         (Some
+                            (breakableInitState
+                               {})) },
+             { nt =
+                 #var"Expr_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"ExprAtom",
+                   ntSym
+                     #var"Expr_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addExprOpAtom
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Expr_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"ExprInfix",
+                   ntSym
+                     #var"Expr_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addExprOpInfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Expr_lclosed",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"ExprPrefix",
+                   ntSym
+                     #var"Expr_lclosed" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addExprOpPrefix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Expr_lopen",
+               label =
+                 {},
+               rhs =
+                 [ ntSym
+                     #var"ExprPostfix",
+                   ntSym
+                     #var"Expr_lopen" ],
+               action =
+                 lam p.
+                   lam seq2.
+                     match
+                       seq2
+                     with
+                       [ UserSym x33,
+                         UserSym cont ]
+                     in
+                     asDyn
+                         (lam st.
+                            fromDyn
+                              cont
+                              (addExprOpPostfix
+                                 p
+                                 (fromDyn
+                                    x33)
+                                 st)) },
+             { nt =
+                 #var"Expr_lopen",
+               label =
+                 {},
+               rhs =
+                 "",
+               action =
+                 lam p.
+                   lam #var"".
                      asDyn
                        (lam st.
-                          fromDyn
-                            cont
-                            (addExprOpAtom
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Expr_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"ExprInfix",
-                 ntSym
-                   #var"Expr_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addExprOpInfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Expr_lclosed",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"ExprPrefix",
-                 ntSym
-                   #var"Expr_lclosed" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addExprOpPrefix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Expr_lopen",
-             label =
-               {},
-             rhs =
-               [ ntSym
-                   #var"ExprPostfix",
-                 ntSym
-                   #var"Expr_lopen" ],
-             action =
-               lam p.
-                 lam seq2.
-                   match
-                     seq2
-                   with
-                     [ UserSym x33,
-                       UserSym cont ]
-                   then
-                     asDyn
-                       (lam st.
-                          fromDyn
-                            cont
-                            (addExprOpPostfix
-                               p
-                               (fromDyn
-                                  x33)
-                               st))
-                   else
-                     never },
-           { nt =
-               #var"Expr_lopen",
-             label =
-               {},
-             rhs =
-               "",
-             action =
-               lam p.
-                 lam #var"".
-                   asDyn
-                     (lam st.
-                        finalizeExprOp
-                          p
-                          st) } ] })
-in
-match
-  target
-with
-  Right table
-then
+                          finalizeExprOp
+                            p
+                            st) } ] })
+  in
+  match
+    target
+  with
+    Right table
+  in
   table
-else
-  never
-
-let parseSelfhost
-: String -> String -> Either [(Info, String)] File
-= lam filename. lam content.
-  use ParseSelfhost in
-  let config = {errors = ref [], content = content} in
-  let res = parseWithTable _table filename config content in
-  switch (res, deref config.errors)
-  case (Right dyn, []) then
-    match fromDyn dyn with (_, res) in Right res
-  case (Left err, errors) then
-    let err = ll1DefaultHighlight content (ll1ToErrorHighlightSpec err) in
-    Left (snoc errors err)
-  case (_, errors) then
-    Left errors
-  end
-
-let parseSelfhostExn
-: String -> String -> File
-= lam filename. lam content.
-  switch parseSelfhost filename content
-  case Left errors then
-    for_ errors (lam x. match x with (info, msg) in printLn (infoErrorString info msg));
-    exit 1
-  case Right file then file
-  end
+let parseSelfhost =
+  lam filename.
+    lam content.
+      use ParseSelfhost
+      in
+      let config4 =
+        { errors =
+            ref
+              "",
+          content =
+            content }
+      in
+      let res60 =
+        parseWithTable
+          _table
+          filename
+          config4
+          content
+      in
+      let #var"X" =
+        (res60, deref
+          (config4.errors))
+      in
+      match
+        #var"X"
+      with
+        (Right dyn, "")
+      then
+        match
+          fromDyn
+            dyn
+        with
+          (_, res60)
+        in
+        Right
+            res60
+      else
+        match
+          #var"X"
+        with
+          (Left err, errors)
+        then
+          let err =
+            ll1DefaultHighlight
+              content
+              (ll1ToErrorHighlightSpec
+                 err)
+          in
+          Left
+            (snoc
+               errors
+               err)
+        else
+          match
+            #var"X"
+          with
+            (_, errors)
+          in
+          Left
+              errors
+let parseSelfhostExn =
+  lam filename.
+    lam content.
+      let #var"X" =
+        parseSelfhost
+          filename
+          content
+      in
+      match
+        #var"X"
+      with
+        Left errors
+      then
+        (for_
+             errors
+             (lam x33.
+                match
+                  x33
+                with
+                  (info, msg)
+                in
+                printLn
+                    (infoErrorString
+                       info
+                       msg)))
+        ; exit
+          1
+      else
+        match
+          #var"X"
+        with
+          Right file
+        in
+        file
+mexpr
+{}

--- a/stdlib/parser/selfhost.syn
+++ b/stdlib/parser/selfhost.syn
@@ -16,6 +16,7 @@ token String {
   repr = StringRepr {},
   constructor = StringTok,
   fragment = StringTokenParser,
+  ty = String,
 }
 token LIdent {
   repr = LIdentRepr {},
@@ -53,7 +54,7 @@ token {fragment = LineCommentParser,}
 token {fragment = MultilineCommentParser,}
 token {fragment = WhitespaceParser,}
 
-prod File: File =
+prod Lang: File =
   "language" name:UIdent
   decls:Decl+
 

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -1645,6 +1645,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
       in result.bind2 precedences badConstructors (lam precedences. lam cs. result.mapM (f precedences) cs)
     in
     let f : [(Name, {bad : Name, grouping : Option (String, String), precedence : Map (Name, Name) Ordering})] -> [ConstructorInfo] -> [GenOperator] -> [String] -> GenOpResult = lam syns. lam constructors. lam groupingOperators. lam extraFragments.
+      use MkOpLanguages in
       let genOpInput =
         { infoFieldLabel = infoFieldLabel
         , termsFieldLabel = termsFieldLabel

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -108,7 +108,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   let filename = args.synFile in
   let destinationFile = args.outFile in
   let content = readFile filename in
-  match parseSelfhostExn filename content with File {decls = decls, name = {v = langName}} in
+  match parseSelfhostExn filename content with LangFile {decls = decls, name = {v = langName}} in
 
   let simpleHighlight
     : Info -> String


### PR DESCRIPTION
This PR primarily updates `tool.mc` to use the new AST in `mlang/ast.mc` instead of the hacky version I had before, which is a necessary step for eventually allowing `include "file.syn"` in the compiler. Additionally:

- Updates `mlang/pprint.mc` such that type parameters to `syn`s are printed, and if a `sem` has both implementation and type annotation both are printed (as `sem f : ty` as well as `sem f arg = ...`, instead of just the latter).
- `tool.mc` and its internal libraries are now better about using `Name`s properly, though it's not quite followed everywhere (but enough to work for the selfhost of `.syn` files).

The last point also means that the generated `.mc` file might differ in some cases from what it used to be, since some `Name`s are now distinct when they weren't before. Feel free to poke me if this happens. 