### PR TITLE
Small refactoring

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -583,6 +583,27 @@ let record_add_bindings : [(String, Expr)] -> Expr -> Expr =
   lam bindings. lam record.
   foldl (lam recacc. lam b : (String, Expr). record_add b.0 b.1 recacc) record bindings
 
+-- Get an optional list of tuple expressions for a record. If the record does
+-- not represent a tuple, None () is returned.
+let record2tuple
+  : all a. Map SID a
+    -> Option [a]
+  = lam bindings.
+    let keys = map sidToString (mapKeys bindings) in
+    match forAll stringIsInt keys with false then None () else
+      let intKeys = map string2int keys in
+      let sortedKeys = sort subi intKeys in
+      -- Check if keys are a sequence 0..(n-1)
+      match sortedKeys with [] then None ()
+      else match sortedKeys with [h] ++ _ in
+           if and (eqi 0 h)
+                (eqi (subi (length intKeys) 1) (last sortedKeys)) then
+             Some (map (lam key. mapLookupOrElse
+                                 (lam. error "Key not found")
+                                 (stringToSid (int2string key)) bindings)
+                     sortedKeys)
+           else None ()
+
 let never_ = use MExprAst in
   TmNever {ty = tyunknown_, info = NoInfo ()}
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -120,32 +120,6 @@ let pprintConString = lam str.
 let pprintTypeString = lam str.
   _parserStr str "#type" (lam str. isUpperAlpha (head str))
 
-----------------------
--- HELPER FUNCTIONS --
-----------------------
-
--- Get an optional list of tuple expressions for a record. If the record does
--- not represent a tuple, None () is returned.
-let record2tuple
-  : all a. Map SID a
-  -> Option [a]
-  = lam bindings.
-    let keys = map sidToString (mapKeys bindings) in
-    match forAll stringIsInt keys with false then None () else
-    let intKeys = map string2int keys in
-    let sortedKeys = sort subi intKeys in
-    -- Check if keys are a sequence 0..(n-1)
-    match sortedKeys with [] then None ()
-    else match sortedKeys with [h] ++ _ in
-      if and (eqi 0 h)
-             (eqi (subi (length intKeys) 1) (last sortedKeys)) then
-        Some (map (lam key. mapLookupOrElse
-                              (lam. error "Key not found")
-                              (stringToSid (int2string key)) bindings)
-                   sortedKeys)
-      else None ()
-
-
 -----------
 -- TERMS --
 -----------

--- a/stdlib/tuple.mc
+++ b/stdlib/tuple.mc
@@ -1,5 +1,5 @@
 /-
-        This file constains utility functions that operate on tuples.
+        This file contains utility functions that operate on tuples.
  -/
 
 -- `tupleCmp2 cmpa cmpb` defines the product order for pairs (a, b), where:
@@ -12,6 +12,24 @@ let tupleCmp2
     match (x, y) with ((a1, b1), (a2, b2)) in
     let cmpa = cmpa a1 a2 in
     if eqi cmpa 0 then cmpb b1 b2 else cmpa
+
+utest
+  let testCmp2 = lam cmp. lam a. lam b. cmp (tupleCmp2 subi subi a b) 0 in
+  utest testCmp2 eqi (0, 0) (0, 0) with true in
+  utest testCmp2 lti (0, 0) (0, 1) with true in
+  utest testCmp2 lti (0, 0) (1, 1) with true in
+  utest testCmp2 lti (0, 1) (1, 1) with true in
+  utest testCmp2 eqi (0, 1) (0, 1) with true in
+  utest testCmp2 eqi (1, 0) (1, 0) with true in
+  utest testCmp2 gti (1, 1) (1, 0) with true in
+  utest testCmp2 gti (1, 1) (0, 1) with true in
+  utest testCmp2 gti (1, 1) (0, 0) with true in
+  utest testCmp2 gti (0, 1) (0, 0) with true in
+  utest testCmp2 gti (1, 0) (0, 0) with true in
+  utest testCmp2 eqi (1, 1) (1, 1) with true in
+  ()
+  with ()
+
 
 -- `tupleCmp3 cmpa cmpb cmpc` defines the product order for triples
 -- (a, b, c), see `tupleCmp2`.
@@ -29,36 +47,21 @@ let tupleCmp3
       if eqi cmpb 0 then cmpc c1 c2 else cmpb
     else cmpa
 
-mexpr
-
-let testCmp2 = lam cmp. lam a. lam b. cmp (tupleCmp2 subi subi a b) 0 in
-utest testCmp2 eqi (0, 0) (0, 0) with true in
-utest testCmp2 lti (0, 0) (0, 1) with true in
-utest testCmp2 lti (0, 0) (1, 1) with true in
-utest testCmp2 lti (0, 1) (1, 1) with true in
-utest testCmp2 eqi (0, 1) (0, 1) with true in
-utest testCmp2 eqi (1, 0) (1, 0) with true in
-utest testCmp2 gti (1, 1) (1, 0) with true in
-utest testCmp2 gti (1, 1) (0, 1) with true in
-utest testCmp2 gti (1, 1) (0, 0) with true in
-utest testCmp2 gti (0, 1) (0, 0) with true in
-utest testCmp2 gti (1, 0) (0, 0) with true in
-utest testCmp2 eqi (1, 1) (1, 1) with true in
-
-let testCmp3 = lam cmp. lam a. lam b. cmp (tupleCmp3 subi subi subi a b) 0 in
-utest testCmp3 eqi (0, 0, 0) (0, 0, 0) with true in
-utest testCmp3 lti (0, 0, 0) (0, 0, 1) with true in
-utest testCmp3 lti (0, 0, 0) (0, 1, 1) with true in
-utest testCmp3 lti (0, 0, 0) (1, 1, 1) with true in
-utest testCmp3 lti (0, 0, 1) (1, 1, 1) with true in
-utest testCmp3 lti (0, 1, 1) (1, 1, 1) with true in
-utest testCmp3 eqi (0, 1, 1) (0, 1, 1) with true in
-utest testCmp3 eqi (1, 0, 1) (1, 0, 1) with true in
-utest testCmp3 eqi (1, 1, 0) (1, 1, 0) with true in
-utest testCmp3 eqi (1, 0, 0) (1, 0, 0) with true in
-utest testCmp3 gti (1, 1, 1) (1, 1, 0) with true in
-utest testCmp3 gti (0, 1, 1) (0, 1, 0) with true in
-utest testCmp3 gti (1, 0, 1) (0, 1, 0) with true in
-utest testCmp3 eqi (1, 1, 1) (1, 1, 1) with true in
-
-()
+utest
+  let testCmp3 = lam cmp. lam a. lam b. cmp (tupleCmp3 subi subi subi a b) 0 in
+  utest testCmp3 eqi (0, 0, 0) (0, 0, 0) with true in
+  utest testCmp3 lti (0, 0, 0) (0, 0, 1) with true in
+  utest testCmp3 lti (0, 0, 0) (0, 1, 1) with true in
+  utest testCmp3 lti (0, 0, 0) (1, 1, 1) with true in
+  utest testCmp3 lti (0, 0, 1) (1, 1, 1) with true in
+  utest testCmp3 lti (0, 1, 1) (1, 1, 1) with true in
+  utest testCmp3 eqi (0, 1, 1) (0, 1, 1) with true in
+  utest testCmp3 eqi (1, 0, 1) (1, 0, 1) with true in
+  utest testCmp3 eqi (1, 1, 0) (1, 1, 0) with true in
+  utest testCmp3 eqi (1, 0, 0) (1, 0, 0) with true in
+  utest testCmp3 gti (1, 1, 1) (1, 1, 0) with true in
+  utest testCmp3 gti (0, 1, 1) (0, 1, 0) with true in
+  utest testCmp3 gti (1, 0, 1) (0, 1, 0) with true in
+  utest testCmp3 eqi (1, 1, 1) (1, 1, 1) with true in
+  ()
+  with ()


### PR DESCRIPTION
This PR contains two refactorings, (i) it moves the helper function `record2tuple` to `ast-builder.mc` (ii) it moves the tests closer to the functions in `tuple.mc`. 