### PR TITLE
Build script fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@
 #  the system, we just run the batch make.sh file.
 ###################################################
 
+export prefix
+export bindir
+export libdir
+
 .PHONY :\
   all\
   boot\

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 #  the system, we just run the batch make.sh file.
 ###################################################
 
+export ocamlprefix
 export prefix
 export bindir
 export libdir

--- a/make.sh
+++ b/make.sh
@@ -25,7 +25,8 @@ LIB_PATH=$HOME/.local/lib/mcore
 export MCORE_LIBS=stdlib=`pwd`/stdlib:test=`pwd`/test
 
 # Setup dune/ocamlfind to use local boot library when available
-export OCAMLPATH=`pwd`/build/lib
+# Do preserve existing OCAML_PATH to find linenoise et al.
+export OCAMLPATH="$(pwd)/build/lib${OCAMLPATH:+:}$OCAMLPATH"
 
 # Compile and build the boot interpreter
 build_boot(){

--- a/make.sh
+++ b/make.sh
@@ -105,27 +105,23 @@ fix () {
 
 compile_test () {
   set +e
+  echo $1
   binary=$(mktemp)
-  output=$1
   compile="$2 --output $binary"
-  output="$output\n$($compile $1 2>&1)"
+  output="$($compile "$1" 2>&1)"
   exit_code=$?
-  if [ $exit_code -eq 0 ]
+  if [ $exit_code -ne 0 ]
   then
-    output="$output$($binary)"
+    printf "$output\nCommand '$compile $1 2>&1' exited with code $exit_code\n\n"
+    rm -f $binary
+    exit 1
+  else
+    output="$($binary)"
     exit_code=$?
     rm $binary
-    if [ $exit_code -ne 0 ]
-    then
-        echo "ERROR: the compiled binary for $1 exited with $exit_code"
-        exit 1
-    fi
-  else
-    echo "ERROR: command '$compile $1 2>&1' exited with $exit_code"
-    rm $binary
-    exit 1
+    printf "$output\n\n"
+    if [ $exit_code -ne 0 ]; then exit 1; fi
   fi
-  printf "$output\n\n"
   set -e
 }
 

--- a/make.sh
+++ b/make.sh
@@ -105,21 +105,20 @@ fix () {
 
 compile_test () {
   set +e
-  echo $1
   binary=$(mktemp)
   compile="$2 --output $binary"
   output="$($compile "$1" 2>&1)"
   exit_code=$?
   if [ $exit_code -ne 0 ]
   then
-    printf "$output\nCommand '$compile $1 2>&1' exited with code $exit_code\n\n"
+    printf "$1\n$output\nCommand '$compile $1 2>&1' exited with code $exit_code\n\n"
     rm -f $binary
     exit 1
   else
     output="$($binary)"
     exit_code=$?
     rm $binary
-    printf "$output\n\n"
+    printf "$1\n$output\n\n"
     if [ $exit_code -ne 0 ]; then exit 1; fi
   fi
   set -e
@@ -127,7 +126,7 @@ compile_test () {
 
 run_test() {
   set +e
-  output="$2\n$($1 "$2" 2>&1)"
+  output="$1\n$($2 "$1" 2>&1)"
   exit_code=$?
   printf "$output\n\n"
   if [ $exit_code -ne 0 ]; then exit 1; fi

--- a/make.sh
+++ b/make.sh
@@ -137,24 +137,17 @@ compile_test () {
     rm $binary
     exit 1
   fi
-  echo "$output\n"
-  set -e
-}
-
-run_test_prototype() {
-  set +e
-  output=$2
-  output="$output\n$($1 $2 2>&1)\n"
-  echo $output
+  printf "$output\n\n"
   set -e
 }
 
 run_test() {
-  run_test_prototype "build/mi run --test --disable-prune-warning" $1
-}
-
-run_test_boot() {
-  run_test_prototype "build/boot eval src/main/mi.mc -- run --test --disable-prune-warning" $1
+  set +e
+  output="$2\n$($1 "$2" 2>&1)"
+  exit_code=$?
+  printf "$output\n\n"
+  if [ $exit_code -ne 0 ]; then exit 1; fi
+  set -e
 }
 
 run_js_test() {
@@ -179,10 +172,7 @@ case $1 in
         build_mi
         ;;
     run-test)
-        run_test "$2"
-        ;;
-    run-test-boot)
-        run_test_boot "$2"
+        run_test "$2" "$3"
         ;;
     compile-test)
         compile_test "$2" "$3"

--- a/make.sh
+++ b/make.sh
@@ -17,8 +17,10 @@ MI_NAME=mi
 MI_LITE_NAME=mi-lite
 MI_TMP_NAME=mi-tmp
 
-BIN_PATH=$HOME/.local/bin
-LIB_PATH=$HOME/.local/lib/mcore
+prefix="${prefix:-$HOME/.local}"
+bindir="${bindir:-$prefix/bin}"
+libdir="${libdir:-$prefix/lib}"
+mcoredir=$libdir/mcore
 
 # Setup environment variable to find standard library
 # (and set test namespace for testing)
@@ -35,7 +37,7 @@ build_boot(){
 }
 
 install_boot(){
-    dune install > /dev/null 2>&1
+    dune install --prefix=$prefix > /dev/null 2>&1
 }
 
 # Compile a new version of the compiler using the current one
@@ -86,10 +88,10 @@ lite() {
 # Install the Miking compiler
 install() {
     if [ -e build/$MI_NAME ]; then
-        rm -rf $LIB_PATH/stdlib
-        mkdir -p $BIN_PATH $LIB_PATH
-        cp -rf stdlib $LIB_PATH
-        cp -f build/$MI_NAME $BIN_PATH
+        rm -rf $libdir/stdlib
+        mkdir -p $bindir $libdir
+        cp -rf stdlib $libdir
+        cp -f build/$MI_NAME $bindir
     else
         echo "No existing compiler binary was found."
         echo "Try compiling the project first!"
@@ -100,8 +102,8 @@ install() {
 uninstall() {
     set +e
     dune uninstall > /dev/null 2>&1
-    rm -f $BIN_PATH/$MI_NAME
-    rm -rf $LIB_PATH/stdlib
+    rm -f $bindir/$MI_NAME
+    rm -rf $mcoredir/stdlib
     set -e
 }
 

--- a/make.sh
+++ b/make.sh
@@ -20,6 +20,7 @@ MI_TMP_NAME=mi-tmp
 prefix="${prefix:-$HOME/.local}"
 bindir="${bindir:-$prefix/bin}"
 libdir="${libdir:-$prefix/lib}"
+ocamlprefix="${ocamlprefix:-${OPAM_SWITCH_PREFIX:-$prefix}}"
 mcoredir=$libdir/mcore
 
 # Setup environment variable to find standard library
@@ -37,7 +38,7 @@ build_boot(){
 }
 
 install_boot(){
-    dune install --prefix=$prefix > /dev/null 2>&1
+    dune install --prefix=$ocamlprefix > /dev/null 2>&1
 }
 
 # Compile a new version of the compiler using the current one
@@ -87,7 +88,7 @@ install() {
 
 # Uninstall the Miking bootstrap interpreter and compiler
 uninstall() {
-    dune uninstall --prefix=$prefix > /dev/null 2>&1
+    dune uninstall --prefix=$ocamlprefix > /dev/null 2>&1
     rm -f $bindir/$MI_NAME
     rm -rf $mcoredir/stdlib
 }

--- a/make.sh
+++ b/make.sh
@@ -52,7 +52,7 @@ build_mi() {
     fi
 }
 
-# Build the Miking compiler
+# Build the Miking compiler.  If $1 is 'lite', skip the last stage.
 build() {
     if [ -e build/$MI_NAME ]
     then
@@ -62,28 +62,15 @@ build() {
         time build/$BOOT_NAME eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc ./$MI_LITE_NAME
         echo "Bootstrapping the Miking compiler (2nd round, might take some more time)"
         time ./$MI_LITE_NAME 1 src/main/mi.mc ./$MI_NAME
-        echo "Bootstrapping the Miking compiler (3rd round, might take some more time)"
-        time ./$MI_NAME compile src/main/mi.mc
+        if [ "$1" != "lite" ]
+        then
+            echo "Bootstrapping the Miking compiler (3rd round, might take some more time)"
+            time ./$MI_NAME compile src/main/mi.mc
+        fi
         mv -f $MI_NAME build/$MI_NAME
         rm -f $MI_LITE_NAME
     fi
 }
-
-# As build(), but skips the third bootstrapping step
-lite() {
-    if [ -e build/$MI_NAME ]
-    then
-        echo "Bootstrapped compiler already exists. Run 'make clean' before to recompile. "
-    else
-        echo "Bootstrapping the Miking compiler (1st round, might take a few minutes)"
-        time build/$BOOT_NAME eval src/main/mi-lite.mc -- 0 src/main/mi-lite.mc ./$MI_LITE_NAME
-        echo "Bootstrapping the Miking compiler (2nd round, might take some more time)"
-        time ./$MI_LITE_NAME 1 src/main/mi.mc ./$MI_NAME
-        mv -f $MI_NAME build/$MI_NAME
-        rm -f $MI_LITE_NAME
-    fi
-}
-
 
 # Install the Miking compiler
 install() {
@@ -163,7 +150,7 @@ case $1 in
         build_boot
         ;;
     lite)
-        lite
+        build lite
         ;;
     install-boot)
         install_boot

--- a/make.sh
+++ b/make.sh
@@ -88,9 +88,9 @@ lite() {
 # Install the Miking compiler
 install() {
     if [ -e build/$MI_NAME ]; then
-        rm -rf $libdir/stdlib
-        mkdir -p $bindir $libdir
-        cp -rf stdlib $libdir
+        rm -rf $mcoredir/stdlib
+        mkdir -p $bindir $mcoredir
+        cp -rf stdlib $mcoredir
         cp -f build/$MI_NAME $bindir
     else
         echo "No existing compiler binary was found."
@@ -100,11 +100,9 @@ install() {
 
 # Uninstall the Miking bootstrap interpreter and compiler
 uninstall() {
-    set +e
-    dune uninstall > /dev/null 2>&1
+    dune uninstall --prefix=$prefix > /dev/null 2>&1
     rm -f $bindir/$MI_NAME
     rm -rf $mcoredir/stdlib
-    set -e
 }
 
 # Lint ocaml source code

--- a/test-boot-run.mk
+++ b/test-boot-run.mk
@@ -7,4 +7,4 @@ all: $(src_files_all)
 selected: $(run_files)
 
 $(src_files_all):
-	@./make.sh run-test-boot $@
+	@./make.sh run-test "build/boot eval src/main/mi.mc -- run --test --disable-prune-warning" $@

--- a/test-boot-run.mk
+++ b/test-boot-run.mk
@@ -7,4 +7,4 @@ all: $(src_files_all)
 selected: $(run_files)
 
 $(src_files_all):
-	@./make.sh run-test "build/boot eval src/main/mi.mc -- run --test --disable-prune-warning" $@
+	@./make.sh run-test $@ "build/boot eval src/main/mi.mc -- run --test --disable-prune-warning"

--- a/test-boot.mk
+++ b/test-boot.mk
@@ -1,7 +1,5 @@
 include test-files.mk
 
-BOOT_NAME = boot
-
 .PHONY: all selected py $(src_files_all)
 
 all: $(src_files_all)
@@ -12,4 +10,4 @@ py: $(python_files)
 
 # File rule
 $(src_files_all):
-	@MCORE_LIBS=stdlib=`pwd`/stdlib:test=`pwd`/test build/${BOOT_NAME} eval --test --disable-prune-warning $@
+	@./make.sh run-test "build/boot eval --test --disable-prune-warning" $@

--- a/test-boot.mk
+++ b/test-boot.mk
@@ -10,4 +10,4 @@ py: $(python_files)
 
 # File rule
 $(src_files_all):
-	@./make.sh run-test "build/boot eval --test --disable-prune-warning" $@
+	@./make.sh run-test $@ "build/boot eval --test --disable-prune-warning"

--- a/test-run.mk
+++ b/test-run.mk
@@ -7,4 +7,4 @@ all: $(src_files_all)
 selected: $(run_files)
 
 $(src_files_all):
-	@./make.sh run-test "build/mi run --test --disable-prune-warning" $@
+	@./make.sh run-test $@ "build/mi run --test --disable-prune-warning"

--- a/test-run.mk
+++ b/test-run.mk
@@ -7,4 +7,4 @@ all: $(src_files_all)
 selected: $(run_files)
 
 $(src_files_all):
-	@./make.sh run-test $@
+	@./make.sh run-test "build/mi run --test --disable-prune-warning" $@


### PR DESCRIPTION
This PR includes a couple of fixes to the build scripts.  The changes are partly (see the commit history) due to Liliana Marie Prikler at TU Graz, who is a major contributor to GNU Guix, who apparently listened to David's Miking talk the other day and subsequently made a [Miking package for Guix](https://issues.guix.gnu.org/64135).

- Change `make.sh` to preserve the existing `OCAMLPATH`, to allow builds relying on `OCAMLPATH` instead of an OPAM installation.
- Change `make.sh` to depend on environment variables `prefix`,`bindir`, `libdir` and  `ocamlprefix`, to enable controlling the installation location.  These default to `$HOME/.local`, `$HOME/.local/bin`, `$HOME/.local/lib` and `$OPAM_SWITCH_PREFIX` if the variables are unset.
- Run the `test-boot` tests via `make.sh` to ensure they get the right environment variable values, and make the handling of interpreted tests in `make.sh` more uniform.
- Remove some code duplication in `make.sh`
- Make `test-compile` print the output of failing tests