### PR TITLE
Symbolize refactor and other changes

### DIFF
--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -13,7 +13,7 @@ include "tuning/instrumentation.mc"
 include "tuning/tune.mc"
 
 lang MCoreTune =
-  BootParser + MExprTypeAnnot + MExprTypeCheck +
+  BootParser + MExprTypeCheck +
   MExprHoles + MExprHoleCFA + NestedMeasuringPoints + DependencyAnalysis +
   Instrumentation + MExprTune
 end

--- a/stdlib/futhark/generate.mc
+++ b/stdlib/futhark/generate.mc
@@ -8,7 +8,7 @@ include "mexpr/ast-builder.mc"
 include "mexpr/cmp.mc"
 include "mexpr/pprint.mc"
 include "mexpr/symbolize.mc"
-include "mexpr/type-annot.mc"
+include "mexpr/type-check.mc"
 include "pmexpr/ast.mc"
 include "pmexpr/utils.mc"
 
@@ -533,7 +533,7 @@ lang FutharkGenerate = FutharkToplevelGenerate + MExprCmp
 end
 
 lang TestLang =
-  FutharkGenerate + FutharkPrettyPrint + MExprSym + MExprTypeAnnot
+  FutharkGenerate + FutharkPrettyPrint + MExprSym + MExprTypeCheck
 end
 
 mexpr
@@ -542,7 +542,7 @@ use TestLang in
 
 let f = nameSym "f" in
 let c = nameSym "c" in
-let chars = typeAnnot (bindall_ [
+let chars = typeCheck (bindall_ [
   nlet_ f (tyarrows_ [tychar_, tybool_]) (nlam_ c tychar_ (
     match_ (nvar_ c) (pchar_ 'a')
       true_
@@ -584,7 +584,7 @@ let map = nameSym "map" in
 let f3 = nameSym "f" in
 let s = nameSym "s" in
 
-let t = typeAnnot (bindall_ [
+let t = typeCheck (bindall_ [
   ntype_ intseq [] (tyseq_ tyint_),
   ntype_ floatseq [] (tyseq_ tyfloat_),
   nlet_ a (ntycon_ intseq) (seq_ [int_ 1, int_ 2, int_ 3]),
@@ -658,7 +658,7 @@ let acc = nameSym "acc" in
 let x = nameSym "x" in
 let y = nameSym "y" in
 let n = nameSym "n" in
-let foldlToFor = typeAnnot
+let foldlToFor = typeCheck
   (nlet_ f (tyarrows_ [tyseq_ tyint_, tyint_]) (
     nlam_ s (tyseq_ tyint_) (
       foldl_
@@ -678,7 +678,7 @@ let entryPoints = setOfSeq nameCmp [f] in
 utest printFutProg (generateProgram entryPoints foldlToFor)
 with printFutProg expected using eqSeq eqc in
 
-let negation = typeAnnot
+let negation = typeCheck
   (nlet_ f (tyarrows_ [tyint_, tyfloat_, tyrecord_ [("a", tyint_), ("b", tyfloat_)]])
     (nlam_ a tyint_ (nlam_ b tyfloat_ (
       urecord_ [("a", negi_ (nvar_ a)), ("b", negf_ (nvar_ b))])))) in
@@ -697,7 +697,7 @@ with printFutProg expected using eqSeq eqc in
 
 let recordTy = tyrecord_ [("a", tyint_), ("b", tyfloat_)] in
 let recordPat = prec_ [("a", npvar_ a), ("b", npvar_ b)] in
-let recordMatchNotProj = typeAnnot
+let recordMatchNotProj = typeCheck
   (nlet_ f (tyarrows_ [recordTy, tyint_])
     (nlam_ x recordTy
       (match_ (nvar_ x) recordPat

--- a/stdlib/futhark/generate.mc
+++ b/stdlib/futhark/generate.mc
@@ -452,7 +452,7 @@ let _collectParams = use FutharkTypeGenerate in
   recursive let work =
     lam params : [(Name, FutType)]. lam typeParams : [FutTypeParam]. lam body : Expr.
     match body with TmLam t then
-      let ty = generateType env t.tyIdent in
+      let ty = generateType env t.tyParam in
       let typeParams = _extractTypeParams typeParams ty in
       let params = snoc params (t.ident, ty) in
       work params typeParams t.body

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -307,7 +307,7 @@ lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst
         (lam v. lam acc.
           match v with (id, ty) in
           TmLam {
-            ident = id, tyAnnot = TyUnknown {info = t.info}, tyIdent = ty,
+            ident = id, tyAnnot = TyUnknown {info = t.info}, tyParam = ty,
             body = acc, ty = TyArrow {from = ty, to = tyTm acc, info = t.info},
             info = t.info})
         inner varNameTypes in

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -496,7 +496,7 @@ let tmLam = use MExprAst in
   TmLam {
     ident = ident,
     tyAnnot = tyAnnot,
-    tyIdent = tyAnnot,
+    tyParam = tyAnnot,
     ty = ty,
     body = body,
     info = info

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -299,7 +299,7 @@ lang LamAst = Ast
   syn Expr =
   | TmLam {ident : Name,
            tyAnnot : Type,
-           tyIdent : Type,
+           tyParam : Type,
            body : Expr,
            ty : Type,
            info : Info}
@@ -323,9 +323,9 @@ lang LamAst = Ast
 
   sem smapAccumL_Expr_TypeLabel (f : acc -> Type -> (acc, Type)) (acc : acc) =
   | TmLam t ->
-    match f acc t.tyIdent with (acc, tyIdent) in
+    match f acc t.tyParam with (acc, tyParam) in
     match f acc t.ty with (acc, ty) in
-    (acc, TmLam {t with tyIdent = tyIdent, ty = ty})
+    (acc, TmLam {t with tyParam = tyParam, ty = ty})
 
   sem smapAccumL_Expr_Expr (f : acc -> Expr -> (acc, Expr)) (acc : acc) =
   | TmLam t ->

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -140,7 +140,7 @@ lang BootParser = MExprAst + ConstTransformer
   | 102 /-TmLam-/ ->
     TmLam {ident = gname t 0,
            tyAnnot = gtype t 0,
-           tyIdent = TyUnknown { info = ginfo t 0 },
+           tyParam = TyUnknown { info = ginfo t 0 },
            ty = TyUnknown { info = ginfo t 0 },
            info = ginfo t 0,
            body = gterm t 0}

--- a/stdlib/mexpr/call-graph.mc
+++ b/stdlib/mexpr/call-graph.mc
@@ -6,7 +6,7 @@ include "digraph.mc"
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/symbolize.mc"
-include "mexpr/type-annot.mc"
+include "mexpr/type-check.mc"
 
 lang MExprCallGraph = MExprAst
   sem constructCallGraph =
@@ -78,7 +78,7 @@ lang MExprCallGraph = MExprAst
   | t -> sfold_Expr_Expr (_findCallEdges src g) edges t
 end
 
-lang TestLang = MExprCallGraph + MExprSym + MExprTypeAnnot
+lang TestLang = MExprCallGraph + MExprSym + MExprTypeCheck
 end
 
 mexpr
@@ -86,7 +86,7 @@ mexpr
 use TestLang in
 
 let preprocess = lam t.
-  typeAnnot (symbolize t)
+  typeCheck (symbolize t)
 in
 
 let a = nameSym "a" in

--- a/stdlib/mexpr/extract.mc
+++ b/stdlib/mexpr/extract.mc
@@ -205,7 +205,7 @@ let inRecursiveBinding = preprocess (bindall_ [
     (h, ulam_ "x" (app_ (nvar_ t1) (var_ "x"))),
     (t1, ulam_ "x" (app_ (nvar_ g) (var_ "x")))
   ],
-  app_ (var_ "h") (int_ 3)
+  app_ (nvar_ h) (int_ 3)
 ]) in
 let extracted = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (muli_ (var_ "x") (int_ 2))),

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -210,7 +210,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
       let body =
         foldr
           (lam freeVar : (Name, Type). lam body.
-            TmLam {ident = freeVar.0, tyAnnot = ityunknown_ info, tyIdent = freeVar.1,
+            TmLam {ident = freeVar.0, tyAnnot = ityunknown_ info, tyParam = freeVar.1,
                    body = body, info = info,
                    ty = TyUnknown {info = info}})
           t.body
@@ -255,7 +255,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
           foldr
             (lam freeVar : (Name, Type). lam body.
               let info = infoTm body in
-              TmLam {ident = freeVar.0, tyAnnot = ityunknown_ info, tyIdent = freeVar.1,
+              TmLam {ident = freeVar.0, tyAnnot = ityunknown_ info, tyParam = freeVar.1,
                      body = body, info = info,
                      ty = TyUnknown {info = info}})
             bind.body fv in

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -215,8 +215,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
                    ty = TyUnknown {info = info}})
           t.body
           fv in
-      let annot = optionGetOr t.tyBody (sremoveUnknown t.tyAnnot) in
-      let tyBody = updateBindingType fv annot in
+      let tyBody = updateBindingType fv t.tyBody in
       let tyAnnot = if null fv then t.tyAnnot else ityunknown_ t.info in
       let subExpr = lam info.
         foldr
@@ -260,8 +259,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst
                      body = body, info = info,
                      ty = TyUnknown {info = info}})
             bind.body fv in
-        let annot = optionGetOr bind.tyBody (sremoveUnknown bind.tyAnnot) in
-        let tyBody = updateBindingType fv annot in
+        let tyBody = updateBindingType fv bind.tyBody in
         let tyAnnot = if null fv then bind.tyAnnot else ityunknown_ bind.info in
         let body = insertFreeVariablesH solutions subMap body in
         {bind with tyBody = tyBody, tyAnnot = tyAnnot, body = body}

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -215,7 +215,8 @@ lang LambdaLiftInsertFreeVariables = MExprAst
                    ty = TyUnknown {info = info}})
           t.body
           fv in
-      let tyBody = updateBindingType fv t.tyBody in
+      let annot = optionGetOr t.tyAnnot (sremoveUnknown t.tyBody) in
+      let tyBody = updateBindingType fv annot in
       let tyAnnot = if null fv then t.tyAnnot else ityunknown_ t.info in
       let subExpr = lam info.
         foldr
@@ -259,7 +260,8 @@ lang LambdaLiftInsertFreeVariables = MExprAst
                      body = body, info = info,
                      ty = TyUnknown {info = info}})
             bind.body fv in
-        let tyBody = updateBindingType fv bind.tyBody in
+        let annot = optionGetOr bind.tyAnnot (sremoveUnknown bind.tyBody) in
+        let tyBody = updateBindingType fv annot in
         let tyAnnot = if null fv then bind.tyAnnot else ityunknown_ bind.info in
         let body = insertFreeVariablesH solutions subMap body in
         {bind with tyBody = tyBody, tyAnnot = tyAnnot, body = body}

--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -403,7 +403,7 @@ lang FunParser =
     let r3 : StrPos = matchKeyword "." r2.pos r2.str in
     let e : ParseResult Expr = parseExprMain r3.pos 0 r3.str in
     {val = TmLam {ident = nameNoSym r2.val, ty = tyunknown_,
-                  tyAnnot = tyunknown_, tyIdent = tyunknown_, body = e.val,
+                  tyAnnot = tyunknown_, tyParam = tyunknown_, body = e.val,
                   info = makeInfo p e.pos},
      pos = e.pos, str = e.str}
 end

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -85,6 +85,18 @@ lang SymLookup
     else
       optionMapOrElse cases.absent cases.present
         (mapLookup (nameGetStr ident) env)
+
+  -- The general case, where we may have a richer element type than simply name.
+  sem setSymbolWith
+    : all a. (Name -> a)
+    -> Map String a
+    -> Name
+    -> (Map String a, Name)
+  sem setSymbolWith newElem env =| ident ->
+    if nameHasSym ident then (env, ident)
+    else
+      let ident = nameSetNewSym ident in
+      (mapInsert (nameGetStr ident) (newElem ident) env, ident)
 end
 
 -----------

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -1,8 +1,8 @@
 -- Symbolization of the MExpr ast. Ignores already symbolized variables,
 -- constructors, and type variables.
 --
--- NOTE(dlunde,2020-09-25):
--- * Add support for unbound variables and constructors (similarly to eq.mc)?
+-- NOTE(aathn, 2023-05-10): Add support for symbolizing and returning the
+-- free variables of an expression (similarly to eq.mc)?
 
 include "common.mc"
 include "map.mc"
@@ -23,57 +23,81 @@ include "type.mc"
 -- The environment differs from boot in that we use strings directly (we do
 -- have SIDs available, however, if needed).
 
-type SymEnv = {
+-- Poor man's row polymorphism: ext represents an arbitrary extension of the environment
+type SymEnvBase ext = {
   varEnv: Map String Name,
   conEnv: Map String Name,
   tyVarEnv: Map String Name,
-  tyConEnv: Map String (Name, [Name], Type),
-  strictTypeVars: Bool,
+  tyConEnv: Map String Name,
   allowFree: Bool,
-  ignoreExternals: Bool
+  ignoreExternals: Bool,
+  ext: ext
 }
 
-let symEnvEmpty = {
+type SymEnv = SymEnvBase ()
+
+let mkSymEnvEmpty = lam ext. {
   varEnv = mapEmpty cmpString,
   conEnv = mapEmpty cmpString,
   tyVarEnv = mapEmpty cmpString,
 
   -- Built-in type constructors
   tyConEnv =
-  mapFromSeq cmpString (
-    map (lam t: (String, [String]).
-      (t.0, (nameNoSym t.0, map nameSym t.1, tyvariant_ [])))
-      builtinTypes
-  ),
+  mapFromSeq cmpString (map (lam t. (t.0, nameNoSym t.0)) builtinTypes),
 
-  strictTypeVars = true,
   allowFree = false,
-  ignoreExternals = false
+  ignoreExternals = false,
+  ext = ext
 }
+
+let symEnvEmpty = mkSymEnvEmpty ()
+
+type LookupParams = {kind : String, info : [Info], allowFree : Bool}
+
+let _handleUnbound : LookupParams -> Name -> () -> Name
+  = lam lkup. lam ident. lam.
+    if lkup.allowFree then ident
+    else
+      errorSingle lkup.info
+        (join ["Unknown ", lkup.kind, " in symbolizeExpr: ", nameGetStr ident])
+
+let _lookupName : LookupParams -> Name -> Map String Name -> Name
+  = lam lkup. lam ident. lam env.
+    optionGetOrElse (_handleUnbound lkup ident)
+      (mapLookup (nameGetStr ident) env)
+
+let _getName : LookupParams -> Name -> Map String Name -> Name
+  = lam lkup. lam ident. lam env.
+    if nameHasSym ident then ident
+    else _lookupName lkup ident env
+
+let _setName : Map String Name -> Name -> (Map String Name, Name)
+  = lam env. lam ident.
+    if nameHasSym ident then (env, ident)
+    else
+      let ident = nameSetNewSym ident in
+      (mapInsert (nameGetStr ident) ident env, ident)
 
 -----------
 -- TERMS --
 -----------
 
 lang Sym = Ast
-  sem symbolizeType (env : SymEnv) =
-  | t -> smap_Type_Type (symbolizeType env) t
-
   -- Symbolize with an environment
+  sem symbolizeExpr : SymEnv -> Expr -> Expr
   sem symbolizeExpr (env : SymEnv) =
-  | t ->
-    let t = smap_Expr_Expr (symbolizeExpr env) t in
-    withType (symbolizeType env (tyTm t)) t
+  | t -> symbolizeExprBase symbolizeExpr env t
 
-  -- Same as symbolizeExpr, but also return an env with all names bound at the
-  -- top-level
-  sem symbolizeTopExpr (env : SymEnv) =
-  | t ->
-    let t = symbolizeExpr env t in
-    addTopNames env t
+  -- Extensible symbolization function: the argument function should be used in
+  -- place of all recursive calls.
+  sem symbolizeExprBase
+    : all ext. (SymEnvBase ext -> Expr -> Expr) -> SymEnvBase ext -> Expr -> Expr
+  sem symbolizeExprBase symbolize env =
+  | t -> smap_Expr_Expr (symbolize env) t
 
-  sem addTopNames (env : SymEnv) =
-  | t -> env
+  sem symbolizeType : all ext. SymEnvBase ext -> Type -> Type
+  sem symbolizeType env =
+  | t -> smap_Type_Type (symbolizeType env) t
 
   -- TODO(vipa, 2020-09-23): env is constant throughout symbolizePat,
   -- so it would be preferrable to pass it in some other way, a reader
@@ -81,7 +105,9 @@ lang Sym = Ast
   -- nice to pass via state monad or something.  env is the
   -- environment from the outside, plus the names added thus far in
   -- the pattern patEnv is only the newly added names
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
+  sem symbolizePat
+    : all ext. SymEnvBase ext -> Map String Name -> Pat -> (Map String Name, Pat)
+  sem symbolizePat env patEnv =
   | t -> smapAccumL_Pat_Pat (symbolizePat env) patEnv t
 
   -- Symbolize with builtin environment
@@ -90,426 +116,234 @@ lang Sym = Ast
     let env = symEnvEmpty in
     symbolizeExpr env expr
 
-  sem symbolizeTop =
-  | expr ->
-    let env = symEnvEmpty in
-    symbolizeTopExpr env expr
-
   -- Symbolize with builtin environment and ignore errors
   sem symbolizeAllowFree =
   | expr ->
     let env = { symEnvEmpty with allowFree = true } in
     symbolizeExpr env expr
-
 end
 
 lang VarSym = Sym + VarAst
-  sem symbolizeExpr (env : SymEnv) =
+  sem symbolizeExprBase symbolize env =
   | TmVar t ->
-    match env with {varEnv = varEnv} then
-      if nameHasSym t.ident then TmVar t
-      else
-        let str = nameGetStr t.ident in
-        let ident =
-          match mapLookup str varEnv with Some ident then ident
-          else if env.allowFree then t.ident
-          else
-            errorSingle [t.info] (concat "Unknown variable in symbolizeExpr: " str)
-        in
-        TmVar {{t with ident = ident}
-                  with ty = symbolizeType env t.ty}
-    else never
+    let ident =
+      _getName {kind = "variable",
+                info = [t.info],
+                allowFree = env.allowFree}
+        t.ident env.varEnv
+    in
+    TmVar {t with ident = ident}
 end
 
 lang LamSym = Sym + LamAst + VarSym
-  sem symbolizeExpr (env : SymEnv) =
+  sem symbolizeExprBase symbolize env =
   | TmLam t ->
-    match env with {varEnv = varEnv} then
-      let ty = symbolizeType env t.ty in
-      let tyAnnot = symbolizeType env t.tyAnnot in
-      let tyIdent = symbolizeType env t.tyIdent in
-      if nameHasSym t.ident then
-        TmLam {t with tyAnnot = tyAnnot,
-                      tyIdent = tyIdent,
-                      body = symbolizeExpr env t.body,
-                      ty = ty}
-      else
-        let ident = nameSetNewSym t.ident in
-        let str = nameGetStr ident in
-        let varEnv = mapInsert str ident varEnv in
-        let env = {env with varEnv = varEnv} in
-        TmLam {t with ident = ident,
-                      tyAnnot = tyAnnot,
-                      tyIdent = tyIdent,
-                      body = symbolizeExpr env t.body,
-                      ty = ty}
-    else never
+    match _setName env.varEnv t.ident with (varEnv, ident) in
+    TmLam {t with ident = ident,
+                  tyAnnot = symbolizeType env t.tyAnnot,
+                  body = symbolize {env with varEnv = varEnv} t.body}
 end
 
 lang LetSym = Sym + LetAst + AllTypeAst
-  sem symbolizeExpr (env : SymEnv) =
+  sem symbolizeExprBase symbolize env =
   | TmLet t ->
-    match env with {varEnv = varEnv} then
-      let tyAnnot = symbolizeType env t.tyAnnot in
-      let tyBody = symbolizeType env t.tyBody in
-      let ty = symbolizeType env t.ty in
-      let body =
-        match stripTyAll tyAnnot with (vars, _) in
-        let tyVarEnv =
-          foldr (lam v. mapInsert (nameGetStr v.0) v.0) env.tyVarEnv vars in
-        symbolizeExpr {env with tyVarEnv = tyVarEnv} t.body
-      in
-      if nameHasSym t.ident then
-        TmLet {t with tyAnnot = tyAnnot,
-                      tyBody = tyBody,
-                      body = body,
-                      inexpr = symbolizeExpr env t.inexpr,
-                      ty = ty}
-      else
-        let ident = nameSetNewSym t.ident in
-        let str = nameGetStr ident in
-        let varEnv = mapInsert str ident varEnv in
-        let env = {env with varEnv = varEnv} in
-        TmLet {t with ident = ident,
-                      tyAnnot = tyAnnot,
-                      tyBody = tyBody,
-                      body = body,
-                      inexpr = symbolizeExpr env t.inexpr,
-                      ty = ty}
-    else never
+    match symbolizeTyAnnot env t.tyAnnot with (tyVarEnv, tyAnnot) in
+    match _setName env.varEnv t.ident with (varEnv, ident) in
+    TmLet {t with ident = ident,
+                  tyAnnot = tyAnnot,
+                  body = symbolize {env with tyVarEnv = tyVarEnv} t.body,
+                  inexpr = symbolize {env with varEnv = varEnv} t.inexpr}
 
-  sem addTopNames (env : SymEnv) =
-  | TmLet t ->
-    let str = nameGetStr t.ident in
-    let varEnv = mapInsert str t.ident env.varEnv in
-    addTopNames {env with varEnv = varEnv} t.inexpr
+  sem symbolizeTyAnnot : all ext. SymEnvBase ext -> Type -> (Map String Name, Type)
+  sem symbolizeTyAnnot env =
+  | tyAnnot ->
+    let setNameFirst = lam env. lam vs.
+      match _setName env vs.0 with (env, v) in
+      (env, (v, vs.1))
+    in
+    match stripTyAll tyAnnot with (vars, stripped) in
+    match mapAccumL setNameFirst env.tyVarEnv vars with (tyVarEnv, vars) in
+    (tyVarEnv,
+     foldr (lam vs. lam ty. TyAll {info = infoTy tyAnnot,
+                                   ident = vs.0, sort = vs.1, ty = ty})
+       (symbolizeType {env with tyVarEnv = tyVarEnv} stripped) vars)
 end
 
-lang ExtSym = Sym + ExtAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmExt t ->
-    match env with {varEnv = varEnv} then
-      let tyIdent = symbolizeType env t.tyIdent in
-      if or env.ignoreExternals (nameHasSym t.ident) then
-        TmExt {{t with inexpr = symbolizeExpr env t.inexpr}
-                  with tyIdent = tyIdent}
-      else
-        let ident = nameSetNewSym t.ident in
-        let str = nameGetStr ident in
-        let varEnv = mapInsert str ident varEnv in
-        let env = {env with varEnv = varEnv} in
-        TmExt {{{t with ident = ident}
-                   with inexpr = symbolizeExpr env t.inexpr}
-                   with tyIdent = tyIdent}
-    else never
-
-  sem addTopNames (env : SymEnv) =
-  | TmExt t ->
-    let str = nameGetStr t.ident in
-    let varEnv = mapInsert str t.ident env.varEnv in
-    addTopNames {env with varEnv = varEnv} t.inexpr
-end
-
-lang TypeSym = Sym + TypeAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmType t ->
-    match env with {tyConEnv = tyConEnv, tyVarEnv = tyVarEnv} in
-    let ty = symbolizeType env t.ty in
-    if nameHasSym t.ident then
-      TmType {{{t with tyIdent = symbolizeType env t.tyIdent}
-                  with inexpr = symbolizeExpr env t.inexpr}
-                  with ty = ty}
-    else
-      let params = map nameSetNewSym t.params in
-      let tyVarEnv =
-        foldr (lam p. mapInsert (nameGetStr p) p) tyVarEnv params in
-      let paramEnv = {env with tyVarEnv = tyVarEnv} in
-      let tyIdent = symbolizeType paramEnv t.tyIdent in
-      let ident = nameSetNewSym t.ident in
-      let str = nameGetStr ident in
-      let tyConEnv = mapInsert str (ident, params, tyIdent) tyConEnv in
-      let env = {env with tyConEnv = tyConEnv} in
-      TmType {{{{{t with ident = ident}
-                    with params = params}
-                    with tyIdent = tyIdent}
-                    with inexpr = symbolizeExpr env t.inexpr}
-                    with ty = ty}
-
-  sem addTopNames (env : SymEnv) =
-  | TmType t ->
-    let str = nameGetStr t.ident in
-    let tyConEnv = mapInsert str (t.ident, t.params, t.tyIdent) env.tyConEnv in
-    addTopNames {env with tyConEnv = tyConEnv} t.inexpr
-end
-
-lang RecLetsSym = Sym + RecLetsAst + AllTypeAst
-  sem symbolizeExpr (env : SymEnv) =
+lang RecLetsSym = Sym + RecLetsAst + LetSym
+  sem symbolizeExprBase symbolize env =
   | TmRecLets t ->
-    match env with {varEnv = varEnv} then
-
-    -- Generate fresh symbols for all identifiers
-    let bindings =
-      map (lam bind : RecLetBinding.
-             if nameHasSym bind.ident then bind
-             else {bind with ident = nameSetNewSym bind.ident})
-        t.bindings in
-
-    -- Add all identifiers to environment
-    let varEnv =
-      foldl
-        (lam varEnv. lam bind : RecLetBinding.
-           mapInsert (nameGetStr bind.ident) bind.ident varEnv)
-        varEnv bindings in
-    let env = {env with varEnv = varEnv} in
+    -- Generate fresh symbols for all identifiers and add to the environment
+    let setNameIdent = lam env. lam b.
+      match _setName env b.ident with (env, ident) in
+      (env, {b with ident = ident})
+    in
+    match mapAccumL setNameIdent env.varEnv t.bindings with (varEnv, bindings) in
+    let newEnv = {env with varEnv = varEnv} in
 
     -- Symbolize all bodies with the new environment
     let bindings =
-      map (lam bind : RecLetBinding.
-        let tyAnnot = symbolizeType env bind.tyAnnot in
-        let tyBody = symbolizeType env bind.tyBody in
-        match stripTyAll tyAnnot with (vars, _) in
-        let tyVarEnv =
-          foldr (lam v. mapInsert (nameGetStr v.0) v.0) env.tyVarEnv vars in
-        {bind with body = symbolizeExpr {env with tyVarEnv = tyVarEnv} bind.body,
-                   tyAnnot = tyAnnot,
-                   tyBody = tyBody})
+      map (lam b. match symbolizeTyAnnot env b.tyAnnot with (tyVarEnv, tyAnnot) in
+                  {b with body = symbolize {newEnv with tyVarEnv = tyVarEnv} b.body,
+                          tyAnnot = tyAnnot})
         bindings in
 
-    TmRecLets {{t with bindings = bindings}
-                  with inexpr = symbolizeExpr env t.inexpr}
+    TmRecLets {t with bindings = bindings,
+                      inexpr = symbolize newEnv t.inexpr}
+end
 
-    else never
+lang ExtSym = Sym + ExtAst
+  sem symbolizeExprBase symbolize env =
+  | TmExt t ->
+    let setName = if env.ignoreExternals then lam x. lam y. (x, y) else _setName in
+    match setName env.varEnv t.ident with (varEnv, ident) in
+    TmExt {t with ident = ident,
+                  inexpr = symbolize {env with varEnv = varEnv} t.inexpr,
+                  tyIdent = symbolizeType env t.tyIdent}
+end
 
-  sem addTopNames (env : SymEnv) =
-  | TmRecLets t ->
-    let varEnv =
-      foldl
-        (lam varEnv. lam bind : RecLetBinding.
-           mapInsert (nameGetStr bind.ident) bind.ident varEnv)
-        env.varEnv t.bindings
-    in
-    addTopNames {env with varEnv = varEnv} t.inexpr
+lang TypeSym = Sym + TypeAst
+  sem symbolizeExprBase symbolize env =
+  | TmType t ->
+    match _setName env.tyConEnv t.ident with (tyConEnv, ident) in
+    match mapAccumL _setName env.tyVarEnv t.params with (tyVarEnv, params) in
+    TmType {t with ident = ident,
+                   params = params,
+                   tyIdent = symbolizeType {env with tyVarEnv = tyVarEnv} t.tyIdent,
+                   inexpr = symbolize {env with tyConEnv = tyConEnv} t.inexpr}
 end
 
 lang DataSym = Sym + DataAst
-  sem symbolizeExpr (env : SymEnv) =
+  sem symbolizeExprBase symbolize env =
   | TmConDef t ->
-    match env with {conEnv = conEnv} then
-      let tyIdent = symbolizeType env t.tyIdent in
-      let ty = symbolizeType env t.ty in
-      if nameHasSym t.ident then
-        TmConDef {{{t with tyIdent = tyIdent}
-                      with inexpr = symbolizeExpr env t.inexpr}
-                      with ty = ty}
-      else
-        let str = nameGetStr t.ident in
-        let ident = nameSetNewSym t.ident in
-        let conEnv = mapInsert str ident conEnv in
-        let env = {env with conEnv = conEnv} in
-        TmConDef {{{{t with ident = ident}
-                       with tyIdent = tyIdent}
-                       with inexpr = symbolizeExpr env t.inexpr}
-                       with ty = ty}
-    else never
-
+    match _setName env.conEnv t.ident with (conEnv, ident) in
+    TmConDef {t with ident = ident,
+                     tyIdent = symbolizeType env t.tyIdent,
+                     inexpr = symbolize {env with conEnv = conEnv} t.inexpr}
   | TmConApp t ->
-    match env with {conEnv = conEnv} then
-      let ty = symbolizeType env t.ty in
-      if nameHasSym t.ident then
-        TmConApp {{t with body = symbolizeExpr env t.body}
-                     with ty = ty}
-      else
-        let str = nameGetStr t.ident in
-        let ident =
-          match mapLookup str conEnv with Some ident then ident
-          else if env.allowFree then t.ident
-          else errorSingle [t.info] (concat "Unknown constructor in symbolizeExpr: " str)
-        in
-        TmConApp {{{t with ident = ident}
-                      with body = symbolizeExpr env t.body}
-                      with ty = ty}
-    else never
-
-  sem addTopNames (env : SymEnv) =
-  | TmConDef t ->
-    let str = nameGetStr t.ident in
-    let conEnv = mapInsert str t.ident env.conEnv in
-    addTopNames {env with conEnv = conEnv} t.inexpr
+    let ident =
+      _getName {kind = "constructor",
+                info = [t.info],
+                allowFree = env.allowFree}
+        t.ident env.conEnv
+    in
+    TmConApp {t with ident = ident,
+                     body = symbolize env t.body}
 end
 
 lang MatchSym = Sym + MatchAst
-  sem symbolizeExpr (env : SymEnv) =
+  sem symbolizeExprBase symbolize env =
   | TmMatch t ->
-    match symbolizePat env (mapEmpty cmpString) t.pat
-    with (thnVarEnv, pat) then
-      let thnPatEnv = {env with varEnv = mapUnion env.varEnv thnVarEnv} in
-      TmMatch {{{{{t with target = symbolizeExpr env t.target}
-                     with pat = pat}
-                     with thn = symbolizeExpr thnPatEnv t.thn}
-                     with els = symbolizeExpr env t.els}
-                     with ty = symbolizeType env t.ty}
-    else never
+    match symbolizePat env (mapEmpty cmpString) t.pat with (thnVarEnv, pat) in
+    let thnPatEnv = {env with varEnv = mapUnion env.varEnv thnVarEnv} in
+    TmMatch {t with target = symbolize env t.target,
+                    pat = pat,
+                    thn = symbolize thnPatEnv t.thn,
+                    els = symbolize env t.els}
 end
 
 -----------
 -- TYPES --
 -----------
 
-lang VariantTypeSym = VariantTypeAst
-  sem symbolizeType (env : SymEnv) =
+lang VariantTypeSym = Sym + VariantTypeAst
+  sem symbolizeType env =
   | TyVariant t & ty ->
     if eqi (mapLength t.constrs) 0 then ty
     else errorSingle [t.info] "Symbolizing non-empty variant types not yet supported"
 end
 
-lang ConAppTypeSym = ConTypeAst + AppTypeAst + AliasTypeAst + VariantTypeAst +
-  UnknownTypeAst + VarTypeSubstitute + AppTypeGetArgs
-  sem symbolizeType (env : SymEnv) =
-  | (TyCon _ | TyApp _) & ty ->
-    let mkAppTy =
-      foldl (lam ty1. lam ty2.
-        TyApp {info = mergeInfo (infoTy ty1) (infoTy ty2), lhs = ty1, rhs = ty2})
+lang ConTypeSym = Sym + ConTypeAst
+  sem symbolizeType env =
+  | TyCon t ->
+    let ident =
+      _getName {kind = "type constructor",
+                info = [t.info],
+                allowFree = env.allowFree}
+        t.ident env.tyConEnv
     in
-    match getTypeArgs ty with (constr, args) in
-    let args = map (symbolizeType env) args in
-    match constr with TyCon t then
-      if nameHasSym t.ident then mkAppTy (TyCon t) args
-      else
-        let str = nameGetStr t.ident in
-        match mapLookup str env.tyConEnv with Some (ident, params, def) then
-          let conTy = TyCon {t with ident = ident} in
-          let appTy = mkAppTy conTy args in
-          let isAlias =
-            match def with TyVariant r then not (mapIsEmpty r.constrs) else true
-          in
-          if isAlias then
-            match (length params, length args) with (paramLen, argLen) in
-            if eqi paramLen argLen then
-              let subst = foldl2 (lam s. lam v. lam t. mapInsert v t s)
-                            (mapEmpty nameCmp) params args
-              in
-              TyAlias {display = appTy, content = substituteVars subst def}
-            else
-              errorSingle [infoTy ty] (join [
-                "* Encountered a misformed type alias.\n",
-                "* Type ", str, " is declared to have ",
-                int2string paramLen, " parameters.\n",
-                "* Found ", int2string argLen, " arguments.\n",
-                "* When symbolizing the type"
-              ])
-          else
-            appTy
-        else
-          if env.strictTypeVars then
-            if env.allowFree then mkAppTy (TyCon t) args
-            else errorSingle [t.info] (join [
-              "* Encountered an unknown type constructor: ", str, "\n",
-              "* When symbolizing the type"
-            ])
-          else
-            TyUnknown {info = t.info}
-    else
-      mkAppTy (symbolizeType env constr) args
+    TyCon {t with ident = ident}
 end
 
 lang VarTypeSym = VarTypeAst + UnknownTypeAst
-  sem symbolizeType (env : SymEnv) =
-  | TyVar t & ty ->
-    if nameHasSym t.ident then ty
-    else
-      let str = nameGetStr t.ident in
-      match mapLookup str env.tyVarEnv with Some ident then
-        TyVar {t with ident = ident}
-      else if env.strictTypeVars then
-        if env.allowFree then TyVar t
-        else errorSingle [t.info] (concat "Unknown type variable in symbolizeExpr: " str)
-      else
-        TyUnknown {info = t.info}
+  sem symbolizeType env =
+  | TyVar t ->
+    let ident =
+      _getName {kind = "type variable",
+                info = [t.info],
+                allowFree = env.allowFree}
+        t.ident env.tyVarEnv
+    in
+    TyVar {t with ident = ident}
 end
 
 lang AllTypeSym = AllTypeAst + VarSortAst
-  sem symbolizeType (env : SymEnv) =
-  | TyAll t & ty ->
-      let sort = smap_VarSort_Type (symbolizeType env) t.sort in
-      if nameHasSym t.ident then
-        TyAll {{t with ty = symbolizeType env t.ty}
-                  with sort = sort}
-      else
-        let str = nameGetStr t.ident in
-        let ident = nameSetNewSym t.ident in
-        let env = {env with tyVarEnv = mapInsert str ident env.tyVarEnv} in
-        TyAll {{{t with ident = ident}
-                   with ty = symbolizeType env t.ty}
-                   with sort = sort}
+  sem symbolizeType env =
+  | TyAll t ->
+    let sort = smap_VarSort_Type (symbolizeType env) t.sort in
+    match _setName env.tyVarEnv t.ident with (tyVarEnv, ident) in
+    TyAll {t with ident = ident,
+                  ty = symbolizeType {env with tyVarEnv = tyVarEnv} t.ty,
+                  sort = sort}
 end
 
 --------------
 -- PATTERNS --
 --------------
 
-let _symbolize_patname: Map String Name -> PatName -> (Map String Name, PatName) =
-  lam varEnv. lam pname.
+let _symbolizePatName: Map String Name -> PatName -> (Map String Name, PatName) =
+  lam patEnv. lam pname.
     match pname with PName name then
-      if nameHasSym name then (varEnv, PName name)
+      if nameHasSym name then (patEnv, PName name)
       else
-        let str = nameGetStr name in
-        let res = mapLookup str varEnv in
-        match res with Some name then
-          let name : Name = name in
-          (varEnv, PName name)
-        else match res with None () then
+        match mapLookup (nameGetStr name) patEnv
+          with Some name then (patEnv, PName name)
+        else
           let name = nameSetNewSym name in
-          let varEnv = mapInsert str name varEnv in
-          (varEnv, PName name)
-        else never
-    else match pname with PWildcard () then (varEnv, PWildcard ())
-    else never
+          (mapInsert (nameGetStr name) name patEnv, PName name)
+    else (patEnv, pname)
 
 lang NamedPatSym = NamedPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
+  sem symbolizePat env patEnv =
   | PatNamed p ->
-    match _symbolize_patname patEnv p.ident with (patEnv, patname) then
-      (patEnv, PatNamed {p with ident = patname})
-    else never
+    match _symbolizePatName patEnv p.ident with (patEnv, patname) in
+    (patEnv, PatNamed {p with ident = patname})
 end
 
 lang SeqEdgePatSym = SeqEdgePat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
+  sem symbolizePat env patEnv =
   | PatSeqEdge p ->
-    let preRes = mapAccumL (symbolizePat env) patEnv p.prefix in
-    let midRes = _symbolize_patname preRes.0 p.middle in
-    let postRes = mapAccumL (symbolizePat env) midRes.0 p.postfix in
-    (postRes.0, PatSeqEdge
-      {{{p with prefix = preRes.1} with middle = midRes.1} with postfix = postRes.1})
+    match mapAccumL (symbolizePat env) patEnv p.prefix with (patEnv, prefix) in
+    match _symbolizePatName patEnv p.middle with (patEnv, middle) in
+    match mapAccumL (symbolizePat env) patEnv p.postfix with (patEnv, postfix) in
+    (patEnv, PatSeqEdge {p with prefix = prefix,
+                                middle = middle,
+                                postfix = postfix})
 end
 
 lang DataPatSym = DataPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
+  sem symbolizePat env patEnv =
   | PatCon r ->
-    match env with {conEnv = conEnv} then
-      let ident =
-        if nameHasSym r.ident then r.ident
-        else
-          let str = nameGetStr r.ident in
-          match mapLookup str conEnv with Some ident then ident
-          else errorSingle [r.info] (concat "Unknown constructor in symbolizeExpr: " str)
-      in
-      match symbolizePat env patEnv r.subpat with (patEnv, subpat) then
-        (patEnv, PatCon {{r with ident = ident} with subpat = subpat})
-      else never
-    else never
+    let ident =
+      _getName {kind = "constructor",
+                info = [r.info],
+                allowFree = env.allowFree}
+        r.ident env.conEnv
+    in
+    match symbolizePat env patEnv r.subpat with (patEnv, subpat) in
+    (patEnv, PatCon {r with ident = ident,
+                            subpat = subpat})
 end
 
 lang NotPatSym = NotPat
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
+  sem symbolizePat env patEnv =
   | PatNot p ->
     -- NOTE(vipa, 2020-09-23): new names in a not-pattern do not
     -- matter since they will never bind (it should probably be an
     -- error to bind a name inside a not-pattern, but we're not doing
     -- that kind of static checks yet.  Note that we still need to run
-    -- symbolizeExpr though, constructors must refer to the right symbol.
-    let res : (Map String Name, Pat) = symbolizePat env patEnv p.subpat in
-    (patEnv, PatNot {p with subpat = res.1})
+    -- symbolizePat though, constructors must refer to the right symbol.
+    match symbolizePat env patEnv p.subpat with (_, subpat) in
+    (patEnv, PatNot {p with subpat = subpat})
 end
 
 ------------------------------
@@ -533,7 +367,7 @@ lang MExprSym =
   MatchSym +
 
   -- Non-default implementations (Types)
-  VariantTypeSym + ConAppTypeSym + VarTypeSym + AllTypeSym +
+  VariantTypeSym + ConTypeSym + VarTypeSym + AllTypeSym +
 
   -- Non-default implementations (Patterns)
   NamedPatSym + SeqEdgePatSym + DataPatSym + NotPatSym
@@ -543,95 +377,80 @@ end
 -- TESTS --
 -----------
 
+let _and = lam cond. lam f. lam. if cond () then f () else false
+let _andFold = lam f. lam acc. lam e. _and acc (f e)
+
 -- To test that the symbolization works as expected, we define functions that
 -- verify all names in the AST have been symbolized.
 lang TestLang = MExprSym + MExprPrettyPrint
   sem isFullySymbolized : Expr -> Bool
   sem isFullySymbolized =
-  | ast -> isFullySymbolizedExpr true ast
+  | ast -> isFullySymbolizedExpr ast ()
 
-  sem isFullySymbolizedExpr : Bool -> Expr -> Bool
-  sem isFullySymbolizedExpr acc =
-  | TmVar t -> if acc then nameHasSym t.ident else false
+  sem isFullySymbolizedExpr : Expr -> () -> Bool
+  sem isFullySymbolizedExpr =
+  | TmVar t -> lam. nameHasSym t.ident
   | TmLam t ->
-    let acc = if acc then nameHasSym t.ident else acc in
-    let acc = isFullySymbolizedType acc t.tyAnnot in
-    let acc = isFullySymbolizedType acc t.tyIdent in
-    let acc = isFullySymbolizedExpr acc t.body in
-    isFullySymbolizedType acc t.ty
+    _and (lam. nameHasSym t.ident)
+      (_and
+         (isFullySymbolizedType t.tyAnnot)
+         (isFullySymbolizedExpr t.body))
   | TmLet t ->
-    let acc = if acc then nameHasSym t.ident else acc in
-    let acc = isFullySymbolizedType acc t.tyAnnot in
-    let acc = isFullySymbolizedType acc t.tyBody in
-    let acc = isFullySymbolizedExpr acc t.body in
-    let acc = isFullySymbolizedExpr acc t.inexpr in
-    isFullySymbolizedType acc t.ty
+    _and (lam. nameHasSym t.ident)
+      (_and (isFullySymbolizedType t.tyAnnot)
+         (_and
+            (isFullySymbolizedExpr t.body)
+            (isFullySymbolizedExpr t.inexpr)))
   | TmRecLets t ->
-    let isFullySymbolizedBinding = lam acc. lam bind.
-      let acc = if acc then nameHasSym bind.ident else acc in
-      let acc = isFullySymbolizedType acc bind.tyAnnot in
-      let acc = isFullySymbolizedType acc bind.tyBody in
-      isFullySymbolizedExpr acc bind.body
+    let isFullySymbolizedBinding = lam b.
+      _and (lam. nameHasSym b.ident)
+        (_and
+           (isFullySymbolizedType b.tyAnnot)
+           (isFullySymbolizedExpr b.body))
     in
-    let acc = foldl isFullySymbolizedBinding acc t.bindings in
-    let acc = isFullySymbolizedExpr acc t.inexpr in
-    isFullySymbolizedType acc t.ty
+    _and
+      (foldl (_andFold isFullySymbolizedBinding) (lam. true) t.bindings)
+      (isFullySymbolizedExpr t.inexpr)
   | TmType t ->
-    let acc =
-      foldl
-        (lam acc. lam id. if acc then nameHasSym id else acc)
-        acc (cons t.ident t.params)
-    in
-    let acc = isFullySymbolizedType acc t.tyIdent in
-    let acc = isFullySymbolizedExpr acc t.inexpr in
-    isFullySymbolizedType acc t.ty
+    _and (lam. forAll nameHasSym t.params)
+      (_and
+         (isFullySymbolizedType t.tyIdent)
+         (isFullySymbolizedExpr t.inexpr))
   | TmConDef t ->
-    let acc = if acc then nameHasSym t.ident else acc in
-    let acc = isFullySymbolizedType acc t.tyIdent in
-    let acc = isFullySymbolizedExpr acc t.inexpr in
-    isFullySymbolizedType acc t.ty
+    _and (lam. nameHasSym t.ident)
+      (_and
+         (isFullySymbolizedType t.tyIdent)
+         (isFullySymbolizedExpr t.inexpr))
   | TmConApp t ->
-    let acc = if acc then nameHasSym t.ident else acc in
-    let acc = isFullySymbolizedExpr acc t.body in
-    isFullySymbolizedType acc t.ty
+    _and (lam. nameHasSym t.ident) (isFullySymbolizedExpr t.body)
   | TmExt t ->
-    let acc = if acc then nameHasSym t.ident else acc in
-    let acc = isFullySymbolizedType acc t.tyIdent in
-    let acc = isFullySymbolizedExpr acc t.inexpr in
-    isFullySymbolizedType acc t.ty
+    _and (lam. nameHasSym t.ident)
+      (_and
+         (isFullySymbolizedType t.tyIdent)
+         (isFullySymbolizedExpr t.inexpr))
   | t ->
-    if acc then
-      let acc = sfold_Expr_Expr isFullySymbolizedExpr acc t in
-      let acc = sfold_Expr_Type isFullySymbolizedType acc t in
-      let acc = sfold_Expr_Pat isFullySymbolizedPat acc t in
-      sfold_Expr_TypeLabel isFullySymbolizedType acc t
-    else false
+    _and (sfold_Expr_Expr (_andFold isFullySymbolizedExpr) (lam. true) t)
+      (_and
+         (sfold_Expr_Type (_andFold isFullySymbolizedType) (lam. true) t)
+         (sfold_Expr_Pat (_andFold isFullySymbolizedPat) (lam. true) t))
 
-  sem isFullySymbolizedPat : Bool -> Pat -> Bool
-  sem isFullySymbolizedPat acc =
-  | PatNamed {ident = PName id, ty = ty} ->
-    let acc = if acc then nameHasSym id else acc in
-    isFullySymbolizedType acc ty
+  sem isFullySymbolizedPat : Pat -> () -> Bool
+  sem isFullySymbolizedPat =
+  | PatNamed {ident = PName id} -> lam. nameHasSym id
   | PatCon t ->
-    let acc = if acc then nameHasSym t.ident else acc in
-    let acc = isFullySymbolizedPat acc t.subpat in
-    isFullySymbolizedType acc t.ty
+    _and (lam. nameHasSym t.ident) (isFullySymbolizedPat t.subpat)
   | p ->
-    if acc then
-      let acc = sfold_Pat_Pat isFullySymbolizedPat acc p in
-      sfold_Pat_Type isFullySymbolizedType acc p
-    else false
+    _and
+      (sfold_Pat_Pat (_andFold isFullySymbolizedPat) (lam. true) p)
+      (sfold_Pat_Type (_andFold isFullySymbolizedType) (lam. true) p)
 
-  sem isFullySymbolizedType : Bool -> Type -> Bool
-  sem isFullySymbolizedType acc =
-  | TyCon {ident = ident} | TyVar {ident = ident} ->
-    if acc then nameHasSym ident else acc
+  sem isFullySymbolizedType : Type -> () -> Bool
+  sem isFullySymbolizedType =
+  | TyCon {ident = ident} | TyVar {ident = ident} -> lam. nameHasSym ident
   | TyAll t ->
-    let acc = if acc then nameHasSym t.ident else acc in
-    isFullySymbolizedType acc t.ty
+    _and (lam. nameHasSym t.ident) (isFullySymbolizedType t.ty)
   | ty ->
-    if acc then sfold_Type_Type isFullySymbolizedType acc ty
-    else false
+    sfold_Type_Type (_andFold isFullySymbolizedType) (lam. true) ty
 end
 
 mexpr
@@ -646,8 +465,7 @@ utest isFullySymbolized (nulam_ x (nvar_ x)) with true in
 let testSymbolize = lam ast. lam testEqStr.
   let symbolizeCalls =
     [ symbolize
-    , symbolizeExpr {symEnvEmpty with allowFree = true}
-    , symbolizeExpr {symEnvEmpty with strictTypeVars = false} ] in
+    , symbolizeExpr {symEnvEmpty with allowFree = true}] in
   foldl
     (lam acc. lam symb.
       if acc then

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -34,7 +34,8 @@ type Level = Int
 type TCEnv = {
   varEnv: Map Name Type,
   conEnv: Map Name Type,
-  tyScopes: Map Name Level,
+  tyVarEnv: Map Name Level,
+  tyConEnv: Map Name (Level, [Name], Type),
   currentLvl: Level,
   disableRecordPolymorphism: Bool
 }
@@ -42,9 +43,11 @@ type TCEnv = {
 let _tcEnvEmpty = {
   varEnv = mapEmpty nameCmp,
   conEnv = mapEmpty nameCmp,
-  tyScopes =
+  tyVarEnv = mapEmpty nameCmp,
+  tyConEnv =
   mapFromSeq nameCmp
-    (map (lam t: (String, [String]). (nameNoSym t.0, 0)) builtinTypes),
+    (map (lam t: (String, [String]).
+      (nameNoSym t.0, (0, map nameSym t.1, tyvariant_ []))) builtinTypes),
 
   currentLvl = 0,
   disableRecordPolymorphism = true
@@ -62,7 +65,8 @@ type UnifyEnv = {
   foundType: Type,  -- The inferred type of the expression
   lhsName: Type,  -- The currently examined left-hand subtype, before resolving aliases
   rhsName: Type,  -- The currently examined right-hand subtype, before resolving aliases
-  tyScopes: Map Name Level,  -- The free types in scope and their levels
+  tyVarEnv: Map Name Level,  -- The free type variables in scope and their levels
+  tyConEnv: Map Name (Level, [Name], Type),  -- The free type constructors in scope
   names: BiNameMap  -- The bijective correspondence between bound variables in scope
 }
 
@@ -172,7 +176,8 @@ lang Unify = FlexTypeAst + AliasTypeAst + PrettyPrint + Cmp + FlexTypeCmp
       foundType = ty2,
       lhsName = ty1,
       rhsName = ty2,
-      tyScopes = tcEnv.tyScopes
+      tyVarEnv = tcEnv.tyVarEnv,
+      tyConEnv = tcEnv.tyConEnv
     } in
     unifyTypes env (ty1, ty2)
 
@@ -275,7 +280,7 @@ lang VarTypeUnify = Unify + VarTypeAst
   sem unifyCheckBase env boundVars tv =
   | TyVar t ->
     if not (setMem t.ident boundVars) then
-      match optionMap (lti tv.level) (mapLookup t.ident env.tyScopes) with
+      match optionMap (lti tv.level) (mapLookup t.ident env.tyVarEnv) with
         !Some false then
         let msg = join [
           "* Encountered a type variable escaping its scope: ",
@@ -392,7 +397,7 @@ lang ConTypeUnify = Unify + ConTypeAst
 
   sem unifyCheckBase env boundVars tv =
   | TyCon t ->
-    match optionMap (lti tv.level) (mapLookup t.ident env.tyScopes) with
+    match optionMap (lam r. lti tv.level r.0) (mapLookup t.ident env.tyConEnv) with
       !Some false then
       let msg = join [
         "* Encountered a type constructor escaping its scope: ",
@@ -529,9 +534,73 @@ end
 
 -- The default cases handle all other constructors!
 
--------------------
--- TYPE CHECKING --
--------------------
+-------------------------
+-- TYPE CHECKING UTILS --
+-------------------------
+
+-- resolveType resolves type aliases and substitutes Unknown types with type
+-- variables.
+-- NOTE(aathn, 2023-05-10): In the future, this should be replaced
+-- with something which also performs a proper kind check.
+lang ResolveType = ConTypeAst + AppTypeAst + AliasTypeAst + VariantTypeAst +
+  UnknownTypeAst + VarSortAst + VarTypeSubstitute + AppTypeGetArgs
+  sem resolveType
+    : Info -> Option (VarSort, Level)
+      -> Map Name (Level, [Name], Type) -> Type -> Type
+  sem resolveType info sort tycons =
+  | (TyCon _ | TyApp _) & ty ->
+    let mkAppTy =
+      foldl (lam ty1. lam ty2.
+        TyApp {info = mergeInfo (infoTy ty1) (infoTy ty2), lhs = ty1, rhs = ty2}) in
+    match getTypeArgs ty with (constr, args) in
+    let args = map (resolveType info sort tycons) args in
+    match constr with (TyCon t) & conTy then
+      match mapLookup t.ident tycons with Some (_, params, def) then
+        let appTy = mkAppTy conTy args in
+        match def with !TyVariant _ then  -- It's an alias
+          match (length params, length args) with (paramLen, argLen) in
+          if eqi paramLen argLen then
+            let subst = foldl2 (lam s. lam v. lam t. mapInsert v t s)
+                          (mapEmpty nameCmp) params args
+            in
+            -- We assume def has already been resolved before being put into tycons
+            TyAlias {display = appTy, content = substituteVars subst def}
+          else
+            errorSingle [infoTy ty] (join [
+              "* Encountered a misformed type alias.\n",
+              "* Type ", nameGetStr t.ident, " is declared to have ",
+              int2string paramLen, " parameters.\n",
+              "* Found ", int2string argLen, " arguments.\n",
+              "* When checking the annotation"
+            ])
+        else
+          appTy
+      else
+        errorSingle [t.info] (join [
+          "* Encountered an unknown type constructor: ", nameGetStr t.ident, "\n",
+          "* When checking the annotation"
+        ])
+    else
+      mkAppTy (resolveType info sort tycons constr) args
+
+  | TyUnknown _ ->
+    match sort with Some (sort, lvl) then
+      newflexvar sort lvl info
+    else
+      let msg = join [
+        "* Encountered Unknown type in an illegal position.\n",
+        "* Unknown is only allowed in annotations, not in definitions or declarations.\n",
+        "* When type checking the expression\n"
+      ] in
+      errorSingle [info] msg
+
+  -- If we encounter a TyAlias, it means that the type was already processed by
+  -- a previous call to typeCheck.
+  | TyAlias t -> TyAlias t
+
+  | ty ->
+    smap_Type_Type (resolveType info sort tycons) ty
+end
 
 lang RemoveFlex = FlexTypeAst + UnknownTypeAst + RecordTypeAst
   sem removeFlexType =
@@ -558,24 +627,9 @@ lang RemoveFlex = FlexTypeAst + UnknownTypeAst + RecordTypeAst
     smap_Pat_Pat removeFlexPat pat
 end
 
-lang SubstituteUnknown = UnknownTypeAst + VarSortAst
-  sem substituteUnknown (sort : VarSort) (lvl : Level) (info : Info) =
-  | TyUnknown _ ->
-    newflexvar sort lvl info
-  | ty ->
-    smap_Type_Type (substituteUnknown sort lvl info) ty
-
-  sem checkUnknown (info : Info) =
-  | TyUnknown _ ->
-    let msg = join [
-      "* Encountered Unknown type in an illegal position.\n",
-      "* Unknown is only allowed in annotations, not in definitions or declarations.\n",
-      "* When type checking the expression\n"
-    ] in
-    errorSingle [info] msg
-  | ty ->
-    sfold_Type_Type (lam. lam ty. checkUnknown info ty) () ty
-end
+-------------------
+-- TYPE CHECKING --
+-------------------
 
 lang TypeCheck = Unify + Generalize + RemoveFlex
   -- Type check 'tm', with FreezeML-style type inference. Returns the
@@ -633,13 +687,11 @@ lang VarTypeCheck = TypeCheck + VarAst
       errorSingle [t.info] msg
 end
 
-lang LamTypeCheck = TypeCheck + LamAst + SubstituteUnknown
+lang LamTypeCheck = TypeCheck + LamAst + ResolveType
   sem typeCheckExpr env =
   | TmLam t ->
-    -- If there is a programmer annotation, use it; otherwise, use the tyIdent field,
-    -- in which there may be a propagated type from an earlier annotation.
-    let tyAnnot = optionGetOr t.tyIdent (sremoveUnknown t.tyAnnot) in
-    let tyIdent = substituteUnknown (MonoVar ()) env.currentLvl t.info tyAnnot in
+    let tyIdent =
+      resolveType t.info (Some (MonoVar (), env.currentLvl)) env.tyConEnv t.tyAnnot in
     let body = typeCheckExpr (_insertVar t.ident tyIdent env) t.body in
     let tyLam = ityarrow_ t.info tyIdent (tyTm body) in
     TmLam {t with body = body, tyIdent = tyIdent, ty = tyLam}
@@ -685,17 +737,18 @@ lang FlexDisableGeneralize = Unify
 end
 
 lang LetTypeCheck =
-  TypeCheck + LetAst + LamAst + FunTypeAst + SubstituteUnknown +
+  TypeCheck + LetAst + LamAst + FunTypeAst + ResolveType +
   IsValue + FlexDisableGeneralize
   sem typeCheckExpr env =
   | TmLet t ->
     let newLvl = addi 1 env.currentLvl in
-    let tyBody = substituteUnknown (PolyVar ()) newLvl t.info t.tyAnnot in
+    let tyBody =
+      resolveType t.info (Some (PolyVar (), newLvl)) env.tyConEnv t.tyAnnot in
     match
       if isValue (GVal ()) t.body then
         match stripTyAll tyBody with (vars, stripped) in
-        let newTyVars = foldr (lam v. mapInsert v.0 newLvl) env.tyScopes vars in
-        let newEnv = {env with currentLvl = newLvl, tyScopes = newTyVars} in
+        let newTyVars = foldr (lam v. mapInsert v.0 newLvl) env.tyVarEnv vars in
+        let newEnv = {env with currentLvl = newLvl, tyVarEnv = newTyVars} in
         let body = typeCheckExpr newEnv (propagateTyAnnot (t.body, stripped)) in
         -- Unify the annotated type with the inferred one and generalize
         unify newEnv [infoTy t.tyAnnot, infoTm body] stripped (tyTm body);
@@ -711,16 +764,19 @@ lang LetTypeCheck =
         (body, tyBody)
       with (body, tyBody) in
     let inexpr = typeCheckExpr (_insertVar t.ident tyBody env) t.inexpr in
-    TmLet {t with body = body
-                , tyBody = tyBody
-                , inexpr = inexpr
-                , ty = tyTm inexpr}
+    -- NOTE(aathn, 2023-05-10): tyBody is updated but not tyAnnot,
+    -- which means that aliases will not be resolved in tyAnnot.
+    -- Later stages should refer exclusively to tyBody.
+    TmLet {t with body = body,
+                  tyBody = tyBody,
+                  inexpr = inexpr,
+                  ty = tyTm inexpr}
 
   sem propagateTyAnnot =
   | (TmLam l, TyArrow a) ->
     let body = propagateTyAnnot (l.body, a.to) in
     let ty = optionGetOr a.from (sremoveUnknown l.tyAnnot) in
-    TmLam {l with body = body, tyIdent = ty}
+    TmLam {l with body = body, tyAnnot = ty}
   | (tm, ty) -> tm
 end
 
@@ -731,7 +787,8 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck + FlexDisableGener
     let newLvl = addi 1 env.currentLvl in
     -- First: Generate a new environment containing the recursive bindings
     let recLetEnvIteratee = lam acc. lam b: RecLetBinding.
-      let tyBody = substituteUnknown (PolyVar ()) newLvl t.info b.tyAnnot in
+      let tyBody =
+        resolveType t.info (Some (PolyVar (), newLvl)) env.tyConEnv b.tyAnnot in
       let vars = if isValue (GVal ()) b.body then (stripTyAll tyBody).0 else [] in
       let newEnv = _insertVar b.ident tyBody acc.0 in
       let newTyVars = foldr (uncurry mapInsert) acc.1 vars in
@@ -739,14 +796,14 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst + LetTypeCheck + FlexDisableGener
     in
     match mapAccumL recLetEnvIteratee (env, mapEmpty nameCmp) t.bindings
       with ((recLetEnv, tyVars), bindings) in
-    let newScopes =
-      mapFoldWithKey (lam vs. lam v. lam. mapInsert v newLvl vs) recLetEnv.tyScopes tyVars in
+    let newTyVarEnv =
+      mapFoldWithKey (lam vs. lam v. lam. mapInsert v newLvl vs) recLetEnv.tyVarEnv tyVars in
 
     -- Second: Type check the body of each binding in the new environment
     let typeCheckBinding = lam b: RecLetBinding.
       let body =
         if isValue (GVal ()) b.body then
-          let newEnv = {recLetEnv with currentLvl = newLvl, tyScopes = newScopes} in
+          let newEnv = {recLetEnv with currentLvl = newLvl, tyVarEnv = newTyVarEnv} in
           match stripTyAll b.tyBody with (_, stripped) in
           let body = typeCheckExpr newEnv (propagateTyAnnot (b.body, stripped)) in
           -- Unify the inferred type of the body with the annotated one
@@ -830,34 +887,28 @@ lang RecordTypeCheck = TypeCheck + RecordAst + RecordTypeAst
     TmRecordUpdate {t with rec = rec, value = value, ty = tyTm rec}
 end
 
-lang TypeTypeCheck = TypeCheck + TypeAst + VariantTypeAst + SubstituteUnknown
+lang TypeTypeCheck = TypeCheck + TypeAst + VariantTypeAst + ResolveType
   sem typeCheckExpr env =
   | TmType t ->
-    checkUnknown t.info t.tyIdent;
-    let isAlias =
-      match t.tyIdent with TyVariant r then not (mapIsEmpty r.constrs) else true in
+    let tyIdent = resolveType t.info (None ()) env.tyConEnv t.tyIdent in
+    -- NOTE(aathn, 2023-05-08): Aliases are treated as the underlying
+    -- type and do not need to be scope checked.
+    let newLvl =
+      match tyIdent with !TyVariant _ then addi 1 env.currentLvl else 0 in
+    let newTyConEnv = mapInsert t.ident (newLvl, t.params, tyIdent) env.tyConEnv in
     let inexpr =
-      if isAlias then
-        -- NOTE(aathn, 2023-05-08): Aliases are treated as the
-        -- underlying type and do not need to be scope checked.
-        typeCheckExpr env t.inexpr
-      else
-        let newLvl = addi 1 env.currentLvl in
-        let newScopes = mapInsert t.ident newLvl env.tyScopes in
-        let inexpr =
-          typeCheckExpr {env with currentLvl = newLvl, tyScopes = newScopes} t.inexpr in
-        unify env [t.info, infoTm inexpr] (newvar env.currentLvl t.info) (tyTm inexpr);
-        inexpr
-    in
-    TmType {t with inexpr = inexpr, ty = tyTm inexpr}
+      typeCheckExpr {env with currentLvl = addi 1 env.currentLvl,
+                              tyConEnv = newTyConEnv} t.inexpr in
+    unify env [t.info, infoTm inexpr] (newvar env.currentLvl t.info) (tyTm inexpr);
+    TmType {t with tyIdent = tyIdent, inexpr = inexpr, ty = tyTm inexpr}
 end
 
-lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + SubstituteUnknown
+lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + ResolveType
   sem typeCheckExpr env =
   | TmConDef t ->
-    checkUnknown t.info t.tyIdent;
-    let inexpr = typeCheckExpr (_insertCon t.ident t.tyIdent env) t.inexpr in
-    TmConDef {t with inexpr = inexpr, ty = tyTm inexpr}
+    let tyIdent = resolveType t.info (None ()) env.tyConEnv t.tyIdent in
+    let inexpr = typeCheckExpr (_insertCon t.ident tyIdent env) t.inexpr in
+    TmConDef {t with tyIdent = tyIdent, inexpr = inexpr, ty = tyTm inexpr}
   | TmConApp t ->
     let body = typeCheckExpr env t.body in
     match mapLookup t.ident env.conEnv with Some lty then
@@ -896,13 +947,13 @@ lang NeverTypeCheck = TypeCheck + NeverAst
   | TmNever t -> TmNever {t with ty = newvar env.currentLvl t.info}
 end
 
-lang ExtTypeCheck = TypeCheck + ExtAst + SubstituteUnknown
+lang ExtTypeCheck = TypeCheck + ExtAst + ResolveType
   sem typeCheckExpr env =
   | TmExt t ->
-    checkUnknown t.info t.tyIdent;
-    let env = {env with varEnv = mapInsert t.ident t.tyIdent env.varEnv} in
+    let tyIdent = resolveType t.info (None ()) env.tyConEnv t.tyIdent in
+    let env = {env with varEnv = mapInsert t.ident tyIdent env.varEnv} in
     let inexpr = typeCheckExpr env t.inexpr in
-    TmExt {t with inexpr = inexpr, ty = tyTm inexpr}
+    TmExt {t with tyIdent = tyIdent, inexpr = inexpr, ty = tyTm inexpr}
 end
 
 ---------------------------

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -690,11 +690,11 @@ end
 lang LamTypeCheck = TypeCheck + LamAst + ResolveType
   sem typeCheckExpr env =
   | TmLam t ->
-    let tyIdent =
+    let tyParam =
       resolveType t.info (Some (MonoVar (), env.currentLvl)) env.tyConEnv t.tyAnnot in
-    let body = typeCheckExpr (_insertVar t.ident tyIdent env) t.body in
-    let tyLam = ityarrow_ t.info tyIdent (tyTm body) in
-    TmLam {t with body = body, tyIdent = tyIdent, ty = tyLam}
+    let body = typeCheckExpr (_insertVar t.ident tyParam env) t.body in
+    let tyLam = ityarrow_ t.info tyParam (tyTm body) in
+    TmLam {t with body = body, tyParam = tyParam, ty = tyLam}
 end
 
 lang AppTypeCheck = TypeCheck + AppAst

--- a/stdlib/mexpr/utest-generate.mc
+++ b/stdlib/mexpr/utest-generate.mc
@@ -147,7 +147,7 @@ let _var = lam id. lam ty.
   TmVar {ident = id, ty = ty, info = _utestInfo, frozen = false}
 let _lam = lam id. lam ty. lam body.
   use MExprAst in
-  TmLam {ident = id, tyAnnot = ty, tyIdent = ty, body = body,
+  TmLam {ident = id, tyAnnot = ty, tyParam = ty, body = body,
          ty = _tyarrows [ty, tyTm body], info = _utestInfo}
 let _seq = lam tms. lam ty.
   use MExprAst in

--- a/stdlib/mexpr/utils.mc
+++ b/stdlib/mexpr/utils.mc
@@ -169,11 +169,11 @@ let expr = lam id. bindall_ [
 let replace = mapFromSeq nameCmp [(nameNoSym "x", nameNoSym "y")] in
 utest pp (substituteIdentifiers replace (expr "x")) with pp (expr "y") using eqString in
 
-let parseProgram : String -> Expr = 
+let parseProgram : String -> Expr =
   lam str.
   let parseArgs = {defaultBootParserParseMExprStringArg with allowFree = true} in
   let ast = parseMExprString parseArgs str in
-  symbolizeExpr {symEnvEmpty with allowFree = true} ast
+  symbolizeAllowFree ast
 in
 
 let matchOpt : all a. all b. Option a -> Option b -> Bool =

--- a/stdlib/mexpr/utils.mc
+++ b/stdlib/mexpr/utils.mc
@@ -34,7 +34,7 @@ lang MExprSubstitute = MExprAst
   | TmLam t ->
     TmLam {t with ident = subIdent replacements t.ident,
                   tyAnnot = substituteIdentifiersType replacements t.tyAnnot,
-                  tyIdent = substituteIdentifiersType replacements t.tyIdent,
+                  tyParam = substituteIdentifiersType replacements t.tyParam,
                   body = substituteIdentifiersExpr replacements t.body,
                   ty = substituteIdentifiersType replacements t.ty}
   | TmType t ->

--- a/stdlib/ocaml/external.mc
+++ b/stdlib/ocaml/external.mc
@@ -152,7 +152,7 @@ lang OCamlDataConversionHelpers =
                     TmLam {
                       ident = ident,
                       tyAnnot = TyUnknown { info = info },
-                      tyIdent = TyUnknown { info = info },
+                      tyParam = TyUnknown { info = info },
                       body = body,
                       ty = TyUnknown { info = info },
                       info = info

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -1,79 +1,43 @@
 include "ocaml/ast.mc"
 include "mexpr/symbolize.mc"
 
-let _symbolizeVarName = lam env : SymEnv. lam ident.
-  match env with {varEnv = varEnv} then
-    if nameHasSym ident then (env, ident)
-    else
-      let ident = nameSetNewSym ident in
-      let str = nameGetStr ident in
-      let varEnv = mapInsert str ident varEnv in
-      let env = {env with varEnv = varEnv} in
-      (env, ident)
-  else never
-
 lang OCamlSym =
   VarSym + AppAst + LamSym + LetSym + RecLetsSym + RecordAst + ConstAst
   + NamedPatSym + IntPat + CharPat + BoolPat + RecordAst
   + OCamlMatch + OCamlTuple + OCamlData
   + UnknownTypeAst + IntTypeAst + BoolTypeAst + FloatTypeAst + CharTypeAst
-  + RecordTypeAst + ConAppTypeSym + OCamlExternal
+  + RecordTypeAst + ConTypeSym + OCamlExternal
   + OCamlString + OCamlRecord + OCamlLabel
 
-  sem symbolizeExpr (env : SymEnv) =
+  sem symbolizeExprBase symbolize env =
   | OTmMatch {target = target, arms = arms} ->
-    let symbArm = lam arm. match arm with (pat, expr) then
-      match symbolizePat env (mapEmpty cmpString) pat with (patEnv, pat) then
-        let thnEnv = {env with varEnv = mapUnion env.varEnv patEnv} in
-        (pat, symbolizeExpr thnEnv expr)
-      else never else never in
-    OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
-  | OTmTuple { values = values } ->
-    OTmTuple { values = map (symbolizeExpr env) values }
-  | OTmConApp t ->
-    match _symbolizeVarName env t.ident with (env, ident) then
-      let args = map (symbolizeExpr env) t.args in
-      OTmConApp {{t with ident = ident}
-                    with args = args}
-    else never
-  | OTmVarExt t -> OTmVarExt t
-  | OTmConAppExt ({ args = args } & t) ->
-    OTmConAppExt {t with args = map (symbolizeExpr env) args}
-  | OTmString t -> OTmString t
-  | OTmLabel t -> OTmLabel {t with arg = symbolizeExpr env t.arg }
-  | OTmRecord t ->
-    let bindings =
-      map (lam b : (String, Expr). (b.0, symbolizeExpr env b.1)) t.bindings
+    let symbArm = lam arm.
+      match arm with (pat, expr) in
+      match symbolizePat env (mapEmpty cmpString) pat with (patEnv, pat) in
+      let thnEnv = {env with varEnv = mapUnion env.varEnv patEnv} in
+      (pat, symbolize thnEnv expr)
     in
-    OTmRecord {t with bindings = bindings}
-  | OTmProject t -> OTmProject {t with tm = symbolizeExpr env t.tm}
+    OTmMatch { target = symbolize env target, arms = map symbArm arms }
+  | OTmConApp t ->
+    let ident =
+      _getName {kind = "constructor",
+                info = [],
+                allowFree = env.allowFree}
+        t.ident env.conEnv
+    in
+    let args = map (symbolize env) t.args in
+    OTmConApp {t with ident = ident,
+                      args = args}
 
-  sem symbolizePat (env : SymEnv) (patEnv : Map String Name) =
-  | OPatTuple { pats = pats } ->
-    match mapAccumL (symbolizePat env) patEnv pats with (patEnv, pats) then
-      (patEnv, OPatTuple { pats = pats })
-    else never
+  sem symbolizePat env patEnv =
   | OPatCon t ->
-    match env with {conEnv = conEnv} then
-      let ident =
-        if nameHasSym t.ident then t.ident
-        else
-          let str = nameGetStr t.ident in
-          match mapLookup str conEnv with Some ident then ident
-          else error (concat "Unknown constructor in symbolizeExpr: " str)
-      in
-      match mapAccumL (symbolizePat env) patEnv t.args with (patEnv, args) then
-        (patEnv, OPatCon {{t with ident = ident}
-                           with args = args})
-      else never
-    else never
-  | OPatConExt ({ args = pats } & t) ->
-    match mapAccumL (symbolizePat env) patEnv pats with (patEnv, pats) then
-      (patEnv, OPatConExt { t with args = pats })
-    else never
-  | OPatRecord t ->
-    let symf = lam patEnv. lam _i. lam p. symbolizePat env patEnv p in
-    match mapMapAccum symf patEnv t.bindings with (env, bindings) then
-      (env, OPatRecord {t with bindings = bindings})
-    else never
+    let ident =
+      _getName {kind = "constructor",
+                info = [],
+                allowFree = env.allowFree}
+        t.ident env.conEnv
+    in
+    match mapAccumL (symbolizePat env) patEnv t.args with (patEnv, args) in
+    (patEnv, OPatCon {t with ident = ident,
+                             args = args})
 end

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -20,10 +20,10 @@ lang OCamlSym =
     OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
   | OTmConApp t ->
     let ident =
-      _getName {kind = "constructor",
-                info = [],
-                allowFree = env.allowFree}
-        t.ident env.conEnv
+      getSymbol {kind = "constructor",
+                 info = [],
+                 allowFree = env.allowFree}
+        env.conEnv t.ident
     in
     let args = map (symbolizeExpr env) t.args in
     OTmConApp {t with ident = ident,
@@ -32,10 +32,10 @@ lang OCamlSym =
   sem symbolizePat env patEnv =
   | OPatCon t ->
     let ident =
-      _getName {kind = "constructor",
-                info = [],
-                allowFree = env.allowFree}
-        t.ident env.conEnv
+      getSymbol {kind = "constructor",
+                 info = [],
+                 allowFree = env.allowFree}
+        env.conEnv t.ident
     in
     match mapAccumL (symbolizePat env) patEnv t.args with (patEnv, args) in
     (patEnv, OPatCon {t with ident = ident,

--- a/stdlib/ocaml/symbolize.mc
+++ b/stdlib/ocaml/symbolize.mc
@@ -9,15 +9,15 @@ lang OCamlSym =
   + RecordTypeAst + ConTypeSym + OCamlExternal
   + OCamlString + OCamlRecord + OCamlLabel
 
-  sem symbolizeExprBase symbolize env =
+  sem symbolizeExpr (env : SymEnv) =
   | OTmMatch {target = target, arms = arms} ->
     let symbArm = lam arm.
       match arm with (pat, expr) in
       match symbolizePat env (mapEmpty cmpString) pat with (patEnv, pat) in
       let thnEnv = {env with varEnv = mapUnion env.varEnv patEnv} in
-      (pat, symbolize thnEnv expr)
+      (pat, symbolizeExpr thnEnv expr)
     in
-    OTmMatch { target = symbolize env target, arms = map symbArm arms }
+    OTmMatch { target = symbolizeExpr env target, arms = map symbArm arms }
   | OTmConApp t ->
     let ident =
       _getName {kind = "constructor",
@@ -25,7 +25,7 @@ lang OCamlSym =
                 allowFree = env.allowFree}
         t.ident env.conEnv
     in
-    let args = map (symbolize env) t.args in
+    let args = map (symbolizeExpr env) t.args in
     OTmConApp {t with ident = ident,
                       args = args}
 

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -2,7 +2,6 @@ include "mexpr/keyword-maker.mc"
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/type-check.mc"
-include "mexpr/type-annot.mc"
 include "mexpr/eval.mc"
 include "mexpr/info.mc"
 include "mexpr/eq.mc"
@@ -13,7 +12,7 @@ include "list.mc"
 
 
 lang PEvalAst = KeywordMaker + MExpr + MExprEq + Eval + PrettyPrint
-                + MExprTypeCheck + LamEval + TypeAnnot + MExprPEval
+                + MExprTypeCheck + LamEval + MExprPEval
 
   syn Expr =
   | TmPEval {e: Expr, info: Info}
@@ -38,11 +37,6 @@ lang PEvalAst = KeywordMaker + MExpr + MExprEq + Eval + PrettyPrint
   sem typeCheckExpr (env : TCEnv) = 
   | TmPEval t -> 
     let e = typeCheckExpr env t.e in
-    TmPEval {t with e = e}
-
-  sem typeAnnotExpr (env : TypeEnv) = 
-  | TmPEval t -> 
-    let e = typeAnnotExpr env t.e in
     TmPEval {t with e = e}
 
   sem smapAccumL_Expr_Expr f acc =

--- a/stdlib/pmexpr/compile.mc
+++ b/stdlib/pmexpr/compile.mc
@@ -194,9 +194,9 @@ lang PMExprCudaWellFormed =
   sem instrumentCudaWellFormedChecks : Int -> Expr -> Expr
   sem instrumentCudaWellFormedChecks tensorMaxRank =
   | TmLam t ->
-    checkCudaParameterTypeWellFormedness t.info () t.tyIdent;
+    checkCudaParameterTypeWellFormedness t.info () t.tyParam;
     let body = instrumentCudaWellFormedChecks tensorMaxRank t.body in
-    TmLam {t with body = cudaCheckTensorRank tensorMaxRank t.ident body t.tyIdent}
+    TmLam {t with body = cudaCheckTensorRank tensorMaxRank t.ident body t.tyParam}
   | body -> body
 
   sem checkCudaParameterTypeWellFormedness : Info -> () -> Type -> ()
@@ -262,9 +262,9 @@ lang PMExprFutharkWellFormed =
   sem instrumentFutharkWellFormedChecks : Expr -> Expr
   sem instrumentFutharkWellFormedChecks =
   | TmLam t ->
-    checkFutharkParameterTypeWellFormedness t.info () t.tyIdent;
+    checkFutharkParameterTypeWellFormedness t.info () t.tyParam;
     let body = instrumentFutharkWellFormedChecks t.body in
-    TmLam {t with body = futharkCheckSequenceRegularity t.ident body t.tyIdent}
+    TmLam {t with body = futharkCheckSequenceRegularity t.ident body t.tyParam}
   | body -> body
 
   sem checkFutharkParameterTypeWellFormedness : Info -> () -> Type -> ()

--- a/stdlib/pmexpr/demote.mc
+++ b/stdlib/pmexpr/demote.mc
@@ -82,7 +82,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
           ty = tyuk, info = t.info},
         rhs = TmLam {
           ident = iid,
-          tyAnnot = TyInt {info = t.info}, tyIdent = TyInt {info = t.info},
+          tyAnnot = TyInt {info = t.info}, tyParam = TyInt {info = t.info},
           body = TmRecord {
             bindings = mapFromSeq cmpSID [
               (stringToSid "0", access aid (tyTm t.as) lty),
@@ -107,7 +107,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
       lhs = TmApp {
         lhs = TmConst {val = CMap (), ty = tyuk, info = t.info},
         rhs = TmLam {
-          ident = xid, tyAnnot = tytuple, tyIdent = tytuple,
+          ident = xid, tyAnnot = tytuple, tyParam = tytuple,
           body = TmApp {
             lhs = TmApp {
               lhs = demoteParallel t.f,
@@ -143,7 +143,7 @@ lang PMExprDemoteLoop = PMExprAst
     let unitTy = TyRecord {fields = mapEmpty cmpSID, info = t.info} in
     let acc = TmRecord {bindings = mapEmpty cmpSID, ty = unitTy, info = t.info} in
     let f = TmLam {
-      ident = nameNoSym "", tyAnnot = unitTy, tyIdent = unitTy, body = t.f,
+      ident = nameNoSym "", tyAnnot = unitTy, tyParam = unitTy, body = t.f,
       ty = TyArrow {from = unitTy, to = tyTm t.f, info = t.info},
       info = t.info} in
     let accLoop = TmLoopAcc {
@@ -206,10 +206,10 @@ lang PMExprDemoteLoop = PMExprAst
     let loopBindingDef = {
       ident = loopId, tyAnnot = loopTy, tyBody = loopTy, info = t.info,
       body = TmLam {
-        ident = accIdent, tyAnnot = accTy, tyIdent = accTy,
+        ident = accIdent, tyAnnot = accTy, tyParam = accTy,
         body = TmLam {
           ident = iIdent,
-          tyAnnot = TyInt {info = t.info}, tyIdent = TyInt {info = t.info},
+          tyAnnot = TyInt {info = t.info}, tyParam = TyInt {info = t.info},
           body = TmMatch {
             target = loopCompareExpr,
             pat = PatBool {val = true, ty = TyBool {info = t.info}, info = t.info},

--- a/stdlib/pmexpr/extract.mc
+++ b/stdlib/pmexpr/extract.mc
@@ -121,7 +121,7 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
         tyAnnot = funcType,
         tyBody = funcType,
         body = TmLam {
-          ident = paramId, tyAnnot = paramTy, tyIdent = paramTy, body = t.e,
+          ident = paramId, tyAnnot = paramTy, tyParam = paramTy, body = t.e,
           ty = TyArrow {from = paramTy, to = retType, info = info},
           info = info},
         inexpr = TmApp {

--- a/stdlib/pmexpr/parallel-patterns.mc
+++ b/stdlib/pmexpr/parallel-patterns.mc
@@ -230,7 +230,7 @@ let mapPattern : () -> Pattern =
           lhs = TmApp {
             lhs = TmConst {val = CMap (), ty = mapTy, info = info},
             rhs = TmLam {
-              ident = x, tyAnnot = tyTm headExpr, tyIdent = tyTm headExpr, body = els,
+              ident = x, tyAnnot = tyTm headExpr, tyParam = tyTm headExpr, body = els,
               ty = fType, info = infoTm els},
             ty = innerAppType, info = info},
           rhs = sExpr,
@@ -311,9 +311,9 @@ let map2Pattern : () -> Pattern =
         let els = eliminateUnusedLetExpressions (bind_ els fResultVar) in
         TmMap2 {
           f = TmLam {
-            ident = x, tyAnnot = tyTm headFstExpr, tyIdent = tyTm headFstExpr,
+            ident = x, tyAnnot = tyTm headFstExpr, tyParam = tyTm headFstExpr,
             body = TmLam {
-              ident = y, tyAnnot = tyTm headSndExpr, tyIdent = tyTm headSndExpr, body = els,
+              ident = y, tyAnnot = tyTm headSndExpr, tyParam = tyTm headSndExpr, body = els,
               ty = TyArrow {from = tyTm headSndExpr, to = tyTm els, info = info},
               info = infoTm els},
             ty = TyArrow {
@@ -422,9 +422,9 @@ let reducePattern : () -> Pattern =
       let elemTy = tyTm headExpr in
       let accTy = tyTm accExpr in
       let f = TmLam {
-        ident = x, tyAnnot = accTy, tyIdent = accTy,
+        ident = x, tyAnnot = accTy, tyParam = accTy,
         body = TmLam {
-          ident = y, tyAnnot = elemTy, tyIdent = elemTy, body = els,
+          ident = y, tyAnnot = elemTy, tyParam = elemTy, body = els,
           ty = TyArrow {from = elemTy, to = accTy,
                         info = infoTm els},
           info = info},

--- a/stdlib/pmexpr/parallel-rewrite.mc
+++ b/stdlib/pmexpr/parallel-rewrite.mc
@@ -94,7 +94,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
                   TmLam {
                     ident = name,
                     tyAnnot = TyUnknown {info = info},
-                    tyIdent = TyUnknown {info = info},
+                    tyParam = TyUnknown {info = info},
                     body = e,
                     ty = tyTm e,
                     info = info})

--- a/stdlib/pmexpr/tailrecursion.mc
+++ b/stdlib/pmexpr/tailrecursion.mc
@@ -230,7 +230,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
       let bodyWithAcc = TmLam {
         ident = accIdent,
         tyAnnot = accType,
-        tyIdent = accType,
+        tyParam = accType,
         body = functionBody,
         ty = TyArrow {from = accType, to = binding.tyBody, info = binding.info},
         info = binding.info

--- a/stdlib/pmexpr/utest-size-constraint.mc
+++ b/stdlib/pmexpr/utest-size-constraint.mc
@@ -66,7 +66,7 @@ lang PMExprUtestSizeConstraint = PMExprAst
   | TmLam t ->
     recursive let extractLambdas = lam acc : Map Name Type. lam e : Expr.
       match e with TmLam t then
-        let acc = mapInsert t.ident t.tyIdent acc in
+        let acc = mapInsert t.ident t.tyParam acc in
         extractLambdas acc t.body
       else (acc, e) in
     recursive let replaceFunctionBody = lam body : Expr. lam e : Expr.

--- a/stdlib/pmexpr/utils.mc
+++ b/stdlib/pmexpr/utils.mc
@@ -22,7 +22,7 @@ recursive let replaceFunctionBody : Expr -> Expr -> Expr =
   lam funcExpr. lam newExpr.
   match funcExpr with TmLam t then
     let body = replaceFunctionBody t.body newExpr in
-    let ty = TyArrow {from = t.tyIdent, to = tyTm body, info = infoTy t.ty} in
+    let ty = TyArrow {from = t.tyParam, to = tyTm body, info = infoTy t.ty} in
     TmLam {{t with body = body} with ty = ty}
   else newExpr
 end
@@ -46,7 +46,7 @@ let functionParametersAndBody : Expr -> ([(Name, Type, Info)], Expr) =
   lam functionExpr.
   recursive let work = lam acc. lam e.
     match e with TmLam t then
-      work (snoc acc (t.ident, t.tyIdent, t.info)) t.body
+      work (snoc acc (t.ident, t.tyParam, t.info)) t.body
     else (acc, e)
   in work [] functionExpr
 

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -35,7 +35,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeCheck
   sem withType (ty : Type) =
   | TmHole t -> TmHole {t with ty = ty}
 
-  sem symbolizeExprBase symbolize env =
+  sem symbolizeExpr (env : SymEnv) =
   | TmHole h -> TmHole h
 
   sem default =

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -2,7 +2,6 @@ include "mexpr/ast.mc"
 include "mexpr/anf.mc"
 include "mexpr/keyword-maker.mc"
 include "mexpr/boot-parser.mc"
-include "mexpr/type-annot.mc"
 include "mexpr/type-check.mc"
 
 -- Defines AST nodes for holes.
@@ -17,7 +16,7 @@ let _expectConstInt : Info -> String -> Expr -> Int =
     match i with TmConst {val = CInt {val = i}} then i
     else errorSingle [info] (concat "Expected a constant integer: " s)
 
-lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot + TypeCheck
+lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeCheck
   syn Hole =
 
   syn Expr =
@@ -118,13 +117,6 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot + TypeCheck
                 , ty = hty
                 , inner = holeMap bindings})
     else error "impossible"
-
-  sem typeAnnotExpr (env : TypeEnv) =
-  | TmHole t ->
-    let default = typeAnnotExpr env t.default in
-    let ty = hty t.info t.inner in
-    TmHole {{t with default = default}
-               with ty = ty}
 
   sem hty : Info -> Hole -> Type
 
@@ -289,7 +281,7 @@ lang HoleAnnotation = Ast
 end
 
 -- Independency annotation
-lang IndependentAst = HoleAnnotation + KeywordMaker + ANF + PrettyPrint + TypeAnnot
+lang IndependentAst = HoleAnnotation + KeywordMaker + ANF + PrettyPrint
   syn Expr =
   | TmIndependent {lhs : Expr,
                    rhs : Expr,
@@ -341,11 +333,6 @@ lang IndependentAst = HoleAnnotation + KeywordMaker + ANF + PrettyPrint + TypeAn
     let aindent = pprintIncr indent in
     match printParen aindent env t.rhs with (env, rhs) in
     (env, join ["independent ", lhs, pprintNewline aindent, rhs])
-
-  sem typeAnnotExpr (env : TypeEnv) =
-  | TmIndependent t ->
-    let lhs = typeAnnotExpr env t.lhs in
-    TmIndependent {t with lhs = lhs}
 end
 
 let holeBool_ : Bool -> Int -> Expr =

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -36,7 +36,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeAnnot + TypeCheck
   sem withType (ty : Type) =
   | TmHole t -> TmHole {t with ty = ty}
 
-  sem symbolizeExpr (env : SymEnv) =
+  sem symbolizeExprBase symbolize env =
   | TmHole h -> TmHole h
 
   sem default =

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -130,7 +130,7 @@ lang ContextExpand = HoleAst
   | tm ->
     use BootParser in
     let impl = parseMExprStringKeywords [] "
-    let eqSeq = lam eq : (a -> b -> Bool). lam s1 : [a]. lam s2 : [b].
+    let eqSeq = lam eq. lam s1. lam s2.
       recursive let work = lam s1. lam s2.
         match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) then
           if eq h1 h2 then work t1 t2
@@ -221,7 +221,7 @@ lang ContextExpand = HoleAst
     " in
 
     use MExprSym in
-    let impl = symbolizeExpr {symEnvEmpty with strictTypeVars = false} impl in
+    let impl = symbolize impl in
 
     let getName : String -> Expr -> Name = lam s. lam expr.
       use MExprFindSym in

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -456,7 +456,7 @@ let debug = false in
 let parse = lam str.
   let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords ast in
-  symbolizeExpr {symEnvEmpty with strictTypeVars = false} ast
+  symbolize ast
 in
 let test
 : Bool -> Expr -> [String] -> [(String, [AbsVal], Map NameInfo (Map [NameInfo] Int), IndexMap)] =
@@ -771,7 +771,7 @@ using eqTestHole in
 let t = parse
 "
 type T in
-con C: Bool -> t in
+con C: Bool -> T in
 let h = hole (Boolean {default = true}) in
 let p = C h in
 let res = match h with a | true then 1 else 2 in

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -578,7 +578,7 @@ let timeSensitive = false in
 let parse = lam str.
   let ast = parseMExprStringKeywords holeKeywords str in
   let ast = makeKeywords ast in
-  symbolizeExpr {symEnvEmpty with strictTypeVars = false} ast
+  symbolize ast
 in
 
 let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchState) =


### PR DESCRIPTION
This PR refactors `mexpr/symbolize.mc` to (1) reduce code duplication by a fair amount ~and (2) make it extensible in preparation of writing `mlang/symbolize.mc`~.  It also includes some other changes, listed below.

Note that this PR is based on #726, so the diff shown is not accurate (look  [here](https://github.com/miking-lang/miking/pull/730/files/8b7fd459b313ed5365fbb02c28f0eb7a7e485df7..049323263848b2c2b548e89cacbc08fec9efbdba) for the actual diff).

Changes:
- Refactor `symbolize.mc`.
- Move type alias resolution to `type-check.mc`.  The original motivation for putting it in `symbolize` was for convenience and efficiency, since it meant that alias resolution could be done in the same traversal as symbolization and the type checker didn't need to track and resolve aliases.  However, I think it is more logical to have a separation of concerns where the symbolization is only concerned with simple name resolution, and the type checker is responsible for the workings of type declarations.  The type checker will need to track type constructors anyways when we add kind checking, so it seems reasonable to make this change now.
- Rename `tyIdent` field of `TmLam` to `tyParam`.  `tyIdent` is used in `TmExt`, `TmType`, `TmConDef` to denote type declarations (part of the surface syntax), whereas only for `TmLam` it was a typechecker-added tag.
- Remove all remaining uses of `typeAnnot` except for the one in `ocaml/mcore.mc` which is still necessary for compilation.

These changes seem to make the first stage of bootstrapping about 10 seconds slower, I haven't looked into the details yet.