### PR TITLE
Stdlib additions, pretty print improvements, and improved constant folding

### DIFF
--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -235,6 +235,18 @@ let mapGetMin : all k. all v. Map k v -> Option (k, v) =
       match avlSplitFirst m.root with (k, v, _) in
       Some (k, v)
 
+-- `mapFilterWithKey p m` filters the map `m` with the predicate `p`.
+let mapFilterWithKey : all k. all v. (k -> v -> Bool) -> Map k v -> Map k v
+  = lam p. lam m.
+    mapFoldWithKey
+      (lam m. lam k. lam v. if p k v then mapInsert k v m else m)
+      (mapEmpty (mapGetCmpFun m))
+      m
+
+-- `mapFilter p m` filters the map `m` with the predicate `p`.
+let mapFilter : all k. all v. (v -> Bool) -> Map k v -> Map k v
+  = lam p. mapFilterWithKey (lam. p)
+
 mexpr
 
 let m = mapEmpty subi in
@@ -370,5 +382,25 @@ utest
 in
 
 utest mapGetMin m with Some (1, "1") in
+
+let m = mapFromSeq subi [
+  (1, "1"),
+  (2, "2"),
+  (3, "3")
+] in
+utest
+  mapBindings (mapFilterWithKey (lam k. lam v. and (gti k 1) (eqString v "3")) m)
+  with [(3, "3")]
+in
+
+let m = mapFromSeq subi [
+  (1, "1"),
+  (2, "2"),
+  (3, "3")
+] in
+utest
+  mapBindings (mapFilter (lam v. or (eqString v "1") (eqString v "3")) m)
+  with [(1, "1"), (3, "3")]
+in
 
 ()


### PR DESCRIPTION
This PR consists of a few minor tweaks and changes.

1. It adds a function `mapFilter` and `mapFilterWithKey` that filters the bindings of a map to the `map.mc` library.
2. It improves pretty-printing of record/tuple projections in MExpr (avoiding unnecessary parenthesis).
3. It adds new cases to `constant-fold.mc` to simplify expressions on the form `mulf (mulf x 2.) 3.` and its variations.
4. ~It adds a new function `optionCatSome : all a. [Option a] -> [a]` to `option.mc` that filters and extracts Some values from a sequence~.
5. It adds a parsing option for float intervals, removes some unnecessary annotations, and fixes a bug in `arg.mc`  