### PR TITLE
Fix precedence for TyAlias and TyFlex

### DIFF
--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1158,7 +1158,7 @@ end
 
 lang AliasTypePrettyPrint = PrettyPrint + AliasTypeAst
   sem typePrecedence =
-  | TyAlias _ -> 1
+  | TyAlias t -> typePrecedence t.display
 
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
   | TyAlias t -> getTypeStringCode indent env t.display

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -128,6 +128,14 @@ lang FlexTypeCmp = Cmp + FlexTypeAst
 end
 
 lang FlexTypePrettyPrint = IdentifierPrettyPrint + VarSortPrettyPrint + FlexTypeAst
+  sem typePrecedence =
+  | TyFlex t ->
+    switch deref t.contents
+    case Unbound _ then
+      100000
+    case Link ty then
+      typePrecedence ty
+    end
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
   | TyFlex t ->
     switch deref t.contents


### PR DESCRIPTION
This PR makes `TyAlias` and `TyFlex` report the correct precedence (i.e., the precedence of the thing they will `pprint` as), which fixes printing of parentheses in types, which would sometimes print too many or too few parentheses.