### PR TITLE
miking-pack updates and darwin support

### DIFF
--- a/misc/packaging/README.md
+++ b/misc/packaging/README.md
@@ -30,52 +30,55 @@ To produce a shell with Miking itself, use the following command.
 
 To support native compilation, ocaml, findlib, dune and a C compiler must also be added to the environment.
 
-## Self-contained tarball script
+## Self-contained tarball scripts
 
-`miking-pack` is a shell script which uses the Nix package definition to produce a completely self-contained tarball with Miking and its dependencies for binary distribution.
-The current version of the script works only for x86-64 Linux and WSL, but in the future it will also support macOS and ARM.
-The script requires Nix to be installed on the build system, and can be run as follows.
+The scripts `miking-pack-linux` and `miking-pack-darwin` use the Nix package definition to produce a completely self-contained tarball with Miking and its dependencies for binary distribution.
+The former works for x86-64 Linux and WSL, and the latter works for x86-64 and arm64 macOS.
+The scripts requires Nix to be installed on the build system, and can be run as follows.
 
-    $ /path/to/miking-pack
+    $ /path/to/miking-pack-linux  # or $ /path/to/miking-pack-darwin
 
 This produces a tarball `miking-pack.tar.gz` in the current working directory with structure
 
-    miking-pack/
+    miking-pack.XXXXXX/  # XXXXXX is a random string generated at build time
       bin/
         ...
       lib/
         mcore/stdlib/
         ...
       mi
-      mi-setup
+      mi-setup  # only on Linux
       ...
 
-The directories `bin/` and `lib/`, et.c., contain the necessary dependencies for the Miking compiler.
-`mi-setup` is a shell script which must be run after extracting the tarball to set the dynamic linker path inside the bundled executables, and `mi` runs the Miking compiler itself.
+The directories `bin/` and `lib/`, et.c., contain the necessary dependencies for the Miking compiler, and `mi` runs the Miking compiler itself.
+The Linux version further includes a shell script `mi-setup` which must be run after extracting the tarball to set the dynamic linker path inside the bundled executables.
 To use this bundle on a system, simply run
 
-    tar xzf miking-pack.tar.gz
-    miking-pack/mi-setup
+    $ tar xzf miking-pack.tar.gz
+    $ miking-pack.XXXXXX/mi-setup  # only on Linux
 
 You should then be able to compile Miking programs using, e.g.,
 
-    miking-pack/mi compile my_file.mc
+    $ miking-pack.XXXXXX/mi compile my_file.mc
 
-Note that the `mi-setup` command only needs to be run once as an installation procedure.
-The `miking-pack` folder can be renamed and moved around freely as long as its internal structure is preserved, but then `mi-setup` must be run again afterwards (and any binaries compiled with the bundled mi will cease to work unless their dynamic linker path is updated as well).
+Note that the `mi-setup` script on Linux only needs to be run once as an installation procedure.
+The `miking-pack.XXXXXX` folder can be renamed and moved around freely as long as its internal structure is preserved, but then `mi-setup` must be run again afterwards, and any binaries compiled with the bundled `mi` will cease to work.
 
 `mi-setup` is a POSIX shell script which depends on the commands `realpath`, `dirname` and `find` usually available on any Unix system (included in coreutils and findutils respectively).
 
+The tarball includes everything needed for `test-compile` to pass, including a C compiler, OCaml, `owl` and C library dependencies.
+
 ### Implementation
 
-The `miking-pack` script works by the following steps:
+The `miking-pack` script works roughly by the following steps:
 
 1. Invoke `nix-store -qR` to get all the runtime dependencies of Miking and copy them to a temporary directory.
 
-2. Patch the binary-specific shared library paths (using the `patchelf` tool) to point to the bundle's `lib` directory (relative to the file itself using the `$ORIGIN` feature for `rpath`s), and remove a few occurrences of absolute paths inside the dependencies.
+2. Patch the shared library paths of copied binaries (using `patchelf` on Linux or `install_name_tool` on macOS) to point to the bundle's `lib` directory, and remove a few occurrences of absolute paths.
 
-3. Create an `mi-setup` script which invokes a statically linked `patchelf` included in the bundle to update the dynamic linker path in all executables to point to the bundled dynamic linker (the path is absolute, so this must be done on the user system).
+3. On Linux, create an `mi-setup` script which invokes a statically linked `patchelf` included in the bundle to update the dynamic linker path in all executables to point to the bundled dynamic linker (the path is absolute, so this must be done on the user system).
+   On macOS, the system's dynamic linker `/usr/lib/dyld` is used instead.
 
-4. Create a wrapper script `mi` which sets `OCAMLPATH`, `OCAMLLIB`, `PATH`, `LIBRARY_PATH` and `MCORE_LIBS` to point to the right directories within the bundle before invoking the real `mi` executable.  It also sets `OCAMLPARAM` to make the compiled binary get the appropriate dynamic linker and `rpath` paths, and unsets `LD_LIBRARY_PATH` and `OPAM_SWITCH_PREFIX` to ensure they don't interfere with the bundle.
+4. Create a wrapper script `mi` which sets `OCAMLPATH`, `OCAMLLIB`, `PATH`, `LIBRARY_PATH` and `MCORE_LIBS` to point to the right directories within the bundle before invoking the real `mi` executable.  It also sets `OCAMLPARAM` to make the binaries compiled by `mi` get the appropriate rpaths, and unsets a few variables to ensure they don't interfere with the bundle.
 
 5. Create a tarball containing the above.

--- a/misc/packaging/default.nix
+++ b/misc/packaging/default.nix
@@ -1,7 +1,11 @@
 with import <nixpkgs> {};
+let ocamlBase = ocaml-ng.ocamlPackages_5_0.ocaml; in
 rec {
   miking = callPackage (import ./miking.nix) {};
   miking-shell = mkShell {
     buildInputs = [ miking ];
   };
+  ocaml-with-cc = ocamlBase.overrideAttrs (finalAttrs: previousAttrs: {
+    preConfigure = ''AS="cc -c" ASPP="cc -c"'';
+  });
 }

--- a/misc/packaging/default.nix
+++ b/misc/packaging/default.nix
@@ -1,11 +1,38 @@
-with import <nixpkgs> {};
-let ocamlBase = ocaml-ng.ocamlPackages_5_0.ocaml; in
+with import <nixpkgs> {
+  overlays =
+    [ (pkgs-self: pkgs-super:
+      { ocamlPackages =
+          if pkgs-super.stdenv.isDarwin then
+            pkgs-super.ocaml-ng.ocamlPackages_5_0.overrideScope' (self: super: {
+              ocaml = super.ocaml.overrideAttrs (finalAttrs: previousAttrs: {
+                preConfigure = ''AS="cc -c" ASPP="cc -c"'';
+              });
+              owl-base = super.owl-base.overrideAttrs (finalAttrs: previousAttrs: {
+                version = "1.1";
+                src = pkgs-super.fetchurl {
+                  url = "https://github.com/owlbarn/owl/releases/download/${finalAttrs.version}/owl-${finalAttrs.version}.tbz";
+                  hash = "sha256-mDYCZ2z33VTEvc6gV4JTecIXA/vHIWuU37BADGl/yog=";
+                };
+                meta = {
+                  inherit (previousAttrs.meta) description homepage changelog maintainers license;
+                };
+              });
+              owl = super.owl.overrideAttrs (finalAttrs: previousAttrs: {
+                inherit (self.owl-base) version src meta;
+                preBuild = ''
+                  export OWL_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -msse2 -fno-strict-aliasing"
+                '';
+                hardeningDisable = [ "strictoverflow" ];
+              });
+            })
+          else
+            pkgs-super.ocaml-ng.ocamlPackages_5_0;
+      })
+    ];
+};
 rec {
   miking = callPackage (import ./miking.nix) {};
   miking-shell = mkShell {
     buildInputs = [ miking ];
   };
-  ocaml-with-cc = ocamlBase.overrideAttrs (finalAttrs: previousAttrs: {
-    preConfigure = ''AS="cc -c" ASPP="cc -c"'';
-  });
 }

--- a/misc/packaging/miking-pack
+++ b/misc/packaging/miking-pack
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p bash coreutils file gnugrep gnused gnutar gzip patchelf
+#! nix-shell -i bash -p nix git --pure
 
 # Build a tarball with Miking and the necessary dependencies.
 # Usage:
@@ -11,41 +11,62 @@
 
 set -e
 
-export TMP_DIR="/tmp/miking-pack"
+export packdir="$(mktemp -d /tmp/miking-pack.XXXXXX)"
 
-init_temp_dir() {
-    echo "Making build directory at $TMP_DIR."
-    rm -rvf $TMP_DIR
-    mkdir -v $TMP_DIR
+custom_deps=('miking')
+
+ocaml_deps=('ocaml' 'findlib' 'dune_3' 'owl' 'lwt' 'toml')
+
+nixpkgs_deps=('binutils-unwrapped' 'gcc.cc')
+
+static_deps=('patchelf' 'gnugrep' 'file')
+
+install_dep() {
+    echo "Copying from $1 to $packdir."
+    cp -an $1/* $packdir
+    # Files copied from the nix store are unwritable, so update the permissions.
+    chmod -R +w $packdir
+}
+
+install_transitive_deps() {
+    nix-store --query --requisites "$1" | while read dep_path; do
+        install_dep "$dep_path"
+    done
 }
 
 install_miking() {
-    echo "Installing Miking and dependencies to $TMP_DIR."
-    mi_path="$(nix-build "$(dirname "${BASH_SOURCE[0]}")" -A miking --no-out-link)"
-    nix-store --query --requisites "$mi_path" | while read dep_path; do
-        cp -drnv $dep_path/* $TMP_DIR
-        # Files copied from the nix store are unwritable, so update the permissions.
-        chmod +w -R $TMP_DIR
+    echo "Installing Miking and dependencies to $packdir."
+    for dep in "${custom_deps[@]}"; do
+        install_transitive_deps \
+            "$(nix-build "$(dirname "${BASH_SOURCE[0]}")" -A $dep --no-out-link)"
     done
-    for dep in 'patchelf' 'gnugrep' 'file'; do
-        cp -drv $(nix-build '<nixpkgs>' -A pkgsStatic.$dep --no-out-link)/* $TMP_DIR
-        chmod +w -R $TMP_DIR
+    for dep in "${ocaml_deps[@]}"; do
+        install_transitive_deps \
+            "$(nix-build '<nixpkgs>' -A ocaml-ng.ocamlPackages_5_0.$dep --no-out-link)"
+    done
+    for dep in "${nixpkgs_deps[@]}"; do
+        install_transitive_deps "$(nix-build '<nixpkgs>' -A $dep --no-out-link)"
+    done
+    for dep in "${static_deps[@]}"; do
+        install_dep "$(nix-build '<nixpkgs>' -A pkgsStatic.$dep --no-out-link)"
     done
 }
 
 patch_binaries() {
     echo "Patching dynamic library paths in binaries."
-    find $TMP_DIR/bin $TMP_DIR/libexec $TMP_DIR/lib -type f \
+    find $packdir/bin $packdir/libexec $packdir/lib -type f \
          ! -name '*.a' ! -name '*.cma' ! -name '*.cmi' ! -name '*.cmti' ! -name '*.cmx' \
          ! -name '*.h' ! -name '*.la' ! -name '*.ml' ! -name '*.mli' ! -name '*.o' \
          -exec bash -c 'file {} | grep -e "ELF.*\(executable\|shared\).*dynamic"' \; \
-         -exec bash -c 'patchelf --set-rpath "\$ORIGIN/$(realpath --relative-to="$(dirname {})" $TMP_DIR/lib)" {}' \;
-    sed -i -e 's,/nix/store/[^/]*/lib/,,g' $TMP_DIR/lib/libc.so $TMP_DIR/lib/libm.so
+         -exec bash -c 'patchelf --set-rpath "\$ORIGIN/$(realpath --relative-to="$(dirname {})" $packdir/lib)" {}' \;
+    sed -i -e 's,/nix/store/[^/]*/lib/,,g' $packdir/lib/libc.so $packdir/lib/libm.so
+    mv $packdir/bin/.mi-wrapped $packdir/bin/mi
+    ln -s gcc $packdir/bin/cc
 }
 
 prepare_scripts() {
     echo "Preparing setup and wrapper scripts."
-    cat <<'EOS' > $TMP_DIR/mi-setup
+    cat <<'EOS' > $packdir/mi-setup
 #!/bin/sh
 echo "Setting up bundled Miking for use."
 export SOURCE="$(dirname "$(realpath "$0")")"
@@ -57,7 +78,7 @@ find $SOURCE/bin $SOURCE/libexec -type f \
      --set-interpreter $SOURCE/lib/ld-linux-x86-64.so.2 {} \;
 echo "Finished setup."
 EOS
-    cat <<'EOS' > $TMP_DIR/mi
+    cat <<'EOS' > $packdir/mi
 #!/bin/sh
 SOURCE="$(dirname "$(realpath "$0")")"
 export OCAMLPATH="$SOURCE/lib/ocaml:$SOURCE/lib/ocaml/5.0.0/site-lib"
@@ -70,15 +91,15 @@ unset  OPAM_SWITCH_PREFIX
 unset  LD_LIBRARY_PATH
 exec -a "$0" "$SOURCE/bin/mi" "$@"
 EOS
-    chmod +x $TMP_DIR/mi $TMP_DIR/mi-setup
+    chmod +x $packdir/mi $packdir/mi-setup
 }
 
 make_tarball() {
-    init_temp_dir
     install_miking
     patch_binaries
     prepare_scripts
-    tar -C /tmp -czvf miking-pack.tar.gz ./miking-pack
+    tar -C "$(dirname $packdir)" -czvf miking-pack.tar.gz "$(basename $packdir)"
+    rm -rf $packdir
 }
 
 make_tarball

--- a/misc/packaging/miking-pack-darwin
+++ b/misc/packaging/miking-pack-darwin
@@ -13,11 +13,9 @@ set -e
 
 export packdir="$(mktemp -d /tmp/miking-pack.XXXXXX)"
 
-custom_deps=('miking')
+top_deps=('clang.cc' 'llvmPackages.compiler-rt' 'miking')
 
 ocaml_deps=('ocaml' 'findlib' 'dune_3' 'owl' 'lwt' 'toml')
-
-nixpkgs_deps=('binutils-unwrapped' 'clang.cc')
 
 declare -A installed_deps
 
@@ -42,16 +40,13 @@ install_transitive_deps() {
 
 install_miking() {
     echo "Installing Miking and dependencies to $packdir."
-    for dep in "${custom_deps[@]}"; do
+    for dep in "${top_deps[@]}"; do
         install_transitive_deps \
             "$(nix-build "$(dirname "${BASH_SOURCE[0]}")" -A $dep --no-out-link)"
     done
     for dep in "${ocaml_deps[@]}"; do
         install_transitive_deps \
-            "$(nix-build '<nixpkgs>' -A ocaml-ng.ocamlPackages_5_0.$dep --no-out-link)"
-    done
-    for dep in "${nixpkgs_deps[@]}"; do
-        install_transitive_deps "$(nix-build '<nixpkgs>' -A $dep --no-out-link)"
+	    "$(nix-build "$(dirname "${BASH_SOURCE[0]}")" -A ocamlPackages.$dep --no-out-link)"
     done
 }
 
@@ -66,20 +61,24 @@ patch_binaries() {
 }
 
 prepare_scripts() {
-    echo "Preparing setup and wrapper scripts."
+    echo "Preparing wrapper scripts."
     cat <<'EOS' > "$packdir/mi"
 #!/bin/sh
 SOURCE="$(dirname "$(realpath "$0")")"
 export OCAMLPATH="$SOURCE/lib/ocaml:$SOURCE/lib/ocaml/5.0.0/site-lib"
 export OCAMLLIB="$SOURCE/lib/ocaml"
-export OCAMLPARAM=":_:ccopt=-Wl,-rpath,$SOURCE/lib"
+export OCAMLPARAM=":_:ccopt=-resource-dir=$SOURCE:ccopt=-Wl,-rpath,$SOURCE/lib"
 export PATH="$SOURCE/bin"
 export LIBRARY_PATH="$SOURCE/lib"
 export MCORE_LIBS="stdlib=$SOURCE/lib/mcore/stdlib"
 unset  OPAM_SWITCH_PREFIX
 exec -a "$0" "$SOURCE/bin/mi" "$@"
 EOS
-    chmod +x "$packdir/mi"
+    cat <<'EOS' > "$packdir/bin/as"
+#!/bin/sh
+exec clang -x assembler -integrated-as -c "$@"
+EOS
+    chmod +x "$packdir/mi" "$packdir/bin/as"
 }
 
 make_tarball() {

--- a/misc/packaging/miking-pack-darwin
+++ b/misc/packaging/miking-pack-darwin
@@ -19,8 +19,6 @@ ocaml_deps=('findlib' 'dune_3' 'owl' 'lwt' 'toml')
 
 nixpkgs_deps=('binutils-unwrapped' 'gcc.cc')
 
-static_deps=('patchelf' 'gnugrep' 'file')
-
 install_dep() {
     echo "Copying from $1 to $packdir."
     cp -an $1/* $packdir
@@ -47,9 +45,6 @@ install_miking() {
     for dep in "${nixpkgs_deps[@]}"; do
         install_transitive_deps "$(nix-build '<nixpkgs>' -A $dep --no-out-link)"
     done
-    for dep in "${static_deps[@]}"; do
-        install_dep "$(nix-build '<nixpkgs>' -A pkgsStatic.$dep --no-out-link)"
-    done
 }
 
 patch_binaries() {
@@ -57,27 +52,13 @@ patch_binaries() {
     find $packdir/bin $packdir/libexec $packdir/lib -type f \
          ! -name '*.a' ! -name '*.cma' ! -name '*.cmi' ! -name '*.cmti' ! -name '*.cmx' \
          ! -name '*.h' ! -name '*.la' ! -name '*.ml' ! -name '*.mli' ! -name '*.o' \
-         -exec bash -c 'file {} | grep -e "ELF.*\(executable\|shared\).*dynamic"' \; \
-         -exec bash -c 'patchelf --set-rpath "\$ORIGIN/$(realpath --relative-to="$(dirname {})" $packdir/lib)" {}' \;
-    sed -i -e 's,/nix/store/[^/]*/lib/,,g' $packdir/lib/libc.so $packdir/lib/libm.so
+         -exec bash -c 'file {} | grep -e "Mach-O"' \; \
+         -exec bash -c 'otool -L {} | grep -oe "/nix/store/[^/]*/[^ ]*" | while read name; do install_name_tool -change $name "@loader_path/$(realpath --relative-to="$(dirname {})" $packdir/lib)/$(basename $name)" {}; done' \;
     mv $packdir/bin/.mi-wrapped $packdir/bin/mi
-    ln -s gcc $packdir/bin/cc
 }
 
 prepare_scripts() {
     echo "Preparing setup and wrapper scripts."
-    cat <<'EOS' > $packdir/mi-setup
-#!/bin/sh
-echo "Setting up bundled Miking for use."
-export SOURCE="$(dirname "$(realpath "$0")")"
-echo "Bundle directory:  $SOURCE"
-export MAGIC="$SOURCE/share/misc/magic.mgc"
-find $SOURCE/bin $SOURCE/libexec -type f \
-     -exec /bin/sh -c '$SOURCE/bin/file {} | $SOURCE/bin/grep -qe "ELF.*executable.*dynamic"' \; \
-     -exec $SOURCE/bin/patchelf \
-     --set-interpreter $SOURCE/lib/ld-linux-x86-64.so.2 {} \;
-echo "Finished setup."
-EOS
     cat <<'EOS' > $packdir/mi
 #!/bin/sh
 SOURCE="$(dirname "$(realpath "$0")")"
@@ -86,12 +67,10 @@ export OCAMLLIB="$SOURCE/lib/ocaml"
 export PATH="$SOURCE/bin"
 export LIBRARY_PATH="$SOURCE/lib"
 export MCORE_LIBS="stdlib=$SOURCE/lib/mcore/stdlib"
-export OCAMLPARAM=":_:ccopt=-Wl,--dynamic-linker=$SOURCE/lib/ld-linux-x86-64.so.2,-rpath=$SOURCE/lib"
 unset  OPAM_SWITCH_PREFIX
-unset  LD_LIBRARY_PATH
 exec -a "$0" "$SOURCE/bin/mi" "$@"
 EOS
-    chmod +x $packdir/mi $packdir/mi-setup
+    chmod +x $packdir/mi
 }
 
 make_tarball() {

--- a/misc/packaging/miking-pack-darwin
+++ b/misc/packaging/miking-pack-darwin
@@ -13,9 +13,9 @@ set -e
 
 export packdir="$(mktemp -d /tmp/miking-pack.XXXXXX)"
 
-custom_deps=('ocaml-with-cc' 'miking')
+custom_deps=('miking')
 
-ocaml_deps=('findlib' 'dune_3' 'owl' 'lwt' 'toml')
+ocaml_deps=('ocaml' 'findlib' 'dune_3' 'owl' 'lwt' 'toml')
 
 nixpkgs_deps=('binutils-unwrapped' 'clang.cc')
 

--- a/misc/packaging/miking-pack-darwin
+++ b/misc/packaging/miking-pack-darwin
@@ -4,7 +4,7 @@
 # Build a tarball with Miking and the necessary dependencies.
 # Usage:
 #
-#     $ /path/to/miking-pack
+#     $ /path/to/miking-pack-darwin
 #
 # To run this script, you need only Nix.  See README.md for more
 # information.
@@ -17,17 +17,25 @@ custom_deps=('ocaml-with-cc' 'miking')
 
 ocaml_deps=('findlib' 'dune_3' 'owl' 'lwt' 'toml')
 
-nixpkgs_deps=('binutils-unwrapped' 'gcc.cc')
+nixpkgs_deps=('binutils-unwrapped' 'clang.cc')
+
+declare -A installed_deps
 
 install_dep() {
-    echo "Copying from $1 to $packdir."
-    cp -an $1/* $packdir
-    # Files copied from the nix store are unwritable, so update the permissions.
-    chmod -R +w $packdir
+    if [ ! "${installed_deps[$1]+present}" ]; then
+        echo "Copying from $1 to $packdir."
+        cp -an $1/* "$packdir" || :
+        # Files copied from the nix store are unwritable, so update the permissions.
+        chmod -R +w "$packdir"
+        installed_deps["$1"]=
+    else
+	echo "Skipping installed path $1."
+    fi
 }
 
 install_transitive_deps() {
-    nix-store --query --requisites "$1" | while read dep_path; do
+    # We assume nix store paths contain no spaces or newlines.
+    for dep_path in $(nix-store --query --requisites "$1"); do
         install_dep "$dep_path"
     done
 }
@@ -49,28 +57,29 @@ install_miking() {
 
 patch_binaries() {
     echo "Patching dynamic library paths in binaries."
-    find $packdir/bin $packdir/libexec $packdir/lib -type f \
+    find "$packdir/bin" "$packdir/libexec" "$packdir/lib" -type f \
          ! -name '*.a' ! -name '*.cma' ! -name '*.cmi' ! -name '*.cmti' ! -name '*.cmx' \
          ! -name '*.h' ! -name '*.la' ! -name '*.ml' ! -name '*.mli' ! -name '*.o' \
-         -exec bash -c 'file {} | grep -e "Mach-O"' \; \
-         -exec bash -c 'otool -L {} | grep -oe "/nix/store/[^/]*/[^ ]*" | while read name; do install_name_tool -change $name "@loader_path/$(realpath --relative-to="$(dirname {})" $packdir/lib)/$(basename $name)" {}; done' \;
-    mv $packdir/bin/.mi-wrapped $packdir/bin/mi
+         -exec bash -c 'file "{}" | grep -e "Mach-O"' \; \
+         -exec bash -c 'for name in $(otool -L "{}" | grep -oe "/nix/store/[^/]*/[^ ]*"); do install_name_tool -change "$name" "@loader_path/$(realpath --relative-to="$(dirname "{}")" "$packdir/${name#/nix/store/*/}")" "{}"; done; f="{}"; install_name_tool -id "@rpath/${f#$packdir/lib/}" "{}"' \;
+    mv "$packdir/bin/.mi-wrapped" "$packdir/bin/mi"
 }
 
 prepare_scripts() {
     echo "Preparing setup and wrapper scripts."
-    cat <<'EOS' > $packdir/mi
+    cat <<'EOS' > "$packdir/mi"
 #!/bin/sh
 SOURCE="$(dirname "$(realpath "$0")")"
 export OCAMLPATH="$SOURCE/lib/ocaml:$SOURCE/lib/ocaml/5.0.0/site-lib"
 export OCAMLLIB="$SOURCE/lib/ocaml"
+export OCAMLPARAM=":_:ccopt=-Wl,-rpath,$SOURCE/lib"
 export PATH="$SOURCE/bin"
 export LIBRARY_PATH="$SOURCE/lib"
 export MCORE_LIBS="stdlib=$SOURCE/lib/mcore/stdlib"
 unset  OPAM_SWITCH_PREFIX
 exec -a "$0" "$SOURCE/bin/mi" "$@"
 EOS
-    chmod +x $packdir/mi
+    chmod +x "$packdir/mi"
 }
 
 make_tarball() {
@@ -78,7 +87,7 @@ make_tarball() {
     patch_binaries
     prepare_scripts
     tar -C "$(dirname $packdir)" -czvf miking-pack.tar.gz "$(basename $packdir)"
-    rm -rf $packdir
+    rm -rf "$packdir"
 }
 
 make_tarball

--- a/misc/packaging/miking-pack-linux
+++ b/misc/packaging/miking-pack-linux
@@ -13,11 +13,9 @@ set -e
 
 export packdir="$(mktemp -d /tmp/miking-pack.XXXXXX)"
 
-custom_deps=('miking')
+top_deps=('binutils-unwrapped' 'gcc.cc' 'miking')
 
 ocaml_deps=('ocaml' 'findlib' 'dune_3' 'owl' 'lwt' 'toml')
-
-nixpkgs_deps=('binutils-unwrapped' 'gcc.cc')
 
 static_deps=('patchelf' 'gnugrep' 'file')
 
@@ -44,16 +42,13 @@ install_transitive_deps() {
 
 install_miking() {
     echo "Installing Miking and dependencies to $packdir."
-    for dep in "${custom_deps[@]}"; do
+    for dep in "${top_deps[@]}"; do
         install_transitive_deps \
             "$(nix-build "$(dirname "${BASH_SOURCE[0]}")" -A $dep --no-out-link)"
     done
     for dep in "${ocaml_deps[@]}"; do
         install_transitive_deps \
-            "$(nix-build '<nixpkgs>' -A ocaml-ng.ocamlPackages_5_0.$dep --no-out-link)"
-    done
-    for dep in "${nixpkgs_deps[@]}"; do
-        install_transitive_deps "$(nix-build '<nixpkgs>' -A $dep --no-out-link)"
+            "$(nix-build "$(dirname "${BASH_SOURCE[0]}")" -A ocamlPackages.$dep --no-out-link)"
     done
     for dep in "${static_deps[@]}"; do
         install_dep "$(nix-build '<nixpkgs>' -A pkgsStatic.$dep --no-out-link)"
@@ -90,15 +85,15 @@ EOS
 SOURCE="$(dirname "$(realpath "$0")")"
 export OCAMLPATH="$SOURCE/lib/ocaml:$SOURCE/lib/ocaml/5.0.0/site-lib"
 export OCAMLLIB="$SOURCE/lib/ocaml"
+export OCAMLPARAM=":_:ccopt=-Wl,--dynamic-linker=$SOURCE/lib/ld-linux-x86-64.so.2,-rpath=$SOURCE/lib"
 export PATH="$SOURCE/bin"
 export LIBRARY_PATH="$SOURCE/lib"
 export MCORE_LIBS="stdlib=$SOURCE/lib/mcore/stdlib"
-export OCAMLPARAM=":_:ccopt=-Wl,--dynamic-linker=$SOURCE/lib/ld-linux-x86-64.so.2,-rpath=$SOURCE/lib"
 unset  OPAM_SWITCH_PREFIX
 unset  LD_LIBRARY_PATH
 exec -a "$0" "$SOURCE/bin/mi" "$@"
 EOS
-    chmod +x "$packdir/mi" "$packdir/mi-setup"
+    chmod +x "$packdir/mi-setup" "$packdir/mi"
 }
 
 make_tarball() {

--- a/misc/packaging/miking-pack-linux
+++ b/misc/packaging/miking-pack-linux
@@ -4,7 +4,7 @@
 # Build a tarball with Miking and the necessary dependencies.
 # Usage:
 #
-#     $ /path/to/miking-pack
+#     $ /path/to/miking-pack-linux
 #
 # To run this script, you need only Nix.  See README.md for more
 # information.
@@ -13,23 +13,31 @@ set -e
 
 export packdir="$(mktemp -d /tmp/miking-pack.XXXXXX)"
 
-custom_deps=('ocaml-with-cc' 'miking')
+custom_deps=('miking')
 
-ocaml_deps=('findlib' 'dune_3' 'owl' 'lwt' 'toml')
+ocaml_deps=('ocaml' 'findlib' 'dune_3' 'owl' 'lwt' 'toml')
 
 nixpkgs_deps=('binutils-unwrapped' 'gcc.cc')
 
 static_deps=('patchelf' 'gnugrep' 'file')
 
+declare -A installed_deps
+
 install_dep() {
-    echo "Copying from $1 to $packdir."
-    cp -an $1/* $packdir
-    # Files copied from the nix store are unwritable, so update the permissions.
-    chmod -R +w $packdir
+    if [ ! "${installed_deps[$1]+present}" ]; then
+        echo "Copying from $1 to $packdir."
+        cp -an $1/* "$packdir"
+        # Files copied from the nix store are unwritable, so update the permissions.
+        chmod -R +w "$packdir"
+        installed_deps["$1"]=
+    else
+	echo "Skipping installed path $1."
+    fi
 }
 
 install_transitive_deps() {
-    nix-store --query --requisites "$1" | while read dep_path; do
+    # We assume nix store paths contain no spaces or newlines.
+    for dep_path in $(nix-store --query --requisites "$1"); do
         install_dep "$dep_path"
     done
 }
@@ -54,31 +62,30 @@ install_miking() {
 
 patch_binaries() {
     echo "Patching dynamic library paths in binaries."
-    find $packdir/bin $packdir/libexec $packdir/lib -type f \
+    find "$packdir/bin" "$packdir/libexec" "$packdir/lib" -type f \
          ! -name '*.a' ! -name '*.cma' ! -name '*.cmi' ! -name '*.cmti' ! -name '*.cmx' \
          ! -name '*.h' ! -name '*.la' ! -name '*.ml' ! -name '*.mli' ! -name '*.o' \
-         -exec bash -c 'file {} | grep -e "ELF.*\(executable\|shared\).*dynamic"' \; \
-         -exec bash -c 'patchelf --set-rpath "\$ORIGIN/$(realpath --relative-to="$(dirname {})" $packdir/lib)" {}' \;
-    sed -i -e 's,/nix/store/[^/]*/lib/,,g' $packdir/lib/libc.so $packdir/lib/libm.so
-    mv $packdir/bin/.mi-wrapped $packdir/bin/mi
-    ln -s gcc $packdir/bin/cc
+         -exec bash -c 'file "{}" | grep -e "ELF.*\(executable\|shared\).*dynamic"' \; \
+         -exec bash -c 'patchelf --set-rpath "\$ORIGIN/$(realpath --relative-to="$(dirname "{}")" "$packdir/lib")" "{}"' \;
+    sed -i -e 's,/nix/store/[^/]*/lib/,,g' "$packdir/lib/libc.so" "$packdir/lib/libm.so"
+    mv "$packdir/bin/.mi-wrapped" "$packdir/bin/mi"
 }
 
 prepare_scripts() {
     echo "Preparing setup and wrapper scripts."
-    cat <<'EOS' > $packdir/mi-setup
+    cat <<'EOS' > "$packdir/mi-setup"
 #!/bin/sh
+set -e
 echo "Setting up bundled Miking for use."
 export SOURCE="$(dirname "$(realpath "$0")")"
 echo "Bundle directory:  $SOURCE"
 export MAGIC="$SOURCE/share/misc/magic.mgc"
-find $SOURCE/bin $SOURCE/libexec -type f \
-     -exec /bin/sh -c '$SOURCE/bin/file {} | $SOURCE/bin/grep -qe "ELF.*executable.*dynamic"' \; \
-     -exec $SOURCE/bin/patchelf \
-     --set-interpreter $SOURCE/lib/ld-linux-x86-64.so.2 {} \;
+find "$SOURCE/bin" "$SOURCE/libexec" -type f \
+     -exec /bin/sh -c '"$SOURCE/bin/file" "{}" | "$SOURCE/bin/grep" -qe "ELF.*executable.*dynamic"' \; \
+     -exec "$SOURCE/bin/patchelf" --set-interpreter "$SOURCE/lib/ld-linux-x86-64.so.2" "{}" \;
 echo "Finished setup."
 EOS
-    cat <<'EOS' > $packdir/mi
+    cat <<'EOS' > "$packdir/mi"
 #!/bin/sh
 SOURCE="$(dirname "$(realpath "$0")")"
 export OCAMLPATH="$SOURCE/lib/ocaml:$SOURCE/lib/ocaml/5.0.0/site-lib"
@@ -91,7 +98,7 @@ unset  OPAM_SWITCH_PREFIX
 unset  LD_LIBRARY_PATH
 exec -a "$0" "$SOURCE/bin/mi" "$@"
 EOS
-    chmod +x $packdir/mi $packdir/mi-setup
+    chmod +x "$packdir/mi" "$packdir/mi-setup"
 }
 
 make_tarball() {
@@ -99,7 +106,7 @@ make_tarball() {
     patch_binaries
     prepare_scripts
     tar -C "$(dirname $packdir)" -czvf miking-pack.tar.gz "$(basename $packdir)"
-    rm -rf $packdir
+    rm -rf "$packdir"
 }
 
 make_tarball

--- a/misc/packaging/miking.nix
+++ b/misc/packaging/miking.nix
@@ -1,10 +1,10 @@
 { lib, stdenv,
   coreutils,
   makeWrapper,
-  ocaml-ng
+  ocamlPackages
 }:
 
-with ocaml-ng.ocamlPackages_5_0;
+with ocamlPackages;
 
 stdenv.mkDerivation rec {
   pname = "miking";


### PR DESCRIPTION
This pull request features updates to the packaging scripts in `misc/packaging`.

- `miking-pack` is renamed to `miking-pack-linux`.
-  A new script `miking-pack-darwin` producing a self-contained tarball for x86_64 or arm64 macOS is added.  The script must be run on the corresponding platform.
- Minor updates and improvements to the scripts.
- Update `misc/packaging/README.md`.