### PR TITLE
Fix incorrect print of negative integers in `pprint.mc`

### DIFF
--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -667,7 +667,9 @@ end
 
 lang IntPrettyPrint = IntAst + IntPat + ConstPrettyPrint
   sem getConstStringCode (indent : Int) =
-  | CInt t -> int2string t.val
+  | CInt t ->
+    if lti t.val 0 then join ["(negi ", int2string (negi t.val), ")"]
+    else int2string t.val
 end
 
 lang ArithIntPrettyPrint = ArithIntAst + ConstPrettyPrint


### PR DESCRIPTION
`mexpr/pprint.mc` is currently printing negative integers as `-i`, which does not parse. This PR fixes this in the same way as for printing floats (`negi i` whenever the corresponding literal is negative).