### PR TITLE
New library `stats.mc` and other small fixes and additions

### DIFF
--- a/stdlib/arg.mc
+++ b/stdlib/arg.mc
@@ -268,7 +268,7 @@ let argPrintErrorString = lam result.
   end
 
 let argPrintError = lam result.
-  print (join [argPrintErrorString result, "\n"])
+  error (join [argPrintErrorString result, "\n"])
 
 
 mexpr
@@ -368,8 +368,9 @@ let testOptions = {
 } in
 let argParseCustom = argParse_general testOptions in
 let res : ArgResult Options =
-  match argParseCustom default config with ParseOK r then r
-  else error "Incorrect type"
+  let r = argParseCustom default config in
+  match r with ParseOK r then r
+  else argPrintError r
 in
 let opt : Options = res.options in
 utest res.strings with ["file.mc", "f2"] using eqSeq eqString in

--- a/stdlib/arg.mc
+++ b/stdlib/arg.mc
@@ -284,6 +284,7 @@ utest stringLineFormat s1 13 1 0 with s2 in
 
 type Options = {
   foo : Bool,
+  fooExt : Bool,
   len : Int,
   message : String,
   real : Float,
@@ -294,6 +295,7 @@ type Options = {
 
 let default = {
   foo = false,
+  fooExt = true,
   len = 7,
   message = "",
   real = 0.,
@@ -303,6 +305,12 @@ let default = {
 } in
 
 let config = [
+  -- NOTE(2023-06-28,dlunde): We must handle the option "--foo-ext" before
+  -- "--foo", as the latter is a prefix of the former. If we reverse their
+  -- order in the config list, the parsing fails. Bug or feature?
+  ([("--foo-ext", "", "")],
+   "This is another boolean option. ",
+   lam p. { p.options with fooExt = false }),
   ([("--foo", "", "")],
    "This is a boolean option. ",
    lam p. { p.options with foo = true }),
@@ -347,7 +355,9 @@ let testOptions = {
   args = [
     "file.mc",
     "--len", "12",
-    "--foo", "-m",
+    "--foo",
+    "--foo-ext",
+    "-m",
     "mymsg",
     "--real", "1.",
     "--positiveReal", "1.",
@@ -364,6 +374,7 @@ in
 let opt : Options = res.options in
 utest res.strings with ["file.mc", "f2"] using eqSeq eqString in
 utest opt.foo with true in
+utest opt.fooExt with false in
 utest opt.message with "mymsg" in
 utest opt.len with 12 in
 
@@ -471,6 +482,6 @@ utest res with ParseFailUnknownOption("--unknown") in
 
 let text = argHelpOptions config in
 --print "\n---\n"; print text; print "\n---\n";
-utest length text with 776 in
+utest length text with 838 in
 
 ()

--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -82,3 +82,12 @@ let bool2string: Bool -> String = lam b.
 
 utest bool2string true with "true"
 utest bool2string false with "false"
+
+-- String to Boolean
+let string2bool: String -> Bool = lam s.
+  match s with "true" then true
+  else match s with "false" then false
+  else error (concat "Cannot convert string " (concat s " to Bool."))
+
+utest string2bool "true" with true
+utest string2bool "false" with false

--- a/stdlib/ext/dist-ext.ext-ocaml.mc
+++ b/stdlib/ext/dist-ext.ext-ocaml.mc
@@ -123,8 +123,9 @@ let distExtMap =
       { expr = "
         fun seed -> (
           Random.init seed;
+          Owl_base_stats_prng.init seed;
           Owl_stats_prng.sfmt_seed seed;
-          Owl_stats_prng.init seed
+          Owl_stats_prng.ziggurat_init ()
         )",
         ty = tyarrows_ [tyint_, otyunit_],
         libraries = ["owl"],

--- a/stdlib/ext/dist-ext.mc
+++ b/stdlib/ext/dist-ext.mc
@@ -137,7 +137,13 @@ let exponentialPdf : Float -> Float -> Float = lam lambda. lam x.
 
 -- Seed
 external externalSetSeed ! : Int -> ()
-let setSeed : Int -> () = lam seed. externalSetSeed seed
+let setSeed : Int -> () = lam seed.
+
+  -- VERY important to also call this intrinsic here. Otherwise, the compiled code
+  -- _self-initializes the seed_ at the first call to the intrinsic randIntU.
+  randSetSeed seed;
+
+  externalSetSeed seed
 
 mexpr
 
@@ -220,6 +226,13 @@ utest exp (exponentialLogPdf 1.0 2.0) with 0.135335283237 using _eqf in
 utest exponentialPdf 2.0 2.0 with 0.0366312777775 using _eqf in
 
 -- Testing seed
-utest setSeed 0; uniformSample () with setSeed 0; uniformSample () in
+utest setSeed 0; uniformSample (); uniformSample ()
+with setSeed 0; uniformSample (); uniformSample () in
+utest setSeed 0; gaussianSample 0. 1.; gaussianSample 0. 1.
+with  setSeed 0; gaussianSample 0. 1.; gaussianSample 0. 1. in
+utest setSeed 0; uniformSample (); gaussianSample 0. 1.
+with  setSeed 0; uniformSample (); gaussianSample 0. 1. in
+utest setSeed 0; gaussianSample 0. 1.; gaussianSample 0. 1.; uniformSample ()
+with  setSeed 0; gaussianSample 0. 1.; gaussianSample 0. 1.; uniformSample () in
 
 ()

--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -1,5 +1,5 @@
 include "ext/math-ext.mc"
-include "common.mc"
+include "bool.mc"
 
 -- Float stuff
 let inf = divf 1.0 0.0

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -465,8 +465,7 @@ utest _test factorial with _parse "
     in
     t1
   in
-  let t5 = () in
-  t5
+  ()
 " using eqExpr in
 
 let const = _parse "1" in
@@ -522,7 +521,7 @@ let nestedreclet = _parse "
 " in
 utest _test nestedreclet with _parse "
   recursive let f = lam a. lam b. lam c. 1 in
-  let t = () in t
+  ()
 " using eqExpr in
 
 -- Tests for full ANF

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -329,6 +329,9 @@ lang MExprANF =
   | TmLam _ -> false
   | TmConst _ -> false
   | TmNever _ -> false
+  | TmRecord r ->
+    if mapIsEmpty r.bindings then false
+    else true
 
 end
 

--- a/stdlib/stats.mc
+++ b/stdlib/stats.mc
@@ -38,8 +38,7 @@ let logWeightedMean: [Float] -> [Float] -> Float = lam lws. lam vs.
 
 mexpr
 
-let cmpfe = cmpfApprox 1e-10 in
-let eqfe = lam f1. lam f2. if eqi (cmpfe f1 f2) 0 then true else false in
+let eqfe = eqfApprox 1e-10 in
 
 utest logSumExp [log 1., log 2., log 3.] with log 6. using eqfe in
 utest logSumExp [log 5., log 6., log 7.] with log 18. using eqfe in

--- a/stdlib/stats.mc
+++ b/stdlib/stats.mc
@@ -1,0 +1,60 @@
+-- Standard statistics-related functions
+
+include "math.mc"
+include "seq.mc"
+
+-- logSumExp function, using logSumExp-trick.
+let logSumExp: [Float] -> Float = lam vs.
+  let max =
+    foldl (lam acc. lam v. if geqf v acc then v else acc) (negf inf) vs in
+  addf max (log (foldl (lam acc. lam v. addf acc (exp (subf v max))) 0. vs))
+
+-- Normalize a flot sequence (i.e., scale elements so that the sum of all
+-- elements is 1).
+let normalizeFloatSeq: [Float] -> [Float] = lam vs.
+  let sum = foldl1 addf vs in
+  map (lam v. divf v sum) vs
+
+-- Standard arithmetic mean.
+let mean: [Float] -> Float = lam vs.
+  let sum = foldl1 addf vs in
+  divf sum (int2float (length vs))
+
+-- Weighted arithmetic mean (normalizes weights).
+let weightedMean: [Float] -> [Float] -> Float = lam ws. lam vs.
+  let nws = normalizeFloatSeq ws in
+  foldl2 (lam acc. lam w. lam v. addf acc (mulf w v)) 0. nws vs
+
+-- Numerically stable (hopefully) log-weighted arithmetic mean (normalizes
+-- weights).
+let logWeightedMean: [Float] -> [Float] -> Float = lam lws. lam vs.
+  let l = int2float (length lws) in
+  let lse = logSumExp lws in
+  let m = subf lse (log l) in
+  let nlws = map (lam lw. subf lw m) lws in
+  let nws = map exp nlws in -- Normalized weights, weight sum is l = (length lws)
+  foldl2 (lam acc. lam nw. lam v. addf acc (divf (mulf nw v) l)) 0. nws vs
+
+
+mexpr
+
+let cmpfe = cmpfApprox 1e-10 in
+let eqfe = lam f1. lam f2. if eqi (cmpfe f1 f2) 0 then true else false in
+
+utest logSumExp [log 1., log 2., log 3.] with log 6. using eqfe in
+utest logSumExp [log 5., log 6., log 7.] with log 18. using eqfe in
+utest logSumExp [log 0.001, log 0.002, log 0.003] with log 0.006 using eqfe in
+
+utest normalizeFloatSeq [2., 3., 5.] with [0.2, 0.3, 0.5] in
+utest normalizeFloatSeq [20., 30., 50.] with [0.2, 0.3, 0.5] in
+
+utest mean [1., 2., 3.] with 2. using eqfe in
+utest mean [1., 5., 3.] with 3. using eqfe in
+
+utest weightedMean [1., 5., 4.] [1., 2., 8.] with 4.3 using eqfe in
+utest weightedMean [2., 3., 5.] [1., 2., 8.] with 4.8 using eqfe in
+
+utest logWeightedMean [log 1., log 5., log 4.] [1., 2., 8.] with 4.3 using eqfe in
+utest logWeightedMean [log 2., log 3., log 5.] [1., 2., 8.] with 4.8 using eqfe in
+
+()

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -26,6 +26,9 @@ let _commandListTimeoutWrap : Float -> [String] -> [String] = lam timeoutSec. la
 let sysFileExists: String -> Bool = lam file.
   if eqi (_commandList ["test", "-e", file]) 0 then true else false
 
+let sysCopyFile = lam fromFile. lam toFile.
+  _commandList ["cp", "-f", fromFile, toFile]
+
 let sysMoveFile = lam fromFile. lam toFile.
   _commandList ["mv", "-f", fromFile, toFile]
 


### PR DESCRIPTION
Changes:
- Add a `stats.mc` library including basic statistics-related functions.
- Add test case in `arg.mc` illustrating option order sensitivity.
- Add `string2bool` function in `bool.mc`
- Fix interesting bug resulting from the combination of the external `externalSetSeed` (used to simultaneously set both Owl and OCaml `Random` seeds) and the intrinsics `randSetSeed`/`randIntU`. Basically, I expected the sequence
    ```
    externalSetSeed 0 -- Calls Random.init 0 internally
    let x = randIntU 0 10 in
    ...
    ```
    to always result in the same value for `x`. However, `randSetSeed`/`randIntU` has an internal mechanism in which `randIntU` _randomly_ initializes the seed if `randSetSeed` has never been called before. This messed up the example above (and I probably think we should change this behavior). I fixed it for now by making `setSeed` (that wraps `externalSetSeed`) to also call `randSetSeed`.
- Change `math.mc` to include `bool.mc` instead of `common.mc`. Including `common.mc` caused an inclusion of the polymorphic `Option` type in RootPPL (in Miking DPPL), and type and constructor definitions are not dead-code-eliminated (possibly something we want to fix?).
- Change so that MExprANF does not lift unit values (i.e., empty records).
- Fix some errors in `lamlift.mc` (contribution by @larshum).
- Add a `sysCopyFile` function in `sys.mc`.
