### PR TITLE
0-CFA additions and bug fixes

### DIFF
--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -269,6 +269,13 @@ lang CFA = CFABase
         graph avs
     else graph
 
+  -- Helper function for initializing a constraint for a given name (mainly
+  -- used for convenience in initConstraint)
+  sem initConstraintNames: [IName] -> CFAGraph -> Constraint -> CFAGraph
+  sem initConstraintNames (names: [IName]) (graph: CFAGraph) =
+  | cstr ->
+    foldl (lam graph. lam name. initConstraintName name graph cstr) graph names
+
   sem dataLookup: IName -> CFAGraph -> Set AbsVal
   sem dataLookup (key: IName) =
   | graph -> tensorLinearGetExn graph.data key

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -1503,7 +1503,7 @@ lang TensorOpCFA = CFA + ConstCFA + TensorOpAst + SetCFA
     initConstraint graph (CstrDirect {lhs = get args 0, rhs = res})
 
   | CTensorSubExn _ ->
-    utest length args with 2 in
+    utest length args with 3 in
     initConstraint graph (CstrDirect {lhs = get args 0, rhs = res})
 
 end
@@ -3834,6 +3834,59 @@ utest _test false t ["t1", "t2", "t3", "t4", "t5"] with [
   ("t3", ["x","y"]),
   ("t4", ["x","y"]),
   ("t5", ["x","y"])
+] using eqTestLam in
+
+-- Tensor
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+
+  let t1 = tensorCreateUninitInt [3,3] in
+  let t2 = tensorCreateUninitFloat [3,3] in
+  let t3 = tensorCreateCArrayInt [3,3] (lam i1. 1) in
+  let t4 = tensorCreateCArrayFloat [3,3] (lam f1. 1.0) in
+  let t5 = tensorCreateDense [3,3] (lam x1. f) in
+  let t6 = tensorGetExn t1 [0,0] in
+  let t7 = tensorGetExn t5 [0,0] in
+  let t8 = tensorLinearGetExn t2 0 in
+  let t9 = tensorLinearGetExn t5 0 in
+  let t10 = tensorReshapeExn t5 [1,9] in
+  let t11 = tensorCopy t10 in
+  let t12 = tensorTransposeExn t11 0 1 in
+  let t13 = tensorSliceExn t5 [0] in
+  let t14 = tensorSubExn t5 1 1 in
+  let t15 = tensorShape t14 in
+  let t16 = map (lam x2. g) t15 in
+  let t17 = get t16 0 in
+  let t18 = tensorLinearGetExn t12 0 in
+  let t19 = tensorLinearGetExn t13 0 in
+  let t20 = tensorLinearGetExn t14 0 in
+  ()
+------------------------" in
+utest _test false t
+  ["t1","t2","t3","t4","t5","t6","t7","t8","t9","t10",
+   "t11","t12","t13","t14","t15","t16","t17","t18","t19","t20"]
+with [
+  ("t1",  []),
+  ("t2",  []),
+  ("t3",  []),
+  ("t4",  []),
+  ("t5",  []),
+  ("t6",  []),
+  ("t7",  ["x"]),
+  ("t8",  []),
+  ("t9",  ["x"]),
+  ("t10", []),
+  ("t11", []),
+  ("t12", []),
+  ("t13", []),
+  ("t14", []),
+  ("t15", []),
+  ("t16", []),
+  ("t17", ["y"]),
+  ("t18", ["x"]),
+  ("t19", ["x"]),
+  ("t20", ["x"])
 ] using eqTestLam in
 
 -----------------

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -1428,29 +1428,36 @@ lang RefOpCFA = CFA + ConstCFA + RefOpAst
 
 end
 
--- TODO(dlunde,2021-11-11): Mutability complicates the analysis, but could
--- probably be added.
 lang TensorOpCFA = CFA + ConstCFA + TensorOpAst
   sem generateConstraintsConst info ident =
-  -- | CTensorCreateUninitInt _ -> []
-  -- | CTensorCreateUninitFloat _ -> []
-  -- | CTensorCreateInt _ -> []
-  -- | CTensorCreateFloat _ -> []
-  -- | CTensorCreate _ -> []
-  -- | CTensorGetExn _ -> []
+  -- Contains simple values (int, float), that require no handling for the
+  -- basic analysis.
+  | CTensorCreateUninitInt _ -> []
+  | CTensorCreateUninitFloat _ -> []
+  | CTensorCreateInt _ -> []
+  | CTensorCreateFloat _ -> []
+
+  | CTensorCreate _ -> []
+  | CTensorGetExn _ -> []
+  | CTensorLinearGetExn _ -> []
+  | CTensorReshapeExn _ -> []
+  | CTensorCopy _ -> []
+  | CTensorTransposeExn _ -> []
+  | CTensorSliceExn _ -> []
+  | CTensorSubExn _ -> []
+
+  -- Returns simple values (unit, boolean, string) that require no handling for
+  -- the basic analysis.
+  | CTensorIterSlice _ -> []
+  | CTensorEq _ -> []
+  | CTensorToString _ -> []
+  | CTensorRank _ -> []
+  | CTensorShape _ -> []
+
+  -- TODO(dlunde,2021-11-11): Mutability complicates the analysis, but could
+  -- probably be added.
   -- | CTensorSetExn _ -> []
-  -- | CTensorLinearGetExn _ -> []
   -- | CTensorLinearSetExn _ -> []
-  -- | CTensorRank _ -> []
-  -- | CTensorShape _ -> []
-  -- | CTensorReshapeExn _ -> []
-  -- | CTensorCopy _ -> []
-  -- | CTensorTransposeExn _ -> []
-  -- | CTensorSliceExn _ -> []
-  -- | CTensorSubExn _ -> []
-  -- | CTensorIterSlice _ -> []
-  -- | CTensorEq _ -> []
-  -- | CTensorToString _ -> []
 end
 
 lang BootParserCFA = CFA + ConstCFA + BootParserAst

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -1472,7 +1472,7 @@ lang TensorOpCFA = CFA + ConstCFA + TensorOpAst + SetCFA + AppCFA
   | CTensorCreateInt _ -> 2
   | CTensorCreateFloat _ -> 2
   | CTensorCreate _ -> 2
-  | CTensorIterSlice _ -> 2
+  | CTensorIterSlice _ -> 4
 
   sem generateConstraintsConst graph info ident =
   | ( CTensorCreateUninitInt _
@@ -1528,6 +1528,16 @@ lang TensorOpCFA = CFA + ConstCFA + TensorOpAst + SetCFA + AppCFA
     join [
       appConstraints f i a1,
       [CstrInit { lhs = AVSet {names = setOfSeq subi [a1]}, rhs = res }]
+    ]
+  | CTensorIterSlice _ ->
+    utest length args with 2 in
+    let f = get args 0 in
+    let tensor = get args 1 in
+    match intermediates with [ti,i,a1,empty] in
+    join [
+      [CstrSet {lhs = tensor, rhs = ti}],
+      appConstraints f i a1,
+      appConstraints a1 ti empty
     ]
   | ( CTensorGetExn _
     | CTensorLinearGetExn _ ) ->
@@ -2206,11 +2216,12 @@ let t = _parse "
   let t18 = tensorLinearGetExn t12 0 in
   let t19 = tensorLinearGetExn t13 0 in
   let t20 = tensorLinearGetExn t14 0 in
+  let t21 = tensorIterSlice (lam i. lam e. let t22 = e in ()) t5 in
   ()
 ------------------------" in
 utest _test false t
   ["t1","t2","t3","t4","t5","t6","t7","t8","t9","t10",
-   "t11","t12","t13","t14","t15","t16","t17","t18","t19","t20"]
+   "t11","t12","t13","t14","t15","t16","t17","t18","t19","t20", "t21", "t22"]
 with [
   ("t1",  []),
   ("t2",  []),
@@ -2231,7 +2242,9 @@ with [
   ("t17", ["y"]),
   ("t18", ["x"]),
   ("t19", ["x"]),
-  ("t20", ["x"])
+  ("t20", ["x"]),
+  ("t21", []),
+  ("t22", ["x"])
 ] using eqTestLam in
 
 ()

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -1,8 +1,6 @@
--- CFA framework for MExpr. The language fragment MExprCFA is a specialized
--- implementation for 0-CFA (0 = context insensitive), while the language
--- fragment MExprKCFA performs k-CFA, where k is the number of most recent
--- function calls to consider in the context. The algorithm is loosely based on
--- Table 3.7 in the book "Principles of Program Analysis" (Nielson et al.).
+-- 0-CFA framework for MExpr. The algorithm is loosely
+-- based on Table 3.7 in the book "Principles of Program Analysis" (Nielson et
+-- al.).
 --
 -- Some details:
 -- - Only works on fully labelled terms provided by MExprANFAll (see mexpr/anf.mc).
@@ -85,6 +83,13 @@ lang CFABase = Ast + LetAst + MExprIndex + MExprFreeVars + MExprPrettyPrint
   -- NAME-INTEGER MAPPING --
   --------------------------
 
+  sem name2intAcc: IndexAcc -> Info -> Name -> IName
+  sem name2intAcc ia info =
+  | name ->
+    mapLookupOrElse (lam.
+        errorSingle [info] (concat "name2intAcc failed: " (nameGetStr name))
+      ) name ia.map
+
   sem name2int: IndexMap -> Info -> Name -> IName
   sem name2int im info =
   | name ->
@@ -121,9 +126,8 @@ end
 
 lang CFA = CFABase
 
-  type GenFun = Expr -> [Constraint]
   type MatchGenFun = IName -> IName -> Pat -> [Constraint]
-  type ConstPropFun = IName -> [IName] -> Const -> [Constraint]
+  type ConstPropFun = IName -> [IName] -> [IName] -> Const -> [Constraint]
 
   type CFAGraph = {
 
@@ -158,21 +162,38 @@ lang CFA = CFABase
 
   }
 
-  sem emptyCFAGraph: Expr -> CFAGraph
-  sem emptyCFAGraph =
+  -- Used during CFAGraph construction
+  type CFAGraphInit = {
+    mcgfs: [MatchGenFun],
+    cpfs: [ConstPropFun],
+    cstrs: [Constraint],
+    ia: IndexAcc
+  }
+
+  type GenFun = CFAGraphInit -> Expr -> CFAGraphInit
+
+  sem emptyCFAGraphInit: Expr -> CFAGraphInit
+  sem emptyCFAGraphInit =
+  | t -> { mcgfs = [], cpfs = [], cstrs = [], ia = indexAccGen t }
+
+  sem finalizeCFAGraphInit: CFAGraphInit -> CFAGraph
+  sem finalizeCFAGraphInit =
   | t ->
     -- NOTE(Linnea,2022-06-22): Experiments have shown that lists are better
     -- than ropes for 'worklist' and 'edges', especially for 'worklist'
-    let im = indexGen t in
+    let im = indexClose t.ia in
     let shape = tensorShape im.int2name in
     let elist = toList [] in
-    { worklist = elist,
+    let graph = { worklist = elist,
       data = tensorCreateDense shape (lam. setEmpty cmpAbsVal),
       edges = tensorCreateDense shape (lam. setEmpty cmpConstraint),
-      mcgfs = [],
-      cpfs = [],
+      mcgfs = t.mcgfs,
+      cpfs = t.cpfs,
       im = im,
-      graphData = None () }
+      graphData = None () } in
+    let graph = foldl initConstraint graph t.cstrs in
+    graph
+
 
   -- This function converts the data-flow result into a map, which might be more
   -- convenient to operate on for later analysis steps.
@@ -184,9 +205,12 @@ lang CFA = CFABase
       ) (mapEmpty nameCmp) graph.data
 
   -- Main algorithm
-  sem solveCfa: CFAGraph -> CFAGraph
+  sem solveCfa: CFAGraphInit -> CFAGraph
   sem solveCfa =
   | graph ->
+    -- Finalize graph
+    let graph = finalizeCFAGraphInit graph in
+
     -- Iteration
     recursive let iter = lam graph: CFAGraph.
       if null graph.worklist then graph
@@ -200,13 +224,17 @@ lang CFA = CFABase
     iter graph
 
   -- Main algorithm (debug version)
-  sem solveCfaDebug : PprintEnv -> CFAGraph -> (PprintEnv, CFAGraph)
+  sem solveCfaDebug : PprintEnv -> CFAGraphInit -> (PprintEnv, CFAGraph)
   sem solveCfaDebug pprintenv =
   | graph ->
     -- NOTE(Linnea,2022-06-22): Experiments have shown that using `cfaDebug` as
     -- the main entry point causes overhead when no printing takes place, as we
     -- have to match on the pprintenv in every iteration. Therefore, some code
     -- duplication takes place here.
+
+    -- Finalize graph
+    let graph = finalizeCFAGraphInit graph in
+
     let printGraph = lam pprintenv. lam graph. lam str.
       match cfaGraphToString pprintenv graph with (pprintenv, graph) in
       printLn (join ["\n--- ", str, " ---"]);
@@ -230,17 +258,17 @@ lang CFA = CFABase
 
   -- Base constraint generation function (must still be included manually in
   -- constraintGenFuns)
-  sem generateConstraints: IndexMap -> Expr -> [Constraint]
-  sem generateConstraints im =
-  | t -> []
+  sem generateConstraints: GenFun
+  sem generateConstraints graph =
+  | t -> graph
 
   -- Call a set of constraint generation functions on each term in program.
   -- Useful when defining values of type CFAGraph.
-  sem collectConstraints: [GenFun] -> [Constraint] -> Expr -> [Constraint]
-  sem collectConstraints (cgfs: [GenFun]) (acc: [Constraint]) =
+  sem collectConstraints: [GenFun] -> CFAGraphInit -> Expr -> CFAGraphInit
+  sem collectConstraints (cgfs: [GenFun]) (graph: CFAGraphInit) =
   | t ->
-    let acc = foldl (lam acc. lam f. concat (f t) acc) acc cgfs in
-    sfold_Expr_Expr (collectConstraints cgfs) acc t
+    let graph = foldl (lam graph. lam f. f graph t) graph cgfs in
+    sfold_Expr_Expr (collectConstraints cgfs) graph t
 
   sem initConstraint: CFAGraph -> Constraint -> CFAGraph
 
@@ -444,12 +472,13 @@ end
 
 lang VarCFA = CFA + BaseConstraint + VarAst
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmLet { ident = ident, body = TmVar t, info = info } ->
-    [ CstrDirect {
-        lhs = name2int im t.info t.ident,
-        rhs = name2int im info ident
-      } ]
+    let cstr = CstrDirect {
+      lhs = name2intAcc graph.ia t.info t.ident,
+      rhs = name2intAcc graph.ia info ident
+    } in
+    { graph with cstrs = cons cstr graph.cstrs }
 
   sem exprName =
   | TmVar t -> t.ident
@@ -468,13 +497,14 @@ lang LamCFA = CFA + BaseConstraint + LamAst
      let diff = subi lhs rhs in
      if eqi diff 0 then subi lbody rbody else diff
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmLet { ident = ident, body = TmLam t, info = info } ->
     let av: AbsVal = AVLam {
-      ident = name2int im t.info t.ident,
-      body = name2int im (infoTm t.body) (exprName t.body)
+      ident = name2intAcc graph.ia t.info t.ident,
+      body = name2intAcc graph.ia (infoTm t.body) (exprName t.body)
     } in
-    [ CstrInit { lhs = av, rhs = name2int im info ident } ]
+    let cstr = CstrInit { lhs = av, rhs = name2intAcc graph.ia info ident } in
+    { graph with cstrs = cons cstr graph.cstrs }
 
   sem absValToString im (env: PprintEnv) =
   | AVLam { ident = ident, body = body } ->
@@ -493,17 +523,19 @@ lang RecLetsCFA = CFA + LamCFA + RecLetsAst
   sem exprName =
   | TmRecLets t -> exprName t.inexpr
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmRecLets { bindings = bindings } ->
-    map (lam b: RecLetBinding.
-      match b.body with TmLam t then
-        let av: AbsVal = AVLam {
-          ident = name2int im t.info t.ident,
-          body = name2int im (infoTm t.body) (exprName t.body)
-        } in
-        CstrInit { lhs = av, rhs = name2int im b.info b.ident }
-      else errorSingle [infoTm b.body] "Not a lambda in recursive let body"
-    ) bindings
+    let cstrs = map (lam b: RecLetBinding.
+        match b.body with TmLam t then
+          let av: AbsVal = AVLam {
+            ident = name2intAcc graph.ia t.info t.ident,
+            body = name2intAcc graph.ia (infoTm t.body) (exprName t.body)
+          } in
+          CstrInit { lhs = av, rhs = name2intAcc graph.ia b.info b.ident }
+        else errorSingle [infoTm b.body] "Not a lambda in recursive let body"
+      ) bindings
+    in
+    { graph with cstrs = concat cstrs graph.cstrs }
 
 end
 
@@ -514,32 +546,65 @@ lang ConstCFA = CFA + ConstAst + BaseConstraint + Cmp
   -- arguments applied to it. It also includes the `let` name that binds the
   -- constant and syntactically distinguishes it from other of its kind in the
   -- program.
-  | AVConst { id: IName, const: Const, args: [IName] }
+  --
+  -- The `intermediates` sequence stores internal generated names used to
+  -- implement higher-order constants such as foldl and map. The intermediates
+  -- sequence is empty for all non-higher-order constants.
+  | AVConst { id: IName, const: Const, args: [IName], intermediates: [IName] }
 
   sem absValToString im (env: PprintEnv) =
-  | AVConst { id = id, const = const, args = args } ->
+  | AVConst { id = id, const = const, args = args, intermediates = intermediates } ->
     let const = getConstStringCode 0 const in
     match mapAccumL (pprintVarIName im) env args with (env,args) in
     let args = strJoin ", " args in
     match pprintVarIName im env id with (env,id) in
-    (env, join [const,"<", id, ">", "(", args, ")"])
+    match mapAccumL (pprintVarIName im) env intermediates with (env,intermediates) in
+    (env, join [const,"<", id, ">", "(", args, ")",
+                if null intermediates then "" else
+                  join ["[", strJoin ", " intermediates, "]"]])
 
   sem cmpAbsValH =
   | (AVConst lhs, AVConst rhs) ->
     let cmp = cmpConst lhs.const rhs.const in
     if eqi 0 cmp then
       let ncmp = subi lhs.id rhs.id in
-      if eqi 0 ncmp then seqCmp subi lhs.args rhs.args
+      if eqi 0 ncmp then
+        let acmp = seqCmp subi lhs.args rhs.args in
+        if eqi 0 acmp then seqCmp subi lhs.intermediates rhs.intermediates
+        else acmp
       else ncmp
     else cmp
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmLet { ident = ident, body = TmConst t, info = info } ->
-    generateConstraintsConst t.info (name2int im info ident) t.val
+    generateConstraintsConst graph t.info (name2intAcc graph.ia info ident) t.val
 
-  sem generateConstraintsConst: Info -> IName -> Const -> [Constraint]
-  sem generateConstraintsConst info ident =
+  sem generateConstraintsConst: CFAGraphInit -> Info
+                                -> IName -> Const -> CFAGraphInit
+  sem generateConstraintsConst graph info ident =
   | _ -> errorSingle [info] "Constant not supported in CFA"
+
+  sem numConstIntermediates: Const -> Int
+  sem numConstIntermediates =
+  | _ -> 0
+
+  sem addNewConst: CFAGraphInit -> IName -> Const -> CFAGraphInit
+  sem addNewConst graph ident =
+  | const ->
+    let intermediates =
+      create (numConstIntermediates const) (lam. nameSym "_intrm_") in
+    match mapAccumL addKeyGet graph.ia intermediates with (ia, intermediates) in
+    let cstr = CstrInit {
+      lhs = AVConst {
+        id = ident,
+        const = const,
+        args = [],
+        intermediates = intermediates
+      },
+      rhs = ident
+    } in
+    { graph with cstrs = cons cstr graph.cstrs, ia = ia }
+
 end
 
 lang AppCFA = CFA + ConstCFA + BaseConstraint + LamCFA + AppAst + MExprArity
@@ -581,13 +646,15 @@ lang AppCFA = CFA + ConstCFA + BaseConstraint + LamCFA + AppAst + MExprArity
       initConstraint graph (CstrDirect { lhs = b, rhs = res })
     else graph
   | CstrConstApp { lhs = lhs, rhs = rhs, res = res } ->
-    match update.1 with AVConst ({ const = const, args = args } & avc) then
-      let arity = constArity const in
-      let args = snoc args rhs in
+    match update.1 with AVConst avc then
+      let arity = constArity avc.const in
+      let args = snoc avc.args rhs in
       if eqi arity (length args) then
         -- Last application, call constant propagation functions
         let cstrs =
-          foldl (lam acc. lam p. concat (p res args const) acc) [] graph.cpfs
+          foldl (lam acc. lam p.
+                   concat (p res args avc.intermediates avc.const) acc)
+            [] graph.cpfs
         in
         foldl initConstraint graph cstrs
       else
@@ -609,20 +676,25 @@ lang AppCFA = CFA + ConstCFA + BaseConstraint + LamCFA + AppAst + MExprArity
         ">const< >args< ⊆ ", lhs, " ⇒ ", ">const< >args< ", rhs, " ⊆ ", res
       ])
 
-  sem generateConstraints im =
+  sem appConstraints lhs rhs =
+  | res -> [
+      CstrLamApp {lhs = lhs, rhs = rhs, res = res},
+      CstrConstApp {lhs = lhs, rhs = rhs, res = res}
+    ]
+
+  sem generateConstraints graph =
   | TmLet { ident = ident, body = TmApp app, info = info} ->
     match app.lhs with TmVar l then
       match app.rhs with TmVar r then
-        let lhs = name2int im l.info l.ident in
-        let rhs = name2int im r.info r.ident in
-        let res = name2int im info ident in
-        [ CstrLamApp {lhs = lhs, rhs = rhs,res = res},
-          CstrConstApp {lhs = lhs, rhs = rhs,res = res}
-        ]
+        let lhs = name2intAcc graph.ia l.info l.ident in
+        let rhs = name2intAcc graph.ia r.info r.ident in
+        let res = name2intAcc graph.ia info ident in
+        let cstrs = appConstraints lhs rhs res in
+        { graph with cstrs = concat cstrs graph.cstrs }
       else errorSingle [infoTm app.rhs] "Not a TmVar in application"
     else errorSingle [infoTm app.lhs] "Not a TmVar in application"
 
-  sem propagateConstraintConst : ConstPropFun
+  sem propagateConstraintConst: ConstPropFun
 end
 
 lang RecordCFA = CFA + BaseConstraint + RecordAst
@@ -656,22 +728,25 @@ lang RecordCFA = CFA + BaseConstraint + RecordAst
   sem initConstraint (graph: CFAGraph) =
   | CstrRecordUpdate r & cstr -> initConstraintName r.lhs graph cstr
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmLet { ident = ident, body = TmRecord t, info = info } ->
     let bindings = mapMap (lam v: Expr.
-        match v with TmVar t then name2int im t.info t.ident
+        match v with TmVar t then name2intAcc graph.ia t.info t.ident
         else errorSingle [infoTm v] "Not a TmVar in record"
       ) t.bindings
     in
     let av: AbsVal = AVRec { bindings = bindings } in
-    [ CstrInit { lhs = av, rhs = name2int im info ident } ]
+    let cstr = CstrInit { lhs = av, rhs = name2intAcc graph.ia info ident }  in
+    { graph with cstrs = cons cstr graph.cstrs }
+
   | TmLet { ident = ident, body = TmRecordUpdate t, info = info } ->
     match t.rec with TmVar vrec then
       match t.value with TmVar vval then
-        let lhs = name2int im vrec.info vrec.ident in
-        let val = name2int im vval.info vval.ident in
-        let ident = name2int im info ident in
-        [ CstrRecordUpdate { lhs = lhs, key = t.key, val = val, rhs = ident } ]
+        let lhs = name2intAcc graph.ia vrec.info vrec.ident in
+        let val = name2intAcc graph.ia vval.info vval.ident in
+        let ident = name2intAcc graph.ia info ident in
+        let cstr = CstrRecordUpdate { lhs = lhs, key = t.key, val = val, rhs = ident } in
+        { graph with cstrs = cons cstr graph.cstrs }
       else errorSingle [t.info] "Not a TmVar in record update"
     else errorSingle [t.info] "Not a TmVar in record update"
 
@@ -727,41 +802,6 @@ lang SetCFA = CFA + LamCFA
   -- [{names}] ∈ lhs ⇒ [{names} ∪ {rhs}] ⊆ res
   | CstrSetUnion {lhs : IName, rhs : IName, res : IName}
 
-  -- [{names}] ∈ seq ⇒
-  --   ({lam x. b} ⊆ f ⇒ (names ⊆ x and [{b}] ∈ res))
-  | CstrSetMap1 {seq: IName,       f: IName, res: IName}
-  | CstrSetMap2 {names: Set IName, f: IName, res: IName}
-
-  -- {lam _. b} ⊆ f ⇒
-  --   ([{names}] ∈ seq ⇒
-  --     ({lam y. c} ⊆ b ⇒ (names ⊆ y and [{c}] ∈ res)))
-  | CstrSetMapi {seq: IName, f: IName, res: IName}
-
-  -- [{names}] ∈ seq ⇒
-  --   ({lam x. b} ⊆ f ⇒ names ⊆ x)
-  | CstrSetIter1 {seq: IName,       f: IName}
-  | CstrSetIter2 {names: Set IName, f: IName}
-
-  -- {lam _. b} ⊆ f ⇒
-  --   ([{names}] ∈ seq ⇒
-  --     ({lam y. c} ⊆ b ⇒ names ⊆ y))
-  | CstrSetIteri {seq: IName,       f: IName}
-
-  -- CstrSetFold<n> constraints implement foldl when left = true, and foldr
-  -- otherwise
-  -- l: [{names}] ∈ seq ⇒
-  --      ({lam x. b} ⊆ f ⇒
-  --        (acc ⊆ x and ({lam y. c} ⊆ b ⇒
-  --          (names ⊆ y and c ⊆ res and c ⊆ x ))))
-  -- r: [{names}] ∈ seq ⇒
-  --      ({lam x. b} ⊆ f ⇒
-  --        (names ⊆ x and ({lam y. c} ⊆ b ⇒
-  --          (acc ⊆ y and c ⊆ res and c ⊆ y ))))
-  | CstrSetFold1 {left: Bool, seq:   IName,     f: IName,  acc: IName, res: IName}
-  | CstrSetFold2 {left: Bool, names: Set IName, f: IName,  acc: IName, res: IName}
-  | CstrSetFold3 {left: Bool, names: Set IName, f: AbsVal, acc: IName, res: IName}
-
-
   sem cmpConstraintH =
   | (CstrSet { lhs = lhs1, rhs = rhs1 },
      CstrSet { lhs = lhs2, rhs = rhs2 }) ->
@@ -776,104 +816,10 @@ lang SetCFA = CFA + LamCFA
        if eqi d 0 then subi rhs1 rhs2
        else d
      else d
-  | (CstrSetMap1 { seq = seq1, f = f1, res = res1 },
-     CstrSetMap1 { seq = seq2, f = f2, res = res2 }) ->
-     let d = subi res1 res2 in
-     if eqi d 0 then
-       let d = subi seq1 seq2 in
-       if eqi d 0 then subi f1 f2
-       else d
-     else d
-  | (CstrSetMap2 { f = f1, names = names1, res = res1 },
-     CstrSetMap2 { f = f2, names = names2, res = res2 }) ->
-     let d = subi res1 res2 in
-     if eqi d 0 then
-       let d = subi f1 f2 in
-       if eqi d 0 then setCmp names1 names2
-       else d
-     else d
-  | (CstrSetMapi { seq = seq1, f = f1, res = res1 },
-     CstrSetMapi { seq = seq2, f = f2, res = res2 }) ->
-     let d = subi seq1 seq2 in
-     if eqi d 0 then
-       let d = subi f1 f2 in
-       if eqi d 0 then subi res1 res2
-       else d
-     else d
-  | (CstrSetIter1 { seq = seq1, f = f1 },
-     CstrSetIter1 { seq = seq2, f = f2 }) ->
-     let d = subi seq1 seq2 in
-     if eqi d 0 then
-       subi f1 f2
-     else d
-  | (CstrSetIter2 { f = f1, names = names1 },
-     CstrSetIter2 { f = f2, names = names2 }) ->
-     let d = subi f1 f2 in
-     if eqi d 0 then
-       setCmp names1 names2
-     else d
-  | (CstrSetIteri { seq = seq1, f = f1 },
-     CstrSetIteri { seq = seq2, f = f2 }) ->
-     let d = subi seq1 seq2 in
-     if eqi d 0 then
-       subi f1 f2
-     else d
-  | (CstrSetFold1 { left = l1, seq = seq1, f = f1, acc = acc1, res = res1},
-     CstrSetFold1 { left = l2, seq = seq2, f = f2, acc = acc2, res = res2}) ->
-     let d = subi res1 res2 in
-     if eqi d 0 then
-       let d = subi seq1 seq2 in
-       if eqi d 0 then
-         let d = subi acc1 acc2 in
-         if eqi d 0 then
-           let d = subi f1 f2 in
-           if eqi d 0 then cmpBool l1 l2
-           else d
-         else d
-       else d
-     else d
-  | (CstrSetFold2 { left = l1, names = names1, f = f1, acc = acc1, res = res1 },
-     CstrSetFold2 { left = l2, names = names2, f = f2, acc = acc2, res = res2 }) ->
-     let d = subi res1 res2 in
-     if eqi d 0 then
-       let d = subi acc1 acc2 in
-       if eqi d 0 then
-         let d = subi f1 f2 in
-         if eqi d 0 then
-           let d = setCmp names1 names2 in
-           if eqi d 0 then cmpBool l1 l2
-           else d
-         else d
-       else d
-     else d
-  | (CstrSetFold3 { left = l1, names = names1, f = f1, acc = acc1, res = res1 },
-     CstrSetFold3 { left = l2, names = names2, f = f2, acc = acc2, res = res2 }) ->
-     let d = subi res1 res2 in
-     if eqi d 0 then
-       let d = subi acc1 acc2 in
-       if eqi d 0 then
-         let d = cmpAbsVal f1 f2 in
-         if eqi d 0 then
-           let d = setCmp names1 names2 in
-           if eqi d 0 then cmpBool l1 l2
-           else d
-         else d
-       else d
-     else d
 
   sem initConstraint (graph: CFAGraph) =
   | CstrSet r & cstr -> initConstraintName r.lhs graph cstr
   | CstrSetUnion r & cstr -> initConstraintName r.lhs graph cstr
-  | CstrSetMap1 r & cstr -> initConstraintName r.seq graph cstr
-  | CstrSetMap2 r & cstr -> initConstraintName r.f graph cstr
-  | CstrSetMapi r & cstr -> initConstraintName r.f graph cstr
-  | CstrSetIter1 r & cstr -> initConstraintName r.seq graph cstr
-  | CstrSetIter2 r & cstr -> initConstraintName r.f graph cstr
-  | CstrSetIteri r & cstr -> initConstraintName r.f graph cstr
-  | CstrSetFold1 r & cstr -> initConstraintName r.seq graph cstr
-  | CstrSetFold2 r & cstr -> initConstraintName r.f graph cstr
-  | CstrSetFold3 { f = AVLam { ident = x, body = b } } & cstr ->
-    initConstraintName b graph cstr
 
   sem constraintToString im (env: PprintEnv) =
   | CstrSet { lhs = lhs, rhs = rhs } ->
@@ -887,85 +833,6 @@ lang SetCFA = CFA + LamCFA
     (env, join [
         "[{names}] ∈ ", lhs, " ⇒ [{names} ∪ { ", rhs," }] ⊆ ", res
       ])
-  | CstrSetMap1 { seq = seq, f = f, res = res } ->
-    match pprintVarIName im env seq with (env,seq) in
-    match pprintVarIName im env f with (env,f) in
-    match pprintVarIName im env res with (env,res) in
-    (env, join [
-        "[{names}] ∈ ", seq, " ⇒ ({lam x. b} ⊆ ", f, " ⇒ (names ⊆ x and [{b}] ∈ ", res, "))"
-      ])
-  | CstrSetMap2 { f = f, names = names, res = res } ->
-    match pprintVarIName im env f with (env,f) in
-    match mapAccumL (pprintVarIName im) env (setToSeq names) with (env,names) in
-    let names = join ["{", strJoin ", " names, "}"] in
-    match pprintVarIName im env res with (env,res) in
-    (env, join [
-        "{lam x. b} ⊆ ", f, " ⇒ (", names, " ⊆ x and [{b}] ∈ ", res, ")"
-      ])
-  | CstrSetMapi { seq = seq, f = f, res = res } ->
-    match pprintVarIName im env seq with (env,seq) in
-    match pprintVarIName im env f with (env,f) in
-    match pprintVarIName im env res with (env,res) in
-    (env, join [
-        "[{names}] ∈ ", seq, " ⇒ ({lam _. b} ⊆ ", f, " ⇒ ({lam y. c} ⊆ b ⇒ (names ⊆ y and [{c}] ∈ ", res, ")))"
-      ])
-  | CstrSetIter1 { seq = seq, f = f } ->
-    match pprintVarIName im env seq with (env,seq) in
-    match pprintVarIName im env f with (env,f) in
-    (env, join [
-        "[{names}] ∈ ", seq, " ⇒ ({lam x. b} ⊆ ", f, " ⇒ names ⊆ x)"
-      ])
-  | CstrSetIter2 { f = f, names = names } ->
-    match pprintVarIName im env f with (env,f) in
-    match mapAccumL (pprintVarIName im) env (setToSeq names) with (env,names) in
-    let names = join ["{", strJoin ", " names, "}"] in
-    (env, join [
-        "{lam x. b} ⊆ ", f, " ⇒ ", names, " ⊆ x"
-      ])
-  | CstrSetIteri { seq = seq, f = f } ->
-    match pprintVarIName im env seq with (env,seq) in
-    match pprintVarIName im env f with (env,f) in
-    (env, join [
-        "[{names}] ∈ ", seq, " ⇒ ({lam _. b} ⊆ ", f, " ⇒ ({lam y. c} ⊆ b ⇒ names ⊆ y))"
-      ])
-  | CstrSetFold1 { left = left, seq = seq, f = f, acc = acc, res = res} ->
-    match pprintVarIName im env seq with (env,seq) in
-    match pprintVarIName im env f with (env,f) in
-    match pprintVarIName im env acc with (env,acc) in
-    match pprintVarIName im env res with (env,res) in
-    (env,
-      if left then join [
-        "[{names}] ∈ ", seq, " ⇒ ({lam x. b} ⊆ ", f, " ⇒ (", acc, " ⊆ x and ({lam y. c} ⊆ b ⇒ (names ⊆ y and c ⊆ ", res, " and c ⊆ x ))))"
-      ] else join [
-        "[{names}] ∈ ", seq, " ⇒ ({lam x. b} ⊆ ", f, " ⇒ (names ⊆ x and ({lam y. c} ⊆ b ⇒ (", acc, " ⊆ y and c ⊆ ", res, " and c ⊆ y ))))"
-      ])
-
-  | CstrSetFold2 { left = left, names = names, f = f, acc = acc, res = res } ->
-    match mapAccumL (pprintVarIName im) env (setToSeq names) with (env,names) in
-    let names = join ["{", strJoin ", " names, "}"] in
-    match pprintVarIName im env f with (env,f) in
-    match pprintVarIName im env acc with (env,acc) in
-    match pprintVarIName im env res with (env,res) in
-    (env,
-      if left then join [
-        "{lam x. b} ⊆ ", f, " ⇒ (", acc, " ⊆ x and ({lam y. c} ⊆ b ⇒ (", names, " ⊆ y and c ⊆ ", res, " and c ⊆ x )))"
-      ] else join [
-        "{lam x. b} ⊆ ", f, " ⇒ (", names, " ⊆ x and ({lam y. c} ⊆ b ⇒ (", acc, " ⊆ y and c ⊆ ", res, " and c ⊆ y )))"
-      ])
-  | CstrSetFold3 { left = left, names = names,
-                   f = AVLam { ident = x, body = b }, acc = acc, res = res } ->
-    match mapAccumL (pprintVarIName im) env (setToSeq names) with (env,names) in
-    let names = join ["{", strJoin ", " names, "}"] in
-    match pprintVarIName im env x with (env,x) in
-    match pprintVarIName im env b with (env,b) in
-    match pprintVarIName im env acc with (env,acc) in
-    match pprintVarIName im env res with (env,res) in
-    (env,
-      if left then join [
-        "{lam y. c} ⊆ ", b, " ⇒ (", names, " ⊆ y and c ⊆ ", res, " and c ⊆ ", x, ")"
-      ] else join [
-        "{lam y. c} ⊆ ", b, " ⇒ (", acc, " ⊆ y and c ⊆ ", res, " and c ⊆ y)"
-      ])
 
   sem propagateConstraint (update: (IName,AbsVal)) (graph: CFAGraph) =
   | CstrSet { lhs = lhs, rhs = rhs } ->
@@ -978,99 +845,21 @@ lang SetCFA = CFA + LamCFA
     match update.1 with AVSet { names = names } then
       addData graph (AVSet {names = setInsert rhs names}) res
     else graph
-  | CstrSetMap1 { seq = seq, f = f, res = res } ->
-    match update.1 with AVSet { names = names } then
-      initConstraint graph (CstrSetMap2 { f = f, names = names, res = res })
-    else graph
-  | CstrSetMap2 { f = f, names = names, res = res } ->
-    match update.1 with AVLam { ident = x, body = b } then
-      -- Add names ⊆ x constraints
-      let graph = setFold (lam graph. lam n.
-          initConstraint graph (CstrDirect { lhs = n, rhs = x })
-        ) graph names in
-      -- Add [{b}] ⊆ res constraint
-      initConstraint graph (
-        CstrInit { lhs = AVSet {names = setOfSeq subi [b]}, rhs = res })
-    else graph
-  | CstrSetMapi { seq = seq, f = f, res = res } ->
-    match update.1 with AVLam { ident = _, body = b } & f then
-      initConstraint graph (CstrSetMap1 { seq = seq, f = b, res = res})
-    else graph
-  | CstrSetIter1 { seq = seq, f = f } ->
-    match update.1 with AVSet { names = names } then
-      initConstraint graph (CstrSetIter2 { f = f, names = names })
-    else graph
-  | CstrSetIter2 { f = f, names = names } ->
-    match update.1 with AVLam { ident = x, body = b } then
-      -- Add names ⊆ x constraints
-      setFold (lam graph. lam n.
-          initConstraint graph (CstrDirect { lhs = n, rhs = x })
-        ) graph names
-    else graph
-  | CstrSetIteri { seq = seq, f = f } ->
-    match update.1 with AVLam { ident = _, body = b } & f then
-      initConstraint graph (CstrSetIter1 { seq = seq, f = b })
-    else graph
-  | CstrSetFold1 { left = left, seq = seq, f = f, acc = acc, res = res } ->
-    match update.1 with AVSet { names = names } then
-      initConstraint graph (
-        CstrSetFold2 {
-          left = left, names = names, f = f, acc = acc, res = res, left = left
-        }
-      )
-    else graph
-  | CstrSetFold2 { left = true, names = names, f = f, acc = acc, res = res } ->
-    match update.1 with AVLam { ident = x, body = b } & f then
-      -- Add acc ⊆ x constraint
-      let graph = initConstraint graph (CstrDirect { lhs = acc, rhs = x }) in
-      initConstraint graph
-        (CstrSetFold3 {left = true, names = names, f = f, acc = acc, res = res})
-    else graph
-  | CstrSetFold2 { left = false, names = names, f = f, acc = acc, res = res } ->
-    match update.1 with AVLam { ident = x, body = b } & f then
-      -- Add names ⊆ x constraint
-      let graph = setFold (lam graph. lam n.
-          initConstraint graph (CstrDirect { lhs = n, rhs = x })
-        ) graph names in
-      initConstraint graph
-        (CstrSetFold3 {left = false, names = names, f = f, acc = acc, res = res})
-    else graph
-  | CstrSetFold3 { left = true, names = names,
-                   f = AVLam { ident = x, body = b }, acc = acc, res = res } ->
-    match update.1 with AVLam { ident = y, body = c } then
-      -- Add names ⊆ y constraints
-      let graph = setFold (lam graph. lam n.
-          initConstraint graph (CstrDirect { lhs = n, rhs = y })
-        ) graph names in
-      -- Add c ⊆ res constraint
-      let graph = initConstraint graph (CstrDirect { lhs = c, rhs = res }) in
-      -- Add c ⊆ x constraint
-      initConstraint graph (CstrDirect { lhs = c, rhs = x })
-    else graph
-  | CstrSetFold3 { left = false, names = names,
-                   f = _, acc = acc, res = res } ->
-    match update.1 with AVLam { ident = y, body = c } then
-      -- Add acc ⊆ y constraint
-      let graph = initConstraint graph (CstrDirect { lhs = acc, rhs = y }) in
-      -- Add c ⊆ res constraint
-      let graph = initConstraint graph (CstrDirect { lhs = c, rhs = res }) in
-      -- Add c ⊆ y constraint
-      initConstraint graph (CstrDirect { lhs = c, rhs = y })
-    else graph
 
 end
 
 lang SeqCFA = CFA + BaseConstraint + SetCFA + SeqAst
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmLet { ident = ident, body = TmSeq t, info = info } ->
     let names = foldl (lam acc: [IName]. lam t: Expr.
       match t with TmVar t then
-        cons (name2int im t.info t.ident) acc
+        cons (name2intAcc graph.ia t.info t.ident) acc
       else acc) [] t.tms
     in
     let av: AbsVal = AVSet { names = setOfSeq subi names } in
-    [ CstrInit { lhs = av, rhs = name2int im info ident } ]
+    let cstr = CstrInit { lhs = av, rhs = name2intAcc graph.ia info ident } in
+    { graph with cstrs = cons cstr graph.cstrs }
 
 end
 
@@ -1090,13 +879,14 @@ lang DataCFA = CFA + BaseConstraint + DataAst
     let idiff = subi ilhs irhs in
     if eqi idiff 0 then subi blhs brhs else idiff
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmLet { ident = ident, body = TmConApp t, info = info } ->
     let body =
-      match t.body with TmVar v then name2int im v.info v.ident
+      match t.body with TmVar v then name2intAcc graph.ia v.info v.ident
       else errorSingle [infoTm t.body] "Not a TmVar in con app" in
-    let av: AbsVal = AVCon { ident = name2int im t.info t.ident, body = body } in
-    [ CstrInit { lhs = av, rhs = name2int im info ident } ]
+    let av: AbsVal = AVCon { ident = name2intAcc graph.ia t.info t.ident, body = body } in
+    let cstr = CstrInit { lhs = av, rhs = name2intAcc graph.ia info ident }  in
+    { graph with cstrs = cons cstr graph.cstrs }
 
   sem absValToString im (env: PprintEnv) =
   | AVCon { ident = ident, body = body } ->
@@ -1142,26 +932,29 @@ lang MatchCFA = CFA + BaseConstraint + MatchAst + MExprCmp
     match pprintVarIName im env target with (env, target) in
     (env, join [id, ": match ", target, " with ", pat])
 
-  sem generateConstraintsMatch: IndexMap -> [MatchGenFun] -> Expr -> [Constraint]
-  sem generateConstraintsMatch im (mcgfs: [MatchGenFun]) =
-  | _ -> []
+  sem generateConstraintsMatch: GenFun
+  sem generateConstraintsMatch graph =
+  | _ -> graph
   | TmLet { ident = ident, body = TmMatch t, info = info } ->
-    let thn = name2int im (infoTm t.thn) (exprName t.thn) in
-    let els = name2int im (infoTm t.els) (exprName t.els) in
-    let ident = name2int im info ident in
+    let thn = name2intAcc graph.ia (infoTm t.thn) (exprName t.thn) in
+    let els = name2intAcc graph.ia (infoTm t.els) (exprName t.els) in
+    let ident = name2intAcc graph.ia info ident in
     let cstrs = [
       CstrDirect { lhs = thn, rhs = ident },
       CstrDirect { lhs = els, rhs = ident }
     ] in
+    let graph = { graph with cstrs = concat cstrs graph.cstrs } in
     match t.target with TmVar tv then
-      foldl (lam acc. lam f.
-          concat (f ident (name2int im tv.info tv.ident) t.pat) acc
-        ) cstrs mcgfs
+      foldl (lam graph. lam f.
+          let cstrs = (f ident (name2intAcc graph.ia tv.info tv.ident) t.pat) in
+          { graph with cstrs = concat cstrs graph.cstrs }
+        ) graph graph.mcgfs
     else errorSingle [infoTm t.target] "Not a TmVar in match target"
 
   sem generateMatchConstraints: MatchGenFun
-  sem generateMatchConstraints (id: IName) (target: IName) =
-  | pat -> [ CstrMatch { id = id, pat = pat, target = target } ]
+  sem generateMatchConstraints id target =
+  | pat ->
+    [CstrMatch { id = id, pat = pat, target = target }]
 
 end
 
@@ -1187,6 +980,11 @@ lang ExtCFA = CFA + ExtAst
   -- the original external definition is quite clunky. Maybe we can
   -- incorporate the fact that externals are always fully applied into the
   -- analysis somehow?
+  -- NOTE(2023-07-12,dlunde): Do we have higher-order externals and/or
+  -- externals returning functions (or constant functions) in Miking? If so,
+  -- I'm not sure how we should handle that (seems very difficult to have some
+  -- general mechanism for this). For now, we assume that externals are never
+  -- higher-order and do not return functions (or constant functions).
   | AVExt { ext: IName, arity: Int, args: [IName] }
 
   sem absValToString im (env: PprintEnv) =
@@ -1242,19 +1040,19 @@ lang ExtCFA = CFA + ExtAst
   -- from `let`s immediately following externals. These `let`s are generated by
   -- the ANF transform and define eta expanded versions of the externals (so
   -- that they can be curried).
-  sem collectConstraints cgfs acc =
+  sem collectConstraints cgfs graph =
   | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } & t ->
-    let acc = foldl (lam acc. lam f. concat (f t) acc) acc cgfs in
-    collectConstraints cgfs acc inexpr
+    let graph = foldl (lam acc. lam f. f graph t) graph cgfs in
+    collectConstraints cgfs graph inexpr
 
-  sem generateConstraints im =
+  sem generateConstraints graph =
   | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
     -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
     -- for externals. Similarly to constants, we probably want to delegate to
     -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
     -- not clear where the `generateConstraintsExts` function should be defined.
     --
-    []
+    graph
 
   sem exprName =
   -- Skip the eta expanded let added by ANF,
@@ -1275,112 +1073,126 @@ end
 -- 2. Implement 'propagateConstraintConst' for the constant.
 
 lang IntCFA = CFA + ConstCFA + IntAst
-  sem generateConstraintsConst info ident =
-  | CInt _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CInt _ -> graph
 end
 
 lang ArithIntCFA = CFA + ConstCFA + ArithIntAst
-  sem generateConstraintsConst info ident =
-  | CAddi _ -> []
-  | CSubi _ -> []
-  | CMuli _ -> []
-  | CDivi _ -> []
-  | CNegi _ -> []
-  | CModi _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CAddi _ -> graph
+  | CSubi _ -> graph
+  | CMuli _ -> graph
+  | CDivi _ -> graph
+  | CNegi _ -> graph
+  | CModi _ -> graph
 end
 
 lang ShiftIntCFA = CFA + ConstCFA + ShiftIntAst
-  sem generateConstraintsConst info ident =
-  | CSlli _ -> []
-  | CSrli _ -> []
-  | CSrai _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CSlli _ -> graph
+  | CSrli _ -> graph
+  | CSrai _ -> graph
 end
 
 lang FloatCFA = CFA + ConstCFA + FloatAst
-  sem generateConstraintsConst info ident =
-  | CFloat _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CFloat _ -> graph
 end
 
 lang ArithFloatCFA = CFA + ConstCFA + ArithFloatAst
-  sem generateConstraintsConst info ident =
-  | CAddf _ -> []
-  | CSubf _ -> []
-  | CMulf _ -> []
-  | CDivf _ -> []
-  | CNegf _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CAddf _ -> graph
+  | CSubf _ -> graph
+  | CMulf _ -> graph
+  | CDivf _ -> graph
+  | CNegf _ -> graph
 end
 
 lang FloatIntConversionCFA = CFA + ConstCFA + FloatIntConversionAst
-  sem generateConstraintsConst info ident =
-  | CFloorfi _ -> []
-  | CCeilfi _ -> []
-  | CRoundfi _ -> []
-  | CInt2float _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CFloorfi _ -> graph
+  | CCeilfi _ -> graph
+  | CRoundfi _ -> graph
+  | CInt2float _ -> graph
 end
 
 lang BoolCFA = CFA + ConstCFA + BoolAst
-  sem generateConstraintsConst info ident =
-  | CBool _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CBool _ -> graph
 end
 
 lang CmpIntCFA = CFA + ConstCFA + CmpIntAst
-  sem generateConstraintsConst info ident =
-  | CEqi _ -> []
-  | CNeqi _ -> []
-  | CLti _ -> []
-  | CGti _ -> []
-  | CLeqi _ -> []
-  | CGeqi _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CEqi _ -> graph
+  | CNeqi _ -> graph
+  | CLti _ -> graph
+  | CGti _ -> graph
+  | CLeqi _ -> graph
+  | CGeqi _ -> graph
 end
 
 lang CmpFloatCFA = CFA + ConstCFA + CmpFloatAst
-  sem generateConstraintsConst info ident =
-  | CEqf _ -> []
-  | CLtf _ -> []
-  | CLeqf _ -> []
-  | CGtf _ -> []
-  | CGeqf _ -> []
-  | CNeqf _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CEqf _ -> graph
+  | CLtf _ -> graph
+  | CLeqf _ -> graph
+  | CGtf _ -> graph
+  | CGeqf _ -> graph
+  | CNeqf _ -> graph
 end
 
 lang CharCFA = CFA + ConstCFA + CharAst
-  sem generateConstraintsConst info ident =
-  | CChar _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CChar _ -> graph
 end
 
 lang CmpCharCFA = CFA + ConstCFA + CmpCharAst
-  sem generateConstraintsConst info ident =
-  | CEqc _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CEqc _ -> graph
 end
 
 lang IntCharConversionCFA = CFA + ConstCFA + IntCharConversionAst
-  sem generateConstraintsConst info ident =
-  | CInt2Char _ -> []
-  | CChar2Int _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CInt2Char _ -> graph
+  | CChar2Int _ -> graph
 end
 
 lang FloatStringConversionCFA = CFA + ConstCFA + FloatStringConversionAst
-  sem generateConstraintsConst info ident =
-  | CStringIsFloat _ -> []
-  | CString2float _ -> []
-  | CFloat2string _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CStringIsFloat _ -> graph
+  | CString2float _ -> graph
+  | CFloat2string _ -> graph
 end
 
 lang SymbCFA = CFA + ConstCFA + SymbAst
-  sem generateConstraintsConst info ident =
-  | CSymb _ -> []
-  | CGensym _ -> []
-  | CSym2hash _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CSymb _ -> graph
+  | CGensym _ -> graph
+  | CSym2hash _ -> graph
 end
 
 lang CmpSymbCFA = CFA + ConstCFA + CmpSymbAst
-  sem generateConstraintsConst info ident =
-  | CEqsym _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CEqsym _ -> graph
 end
 
-lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint + RecordCFA
+lang SeqOpCFA =
+  CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint + RecordCFA + AppCFA
 
-  sem generateConstraintsConst info ident =
+  -- The number
+  sem numConstIntermediates =
+  | CFoldl _ -> 4
+  | CFoldr _ -> 3
+  | CMap _ -> 2
+  | CMapi _ -> 4
+  | CIter _ -> 2
+  | CIteri _ -> 4
+  | ( CCreate _
+    | CCreateList _
+    | CCreateRope _ )
+    -> 2
+
+  sem generateConstraintsConst graph info ident =
   | ( CSet _
     | CGet _
     | CCons _
@@ -1390,6 +1202,8 @@ lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint + RecordCFA
     | CHead _
     | CTail _
     | CSubsequence _
+    | CSplitAt _
+    -- !! Higher-order !! --
     | CFoldl _
     | CFoldr _
     | CMap _
@@ -1399,22 +1213,16 @@ lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint + RecordCFA
     | CCreate _
     | CCreateList _
     | CCreateRope _
-    | CSplitAt _
-    ) & const ->
-    [
-      CstrInit {
-        lhs = AVConst { id = ident, const = const, args = []}, rhs = ident
-      }
-    ]
+    -----------------
+    ) & const -> addNewConst graph ident const
 
   | ( CLength _
     | CNull _
     | CIsList _
     | CIsRope _
-    ) -> []
+    ) -> graph
 
-
-  sem propagateConstraintConst res args =
+  sem propagateConstraintConst res args intermediates =
   | CSet _ ->
     utest length args with 3 in
     let seq = get args 0 in
@@ -1451,44 +1259,6 @@ lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint + RecordCFA
   | CSubsequence _ ->
     utest length args with 3 in
     [CstrDirect {lhs = head args, rhs = res}]
-  | CMap _ ->
-    utest length args with 2 in
-    [CstrSetMap1 {seq = get args 1, f = head args, res = res}]
-  | CFoldl _ ->
-    utest length args with 3 in
-    let seq = get args 2 in
-    let f = head args in
-    let acc = get args 1 in
-    [
-      -- Add acc ⊆ res constraint
-      CstrDirect { lhs = acc, rhs = res },
-      CstrSetFold1 { seq = seq, f = f, acc = acc, res = res, left = true }
-    ]
-  | CFoldr _ ->
-    utest length args with 3 in
-    let seq = get args 2 in
-    let f = head args in
-    let acc = get args 1 in
-    [
-      -- Add acc ⊆ res constraint
-      CstrDirect { lhs = acc, rhs = res },
-      CstrSetFold1 { seq = seq, f = f, acc = acc, res = res, left = false }
-    ]
-  | CMapi _ ->
-    utest length args with 2 in
-    [CstrSetMapi { seq = get args 1, f = head args, res = res }]
-  | CIter _ ->
-    utest length args with 2 in
-    [CstrSetIter1 { seq = get args 1, f = head args }]
-  | CIteri _ ->
-    utest length args with 2 in
-    [CstrSetIteri { seq = get args 1, f = head args }]
-  | ( CCreate _
-    | CCreateList _
-    | CCreateRope _
-    ) ->
-    utest length args with 2 in
-    [ CstrSetMap2 { f = get args 1, names = setEmpty subi, res = res } ]
   | CSplitAt _ ->
     utest length args with 2 in
     let seq = head args in
@@ -1497,50 +1267,140 @@ lang SeqOpCFA = CFA + ConstCFA + SeqCFA + SeqOpAst + BaseConstraint + RecordCFA
     let bindings = mapInsert (stringToSid "1") seq bindings in
     [CstrInit {lhs = AVRec { bindings = bindings }, rhs = res}]
 
+  -- !! Higher-order !! --
+  | CFoldl _ ->
+    utest length args with 3 in
+    let seq = get args 2 in
+    let f = head args in
+    let acc = get args 1 in
+    match intermediates with [li,a1,a2,a3] in
+    join [
+      [CstrDirect { lhs = acc, rhs = res }],
+      [CstrSet { lhs = seq, rhs = li }],
+      appConstraints f acc a1,
+      appConstraints a1 li a2,
+      [CstrDirect { lhs = a2, rhs = res }],
+      appConstraints f a2 a3,
+      appConstraints a3 li res
+    ]
+  | CFoldr _ ->
+    utest length args with 3 in
+    let seq = get args 2 in
+    let f = head args in
+    let acc = get args 1 in
+    match intermediates with [li,a1,a2] in
+    join [
+      [CstrDirect { lhs = acc, rhs = res }],
+      [CstrSet { lhs = seq, rhs = li }],
+      appConstraints f li a1,
+      appConstraints a1 acc a2,
+      [CstrDirect { lhs = a2, rhs = res }],
+      appConstraints a1 a2 res
+    ]
+  | CMap _ ->
+    utest length args with 2 in
+    let seq = get args 1 in
+    let f = head args in
+    match intermediates with [li,a1] in
+    join [
+      [CstrSet { lhs = seq, rhs = li }],
+      appConstraints f li a1,
+      [CstrInit { lhs = AVSet {names = setOfSeq subi [a1]}, rhs = res }]
+    ]
+  | CMapi _ ->
+    utest length args with 2 in
+    let seq = get args 1 in
+    let f = head args in
+    -- NOTE(2023-07-12,dlunde): We assume i is empty here. For some analysis
+    -- that want to track integer values, this won't work.
+    match intermediates with [li,i,a1,a2] in
+    join [
+      [CstrSet { lhs = seq, rhs = li }],
+      appConstraints f i a1,
+      appConstraints a1 li a2,
+      [CstrInit { lhs = AVSet {names = setOfSeq subi [a2]}, rhs = res }]
+    ]
+  | CIter _ ->
+    utest length args with 2 in
+    let seq = get args 1 in
+    let f = head args in
+    match intermediates with [li,empty] in
+    join [
+      [CstrSet { lhs = seq, rhs = li }],
+      appConstraints f li empty
+    ]
+  | CIteri _ ->
+    utest length args with 2 in
+    let seq = get args 1 in
+    let f = head args in
+    -- NOTE(2023-07-12,dlunde): We assume i is empty here. For some analysis
+    -- that want to track integer values, this won't work.
+    match intermediates with [li,i,a1,empty] in
+    join [
+      [CstrSet { lhs = seq, rhs = li }],
+      appConstraints f i a1,
+      appConstraints a1 li empty
+    ]
+  | ( CCreate _
+    | CCreateList _
+    | CCreateRope _
+    ) ->
+    utest length args with 2 in
+    let f = get args 1 in
+    -- NOTE(2023-07-12,dlunde): We assume i is empty here. For some analysis
+    -- that want to track integer values, this won't work.
+    match intermediates with [i,a1] in
+    join [
+      appConstraints f i a1,
+      [CstrInit { lhs = AVSet {names = setOfSeq subi [a1]}, rhs = res }]
+    ]
+  --------------------------------
+
+
 end
 
 lang FileOpCFA = CFA + ConstCFA + FileOpAst
-  sem generateConstraintsConst info ident =
-  | CFileRead _ -> []
-  | CFileWrite _ -> []
-  | CFileExists _ -> []
-  | CFileDelete _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CFileRead _ -> graph
+  | CFileWrite _ -> graph
+  | CFileExists _ -> graph
+  | CFileDelete _ -> graph
 end
 
 lang IOCFA = CFA + ConstCFA + IOAst
-  sem generateConstraintsConst info ident =
-  | CPrint _ -> []
-  | CPrintError _ -> []
-  | CDPrint _ -> []
-  | CFlushStdout _ -> []
-  | CFlushStderr _ -> []
-  | CReadLine _ -> []
-  | CReadBytesAsString _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CPrint _ -> graph
+  | CPrintError _ -> graph
+  | CDPrint _ -> graph
+  | CFlushStdout _ -> graph
+  | CFlushStderr _ -> graph
+  | CReadLine _ -> graph
+  | CReadBytesAsString _ -> graph
 end
 
 lang RandomNumberGeneratorCFA = CFA + ConstCFA + RandomNumberGeneratorAst
-  sem generateConstraintsConst info ident =
-  | CRandIntU _ -> []
-  | CRandSetSeed _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CRandIntU _ -> graph
+  | CRandSetSeed _ -> graph
 end
 
 lang SysCFA = CFA + ConstCFA + SysAst
-  sem generateConstraintsConst info ident =
-  | CExit _ -> []
-  | CError _ -> []
-  | CArgv _ -> []
-  | CCommand _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CExit _ -> graph
+  | CError _ -> graph
+  | CArgv _ -> graph
+  | CCommand _ -> graph
 end
 
 lang TimeCFA = CFA + ConstCFA + TimeAst
-  sem generateConstraintsConst info ident =
-  | CWallTimeMs _ -> []
-  | CSleepMs _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CWallTimeMs _ -> graph
+  | CSleepMs _ -> graph
 end
 
 lang ConTagCFA = CFA + ConstCFA + ConTagAst
-  sem generateConstraintsConst info ident =
-  | CConstructorTag _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CConstructorTag _ -> graph
 end
 
 lang RefOpCFA = CFA + ConstCFA + RefOpAst
@@ -1582,17 +1442,15 @@ lang RefOpCFA = CFA + ConstCFA + RefOpAst
       initConstraint graph (CstrDirect {lhs = contents, rhs = rhs})
     else graph
 
-  sem generateConstraintsConst info ident =
-  | (CRef _ | CDeRef _) & const -> [
-      CstrInit {
-        lhs = AVConst { id = ident, const = const, args = []}, rhs = ident
-      }
-  ]
+  sem generateConstraintsConst graph info ident =
+  | (CRef _ | CDeRef _) & const ->
+    addNewConst graph ident const
+
   -- TODO(dlunde,2021-11-11): Mutability complicates the analysis, but could
   -- probably be added.
-  -- | CModRef _ -> []
+  -- | CModRef _ -> graph
 
-  sem propagateConstraintConst res args =
+  sem propagateConstraintConst res args intermediates =
   | CRef _ ->
     utest length args with 1 in
     [CstrInit {lhs = AVRef { contents = head args }, rhs = res}]
@@ -1602,14 +1460,17 @@ lang RefOpCFA = CFA + ConstCFA + RefOpAst
 
 end
 
-lang TensorOpCFA = CFA + ConstCFA + TensorOpAst + SetCFA
+lang TensorOpCFA = CFA + ConstCFA + TensorOpAst + SetCFA + AppCFA
 
-  sem generateConstraintsConst info ident =
+  sem numConstIntermediates =
+  | CTensorCreateInt _ -> 2
+  | CTensorCreateFloat _ -> 2
+  | CTensorCreate _ -> 2
+  | CTensorIterSlice _ -> 2
+
+  sem generateConstraintsConst graph info ident =
   | ( CTensorCreateUninitInt _
     | CTensorCreateUninitFloat _
-    | CTensorCreateInt _
-    | CTensorCreateFloat _
-    | CTensorCreate _
     | CTensorGetExn _
     | CTensorLinearGetExn _
     | CTensorReshapeExn _
@@ -1618,59 +1479,66 @@ lang TensorOpCFA = CFA + ConstCFA + TensorOpAst + SetCFA
     | CTensorSliceExn _
     | CTensorSubExn _
     | CTensorShape _
+    -- !! Higher-order !! --
+    | CTensorCreateInt _
+    | CTensorCreateFloat _
+    | CTensorCreate _
     | CTensorIterSlice _
-    ) & const -> [
-      CstrInit {
-        lhs = AVConst { id = ident, const = const, args = []}, rhs = ident
-      }
-    ]
+    -------------------
+    ) & const -> addNewConst graph ident const
 
   | ( CTensorRank _
     | CTensorEq _
-    | CTensorToString _ ) -> []
+    | CTensorToString _ ) -> graph
 
   -- TODO(dlunde,2023-07-10): Mutability complicates the analysis, but could
   -- probably be added.
-  -- | CTensorSetExn _ -> []
-  -- | CTensorLinearSetExn _ -> []
+  -- | CTensorSetExn _ -> graph
+  -- | CTensorLinearSetExn _ -> graph
 
-  sem propagateConstraintConst res args =
+  sem propagateConstraintConst res args intermediates =
   -- NOTE(2023-07-10,dlunde): We do not need to track integers and floats (at
   -- least in the basic analysis) and can therefore just initialize empty AVSets
   -- here.
+  --
   | ( CTensorCreateUninitInt _
     | CTensorCreateUninitFloat _
-    | CTensorShape _
-    | CTensorCreateInt _
-    | CTensorCreateFloat _ ) ->
+    | CTensorShape _) ->
+    -- NOTE(2023-07-12,dlunde): We can include CTensorShape here as well, since
+    -- it only returns sequences of integers. For some analysis that want to
+    -- track sequences of integer values (e.g., tensor shapes), this won't
+    -- work.
     let av: AbsVal = AVSet { names = setEmpty subi } in
     [CstrInit { lhs = av, rhs = res }]
-
-  | CTensorCreate _ ->
+  | ( CTensorCreateInt _
+    | CTensorCreateFloat _
+    | CTensorCreate _ ) ->
     utest length args with 2 in
-    [ CstrSetMap2 { f = get args 1, names = setEmpty subi, res = res } ]
-
+    let f = get args 1 in
+    -- NOTE(2023-07-12,dlunde): We assume i is empty here. For some analysis
+    -- that want to track sequences of integer values (e.g., tensor shapes),
+    -- this won't work.
+    match intermediates with [i,a1] in
+    join [
+      appConstraints f i a1,
+      [CstrInit { lhs = AVSet {names = setOfSeq subi [a1]}, rhs = res }]
+    ]
   | ( CTensorGetExn _
     | CTensorLinearGetExn _ ) ->
     utest length args with 2 in
     [CstrSet { lhs = head args, rhs = res }]
-
   | CTensorReshapeExn _ ->
     utest length args with 2 in
     [CstrDirect {lhs = get args 0, rhs = res}]
-
   | CTensorCopy _ ->
     utest length args with 1 in
     [CstrDirect {lhs = get args 0, rhs = res}]
-
   | CTensorTransposeExn _ ->
     utest length args with 3 in
     [CstrDirect {lhs = get args 0, rhs = res}]
-
   | CTensorSliceExn _ ->
     utest length args with 2 in
     [CstrDirect {lhs = get args 0, rhs = res}]
-
   | CTensorSubExn _ ->
     utest length args with 3 in
     [CstrDirect {lhs = get args 0, rhs = res}]
@@ -1678,19 +1546,19 @@ lang TensorOpCFA = CFA + ConstCFA + TensorOpAst + SetCFA
 end
 
 lang BootParserCFA = CFA + ConstCFA + BootParserAst
-  sem generateConstraintsConst info ident =
-  | CBootParserParseMExprString _ -> []
-  | CBootParserParseMCoreFile _ -> []
-  | CBootParserGetId _ -> []
-  | CBootParserGetTerm _ -> []
-  | CBootParserGetType _ -> []
-  | CBootParserGetString _ -> []
-  | CBootParserGetInt _ -> []
-  | CBootParserGetFloat _ -> []
-  | CBootParserGetListLength _ -> []
-  | CBootParserGetConst _ -> []
-  | CBootParserGetPat _ -> []
-  | CBootParserGetInfo _ -> []
+  sem generateConstraintsConst graph info ident =
+  | CBootParserParseMExprString _ -> graph
+  | CBootParserParseMCoreFile _ -> graph
+  | CBootParserGetId _ -> graph
+  | CBootParserGetTerm _ -> graph
+  | CBootParserGetType _ -> graph
+  | CBootParserGetString _ -> graph
+  | CBootParserGetInt _ -> graph
+  | CBootParserGetFloat _ -> graph
+  | CBootParserGetListLength _ -> graph
+  | CBootParserGetConst _ -> graph
+  | CBootParserGetPat _ -> graph
+  | CBootParserGetInfo _ -> graph
 end
 
 --------------
@@ -1820,1770 +1688,25 @@ lang MExprCFA = CFA +
   IntPatCFA + CharPatCFA + BoolPatCFA + AndPatCFA + OrPatCFA + NotPatCFA
 
   -- Function that adds a set of universal base match constraints to a CFAGraph
+  sem addBaseMatchConstraints: CFAGraphInit -> CFAGraphInit
   sem addBaseMatchConstraints =
   | graph ->
     { graph with mcgfs = cons generateMatchConstraints graph.mcgfs }
 
   -- Function that adds a set of universal base constraints to a CFAGraph
-  sem addBaseConstraints (graph: CFAGraph) =
+  sem addBaseConstraints (graph: CFAGraphInit) =
   | t ->
 
     -- Set constant propagation functions
     let graph = {graph with cpfs = cons propagateConstraintConst graph.cpfs} in
 
     -- Initialize constraint generating functions
-    let cgfs = [ generateConstraints graph.im,
-                 generateConstraintsMatch graph.im graph.mcgfs ] in
+    let cgfs = [ generateConstraints, generateConstraintsMatch ] in
 
     -- Recurse over program and generate constraints
-    let cstrs: [Constraint] = collectConstraints cgfs [] t in
+    let graph = collectConstraints cgfs graph t in
 
-    -- Initialize all collected constraints and return
-    foldl initConstraint graph cstrs
-
-end
-
-
---------------------
--- k-CFA FRAGMENT --
---------------------
-
-lang KCFA = CFABase
-
-  type Ctx = [IName]
-  type CtxEnv = Map IName Ctx
-  type GenFunAcc = (CtxEnv, [Constraint])
-  type GenFun = Ctx -> CtxEnv -> Expr -> GenFunAcc
-  type MatchGenFun = (IName,Ctx) -> (IName,Ctx) -> Pat -> [Constraint]
-
-  type CFAGraph = {
-
-    -- Contains updates that needs to be processed in the main CFA loop
-    worklist: [(IName,Ctx,AbsVal)],
-
-    -- Contains abstract values currently associated with each name in the program.
-    data: Tensor[Map Ctx (Set AbsVal)],
-
-    -- For each name in the program, gives constraints which needs to be
-    -- repropagated upon updates to the abstract values for the name.
-    edges: Tensor[Map Ctx (Set Constraint)],
-
-    -- Bidirectional mapping between names and integers.
-    im: IndexMap,
-
-    -- The "k" in k-CFA.
-    k: Int,
-
-    -- Contains a list of functions used for generating constraints
-    cgfs: [GenFun],
-
-    -- Contains a list of functions used for generating match constraints
-    -- TODO(dlunde,2021-11-17): Should be added as a product extension
-    -- in the MatchCFA fragment instead, when possible.
-    mcgfs: [MatchGenFun],
-
-    -- NOTE(dlunde,2021-11-18): Data needed for analyses based on this framework
-    -- must be put below directly, since we do not yet have product extensions.
-
-    -- Used to store any custom data in the graph
-    graphData: Option GraphData
-
-  }
-
-  sem emptyCFAGraph: Int -> Expr -> CFAGraph
-  sem emptyCFAGraph k =
-  | t ->
-    -- NOTE(Linnea,2022-06-22): Experiments have shown that lists are better
-    -- than ropes for 'worklist' and 'edges', especially for 'worklist'
-    let im = indexGen t in
-    let shape = tensorShape im.int2name in
-    { worklist = toList [],
-      data = tensorCreateDense shape (lam. mapEmpty cmpCtx),
-      edges = tensorCreateDense shape (lam. mapEmpty cmpCtx),
-      im = im,
-      k = k,
-      cgfs = [],
-      mcgfs = [],
-      graphData = None () }
-
-  -- This function converts the data-flow result into a map, which might be more
-  -- convenient to operate on for later analysis steps.
-  sem cfaGraphData: CFAGraph -> Map Name (Set AbsVal)
-  sem cfaGraphData =
-  | graph ->
-    tensorFoldi (lam acc. lam i: [Int]. lam vals: Set AbsVal.
-        mapInsert (int2name graph.im (head i)) vals acc
-      ) (mapEmpty nameCmp) graph.data
-
-  -- Main algorithm
-  sem solveCfa: CFAGraph -> CFAGraph
-  sem solveCfa =
-  | graph ->
-    -- Iteration
-    recursive let iter = lam graph: CFAGraph.
-      if null graph.worklist then graph
-      else
-        match head graph.worklist with (q,c,d) & h in
-        let graph = { graph with worklist = tail graph.worklist } in
-        match edgesLookup (q,c) graph with cc in
-        let graph = setFold (propagateConstraint h) graph cc in
-        iter graph
-    in
-    iter graph
-
-  -- Main algorithm (debug version)
-  sem solveCfaDebug : PprintEnv -> CFAGraph -> (PprintEnv, CFAGraph)
-  sem solveCfaDebug pprintenv =
-  | graph ->
-    -- NOTE(Linnea,2022-06-22): Experiments have shown that using `cfaDebug` as
-    -- the main entry point causes overhead when no printing takes place, as we
-    -- have to match on the pprintenv in every iteration. Therefore, some code
-    -- duplication takes place here.
-    let printGraph = lam pprintenv. lam graph. lam str.
-      match cfaGraphToString pprintenv graph with (pprintenv, graph) in
-      printLn (join ["\n--- ", str, " ---"]);
-      printLn graph;
-      pprintenv
-    in
-
-    -- Iteration
-    recursive let iter = lam i. lam pprintenv: PprintEnv. lam graph: CFAGraph.
-      if null graph.worklist then (pprintenv,graph)
-      else
-        let header = concat "INTERMEDIATE CFA GRAPH " (int2string i) in
-        let pprintenv = printGraph pprintenv graph header in
-        match head graph.worklist with (q,c,d) & h in
-        let graph = { graph with worklist = tail graph.worklist } in
-        match edgesLookup (q,c) graph with cc in
-        let graph = setFold (propagateConstraint h) graph cc in
-        iter (addi i 1) pprintenv graph
-    in
-    iter 1 pprintenv graph
-
-  -- Base constraint generation function (must still be included manually in
-  -- constraintGenFuns)
-  sem generateConstraints
-  : IndexMap -> Ctx -> CtxEnv -> Expr -> GenFunAcc
-  sem generateConstraints im ctx env =
-  | t -> (env,[])
-
-  -- Call a set of constraint generation functions on each term in program.
-  -- Useful when defining values of type CFAGraph.
-  sem collectConstraints: Ctx -> [GenFun] -> GenFunAcc -> Expr -> GenFunAcc
-  sem collectConstraints ctx cgfs acc =
-  | t ->
-    let acc = foldl (lam acc. lam f: GenFun.
-        match acc with (env, cstrs) in
-        match f ctx env t with (env, fcstrs) in
-        (env, concat fcstrs cstrs)
-      ) acc cgfs
-    in
-    sfold_Expr_Expr (collectConstraints ctx cgfs) acc t
-
-  sem initConstraint: CFAGraph -> Constraint -> CFAGraph
-
-  -- Function that initializes all constraints in a CFAGraph for a given context
-  -- and context environment
-  sem initConstraints
-  : Ctx -> CtxEnv -> CFAGraph -> Expr -> (CtxEnv, CFAGraph)
-  sem initConstraints ctx env graph =
-  | t ->
-    -- Recurse over program and generate constraints
-    match
-      collectConstraints ctx graph.cgfs (env, []) t
-    with (env, cstrs) in
-
-    -- Initialize all collected constraints and return
-    (env, foldl initConstraint graph cstrs)
-
-  sem propagateConstraint
-  : (IName,Ctx,AbsVal) -> CFAGraph -> Constraint -> CFAGraph
-
-  -- Returns both the new graph, and a Boolean that is true iff the new edge was
-  -- added to the graph.
-  -- NOTE(Linnea, 2022-06-21): Updates the graph by a side effect
-  sem addEdge: CFAGraph -> (IName,Ctx) -> Constraint -> (CFAGraph, Bool)
-  sem addEdge (graph: CFAGraph) (qc: (IName,Ctx)) =
-  | cstr ->
-    match qc with (q,c) in
-    let cstrsq = edgesLookup qc graph in
-    if setMem cstr cstrsq then (graph, false)
-    else
-      let m = mapInsert c (setInsert cstr cstrsq) (
-        tensorLinearGetExn graph.edges q) in
-      tensorLinearSetExn graph.edges q m;
-      (graph, true)
-
-  -- Helper function for initializing a constraint for a given name (mainly
-  -- used for convenience in initConstraint)
-  sem initConstraintName: (IName,Ctx) -> CFAGraph -> Constraint -> CFAGraph
-  sem initConstraintName name graph =
-  | cstr ->
-    match addEdge graph name cstr with (graph, new) in
-    if new then
-      let avs = dataLookup name graph in
-      setFold (lam graph. lam av.
-        propagateConstraint (name.0,name.1,av) graph cstr)
-      graph avs
-    else graph
-
-  sem dataLookup: (IName,Ctx) -> CFAGraph -> Set AbsVal
-  sem dataLookup key =
-  | graph ->
-    let m = tensorLinearGetExn graph.data key.0 in
-    mapLookupOrElse (lam. setEmpty cmpAbsVal) key.1 m
-
-  sem edgesLookup: (IName,Ctx) -> CFAGraph -> Set Constraint
-  sem edgesLookup (key: (IName,Ctx)) =
-  | graph ->
-    let m = tensorLinearGetExn graph.edges key.0 in
-    mapLookupOrElse (lam. setEmpty cmpConstraint) key.1 m
-
-  -- Updates the graph by a side effect
-  sem addData: CFAGraph -> AbsVal -> (IName,Ctx) -> CFAGraph
-  sem addData (graph: CFAGraph) (d: AbsVal) =
-  | (q,c) ->
-    let dq = dataLookup (q,c) graph in
-    if setMem d dq then graph else
-      let m = mapInsert c (setInsert d dq) (tensorLinearGetExn graph.data q) in
-      tensorLinearSetExn graph.data q m;
-      { graph with worklist = cons (q,c,d) graph.worklist }
-
-  --------------------------------------
-  -- CONTEXTS AND CONTEXT ENVIRONMENT --
-  --------------------------------------
-
-  sem ctxEmpty: () -> Ctx
-  sem ctxEmpty =
-  | _ -> []
-
-  sem ctxAdd: Int -> IName -> Ctx -> Ctx
-  sem ctxAdd k n =
-  | ctx ->
-    let ctx = snoc ctx n in
-    if leqi (length ctx) k then ctx else tail ctx
-
-  -- Needed for `Map Ctx (Set AbsVal)`
-  sem cmpCtx: Ctx -> Ctx -> Int
-  sem cmpCtx ctx1 =
-  | ctx2 -> seqCmp subi ctx1 ctx2
-
-  -- Needed for `Set (IName,Ctx)`
-  sem cmpINameCtx: (IName,Ctx) -> (IName,Ctx) -> Int
-  sem cmpINameCtx t1 =
-  | t2 ->
-    let ndiff = subi t1.0 t2.0 in
-    if eqi ndiff 0 then cmpCtx t1.1 t2.1
-    else ndiff
-
-  sem ctxToString: IndexMap -> PprintEnv -> Ctx -> (PprintEnv, String)
-  sem ctxToString im env =
-  | ctx ->
-    match mapAccumL (pprintVarIName im) env ctx with (env,ctx) in
-    (env, join ["<", strJoin "," ctx, ">"])
-
-  sem ctxEnvEmpty: () -> CtxEnv
-  sem ctxEnvEmpty =
-  | _ -> mapEmpty subi
-
-  sem ctxEnvAdd: IName -> Ctx -> CtxEnv -> CtxEnv
-  sem ctxEnvAdd n c =
-  | env ->
-    mapInsert n c env
-
-  sem ctxEnvLookup: IndexMap -> Info -> IName -> CtxEnv -> Ctx
-  sem ctxEnvLookup im info n =
-  | env ->
-    mapLookupOrElse (lam.
-        let name = int2name im n in
-        errorSingle [info] (concat "ctxEnvLookup failed: " (nameGetStr name))
-      ) n env
-
-  -- Keep names that appear free in a given expression.
-  sem ctxEnvFilterFree: IndexMap -> Expr -> CtxEnv -> CtxEnv
-  sem ctxEnvFilterFree im e =
-  | env ->
-    let free: Set Name = freeVars e in
-    mapFoldWithKey (lam acc. lam n. lam ctx.
-        if setMem (int2name im n) free then mapInsert n ctx acc
-        else acc
-      ) (mapEmpty subi) env
-
-  sem cmpCtxEnv: CtxEnv -> CtxEnv -> Int
-  sem cmpCtxEnv env1 =
-  | env2 -> mapCmp cmpCtx env1 env2
-
-  ---------------------
-  -- PRETTY PRINTING --
-  ---------------------
-
-  sem pprintVarINameCtx
-  : IndexMap -> PprintEnv -> (IName,Ctx) -> (PprintEnv, String)
-  sem pprintVarINameCtx im env =
-  | (n,ctx) ->
-    match pprintVarIName im env n with (env,n) in
-    match ctxToString im env ctx with (env,ctx) in
-    (env, join [n, ctx])
-
-  sem pprintConINameCtx
-  : IndexMap -> PprintEnv -> (IName,Ctx) -> (PprintEnv, String)
-  sem pprintConINameCtx im env =
-  | (n,ctx) ->
-    match pprintConIName im env n with (env,n) in
-    match ctxToString im env ctx with (env,ctx) in
-    (env, join [n, ctx])
-
-  -- Prints a CFA graph
-  sem cfaGraphToString (env: PprintEnv) =
-  | graph ->
-    let graph: CFAGraph = graph in
-    let f = lam env. lam e: (IName,Ctx,AbsVal).
-      match pprintVarINameCtx graph.im env (e.0,e.1) with (env,n) in
-      match absValToString graph.im env e.2 with (env,av) in
-      (env,join ["(", n, ", ", av, ")"]) in
-    match mapAccumL f env graph.worklist with (env,worklist) in
-    match mapAccumL (lam env: PprintEnv. lam b:(IName,Map Ctx (Set AbsVal)).
-        match pprintVarIName graph.im env b.0 with (env,b0) in
-        let printAbsVals = lam env. lam s: Set AbsVal.
-          mapAccumL (absValToString graph.im) env (setToSeq s)
-        in
-        match mapAccumL (lam env: PprintEnv. lam b:(Ctx,Set AbsVal).
-            match ctxToString graph.im env b.0 with (env, ctx) in
-            match printAbsVals env b.1 with (env, avs) in
-            (env, (ctx, avs))
-          ) env (mapBindings b.1)
-        with (env,b1)
-        in (env,(b0,b1))
-      ) env (mapi (lam i. lam x. (i,x)) (tensorToSeqExn graph.data))
-    with (env, data) in
-    match mapAccumL (lam env: PprintEnv. lam b:(IName,Map Ctx (Set Constraint)).
-        match pprintVarIName graph.im env b.0 with (env,b0) in
-        let printCstrs = lam env. lam cstrs: Set Constraint.
-          mapAccumL (constraintToString graph.im) env (setToSeq cstrs)
-        in
-        match mapAccumL (lam env: PprintEnv. lam b:(Ctx,Set Constraint).
-            match ctxToString graph.im env b.0 with (env, ctx) in
-            match printCstrs env b.1 with (env, cstrs) in
-            (env, (ctx, cstrs))
-          ) env (mapBindings b.1)
-        with (env,(b1))
-        in (env,(b0,b1))
-      ) env (mapi (lam i. lam x. (i, x)) (tensorToSeqExn graph.edges))
-    with (env, edges) in
-
-    let strJoinNonEmpty = lam delim: String. lam strs: [String].
-      strJoin delim (filter (lam s. not (null s)) strs)
-    in
-
-    let str = join [
-      "*** WORKLIST ***\n",
-      "  [", strJoin ", " worklist, "]\n",
-      "*** DATA ***\n",
-      strJoinNonEmpty "\n" (map (lam b:(String,[(String, [String])]).
-        match b with (n, ctxsAvs) in
-        let f = lam avs.
-          strJoin "\n" (map (concat "    ") avs)
-        in
-        let entries: [String] = map (lam ctxAvs: (String, [String]).
-            match ctxAvs with (ctx, avs) in
-            join ["  ", join [b.0, ctx], " =\n", f avs]
-          ) ctxsAvs
-        in strJoin "\n" entries
-      ) data), "\n",
-      "*** EDGES ***\n",
-      strJoinNonEmpty "\n" (map (lam b:(String,[(String, [String])]).
-        match b with (n, ctxCstrs) in
-        let f = lam cstrs.
-          strJoin "\n" (map (concat "    ") cstrs)
-        in
-        let entries: [String] = map (lam cc: (String, [String]).
-            match cc with (ctx, cstrs) in
-            join ["  ", join [b.0, ctx], " =\n", f cstrs]
-          ) ctxCstrs
-        in strJoin "\n" entries
-      ) edges), "\n"
-
-    ] in
-
-    (env, str)
-
-end
-
-----------------------
--- BASE CONSTRAINTS --
-----------------------
-
-lang KBaseConstraint = KCFA
-
-  syn Constraint =
-  -- {lhs} ⊆ rhs
-  | CstrInit { lhs: AbsVal, rhs: (IName,Ctx) }
-  -- lhs ⊆ rhs
-  | CstrDirect { lhs: (IName,Ctx), rhs: (IName,Ctx) }
-  -- {lhsav} ⊆ lhs ⇒ {rhsav} ⊆ rhs
-  | CstrDirectAv { lhs: (IName,Ctx), lhsav: AbsVal,
-                   rhs: (IName,Ctx), rhsav: AbsVal }
-  -- {lhsav} ⊆ lhs ⇒ [rhs]
-  | CstrDirectAvCstrs { lhs: (IName,Ctx), lhsav: AbsVal, rhs: [Constraint] }
-
-  sem cmpConstraintH =
-  | (CstrInit { lhs = lhs1, rhs = rhs1 },
-     CstrInit { lhs = lhs2, rhs = rhs2 }) ->
-     let d = cmpAbsVal lhs1 lhs2 in
-     if eqi d 0 then cmpINameCtx rhs1 rhs2
-     else d
-  | (CstrDirect { lhs = lhs1, rhs = rhs1 },
-     CstrDirect { lhs = lhs2, rhs = rhs2 }) ->
-     let d = cmpINameCtx lhs1 lhs2 in
-     if eqi d 0 then cmpINameCtx rhs1 rhs2
-     else d
-  | (CstrDirectAv t1, CstrDirectAv t2) ->
-     let d = cmpINameCtx t1.lhs t2.lhs in
-     if eqi d 0 then
-       let d = cmpINameCtx t1.rhs t2.rhs in
-       if eqi d 0 then
-         let d = cmpAbsVal t1.lhsav t2.lhsav in
-         if eqi d 0 then cmpAbsVal t1.rhsav t2.rhsav
-         else d
-       else d
-     else d
-  | (CstrDirectAvCstrs t1, CstrDirectAvCstrs t2) ->
-     let d = cmpINameCtx t1.lhs t2.lhs in
-     if eqi d 0 then
-       let d = cmpAbsVal t1.lhsav t2.lhsav in
-       if eqi d 0 then seqCmp cmpConstraint t1.rhs t2.rhs
-       else d
-     else d
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrInit r -> addData graph r.lhs r.rhs
-  | CstrDirect r & cstr -> initConstraintName r.lhs graph cstr
-  | CstrDirectAv r & cstr -> initConstraintName r.lhs graph cstr
-  | CstrDirectAvCstrs r & cstr -> initConstraintName r.lhs graph cstr
-
-  sem constraintToString im (env: PprintEnv) =
-  | CstrInit { lhs = lhs, rhs = rhs } ->
-    match absValToString im env lhs with (env,lhs) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    (env, join ["{", lhs, "}", " ⊆ ", rhs])
-  | CstrDirect { lhs = lhs, rhs = rhs } ->
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    (env, join [lhs, " ⊆ ", rhs])
-  | CstrDirectAv { lhs = lhs, lhsav = lhsav, rhs = rhs, rhsav = rhsav } ->
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match absValToString im env lhsav with (env,lhsav) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    match absValToString im env rhsav with (env,rhsav) in
-    (env, join ["{", lhsav ,"} ⊆ ", lhs, " ⇒ {", rhsav ,"} ⊆ ", rhs])
-  | CstrDirectAvCstrs { lhs = lhs, lhsav = lhsav, rhs = rhs } ->
-    match mapAccumL (constraintToString im) env rhs with (env,rhs) in
-    let rhs = strJoin " AND " rhs in
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match absValToString im env lhsav with (env,lhsav) in
-    (env, join [ "{", lhsav, "} ⊆ ", lhs, " ⇒ (", rhs, ")" ])
-
-  sem isDirect: AbsVal -> Bool
-  sem isDirect =
-  | _ -> true
-
-  sem directTransition: CFAGraph -> (IName,Ctx) -> AbsVal -> AbsVal
-  sem directTransition graph rhs =
-  | av -> av
-
-  sem propagateConstraint (update: (IName,Ctx,AbsVal)) (graph: CFAGraph) =
-  | CstrDirect r -> propagateDirectConstraint r.rhs graph update.2
-  | CstrDirectAv r ->
-    if eqAbsVal update.2 r.lhsav then
-      addData graph r.rhsav r.rhs
-    else graph
-  | CstrDirectAvCstrs r & cstr ->
-    if eqAbsVal update.2 r.lhsav then
-      foldl initConstraint graph r.rhs
-    else graph
-
-  sem propagateDirectConstraint: (IName,Ctx) -> CFAGraph -> AbsVal -> CFAGraph
-  sem propagateDirectConstraint rhs graph =
-  | av ->
-    if isDirect av then
-      addData graph (directTransition graph rhs av) rhs
-    else graph
-end
-
------------
--- TERMS --
------------
-
-lang VarKCFA = KCFA + KBaseConstraint + VarAst
-
-  sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmVar t, info = info } ->
-    let ident = name2int im info ident in
-    let lhs = name2int im t.info t.ident in
-    let cstrs =
-      [ CstrDirect {
-        lhs = (lhs, ctxEnvLookup im t.info lhs env),
-        rhs = (ident, ctx)
-      } ]
-    in
-    (ctxEnvAdd ident ctx env, cstrs)
-
-  sem exprName =
-  | TmVar t -> t.ident
-end
-
-lang LamKCFA = KCFA + KBaseConstraint + LamAst
-
-  -- Abstract representation of lambdas.
-  syn AbsVal =
-  | AVLam { ident: IName, bident: IName, body: Expr, env: CtxEnv }
-
-  sem cmpAbsValH =
-  | (AVLam { ident = lhs, bident = lbody, env = lenv },
-     AVLam { ident = rhs, bident = rbody, env = renv }) ->
-     let diff = subi lhs rhs in
-     if eqi diff 0 then
-       let diff = subi lbody rbody in
-       if eqi diff 0 then cmpCtxEnv lenv renv else diff
-     else diff
-
-  sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmLam t, info = info } ->
-    let ident = name2int im info ident in
-    let av: AbsVal = AVLam {
-      ident = name2int im t.info t.ident,
-      bident = name2int im (infoTm t.body) (exprName t.body),
-      body = t.body,
-      env = ctxEnvFilterFree im (TmLam t) env
-    } in
-    let cstrs = [ CstrInit { lhs = av, rhs = (ident, ctx) } ] in
-    (ctxEnvAdd ident ctx env, cstrs)
-
-  sem absValToString im (env: PprintEnv) =
-  | AVLam { ident = ident, bident = bident } ->
-    match pprintVarIName im env ident with (env,ident) in
-    match pprintVarIName im env bident with (env,bident) in
-    (env, join ["lam ", ident, ". ", bident])
-
-  -- We analyze the terms in the lambda body when discovering an application of
-  -- an `AVLam`. Hence, we do nothing here.
-  sem collectConstraints ctx cgfs acc =
-  | TmLam t -> acc
-end
-
-lang LetKCFA = KCFA + LetAst
-  sem exprName =
-  | TmLet t -> exprName t.inexpr
-end
-
-lang RecLetsKCFA = KCFA + LamKCFA + RecLetsAst
-  sem exprName =
-  | TmRecLets t -> exprName t.inexpr
-
-  sem generateConstraints im ctx env =
-  | TmRecLets ({ bindings = bindings } & t) ->
-    -- Make each binding available in the environment
-    let idents = map (lam b. name2int im b.info b.ident) bindings in
-    let envBody = foldl (lam env. lam i.
-        ctxEnvAdd i ctx env) (ctxEnvFilterFree im (TmRecLets t) env) idents in
-    let cstrs = map (lam identBind: (IName, RecLetBinding).
-      match identBind with (ident, b) in
-      match b.body with TmLam t then
-        let av: AbsVal = AVLam {
-          ident = name2int im t.info t.ident,
-          bident = name2int im (infoTm t.body) (exprName t.body),
-          body = t.body,
-          env = envBody
-        } in
-        CstrInit { lhs = av, rhs = (ident, ctx) }
-      else errorSingle [infoTm b.body] "Not a lambda in recursive let body"
-    ) (zip idents bindings) in
-    let env = foldl (lam env. lam i. ctxEnvAdd i ctx env) env idents in
-    (env, cstrs)
-end
-
-lang ConstKCFA = KCFA + ConstAst + KBaseConstraint + Cmp
-
-  syn AbsVal =
-  -- Abstract representation of constants. Contains the constant and the
-  -- arguments applied to it. It also includes the `let` name that binds the
-  -- constant and syntactically distinguishes it from other of its kind in the
-  -- program.
-  | AVConst { id: (IName,Ctx), const: Const, args: [(IName,Ctx)] }
-
-  sem absValToString im (env: PprintEnv) =
-  | AVConst { id = id, const = const, args = args } ->
-    let const = getConstStringCode 0 const in
-    match mapAccumL (pprintVarINameCtx im) env args with (env,args) in
-    let args = strJoin ", " args in
-    match pprintVarINameCtx im env id with (env,id) in
-    (env, join [const,"<", id, ">", "(", args, ")"])
-
-  sem cmpAbsValH =
-  | (AVConst lhs, AVConst rhs) ->
-    let cmp = cmpConst lhs.const rhs.const in
-    if eqi 0 cmp then
-      let ncmp = cmpINameCtx lhs.id rhs.id in
-      if eqi 0 ncmp then seqCmp cmpINameCtx lhs.args rhs.args
-      else ncmp
-    else cmp
-
-  sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmConst t, info = info } ->
-    let ident = name2int im info ident in
-    let cstrs = generateConstraintsConst t.info (ident,ctx) t.val in
-    (ctxEnvAdd ident ctx env, cstrs)
-
-  sem generateConstraintsConst: Info -> (IName,Ctx) -> Const -> [Constraint]
-  sem generateConstraintsConst info ident =
-  | _ -> errorSingle [info] "Constant not supported in CFA"
-end
-
-lang AppKCFA = KCFA + ConstKCFA + KBaseConstraint + LamKCFA + AppAst + MExprArity
-
-  syn Constraint =
-  -- {lam x. b} ⊆ lhs ⇒ (rhs ⊆ x and b ⊆ res)
-  | CstrLamApp { lhs: (IName,Ctx), rhs: (IName,Ctx), res: (IName,Ctx) }
-  -- {const args} ⊆ lhs ⇒ {const args lhs} ⊆ res
-  | CstrConstApp { lhs: (IName,Ctx), rhs: (IName,Ctx),
-                   res: (IName,Ctx) }
-
-  sem cmpConstraintH =
-  | (CstrLamApp { lhs = lhs1, rhs = rhs1, res = res1 },
-     CstrLamApp { lhs = lhs2, rhs = rhs2, res = res2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx lhs1 lhs2 in
-       if eqi d 0 then cmpINameCtx rhs1 rhs2
-       else d
-     else d
-  | (CstrConstApp { lhs = lhs1, rhs = rhs1, res = res1 },
-     CstrConstApp { lhs = lhs2, rhs = rhs2, res = res2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx lhs1 lhs2 in
-       if eqi d 0 then cmpINameCtx rhs1 rhs2
-       else d
-     else d
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrLamApp r & cstr -> initConstraintName r.lhs graph cstr
-  | CstrConstApp r & cstr -> initConstraintName r.lhs graph cstr
-
-  sem propagateConstraint (update: (IName,Ctx,AbsVal)) (graph: CFAGraph) =
-  | CstrLamApp { lhs = lhs, rhs = rhs, res = res } ->
-    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
-    then
-      let ctxBody = ctxAdd graph.k res.0 res.1 in
-      let envBody = ctxEnvAdd x ctxBody env in
-      -- Analyze the lambda body
-      match initConstraints ctxBody envBody graph body with (envBody, graph) in
-      -- Add rhs ⊆ x constraint
-      let graph = initConstraint graph (CstrDirect {
-          lhs = rhs, rhs = (x, ctxBody)
-        }) in
-      -- Add b ⊆ res constraint
-      let graph = initConstraint graph (CstrDirect {
-          lhs = (b, ctxEnvLookup graph.im (infoTm body) b envBody), rhs = res
-        }) in
-      graph
-    else graph
-  | CstrConstApp { lhs = lhs, rhs = rhs, res = res } ->
-    match update.2 with AVConst ({ const = const, args = args } & avc) then
-      let arity = constArity const in
-      let args = snoc args rhs in
-      if eqi arity (length args) then
-        -- Last application
-        propagateConstraintConst res args graph const
-      else
-        -- Curried application, add the new argument
-        addData graph (AVConst { avc with args = args }) res
-    else graph
-
-  sem constraintToString im (env: PprintEnv) =
-  | CstrLamApp { lhs = lhs, rhs = rhs, res = res } ->
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    match pprintVarINameCtx im env res with (env,res) in
-    (env, join ["{lam >x<. >b<} ⊆ ", lhs, " ⇒ ", rhs, " ⊆ >x< AND >b< ⊆ ", res])
-  | CstrConstApp { lhs = lhs, rhs = rhs, res = res } ->
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    match pprintVarINameCtx im env res with (env,res) in
-    (env, join [
-        ">const< >args< ⊆ ", lhs, " ⇒ ", ">const< >args< ", rhs, " ⊆ ", res
-      ])
-
-  sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmApp app, info = info} ->
-    let ident = name2int im info ident in
-    match app.lhs with TmVar l then
-      match app.rhs with TmVar r then
-        let lhs = name2int im l.info l.ident in
-        let rhs = name2int im r.info r.ident in
-        let lenv = ctxEnvLookup im l.info lhs env in
-        let renv = ctxEnvLookup im r.info rhs env in
-        let cstrs =
-          [ CstrLamApp {
-              lhs = (lhs, lenv),
-              rhs = (rhs, renv),
-                res = (ident, ctx)
-              },
-            CstrConstApp {
-              lhs = (lhs, lenv),
-              rhs = (rhs, renv),
-              res = (ident, ctx)
-            }
-          ]
-        in
-        (ctxEnvAdd ident ctx env, cstrs)
-      else errorSingle [infoTm app.rhs] "Not a TmVar in application"
-    else errorSingle [infoTm app.lhs] "Not a TmVar in application"
-
-  sem propagateConstraintConst
-  : (IName,Ctx) -> [(IName,Ctx)] -> CFAGraph -> Const -> CFAGraph
-end
-
-lang RecordKCFA = KCFA + KBaseConstraint + RecordAst
-
-  syn AbsVal =
-  -- Abstract representation of records. The bindings are from SIDs to names,
-  -- rather than expressions.
-  | AVRec { bindings: Map SID (IName,Ctx) }
-
-  sem cmpAbsValH =
-  | (AVRec { bindings = lhs }, AVRec { bindings = rhs }) ->
-    mapCmp cmpINameCtx lhs rhs
-
-  syn Constraint =
-  -- r ∈ lhs ⇒ { r with key = val } ∈ rhs
-  | CstrRecordUpdate { lhs: (IName,Ctx), key: SID, val: (IName,Ctx),
-                       rhs: (IName,Ctx) }
-
-  sem cmpConstraintH =
-  | (CstrRecordUpdate { lhs = lhs1, key = key1, val = val1, rhs = rhs1 },
-     CstrRecordUpdate { lhs = lhs2, key = key2, val = val2, rhs = rhs2 }) ->
-     let d = cmpINameCtx lhs1 lhs2 in
-     if eqi d 0 then
-       let d = cmpSID key1 key2 in
-       if eqi d 0 then
-         let d = cmpINameCtx val1 val2 in
-         if eqi d 0 then cmpINameCtx rhs1 rhs2
-         else d
-       else d
-     else d
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrRecordUpdate r & cstr -> initConstraintName r.lhs graph cstr
-
-  sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmRecord t, info = info } ->
-    let bindings = mapMap (lam v: Expr.
-        match v with TmVar t then
-          let vident = name2int im t.info t.ident in
-          let vctx = ctxEnvLookup im t.info vident env in
-          (vident,vctx)
-        else errorSingle [infoTm v] "Not a TmVar in record"
-      ) t.bindings
-    in
-    let av: AbsVal = AVRec { bindings = bindings } in
-    let ident = name2int im info ident in
-    let cstrs = [ CstrInit { lhs = av, rhs = (ident, ctx) } ] in
-    (ctxEnvAdd ident ctx env, cstrs)
-  | TmLet { ident = ident, body = TmRecordUpdate t, info = info } ->
-    match t.rec with TmVar vrec then
-      match t.value with TmVar vval then
-        let lhs = name2int im vrec.info vrec.ident in
-        let val = name2int im vval.info vval.ident in
-        let ident = name2int im info ident in
-        let cstrs =
-          [ CstrRecordUpdate { lhs = (lhs, ctxEnvLookup im vrec.info lhs env),
-                               key = t.key,
-                               val = (val, ctxEnvLookup im vval.info val env),
-                               rhs = (ident, ctx)}
-          ] in
-        (ctxEnvAdd ident ctx env, cstrs)
-      else errorSingle [t.info] "Not a TmVar in record update"
-    else errorSingle [t.info] "Not a TmVar in record update"
-
-  sem propagateConstraint (update: (IName,Ctx,AbsVal)) (graph: CFAGraph) =
-  | CstrRecordUpdate { lhs = lhs, key = key, val = val, rhs = rhs } ->
-    match update.2 with AVRec { bindings = bindings } then
-      let av = AVRec { bindings = mapInsert key val bindings } in
-      initConstraint graph (CstrInit { lhs = av, rhs = rhs })
-    else graph
-
-  sem absValToString im (env: PprintEnv) =
-  | AVRec { bindings = bindings } ->
-    match mapMapAccum (lam env. lam k. lam v.
-        match pprintVarINameCtx im env v with (env, v) in
-        (env, join [pprintLabelString k, " = ", v])
-      ) env bindings
-    with (env, bindings) in
-    let binds = mapValues bindings in
-    let merged = strJoin ", " binds in
-    (env, join ["{ ", merged, " }"])
-
-  sem constraintToString im (env: PprintEnv) =
-  | CstrRecordUpdate { lhs = lhs, key = key, val = val, rhs = rhs } ->
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match pprintLabelString key with key in
-    match pprintVarINameCtx im env val with (env,val) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    (env, join [">r< ∈ ", lhs, " ⇒ { >r< with ", key, " = ", val, " } ∈ ", rhs])
-
-end
-
-lang SeqKCFA = KCFA + KBaseConstraint + SeqAst
-
-  syn AbsVal =
-  -- Abstract representation of sequences. Contains a set of names that may
-  -- flow to the sequence.
-  | AVSeq { names: Set (IName,Ctx) }
-
-  sem cmpAbsValH =
-  | (AVSeq { names = lhs }, AVSeq { names = rhs }) -> setCmp lhs rhs
-
-  sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmSeq t, info = info } ->
-    let names = foldl (lam acc: [(IName,Ctx)]. lam t: Expr.
-      match t with TmVar t then
-        let tident = name2int im t.info t.ident in
-        cons (tident, ctxEnvLookup im t.info tident env) acc
-      else acc) [] t.tms
-    in
-    let av: AbsVal = AVSeq { names = setOfSeq cmpINameCtx names } in
-    let ident = name2int im info ident in
-    let cstrs = [ CstrInit { lhs = av, rhs = (ident, ctx) } ] in
-    (ctxEnvAdd ident ctx env, cstrs)
-
-  sem absValToString im (env: PprintEnv) =
-  | AVSeq { names = names } ->
-    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
-    with (env,names) in
-    let names = strJoin ", " names in
-    (env, join ["[{", names, "}]"])
-end
-
-lang TypeKCFA = KCFA + TypeAst
-  sem exprName =
-  | TmType t -> exprName t.inexpr
-end
-
-lang DataKCFA = KCFA + KBaseConstraint + DataAst
-  syn AbsVal =
-  -- Abstract representation of constructed data.
-  | AVCon { ident: (IName,Ctx), body: (IName,Ctx) }
-
-  sem cmpAbsValH =
-  | (AVCon { ident = ilhs, body = blhs },
-     AVCon { ident = irhs, body = brhs }) ->
-    let idiff = cmpINameCtx ilhs irhs in
-    if eqi idiff 0 then cmpINameCtx blhs brhs else idiff
-
-  sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmConApp t, info = info } ->
-    let body =
-      match t.body with TmVar v then name2int im v.info v.ident
-      else errorSingle [infoTm t.body] "Not a TmVar in con app" in
-    let ctxBody = ctxEnvLookup im (infoTm t.body) body env in
-    let av: AbsVal = AVCon {
-        ident = (name2int im t.info t.ident, ctx),
-        body = (body, ctxBody)
-      } in
-    let ident = name2int im info ident in
-    let cstrs = [ CstrInit { lhs = av, rhs = (ident,ctx) } ] in
-    (ctxEnvAdd ident ctx env, cstrs)
-
-  sem absValToString im (env: PprintEnv) =
-  | AVCon { ident = ident, body = body } ->
-    match pprintConINameCtx im env ident with (env,ident) in
-    match pprintVarINameCtx im env body with (env,body) in
-    (env, join [ident, " ", body])
-
-  sem exprName =
-  | TmConDef t -> exprName t.inexpr
-
-end
-
-lang MatchKCFA = KCFA + KBaseConstraint + MatchAst + MExprCmp
-
-  syn Constraint =
-  | CstrMatch { id: (IName,Ctx), pat: Pat, target: (IName,Ctx) }
-
-  sem cmpConstraintH =
-  | (CstrMatch { id = id1, pat = pat1, target = target1 },
-     CstrMatch { id = id2, pat = pat2, target = target2 }) ->
-     let d = cmpINameCtx id1 id2 in
-     if eqi d 0 then
-       let d = cmpINameCtx target1 target2 in
-       if eqi d 0 then cmpPat pat1 pat2
-       else d
-     else d
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrMatch r & cstr -> initConstraintName r.target graph cstr
-
-  sem propagateConstraint (update: (IName,Ctx,AbsVal)) graph =
-  | CstrMatch r ->
-    propagateMatchConstraint graph r.id (r.pat,update.2)
-
-  sem propagateMatchConstraint
-  : CFAGraph -> (IName,Ctx) -> (Pat,AbsVal) -> CFAGraph
-  sem propagateMatchConstraint graph id =
-  | _ -> graph -- Default: do nothing
-
-  sem constraintToString im (env: PprintEnv) =
-  | CstrMatch { id = id, pat = pat, target = target } ->
-    match pprintVarINameCtx im env id with (env, id) in
-    match getPatStringCode 0 env pat with (env, pat) in
-    match pprintVarINameCtx im env target with (env, target) in
-    (env, join [id, ": match ", target, " with ", pat])
-
-  sem generateConstraintsMatch
-  : IndexMap -> [MatchGenFun] -> Ctx -> CtxEnv -> Expr -> GenFunAcc
-  sem generateConstraintsMatch im mcgfs ctx env =
-  | _ -> (env,[])
-  | TmLet { ident = ident, body = TmMatch t, info = info } ->
-    let thn = name2int im (infoTm t.thn) (exprName t.thn) in
-    let els = name2int im (infoTm t.els) (exprName t.els) in
-    let ident = name2int im info ident in
-    let cstrs = [
-      CstrDirect { lhs = (thn,ctx), rhs = (ident,ctx) },
-      CstrDirect { lhs = (els,ctx), rhs = (ident,ctx) }
-    ] in
-    let cstrs =
-      match t.target with TmVar tv then
-        let target = name2int im tv.info tv.ident in
-        let targetCtx = ctxEnvLookup im tv.info target env in
-        foldl (lam acc. lam f.
-            concat (f (ident,ctx) (target, targetCtx) t.pat) acc
-          ) cstrs mcgfs
-      else errorSingle [infoTm t.target] "Not a TmVar in match target"
-    in
-    -- Add the names bound in the pattern to the environment
-    let names = map (name2int im t.info) (patNames [] t.pat) in
-    let env = foldl (lam acc. lam n. ctxEnvAdd n ctx acc) env names in
-    (ctxEnvAdd ident ctx env, cstrs)
-
-  sem generateMatchConstraints
-  : (IName,Ctx) -> (IName,Ctx) -> Pat -> [Constraint]
-  sem generateMatchConstraints id target =
-  | pat -> [ CstrMatch { id = id, pat = pat, target = target } ]
-
-  -- Returns the set of names bound in a pattern
-  sem patNames: [Name] -> Pat -> [Name]
-  sem patNames acc =
-  | p ->
-    sfold_Pat_Pat patNames acc p
-
-end
-
-lang UtestKCFA = KCFA + UtestAst
-  sem exprName =
-  | TmUtest t -> exprName t.next
-end
-
-lang NeverKCFA = KCFA + NeverAst
-  -- Nothing to be done here
-end
-
-lang ExtKCFA = KCFA + ExtAst
-
-  syn AbsVal =
-  -- Abstract representation of externals. Handled in a similar way as
-  -- constants. We directly store the external arity in the abstract
-  -- value. Note that ANF eta expands all external definitions, so from the
-  -- perspective of CFA, externals are curried (need not be fully applied as in
-  -- standard MExpr).
-  -- NOTE(dlunde,2022-06-15): I'm not convinced the current approach for
-  -- handling externals is optimal. The additional `let` added by ANF to shadow
-  -- the original external definition is quite clunky. Maybe we can
-  -- incorporate the fact that externals are always fully applied into the
-  -- analysis somehow?
-  | AVExt { ext: (IName,Ctx), arity: Int, args: [(IName,Ctx)] }
-
-  sem absValToString im (env: PprintEnv) =
-  | AVExt { ext = ext, args = args } ->
-    -- We ignore the arity (one can simply look up the ext to get the arity)
-    match mapAccumL (pprintVarINameCtx im) env args with (env,args) in
-    let args = strJoin ", " args in
-    match pprintVarINameCtx im env ext with (env,ext) in
-    (env, join [ext, "(", args, ")"])
-
-  sem cmpAbsValH =
-  | (AVExt lhs, AVExt rhs) ->
-    -- We ignore the arity (if ext is the same, arity is the same)
-    let cmp = cmpINameCtx lhs.ext rhs.ext in
-    if eqi 0 cmp then seqCmp cmpINameCtx lhs.args rhs.args
-    else cmp
-
-  syn Constraint =
-  -- {ext args} ⊆ lhs ⇒ {ext args lhs} ⊆ res
-  | CstrExtApp { lhs: (IName,Ctx),
-                 rhs : (IName,Ctx),
-                 res: (IName,Ctx) }
-
-  sem cmpConstraintH =
-  | (CstrExtApp { lhs = lhs1, rhs = rhs1, res = res1 },
-     CstrExtApp { lhs = lhs2, rhs = rhs2, res = res2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx lhs1 lhs2 in
-       if eqi d 0 then cmpINameCtx rhs1 rhs2
-       else d
-     else d
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrExtApp r & cstr -> initConstraintName r.lhs graph cstr
-
-  sem propagateConstraint update graph =
-  | CstrExtApp { lhs = lhs, rhs = rhs, res = res } ->
-    match update.2
-    with AVExt ({ ext = ext, args = args, arity = arity } & ave) then
-      let args = snoc args rhs in
-      if eqi arity (length args) then
-        -- Last application
-        -- TODO(dlunde,2022-06-15): We currently do nothing here. Optimally, we
-        -- would like to delegate to a `propagateConstraintExt` here, similar
-        -- to constants. I'm not sure where/how `propagateConstraintExt` should
-        -- be defined.
-        graph
-      else
-        -- Curried application, add the new argument
-        addData graph (AVExt { ave with args = args }) res
-    else graph
-
-  -- This ensures that `collectConstraints` does _not_ try to collect constraints
-  -- from `let`s immediately following externals. These `let`s are generated by
-  -- the ANF transform and define eta expanded versions of the externals (so
-  -- that they can be curried).
-  sem collectConstraints ctx cgfs acc =
-  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } & t ->
-    let acc = foldl (lam acc. lam f.
-        match acc with (env, cstrs) in
-        match f ctx env t with (env, fcstrs) in
-        (env, concat fcstrs cstrs)
-      ) acc cgfs in
-    collectConstraints ctx cgfs acc inexpr
-
-  sem generateConstraints im ctx env =
-  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
-    -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
-    -- for externals. Similarly to constants, we probably want to delegate to
-    -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
-    -- not clear where the `generateConstraintsExts` function should be defined.
-    --
-    (env,[])
-
-  sem exprName =
-  -- Skip the eta expanded let added by ANF,
-  | TmExt { inexpr = TmLet { inexpr = inexpr }} -> exprName inexpr
-
-end
-
----------------
--- CONSTANTS --
----------------
--- Most data-flow constraints will need to add data-flow components related to
--- constants (e.g., abstract values for positive and negative integers).
--- However, in this base version of k-CFA, only some data flow constraints are
--- generated.
-
--- To add data-flow constraints to a constant:
--- 1. Implement 'generateConstraintsConst' fot the constant.
--- 2. Implement 'propagateConstraintConst' for the constant.
-
-lang IntKCFA = KCFA + ConstKCFA + IntAst
-  sem generateConstraintsConst info ident =
-  | CInt _ -> []
-end
-
-lang ArithIntKCFA = KCFA + ConstKCFA + ArithIntAst
-  sem generateConstraintsConst info ident =
-  | CAddi _ -> []
-  | CSubi _ -> []
-  | CMuli _ -> []
-  | CDivi _ -> []
-  | CNegi _ -> []
-  | CModi _ -> []
-end
-
-lang ShiftIntKCFA = KCFA + ConstKCFA + ShiftIntAst
-  sem generateConstraintsConst info ident =
-  | CSlli _ -> []
-  | CSrli _ -> []
-  | CSrai _ -> []
-end
-
-lang FloatKCFA = KCFA + ConstKCFA + FloatAst
-  sem generateConstraintsConst info ident =
-  | CFloat _ -> []
-end
-
-lang ArithFloatKCFA = KCFA + ConstKCFA + ArithFloatAst
-  sem generateConstraintsConst info ident =
-  | CAddf _ -> []
-  | CSubf _ -> []
-  | CMulf _ -> []
-  | CDivf _ -> []
-  | CNegf _ -> []
-end
-
-lang FloatIntConversionKCFA = KCFA + ConstKCFA + FloatIntConversionAst
-  sem generateConstraintsConst info ident =
-  | CFloorfi _ -> []
-  | CCeilfi _ -> []
-  | CRoundfi _ -> []
-  | CInt2float _ -> []
-end
-
-lang BoolKCFA = KCFA + ConstKCFA + BoolAst
-  sem generateConstraintsConst info ident =
-  | CBool _ -> []
-end
-
-lang CmpIntKCFA = KCFA + ConstKCFA + CmpIntAst
-  sem generateConstraintsConst info ident =
-  | CEqi _ -> []
-  | CNeqi _ -> []
-  | CLti _ -> []
-  | CGti _ -> []
-  | CLeqi _ -> []
-  | CGeqi _ -> []
-end
-
-lang CmpFloatKCFA = KCFA + ConstKCFA + CmpFloatAst
-  sem generateConstraintsConst info ident =
-  | CEqf _ -> []
-  | CLtf _ -> []
-  | CLeqf _ -> []
-  | CGtf _ -> []
-  | CGeqf _ -> []
-  | CNeqf _ -> []
-end
-
-lang CharKCFA = KCFA + ConstKCFA + CharAst
-  sem generateConstraintsConst info ident =
-  | CChar _ -> []
-end
-
-lang CmpCharKCFA = KCFA + ConstKCFA + CmpCharAst
-  sem generateConstraintsConst info ident =
-  | CEqc _ -> []
-end
-
-lang IntCharConversionKCFA = KCFA + ConstKCFA + IntCharConversionAst
-  sem generateConstraintsConst info ident =
-  | CInt2Char _ -> []
-  | CChar2Int _ -> []
-end
-
-lang FloatStringConversionKCFA = KCFA + ConstKCFA + FloatStringConversionAst
-  sem generateConstraintsConst info ident =
-  | CStringIsFloat _ -> []
-  | CString2float _ -> []
-  | CFloat2string _ -> []
-end
-
-lang SymbKCFA = KCFA + ConstKCFA + SymbAst
-  sem generateConstraintsConst info ident =
-  | CSymb _ -> []
-  | CGensym _ -> []
-  | CSym2hash _ -> []
-end
-
-lang CmpSymbKCFA = KCFA + ConstKCFA + CmpSymbAst
-  sem generateConstraintsConst info ident =
-  | CEqsym _ -> []
-end
-
-lang SeqOpKCFA = KCFA + ConstKCFA + SeqKCFA + SeqOpAst + KBaseConstraint
-               + LamKCFA
-
-  syn Constraint =
-  -- [{names}] ⊆ lhs ⇒ ∀n ∈ names: {n} ⊆ rhs
-  | CstrSeq {lhs : (IName,Ctx), rhs : (IName,Ctx)}
-  -- [{names}] ⊆ lhs ⇒ [{names} ∪ {rhs}] ⊆ res
-  | CstrSeqUnion {lhs : (IName,Ctx),
-                  rhs : (IName,Ctx),
-                  res : (IName,Ctx)}
-  -- [{names}] ∈ seq ⇒ [{f n : n ∈ names}] ∈ res
-  | CstrSeqMap1 {seq: (IName,Ctx), f: (IName,Ctx), res: (IName,Ctx)}
-  -- {lam x. b} ⊆ f ⇒ (names ⊆ x and [{b}] ∈ res)
-  | CstrSeqMap2 {f: (IName,Ctx), names: Set (IName,Ctx), res: (IName,Ctx)}
-
-  -- TODO(2023-07-11,dlunde): I suspect the fold constraints below have the
-  -- same problem as in the 0-CFA case. Namely, the constraint that c ⊆ y or c
-  -- ⊆ x (whichever is the accumulator) is missing.
-  -- CstrSeqFold<n> implements foldl when left = true, and foldr otherwise
-  -- l: [{names}] ∈ seq ⇒ [{f acc n : n ∈ names}] ∈ res
-  -- r: [{names}] ∈ seq ⇒ [{f n acc : n ∈ names}] ∈ res
-  | CstrSeqFold1 { seq: (IName,Ctx), f: (IName,Ctx), acc: (IName,Ctx),
-                   res: (IName,Ctx), left: Bool }
-  -- l: {lam x. b} ⊆ f ⇒ (acc ⊆ x and {lam y. c} ⊆ b ⇒ (names ⊆ y and c ⊆ res))
-  -- r: {lam x. b} ⊆ f ⇒ (names ⊆ x and {lam y. c} ⊆ b ⇒ (acc ⊆ y and c ⊆ res))
-  | CstrSeqFold2 { f: (IName,Ctx), acc: (IName,Ctx), names: Set (IName,Ctx),
-                   res: (IName,Ctx), left: Bool }
-  -- {lam x. b} ⊆ f ⇒ (names ⊆ x and b ⊆ res)
-  | CstrSeqFold3 { f: (IName,Ctx), names: Set (IName,Ctx), res: (IName,Ctx) }
-
-  sem cmpConstraintH =
-  | (CstrSeq { lhs = lhs1, rhs = rhs1 },
-     CstrSeq { lhs = lhs2, rhs = rhs2 }) ->
-     let d = cmpINameCtx lhs1 lhs2 in
-     if eqi d 0 then cmpINameCtx rhs1 rhs2
-     else d
-  | (CstrSeqUnion { lhs = lhs1, rhs = rhs1, res = res1 },
-     CstrSeqUnion { lhs = lhs2, rhs = rhs2, res = res2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx lhs1 lhs2 in
-       if eqi d 0 then cmpINameCtx rhs1 rhs2
-       else d
-     else d
-  | (CstrSeqMap1 { seq = seq1, f = f1, res = res1 },
-     CstrSeqMap1 { seq = seq2, f = f2, res = res2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx seq1 seq2 in
-       if eqi d 0 then cmpINameCtx f1 f2
-       else d
-     else d
-  | (CstrSeqMap2 { f = f1, names = names1, res = res1 },
-     CstrSeqMap2 { f = f2, names = names2, res = res2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx f1 f2 in
-       if eqi d 0 then setCmp names1 names2
-       else d
-     else d
-  | (CstrSeqFold1 { seq = seq1, f = f1, acc = acc1, res = res1, left = l1 },
-     CstrSeqFold1 { seq = seq2, f = f2, acc = acc2, res = res2, left = l2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx seq1 seq2 in
-       if eqi d 0 then
-         let d = cmpINameCtx acc1 acc2 in
-         if eqi d 0 then
-           let d = cmpINameCtx f1 f2 in
-           if eqi d 0 then cmpBool l1 l2
-           else d
-         else d
-       else d
-     else d
-  | (CstrSeqFold2 { f = f1, acc = acc1, names = names1, res = res1, left = l1 },
-     CstrSeqFold2 { f = f2, acc = acc2, names = names2, res = res2, left = l2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx acc1 acc2 in
-       if eqi d 0 then
-         let d = cmpINameCtx f1 f2 in
-         if eqi d 0 then
-           let d = setCmp names1 names2 in
-           if eqi d 0 then cmpBool l1 l2
-           else d
-         else d
-       else d
-     else d
-  | (CstrSeqFold3 { f = f1, names = names1, res = res1 },
-     CstrSeqFold3 { f = f2, names = names2, res = res2 }) ->
-     let d = cmpINameCtx res1 res2 in
-     if eqi d 0 then
-       let d = cmpINameCtx f1 f2 in
-       if eqi d 0 then setCmp names1 names2
-       else d
-     else d
-
-  sem initConstraint (graph: CFAGraph) =
-  | CstrSeq r & cstr -> initConstraintName r.lhs graph cstr
-  | CstrSeqUnion r & cstr -> initConstraintName r.lhs graph cstr
-  | CstrSeqMap1 r & cstr -> initConstraintName r.seq graph cstr
-  | CstrSeqMap2 r & cstr -> initConstraintName r.f graph cstr
-  | CstrSeqFold1 r & cstr -> initConstraintName r.seq graph cstr
-  | CstrSeqFold2 r & cstr -> initConstraintName r.f graph cstr
-  | CstrSeqFold3 r & cstr -> initConstraintName r.f graph cstr
-
-  sem constraintToString im (env: PprintEnv) =
-  | CstrSeq { lhs = lhs, rhs = rhs } ->
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    (env, join [ "[{names}] ⊆ ", lhs, " ⇒ ∀n ∈ names: {n} ⊆ ", rhs ])
-  | CstrSeqUnion { lhs = lhs, rhs = rhs, res = res } ->
-    match pprintVarINameCtx im env lhs with (env,lhs) in
-    match pprintVarINameCtx im env rhs with (env,rhs) in
-    match pprintVarINameCtx im env res with (env,res) in
-    (env, join [
-        "[{names}] ⊆ ", lhs, " ⇒ [{names} ∪ { ", rhs," }] ⊆ ", res
-      ])
-  | CstrSeqMap1 { seq = seq, f = f, res = res } ->
-    match pprintVarINameCtx im env seq with (env,seq) in
-    match pprintVarINameCtx im env f with (env,f) in
-    match pprintVarINameCtx im env res with (env,res) in
-    (env, join [
-        "[{names}] ∈ ", seq, " ⇒ [{", f, " n : n ∈ names}] ∈ ", res
-      ])
-  | CstrSeqMap2 { f = f, names = names, res = res } ->
-    match pprintVarINameCtx im env f with (env,f) in
-    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
-    with (env,names) in
-    match pprintVarINameCtx im env res with (env,res) in
-    (env, join [
-        "{lam x. b} ⊆ ", f, " ⇒ {", strJoin ", " names, "} ⊆ x AND ",
-        "[{b}] ∈ ", res
-      ])
-  | CstrSeqFold1 { seq = seq, f = f, acc = acc, res = res, left = left } ->
-    match pprintVarINameCtx im env seq with (env,seq) in
-    match pprintVarINameCtx im env f with (env,f) in
-    match pprintVarINameCtx im env acc with (env,acc) in
-    match pprintVarINameCtx im env res with (env,res) in
-    let app = if left then [" ", acc, " n"] else [" n ", acc] in
-    (env, join [
-        "[{names}] ∈ ", seq, " ⇒ [{", f, join app, " : n ∈ names}] ∈ ", res
-      ])
-  | CstrSeqFold2 { f = f, acc = acc, names = names, res = res, left = left } ->
-    match pprintVarINameCtx im env f with (env,f) in
-    match pprintVarINameCtx im env acc with (env,acc) in
-    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
-    with (env,names) in
-    match pprintVarINameCtx im env res with (env,res) in
-    let args =
-      if left then (acc, join ["{", strJoin ", " names, "}"])
-      else (join ["{", strJoin ", " names, "}"], acc) in
-    (env, join [
-        "{lam x. b} ⊆ ", f, " ⇒ ", args.0, " ⊆ x AND ",
-        "{lam y. c} ⊆ b ⇒ ", args.1, " ⊆ y AND {c} ⊆ ", res
-      ])
-  | CstrSeqFold3 { f = f, names = names, res = res } ->
-    match pprintVarINameCtx im env f with (env,f) in
-    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
-    with (env,names) in
-    match pprintVarINameCtx im env res with (env,res) in
-    (env, join [
-        "{lam x. b} ⊆ ", f, " ⇒ {", (strJoin ", " names), "} ⊆ x AND ",
-        "b ⊆ ", res
-      ])
-
-  sem propagateConstraint update graph =
-  | CstrSeq { lhs = lhs, rhs = rhs } ->
-    match update.2 with AVSeq { names = names } then
-      setFold (lam graph. lam name.
-          initConstraint graph (CstrDirect {lhs = name, rhs = rhs})
-        ) graph names
-    else graph
-  | CstrSeqUnion { lhs = lhs, rhs = rhs, res = res } ->
-    match update.2 with AVSeq { names = names } then
-      addData graph (AVSeq {names = setInsert rhs names}) res
-    else graph
-  | CstrSeqMap1 { seq = seq, f = f, res = res } ->
-    match update.2 with AVSeq { names = names } then
-      initConstraint graph (CstrSeqMap2 { f = f, names = names, res = res })
-    else graph
-  | CstrSeqMap2 { f = f, names = names, res = res } ->
-    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
-    then
-      -- All calls to 'f' within the map get the same context
-      let ctxBody = res.1 in
-      let envBody = ctxEnvAdd x ctxBody env in
-      -- Analyze the lambda body
-      match initConstraints ctxBody envBody graph body with (envBody, graph) in
-      -- Add names ⊆ x constraints
-      let graph = setFold (lam graph. lam n.
-          initConstraint graph (CstrDirect { lhs = n, rhs = (x, ctxBody) })
-        ) graph names in
-      -- Add [{b}] ⊆ res constraint
-      let ctx = ctxEnvLookup graph.im (infoTm body) b envBody in
-      initConstraint graph (CstrInit {
-        lhs = AVSeq { names = setOfSeq cmpINameCtx [(b, ctx)]},
-        rhs = res })
-    else graph
-  | CstrSeqFold1 { seq = seq, f = f, acc = acc, res = res, left = left } ->
-    match update.2 with AVSeq { names = names } then
-      initConstraint graph (
-        CstrSeqFold2 { f = f, acc = acc, names = names, res = res, left = left }
-      )
-    else graph
-  | CstrSeqFold2 { f = f, acc = acc, names = names, res = res, left = left } ->
-    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
-    then
-      let ctxBody = res.1 in
-      let envBody = ctxEnvAdd x ctxBody env in
-      -- Analyze the lambda body
-      match initConstraints ctxBody envBody graph body with (envBody, graph) in
-      let ctxBident = ctxEnvLookup graph.im (infoTm body) b envBody in
-      if left then
-        -- Add acc ⊆ x constraint
-        let graph = initConstraint graph (CstrDirect {
-          lhs = acc, rhs = (x, ctxBody) }) in
-        initConstraint graph (CstrSeqFold3 {
-          f = (b, ctxBident), names = names, res = res})
-      else
-        -- Add names ⊆ x constraint
-        let graph = setFold (lam graph. lam n.
-            initConstraint graph (CstrDirect { lhs = n, rhs = (x, ctxBody) })
-          ) graph names in
-        initConstraint graph (CstrSeqFold3 {
-          f = (b, ctxBident), names = setOfSeq cmpINameCtx [acc], res = res})
-    else graph
-  | CstrSeqFold3 { f = f, names = names, res = res } ->
-    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
-    then
-      let ctxBody = res.1 in
-      let envBody = ctxEnvAdd x ctxBody env in
-      -- Analyze the lambda body
-      match initConstraints ctxBody envBody graph body with (envBody, graph) in
-      let ctxBident = ctxEnvLookup graph.im (infoTm body) b envBody in
-      -- Add names ⊆ x constraints
-      let graph = setFold (lam graph. lam n.
-          initConstraint graph (CstrDirect { lhs = n, rhs = (x, ctxBody) })
-        ) graph names in
-      -- Add b ⊆ res constraint
-      initConstraint graph (CstrDirect { lhs = (b, ctxBident), rhs = res })
-    else graph
-
-  sem generateConstraintsConst info ident =
-  | ( CSet _
-    | CGet _
-    | CCons _
-    | CSnoc _
-    | CConcat _
-    | CReverse _
-    | CHead _
-    | CTail _
-    | CSubsequence _
-    | CFoldl _
-    | CFoldr _
-    | CMap _
-    ) & const ->
-    [
-      CstrInit {
-        lhs = AVConst { id = ident, const = const, args = []}, rhs = ident
-      }
-    ]
-
-  | ( CLength _
-    | CNull _
-    | CIsList _
-    | CIsRope _
-    ) -> []
-
-  -- TODO(Linnea, 2022-05-13): Add flow constraints to all sequence operations
-  -- | ( CMapi _
-  --   | CIter _
-  --   | CIteri _
-  --   | CCreate _
-  --   | CCreateList _
-  --   | CCreateRope _
-  --   | CSplitAt _
-  --   ) -> []
-
-  sem propagateConstraintConst res args graph =
-  | CSet _ ->
-    utest length args with 3 in
-    let seq = get args 0 in
-    let val = get args 2 in
-    initConstraint graph (CstrSeqUnion {lhs = seq, rhs = val, res = res})
-  | CGet _ ->
-    utest length args with 2 in
-    initConstraint graph (CstrSeq {lhs = head args, rhs = res})
-  | CCons _ ->
-    utest length args with 2 in
-    let val = get args 0 in
-    let seq = get args 1 in
-    initConstraint graph (CstrSeqUnion {lhs = seq, rhs = val, res = res})
-  | CSnoc _ ->
-    utest length args with 2 in
-    let seq = get args 0 in
-    let val = get args 1 in
-    initConstraint graph (CstrSeqUnion {lhs = seq, rhs = val, res = res})
-  | CConcat _ ->
-    utest length args with 2 in
-    let graph = initConstraint graph (CstrDirect {lhs = head args, rhs = res}) in
-    initConstraint graph (CstrDirect {lhs = get args 1, rhs = res})
-  | CReverse _ ->
-    utest length args with 1 in
-    initConstraint graph (CstrDirect {lhs = head args, rhs = res})
-  | CHead _ ->
-    utest length args with 1 in
-    initConstraint graph (CstrSeq {lhs = head args, rhs = res})
-  | CTail _ ->
-    utest length args with 1 in
-    initConstraint graph (CstrDirect {lhs = head args, rhs = res})
-  | CSubsequence _ ->
-    utest length args with 3 in
-    initConstraint graph (CstrDirect {lhs = head args, rhs = res})
-  | CMap _ ->
-    utest length args with 2 in
-    initConstraint graph (
-      CstrSeqMap1 {seq = get args 1, f = head args, res = res})
-  | CFoldl _ ->
-    utest length args with 3 in
-    let seq = get args 2 in
-    let f = head args in
-    let acc = get args 1 in
-    -- Add acc ⊆ res constraint
-    let graph = initConstraint graph (CstrDirect { lhs = acc, rhs = res }) in
-    initConstraint graph (CstrSeqFold1 {
-      seq = seq, f = f, acc = acc, res = res, left = true})
-  | CFoldr _ ->
-    utest length args with 3 in
-    let seq = get args 2 in
-    let f = head args in
-    let acc = get args 1 in
-    -- Add acc ⊆ res constraint
-    let graph = initConstraint graph (CstrDirect { lhs = acc, rhs = res }) in
-    initConstraint graph (CstrSeqFold1 {
-      seq = seq, f = f, acc = acc, res = res, left = false})
-
-end
-
-lang FileOpKCFA = KCFA + ConstKCFA + FileOpAst
-  sem generateConstraintsConst info ident =
-  | CFileRead _ -> []
-  | CFileWrite _ -> []
-  | CFileExists _ -> []
-  | CFileDelete _ -> []
-end
-
-lang IOKCFA = KCFA + ConstKCFA + IOAst
-  sem generateConstraintsConst info ident =
-  | CPrint _ -> []
-  | CPrintError _ -> []
-  | CDPrint _ -> []
-  | CFlushStdout _ -> []
-  | CFlushStderr _ -> []
-  | CReadLine _ -> []
-  | CReadBytesAsString _ -> []
-end
-
-lang RandomNumberGeneratorKCFA = KCFA + ConstKCFA + RandomNumberGeneratorAst
-  sem generateConstraintsConst info ident =
-  | CRandIntU _ -> []
-  | CRandSetSeed _ -> []
-end
-
-lang SysKCFA = KCFA + ConstKCFA + SysAst
-  sem generateConstraintsConst info ident =
-  | CExit _ -> []
-  | CError _ -> []
-  | CArgv _ -> []
-  | CCommand _ -> []
-end
-
-lang TimeKCFA = KCFA + ConstKCFA + TimeAst
-  sem generateConstraintsConst info ident =
-  | CWallTimeMs _ -> []
-  | CSleepMs _ -> []
-end
-
-lang ConTagKCFA = KCFA + ConstKCFA + ConTagAst
-  sem generateConstraintsConst info ident =
-  | CConstructorTag _ -> []
-end
-
--- TODO(dlunde,2021-11-11): Mutability complicates the analysis, but could
--- probably be added.
-lang RefOpKCFA = KCFA + ConstKCFA + RefOpAst
-  sem generateConstraintsConst info ident =
-  -- | CRef _ -> []
-  -- | CModRef _ -> []
-  -- | CDeRef _ -> []
-end
-
--- TODO(dlunde,2021-11-11): Mutability complicates the analysis, but could
--- probably be added.
-lang TensorOpKCFA = KCFA + ConstKCFA + TensorOpAst
-  sem generateConstraintsConst info ident =
-  -- | CTensorCreateUninitInt _ -> []
-  -- | CTensorCreateUninitFloat _ -> []
-  -- | CTensorCreateInt _ -> []
-  -- | CTensorCreateFloat _ -> []
-  -- | CTensorCreate _ -> []
-  -- | CTensorGetExn _ -> []
-  -- | CTensorSetExn _ -> []
-  -- | CTensorLinearGetExn _ -> []
-  -- | CTensorLinearSetExn _ -> []
-  -- | CTensorRank _ -> []
-  -- | CTensorShape _ -> []
-  -- | CTensorReshapeExn _ -> []
-  -- | CTensorCopy _ -> []
-  -- | CTensorTransposeExn _ -> []
-  -- | CTensorSliceExn _ -> []
-  -- | CTensorSubExn _ -> []
-  -- | CTensorIterSlice _ -> []
-  -- | CTensorEq _ -> []
-  -- | CTensorToString _ -> []
-end
-
-lang BootParserKCFA = KCFA + ConstKCFA + BootParserAst
-  sem generateConstraintsConst info ident =
-  | CBootParserParseMExprString _ -> []
-  | CBootParserParseMCoreFile _ -> []
-  | CBootParserGetId _ -> []
-  | CBootParserGetTerm _ -> []
-  | CBootParserGetType _ -> []
-  | CBootParserGetString _ -> []
-  | CBootParserGetInt _ -> []
-  | CBootParserGetFloat _ -> []
-  | CBootParserGetListLength _ -> []
-  | CBootParserGetConst _ -> []
-  | CBootParserGetPat _ -> []
-  | CBootParserGetInfo _ -> []
-end
-
---------------
--- PATTERNS --
---------------
-
-lang NamedPatKCFA = MatchKCFA + NamedPat + KBaseConstraint
-  sem propagateMatchConstraint graph (id: (IName,Ctx)) =
-  | (PatNamed { ident = PName n, info = info }, av) ->
-    -- OPT(Linnea,2022-06-29): Can we avoid doing name2int every time here?
-    propagateDirectConstraint (name2int graph.im info n, id.1) graph av
-  | (PatNamed { ident = PWildcard _ }, _) -> graph
-
-  sem patNames acc =
-  | PatNamed { ident = PName n } -> cons n acc
-end
-
-lang SeqTotPatKCFA = MatchKCFA + SeqKCFA + SeqTotPat
-  sem propagateMatchConstraint graph (id: (IName,Ctx)) =
-  | (PatSeqTot p, AVSeq { names = names }) ->
-    let f = lam graph. lam pat: Pat. setFold (lam graph: CFAGraph. lam name.
-        let cstrs =
-          foldl (lam acc. lam f. concat (f id name pat) acc) [] graph.mcgfs
-        in
-        foldl initConstraint graph cstrs
-      ) graph names in
-    foldl f graph p.pats
-end
-
-lang SeqEdgePatKCFA = MatchKCFA + SeqKCFA + SeqEdgePat
-  sem propagateMatchConstraint graph (id: (IName,Ctx)) =
-  | (PatSeqEdge p, AVSeq { names = names } & av) ->
-    let f = lam graph. lam pat: Pat. setFold (lam graph: CFAGraph. lam name.
-        let cstrs = foldl (lam acc. lam f. concat (f id name pat) acc)
-          [] graph.mcgfs in
-        foldl initConstraint graph cstrs
-      ) graph names in
-    let graph = foldl f graph p.prefix in
-    let graph = foldl f graph p.postfix in
-    match p.middle with PName rhs
-    then addData graph av (name2int graph.im p.info rhs, id.1)
-    else graph
-  | (PatSeqEdge p, av) ->
-    match p.middle with PName rhs
-    then addData graph av (name2int graph.im p.info rhs, id.1)
-    else graph
-
-  sem patNames acc =
-  | PatSeqEdge { middle = PName n } & p ->
-    sfold_Pat_Pat patNames (cons n acc) p
-end
-
-lang RecordPatKCFA = MatchKCFA + RecordKCFA + RecordPat
-  sem propagateMatchConstraint graph id =
-  | (PatRecord { bindings = pbindings }, AVRec { bindings = abindings }) ->
-    -- Check if record pattern is compatible with abstract value record
-    let compatible = mapAllWithKey (lam k. lam. mapMem k abindings) pbindings in
-    if compatible then
-      mapFoldWithKey (lam graph: CFAGraph. lam k. lam pb: Pat.
-        let ab: (IName,Ctx) = mapFindExn k abindings in
-        let cstrs = foldl (lam acc. lam f. concat (f id ab pb) acc)
-          [] graph.mcgfs in
-        foldl initConstraint graph cstrs
-      ) graph pbindings
-    else graph -- Nothing to be done
-end
-
-lang DataPatKCFA = MatchKCFA + DataKCFA + DataPat
-  sem propagateMatchConstraint graph id =
-  | (PatCon p, AVCon { ident = ident, body = body }) ->
-    if nameEq p.ident (int2name graph.im ident.0) then
-      let cstrs = foldl (lam acc. lam f. concat (f id body p.subpat) acc)
-        [] graph.mcgfs in
-      foldl initConstraint graph cstrs
-    else graph
-end
-
-lang IntPatKCFA = MatchKCFA + IntPat
-  sem propagateMatchConstraint graph id =
-  | (PatInt p, _) -> graph
-end
-
-lang CharPatKCFA = MatchKCFA + CharPat
-  sem propagateMatchConstraint graph id =
-  | (PatChar p, _) -> graph
-end
-
-lang BoolPatKCFA = MatchKCFA + BoolPat
-  sem propagateMatchConstraint graph id =
-  | (PatBool p, _) -> graph
-end
-
-lang AndPatKCFA = MatchKCFA + AndPat
-  sem propagateMatchConstraint graph id =
-  | (PatAnd p, av) ->
-    let graph = propagateMatchConstraint graph id (p.lpat, av) in
-    propagateMatchConstraint graph id (p.rpat, av)
-end
-
-lang OrPatKCFA = MatchKCFA + OrPat
-  sem propagateMatchConstraint graph id =
-  | (PatOr p, av) ->
-    let graph = propagateMatchConstraint graph id (p.lpat, av) in
-    propagateMatchConstraint graph id (p.rpat, av)
-end
-
-lang NotPatKCFA = MatchKCFA + NotPat
-  sem propagateMatchConstraint graph id =
-  | (PatNot p, _) -> graph
-end
-
------------------
--- MEXPR k-CFA --
------------------
-
-lang MExprKCFA = KCFA +
-
-  -- Base constraints
-  KBaseConstraint +
-
-  -- Terms
-  VarKCFA + LamKCFA + AppKCFA +
-  LetKCFA + RecLetsKCFA + ConstKCFA + SeqKCFA + RecordKCFA + TypeKCFA + DataKCFA +
-  MatchKCFA + UtestKCFA + NeverKCFA + ExtKCFA +
-
-  -- Constants
-  IntKCFA + ArithIntKCFA + ShiftIntKCFA + FloatKCFA + ArithFloatKCFA +
-  FloatIntConversionKCFA + BoolKCFA + CmpIntKCFA + CmpFloatKCFA + CharKCFA +
-  CmpCharKCFA + IntCharConversionKCFA + FloatStringConversionKCFA + SymbKCFA +
-  CmpSymbKCFA + SeqOpKCFA + FileOpKCFA + IOKCFA + RandomNumberGeneratorKCFA +
-  SysKCFA + TimeKCFA + ConTagKCFA + RefOpKCFA + TensorOpKCFA + BootParserKCFA +
-
-  -- Patterns
-  NamedPatKCFA + SeqTotPatKCFA + SeqEdgePatKCFA + RecordPatKCFA + DataPatKCFA +
-  IntPatKCFA + CharPatKCFA + BoolPatKCFA + AndPatKCFA + OrPatKCFA + NotPatKCFA
-
-  -- Function that adds a set of universal base match constraints to a CFAGraph
-  sem addBaseMatchConstraints =
-  | graph ->
-    { graph with mcgfs = concat [generateMatchConstraints] graph.mcgfs }
-
-  -- Function that adds a set of universal base constraints to a CFAGraph
-  sem addBaseConstraints =
-  | graph ->
-    let cgfs = [ generateConstraints graph.im,
-                 generateConstraintsMatch graph.im graph.mcgfs ] in
-    { graph with cgfs = concat cgfs graph.cgfs }
-
-  -- Function that initializes the constraints in a CFAGraph for an empty
-  -- context and context environment
-  sem initConstraintsEmpty: CFAGraph -> Expr -> CFAGraph
-  sem initConstraintsEmpty graph =
-  | t ->
-    match initConstraints (ctxEmpty ()) (ctxEnvEmpty ()) graph t with (_, graph)
-    in graph
+    graph
 
 end
 
@@ -3596,7 +1719,7 @@ lang Test = MExprCFA + MExprANFAll + BootParser + MExprPrettyPrint
   sem testCfa : Expr -> CFAGraph
   sem testCfa =
   | t ->
-    let graph = emptyCFAGraph t in
+    let graph = emptyCFAGraphInit t in
     let graph = addBaseMatchConstraints graph in
     let graph = addBaseConstraints graph t in
     solveCfa graph
@@ -3604,44 +1727,14 @@ lang Test = MExprCFA + MExprANFAll + BootParser + MExprPrettyPrint
   sem testCfaDebug : PprintEnv -> Expr -> (PprintEnv, CFAGraph)
   sem testCfaDebug pprintenv =
   | t ->
-    let graph = emptyCFAGraph t in
+    let graph = emptyCFAGraphInit t in
     let graph = addBaseMatchConstraints graph in
     let graph = addBaseConstraints graph t in
     solveCfaDebug pprintenv graph
 
 end
 
------------------
--- TESTS k-CFA --
------------------
-
-lang KTest = MExprKCFA + MExprANFAll + BootParser + MExprPrettyPrint
-
-  sem testCfa : Int -> Expr -> CFAGraph
-  sem testCfa k =
-  | t ->
-    let graph = emptyCFAGraph k t in
-    let graph = addBaseMatchConstraints graph in
-    let graph = addBaseConstraints graph in
-    let graph = initConstraintsEmpty graph t in
-    solveCfa graph
-
-  sem testCfaDebug : PprintEnv -> Int -> Expr -> (PprintEnv, CFAGraph)
-  sem testCfaDebug pprintenv k =
-  | t ->
-    let graph = emptyCFAGraph k t in
-    let graph = addBaseMatchConstraints graph in
-    let graph = addBaseConstraints graph in
-    let graph = initConstraintsEmpty graph t in
-    solveCfaDebug pprintenv graph
-
-end
-
 mexpr
------------------
--- TESTS 0-CFA --
------------------
-
 use Test in
 
 -- Test functions --
@@ -3826,12 +1919,18 @@ let t = _parse "
   let r2 = head s2 in
   let s3 = mapi (lam i. lam x. x) [lam y. y, lam z. z] in
   let r3 = head s3 in
+  let s4 = map (map (lam x. let t1 = x in x)) [[lam y. y], [lam z. z]] in
+  let r4 = head (head s4) in
+  let s5 = map (mapi (lam i. lam x. let t1 = x in x)) [[lam y. y], [lam z. z]] in
+  let r5 = head (head s4) in
   ()
 ------------------------" in
-utest _test false t ["r1", "r2", "r3"] with [
+utest _test false t ["r1", "r2", "r3", "r4", "r5"] with [
   ("r1", ["y", "z"]),
   ("r2", ["d"]),
-  ("r3", ["y", "z"])
+  ("r3", ["y", "z"]),
+  ("r4", ["y", "z"]),
+  ("r5", ["y", "z"])
 ] using eqTestLam in
 
 -- Iter over sequences
@@ -3839,11 +1938,15 @@ let t = _parse "
   let s0 = lam a. a in
   let s1 = iter (lam x. let t1 = x in x) [lam y. y, lam z. z] in
   let s2 = iteri (lam i. lam x. let t2 = x in x) [lam y. y, lam z. z] in
+  let s3 = iter (iter (lam x. let t3 = x in x)) [[lam y. y], [lam z. z]] in
+  let s4 = iter (iteri (lam i. lam x. let t4 = x in x)) [[lam y. y], [lam z. z]] in
   ()
 ------------------------" in
-utest _test false t ["t1", "t2"] with [
+utest _test false t ["t1", "t2", "t3", "t4"] with [
   ("t1", ["y", "z"]),
-  ("t2", ["y", "z"])
+  ("t2", ["y", "z"]),
+  ("t3", ["y", "z"]),
+  ("t4", ["y", "z"])
 ] using eqTestLam in
 
 -- Create sequences
@@ -3884,13 +1987,19 @@ let t = _parse "
   let r2 = foldl (lam a2. lam e2. a2 e2) f [g, h] in
   let r3 = foldl (lam a3. lam e3. a3 e3) (lam w. w) [] in
   let r4 = foldl (lam a4. lam e4. let t1 = a4 in e4) (lam v. v) [f,g,h] in
+  let r5 =
+    foldl (foldl (lam a5. lam e5. let t2 = a5 in e5)) (lam u. u)
+      [[f],[g],[h]] in
   ()
 ------------------------" in
-utest _test false t ["r1", "r2", "r3", "t1"] with [
+utest _test false t ["r1", "r2", "r3", "r4", "t1", "r5", "t2"] with [
   ("r1", ["x"]),
   ("r2", ["x", "y", "z"]),
   ("r3", ["w"]),
-  ("t1", ["v", "z", "y", "x"])
+  ("r4", ["v", "z", "y", "x"]),
+  ("t1", ["v", "z", "y", "x"]),
+  ("r5", ["u", "z", "y", "x"]),
+  ("t2", ["u", "z", "y", "x"])
 ] using eqTestLam in
 
 -- Foldr
@@ -3902,13 +2011,19 @@ let t = _parse "
   let r2 = foldr (lam e2. lam a2. a2 e2) f [g, h] in
   let r3 = foldr (lam e3. lam a3. a3 e3) (lam w. w) [] in
   let r4 = foldr (lam e4. lam a4. let t1 = a4 in e4) (lam v. v) [f,g,h] in
+  let r5 =
+    foldl (foldr (lam e5. lam a5. let t2 = a5 in e5)) (lam u. u)
+      [[f],[g],[h]] in
   ()
 ------------------------" in
-utest _test false t ["r1", "r2", "r3", "t1"] with [
+utest _test false t ["r1", "r2", "r3", "r4", "t1", "r5", "t2"] with [
   ("r1", ["x"]),
-  ("r2", ["x", "y", "z"]),
+  ("r2", ["z", "y", "x"]),
   ("r3", ["w"]),
-  ("t1", ["v", "x", "y", "z"])
+  ("r4", ["v", "z", "y", "x"]),
+  ("t1", ["v", "z", "y", "x"]),
+  ("r5", ["u", "z", "y", "x"]),
+  ("t2", ["u", "z", "y", "x"])
 ] using eqTestLam in
 
 -- Record
@@ -4112,471 +2227,5 @@ with [
   ("t19", ["x"]),
   ("t20", ["x"])
 ] using eqTestLam in
-
------------------
--- TESTS k-CFA --
------------------
-
-use KTest in
-
--- Test functions --
-let _parse = parseMExprStringKeywords [] in
-let _testBase: Option PprintEnv -> Int -> Expr -> (Option PprintEnv, CFAGraph) =
-  lam env: Option PprintEnv. lam k. lam t: Expr.
-    match env with Some env then
-      -- Version with debug printouts
-      let tANF = normalizeTerm t in
-      match pprintCode 0 env t with (env,tStr) in
-      printLn "\n--- ORIGINAL PROGRAM ---";
-      printLn tStr;
-      match pprintCode 0 env tANF with (env,tANFStr) in
-      printLn "\n--- ANF ---";
-      printLn tANFStr;
-      match testCfaDebug env k tANF with (env,cfaRes) in
-      match cfaGraphToString env cfaRes with (env, resStr) in
-      printLn "\n--- FINAL CFA GRAPH ---";
-      printLn resStr;
-      (Some env,cfaRes)
-
-    else
-      -- Version without debug printouts
-      let tANF = normalizeTerm t in
-      let cfaRes = testCfa k tANF in
-      (None (), cfaRes)
-in
-
-let _test : Bool -> Int -> Expr -> [(String, [String])]
-          -> [(String,[String],[String])] =
-  lam debug. lam k. lam t. lam vars.
-    let env = if debug then Some pprintEnvEmpty else None () in
-    match _testBase env k t with (_, cfaRes) in
-    let stringMap: Map String Int = mapFoldWithKey (
-        lam acc: Map String Int. lam n: Name. lam i: Int.
-          mapInsert (nameGetStr n) i acc
-      ) (mapEmpty cmpString) cfaRes.im.name2int
-    in
-    let string2int: String -> Int = lam s. mapFindExn s stringMap in
-    let int2string: Int -> String = lam i. nameGetStr (int2name cfaRes.im i) in
-    map (lam var: (String, [String]).
-      let avs = mapFoldWithKey (lam acc: Set AbsVal. lam ctx. lam avs: Set AbsVal.
-          let ctx = map int2string ctx in
-          if eqSeq eqString ctx var.1 then avs else acc
-        ) (setEmpty cmpAbsVal) (tensorLinearGetExn cfaRes.data (string2int var.0))
-      in
-      let val = setFold
-        (lam acc. lam av.
-           match av with AVLam { ident = i } then
-             cons (nameGetStr (int2name cfaRes.im i)) acc
-           else acc)
-        [] avs
-      in (var.0, var.1, val)
-    ) vars
-in
-
-let _test0 : Bool -> Expr -> [String]
-          -> [(String,[String],[String])] =
-  lam debug. lam t. lam vars.
-    _test debug 0 t (map (lam v. (v,[])) vars)
-in
-
--- Custom equality function for testing lambda control flow only
-let eqTestLam = eqSeq (
-  lam t1:(String,[String],[String]). lam t2:(String,[String],[String]).
-    if eqString t1.0 t2.0 then
-      if eqSeq eqString t1.1 t2.1 then
-        let t12 = setOfSeq cmpString t1.2 in
-        let t22 = setOfSeq cmpString t2.2 in
-        setEq t12 t22
-      else false
-    else false)
-in
-
-let eqTestLam0 =
-  lam t1:[(String,[String],[String])]. lam t2:[(String,[String])].
-    let f = map (lam t:(String,[String]). (t.0,[],t.1)) in
-    eqTestLam t1 (f t2)
-in
---------------------
-
--- First test from Nielson et al.
-let t = _parse "
-  (lam x. x) (lam y. y)
-------------------------" in
-utest _test0 false t ["x","y"] with [
-  ("x", ["y"]),
-  ("y", [])
-] using eqTestLam0 in
-
--- Second test from Nielson et al.
-let t = _parse "
-  let f = lam x. x 1 in
-  let g = lam y. addi y 2 in
-  let h = lam z. addi z 3 in
-  let res = addi (f g) (f h) in
-  res
-------------------------" in
-utest _test0 false t ["f","g","h","x","y","z","res"] with [
-  ("f", ["x"]),
-  ("g", ["y"]),
-  ("h", ["z"]),
-  ("x", ["y","z"]),
-  ("y", []),
-  ("z", []),
-  ("res", [])
-] using eqTestLam0 in
-
--- Third test from Nielson et al.
-let t = _parse "
-recursive let g = lam x.
-  g (lam y. y)
-in
-let res = g (lam z. z) in
-res
-------------------------" in
-utest _test0 false t ["g","x","y","z","res"] with [
-  ("g", ["x"]),
-  ("x", ["y","z"]),
-  ("y", []),
-  ("z", []),
-  ("res", [])
-] using eqTestLam0 in
-
--- Example 3.34 from Nielson et al (0-CFA).
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let a = f f in
-  let b = f g in
-  b
-------------------------" in
-utest _test0 false t ["a", "b"] with [
-  ("a", ["x", "y"]),
-  ("b", ["x", "y"])
-] using eqTestLam0 in
-
--- Example 3.34 from Nielson et al (1-CFA).
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let a = f f in
-  let b = f g in
-  b
-------------------------" in
-utest _test false 1 t [("a",[]), ("b",[]), ("x",["a"]), ("x",["b"])] with [
-  ("a", [], ["x"]),
-  ("b", [], ["y"]),
-  ("x", ["a"], ["x"]),
-  ("x", ["b"], ["y"])
-] using eqTestLam in
-
--- Third test using 2-CFA
-let t = _parse "
-let f = lam y. y in
-recursive let g = lam x.
-  let a = g f in
-  a
-in
-let res = g (lam z. z) in
-res
-------------------------" in
-utest _test false 2 t [
-  ("g",[]),
-  ("x",["res"]),("x",["res","a"]),("x",["a","a"]),
-  ("res", [])
-] with [
-  ("g", [], ["x"]),
-  ("x", ["res"], ["z"]),
-  ("x", ["res","a"], ["y"]),
-  ("x", ["a","a"], ["y"]),
-  ("res", [], [])
-] using eqTestLam in
-
--- 2-CFA
-let t = _parse "
-let f = lam x. x in
-let g = lam y.
-  let t = f y in
-  t
-in
-let h = lam z. z in
-let a = g h in
-let b = g f in
-a
-------------------------" in
-utest _test false 2 t [("a",[]),("b",[]),("x",["a","t"]),("x",["b","t"])] with [
-  ("a", [], ["z"]),
-  ("b", [], ["x"]),
-  ("x", ["a","t"], ["z"]),
-  ("x", ["b","t"], ["x"])
-] using eqTestLam in
-
--- Sequence
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let seq = [f, lam z. z] in
-  let res = match seq with [a] ++ _ then
-      a g
-    else
-      (lam v. v)
-  in res
-------------------------" in
-utest _test0 false t ["res","a"] with [
-  ("res", ["v","y"]),
-  ("a", ["x","z"])
-] using eqTestLam0 in
-
--- Sequence operations (basic)
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let s1 = [f, lam z. z] in
-  let hd = head in
-  let b = hd in
-  let resHead = b s1 in
-  let s2 = concat s1 [lam v. v] in
-  let resConcat = b s2 in
-  let s3 = set s1 0 g in
-  let resSet = head s3 in
-  let resGet = get s1 1 in
-  let s4 = cons g s1 in
-  let resCons = head s4 in
-  let s5 = snoc s1 (lam r. r) in
-  let resSnoc = head s5 in
-  let resLength = length s1 in
-  let s6 = reverse s1 in
-  let resReverse = head s6 in
-  let s7 = tail s1 in
-  let resTail = head s1 in
-  let resNull = null s1 in
-  let resIsList = isList s1 in
-  let resIsRope = isRope s1 in
-  let s8 = subsequence s1 0 0 in
-  let resSubsequence = head s8 in
-  ()
-------------------------" in
-utest _test0 false t [
-  "resHead",
-  "resConcat",
-  "resSet",
-  "resGet",
-  "resCons",
-  "resSnoc",
-  "resLength",
-  "resReverse",
-  "resTail",
-  "resNull",
-  "resIsList",
-  "resIsRope",
-  "resSubsequence"
-] with [
-  ("resHead", ["x","z"]),
-  ("resConcat", ["x","z","v"]),
-  ("resSet", ["x","z","y"]),
-  ("resGet", ["x","z"]),
-  ("resCons", ["x","z","y"]),
-  ("resSnoc", ["x","z","r"]),
-  ("resLength", []),
-  ("resReverse", ["x","z"]),
-  ("resTail", ["x","z"]),
-  ("resNull", []),
-  ("resIsList", []),
-  ("resIsRope", []),
-  ("resSubsequence", ["x", "z"])
-] using eqTestLam0 in
-
--- Map over sequences
-let t = _parse "
-  let s1 = map (lam x. x) [lam y. y, lam z. z] in
-  let r1 = head s1 in
-  let s2 = map (lam a. lam d. d) [lam b. b, lam c. c] in
-  let r2 = head s2 in
-  ()
-------------------------" in
-utest _test0 false t ["r1", "r2"] with [
-  ("r1", ["y", "z"]),
-  ("r2", ["d"])
-] using eqTestLam0 in
-
--- Foldl
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let h = lam z. z in
-  let r1 = foldl (lam a1. lam e1. a1) f [g, h] in
-  let r2 = foldl (lam a2. lam e2. a2 e2) f [g, h] in
-  let r3 = foldl (lam a3. lam e3. a3 e3) (lam w. w) [] in
-  ()
-------------------------" in
-utest _test0 false t ["r1", "r2", "r3"] with [
-  ("r1", ["x"]),
-  ("r2", ["x", "y", "z"]),
-  ("r3", ["w"])
-] using eqTestLam0 in
-
--- Foldr
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let h = lam z. z in
-  let r1 = foldr (lam e1. lam a1. a1) f [g, h] in
-  let r2 = foldr (lam e2. lam a2. a2 e2) f [g, h] in
-  let r3 = foldr (lam e3. lam a3. a3 e3) (lam w. w) [] in
-  ()
-------------------------" in
-utest _test0 false t ["r1", "r2", "r3"] with [
-  ("r1", ["x"]),
-  ("r2", ["x", "y", "z"]),
-  ("r3", ["w"])
-] using eqTestLam0 in
-
--- Record
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let r = { a = f, b = 3 } in
-  let res = match r with { a = a } then
-      a g
-    else
-      (lam z. z)
-  in res
-------------------------" in
-utest _test0 false t ["res","a"] with [
-  ("res", ["y","z"]),
-  ("a", ["x"])
-] using eqTestLam0 in
-
--- Record update
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let h = lam w. w in
-  let r1 = { a = f, b = 3 } in
-  let r2 = { r1 with a = h } in
-  let res = match r2 with { a = a } then
-      a g
-    else
-      (lam z. z)
-  in res
-------------------------" in
-utest _test0 false t ["res","a"] with [
-  ("res", ["y","z"]),
-  ("a", ["w"])
-] using eqTestLam0 in
-
--- ConApp
-let t = _parse "
-  type T in
-  con C: (a -> a) -> T in
-  let f = lam x. x in
-
-  let g = lam y. y in
-  let d = C f in
-  let res = match d with C a then
-      a g
-    else
-      (lam z. z)
-  in res
-------------------------" in
-utest _test0 false t ["res","a"] with [
-  ("res", ["y","z"]),
-  ("a", ["x"])
-] using eqTestLam0 in
-
--- Nested
-let t = _parse "
-  type T in
-  con C: (a -> a) -> T in
-  let f = lam x. x in
-  let g = lam y. y in
-  let d = { a = [C f], b = 3 } in
-  let res = match d with { a = [C a] } then
-      a g
-    else
-      (lam z. z)
-  in res
-------------------------" in
-utest _test0 false t ["res","a"] with [
-  ("res", ["y","z"]),
-  ("a", ["x"])
-] using eqTestLam0 in
-
-let t = _parse "
-  let f = lam x.
-    recursive let g = lam y.
-      let a = g x in
-      a
-    in
-    let d = g x in
-    d
-  in
-  let b = f (lam z. z) in
-  let c = f (lam w. w) in
-  c
-------------------------" in
-utest _test false 3 t [
-  ("y", ["b","d","a"]),
-  ("y", ["c","d","a"]),
-  ("y", ["a","a","a"])
-] with [
-  ("y", ["b","d","a"], ["z"]),
-  ("y", ["c","d","a"], ["w"]),
-  ("y", ["a","a","a"], ["z", "w"])
-] using eqTestLam in
-
--- And pattern
-let t = _parse "
-  let f = lam x. x in
-  let g = lam y. y in
-  let res =
-    match f with a & b then a g
-    else (lam z. z)
-  in res
-------------------------" in
-utest _test0 false t ["res", "a", "b"] with [
-  ("res", ["y","z"]),
-  ("a", ["x"]),
-  ("b", ["x"])
-] using eqTestLam0 in
-
--- Or pattern
-let t = _parse "
-  type T in
-  con C1: (a -> a) -> T in
-  con C2: (a -> a) -> T in
-  let f = lam x. x in
-  let g = lam y. y in
-  let h = (C1 f, f) in
-  let res =
-    match h with (C1 _, rhs) | (C2 _, rhs) then rhs g
-    else (lam z. z)
-  in res
-------------------------" in
-utest _test0 false t ["res", "rhs"] with [
-  ("res", ["y","z"]),
-  ("rhs", ["x"])
-] using eqTestLam0 in
-
--- Not pattern
-let t = _parse "
-  type T in
-  con C: (a -> a) -> T in
-  let f = lam x. x in
-  let g = lam y. y in
-  let h = (C f, f) in
-  let res =
-    match h with ! (C _, rhs) then (lam yy. yy)
-    else (lam z. z)
-  in
-  let res2 =
-    match h with ! (C _, rhs) & (_, p) then (lam k. k)
-    else (lam w. w)
-  in res
-------------------------" in
-utest _test0 false t ["res", "res2", "p"] with [
-  ("res", ["yy","z"]),
-  ("res2", ["k","w"]),
-  ("p", ["x"])
-] using eqTestLam0 in
 
 ()

--- a/stdlib/mexpr/kcfa.mc
+++ b/stdlib/mexpr/kcfa.mc
@@ -8,6 +8,11 @@
 --   constraints from table 3.7 in Nielson et al. (see p. 202 in Nielson et al.
 --   for a discussion about this).
 --
+-- TODO(2023-07-11,dlunde): I just fixed a number of bugs in cfa.mc related to
+-- higher-order constants (and this also involved quite significant changes in
+-- other parts of the CFA framework). I am pretty sure k-CFA also have the same
+-- bugs/problems with higher-order constants, but I have not fixed them. We
+-- should rework kcfa.mc in the same way as for cfa.mc.
 
 include "set.mc"
 include "either.mc"
@@ -1192,9 +1197,6 @@ lang SeqOpKCFA = KCFA + ConstKCFA + SeqKCFA + SeqOpAst + KBaseConstraint
   -- {lam x. b} ⊆ f ⇒ (names ⊆ x and [{b}] ∈ res)
   | CstrSeqMap2 {f: (IName,Ctx), names: Set (IName,Ctx), res: (IName,Ctx)}
 
-  -- TODO(2023-07-11,dlunde): I suspect the fold constraints below have the
-  -- same problem as in the 0-CFA case. Namely, the constraint that c ⊆ y or c
-  -- ⊆ x (whichever is the accumulator) is missing.
   -- CstrSeqFold<n> implements foldl when left = true, and foldr otherwise
   -- l: [{names}] ∈ seq ⇒ [{f acc n : n ∈ names}] ∈ res
   -- r: [{names}] ∈ seq ⇒ [{f n acc : n ∈ names}] ∈ res

--- a/stdlib/mexpr/kcfa.mc
+++ b/stdlib/mexpr/kcfa.mc
@@ -1,0 +1,2263 @@
+-- k-CFA framework for MExpr, where k is the number of most recent
+-- function calls to consider in the context. The algorithm is loosely based on
+-- Table 3.7 in the book "Principles of Program Analysis" (Nielson et al.).
+--
+-- Some details:
+-- - Only works on fully labelled terms provided by MExprANFAll (see mexpr/anf.mc).
+-- - Uses efficient lazy constraint expansion, and not the static
+--   constraints from table 3.7 in Nielson et al. (see p. 202 in Nielson et al.
+--   for a discussion about this).
+--
+
+include "set.mc"
+include "either.mc"
+include "name.mc"
+include "tensor.mc"
+include "stringid.mc"
+
+include "pprint.mc"
+include "boot-parser.mc"
+include "ast.mc"
+include "anf.mc"
+include "ast-builder.mc"
+include "cmp.mc"
+include "const-arity.mc"
+include "index.mc"
+include "free-vars.mc"
+
+include "cfa.mc"
+
+lang KCFA = CFABase
+
+  type Ctx = [IName]
+  type CtxEnv = Map IName Ctx
+  type GenFunAcc = (CtxEnv, [Constraint])
+  type GenFun = Ctx -> CtxEnv -> Expr -> GenFunAcc
+  type MatchGenFun = (IName,Ctx) -> (IName,Ctx) -> Pat -> [Constraint]
+
+  type CFAGraph = {
+
+    -- Contains updates that needs to be processed in the main CFA loop
+    worklist: [(IName,Ctx,AbsVal)],
+
+    -- Contains abstract values currently associated with each name in the program.
+    data: Tensor[Map Ctx (Set AbsVal)],
+
+    -- For each name in the program, gives constraints which needs to be
+    -- repropagated upon updates to the abstract values for the name.
+    edges: Tensor[Map Ctx (Set Constraint)],
+
+    -- Bidirectional mapping between names and integers.
+    im: IndexMap,
+
+    -- The "k" in k-CFA.
+    k: Int,
+
+    -- Contains a list of functions used for generating constraints
+    cgfs: [GenFun],
+
+    -- Contains a list of functions used for generating match constraints
+    -- TODO(dlunde,2021-11-17): Should be added as a product extension
+    -- in the MatchCFA fragment instead, when possible.
+    mcgfs: [MatchGenFun],
+
+    -- NOTE(dlunde,2021-11-18): Data needed for analyses based on this framework
+    -- must be put below directly, since we do not yet have product extensions.
+
+    -- Used to store any custom data in the graph
+    graphData: Option GraphData
+
+  }
+
+  sem emptyCFAGraph: Int -> Expr -> CFAGraph
+  sem emptyCFAGraph k =
+  | t ->
+    -- NOTE(Linnea,2022-06-22): Experiments have shown that lists are better
+    -- than ropes for 'worklist' and 'edges', especially for 'worklist'
+    let im = indexGen t in
+    let shape = tensorShape im.int2name in
+    { worklist = toList [],
+      data = tensorCreateDense shape (lam. mapEmpty cmpCtx),
+      edges = tensorCreateDense shape (lam. mapEmpty cmpCtx),
+      im = im,
+      k = k,
+      cgfs = [],
+      mcgfs = [],
+      graphData = None () }
+
+  -- This function converts the data-flow result into a map, which might be more
+  -- convenient to operate on for later analysis steps.
+  sem cfaGraphData: CFAGraph -> Map Name (Set AbsVal)
+  sem cfaGraphData =
+  | graph ->
+    tensorFoldi (lam acc. lam i: [Int]. lam vals: Set AbsVal.
+        mapInsert (int2name graph.im (head i)) vals acc
+      ) (mapEmpty nameCmp) graph.data
+
+  -- Main algorithm
+  sem solveCfa: CFAGraph -> CFAGraph
+  sem solveCfa =
+  | graph ->
+    -- Iteration
+    recursive let iter = lam graph: CFAGraph.
+      if null graph.worklist then graph
+      else
+        match head graph.worklist with (q,c,d) & h in
+        let graph = { graph with worklist = tail graph.worklist } in
+        match edgesLookup (q,c) graph with cc in
+        let graph = setFold (propagateConstraint h) graph cc in
+        iter graph
+    in
+    iter graph
+
+  -- Main algorithm (debug version)
+  sem solveCfaDebug : PprintEnv -> CFAGraph -> (PprintEnv, CFAGraph)
+  sem solveCfaDebug pprintenv =
+  | graph ->
+    -- NOTE(Linnea,2022-06-22): Experiments have shown that using `cfaDebug` as
+    -- the main entry point causes overhead when no printing takes place, as we
+    -- have to match on the pprintenv in every iteration. Therefore, some code
+    -- duplication takes place here.
+    let printGraph = lam pprintenv. lam graph. lam str.
+      match cfaGraphToString pprintenv graph with (pprintenv, graph) in
+      printLn (join ["\n--- ", str, " ---"]);
+      printLn graph;
+      pprintenv
+    in
+
+    -- Iteration
+    recursive let iter = lam i. lam pprintenv: PprintEnv. lam graph: CFAGraph.
+      if null graph.worklist then (pprintenv,graph)
+      else
+        let header = concat "INTERMEDIATE CFA GRAPH " (int2string i) in
+        let pprintenv = printGraph pprintenv graph header in
+        match head graph.worklist with (q,c,d) & h in
+        let graph = { graph with worklist = tail graph.worklist } in
+        match edgesLookup (q,c) graph with cc in
+        let graph = setFold (propagateConstraint h) graph cc in
+        iter (addi i 1) pprintenv graph
+    in
+    iter 1 pprintenv graph
+
+  -- Base constraint generation function (must still be included manually in
+  -- constraintGenFuns)
+  sem generateConstraints
+  : IndexMap -> Ctx -> CtxEnv -> Expr -> GenFunAcc
+  sem generateConstraints im ctx env =
+  | t -> (env,[])
+
+  -- Call a set of constraint generation functions on each term in program.
+  -- Useful when defining values of type CFAGraph.
+  sem collectConstraints: Ctx -> [GenFun] -> GenFunAcc -> Expr -> GenFunAcc
+  sem collectConstraints ctx cgfs acc =
+  | t ->
+    let acc = foldl (lam acc. lam f: GenFun.
+        match acc with (env, cstrs) in
+        match f ctx env t with (env, fcstrs) in
+        (env, concat fcstrs cstrs)
+      ) acc cgfs
+    in
+    sfold_Expr_Expr (collectConstraints ctx cgfs) acc t
+
+  sem initConstraint: CFAGraph -> Constraint -> CFAGraph
+
+  -- Function that initializes all constraints in a CFAGraph for a given context
+  -- and context environment
+  sem initConstraints
+  : Ctx -> CtxEnv -> CFAGraph -> Expr -> (CtxEnv, CFAGraph)
+  sem initConstraints ctx env graph =
+  | t ->
+    -- Recurse over program and generate constraints
+    match
+      collectConstraints ctx graph.cgfs (env, []) t
+    with (env, cstrs) in
+
+    -- Initialize all collected constraints and return
+    (env, foldl initConstraint graph cstrs)
+
+  sem propagateConstraint
+  : (IName,Ctx,AbsVal) -> CFAGraph -> Constraint -> CFAGraph
+
+  -- Returns both the new graph, and a Boolean that is true iff the new edge was
+  -- added to the graph.
+  -- NOTE(Linnea, 2022-06-21): Updates the graph by a side effect
+  sem addEdge: CFAGraph -> (IName,Ctx) -> Constraint -> (CFAGraph, Bool)
+  sem addEdge (graph: CFAGraph) (qc: (IName,Ctx)) =
+  | cstr ->
+    match qc with (q,c) in
+    let cstrsq = edgesLookup qc graph in
+    if setMem cstr cstrsq then (graph, false)
+    else
+      let m = mapInsert c (setInsert cstr cstrsq) (
+        tensorLinearGetExn graph.edges q) in
+      tensorLinearSetExn graph.edges q m;
+      (graph, true)
+
+  -- Helper function for initializing a constraint for a given name (mainly
+  -- used for convenience in initConstraint)
+  sem initConstraintName: (IName,Ctx) -> CFAGraph -> Constraint -> CFAGraph
+  sem initConstraintName name graph =
+  | cstr ->
+    match addEdge graph name cstr with (graph, new) in
+    if new then
+      let avs = dataLookup name graph in
+      setFold (lam graph. lam av.
+        propagateConstraint (name.0,name.1,av) graph cstr)
+      graph avs
+    else graph
+
+  sem dataLookup: (IName,Ctx) -> CFAGraph -> Set AbsVal
+  sem dataLookup key =
+  | graph ->
+    let m = tensorLinearGetExn graph.data key.0 in
+    mapLookupOrElse (lam. setEmpty cmpAbsVal) key.1 m
+
+  sem edgesLookup: (IName,Ctx) -> CFAGraph -> Set Constraint
+  sem edgesLookup (key: (IName,Ctx)) =
+  | graph ->
+    let m = tensorLinearGetExn graph.edges key.0 in
+    mapLookupOrElse (lam. setEmpty cmpConstraint) key.1 m
+
+  -- Updates the graph by a side effect
+  sem addData: CFAGraph -> AbsVal -> (IName,Ctx) -> CFAGraph
+  sem addData (graph: CFAGraph) (d: AbsVal) =
+  | (q,c) ->
+    let dq = dataLookup (q,c) graph in
+    if setMem d dq then graph else
+      let m = mapInsert c (setInsert d dq) (tensorLinearGetExn graph.data q) in
+      tensorLinearSetExn graph.data q m;
+      { graph with worklist = cons (q,c,d) graph.worklist }
+
+  --------------------------------------
+  -- CONTEXTS AND CONTEXT ENVIRONMENT --
+  --------------------------------------
+
+  sem ctxEmpty: () -> Ctx
+  sem ctxEmpty =
+  | _ -> []
+
+  sem ctxAdd: Int -> IName -> Ctx -> Ctx
+  sem ctxAdd k n =
+  | ctx ->
+    let ctx = snoc ctx n in
+    if leqi (length ctx) k then ctx else tail ctx
+
+  -- Needed for `Map Ctx (Set AbsVal)`
+  sem cmpCtx: Ctx -> Ctx -> Int
+  sem cmpCtx ctx1 =
+  | ctx2 -> seqCmp subi ctx1 ctx2
+
+  -- Needed for `Set (IName,Ctx)`
+  sem cmpINameCtx: (IName,Ctx) -> (IName,Ctx) -> Int
+  sem cmpINameCtx t1 =
+  | t2 ->
+    let ndiff = subi t1.0 t2.0 in
+    if eqi ndiff 0 then cmpCtx t1.1 t2.1
+    else ndiff
+
+  sem ctxToString: IndexMap -> PprintEnv -> Ctx -> (PprintEnv, String)
+  sem ctxToString im env =
+  | ctx ->
+    match mapAccumL (pprintVarIName im) env ctx with (env,ctx) in
+    (env, join ["<", strJoin "," ctx, ">"])
+
+  sem ctxEnvEmpty: () -> CtxEnv
+  sem ctxEnvEmpty =
+  | _ -> mapEmpty subi
+
+  sem ctxEnvAdd: IName -> Ctx -> CtxEnv -> CtxEnv
+  sem ctxEnvAdd n c =
+  | env ->
+    mapInsert n c env
+
+  sem ctxEnvLookup: IndexMap -> Info -> IName -> CtxEnv -> Ctx
+  sem ctxEnvLookup im info n =
+  | env ->
+    mapLookupOrElse (lam.
+        let name = int2name im n in
+        errorSingle [info] (concat "ctxEnvLookup failed: " (nameGetStr name))
+      ) n env
+
+  -- Keep names that appear free in a given expression.
+  sem ctxEnvFilterFree: IndexMap -> Expr -> CtxEnv -> CtxEnv
+  sem ctxEnvFilterFree im e =
+  | env ->
+    let free: Set Name = freeVars e in
+    mapFoldWithKey (lam acc. lam n. lam ctx.
+        if setMem (int2name im n) free then mapInsert n ctx acc
+        else acc
+      ) (mapEmpty subi) env
+
+  sem cmpCtxEnv: CtxEnv -> CtxEnv -> Int
+  sem cmpCtxEnv env1 =
+  | env2 -> mapCmp cmpCtx env1 env2
+
+  ---------------------
+  -- PRETTY PRINTING --
+  ---------------------
+
+  sem pprintVarINameCtx
+  : IndexMap -> PprintEnv -> (IName,Ctx) -> (PprintEnv, String)
+  sem pprintVarINameCtx im env =
+  | (n,ctx) ->
+    match pprintVarIName im env n with (env,n) in
+    match ctxToString im env ctx with (env,ctx) in
+    (env, join [n, ctx])
+
+  sem pprintConINameCtx
+  : IndexMap -> PprintEnv -> (IName,Ctx) -> (PprintEnv, String)
+  sem pprintConINameCtx im env =
+  | (n,ctx) ->
+    match pprintConIName im env n with (env,n) in
+    match ctxToString im env ctx with (env,ctx) in
+    (env, join [n, ctx])
+
+  -- Prints a CFA graph
+  sem cfaGraphToString (env: PprintEnv) =
+  | graph ->
+    let graph: CFAGraph = graph in
+    let f = lam env. lam e: (IName,Ctx,AbsVal).
+      match pprintVarINameCtx graph.im env (e.0,e.1) with (env,n) in
+      match absValToString graph.im env e.2 with (env,av) in
+      (env,join ["(", n, ", ", av, ")"]) in
+    match mapAccumL f env graph.worklist with (env,worklist) in
+    match mapAccumL (lam env: PprintEnv. lam b:(IName,Map Ctx (Set AbsVal)).
+        match pprintVarIName graph.im env b.0 with (env,b0) in
+        let printAbsVals = lam env. lam s: Set AbsVal.
+          mapAccumL (absValToString graph.im) env (setToSeq s)
+        in
+        match mapAccumL (lam env: PprintEnv. lam b:(Ctx,Set AbsVal).
+            match ctxToString graph.im env b.0 with (env, ctx) in
+            match printAbsVals env b.1 with (env, avs) in
+            (env, (ctx, avs))
+          ) env (mapBindings b.1)
+        with (env,b1)
+        in (env,(b0,b1))
+      ) env (mapi (lam i. lam x. (i,x)) (tensorToSeqExn graph.data))
+    with (env, data) in
+    match mapAccumL (lam env: PprintEnv. lam b:(IName,Map Ctx (Set Constraint)).
+        match pprintVarIName graph.im env b.0 with (env,b0) in
+        let printCstrs = lam env. lam cstrs: Set Constraint.
+          mapAccumL (constraintToString graph.im) env (setToSeq cstrs)
+        in
+        match mapAccumL (lam env: PprintEnv. lam b:(Ctx,Set Constraint).
+            match ctxToString graph.im env b.0 with (env, ctx) in
+            match printCstrs env b.1 with (env, cstrs) in
+            (env, (ctx, cstrs))
+          ) env (mapBindings b.1)
+        with (env,(b1))
+        in (env,(b0,b1))
+      ) env (mapi (lam i. lam x. (i, x)) (tensorToSeqExn graph.edges))
+    with (env, edges) in
+
+    let strJoinNonEmpty = lam delim: String. lam strs: [String].
+      strJoin delim (filter (lam s. not (null s)) strs)
+    in
+
+    let str = join [
+      "*** WORKLIST ***\n",
+      "  [", strJoin ", " worklist, "]\n",
+      "*** DATA ***\n",
+      strJoinNonEmpty "\n" (map (lam b:(String,[(String, [String])]).
+        match b with (n, ctxsAvs) in
+        let f = lam avs.
+          strJoin "\n" (map (concat "    ") avs)
+        in
+        let entries: [String] = map (lam ctxAvs: (String, [String]).
+            match ctxAvs with (ctx, avs) in
+            join ["  ", join [b.0, ctx], " =\n", f avs]
+          ) ctxsAvs
+        in strJoin "\n" entries
+      ) data), "\n",
+      "*** EDGES ***\n",
+      strJoinNonEmpty "\n" (map (lam b:(String,[(String, [String])]).
+        match b with (n, ctxCstrs) in
+        let f = lam cstrs.
+          strJoin "\n" (map (concat "    ") cstrs)
+        in
+        let entries: [String] = map (lam cc: (String, [String]).
+            match cc with (ctx, cstrs) in
+            join ["  ", join [b.0, ctx], " =\n", f cstrs]
+          ) ctxCstrs
+        in strJoin "\n" entries
+      ) edges), "\n"
+
+    ] in
+
+    (env, str)
+
+end
+
+----------------------
+-- BASE CONSTRAINTS --
+----------------------
+
+lang KBaseConstraint = KCFA
+
+  syn Constraint =
+  -- {lhs} ⊆ rhs
+  | CstrInit { lhs: AbsVal, rhs: (IName,Ctx) }
+  -- lhs ⊆ rhs
+  | CstrDirect { lhs: (IName,Ctx), rhs: (IName,Ctx) }
+  -- {lhsav} ⊆ lhs ⇒ {rhsav} ⊆ rhs
+  | CstrDirectAv { lhs: (IName,Ctx), lhsav: AbsVal,
+                   rhs: (IName,Ctx), rhsav: AbsVal }
+  -- {lhsav} ⊆ lhs ⇒ [rhs]
+  | CstrDirectAvCstrs { lhs: (IName,Ctx), lhsav: AbsVal, rhs: [Constraint] }
+
+  sem cmpConstraintH =
+  | (CstrInit { lhs = lhs1, rhs = rhs1 },
+     CstrInit { lhs = lhs2, rhs = rhs2 }) ->
+     let d = cmpAbsVal lhs1 lhs2 in
+     if eqi d 0 then cmpINameCtx rhs1 rhs2
+     else d
+  | (CstrDirect { lhs = lhs1, rhs = rhs1 },
+     CstrDirect { lhs = lhs2, rhs = rhs2 }) ->
+     let d = cmpINameCtx lhs1 lhs2 in
+     if eqi d 0 then cmpINameCtx rhs1 rhs2
+     else d
+  | (CstrDirectAv t1, CstrDirectAv t2) ->
+     let d = cmpINameCtx t1.lhs t2.lhs in
+     if eqi d 0 then
+       let d = cmpINameCtx t1.rhs t2.rhs in
+       if eqi d 0 then
+         let d = cmpAbsVal t1.lhsav t2.lhsav in
+         if eqi d 0 then cmpAbsVal t1.rhsav t2.rhsav
+         else d
+       else d
+     else d
+  | (CstrDirectAvCstrs t1, CstrDirectAvCstrs t2) ->
+     let d = cmpINameCtx t1.lhs t2.lhs in
+     if eqi d 0 then
+       let d = cmpAbsVal t1.lhsav t2.lhsav in
+       if eqi d 0 then seqCmp cmpConstraint t1.rhs t2.rhs
+       else d
+     else d
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrInit r -> addData graph r.lhs r.rhs
+  | CstrDirect r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrDirectAv r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrDirectAvCstrs r & cstr -> initConstraintName r.lhs graph cstr
+
+  sem constraintToString im (env: PprintEnv) =
+  | CstrInit { lhs = lhs, rhs = rhs } ->
+    match absValToString im env lhs with (env,lhs) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    (env, join ["{", lhs, "}", " ⊆ ", rhs])
+  | CstrDirect { lhs = lhs, rhs = rhs } ->
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    (env, join [lhs, " ⊆ ", rhs])
+  | CstrDirectAv { lhs = lhs, lhsav = lhsav, rhs = rhs, rhsav = rhsav } ->
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match absValToString im env lhsav with (env,lhsav) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    match absValToString im env rhsav with (env,rhsav) in
+    (env, join ["{", lhsav ,"} ⊆ ", lhs, " ⇒ {", rhsav ,"} ⊆ ", rhs])
+  | CstrDirectAvCstrs { lhs = lhs, lhsav = lhsav, rhs = rhs } ->
+    match mapAccumL (constraintToString im) env rhs with (env,rhs) in
+    let rhs = strJoin " AND " rhs in
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match absValToString im env lhsav with (env,lhsav) in
+    (env, join [ "{", lhsav, "} ⊆ ", lhs, " ⇒ (", rhs, ")" ])
+
+  sem isDirect: AbsVal -> Bool
+  sem isDirect =
+  | _ -> true
+
+  sem directTransition: CFAGraph -> (IName,Ctx) -> AbsVal -> AbsVal
+  sem directTransition graph rhs =
+  | av -> av
+
+  sem propagateConstraint (update: (IName,Ctx,AbsVal)) (graph: CFAGraph) =
+  | CstrDirect r -> propagateDirectConstraint r.rhs graph update.2
+  | CstrDirectAv r ->
+    if eqAbsVal update.2 r.lhsav then
+      addData graph r.rhsav r.rhs
+    else graph
+  | CstrDirectAvCstrs r & cstr ->
+    if eqAbsVal update.2 r.lhsav then
+      foldl initConstraint graph r.rhs
+    else graph
+
+  sem propagateDirectConstraint: (IName,Ctx) -> CFAGraph -> AbsVal -> CFAGraph
+  sem propagateDirectConstraint rhs graph =
+  | av ->
+    if isDirect av then
+      addData graph (directTransition graph rhs av) rhs
+    else graph
+end
+
+-----------
+-- TERMS --
+-----------
+
+lang VarKCFA = KCFA + KBaseConstraint + VarAst
+
+  sem generateConstraints im ctx env =
+  | TmLet { ident = ident, body = TmVar t, info = info } ->
+    let ident = name2int im info ident in
+    let lhs = name2int im t.info t.ident in
+    let cstrs =
+      [ CstrDirect {
+        lhs = (lhs, ctxEnvLookup im t.info lhs env),
+        rhs = (ident, ctx)
+      } ]
+    in
+    (ctxEnvAdd ident ctx env, cstrs)
+
+  sem exprName =
+  | TmVar t -> t.ident
+end
+
+lang LamKCFA = KCFA + KBaseConstraint + LamAst
+
+  -- Abstract representation of lambdas.
+  syn AbsVal =
+  | AVLam { ident: IName, bident: IName, body: Expr, env: CtxEnv }
+
+  sem cmpAbsValH =
+  | (AVLam { ident = lhs, bident = lbody, env = lenv },
+     AVLam { ident = rhs, bident = rbody, env = renv }) ->
+     let diff = subi lhs rhs in
+     if eqi diff 0 then
+       let diff = subi lbody rbody in
+       if eqi diff 0 then cmpCtxEnv lenv renv else diff
+     else diff
+
+  sem generateConstraints im ctx env =
+  | TmLet { ident = ident, body = TmLam t, info = info } ->
+    let ident = name2int im info ident in
+    let av: AbsVal = AVLam {
+      ident = name2int im t.info t.ident,
+      bident = name2int im (infoTm t.body) (exprName t.body),
+      body = t.body,
+      env = ctxEnvFilterFree im (TmLam t) env
+    } in
+    let cstrs = [ CstrInit { lhs = av, rhs = (ident, ctx) } ] in
+    (ctxEnvAdd ident ctx env, cstrs)
+
+  sem absValToString im (env: PprintEnv) =
+  | AVLam { ident = ident, bident = bident } ->
+    match pprintVarIName im env ident with (env,ident) in
+    match pprintVarIName im env bident with (env,bident) in
+    (env, join ["lam ", ident, ". ", bident])
+
+  -- We analyze the terms in the lambda body when discovering an application of
+  -- an `AVLam`. Hence, we do nothing here.
+  sem collectConstraints ctx cgfs acc =
+  | TmLam t -> acc
+end
+
+lang LetKCFA = KCFA + LetAst
+  sem exprName =
+  | TmLet t -> exprName t.inexpr
+end
+
+lang RecLetsKCFA = KCFA + LamKCFA + RecLetsAst
+  sem exprName =
+  | TmRecLets t -> exprName t.inexpr
+
+  sem generateConstraints im ctx env =
+  | TmRecLets ({ bindings = bindings } & t) ->
+    -- Make each binding available in the environment
+    let idents = map (lam b. name2int im b.info b.ident) bindings in
+    let envBody = foldl (lam env. lam i.
+        ctxEnvAdd i ctx env) (ctxEnvFilterFree im (TmRecLets t) env) idents in
+    let cstrs = map (lam identBind: (IName, RecLetBinding).
+      match identBind with (ident, b) in
+      match b.body with TmLam t then
+        let av: AbsVal = AVLam {
+          ident = name2int im t.info t.ident,
+          bident = name2int im (infoTm t.body) (exprName t.body),
+          body = t.body,
+          env = envBody
+        } in
+        CstrInit { lhs = av, rhs = (ident, ctx) }
+      else errorSingle [infoTm b.body] "Not a lambda in recursive let body"
+    ) (zip idents bindings) in
+    let env = foldl (lam env. lam i. ctxEnvAdd i ctx env) env idents in
+    (env, cstrs)
+end
+
+lang ConstKCFA = KCFA + ConstAst + KBaseConstraint + Cmp
+
+  syn AbsVal =
+  -- Abstract representation of constants. Contains the constant and the
+  -- arguments applied to it. It also includes the `let` name that binds the
+  -- constant and syntactically distinguishes it from other of its kind in the
+  -- program.
+  | AVConst { id: (IName,Ctx), const: Const, args: [(IName,Ctx)] }
+
+  sem absValToString im (env: PprintEnv) =
+  | AVConst { id = id, const = const, args = args } ->
+    let const = getConstStringCode 0 const in
+    match mapAccumL (pprintVarINameCtx im) env args with (env,args) in
+    let args = strJoin ", " args in
+    match pprintVarINameCtx im env id with (env,id) in
+    (env, join [const,"<", id, ">", "(", args, ")"])
+
+  sem cmpAbsValH =
+  | (AVConst lhs, AVConst rhs) ->
+    let cmp = cmpConst lhs.const rhs.const in
+    if eqi 0 cmp then
+      let ncmp = cmpINameCtx lhs.id rhs.id in
+      if eqi 0 ncmp then seqCmp cmpINameCtx lhs.args rhs.args
+      else ncmp
+    else cmp
+
+  sem generateConstraints im ctx env =
+  | TmLet { ident = ident, body = TmConst t, info = info } ->
+    let ident = name2int im info ident in
+    let cstrs = generateConstraintsConst t.info (ident,ctx) t.val in
+    (ctxEnvAdd ident ctx env, cstrs)
+
+  sem generateConstraintsConst: Info -> (IName,Ctx) -> Const -> [Constraint]
+  sem generateConstraintsConst info ident =
+  | _ -> errorSingle [info] "Constant not supported in CFA"
+end
+
+lang AppKCFA = KCFA + ConstKCFA + KBaseConstraint + LamKCFA + AppAst + MExprArity
+
+  syn Constraint =
+  -- {lam x. b} ⊆ lhs ⇒ (rhs ⊆ x and b ⊆ res)
+  | CstrLamApp { lhs: (IName,Ctx), rhs: (IName,Ctx), res: (IName,Ctx) }
+  -- {const args} ⊆ lhs ⇒ {const args lhs} ⊆ res
+  | CstrConstApp { lhs: (IName,Ctx), rhs: (IName,Ctx),
+                   res: (IName,Ctx) }
+
+  sem cmpConstraintH =
+  | (CstrLamApp { lhs = lhs1, rhs = rhs1, res = res1 },
+     CstrLamApp { lhs = lhs2, rhs = rhs2, res = res2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx lhs1 lhs2 in
+       if eqi d 0 then cmpINameCtx rhs1 rhs2
+       else d
+     else d
+  | (CstrConstApp { lhs = lhs1, rhs = rhs1, res = res1 },
+     CstrConstApp { lhs = lhs2, rhs = rhs2, res = res2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx lhs1 lhs2 in
+       if eqi d 0 then cmpINameCtx rhs1 rhs2
+       else d
+     else d
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrLamApp r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrConstApp r & cstr -> initConstraintName r.lhs graph cstr
+
+  sem propagateConstraint (update: (IName,Ctx,AbsVal)) (graph: CFAGraph) =
+  | CstrLamApp { lhs = lhs, rhs = rhs, res = res } ->
+    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
+    then
+      let ctxBody = ctxAdd graph.k res.0 res.1 in
+      let envBody = ctxEnvAdd x ctxBody env in
+      -- Analyze the lambda body
+      match initConstraints ctxBody envBody graph body with (envBody, graph) in
+      -- Add rhs ⊆ x constraint
+      let graph = initConstraint graph (CstrDirect {
+          lhs = rhs, rhs = (x, ctxBody)
+        }) in
+      -- Add b ⊆ res constraint
+      let graph = initConstraint graph (CstrDirect {
+          lhs = (b, ctxEnvLookup graph.im (infoTm body) b envBody), rhs = res
+        }) in
+      graph
+    else graph
+  | CstrConstApp { lhs = lhs, rhs = rhs, res = res } ->
+    match update.2 with AVConst ({ const = const, args = args } & avc) then
+      let arity = constArity const in
+      let args = snoc args rhs in
+      if eqi arity (length args) then
+        -- Last application
+        propagateConstraintConst res args graph const
+      else
+        -- Curried application, add the new argument
+        addData graph (AVConst { avc with args = args }) res
+    else graph
+
+  sem constraintToString im (env: PprintEnv) =
+  | CstrLamApp { lhs = lhs, rhs = rhs, res = res } ->
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    match pprintVarINameCtx im env res with (env,res) in
+    (env, join ["{lam >x<. >b<} ⊆ ", lhs, " ⇒ ", rhs, " ⊆ >x< AND >b< ⊆ ", res])
+  | CstrConstApp { lhs = lhs, rhs = rhs, res = res } ->
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    match pprintVarINameCtx im env res with (env,res) in
+    (env, join [
+        ">const< >args< ⊆ ", lhs, " ⇒ ", ">const< >args< ", rhs, " ⊆ ", res
+      ])
+
+  sem generateConstraints im ctx env =
+  | TmLet { ident = ident, body = TmApp app, info = info} ->
+    let ident = name2int im info ident in
+    match app.lhs with TmVar l then
+      match app.rhs with TmVar r then
+        let lhs = name2int im l.info l.ident in
+        let rhs = name2int im r.info r.ident in
+        let lenv = ctxEnvLookup im l.info lhs env in
+        let renv = ctxEnvLookup im r.info rhs env in
+        let cstrs =
+          [ CstrLamApp {
+              lhs = (lhs, lenv),
+              rhs = (rhs, renv),
+                res = (ident, ctx)
+              },
+            CstrConstApp {
+              lhs = (lhs, lenv),
+              rhs = (rhs, renv),
+              res = (ident, ctx)
+            }
+          ]
+        in
+        (ctxEnvAdd ident ctx env, cstrs)
+      else errorSingle [infoTm app.rhs] "Not a TmVar in application"
+    else errorSingle [infoTm app.lhs] "Not a TmVar in application"
+
+  sem propagateConstraintConst
+  : (IName,Ctx) -> [(IName,Ctx)] -> CFAGraph -> Const -> CFAGraph
+end
+
+lang RecordKCFA = KCFA + KBaseConstraint + RecordAst
+
+  syn AbsVal =
+  -- Abstract representation of records. The bindings are from SIDs to names,
+  -- rather than expressions.
+  | AVRec { bindings: Map SID (IName,Ctx) }
+
+  sem cmpAbsValH =
+  | (AVRec { bindings = lhs }, AVRec { bindings = rhs }) ->
+    mapCmp cmpINameCtx lhs rhs
+
+  syn Constraint =
+  -- r ∈ lhs ⇒ { r with key = val } ∈ rhs
+  | CstrRecordUpdate { lhs: (IName,Ctx), key: SID, val: (IName,Ctx),
+                       rhs: (IName,Ctx) }
+
+  sem cmpConstraintH =
+  | (CstrRecordUpdate { lhs = lhs1, key = key1, val = val1, rhs = rhs1 },
+     CstrRecordUpdate { lhs = lhs2, key = key2, val = val2, rhs = rhs2 }) ->
+     let d = cmpINameCtx lhs1 lhs2 in
+     if eqi d 0 then
+       let d = cmpSID key1 key2 in
+       if eqi d 0 then
+         let d = cmpINameCtx val1 val2 in
+         if eqi d 0 then cmpINameCtx rhs1 rhs2
+         else d
+       else d
+     else d
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrRecordUpdate r & cstr -> initConstraintName r.lhs graph cstr
+
+  sem generateConstraints im ctx env =
+  | TmLet { ident = ident, body = TmRecord t, info = info } ->
+    let bindings = mapMap (lam v: Expr.
+        match v with TmVar t then
+          let vident = name2int im t.info t.ident in
+          let vctx = ctxEnvLookup im t.info vident env in
+          (vident,vctx)
+        else errorSingle [infoTm v] "Not a TmVar in record"
+      ) t.bindings
+    in
+    let av: AbsVal = AVRec { bindings = bindings } in
+    let ident = name2int im info ident in
+    let cstrs = [ CstrInit { lhs = av, rhs = (ident, ctx) } ] in
+    (ctxEnvAdd ident ctx env, cstrs)
+  | TmLet { ident = ident, body = TmRecordUpdate t, info = info } ->
+    match t.rec with TmVar vrec then
+      match t.value with TmVar vval then
+        let lhs = name2int im vrec.info vrec.ident in
+        let val = name2int im vval.info vval.ident in
+        let ident = name2int im info ident in
+        let cstrs =
+          [ CstrRecordUpdate { lhs = (lhs, ctxEnvLookup im vrec.info lhs env),
+                               key = t.key,
+                               val = (val, ctxEnvLookup im vval.info val env),
+                               rhs = (ident, ctx)}
+          ] in
+        (ctxEnvAdd ident ctx env, cstrs)
+      else errorSingle [t.info] "Not a TmVar in record update"
+    else errorSingle [t.info] "Not a TmVar in record update"
+
+  sem propagateConstraint (update: (IName,Ctx,AbsVal)) (graph: CFAGraph) =
+  | CstrRecordUpdate { lhs = lhs, key = key, val = val, rhs = rhs } ->
+    match update.2 with AVRec { bindings = bindings } then
+      let av = AVRec { bindings = mapInsert key val bindings } in
+      initConstraint graph (CstrInit { lhs = av, rhs = rhs })
+    else graph
+
+  sem absValToString im (env: PprintEnv) =
+  | AVRec { bindings = bindings } ->
+    match mapMapAccum (lam env. lam k. lam v.
+        match pprintVarINameCtx im env v with (env, v) in
+        (env, join [pprintLabelString k, " = ", v])
+      ) env bindings
+    with (env, bindings) in
+    let binds = mapValues bindings in
+    let merged = strJoin ", " binds in
+    (env, join ["{ ", merged, " }"])
+
+  sem constraintToString im (env: PprintEnv) =
+  | CstrRecordUpdate { lhs = lhs, key = key, val = val, rhs = rhs } ->
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match pprintLabelString key with key in
+    match pprintVarINameCtx im env val with (env,val) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    (env, join [">r< ∈ ", lhs, " ⇒ { >r< with ", key, " = ", val, " } ∈ ", rhs])
+
+end
+
+lang SeqKCFA = KCFA + KBaseConstraint + SeqAst
+
+  syn AbsVal =
+  -- Abstract representation of sequences. Contains a set of names that may
+  -- flow to the sequence.
+  | AVSeq { names: Set (IName,Ctx) }
+
+  sem cmpAbsValH =
+  | (AVSeq { names = lhs }, AVSeq { names = rhs }) -> setCmp lhs rhs
+
+  sem generateConstraints im ctx env =
+  | TmLet { ident = ident, body = TmSeq t, info = info } ->
+    let names = foldl (lam acc: [(IName,Ctx)]. lam t: Expr.
+      match t with TmVar t then
+        let tident = name2int im t.info t.ident in
+        cons (tident, ctxEnvLookup im t.info tident env) acc
+      else acc) [] t.tms
+    in
+    let av: AbsVal = AVSeq { names = setOfSeq cmpINameCtx names } in
+    let ident = name2int im info ident in
+    let cstrs = [ CstrInit { lhs = av, rhs = (ident, ctx) } ] in
+    (ctxEnvAdd ident ctx env, cstrs)
+
+  sem absValToString im (env: PprintEnv) =
+  | AVSeq { names = names } ->
+    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
+    with (env,names) in
+    let names = strJoin ", " names in
+    (env, join ["[{", names, "}]"])
+end
+
+lang TypeKCFA = KCFA + TypeAst
+  sem exprName =
+  | TmType t -> exprName t.inexpr
+end
+
+lang DataKCFA = KCFA + KBaseConstraint + DataAst
+  syn AbsVal =
+  -- Abstract representation of constructed data.
+  | AVCon { ident: (IName,Ctx), body: (IName,Ctx) }
+
+  sem cmpAbsValH =
+  | (AVCon { ident = ilhs, body = blhs },
+     AVCon { ident = irhs, body = brhs }) ->
+    let idiff = cmpINameCtx ilhs irhs in
+    if eqi idiff 0 then cmpINameCtx blhs brhs else idiff
+
+  sem generateConstraints im ctx env =
+  | TmLet { ident = ident, body = TmConApp t, info = info } ->
+    let body =
+      match t.body with TmVar v then name2int im v.info v.ident
+      else errorSingle [infoTm t.body] "Not a TmVar in con app" in
+    let ctxBody = ctxEnvLookup im (infoTm t.body) body env in
+    let av: AbsVal = AVCon {
+        ident = (name2int im t.info t.ident, ctx),
+        body = (body, ctxBody)
+      } in
+    let ident = name2int im info ident in
+    let cstrs = [ CstrInit { lhs = av, rhs = (ident,ctx) } ] in
+    (ctxEnvAdd ident ctx env, cstrs)
+
+  sem absValToString im (env: PprintEnv) =
+  | AVCon { ident = ident, body = body } ->
+    match pprintConINameCtx im env ident with (env,ident) in
+    match pprintVarINameCtx im env body with (env,body) in
+    (env, join [ident, " ", body])
+
+  sem exprName =
+  | TmConDef t -> exprName t.inexpr
+
+end
+
+lang MatchKCFA = KCFA + KBaseConstraint + MatchAst + MExprCmp
+
+  syn Constraint =
+  | CstrMatch { id: (IName,Ctx), pat: Pat, target: (IName,Ctx) }
+
+  sem cmpConstraintH =
+  | (CstrMatch { id = id1, pat = pat1, target = target1 },
+     CstrMatch { id = id2, pat = pat2, target = target2 }) ->
+     let d = cmpINameCtx id1 id2 in
+     if eqi d 0 then
+       let d = cmpINameCtx target1 target2 in
+       if eqi d 0 then cmpPat pat1 pat2
+       else d
+     else d
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrMatch r & cstr -> initConstraintName r.target graph cstr
+
+  sem propagateConstraint (update: (IName,Ctx,AbsVal)) graph =
+  | CstrMatch r ->
+    propagateMatchConstraint graph r.id (r.pat,update.2)
+
+  sem propagateMatchConstraint
+  : CFAGraph -> (IName,Ctx) -> (Pat,AbsVal) -> CFAGraph
+  sem propagateMatchConstraint graph id =
+  | _ -> graph -- Default: do nothing
+
+  sem constraintToString im (env: PprintEnv) =
+  | CstrMatch { id = id, pat = pat, target = target } ->
+    match pprintVarINameCtx im env id with (env, id) in
+    match getPatStringCode 0 env pat with (env, pat) in
+    match pprintVarINameCtx im env target with (env, target) in
+    (env, join [id, ": match ", target, " with ", pat])
+
+  sem generateConstraintsMatch
+  : IndexMap -> [MatchGenFun] -> Ctx -> CtxEnv -> Expr -> GenFunAcc
+  sem generateConstraintsMatch im mcgfs ctx env =
+  | _ -> (env,[])
+  | TmLet { ident = ident, body = TmMatch t, info = info } ->
+    let thn = name2int im (infoTm t.thn) (exprName t.thn) in
+    let els = name2int im (infoTm t.els) (exprName t.els) in
+    let ident = name2int im info ident in
+    let cstrs = [
+      CstrDirect { lhs = (thn,ctx), rhs = (ident,ctx) },
+      CstrDirect { lhs = (els,ctx), rhs = (ident,ctx) }
+    ] in
+    let cstrs =
+      match t.target with TmVar tv then
+        let target = name2int im tv.info tv.ident in
+        let targetCtx = ctxEnvLookup im tv.info target env in
+        foldl (lam acc. lam f.
+            concat (f (ident,ctx) (target, targetCtx) t.pat) acc
+          ) cstrs mcgfs
+      else errorSingle [infoTm t.target] "Not a TmVar in match target"
+    in
+    -- Add the names bound in the pattern to the environment
+    let names = map (name2int im t.info) (patNames [] t.pat) in
+    let env = foldl (lam acc. lam n. ctxEnvAdd n ctx acc) env names in
+    (ctxEnvAdd ident ctx env, cstrs)
+
+  sem generateMatchConstraints
+  : (IName,Ctx) -> (IName,Ctx) -> Pat -> [Constraint]
+  sem generateMatchConstraints id target =
+  | pat -> [ CstrMatch { id = id, pat = pat, target = target } ]
+
+  -- Returns the set of names bound in a pattern
+  sem patNames: [Name] -> Pat -> [Name]
+  sem patNames acc =
+  | p ->
+    sfold_Pat_Pat patNames acc p
+
+end
+
+lang UtestKCFA = KCFA + UtestAst
+  sem exprName =
+  | TmUtest t -> exprName t.next
+end
+
+lang NeverKCFA = KCFA + NeverAst
+  -- Nothing to be done here
+end
+
+lang ExtKCFA = KCFA + ExtAst
+
+  syn AbsVal =
+  -- Abstract representation of externals. Handled in a similar way as
+  -- constants. We directly store the external arity in the abstract
+  -- value. Note that ANF eta expands all external definitions, so from the
+  -- perspective of CFA, externals are curried (need not be fully applied as in
+  -- standard MExpr).
+  -- NOTE(dlunde,2022-06-15): I'm not convinced the current approach for
+  -- handling externals is optimal. The additional `let` added by ANF to shadow
+  -- the original external definition is quite clunky. Maybe we can
+  -- incorporate the fact that externals are always fully applied into the
+  -- analysis somehow?
+  | AVExt { ext: (IName,Ctx), arity: Int, args: [(IName,Ctx)] }
+
+  sem absValToString im (env: PprintEnv) =
+  | AVExt { ext = ext, args = args } ->
+    -- We ignore the arity (one can simply look up the ext to get the arity)
+    match mapAccumL (pprintVarINameCtx im) env args with (env,args) in
+    let args = strJoin ", " args in
+    match pprintVarINameCtx im env ext with (env,ext) in
+    (env, join [ext, "(", args, ")"])
+
+  sem cmpAbsValH =
+  | (AVExt lhs, AVExt rhs) ->
+    -- We ignore the arity (if ext is the same, arity is the same)
+    let cmp = cmpINameCtx lhs.ext rhs.ext in
+    if eqi 0 cmp then seqCmp cmpINameCtx lhs.args rhs.args
+    else cmp
+
+  syn Constraint =
+  -- {ext args} ⊆ lhs ⇒ {ext args lhs} ⊆ res
+  | CstrExtApp { lhs: (IName,Ctx),
+                 rhs : (IName,Ctx),
+                 res: (IName,Ctx) }
+
+  sem cmpConstraintH =
+  | (CstrExtApp { lhs = lhs1, rhs = rhs1, res = res1 },
+     CstrExtApp { lhs = lhs2, rhs = rhs2, res = res2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx lhs1 lhs2 in
+       if eqi d 0 then cmpINameCtx rhs1 rhs2
+       else d
+     else d
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrExtApp r & cstr -> initConstraintName r.lhs graph cstr
+
+  sem propagateConstraint update graph =
+  | CstrExtApp { lhs = lhs, rhs = rhs, res = res } ->
+    match update.2
+    with AVExt ({ ext = ext, args = args, arity = arity } & ave) then
+      let args = snoc args rhs in
+      if eqi arity (length args) then
+        -- Last application
+        -- TODO(dlunde,2022-06-15): We currently do nothing here. Optimally, we
+        -- would like to delegate to a `propagateConstraintExt` here, similar
+        -- to constants. I'm not sure where/how `propagateConstraintExt` should
+        -- be defined.
+        graph
+      else
+        -- Curried application, add the new argument
+        addData graph (AVExt { ave with args = args }) res
+    else graph
+
+  -- This ensures that `collectConstraints` does _not_ try to collect constraints
+  -- from `let`s immediately following externals. These `let`s are generated by
+  -- the ANF transform and define eta expanded versions of the externals (so
+  -- that they can be curried).
+  sem collectConstraints ctx cgfs acc =
+  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } & t ->
+    let acc = foldl (lam acc. lam f.
+        match acc with (env, cstrs) in
+        match f ctx env t with (env, fcstrs) in
+        (env, concat fcstrs cstrs)
+      ) acc cgfs in
+    collectConstraints ctx cgfs acc inexpr
+
+  sem generateConstraints im ctx env =
+  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
+    -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
+    -- for externals. Similarly to constants, we probably want to delegate to
+    -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
+    -- not clear where the `generateConstraintsExts` function should be defined.
+    --
+    (env,[])
+
+  sem exprName =
+  -- Skip the eta expanded let added by ANF,
+  | TmExt { inexpr = TmLet { inexpr = inexpr }} -> exprName inexpr
+
+end
+
+---------------
+-- CONSTANTS --
+---------------
+-- Most data-flow constraints will need to add data-flow components related to
+-- constants (e.g., abstract values for positive and negative integers).
+-- However, in this base version of k-CFA, only some data flow constraints are
+-- generated.
+
+-- To add data-flow constraints to a constant:
+-- 1. Implement 'generateConstraintsConst' fot the constant.
+-- 2. Implement 'propagateConstraintConst' for the constant.
+
+lang IntKCFA = KCFA + ConstKCFA + IntAst
+  sem generateConstraintsConst info ident =
+  | CInt _ -> []
+end
+
+lang ArithIntKCFA = KCFA + ConstKCFA + ArithIntAst
+  sem generateConstraintsConst info ident =
+  | CAddi _ -> []
+  | CSubi _ -> []
+  | CMuli _ -> []
+  | CDivi _ -> []
+  | CNegi _ -> []
+  | CModi _ -> []
+end
+
+lang ShiftIntKCFA = KCFA + ConstKCFA + ShiftIntAst
+  sem generateConstraintsConst info ident =
+  | CSlli _ -> []
+  | CSrli _ -> []
+  | CSrai _ -> []
+end
+
+lang FloatKCFA = KCFA + ConstKCFA + FloatAst
+  sem generateConstraintsConst info ident =
+  | CFloat _ -> []
+end
+
+lang ArithFloatKCFA = KCFA + ConstKCFA + ArithFloatAst
+  sem generateConstraintsConst info ident =
+  | CAddf _ -> []
+  | CSubf _ -> []
+  | CMulf _ -> []
+  | CDivf _ -> []
+  | CNegf _ -> []
+end
+
+lang FloatIntConversionKCFA = KCFA + ConstKCFA + FloatIntConversionAst
+  sem generateConstraintsConst info ident =
+  | CFloorfi _ -> []
+  | CCeilfi _ -> []
+  | CRoundfi _ -> []
+  | CInt2float _ -> []
+end
+
+lang BoolKCFA = KCFA + ConstKCFA + BoolAst
+  sem generateConstraintsConst info ident =
+  | CBool _ -> []
+end
+
+lang CmpIntKCFA = KCFA + ConstKCFA + CmpIntAst
+  sem generateConstraintsConst info ident =
+  | CEqi _ -> []
+  | CNeqi _ -> []
+  | CLti _ -> []
+  | CGti _ -> []
+  | CLeqi _ -> []
+  | CGeqi _ -> []
+end
+
+lang CmpFloatKCFA = KCFA + ConstKCFA + CmpFloatAst
+  sem generateConstraintsConst info ident =
+  | CEqf _ -> []
+  | CLtf _ -> []
+  | CLeqf _ -> []
+  | CGtf _ -> []
+  | CGeqf _ -> []
+  | CNeqf _ -> []
+end
+
+lang CharKCFA = KCFA + ConstKCFA + CharAst
+  sem generateConstraintsConst info ident =
+  | CChar _ -> []
+end
+
+lang CmpCharKCFA = KCFA + ConstKCFA + CmpCharAst
+  sem generateConstraintsConst info ident =
+  | CEqc _ -> []
+end
+
+lang IntCharConversionKCFA = KCFA + ConstKCFA + IntCharConversionAst
+  sem generateConstraintsConst info ident =
+  | CInt2Char _ -> []
+  | CChar2Int _ -> []
+end
+
+lang FloatStringConversionKCFA = KCFA + ConstKCFA + FloatStringConversionAst
+  sem generateConstraintsConst info ident =
+  | CStringIsFloat _ -> []
+  | CString2float _ -> []
+  | CFloat2string _ -> []
+end
+
+lang SymbKCFA = KCFA + ConstKCFA + SymbAst
+  sem generateConstraintsConst info ident =
+  | CSymb _ -> []
+  | CGensym _ -> []
+  | CSym2hash _ -> []
+end
+
+lang CmpSymbKCFA = KCFA + ConstKCFA + CmpSymbAst
+  sem generateConstraintsConst info ident =
+  | CEqsym _ -> []
+end
+
+lang SeqOpKCFA = KCFA + ConstKCFA + SeqKCFA + SeqOpAst + KBaseConstraint
+               + LamKCFA
+
+  syn Constraint =
+  -- [{names}] ⊆ lhs ⇒ ∀n ∈ names: {n} ⊆ rhs
+  | CstrSeq {lhs : (IName,Ctx), rhs : (IName,Ctx)}
+  -- [{names}] ⊆ lhs ⇒ [{names} ∪ {rhs}] ⊆ res
+  | CstrSeqUnion {lhs : (IName,Ctx),
+                  rhs : (IName,Ctx),
+                  res : (IName,Ctx)}
+  -- [{names}] ∈ seq ⇒ [{f n : n ∈ names}] ∈ res
+  | CstrSeqMap1 {seq: (IName,Ctx), f: (IName,Ctx), res: (IName,Ctx)}
+  -- {lam x. b} ⊆ f ⇒ (names ⊆ x and [{b}] ∈ res)
+  | CstrSeqMap2 {f: (IName,Ctx), names: Set (IName,Ctx), res: (IName,Ctx)}
+
+  -- TODO(2023-07-11,dlunde): I suspect the fold constraints below have the
+  -- same problem as in the 0-CFA case. Namely, the constraint that c ⊆ y or c
+  -- ⊆ x (whichever is the accumulator) is missing.
+  -- CstrSeqFold<n> implements foldl when left = true, and foldr otherwise
+  -- l: [{names}] ∈ seq ⇒ [{f acc n : n ∈ names}] ∈ res
+  -- r: [{names}] ∈ seq ⇒ [{f n acc : n ∈ names}] ∈ res
+  | CstrSeqFold1 { seq: (IName,Ctx), f: (IName,Ctx), acc: (IName,Ctx),
+                   res: (IName,Ctx), left: Bool }
+  -- l: {lam x. b} ⊆ f ⇒ (acc ⊆ x and {lam y. c} ⊆ b ⇒ (names ⊆ y and c ⊆ res))
+  -- r: {lam x. b} ⊆ f ⇒ (names ⊆ x and {lam y. c} ⊆ b ⇒ (acc ⊆ y and c ⊆ res))
+  | CstrSeqFold2 { f: (IName,Ctx), acc: (IName,Ctx), names: Set (IName,Ctx),
+                   res: (IName,Ctx), left: Bool }
+  -- {lam x. b} ⊆ f ⇒ (names ⊆ x and b ⊆ res)
+  | CstrSeqFold3 { f: (IName,Ctx), names: Set (IName,Ctx), res: (IName,Ctx) }
+
+  sem cmpConstraintH =
+  | (CstrSeq { lhs = lhs1, rhs = rhs1 },
+     CstrSeq { lhs = lhs2, rhs = rhs2 }) ->
+     let d = cmpINameCtx lhs1 lhs2 in
+     if eqi d 0 then cmpINameCtx rhs1 rhs2
+     else d
+  | (CstrSeqUnion { lhs = lhs1, rhs = rhs1, res = res1 },
+     CstrSeqUnion { lhs = lhs2, rhs = rhs2, res = res2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx lhs1 lhs2 in
+       if eqi d 0 then cmpINameCtx rhs1 rhs2
+       else d
+     else d
+  | (CstrSeqMap1 { seq = seq1, f = f1, res = res1 },
+     CstrSeqMap1 { seq = seq2, f = f2, res = res2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx seq1 seq2 in
+       if eqi d 0 then cmpINameCtx f1 f2
+       else d
+     else d
+  | (CstrSeqMap2 { f = f1, names = names1, res = res1 },
+     CstrSeqMap2 { f = f2, names = names2, res = res2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx f1 f2 in
+       if eqi d 0 then setCmp names1 names2
+       else d
+     else d
+  | (CstrSeqFold1 { seq = seq1, f = f1, acc = acc1, res = res1, left = l1 },
+     CstrSeqFold1 { seq = seq2, f = f2, acc = acc2, res = res2, left = l2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx seq1 seq2 in
+       if eqi d 0 then
+         let d = cmpINameCtx acc1 acc2 in
+         if eqi d 0 then
+           let d = cmpINameCtx f1 f2 in
+           if eqi d 0 then cmpBool l1 l2
+           else d
+         else d
+       else d
+     else d
+  | (CstrSeqFold2 { f = f1, acc = acc1, names = names1, res = res1, left = l1 },
+     CstrSeqFold2 { f = f2, acc = acc2, names = names2, res = res2, left = l2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx acc1 acc2 in
+       if eqi d 0 then
+         let d = cmpINameCtx f1 f2 in
+         if eqi d 0 then
+           let d = setCmp names1 names2 in
+           if eqi d 0 then cmpBool l1 l2
+           else d
+         else d
+       else d
+     else d
+  | (CstrSeqFold3 { f = f1, names = names1, res = res1 },
+     CstrSeqFold3 { f = f2, names = names2, res = res2 }) ->
+     let d = cmpINameCtx res1 res2 in
+     if eqi d 0 then
+       let d = cmpINameCtx f1 f2 in
+       if eqi d 0 then setCmp names1 names2
+       else d
+     else d
+
+  sem initConstraint (graph: CFAGraph) =
+  | CstrSeq r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrSeqUnion r & cstr -> initConstraintName r.lhs graph cstr
+  | CstrSeqMap1 r & cstr -> initConstraintName r.seq graph cstr
+  | CstrSeqMap2 r & cstr -> initConstraintName r.f graph cstr
+  | CstrSeqFold1 r & cstr -> initConstraintName r.seq graph cstr
+  | CstrSeqFold2 r & cstr -> initConstraintName r.f graph cstr
+  | CstrSeqFold3 r & cstr -> initConstraintName r.f graph cstr
+
+  sem constraintToString im (env: PprintEnv) =
+  | CstrSeq { lhs = lhs, rhs = rhs } ->
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    (env, join [ "[{names}] ⊆ ", lhs, " ⇒ ∀n ∈ names: {n} ⊆ ", rhs ])
+  | CstrSeqUnion { lhs = lhs, rhs = rhs, res = res } ->
+    match pprintVarINameCtx im env lhs with (env,lhs) in
+    match pprintVarINameCtx im env rhs with (env,rhs) in
+    match pprintVarINameCtx im env res with (env,res) in
+    (env, join [
+        "[{names}] ⊆ ", lhs, " ⇒ [{names} ∪ { ", rhs," }] ⊆ ", res
+      ])
+  | CstrSeqMap1 { seq = seq, f = f, res = res } ->
+    match pprintVarINameCtx im env seq with (env,seq) in
+    match pprintVarINameCtx im env f with (env,f) in
+    match pprintVarINameCtx im env res with (env,res) in
+    (env, join [
+        "[{names}] ∈ ", seq, " ⇒ [{", f, " n : n ∈ names}] ∈ ", res
+      ])
+  | CstrSeqMap2 { f = f, names = names, res = res } ->
+    match pprintVarINameCtx im env f with (env,f) in
+    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
+    with (env,names) in
+    match pprintVarINameCtx im env res with (env,res) in
+    (env, join [
+        "{lam x. b} ⊆ ", f, " ⇒ {", strJoin ", " names, "} ⊆ x AND ",
+        "[{b}] ∈ ", res
+      ])
+  | CstrSeqFold1 { seq = seq, f = f, acc = acc, res = res, left = left } ->
+    match pprintVarINameCtx im env seq with (env,seq) in
+    match pprintVarINameCtx im env f with (env,f) in
+    match pprintVarINameCtx im env acc with (env,acc) in
+    match pprintVarINameCtx im env res with (env,res) in
+    let app = if left then [" ", acc, " n"] else [" n ", acc] in
+    (env, join [
+        "[{names}] ∈ ", seq, " ⇒ [{", f, join app, " : n ∈ names}] ∈ ", res
+      ])
+  | CstrSeqFold2 { f = f, acc = acc, names = names, res = res, left = left } ->
+    match pprintVarINameCtx im env f with (env,f) in
+    match pprintVarINameCtx im env acc with (env,acc) in
+    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
+    with (env,names) in
+    match pprintVarINameCtx im env res with (env,res) in
+    let args =
+      if left then (acc, join ["{", strJoin ", " names, "}"])
+      else (join ["{", strJoin ", " names, "}"], acc) in
+    (env, join [
+        "{lam x. b} ⊆ ", f, " ⇒ ", args.0, " ⊆ x AND ",
+        "{lam y. c} ⊆ b ⇒ ", args.1, " ⊆ y AND {c} ⊆ ", res
+      ])
+  | CstrSeqFold3 { f = f, names = names, res = res } ->
+    match pprintVarINameCtx im env f with (env,f) in
+    match mapAccumL (pprintVarINameCtx im) env (setToSeq names)
+    with (env,names) in
+    match pprintVarINameCtx im env res with (env,res) in
+    (env, join [
+        "{lam x. b} ⊆ ", f, " ⇒ {", (strJoin ", " names), "} ⊆ x AND ",
+        "b ⊆ ", res
+      ])
+
+  sem propagateConstraint update graph =
+  | CstrSeq { lhs = lhs, rhs = rhs } ->
+    match update.2 with AVSeq { names = names } then
+      setFold (lam graph. lam name.
+          initConstraint graph (CstrDirect {lhs = name, rhs = rhs})
+        ) graph names
+    else graph
+  | CstrSeqUnion { lhs = lhs, rhs = rhs, res = res } ->
+    match update.2 with AVSeq { names = names } then
+      addData graph (AVSeq {names = setInsert rhs names}) res
+    else graph
+  | CstrSeqMap1 { seq = seq, f = f, res = res } ->
+    match update.2 with AVSeq { names = names } then
+      initConstraint graph (CstrSeqMap2 { f = f, names = names, res = res })
+    else graph
+  | CstrSeqMap2 { f = f, names = names, res = res } ->
+    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
+    then
+      -- All calls to 'f' within the map get the same context
+      let ctxBody = res.1 in
+      let envBody = ctxEnvAdd x ctxBody env in
+      -- Analyze the lambda body
+      match initConstraints ctxBody envBody graph body with (envBody, graph) in
+      -- Add names ⊆ x constraints
+      let graph = setFold (lam graph. lam n.
+          initConstraint graph (CstrDirect { lhs = n, rhs = (x, ctxBody) })
+        ) graph names in
+      -- Add [{b}] ⊆ res constraint
+      let ctx = ctxEnvLookup graph.im (infoTm body) b envBody in
+      initConstraint graph (CstrInit {
+        lhs = AVSeq { names = setOfSeq cmpINameCtx [(b, ctx)]},
+        rhs = res })
+    else graph
+  | CstrSeqFold1 { seq = seq, f = f, acc = acc, res = res, left = left } ->
+    match update.2 with AVSeq { names = names } then
+      initConstraint graph (
+        CstrSeqFold2 { f = f, acc = acc, names = names, res = res, left = left }
+      )
+    else graph
+  | CstrSeqFold2 { f = f, acc = acc, names = names, res = res, left = left } ->
+    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
+    then
+      let ctxBody = res.1 in
+      let envBody = ctxEnvAdd x ctxBody env in
+      -- Analyze the lambda body
+      match initConstraints ctxBody envBody graph body with (envBody, graph) in
+      let ctxBident = ctxEnvLookup graph.im (infoTm body) b envBody in
+      if left then
+        -- Add acc ⊆ x constraint
+        let graph = initConstraint graph (CstrDirect {
+          lhs = acc, rhs = (x, ctxBody) }) in
+        initConstraint graph (CstrSeqFold3 {
+          f = (b, ctxBident), names = names, res = res})
+      else
+        -- Add names ⊆ x constraint
+        let graph = setFold (lam graph. lam n.
+            initConstraint graph (CstrDirect { lhs = n, rhs = (x, ctxBody) })
+          ) graph names in
+        initConstraint graph (CstrSeqFold3 {
+          f = (b, ctxBident), names = setOfSeq cmpINameCtx [acc], res = res})
+    else graph
+  | CstrSeqFold3 { f = f, names = names, res = res } ->
+    match update.2 with AVLam { ident = x, bident = b, body = body, env = env }
+    then
+      let ctxBody = res.1 in
+      let envBody = ctxEnvAdd x ctxBody env in
+      -- Analyze the lambda body
+      match initConstraints ctxBody envBody graph body with (envBody, graph) in
+      let ctxBident = ctxEnvLookup graph.im (infoTm body) b envBody in
+      -- Add names ⊆ x constraints
+      let graph = setFold (lam graph. lam n.
+          initConstraint graph (CstrDirect { lhs = n, rhs = (x, ctxBody) })
+        ) graph names in
+      -- Add b ⊆ res constraint
+      initConstraint graph (CstrDirect { lhs = (b, ctxBident), rhs = res })
+    else graph
+
+  sem generateConstraintsConst info ident =
+  | ( CSet _
+    | CGet _
+    | CCons _
+    | CSnoc _
+    | CConcat _
+    | CReverse _
+    | CHead _
+    | CTail _
+    | CSubsequence _
+    | CFoldl _
+    | CFoldr _
+    | CMap _
+    ) & const ->
+    [
+      CstrInit {
+        lhs = AVConst { id = ident, const = const, args = []}, rhs = ident
+      }
+    ]
+
+  | ( CLength _
+    | CNull _
+    | CIsList _
+    | CIsRope _
+    ) -> []
+
+  -- TODO(Linnea, 2022-05-13): Add flow constraints to all sequence operations
+  -- | ( CMapi _
+  --   | CIter _
+  --   | CIteri _
+  --   | CCreate _
+  --   | CCreateList _
+  --   | CCreateRope _
+  --   | CSplitAt _
+  --   ) -> []
+
+  sem propagateConstraintConst res args graph =
+  | CSet _ ->
+    utest length args with 3 in
+    let seq = get args 0 in
+    let val = get args 2 in
+    initConstraint graph (CstrSeqUnion {lhs = seq, rhs = val, res = res})
+  | CGet _ ->
+    utest length args with 2 in
+    initConstraint graph (CstrSeq {lhs = head args, rhs = res})
+  | CCons _ ->
+    utest length args with 2 in
+    let val = get args 0 in
+    let seq = get args 1 in
+    initConstraint graph (CstrSeqUnion {lhs = seq, rhs = val, res = res})
+  | CSnoc _ ->
+    utest length args with 2 in
+    let seq = get args 0 in
+    let val = get args 1 in
+    initConstraint graph (CstrSeqUnion {lhs = seq, rhs = val, res = res})
+  | CConcat _ ->
+    utest length args with 2 in
+    let graph = initConstraint graph (CstrDirect {lhs = head args, rhs = res}) in
+    initConstraint graph (CstrDirect {lhs = get args 1, rhs = res})
+  | CReverse _ ->
+    utest length args with 1 in
+    initConstraint graph (CstrDirect {lhs = head args, rhs = res})
+  | CHead _ ->
+    utest length args with 1 in
+    initConstraint graph (CstrSeq {lhs = head args, rhs = res})
+  | CTail _ ->
+    utest length args with 1 in
+    initConstraint graph (CstrDirect {lhs = head args, rhs = res})
+  | CSubsequence _ ->
+    utest length args with 3 in
+    initConstraint graph (CstrDirect {lhs = head args, rhs = res})
+  | CMap _ ->
+    utest length args with 2 in
+    initConstraint graph (
+      CstrSeqMap1 {seq = get args 1, f = head args, res = res})
+  | CFoldl _ ->
+    utest length args with 3 in
+    let seq = get args 2 in
+    let f = head args in
+    let acc = get args 1 in
+    -- Add acc ⊆ res constraint
+    let graph = initConstraint graph (CstrDirect { lhs = acc, rhs = res }) in
+    initConstraint graph (CstrSeqFold1 {
+      seq = seq, f = f, acc = acc, res = res, left = true})
+  | CFoldr _ ->
+    utest length args with 3 in
+    let seq = get args 2 in
+    let f = head args in
+    let acc = get args 1 in
+    -- Add acc ⊆ res constraint
+    let graph = initConstraint graph (CstrDirect { lhs = acc, rhs = res }) in
+    initConstraint graph (CstrSeqFold1 {
+      seq = seq, f = f, acc = acc, res = res, left = false})
+
+end
+
+lang FileOpKCFA = KCFA + ConstKCFA + FileOpAst
+  sem generateConstraintsConst info ident =
+  | CFileRead _ -> []
+  | CFileWrite _ -> []
+  | CFileExists _ -> []
+  | CFileDelete _ -> []
+end
+
+lang IOKCFA = KCFA + ConstKCFA + IOAst
+  sem generateConstraintsConst info ident =
+  | CPrint _ -> []
+  | CPrintError _ -> []
+  | CDPrint _ -> []
+  | CFlushStdout _ -> []
+  | CFlushStderr _ -> []
+  | CReadLine _ -> []
+  | CReadBytesAsString _ -> []
+end
+
+lang RandomNumberGeneratorKCFA = KCFA + ConstKCFA + RandomNumberGeneratorAst
+  sem generateConstraintsConst info ident =
+  | CRandIntU _ -> []
+  | CRandSetSeed _ -> []
+end
+
+lang SysKCFA = KCFA + ConstKCFA + SysAst
+  sem generateConstraintsConst info ident =
+  | CExit _ -> []
+  | CError _ -> []
+  | CArgv _ -> []
+  | CCommand _ -> []
+end
+
+lang TimeKCFA = KCFA + ConstKCFA + TimeAst
+  sem generateConstraintsConst info ident =
+  | CWallTimeMs _ -> []
+  | CSleepMs _ -> []
+end
+
+lang ConTagKCFA = KCFA + ConstKCFA + ConTagAst
+  sem generateConstraintsConst info ident =
+  | CConstructorTag _ -> []
+end
+
+-- TODO(dlunde,2021-11-11): Mutability complicates the analysis, but could
+-- probably be added.
+lang RefOpKCFA = KCFA + ConstKCFA + RefOpAst
+  sem generateConstraintsConst info ident =
+  -- | CRef _ -> []
+  -- | CModRef _ -> []
+  -- | CDeRef _ -> []
+end
+
+-- TODO(dlunde,2021-11-11): Mutability complicates the analysis, but could
+-- probably be added.
+lang TensorOpKCFA = KCFA + ConstKCFA + TensorOpAst
+  sem generateConstraintsConst info ident =
+  -- | CTensorCreateUninitInt _ -> []
+  -- | CTensorCreateUninitFloat _ -> []
+  -- | CTensorCreateInt _ -> []
+  -- | CTensorCreateFloat _ -> []
+  -- | CTensorCreate _ -> []
+  -- | CTensorGetExn _ -> []
+  -- | CTensorSetExn _ -> []
+  -- | CTensorLinearGetExn _ -> []
+  -- | CTensorLinearSetExn _ -> []
+  -- | CTensorRank _ -> []
+  -- | CTensorShape _ -> []
+  -- | CTensorReshapeExn _ -> []
+  -- | CTensorCopy _ -> []
+  -- | CTensorTransposeExn _ -> []
+  -- | CTensorSliceExn _ -> []
+  -- | CTensorSubExn _ -> []
+  -- | CTensorIterSlice _ -> []
+  -- | CTensorEq _ -> []
+  -- | CTensorToString _ -> []
+end
+
+lang BootParserKCFA = KCFA + ConstKCFA + BootParserAst
+  sem generateConstraintsConst info ident =
+  | CBootParserParseMExprString _ -> []
+  | CBootParserParseMCoreFile _ -> []
+  | CBootParserGetId _ -> []
+  | CBootParserGetTerm _ -> []
+  | CBootParserGetType _ -> []
+  | CBootParserGetString _ -> []
+  | CBootParserGetInt _ -> []
+  | CBootParserGetFloat _ -> []
+  | CBootParserGetListLength _ -> []
+  | CBootParserGetConst _ -> []
+  | CBootParserGetPat _ -> []
+  | CBootParserGetInfo _ -> []
+end
+
+--------------
+-- PATTERNS --
+--------------
+
+lang NamedPatKCFA = MatchKCFA + NamedPat + KBaseConstraint
+  sem propagateMatchConstraint graph (id: (IName,Ctx)) =
+  | (PatNamed { ident = PName n, info = info }, av) ->
+    -- OPT(Linnea,2022-06-29): Can we avoid doing name2int every time here?
+    propagateDirectConstraint (name2int graph.im info n, id.1) graph av
+  | (PatNamed { ident = PWildcard _ }, _) -> graph
+
+  sem patNames acc =
+  | PatNamed { ident = PName n } -> cons n acc
+end
+
+lang SeqTotPatKCFA = MatchKCFA + SeqKCFA + SeqTotPat
+  sem propagateMatchConstraint graph (id: (IName,Ctx)) =
+  | (PatSeqTot p, AVSeq { names = names }) ->
+    let f = lam graph. lam pat: Pat. setFold (lam graph: CFAGraph. lam name.
+        let cstrs =
+          foldl (lam acc. lam f. concat (f id name pat) acc) [] graph.mcgfs
+        in
+        foldl initConstraint graph cstrs
+      ) graph names in
+    foldl f graph p.pats
+end
+
+lang SeqEdgePatKCFA = MatchKCFA + SeqKCFA + SeqEdgePat
+  sem propagateMatchConstraint graph (id: (IName,Ctx)) =
+  | (PatSeqEdge p, AVSeq { names = names } & av) ->
+    let f = lam graph. lam pat: Pat. setFold (lam graph: CFAGraph. lam name.
+        let cstrs = foldl (lam acc. lam f. concat (f id name pat) acc)
+          [] graph.mcgfs in
+        foldl initConstraint graph cstrs
+      ) graph names in
+    let graph = foldl f graph p.prefix in
+    let graph = foldl f graph p.postfix in
+    match p.middle with PName rhs
+    then addData graph av (name2int graph.im p.info rhs, id.1)
+    else graph
+  | (PatSeqEdge p, av) ->
+    match p.middle with PName rhs
+    then addData graph av (name2int graph.im p.info rhs, id.1)
+    else graph
+
+  sem patNames acc =
+  | PatSeqEdge { middle = PName n } & p ->
+    sfold_Pat_Pat patNames (cons n acc) p
+end
+
+lang RecordPatKCFA = MatchKCFA + RecordKCFA + RecordPat
+  sem propagateMatchConstraint graph id =
+  | (PatRecord { bindings = pbindings }, AVRec { bindings = abindings }) ->
+    -- Check if record pattern is compatible with abstract value record
+    let compatible = mapAllWithKey (lam k. lam. mapMem k abindings) pbindings in
+    if compatible then
+      mapFoldWithKey (lam graph: CFAGraph. lam k. lam pb: Pat.
+        let ab: (IName,Ctx) = mapFindExn k abindings in
+        let cstrs = foldl (lam acc. lam f. concat (f id ab pb) acc)
+          [] graph.mcgfs in
+        foldl initConstraint graph cstrs
+      ) graph pbindings
+    else graph -- Nothing to be done
+end
+
+lang DataPatKCFA = MatchKCFA + DataKCFA + DataPat
+  sem propagateMatchConstraint graph id =
+  | (PatCon p, AVCon { ident = ident, body = body }) ->
+    if nameEq p.ident (int2name graph.im ident.0) then
+      let cstrs = foldl (lam acc. lam f. concat (f id body p.subpat) acc)
+        [] graph.mcgfs in
+      foldl initConstraint graph cstrs
+    else graph
+end
+
+lang IntPatKCFA = MatchKCFA + IntPat
+  sem propagateMatchConstraint graph id =
+  | (PatInt p, _) -> graph
+end
+
+lang CharPatKCFA = MatchKCFA + CharPat
+  sem propagateMatchConstraint graph id =
+  | (PatChar p, _) -> graph
+end
+
+lang BoolPatKCFA = MatchKCFA + BoolPat
+  sem propagateMatchConstraint graph id =
+  | (PatBool p, _) -> graph
+end
+
+lang AndPatKCFA = MatchKCFA + AndPat
+  sem propagateMatchConstraint graph id =
+  | (PatAnd p, av) ->
+    let graph = propagateMatchConstraint graph id (p.lpat, av) in
+    propagateMatchConstraint graph id (p.rpat, av)
+end
+
+lang OrPatKCFA = MatchKCFA + OrPat
+  sem propagateMatchConstraint graph id =
+  | (PatOr p, av) ->
+    let graph = propagateMatchConstraint graph id (p.lpat, av) in
+    propagateMatchConstraint graph id (p.rpat, av)
+end
+
+lang NotPatKCFA = MatchKCFA + NotPat
+  sem propagateMatchConstraint graph id =
+  | (PatNot p, _) -> graph
+end
+
+-----------------
+-- MEXPR k-CFA --
+-----------------
+
+lang MExprKCFA = KCFA +
+
+  -- Base constraints
+  KBaseConstraint +
+
+  -- Terms
+  VarKCFA + LamKCFA + AppKCFA +
+  LetKCFA + RecLetsKCFA + ConstKCFA + SeqKCFA + RecordKCFA + TypeKCFA + DataKCFA +
+  MatchKCFA + UtestKCFA + NeverKCFA + ExtKCFA +
+
+  -- Constants
+  IntKCFA + ArithIntKCFA + ShiftIntKCFA + FloatKCFA + ArithFloatKCFA +
+  FloatIntConversionKCFA + BoolKCFA + CmpIntKCFA + CmpFloatKCFA + CharKCFA +
+  CmpCharKCFA + IntCharConversionKCFA + FloatStringConversionKCFA + SymbKCFA +
+  CmpSymbKCFA + SeqOpKCFA + FileOpKCFA + IOKCFA + RandomNumberGeneratorKCFA +
+  SysKCFA + TimeKCFA + ConTagKCFA + RefOpKCFA + TensorOpKCFA + BootParserKCFA +
+
+  -- Patterns
+  NamedPatKCFA + SeqTotPatKCFA + SeqEdgePatKCFA + RecordPatKCFA + DataPatKCFA +
+  IntPatKCFA + CharPatKCFA + BoolPatKCFA + AndPatKCFA + OrPatKCFA + NotPatKCFA
+
+  -- Function that adds a set of universal base match constraints to a CFAGraph
+  sem addBaseMatchConstraints =
+  | graph ->
+    { graph with mcgfs = concat [generateMatchConstraints] graph.mcgfs }
+
+  -- Function that adds a set of universal base constraints to a CFAGraph
+  sem addBaseConstraints =
+  | graph ->
+    let cgfs = [ generateConstraints graph.im,
+                 generateConstraintsMatch graph.im graph.mcgfs ] in
+    { graph with cgfs = concat cgfs graph.cgfs }
+
+  -- Function that initializes the constraints in a CFAGraph for an empty
+  -- context and context environment
+  sem initConstraintsEmpty: CFAGraph -> Expr -> CFAGraph
+  sem initConstraintsEmpty graph =
+  | t ->
+    match initConstraints (ctxEmpty ()) (ctxEnvEmpty ()) graph t with (_, graph)
+    in graph
+
+end
+
+-----------------
+-- TESTS k-CFA --
+-----------------
+
+lang KTest = MExprKCFA + MExprANFAll + BootParser + MExprPrettyPrint
+
+  sem testCfa : Int -> Expr -> CFAGraph
+  sem testCfa k =
+  | t ->
+    let graph = emptyCFAGraph k t in
+    let graph = addBaseMatchConstraints graph in
+    let graph = addBaseConstraints graph in
+    let graph = initConstraintsEmpty graph t in
+    solveCfa graph
+
+  sem testCfaDebug : PprintEnv -> Int -> Expr -> (PprintEnv, CFAGraph)
+  sem testCfaDebug pprintenv k =
+  | t ->
+    let graph = emptyCFAGraph k t in
+    let graph = addBaseMatchConstraints graph in
+    let graph = addBaseConstraints graph in
+    let graph = initConstraintsEmpty graph t in
+    solveCfaDebug pprintenv graph
+
+end
+
+mexpr
+
+-----------------
+-- TESTS k-CFA --
+-----------------
+
+use KTest in
+
+-- Test functions --
+let _parse = parseMExprStringKeywords [] in
+let _testBase: Option PprintEnv -> Int -> Expr -> (Option PprintEnv, CFAGraph) =
+  lam env: Option PprintEnv. lam k. lam t: Expr.
+    match env with Some env then
+      -- Version with debug printouts
+      let tANF = normalizeTerm t in
+      match pprintCode 0 env t with (env,tStr) in
+      printLn "\n--- ORIGINAL PROGRAM ---";
+      printLn tStr;
+      match pprintCode 0 env tANF with (env,tANFStr) in
+      printLn "\n--- ANF ---";
+      printLn tANFStr;
+      match testCfaDebug env k tANF with (env,cfaRes) in
+      match cfaGraphToString env cfaRes with (env, resStr) in
+      printLn "\n--- FINAL CFA GRAPH ---";
+      printLn resStr;
+      (Some env,cfaRes)
+
+    else
+      -- Version without debug printouts
+      let tANF = normalizeTerm t in
+      let cfaRes = testCfa k tANF in
+      (None (), cfaRes)
+in
+
+let _test : Bool -> Int -> Expr -> [(String, [String])]
+          -> [(String,[String],[String])] =
+  lam debug. lam k. lam t. lam vars.
+    let env = if debug then Some pprintEnvEmpty else None () in
+    match _testBase env k t with (_, cfaRes) in
+    let stringMap: Map String Int = mapFoldWithKey (
+        lam acc: Map String Int. lam n: Name. lam i: Int.
+          mapInsert (nameGetStr n) i acc
+      ) (mapEmpty cmpString) cfaRes.im.name2int
+    in
+    let string2int: String -> Int = lam s. mapFindExn s stringMap in
+    let int2string: Int -> String = lam i. nameGetStr (int2name cfaRes.im i) in
+    map (lam var: (String, [String]).
+      let avs = mapFoldWithKey (lam acc: Set AbsVal. lam ctx. lam avs: Set AbsVal.
+          let ctx = map int2string ctx in
+          if eqSeq eqString ctx var.1 then avs else acc
+        ) (setEmpty cmpAbsVal) (tensorLinearGetExn cfaRes.data (string2int var.0))
+      in
+      let val = setFold
+        (lam acc. lam av.
+           match av with AVLam { ident = i } then
+             cons (nameGetStr (int2name cfaRes.im i)) acc
+           else acc)
+        [] avs
+      in (var.0, var.1, val)
+    ) vars
+in
+
+let _test0 : Bool -> Expr -> [String]
+          -> [(String,[String],[String])] =
+  lam debug. lam t. lam vars.
+    _test debug 0 t (map (lam v. (v,[])) vars)
+in
+
+-- Custom equality function for testing lambda control flow only
+let eqTestLam = eqSeq (
+  lam t1:(String,[String],[String]). lam t2:(String,[String],[String]).
+    if eqString t1.0 t2.0 then
+      if eqSeq eqString t1.1 t2.1 then
+        let t12 = setOfSeq cmpString t1.2 in
+        let t22 = setOfSeq cmpString t2.2 in
+        setEq t12 t22
+      else false
+    else false)
+in
+
+let eqTestLam0 =
+  lam t1:[(String,[String],[String])]. lam t2:[(String,[String])].
+    let f = map (lam t:(String,[String]). (t.0,[],t.1)) in
+    eqTestLam t1 (f t2)
+in
+--------------------
+
+-- First test from Nielson et al.
+let t = _parse "
+  (lam x. x) (lam y. y)
+------------------------" in
+utest _test0 false t ["x","y"] with [
+  ("x", ["y"]),
+  ("y", [])
+] using eqTestLam0 in
+
+-- Second test from Nielson et al.
+let t = _parse "
+  let f = lam x. x 1 in
+  let g = lam y. addi y 2 in
+  let h = lam z. addi z 3 in
+  let res = addi (f g) (f h) in
+  res
+------------------------" in
+utest _test0 false t ["f","g","h","x","y","z","res"] with [
+  ("f", ["x"]),
+  ("g", ["y"]),
+  ("h", ["z"]),
+  ("x", ["y","z"]),
+  ("y", []),
+  ("z", []),
+  ("res", [])
+] using eqTestLam0 in
+
+-- Third test from Nielson et al.
+let t = _parse "
+recursive let g = lam x.
+  g (lam y. y)
+in
+let res = g (lam z. z) in
+res
+------------------------" in
+utest _test0 false t ["g","x","y","z","res"] with [
+  ("g", ["x"]),
+  ("x", ["y","z"]),
+  ("y", []),
+  ("z", []),
+  ("res", [])
+] using eqTestLam0 in
+
+-- Example 3.34 from Nielson et al (0-CFA).
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let a = f f in
+  let b = f g in
+  b
+------------------------" in
+utest _test0 false t ["a", "b"] with [
+  ("a", ["x", "y"]),
+  ("b", ["x", "y"])
+] using eqTestLam0 in
+
+-- Example 3.34 from Nielson et al (1-CFA).
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let a = f f in
+  let b = f g in
+  b
+------------------------" in
+utest _test false 1 t [("a",[]), ("b",[]), ("x",["a"]), ("x",["b"])] with [
+  ("a", [], ["x"]),
+  ("b", [], ["y"]),
+  ("x", ["a"], ["x"]),
+  ("x", ["b"], ["y"])
+] using eqTestLam in
+
+-- Third test using 2-CFA
+let t = _parse "
+let f = lam y. y in
+recursive let g = lam x.
+  let a = g f in
+  a
+in
+let res = g (lam z. z) in
+res
+------------------------" in
+utest _test false 2 t [
+  ("g",[]),
+  ("x",["res"]),("x",["res","a"]),("x",["a","a"]),
+  ("res", [])
+] with [
+  ("g", [], ["x"]),
+  ("x", ["res"], ["z"]),
+  ("x", ["res","a"], ["y"]),
+  ("x", ["a","a"], ["y"]),
+  ("res", [], [])
+] using eqTestLam in
+
+-- 2-CFA
+let t = _parse "
+let f = lam x. x in
+let g = lam y.
+  let t = f y in
+  t
+in
+let h = lam z. z in
+let a = g h in
+let b = g f in
+a
+------------------------" in
+utest _test false 2 t [("a",[]),("b",[]),("x",["a","t"]),("x",["b","t"])] with [
+  ("a", [], ["z"]),
+  ("b", [], ["x"]),
+  ("x", ["a","t"], ["z"]),
+  ("x", ["b","t"], ["x"])
+] using eqTestLam in
+
+-- Sequence
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let seq = [f, lam z. z] in
+  let res = match seq with [a] ++ _ then
+      a g
+    else
+      (lam v. v)
+  in res
+------------------------" in
+utest _test0 false t ["res","a"] with [
+  ("res", ["v","y"]),
+  ("a", ["x","z"])
+] using eqTestLam0 in
+
+-- Sequence operations (basic)
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let s1 = [f, lam z. z] in
+  let hd = head in
+  let b = hd in
+  let resHead = b s1 in
+  let s2 = concat s1 [lam v. v] in
+  let resConcat = b s2 in
+  let s3 = set s1 0 g in
+  let resSet = head s3 in
+  let resGet = get s1 1 in
+  let s4 = cons g s1 in
+  let resCons = head s4 in
+  let s5 = snoc s1 (lam r. r) in
+  let resSnoc = head s5 in
+  let resLength = length s1 in
+  let s6 = reverse s1 in
+  let resReverse = head s6 in
+  let s7 = tail s1 in
+  let resTail = head s1 in
+  let resNull = null s1 in
+  let resIsList = isList s1 in
+  let resIsRope = isRope s1 in
+  let s8 = subsequence s1 0 0 in
+  let resSubsequence = head s8 in
+  ()
+------------------------" in
+utest _test0 false t [
+  "resHead",
+  "resConcat",
+  "resSet",
+  "resGet",
+  "resCons",
+  "resSnoc",
+  "resLength",
+  "resReverse",
+  "resTail",
+  "resNull",
+  "resIsList",
+  "resIsRope",
+  "resSubsequence"
+] with [
+  ("resHead", ["x","z"]),
+  ("resConcat", ["x","z","v"]),
+  ("resSet", ["x","z","y"]),
+  ("resGet", ["x","z"]),
+  ("resCons", ["x","z","y"]),
+  ("resSnoc", ["x","z","r"]),
+  ("resLength", []),
+  ("resReverse", ["x","z"]),
+  ("resTail", ["x","z"]),
+  ("resNull", []),
+  ("resIsList", []),
+  ("resIsRope", []),
+  ("resSubsequence", ["x", "z"])
+] using eqTestLam0 in
+
+-- Map over sequences
+let t = _parse "
+  let s1 = map (lam x. x) [lam y. y, lam z. z] in
+  let r1 = head s1 in
+  let s2 = map (lam a. lam d. d) [lam b. b, lam c. c] in
+  let r2 = head s2 in
+  ()
+------------------------" in
+utest _test0 false t ["r1", "r2"] with [
+  ("r1", ["y", "z"]),
+  ("r2", ["d"])
+] using eqTestLam0 in
+
+-- Foldl
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let h = lam z. z in
+  let r1 = foldl (lam a1. lam e1. a1) f [g, h] in
+  let r2 = foldl (lam a2. lam e2. a2 e2) f [g, h] in
+  let r3 = foldl (lam a3. lam e3. a3 e3) (lam w. w) [] in
+  ()
+------------------------" in
+utest _test0 false t ["r1", "r2", "r3"] with [
+  ("r1", ["x"]),
+  ("r2", ["x", "y", "z"]),
+  ("r3", ["w"])
+] using eqTestLam0 in
+
+-- Foldr
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let h = lam z. z in
+  let r1 = foldr (lam e1. lam a1. a1) f [g, h] in
+  let r2 = foldr (lam e2. lam a2. a2 e2) f [g, h] in
+  let r3 = foldr (lam e3. lam a3. a3 e3) (lam w. w) [] in
+  ()
+------------------------" in
+utest _test0 false t ["r1", "r2", "r3"] with [
+  ("r1", ["x"]),
+  ("r2", ["x", "y", "z"]),
+  ("r3", ["w"])
+] using eqTestLam0 in
+
+-- Record
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let r = { a = f, b = 3 } in
+  let res = match r with { a = a } then
+      a g
+    else
+      (lam z. z)
+  in res
+------------------------" in
+utest _test0 false t ["res","a"] with [
+  ("res", ["y","z"]),
+  ("a", ["x"])
+] using eqTestLam0 in
+
+-- Record update
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let h = lam w. w in
+  let r1 = { a = f, b = 3 } in
+  let r2 = { r1 with a = h } in
+  let res = match r2 with { a = a } then
+      a g
+    else
+      (lam z. z)
+  in res
+------------------------" in
+utest _test0 false t ["res","a"] with [
+  ("res", ["y","z"]),
+  ("a", ["w"])
+] using eqTestLam0 in
+
+-- ConApp
+let t = _parse "
+  type T in
+  con C: (a -> a) -> T in
+  let f = lam x. x in
+
+  let g = lam y. y in
+  let d = C f in
+  let res = match d with C a then
+      a g
+    else
+      (lam z. z)
+  in res
+------------------------" in
+utest _test0 false t ["res","a"] with [
+  ("res", ["y","z"]),
+  ("a", ["x"])
+] using eqTestLam0 in
+
+-- Nested
+let t = _parse "
+  type T in
+  con C: (a -> a) -> T in
+  let f = lam x. x in
+  let g = lam y. y in
+  let d = { a = [C f], b = 3 } in
+  let res = match d with { a = [C a] } then
+      a g
+    else
+      (lam z. z)
+  in res
+------------------------" in
+utest _test0 false t ["res","a"] with [
+  ("res", ["y","z"]),
+  ("a", ["x"])
+] using eqTestLam0 in
+
+let t = _parse "
+  let f = lam x.
+    recursive let g = lam y.
+      let a = g x in
+      a
+    in
+    let d = g x in
+    d
+  in
+  let b = f (lam z. z) in
+  let c = f (lam w. w) in
+  c
+------------------------" in
+utest _test false 3 t [
+  ("y", ["b","d","a"]),
+  ("y", ["c","d","a"]),
+  ("y", ["a","a","a"])
+] with [
+  ("y", ["b","d","a"], ["z"]),
+  ("y", ["c","d","a"], ["w"]),
+  ("y", ["a","a","a"], ["z", "w"])
+] using eqTestLam in
+
+-- And pattern
+let t = _parse "
+  let f = lam x. x in
+  let g = lam y. y in
+  let res =
+    match f with a & b then a g
+    else (lam z. z)
+  in res
+------------------------" in
+utest _test0 false t ["res", "a", "b"] with [
+  ("res", ["y","z"]),
+  ("a", ["x"]),
+  ("b", ["x"])
+] using eqTestLam0 in
+
+-- Or pattern
+let t = _parse "
+  type T in
+  con C1: (a -> a) -> T in
+  con C2: (a -> a) -> T in
+  let f = lam x. x in
+  let g = lam y. y in
+  let h = (C1 f, f) in
+  let res =
+    match h with (C1 _, rhs) | (C2 _, rhs) then rhs g
+    else (lam z. z)
+  in res
+------------------------" in
+utest _test0 false t ["res", "rhs"] with [
+  ("res", ["y","z"]),
+  ("rhs", ["x"])
+] using eqTestLam0 in
+
+-- Not pattern
+let t = _parse "
+  type T in
+  con C: (a -> a) -> T in
+  let f = lam x. x in
+  let g = lam y. y in
+  let h = (C f, f) in
+  let res =
+    match h with ! (C _, rhs) then (lam yy. yy)
+    else (lam z. z)
+  in
+  let res2 =
+    match h with ! (C _, rhs) & (_, p) then (lam k. k)
+    else (lam w. w)
+  in res
+------------------------" in
+utest _test0 false t ["res", "res2", "p"] with [
+  ("res", ["yy","z"]),
+  ("res2", ["k","w"]),
+  ("p", ["x"])
+] using eqTestLam0 in
+
+()

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -384,13 +384,12 @@ let test =
 let tensorFoldliSlice
   : all a. all b. (b -> Int -> Tensor[a] -> b) -> b -> Tensor[a] -> b =
   lam f. lam acc. lam t1.
-  let accr = ref acc in
-  tensorIterSlice
-    (lam i. lam t.
-      let acc = f (deref accr) i t in
-      modref accr acc)
-    t1;
-  deref accr
+  let s = head (tensorShape t1) in
+  recursive let rec = lam acc. lam i.
+    if eqi i s then acc else
+      let acc = f acc i (tensorSliceExn t1 [i]) in
+      rec acc (addi i 1)
+  in rec acc 0
 
 utest
   let t = tensorOfSeqExn tensorCreateDense [3] [1, 2, 3] in


### PR DESCRIPTION
- Fixed a number of issues with how we handled higher-order constants in `cfa.mc`. TLDR: The issues were with tracking the accumulator flow in `fold`s, and nested higher-order constant applications.
    
    To fix the issues in a nice (and maintainable) way, I had to make some quite significant changes in the CFA framework. In particular, I changed how `index.mc` works so that we can leave the set of CFA variables open during constraint generation, and then close it at the last moment just before solving the CFA problem. Leaving the set open allows us to create intermediate CFA variables, which significantly simplifies the higher-order constant handling.

    Example illustrating the two main higher-order constant issues.
    ```
    let f = lam x. x in
    let g = lam y. y in
    let h = lam z. z in
    let r4 = foldr (lam e4. lam a4. let t1 = a4 in e4) (lam v. v) [f,g,h] in
    let r5 =
      foldl (foldr (lam e5. lam a5. let t2 = a5 in e5)) (lam u. u)
        [[f],[g],[h]] in
    ()

    ```
    In the above, we must
      1. identify that the lambdas `v`, `x`, `y`, and `z` flow to the variable `t1` and
      2. identify that `u`, `x`, `y`, and `z` flow to `r5`.
    Previously, the analysis only identified `v` for 1 and `u` for 2.
- As a consequence of the above item, I (easily) added support for the missing higher-order constants (e.g., `mapi`, `create`, etc.).
- I moved the k-CFA stuff to a separate file, `kcfa.mc`. I know we have discussed one vs two files before, but I don't recall the conclusion. It was quite cumbersome to work in `cfa.mc` due to all the mirrored names in 0-CFA and k-CFA (hence the split into two files). __Important__: I have not fixed the corresponding higher-order constant issues in `kcfa.mc`. @lingmar Maybe you can make the corresponding updates if you need k-CFA in the future?
- Changed the implementation of `tensorFoldliSlice` to not use mutation (approved by @br4sco).
