### PR TITLE
Add missing case when finding free vars, and rm unused includes

### DIFF
--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1,8 +1,6 @@
 -- Language fragments of MExpr
 
 include "info.mc"
-include "assoc.mc"
-include "info.mc"
 include "name.mc"
 include "string.mc"
 include "stringid.mc"


### PR DESCRIPTION
* Adds check for PatSeqEdge for freeVars