### PR TITLE
Tensor and sequence updates

### DIFF
--- a/stdlib/ext/matrix-ext.ext-ocaml.mc
+++ b/stdlib/ext/matrix-ext.ext-ocaml.mc
@@ -1,0 +1,36 @@
+include "map.mc"
+include "ocaml/ast.mc"
+
+let matrixExtMap =
+  use OCamlTypeAst in
+  mapFromSeq cmpString
+  [
+    ("externalMatrixExponential", [
+      { expr = "Owl_linalg_generic.expm",
+        ty = tyarrows_ [otygenarrayclayoutfloat_, otygenarrayclayoutfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ]),
+    ("externalMatrixTranspose", [
+      { expr = "Owl_dense.Matrix.D.transpose",
+        ty = tyarrows_ [otygenarrayclayoutfloat_, otygenarrayclayoutfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ]),
+    ("externalMatrixMulFloat", [
+      { expr = "Owl_dense.Matrix.D.( $* )",
+        ty = tyarrows_ [tyfloat_, otygenarrayclayoutfloat_, otygenarrayclayoutfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ]),
+    ("externalMatrixMul", [
+      { expr = "Owl_dense.Matrix.D.( *@ )",
+        ty = tyarrows_ [otygenarrayclayoutfloat_, otygenarrayclayoutfloat_, otygenarrayclayoutfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ])
+  ]

--- a/stdlib/ext/matrix-ext.ext-ocaml.mc
+++ b/stdlib/ext/matrix-ext.ext-ocaml.mc
@@ -32,5 +32,12 @@ let matrixExtMap =
         libraries = ["owl"],
         cLibraries = []
       }
+    ]),
+    ("externalMatrixElemMul", [
+      { expr = "Owl_dense.Matrix.D.( * )",
+        ty = tyarrows_ [otygenarrayclayoutfloat_, otygenarrayclayoutfloat_, otygenarrayclayoutfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
     ])
   ]

--- a/stdlib/ext/matrix-ext.mc
+++ b/stdlib/ext/matrix-ext.mc
@@ -1,0 +1,67 @@
+-- External (float) matrix functions, where we represent matrices using tensors.
+
+include "math.mc"
+include "tensor.mc"
+
+external externalMatrixExponential : Tensor[Float] -> Tensor[Float]
+let matrixExponential = lam m. externalMatrixExponential m
+
+external externalMatrixTranspose : Tensor[Float] -> Tensor[Float]
+let matrixTranspose = lam m. externalMatrixTranspose m
+
+external externalMatrixMulFloat : Float -> Tensor[Float] -> Tensor[Float]
+let matrixMulFloat = lam f. lam m. externalMatrixMulFloat f m
+
+external externalMatrixMul : Tensor[Float] -> Tensor[Float] -> Tensor[Float]
+let matrixMul = lam m1. lam m2. externalMatrixMul m1 m2
+
+mexpr
+
+let _m = tensorOfSeqExn tensorCreateCArrayFloat [3,3] in
+let _eqf = lam f1. lam f2. eqi 0 (cmpfApprox 0.01 f1 f2) in
+let _eqm = tensorEq _eqf in
+
+let t = tensorCreateCArrayFloat [3,3] (lam. 1.) in
+utest matrixExponential t with
+  let d = 7.36185 in
+  let o = 6.36185 in
+  _m [d, o, o,
+      o, d, o,
+      o, o, d]
+using _eqm in
+
+utest matrixTranspose
+   (_m [1., 2., 3.,
+        4., 5., 6.,
+        7., 8., 9.])
+with
+   (_m [1., 4., 7.,
+        2., 5., 8.,
+        3., 6., 9.])
+using _eqm in
+
+utest matrixMulFloat
+   2.0
+   (_m [1., 2., 3.,
+        4., 5., 6.,
+        7., 8., 9.])
+with
+   (_m [2., 4., 6.,
+        8., 10., 12.,
+        14., 16., 18.])
+using _eqm in
+
+utest matrixMul
+   (_m [1., 2., 3.,
+        4., 5., 6.,
+        7., 8., 9.])
+   (_m [1., 2., 3.,
+        4., 5., 6.,
+        7., 8., 9.])
+with
+   (_m [30.,  36.,  42.,
+        66.,  81.,  96.,
+        102., 126., 150.])
+using _eqm in
+
+()

--- a/stdlib/ext/matrix-ext.mc
+++ b/stdlib/ext/matrix-ext.mc
@@ -15,6 +15,9 @@ let matrixMulFloat = lam f. lam m. externalMatrixMulFloat f m
 external externalMatrixMul : Tensor[Float] -> Tensor[Float] -> Tensor[Float]
 let matrixMul = lam m1. lam m2. externalMatrixMul m1 m2
 
+external externalMatrixElemMul : Tensor[Float] -> Tensor[Float] -> Tensor[Float]
+let matrixElemMul = lam m1. lam m2. externalMatrixElemMul m1 m2
+
 mexpr
 
 let _m = tensorOfSeqExn tensorCreateCArrayFloat in
@@ -87,6 +90,19 @@ with
    (_m31 [14.,
           32.,
           50.])
+using _eqm in
+
+utest matrixElemMul
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
+with
+   (_m33 [1.,  4.,  9.,
+          16., 25., 36.,
+          49., 64., 81.])
 using _eqm in
 
 ()

--- a/stdlib/ext/matrix-ext.mc
+++ b/stdlib/ext/matrix-ext.mc
@@ -17,7 +17,10 @@ let matrixMul = lam m1. lam m2. externalMatrixMul m1 m2
 
 mexpr
 
-let _m = tensorOfSeqExn tensorCreateCArrayFloat [3,3] in
+let _m = tensorOfSeqExn tensorCreateCArrayFloat in
+let _m33 = _m [3,3] in
+let _m13 = _m [1,3] in
+let _m31 = _m [3,1] in
 let _eqf = lam f1. lam f2. eqi 0 (cmpfApprox 0.01 f1 f2) in
 let _eqm = tensorEq _eqf in
 
@@ -25,43 +28,65 @@ let t = tensorCreateCArrayFloat [3,3] (lam. 1.) in
 utest matrixExponential t with
   let d = 7.36185 in
   let o = 6.36185 in
-  _m [d, o, o,
+  _m33 [d, o, o,
       o, d, o,
       o, o, d]
 using _eqm in
 
 utest matrixTranspose
-   (_m [1., 2., 3.,
-        4., 5., 6.,
-        7., 8., 9.])
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
 with
-   (_m [1., 4., 7.,
-        2., 5., 8.,
-        3., 6., 9.])
+   (_m33 [1., 4., 7.,
+          2., 5., 8.,
+          3., 6., 9.])
 using _eqm in
 
 utest matrixMulFloat
    2.0
-   (_m [1., 2., 3.,
-        4., 5., 6.,
-        7., 8., 9.])
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
 with
-   (_m [2., 4., 6.,
-        8., 10., 12.,
-        14., 16., 18.])
+   (_m33 [2., 4., 6.,
+          8., 10., 12.,
+          14., 16., 18.])
 using _eqm in
 
 utest matrixMul
-   (_m [1., 2., 3.,
-        4., 5., 6.,
-        7., 8., 9.])
-   (_m [1., 2., 3.,
-        4., 5., 6.,
-        7., 8., 9.])
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
 with
-   (_m [30.,  36.,  42.,
-        66.,  81.,  96.,
-        102., 126., 150.])
+   (_m33 [30.,  36.,  42.,
+          66.,  81.,  96.,
+          102., 126., 150.])
+using _eqm in
+
+utest matrixMul
+   (_m13 [1., 2., 3.])
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
+with
+   (_m13 [30.,  36.,  42.])
+using _eqm in
+
+utest matrixMul
+   (_m33 [1., 2., 3.,
+          4., 5., 6.,
+          7., 8., 9.])
+   (_m31 [1.,
+          2.,
+          3.])
+with
+   (_m31 [14.,
+          32.,
+          50.])
 using _eqm in
 
 ()

--- a/stdlib/matrix.mc
+++ b/stdlib/matrix.mc
@@ -1,3 +1,10 @@
 -- Matrix functions
 
 include "ext/matrix-ext.mc"
+
+let matrixCreate: [Int] -> [Float] -> Tensor[Float] =
+  tensorOfSeqExn tensorCreateCArrayFloat
+
+let rvecCreate: Int -> [Float] -> Tensor[Float] = lam dim. matrixCreate [1,dim]
+
+let cvecCreate: Int -> [Float] -> Tensor[Float] = lam dim. matrixCreate [dim,1]

--- a/stdlib/matrix.mc
+++ b/stdlib/matrix.mc
@@ -8,3 +8,24 @@ let matrixCreate: [Int] -> [Float] -> Tensor[Float] =
 let rvecCreate: Int -> [Float] -> Tensor[Float] = lam dim. matrixCreate [1,dim]
 
 let cvecCreate: Int -> [Float] -> Tensor[Float] = lam dim. matrixCreate [dim,1]
+
+let vecToSeqExn: all a. Tensor[a] -> [a] = lam t.
+  let sh = tensorShape t in
+  let n =
+    match tensorShape t with [1,n] | [n,1] then n
+    else error "Not a vector in vecToSeqExn"
+  in
+  tensorToSeqExn (tensorReshapeExn t [n])
+
+mexpr
+
+let _m = tensorOfSeqExn tensorCreateCArrayFloat in
+let _m13 = _m [1,3] in
+let _m31 = _m [3,1] in
+let _eqf = lam f1. lam f2. eqi 0 (cmpfApprox 0.01 f1 f2) in
+let _eqm = tensorEq _eqf in
+
+utest vecToSeqExn (_m13 [1., 2., 3.]) with [1., 2., 3.] using eqSeq eqf in
+utest vecToSeqExn (_m31 [1., 2., 3.]) with [1., 2., 3.] using eqSeq eqf in
+
+()

--- a/stdlib/matrix.mc
+++ b/stdlib/matrix.mc
@@ -1,0 +1,3 @@
+-- Matrix functions
+
+include "ext/matrix-ext.mc"

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -415,7 +415,7 @@ lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst + VariantTypeAst
     match pprintTypeName env ident with (env,identStr) in
     match mapAccumL pprintEnvGetStr env params with (env, paramsStr) in
     let paramStr = strJoin " " (cons "" paramsStr) in
-    match tyIdent with TyUnknown _ | TyVariant _ then
+    match tyIdent with TyVariant _ then
       (env, join ["type ", identStr, paramStr])
     else
       match getTypeStringCode indent env tyIdent with (env, tyIdentStr) in

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -616,14 +616,7 @@ lang ResolveType = ConTypeAst + AppTypeAst + AliasTypeAst + VariantTypeAst +
       mkAppTy (resolveType info allowUnknown tycons constr) args
 
   | TyUnknown _ & ty ->
-    if allowUnknown then ty
-    else
-      let msg = join [
-        "* Encountered Unknown type in an illegal position.\n",
-        "* Unknown is only allowed in annotations, not in definitions or declarations.\n",
-        "* When type checking the expression\n"
-      ] in
-      errorSingle [info] msg
+    ty
 
   -- If we encounter a TyAlias, it means that the type was already processed by
   -- a previous call to typeCheck.

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -4,6 +4,7 @@ include "set.mc"
 include "ext/ext-test.ext-ocaml.mc"           -- For testing
 include "ext/math-ext.ext-ocaml.mc"
 include "ext/dist-ext.ext-ocaml.mc"
+include "ext/matrix-ext.ext-ocaml.mc"
 include "ext/file-ext.ext-ocaml.mc"
 include "ext/toml-ext.ext-ocaml.mc"
 include "ext/async-ext.ext-ocaml.mc"
@@ -43,6 +44,7 @@ let globalExternalImplsMap : Map String [ExternalImpl] =
       mutexExtMap,
       condExtMap,
       distExtMap,
+      matrixExtMap,
       fileExtMap,
       ipoptExtMap,
       tomlExtMap,

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -533,6 +533,17 @@ utest lastIndex (lam x. eqi (length x) 2) [[1,2,3], [1,2], [3], [1,2], [], [1]]
 utest lastIndex (lam x. null x) [[1,2,3], [1,2], [3], [1,2], [], [1]]
       with Some 4 using optionEq eqi
 
+-- Return a sequence of all indices for which the corresponding element
+-- satisfies the predicate.
+let indices : all a. (a -> Bool) -> [a] -> [Int] = lam pred. lam seq.
+  recursive let rec = lam i. lam acc. lam seq.
+    if null seq then acc
+    else if pred (head seq) then rec (addi i 1) (cons i acc) (tail seq)
+    else rec (addi i 1) acc (tail seq)
+  in reverse (rec 0 [] seq)
+
+utest indices (eqi 1) [1,2,3,1,2,3,1,2,3,1] with [0,3,6,9] using eqSeq eqi
+
 -- Check if s1 is a prefix of s2
 recursive let isPrefix : all a. all b. (a -> b -> Bool) -> [a] -> [b] -> Bool
   = lam eq. lam s1. lam s2.

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -124,6 +124,7 @@ utest optionIndexFoldRMM
   [2, 2]
 with None () using optionEq (eqSeq (eqSeq eqi))
 
+
 ---------------------------
 -- SHAPE AND RANK CHECKS --
 ---------------------------


### PR DESCRIPTION
New functions:
- Add some matrix operations via the use of Owl externals. Similarly to `math.mc` and `ext/math-ext.mc`, I created a `matrix.mc` and `ext/matrix-ext.mc`.
- Add function `indices : all a. (a -> Bool) -> [a] -> [Int]` to `seq.mc` that returns a sequence of all indices that satisfy the predicate.
- Add a function `tensorSubSeqExn` to `tensor.mc`. It is easiest to look at the `utest`s to understand the functionality (basically a more general form of `tensorSubExn`).

An additional update is to allow type aliases of the form `type T = Unknown` in the type checker. Furthermore, `type T = Unknown` previously printed (incorrectly, I believe) as `type T`, which I now removed (so that it prints as `type T = Unknown`). The current semantics is to define `T` as an alias for `Unknown`. I.e., it is _not_ the case that all occurences of `T` in the program are the same type. I still find using `type T = Unknown` useful for documentation purposes.
