### PR TITLE
Fix readFile single-character file bug

### DIFF
--- a/src/boot/lib/ustring.ml
+++ b/src/boot/lib/ustring.ml
@@ -725,7 +725,9 @@ let read_bom ic =
   let s = Bytes.create 4 in
   let l = ref 0 in
   try
-    really_input ic s 0 2 ;
+    really_input ic s 0 1 ;
+    l := 1 ;
+    really_input ic s 1 1 ;
     l := 2 ;
     if Bytes.sub s 0 2 = utf16be then (Utf16be, Bytes.empty)
     else (


### PR DESCRIPTION
This fixes a really old issue where the `readFile` intrinsic would return an empty string on an input file containing exactly one character.

The issue is in `ustring.ml`, where the function `lexing_function` tries to detect a file's encoding by reading a byte order mark in the beginning of the file.  In doing so, it starts by reading the first two bytes of the file, and if that fails it simply returns an empty string, failing to account for single-length files.

Resolves #145