### PR TITLE
Partial evaluation updates

### DIFF
--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -183,10 +183,25 @@ lang ConstAppAst = ConstAst
     pprintCode indent env (appSeq_ (uconst_ r.const) r.args)
 end
 
-lang ConstEval =
+lang ConstEvalNoDefault =
   Eval + ConstAppAst + SysAst + SeqAst + UnknownTypeAst + ConstArity +
   PrettyPrint
 
+  sem delta : Info -> (Const, [Expr]) -> Expr
+  sem delta info =
+  -- Intentionally left blank
+
+  sem apply ctx info =
+  | (TmConst r, arg) -> delta info (r.val, [arg])
+  | (TmConstApp r, arg) -> delta info (r.const, snoc r.args arg)
+
+  sem eval ctx =
+  | TmConst {val = CArgv {}, info = info} ->
+    TmSeq {tms = map str_ argv, ty = tyunknown_, info = info}
+  | TmConst c -> TmConst c
+end
+
+lang ConstEval = ConstEvalNoDefault
   sem delta : Info -> (Const, [Expr]) -> Expr
   sem delta info =
   | (const, args) ->
@@ -197,15 +212,6 @@ lang ConstEval =
              "Invalid application\n",
              expr2str (TmConstApp {const = const, args = args, info = info})
            ])
-
-  sem apply ctx info =
-  | (TmConst r, arg) -> delta info (r.val, [arg])
-  | (TmConstApp r, arg) -> delta info (r.const, snoc r.args arg)
-
-  sem eval ctx =
-  | TmConst {val = CArgv {}, info = info} ->
-    TmSeq {tms = map str_ argv, ty = tyunknown_, info = info}
-  | TmConst c -> TmConst c
 end
 
 lang TypeEval = Eval + TypeAst
@@ -337,12 +343,12 @@ end
 -- All constants in boot have not been implemented. Missing ones can be added
 -- as needed.
 
-lang UnsafeCoerceEval = UnsafeCoerceAst + ConstEval + UnsafeCoerceArity
+lang UnsafeCoerceEval = UnsafeCoerceAst + ConstEvalNoDefault + UnsafeCoerceArity
   sem delta info =
   | (CUnsafeCoerce _, [arg]) -> arg
 end
 
-lang ArithIntEval = ArithIntAst + ConstEval + ArithIntArity
+lang ArithIntEval = ArithIntAst + ConstEvalNoDefault + ArithIntArity
   sem delta info =
   | (CAddi _, [TmConst {val = CInt n1}, TmConst (t & {val = CInt n2})]) ->
     TmConst {t with val = CInt {val = addi n1.val n2.val}}
@@ -358,7 +364,7 @@ lang ArithIntEval = ArithIntAst + ConstEval + ArithIntArity
     TmConst {t with val = CInt {val = negi n.val}}
 end
 
-lang ShiftIntEval = ShiftIntAst + ConstEval + ShiftIntArity
+lang ShiftIntEval = ShiftIntAst + ConstEvalNoDefault + ShiftIntArity
   sem delta info =
   | (CSlli _, [TmConst {val = CInt n1}, TmConst (t & {val = CInt n2})]) ->
     TmConst {t with val = CInt {val = slli n1.val n2.val}}
@@ -368,7 +374,7 @@ lang ShiftIntEval = ShiftIntAst + ConstEval + ShiftIntArity
     TmConst {t with val = CInt {val = srai n1.val n2.val}}
 end
 
-lang ArithFloatEval = ArithFloatAst + ConstEval + ArithFloatArity
+lang ArithFloatEval = ArithFloatAst + ConstEvalNoDefault + ArithFloatArity
   sem delta info =
   | (CAddf _, [TmConst {val = CFloat f1}, TmConst (t & {val = CFloat f2})]) ->
     TmConst {t with val = CFloat {val = addf f1.val f2.val}}
@@ -394,7 +400,7 @@ lang FloatIntConversionEval = FloatIntConversionAst + FloatIntConversionArity
     TmConst {t with val = CFloat {val = int2float n.val}}
 end
 
-lang CmpIntEval = CmpIntAst + ConstEval + CmpIntArity
+lang CmpIntEval = CmpIntAst + ConstEvalNoDefault + CmpIntArity
   sem delta info =
   | (CEqi _, [TmConst {val = CInt n1}, TmConst (t & {val = CInt n2})]) ->
     TmConst {t with val = CBool {val = eqi n1.val n2.val}}
@@ -410,14 +416,14 @@ lang CmpIntEval = CmpIntAst + ConstEval + CmpIntArity
     TmConst {t with val = CBool {val = geqi n1.val n2.val}}
 end
 
-lang CmpCharEval = CmpCharAst + ConstEval + CmpCharArity
+lang CmpCharEval = CmpCharAst + ConstEvalNoDefault + CmpCharArity
   sem delta info =
   | (CEqc _, [TmConst {val = CChar c1}, TmConst (t & {val = CChar c2})]) ->
     TmConst {t with val = CBool {val = eqc c1.val c2.val}}
 end
 
 lang IntCharConversionEval =
-  IntCharConversionAst + ConstEval + IntCharConversionArity
+  IntCharConversionAst + ConstEvalNoDefault + IntCharConversionArity
 
   sem delta info =
   | (CInt2Char _, [TmConst (t & {val = CInt n})]) ->
@@ -426,7 +432,7 @@ lang IntCharConversionEval =
     TmConst {t with val = CInt {val = char2int c.val}}
 end
 
-lang CmpFloatEval = CmpFloatAst + ConstEval + CmpFloatArity
+lang CmpFloatEval = CmpFloatAst + ConstEvalNoDefault + CmpFloatArity
   sem delta info =
   | (CEqf _, [TmConst {val = CFloat f1}, TmConst (t & {val = CFloat f2})]) ->
     TmConst {t with val = CBool {val = eqf f1.val f2.val}}
@@ -442,7 +448,7 @@ lang CmpFloatEval = CmpFloatAst + ConstEval + CmpFloatArity
     TmConst {t with val = CBool {val = neqf f1.val f2.val}}
 end
 
-lang SymbEval = SymbAst + IntAst + RecordAst + ConstEval + SymbArity
+lang SymbEval = SymbAst + IntAst + RecordAst + ConstEvalNoDefault + SymbArity
   sem delta info =
   | (CGensym _, [_]) ->
     TmConst {val = CSymb {val = gensym ()}, ty = tyunknown_, info = NoInfo ()}
@@ -450,13 +456,13 @@ lang SymbEval = SymbAst + IntAst + RecordAst + ConstEval + SymbArity
     TmConst {t with val = CInt {val = sym2hash s.val}}
 end
 
-lang CmpSymbEval = CmpSymbAst + ConstEval + CmpSymbArity
+lang CmpSymbEval = CmpSymbAst + ConstEvalNoDefault + CmpSymbArity
   sem delta info =
   | (CEqsym _, [TmConst {val = CSymb s1}, TmConst (t & {val = CSymb s2})]) ->
     TmConst {t with val = CBool {val = eqsym s1.val s2.val}}
 end
 
-lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEval + SeqOpArity
+lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEvalNoDefault + SeqOpArity
   sem delta info =
   | (CHead _, [TmSeq s]) -> head s.tms
   | (CTail _, [TmSeq s]) -> TmSeq {s with tms = tail s.tms}
@@ -653,7 +659,7 @@ lang ConTagEval = ConTagAst + DataAst + IntAst + IntTypeAst + ConTagArity
 end
 
 lang TensorOpEval =
-  TensorOpAst + SeqAst + IntAst + FloatAst + TensorEval + ConstEval + BoolAst +
+  TensorOpAst + SeqAst + IntAst + FloatAst + TensorEval + ConstEvalNoDefault + BoolAst +
   TensorOpArity
 
   sem _ofTmSeq (info : Info) =

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -188,8 +188,6 @@ lang ConstEvalNoDefault =
   PrettyPrint
 
   sem delta : Info -> (Const, [Expr]) -> Expr
-  sem delta info =
-  -- Intentionally left blank
 
   sem apply ctx info =
   | (TmConst r, arg) -> delta info (r.val, [arg])

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -11,8 +11,10 @@ include "error.mc"
 include "list.mc"
 
 
-lang SpecializeAst = KeywordMaker + MExpr + MExprEq + Eval + PrettyPrint
-                + MExprTypeCheck + LamEval + MExprPEval
+lang SpecializeAst =
+  KeywordMaker + MExprAst + MExprParser + MExprPrettyPrint + MExprSym
+  + MExprEq + Eval + PrettyPrint + MExprTypeCheck + LamEval + MExprPEval
+
 
   syn Expr =
   | TmSpecialize {e: Expr, info: Info}
@@ -77,7 +79,7 @@ let specialize_ = lam e.
   TmSpecialize {e = e, info = NoInfo ()}
 
 
-lang TestLang = SpecializeAst + MExprEval
+lang TestLang = SpecializeAst
 end
 
 mexpr

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -13,7 +13,7 @@ include "list.mc"
 
 lang SpecializeAst =
   KeywordMaker + MExprAst + MExprParser + MExprPrettyPrint + MExprSym
-  + MExprEq + Eval + PrettyPrint + MExprTypeCheck + LamEval + MExprPEval
+  + MExprEq + Eval + PrettyPrint + MExprTypeCheck + LamEval
 
 
   syn Expr =
@@ -57,7 +57,7 @@ lang SpecializeAst =
   | TmSpecialize e ->
     switch eval ctx e.e
     case clos & TmClos _ then
-      let res = peval clos in
+      let res = use MExprPEval in peval clos in
         match res with TmLam _ then
           eval (evalCtxEmpty ()) res -- TmClos ...
         else res

--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -300,7 +300,7 @@ lang DataPEval = PEval + DataAst
 
   sem pevalEval ctx k =
   | TmConDef t -> TmConDef {t with inexpr = pevalBind ctx k t.inexpr}
-  | TmConApp t -> pevalBind ctx (lam body. TmConApp {t with body = body}) t.body
+  | TmConApp t -> pevalBind ctx (lam body. k (TmConApp {t with body = body})) t.body
 end
 
 lang SeqPEval = PEval + SeqAst

--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -285,6 +285,24 @@ lang RecordPEval = PEval + RecordAst + VarAst
       r1.rec
 end
 
+lang TypePEval = PEval + TypeAst
+  sem pevalIsValue =
+  | TmType _ -> false
+
+  sem pevalEval ctx k =
+  | TmType t -> TmType {t with inexpr = pevalBind ctx k t.inexpr}
+end
+
+lang DataPEval = PEval + DataAst
+  sem pevalIsValue =
+  | TmConDef _ -> false
+  | TmConApp _ -> false
+
+  sem pevalEval ctx k =
+  | TmConDef t -> TmConDef {t with inexpr = pevalBind ctx k t.inexpr}
+  | TmConApp t -> pevalBind ctx (lam body. TmConApp {t with body = body}) t.body
+end
+
 lang SeqPEval = PEval + SeqAst
   -- NOTE(oerikss, 2022-02-15): We do not have to check inside the sequences as the
   -- elements vill always be values in the PEval transformation.
@@ -299,7 +317,7 @@ lang SeqPEval = PEval + SeqAst
       (lam tms. k (TmSeq { r with tms = tms }))
 end
 
-lang ConstPEval = PEval + ConstEval
+lang ConstPEval = PEval + ConstEvalNoDefault
   sem pevalReadbackH ctx =
   | TmConstApp r ->
     match mapAccumL pevalReadbackH ctx r.args with (ctx, args) in
@@ -316,6 +334,16 @@ lang ConstPEval = PEval + ConstEval
 
   sem pevalEval ctx k =
   | t & (TmConst _ | TmConstApp _) -> k t
+
+  sem delta info =
+  | (const, args) ->
+    if lti (length args) (constArity const) then
+      -- Accumulate arguments if still not a complete application
+      TmConstApp {const = const, args = args, info = info}
+    else
+      -- No available pattern, don't do any partial evaluation
+      let b = astBuilder info in
+      b.appSeq (b.uconst const) args
 
   sem pevalApply info ctx k =
   | (TmConst r, arg) -> k (delta info (r.val, [arg]))
@@ -346,6 +374,30 @@ lang MatchPEval = PEval + MatchEval + NeverAst + VarAst
       r.target
 end
 
+lang UtestPEval = PEval + UtestAst
+  sem pevalIsValue =
+  | TmUtest _ -> false
+
+  sem pevalEval ctx k =
+  | TmUtest t ->
+    pevalBind ctx
+      (lam test.
+         pevalBind ctx
+           (lam expected.
+              let inner = lam tusing.
+                TmUtest { t with test = test,
+                                 expected = expected,
+                                 next = pevalBind ctx k t.next,
+                                 tusing = tusing }
+              in
+              match t.tusing with Some tusing then
+                pevalBind ctx (lam tusing. inner (Some tusing)) tusing
+              else
+                inner (None ()))
+           t.expected)
+      t.test
+end
+
 lang NeverPEval = PEval + NeverAst
   sem pevalIsValue =
   | TmNever _ -> true
@@ -355,6 +407,14 @@ lang NeverPEval = PEval + NeverAst
 
   sem pevalApply info ctx k =
   | (t & TmNever _, _) -> k t
+end
+
+lang ExtPEval = PEval + ExtAst
+  sem pevalIsValue =
+  | TmExt _ -> false
+
+  sem pevalEval ctx k =
+  | TmExt t -> TmExt {t with inexpr = pevalBind ctx k t.inexpr}
 end
 
 lang ArithIntPEval = ArithIntEval + VarAst
@@ -494,7 +554,8 @@ end
 lang MExprPEval =
   -- Terms
   VarPEval + LamPEval + AppPEval + RecordPEval + ConstPEval + LetPEval +
-  RecLetsPEval + MatchPEval + NeverPEval + SeqPEval +
+  RecLetsPEval + MatchPEval + NeverPEval + DataPEval + TypePEval + SeqPEval +
+  UtestPEval + ExtPEval +
 
   -- Constants
   ArithIntPEval + ArithFloatPEval + CmpIntPEval + CmpFloatPEval + IOPEval +


### PR DESCRIPTION
This PR adds the following to `peval.mc`:
- Missing cases for `TmType`, `TmConDef`, `TmConApp`, `TmUtest`, and `TmExt`.
- Reworks the `delta` function used in `peval` to have a catch-all case for constant applications without a specialized handler. The catch-all case simply does no partial evaluation.