### PR TITLE
Packaging updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@
 #  the system, we just run the batch make.sh file.
 ###################################################
 
-export ocamlprefix
 export prefix
 export bindir
 export libdir
+export ocamllibdir
 
 .PHONY :\
   all\

--- a/make.sh
+++ b/make.sh
@@ -20,7 +20,8 @@ MI_TMP_NAME=mi-tmp
 prefix="${prefix:-$HOME/.local}"
 bindir="${bindir:-$prefix/bin}"
 libdir="${libdir:-$prefix/lib}"
-ocamlprefix="${ocamlprefix:-${OPAM_SWITCH_PREFIX:-$prefix}}"
+opamlibdir="${OPAM_SWITCH_PREFIX:+$OPAM_SWITCH_PREFIX/lib}"
+ocamllibdir="${ocamllibdir:-${opamlibdir:-$libdir/ocaml/site-lib}}"
 mcoredir=$libdir/mcore
 
 # Setup environment variable to find standard library
@@ -38,7 +39,7 @@ build_boot(){
 }
 
 install_boot(){
-    dune install --prefix=$ocamlprefix > /dev/null 2>&1
+    dune install --prefix=$prefix --libdir=$ocamllibdir > /dev/null 2>&1
 }
 
 # Compile a new version of the compiler using the current one
@@ -88,7 +89,7 @@ install() {
 
 # Uninstall the Miking bootstrap interpreter and compiler
 uninstall() {
-    dune uninstall --prefix=$ocamlprefix > /dev/null 2>&1
+    dune uninstall --prefix=$prefix --libdir=$ocamllibdir > /dev/null 2>&1
     rm -f $bindir/$MI_NAME
     rm -rf $mcoredir/stdlib
 }

--- a/misc/packaging/README.md
+++ b/misc/packaging/README.md
@@ -14,17 +14,21 @@ To produce a shell with Miking itself, use the following command.
 
     $ nix-shell -A miking-shell
 
+To support native compilation, ocaml, findlib, dune and a C compiler must also be added to the environment.
+
 ## Guix package definition
 
 `miking.scm` contains a package definition of Miking for the [Guix](https://guix.gnu.org) package manager.
 
 For users of Guix, a shell containing all development inputs for Miking can be produced by running the following command from this directory.
 
-    $ guix shell -L . -D miking
+    $ guix shell -L . -D -f miking.scm
 
 To produce a shell with Miking itself, use the following command.
 
-    $ guix shell -L . miking
+    $ guix shell -L . -f miking.scm
+
+To support native compilation, ocaml, findlib, dune and a C compiler must also be added to the environment.
 
 ## Self-contained tarball script
 

--- a/misc/packaging/miking.nix
+++ b/misc/packaging/miking.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub,
+{ lib, stdenv, fetchGit,
   binutils-unwrapped,
   coreutils,
   gcc,
@@ -11,14 +11,11 @@ let ocamlPackages = ocaml-ng.ocamlPackages_5_0; in
 
 stdenv.mkDerivation rec {
   pname = "miking";
-  version = "0.0.1";
+  version = "0.0.0+git";
 
-  src = fetchFromGitHub {
-    owner = "miking-lang";
-    repo = "miking";
-    rev = "fb0e67d781cb24b8c2d25693286054a845d64112";
-    sha256 = "16ixfrrn9ns3ypr7c4krpham1lx32i801d12yv0f4y3fl8fn5vv2";
-  };
+  # Unlike Guix, Nix does not seem to expose the filter used by the git fetcher.
+  # Changing this file will result in another derivation.
+  src = fetchGit ../..;
 
   propagatedBuildInputs = with ocamlPackages;
     [ ocaml
@@ -34,19 +31,6 @@ stdenv.mkDerivation rec {
       owl        # For dist-ext.mc
       toml       # For toml-ext.mc
     ];
-
-  preBuild = ''
-    substituteInPlace make.sh --replace 'OCAMLPATH=' 'OCAMLPATH=$OCAMLPATH:'
-    substituteInPlace test-boot.mk \
-      --replace 'MCORE_LIBS=' 'OCAMLPATH=''${OCAMLPATH}:`pwd`/build/lib MCORE_LIBS='
-  '';
-
-  installPhase = ''
-    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR
-    cp build/mi $out/bin
-    mkdir -p $out/lib/mcore
-    cp -r stdlib $out/lib/mcore
-  '';
 
   doCheck = true;
   checkTarget = "test-compile";

--- a/misc/packaging/miking.nix
+++ b/misc/packaging/miking.nix
@@ -4,16 +4,18 @@
   ocaml-ng
 }:
 
-let ocamlPackages = ocaml-ng.ocamlPackages_5_0; in
+with ocaml-ng.ocamlPackages_5_0;
 
-with ocamlPackages;
 stdenv.mkDerivation rec {
   pname = "miking";
   version = "0.0.0+git";
 
   # Unlike Guix, Nix does not seem to expose the filter used by the git fetcher.
-  # Changing this file will result in another derivation.
-  src = fetchGit ../..;
+  # Each new commit will result in a different derivation.
+  src = fetchGit {
+    url = ../..;
+    ref = "HEAD";
+  };
 
   nativeBuildInputs = [
     ocaml

--- a/misc/packaging/miking.nix
+++ b/misc/packaging/miking.nix
@@ -2,9 +2,7 @@
   binutils-unwrapped,
   coreutils,
   gcc,
-  ocaml-ng,
-  pkgsStatic,
-  which
+  ocaml-ng
 }:
 
 let ocamlPackages = ocaml-ng.ocamlPackages_5_0; in
@@ -26,7 +24,6 @@ stdenv.mkDerivation rec {
       gcc.cc
 
       coreutils  # For sys.mc (mkdir, echo, rm, ...)
-      which      # For sys.mc
       lwt        # For async-ext.mc
       owl        # For dist-ext.mc
       toml       # For toml-ext.mc

--- a/misc/packaging/miking.scm
+++ b/misc/packaging/miking.scm
@@ -27,6 +27,7 @@
               (uri (git-reference
                     (url "https://github.com/ocaml-community/ISO8601.ml")
                     (commit version)))
+              (file-name (git-file-name name version))
               (sha256
                (base32
                 "0nzadswspizi7s6sf67icn2xgc3w150x8vdg5nk1mjrm2s98n6d3"))))
@@ -50,6 +51,7 @@
               (uri (git-reference
                     (url "https://github.com/OCamlPro/ocb")
                     (commit version)))
+              (file-name (git-file-name name version))
               (sha256
                (base32
                 "1nk90jax91ld8qd36qi408mll8a7w1d60fa2qdsnff7cldwixc1d"))))
@@ -71,6 +73,7 @@ provided.")
               (uri (git-reference
                     (url "https://github.com/LaurentMazare/npy-ocaml")
                     (commit version)))
+              (file-name (git-file-name name version))
               (sha256
                (base32
                 "1fryglkm20h6kdqjl55b7065b34bdg3g3p6j0jv33zvd1m5888m1"))))
@@ -94,6 +97,7 @@ from python using numpy.")
               (uri (git-reference
                     (url "https://github.com/ocaml-toml/to.ml")
                     (commit version)))
+              (file-name (git-file-name name version))
               (sha256
                (base32
                 "0z2873mj3i6h9cg8zlkipcjab8jympa4c4avhk4l04755qzphkds"))))
@@ -118,6 +122,7 @@ OCaml primitive types are also supplied.")
               (uri (git-reference
                     (url "https://github.com/owlbarn/owl")
                     (commit version)))
+              (file-name (git-file-name name version))
               (sha256
                (base32
                 "08jvgf1fd7d28cxxjifx4ikmwcbfbiyw0sivw3xy4vdzvbyc9xw9"))))

--- a/misc/packaging/miking.scm
+++ b/misc/packaging/miking.scm
@@ -17,28 +17,30 @@
   #:use-module (gnu packages ocaml))
 
 (define-public ocaml-ISO8601
-  (package
-    (name "ocaml-ISO8601")
-    (version "0.2.6")
-    (source (origin
-              (method git-fetch)
-              (uri (git-reference
-                    (url "https://github.com/ocaml-community/ISO8601.ml")
-                    (commit version)))
-              (file-name (git-file-name name version))
-              (sha256
-               (base32
-                "0nzadswspizi7s6sf67icn2xgc3w150x8vdg5nk1mjrm2s98n6d3"))))
-    (build-system dune-build-system)
-    (arguments
-     '(#:tests? #f)) ;; Tests import Pervasives module, unavailable in OCaml 5 (?)
-    (propagated-inputs (list ocaml-odoc))
-    (native-inputs (list ocaml-ounit))
-    (home-page "https://github.com/ocaml-community/ISO8601.ml/")
-    (synopsis "ISO 8601 and RFC 3339 date parsing for OCaml")
-    (description
-     "OCaml parser and printer for date-times in ISO8601 and RFC 3339")
-    (license license:expat)))
+  ;; NOTE: Using commit from master branch as 0.2.6 uses the Pervasives
+  ;; module in its tests, which is incompatible with OCaml 5.0.
+  (let ((revision "0")
+        (commit "ad50cb01061405623c834608c26f1ef2d44f8340"))
+    (package
+      (name "ocaml-ISO8601")
+      (version (git-version "0.2.6" revision commit))
+      (source (origin
+                (method git-fetch)
+                (uri (git-reference
+                      (url "https://github.com/ocaml-community/ISO8601.ml")
+                      (commit commit)))
+                (file-name (git-file-name name version))
+                (sha256
+                 (base32
+                  "1lvjrxz66b7dv40cbl8xyfv3x8nmwj0m5ipfvxc37mjaaf3xrr5g"))))
+      (build-system dune-build-system)
+      (propagated-inputs (list ocaml-odoc))
+      (native-inputs (list ocaml-ounit))
+      (home-page "https://github.com/ocaml-community/ISO8601.ml/")
+      (synopsis "ISO 8601 and RFC 3339 date parsing for OCaml")
+      (description
+       "OCaml parser and printer for date-times in ISO8601 and RFC 3339")
+      (license license:expat))))
 
 (define-public ocaml-ocb
   (package

--- a/misc/packaging/miking.scm
+++ b/misc/packaging/miking.scm
@@ -178,7 +178,7 @@ algorithms.")
     (inputs
      (list
       ocaml-linenoise
-      coreutils         ;; Miking currently requires mkdir to be available to run
+      coreutils         ;; Miking currently requires mkdir to be able to run
       ))
     (native-inputs
      (list

--- a/misc/packaging/miking.scm
+++ b/misc/packaging/miking.scm
@@ -2,14 +2,12 @@
   #:use-module (guix build-system dune)
   #:use-module (guix build-system gnu)
   #:use-module (guix build-system ocaml)
-  #:use-module (guix build-system trivial)
   #:use-module (guix gexp)
   #:use-module (guix git-download)
   #:use-module (guix packages)
   #:use-module (guix utils)
   #:use-module ((guix licenses) #:prefix license:)
   #:use-module (gnu packages base)
-  #:use-module (gnu packages commencement)
   #:use-module (gnu packages compression)
   #:use-module (gnu packages maths)
   #:use-module (gnu packages python)
@@ -141,34 +139,6 @@ simplifies developing machine learning and neural network
 algorithms.")
     (license license:expat)))
 
-(define-public ocaml-base-bytes
-  (package
-    (name "ocaml-base-bytes")
-    (version "base")
-    (source #f)
-    (build-system trivial-build-system)
-    (arguments
-     (list
-      #:modules '((guix build utils))
-      #:builder
-      #~(begin
-          (use-modules (guix build utils))
-          (let ((bytes (string-append #$output "/lib/ocaml/bytes")))
-            (mkdir-p bytes)
-            (call-with-output-file (string-append bytes "/META")
-              (lambda (port)
-                (format port "name=\"bytes\"
-version=\"[distributed with OCaml 4.02 or above]\"
-description=\"dummy backward-compatibility package for mutable strings\"
-requires=\"\"
-")))))))
-    (home-page "https://opam-4.ocaml.org/packages/base-bytes/")
-    (synopsis "Dummy backward-compatibility package for mutable strings")
-    (description
-     "A dummy package for depending on the base Bytes module distributed with
-the OCaml compiler.")
-    (license license:expat)))
-
 (define-syntax-rule (and/fn functions ...)
   (lambda args (and (apply functions args) ...)))
 
@@ -215,7 +185,6 @@ the OCaml compiler.")
       ))
     (native-inputs
      (list
-      ocaml-base-bytes  ;; For ocaml5.0-{lwt,owl}
       ocaml-lwt         ;; For async-ext.mc
       ocaml-owl         ;; For dist-ext.mc
       ocaml-toml        ;; For toml-ext.mc
@@ -227,9 +196,9 @@ a polymorphic core calculus and a DSL definition language where languages
 can be extended and composed from smaller fragments.
 
 Note: Depending on the target runtime, miking requires the presence of
-additional packages within an environment, such as dune, ocaml, and
-gcc-toolchain for native builds, node for javascript, and a suitable JDK when
-targeting the JVM.")
+additional packages within an environment, such as dune, ocaml, ocaml-findlib
+and gcc-toolchain for native builds, node for javascript, and a suitable JDK
+when targeting the JVM.")
     (home-page "https://miking.org")
     (license license:expat)))
 

--- a/misc/packaging/miking.scm
+++ b/misc/packaging/miking.scm
@@ -11,9 +11,7 @@
   #:use-module (gnu packages base)
   #:use-module (gnu packages commencement)
   #:use-module (gnu packages compression)
-  ;; #:use-module (gnu packages java)
   #:use-module (gnu packages maths)
-  ;; #:use-module (gnu packages node)
   #:use-module (gnu packages python)
   #:use-module (gnu packages python-xyz)
   #:use-module (gnu packages ocaml))
@@ -206,8 +204,7 @@ the OCaml compiler.")
                          `("PATH" suffix
                            (,(dirname (search-input-file inputs "bin/dune"))
                             ,(dirname (search-input-file inputs "bin/ocaml"))
-                            ,(dirname (search-input-file inputs "bin/mkdir"))
-                            ,(dirname (search-input-file inputs "bin/which"))))
+                            ,(dirname (search-input-file inputs "bin/mkdir"))))
                          `("OCAMLPATH" suffix (,(getenv "OCAMLPATH")))))
                     (find-files (string-append (assoc-ref outputs "out")
                                                "/bin"))))))))
@@ -221,7 +218,6 @@ the OCaml compiler.")
       (package-with-ocaml5.0 ocaml-lwt)   ;; For async-ext.mc
       (package-with-ocaml5.0 ocaml-owl)   ;; For dist-ext.mc
       (package-with-ocaml5.0 ocaml-toml)  ;; For toml-ext.mc
-      which                               ;; For sys.mc
       ))
     (native-inputs
      (list ocaml-5.0 ocaml5.0-dune))

--- a/misc/packaging/miking.scm
+++ b/misc/packaging/miking.scm
@@ -201,37 +201,35 @@ the OCaml compiler.")
                    (for-each
                     (lambda (prog)
                       (wrap-program prog
-                         `("PATH" suffix
-                           (,(dirname (search-input-file inputs "bin/dune"))
-                            ,(dirname (search-input-file inputs "bin/ocaml"))
-                            ,(dirname (search-input-file inputs "bin/mkdir"))))
-                         `("OCAMLPATH" suffix (,(getenv "OCAMLPATH")))))
+                         `("PATH" suffix (,(dirname (search-input-file inputs "bin/mkdir"))))
+                         `("OCAMLPATH" suffix (,(string-append (assoc-ref inputs "ocaml-linenoise")
+                                                               "/lib/ocaml/site-lib")))))
                     (find-files (string-append (assoc-ref outputs "out")
                                                "/bin"))))))))
     (inputs
      (list
-      ocaml-5.0
-      ocaml5.0-dune
-      (package-with-ocaml5.0 ocaml-linenoise)
-      coreutils                           ;; For sys.mc (mkdir, echo, rm, ...)
-      ocaml-base-bytes                    ;; Needed for ocaml5.0-{lwt,owl}
-      (package-with-ocaml5.0 ocaml-lwt)   ;; For async-ext.mc
-      (package-with-ocaml5.0 ocaml-owl)   ;; For dist-ext.mc
-      (package-with-ocaml5.0 ocaml-toml)  ;; For toml-ext.mc
+      ocaml-linenoise
+      coreutils         ;; Miking currently requires mkdir to be available to run
       ))
     (native-inputs
-     (list ocaml-5.0 ocaml5.0-dune))
+     (list
+      ocaml-base-bytes  ;; For ocaml5.0-{lwt,owl}
+      ocaml-lwt         ;; For async-ext.mc
+      ocaml-owl         ;; For dist-ext.mc
+      ocaml-toml        ;; For toml-ext.mc
+      ))
     (synopsis "Meta language system for creating embedded DSLs.")
     (description "Miking (Meta vIKING) is a meta language system for creating
 embedded domain-specific and general-purpose languages.  The system features
 a polymorphic core calculus and a DSL definition language where languages
 can be extended and composed from smaller fragments.
 
-Note: Depending on the target runtime, miking requires the precense of
-additional packages within an environment, such as gcc-toolchain for native
-builds, node for javascript, and a suitable JDK when targeting the JVM.")
+Note: Depending on the target runtime, miking requires the presence of
+additional packages within an environment, such as dune, ocaml, and
+gcc-toolchain for native builds, node for javascript, and a suitable JDK when
+targeting the JVM.")
     (home-page "https://miking.org")
     (license license:expat)))
 
 ;; For `guix build -f'
-miking
+(package-with-ocaml5.0 miking)

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -7,6 +7,15 @@ let _pathSep = "/"
 let _tempBase = "/tmp"
 let _null = "/dev/null"
 
+let sysCommandExists : String -> Bool = lam cmd.
+  eqi 0 (command (join ["command -v ", cmd, " >/dev/null 2>&1"]))
+
+utest sysCommandExists "ls" with true
+
+let #var"ASSERT_MKDIR" : () =
+  if sysCommandExists "mkdir" then ()
+  else error "Couldn't find 'mkdir' on PATH, exiting."
+
 let _commandListTime : [String] -> (Float, Int) = lam cmd.
   let cmd = strJoin " " cmd in
   let t1 = wallTimeMs () in
@@ -129,17 +138,12 @@ let sysRunCommand : [String] -> String -> String -> ExecResult =
   lam cmd. lam stdin. lam cwd.
     match sysRunCommandWithTiming cmd stdin cwd with (_, res) then res else never
 
-let sysCommandExists : String -> Bool = lam cmd.
-  eqi 0 (command (join ["which ", cmd, " >/dev/null 2>&1"]))
-
 let sysGetCwd : () -> String = lam. strTrim (sysRunCommand ["pwd"] "" ".").stdout
 
 let sysGetEnv : String -> Option String = lam env.
   let res = strTrim (sysRunCommand ["echo", concat "$" env] "" ".").stdout in
   if null res then None ()
   else Some res
-
-utest sysCommandExists "ls" with true
 
 let sysAppendFile : String -> String -> ReturnCode =
   lam filename. lam str.

--- a/stdlib/sys.mc
+++ b/stdlib/sys.mc
@@ -51,16 +51,21 @@ let sysJoinPath = lam p1. lam p2.
   strJoin _pathSep [p1, p2]
 
 let sysTempMake = lam dir: Bool. lam prefix: String. lam.
+  let maxTries = 10000 in
   recursive let mk = lam base. lam i.
-    let name = concat base (int2string i) in
-    match
-      _commandList [
-        if dir then "mkdir" else "touch",
-        sysJoinPath _tempBase name, "2>", _null
-      ]
-    with 0
-    then name
-    else mk base (addi i 1) in
+    if lti i maxTries then
+      let name = concat base (int2string i) in
+      match
+        _commandList [
+          if dir then "mkdir" else "touch",
+          sysJoinPath _tempBase name, "2>", _null
+        ]
+        with 0
+      then name
+      else mk base (addi i 1)
+    else
+      error "sysTempMake: Failed to make temporary directory."
+  in
   let alphanumStr = create 10 (lam. randAlphanum ()) in
   let base = concat prefix alphanumStr in
   let name = mk base 0 in


### PR DESCRIPTION
This PR updates the nix and guix scripts, again incorporating some changes by Liliana Marie Prikler (see the commit history).  It also makes `sys.mc` check for `mkdir` at startup instead of looping indefinitely when it is not present (and changes `sys.mc` to use builtin `command` instead of depending on `which`).

The guix and nix scripts now build from the local sources instead of an arbitrary commit, and are updated to better follow common practice.