### PR TITLE
Tensor access microbenchmarks

### DIFF
--- a/test/microbenchmark/matrix_mul_carray.mc
+++ b/test/microbenchmark/matrix_mul_carray.mc
@@ -1,0 +1,25 @@
+include "benchmarkcommon.mc"
+include "matrix_mul_dense.mc"
+
+mexpr
+
+-- Benchmark
+benchmark tensorCreateCArrayFloat matMul ();
+
+-- Test
+-- test mat_mul;
+-- Expect
+-- [
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[15., 18., 21.],
+-- 	[42., 54., 66.],
+-- 	[69., 90., 111.]
+-- ]
+()

--- a/test/microbenchmark/matrix_mul_carray.ml
+++ b/test/microbenchmark/matrix_mul_carray.ml
@@ -1,0 +1,38 @@
+let mat_mul mat1 mat2 mat3 : unit =
+  let open Bigarray.Array2 in
+  let m1 = dim1 mat1
+  and n1 = dim2 mat1
+  and m2 = dim1 mat2
+  and n2 = dim2 mat2
+  and m3 = dim1 mat3
+  and n3 = dim2 mat3 in
+  if n1 = m2 && m1 = m3 && n2 = n3 then (
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        mat3.{i, j} <- 0.
+      done
+    done ;
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        for k = 0 to m1 - 1 do
+          mat3.{i, j} <- mat3.{i, j} +. (mat1.{k, j} *. mat2.{i, k})
+        done
+      done
+    done )
+  else failwith "Invalid input"
+
+let _ =
+  let open Bigarray in
+  (* Benchmark *)
+  Matrix_mul_common.benchmark
+    (Array2.of_array Float64 C_layout)
+    Array2.get Array2.set mat_mul ()
+
+(* Test *)
+(* Matrix_mul_common.test_bigarray mat_mul *)
+(*
+      Expected:
+      15., 18., 21.,
+      42., 54., 66.,
+      69., 90., 111.,
+*)

--- a/test/microbenchmark/matrix_mul_carray_genarray.mc
+++ b/test/microbenchmark/matrix_mul_carray_genarray.mc
@@ -1,0 +1,1 @@
+matrix_mul_carray.mc

--- a/test/microbenchmark/matrix_mul_carray_genarray.ml
+++ b/test/microbenchmark/matrix_mul_carray_genarray.ml
@@ -1,0 +1,39 @@
+let mat_mul mat1 mat2 mat3 : unit =
+  let open Bigarray.Genarray in
+  match (dims mat1, dims mat2, dims mat3) with
+  | [|m1; n1|], [|m2; n2|], [|m3; n3|] when n1 = m2 && m1 = m3 && n2 = n3 ->
+      for i = 0 to m3 - 1 do
+        for j = 0 to n3 - 1 do
+          set mat3 [|i; j|] 0.
+        done
+      done ;
+      for i = 0 to m3 - 1 do
+        for j = 0 to n3 - 1 do
+          for k = 0 to m1 - 1 do
+            set mat3 [|i; j|]
+              (get mat3 [|i; j|] +. (get mat1 [|k; j|] *. get mat2 [|i; k|]))
+          done
+        done
+      done
+  | _ ->
+      failwith "Invalid input"
+
+let _ =
+  let open Bigarray in
+  (* Benchmark *)
+  Matrix_mul_common.benchmark
+    (fun arr -> genarray_of_array2 (Array2.of_array Float64 C_layout arr))
+    (fun mat i j -> Genarray.get mat [|i; j|])
+    (fun mat i j v -> Genarray.set mat [|i; j|] v)
+    mat_mul ()
+
+(* Test *)
+(* Matrix_mul_common.test_bigarray (fun mat1 mat2 mat3 -> *)
+(*     mat_mul (genarray_of_array2 mat1) (genarray_of_array2 mat2) *)
+(*       (genarray_of_array2 mat3) ) *)
+(*
+      Expected:
+      15., 18., 21.,
+      42., 54., 66.,
+      69., 90., 111.,
+*)

--- a/test/microbenchmark/matrix_mul_carray_linear.mc
+++ b/test/microbenchmark/matrix_mul_carray_linear.mc
@@ -1,0 +1,25 @@
+include "matrix_mul_dense_linear.mc"
+include "benchmarkcommon.mc"
+
+mexpr
+
+-- Benchmark
+benchmark tensorCreateCArrayFloat matMul ();
+
+-- Test
+-- test mat_mul;
+-- Expect
+-- [
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[15., 18., 21.],
+-- 	[42., 54., 66.],
+-- 	[69., 90., 111.]
+-- ]
+()

--- a/test/microbenchmark/matrix_mul_carray_linear.ml
+++ b/test/microbenchmark/matrix_mul_carray_linear.ml
@@ -1,0 +1,38 @@
+let mat_mul mat1 mat2 mat3 : unit =
+  let open Bigarray.Array2 in
+  let m1 = dim1 mat1
+  and n1 = dim2 mat1
+  and m2 = dim1 mat2
+  and n2 = dim2 mat2
+  and m3 = dim1 mat3
+  and n3 = dim2 mat3 in
+  if n1 = m2 && m1 = m3 && n2 = n3 then (
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        mat3.{i, j} <- 0.
+      done
+    done ;
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        for k = 0 to m1 - 1 do
+          mat3.{i, j} <- mat3.{i, j} +. (mat1.{k, j} *. mat2.{i, k})
+        done
+      done
+    done )
+  else failwith "Invalid input"
+
+let _ =
+  let open Bigarray in
+  (* Benchmark *)
+  Matrix_mul_common.benchmark
+    (Array2.of_array Float64 C_layout)
+    Array2.get Array2.set mat_mul ()
+
+(* Test *)
+(* Matrix_mul_common.test_bigarray mat_mul *)
+(*
+      Expected:
+      15., 18., 21.,
+      42., 54., 66.,
+      69., 90., 111.,
+*)

--- a/test/microbenchmark/matrix_mul_common.mc
+++ b/test/microbenchmark/matrix_mul_common.mc
@@ -1,0 +1,51 @@
+include "benchmarkcommon.mc"
+
+let loop_ = lam n. lam f.
+  recursive let recur = lam i.
+    if geqi i n then () else f i; recur (addi i 1)
+  in
+  recur 0
+
+let n = 10
+
+let _create_benchmark_data = lam tcreate.
+  let mat1 =
+    tcreate [n, n] (lam. int2float (randIntU 0 10))
+  in
+  let mat2 = tensorCopy mat1 in
+  let mat3 = tensorCopy mat1 in
+  (mat1, mat2, mat3)
+
+let create_benchmark_data_dense = lam.
+  _create_benchmark_data tensorCreateDense
+
+let create_benchmark_data_carray = lam.
+  _create_benchmark_data tensorCreateCArrayFloat
+
+let benchmark = lam tcreate. lam matMul. lam.
+  match _create_benchmark_data tcreate with (mat1, mat2, mat3) in
+  let n = subi n 1 in
+  let randomSet = lam mat. lam.
+    tensorSetExn mat [randIntU 0 n, randIntU 0 n] (int2float (randIntU 0 10))
+  in
+  let randomGet = lam mat. lam.
+    tensorGetExn mat [randIntU 0 n, randIntU 0 n]
+  in
+  let sum = ref 0. in
+  bc_repeat (lam.
+    randomSet mat1 ();
+    randomSet mat2 ();
+    matMul mat1 mat2 mat3;
+    modref sum (addf (deref sum) (randomGet mat3 ())));
+  print (float2string (deref sum))
+
+let test = lam mat_mul.
+  let mat1 = tensorCreateDense [9] (lam idx. int2float (head idx)) in
+  let mat1 = tensorReshapeExn mat1 [3, 3] in
+  let mat2 = tensorCopy mat1 in
+  let mat3 = tensorCopy mat1 in
+  mat_mul mat1 mat2 mat3;
+  print (tensor2string float2string mat1);
+  print (tensor2string float2string mat2);
+  print (tensor2string float2string mat3);
+  ()

--- a/test/microbenchmark/matrix_mul_common.ml
+++ b/test/microbenchmark/matrix_mul_common.ml
@@ -1,0 +1,57 @@
+let n = 10
+
+let create_benchmark_data () =
+  let mat1 =
+    Array.init n (fun _ ->
+        Array.init n (fun _ -> float_of_int (Random.int 10)) )
+  in
+  let mat2 = Array.init n (fun i -> Array.copy mat1.(i)) in
+  let mat3 = Array.init n (fun i -> Array.copy mat1.(i)) in
+  (mat1, mat2, mat3)
+
+let benchmark mat_to_mat get set mat_mul () =
+  let mat1, mat2, mat3 = create_benchmark_data () in
+  let mat1, mat2, mat3 = (mat_to_mat mat1, mat_to_mat mat2, mat_to_mat mat2) in
+  let n = pred n in
+  let random_set mat _ =
+    set mat (Random.int n) (Random.int n) (float_of_int (Random.int 10))
+  in
+  let random_get mat _ = get mat (Random.int n) (Random.int n) in
+  let sum = ref 0. in
+  Benchmarkcommon.repeat (fun () ->
+      random_set mat1 () ;
+      random_set mat2 () ;
+      mat_mul mat1 mat2 mat3 ;
+      sum := !sum +. random_get mat3 () ) ;
+  print_float !sum
+
+let test_mat = [|[|0.; 1.; 2.|]; [|3.; 4.; 5.|]; [|6.; 7.; 8.|]|]
+
+let test_array mat_mul =
+  let n = Array.length test_mat in
+  let mat1 = Array.copy test_mat in
+  let mat2 = Array.init n (fun i -> Array.copy mat1.(i)) in
+  let mat3 = Array.make_matrix n n 0. in
+  mat_mul mat1 mat2 mat3 ;
+  for i = 0 to Array.length mat3 - 1 do
+    for j = 0 to Array.length mat3.(0) - 1 do
+      print_float mat3.(i).(j) ;
+      print_string ", "
+    done ;
+    print_newline ()
+  done
+
+let test_bigarray mat_mul =
+  let open Bigarray in
+  let n = Array.length test_mat in
+  let mat1 = Array2.of_array Float64 C_layout test_mat in
+  let mat2 = Array2.of_array Float64 C_layout test_mat in
+  let mat3 = Array2.create Float64 C_layout n n in
+  mat_mul mat1 mat2 mat3 ;
+  for i = 0 to Array2.dim1 mat3 - 1 do
+    for j = 0 to Array2.dim2 mat3 - 1 do
+      print_float mat3.{i, j} ;
+      print_string ", "
+    done ;
+    print_newline ()
+  done

--- a/test/microbenchmark/matrix_mul_dense.mc
+++ b/test/microbenchmark/matrix_mul_dense.mc
@@ -1,0 +1,48 @@
+include "matrix_mul_common.mc"
+
+let matMul : Tensor[Float] -> Tensor[Float] -> Tensor[Float] -> ()
+  = lam mat1. lam mat2. lam mat3.
+  match tensorShape mat1 with [m1, n1] in
+  match tensorShape mat2 with [m2, n2] in
+  match tensorShape mat3 with [m3, n3] in
+  if
+    and
+      (eqi n1 m2)
+      (and
+         (eqi m1 m3)
+         (eqi n2 n3))
+  then
+    loop_ m3 (lam i. loop_ n3 (lam j. tensorSetExn mat3 [i, j] 0.));
+    loop_ m3 (lam i.
+      loop_ n3 (lam j.
+        loop_ m1 (lam k.
+          tensorSetExn mat3 [i, j]
+            (addf
+               (tensorGetExn mat3 [i, j])
+               (mulf
+                  (tensorGetExn mat1 [k, j])
+                  (tensorGetExn mat2 [i, k]))))))
+  else error "Invalid input"
+
+mexpr
+
+-- Benchmark
+benchmark tensorCreateDense matMul ();
+
+-- Test
+-- test mat_mul;
+-- Expect
+-- [
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[15., 18., 21.],
+-- 	[42., 54., 66.],
+-- 	[69., 90., 111.]
+-- ]
+()

--- a/test/microbenchmark/matrix_mul_dense.ml
+++ b/test/microbenchmark/matrix_mul_dense.ml
@@ -1,0 +1,39 @@
+let mat_mul (mat1 : float array array) (mat2 : float array array)
+    (mat3 : float array array) : unit =
+  let open Array in
+  let m1 = length mat1
+  and n1 = length mat1.(0)
+  and m2 = length mat2
+  and n2 = length mat2.(0)
+  and m3 = length mat3
+  and n3 = length mat3.(0) in
+  if n1 = m2 && m1 = m3 && n2 = n3 then (
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        mat3.(i).(j) <- 0.
+      done
+    done ;
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        for k = 0 to m1 - 1 do
+          mat3.(i).(j) <- mat3.(i).(j) +. (mat1.(k).(j) *. mat2.(i).(k))
+        done
+      done
+    done )
+  else failwith "Invalid input"
+
+let _ =
+  (* Benchmark *)
+  Matrix_mul_common.benchmark Fun.id
+    (fun mat i j -> mat.(i).(j))
+    (fun mat i j v -> mat.(i).(j) <- v)
+    mat_mul ()
+
+(* Test *)
+(* Matrix_mul_common.test_array mat_mul *)
+(*
+      Expected:
+      15., 18., 21.,
+      42., 54., 66.,
+      69., 90., 111.,
+*)

--- a/test/microbenchmark/matrix_mul_dense_linear.mc
+++ b/test/microbenchmark/matrix_mul_dense_linear.mc
@@ -1,0 +1,50 @@
+include "matrix_mul_common.mc"
+
+let matMul : Tensor[Float] -> Tensor[Float] -> Tensor[Float] -> ()
+  = lam mat1. lam mat2. lam mat3.
+  match tensorShape mat1 with [m1, n1] in
+  match tensorShape mat2 with [m2, n2] in
+  match tensorShape mat3 with [m3, n3] in
+  if
+    and
+      (eqi n1 m2)
+      (and
+         (eqi m1 m3)
+         (eqi n2 n3))
+  then
+    loop_ m3 (lam i.
+      loop_ n3 (lam j.
+        tensorLinearSetExn mat3 (addi (muli i n3) j) 0.));
+    loop_ m3 (lam i.
+      loop_ n3 (lam j.
+        loop_ m1 (lam k.
+          tensorLinearSetExn mat3 (addi (muli i n3) j)
+            (addf
+               (tensorLinearGetExn mat3 (addi (muli i n3) j))
+               (mulf
+                  (tensorLinearGetExn mat1 (addi (muli k n1) j))
+                  (tensorLinearGetExn mat2 (addi (muli i n2) k)))))))
+  else error "Invalid input"
+
+mexpr
+
+-- Benchmark
+benchmark tensorCreateDense matMul ();
+
+-- Test
+-- test mat_mul;
+-- Expect
+-- [
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[0., 1., 2.],
+-- 	[3., 4., 5.],
+-- 	[6., 7., 8.]
+-- ][
+-- 	[15., 18., 21.],
+-- 	[42., 54., 66.],
+-- 	[69., 90., 111.]
+-- ]
+()

--- a/test/microbenchmark/matrix_mul_dense_linear.ml
+++ b/test/microbenchmark/matrix_mul_dense_linear.ml
@@ -1,0 +1,48 @@
+type mat = float array * int * int
+
+let mat_mul (mat1 : mat) (mat2 : mat) (mat3 : mat) : unit =
+  let mat1, m1, n1 = mat1 and mat2, m2, n2 = mat2 and mat3, m3, n3 = mat3 in
+  if n1 = m2 && m1 = m3 && n2 = n3 then (
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        mat3.((n3 * i) + j) <- 0.
+      done
+    done ;
+    for i = 0 to m3 - 1 do
+      for j = 0 to n3 - 1 do
+        for k = 0 to m1 - 1 do
+          mat3.((n3 * i) + j) <-
+            mat3.((n3 * i) + j) +. (mat1.((n1 * k) + j) *. mat2.((n2 * i) + k))
+        done
+      done
+    done )
+  else failwith "Invalid input"
+
+let _ =
+  let from_matrix mat =
+    let m = Array.length mat and n = Array.length mat.(0) in
+    let a = Array.make (n * m) 0. in
+    for i = 0 to m - 1 do
+      for j = 0 to n - 1 do
+        a.((n * i) + j) <- mat.(i).(j)
+      done
+    done ;
+    (a, m, n)
+  in
+  (* Benchmark *)
+  Matrix_mul_common.benchmark from_matrix
+    (fun (arr, _, n) i j -> arr.((n * i) + j))
+    (fun (arr, _, n) i j v -> arr.((n * i) + j) <- v)
+    mat_mul ()
+
+(* Test *)
+(* Matrix_mul_common.test (fun mat1 mat2 mat3 -> *)
+(*     let open Bigarray in *)
+(*     mat_mul (fun mat1 mat2 mat3 -> *)
+(*         (from_matrix mat1) (from_matrix mat2) (from_matrix mat3) ) ) *)
+(*
+      Expected:
+      15., 18., 21.,
+      42., 54., 66.,
+      69., 90., 111.,
+*)


### PR DESCRIPTION
This PR adds micro-benchmarks for tensor access functions for both dense and c-array type tensors. In both cases, we compare both linear and cartesian indexing. The benchmark consists of matrix multiplication of 10x10 matrices, implemented with a triple for-loop. To summarize:

- `matrix_mul_carray_genarray` compares cartesian indexing of `Bigarray.Genarray`'s and cartesian indexing in `tensorCArrayFloat` tensors (these use OCaml `Bigarray.Genarray`'s to store data).
- `matrix_mul_carray_linear` compares indexing via `Bigarray.Array2` and `tensorLinear{Set/Get}Exn` for `tensorCArrayFloat` tensors.
- `matrix_mul_carray` compares indexing via `Bigarray.Array2` and cartesian indexing of  `tensorCArrayFloat` tensors.
- `matrix_mul_dense_linear` compares linear indexing of OCaml `Array`'s and linear indexing of  `tensorDense` tensors (these use OCaml `Array`'s to store data).
- `matrix_mul_dense` compares indexing into OCaml `float array array` (array's of arrays as constructed by `Array.make_matrix`) and cartesian indexing of `tensorDense` tensors .

On my machine (fish shell)
```{fish}
for f in (ls matrix_mul_*.mc | grep -v common);
    echo $f;
    ./run (basename $f .mc) 1000 12
end
```
gives:
```
matrix_mul_carray_genarray.mc
3. Miking compiler:      0.106629s  0.102799s
4. Ocaml byte code       0.169484s  0.166070s
5. OCaml native:         0.043750s  0.039965s
matrix_mul_carray_linear.mc
3. Miking compiler:      0.310922s  0.288371s
4. Ocaml byte code       0.166769s  0.164053s
5. OCaml native:         0.044848s  0.043388s
matrix_mul_carray.mc
3. Miking compiler:      0.116410s  0.106398s
4. Ocaml byte code       0.149614s  0.161893s
5. OCaml native:         0.045086s  0.044137s
matrix_mul_dense_linear.mc
3. Miking compiler:      0.056913s  0.038683s
4. Ocaml byte code       0.113961s  0.102370s
5. OCaml native:         0.005140s  0.004965s
matrix_mul_dense.mc
3. Miking compiler:      0.146346s  0.133848s
4. Ocaml byte code       0.146877s  0.121061s
5. OCaml native:         0.005402s  0.005251s
```
This indicates a significant overhead (as in orders of magnitude) in our implementation for all cases. `matrix_mul_carray_linear.mc` is expected to perform worse as the current implementation converts from linear indices to cartesian indices before calling `Bigarray.Genarray.{set, get}`. For cartesian indexing of tensors, I suspect a big culprit is creating and copying sequences during indexing. However, the linear indexing is not very good either. There is one extra level of indirection in the implementation where the underlying data type for tensors is decided.  

We do not have for-loops in `MExpr`, so I used `_loop : Int -> (Int -> ()) -> ()` function, and I don't know how much that affects the performance. It is called five times for each matrix multiplication. 