### PR TITLE
Stdlib methods for sequence joining and replacements

### DIFF
--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -642,7 +642,7 @@ utest permute [0, 1, 2] [2, 0, 1] with [1, 2, 0]
 
 
 -- Concatenate a sequence of sequences [s1, s2, ..., sn], interleaving each
--- sequence si with a delimiter
+-- sequence si on a delimiter
 recursive
   let seqJoin: all a. [a] -> [[a]] -> [a] = lam delim. lam ss.
   if null ss
@@ -658,8 +658,8 @@ utest seqJoin [7,7,7,7,7] [[1,2,3]] with [1,2,3]
 utest seqJoin [7,7,7,7] [] with []
 
 
--- Replace all subsequences that match the provided check sequence by a fixed
--- replacement subsequence.
+-- Replace all occurrences of the provided sequence `check` by another sequence
+-- `replacement`, in order of left to right.
 let subseqReplace: all a. (a -> a -> Bool) -> [a] -> [a] -> [a] -> [a] =
     lam eq. lam check. lam replacement. lam seq.
     -- Ignore empty check sequences
@@ -676,7 +676,9 @@ let subseqReplace: all a. (a -> a -> Bool) -> [a] -> [a] -> [a] -> [a] =
         if eq eCheck eSeq then
           work (addi checkIdx 1) (addi seqIdx 1) acc
         else
-          work 0 (addi seqIdx 1) (concat acc (subsequence seq (subi seqIdx checkIdx) (addi checkIdx 1)))
+          work 0 (addi seqIdx 1) (concat acc (subsequence seq
+                                                          (subi seqIdx checkIdx)
+                                                          (addi checkIdx 1)))
     in
     work 0 0 []
 

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -248,7 +248,7 @@ utest stringIsInt "a1" with false
 utest stringIsInt "" with false
 
 
--- Joins the strings in strs on delim
+-- Join a list of strings on a delimiter
 let strJoin: String -> [String] -> String = seqJoin
 
 utest strJoin "--" ["water", "tea", "coffee"] with "water--tea--coffee"
@@ -264,5 +264,6 @@ utest strReplace "" "bar" "a string" with "a string"
 utest strReplace "." "bar" "a string" with "a string"
 utest strReplace "bar" "babar" "foo bar" with "foo babar"
 utest strReplace "-" "--" "mi run -help -flag" with "mi run --help --flag"
-utest strReplace "-" "--" "mi run --help --flag" with "mi run ----help ----flag"
-utest strReplace "viking" "miking" "two vikings on a boat" with "two mikings on a boat"
+utest strReplace "-" "--" "mi --help --flag" with "mi ----help ----flag"
+utest strReplace "viking" "miking" "two vikings" with "two mikings"
+utest strReplace "dog" "cat" "every dog loves dogs" with "every cat loves cats"

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -249,16 +249,20 @@ utest stringIsInt "" with false
 
 
 -- Joins the strings in strs on delim
-recursive
-  let strJoin = lam delim. lam strs.
-    if null strs
-    then ""
-    else if eqi (length strs) 1
-         then head strs
-         else concat (concat (head strs) delim) (strJoin delim (tail strs))
-end
+let strJoin: String -> [String] -> String = seqJoin
 
 utest strJoin "--" ["water", "tea", "coffee"] with "water--tea--coffee"
 utest strJoin "--" [] with emptyStr
 utest strJoin "--" ["coffee"] with "coffee"
 utest strJoin "water" ["coffee", "tea"] with "coffeewatertea"
+
+
+-- Replaces all occurrences of the string by the replacement
+let strReplace: String -> String -> String -> String = subseqReplace eqChar
+
+utest strReplace "" "bar" "a string" with "a string"
+utest strReplace "." "bar" "a string" with "a string"
+utest strReplace "bar" "babar" "foo bar" with "foo babar"
+utest strReplace "-" "--" "mi run -help -flag" with "mi run --help --flag"
+utest strReplace "-" "--" "mi run --help --flag" with "mi run ----help ----flag"
+utest strReplace "viking" "miking" "two vikings on a boat" with "two mikings on a boat"


### PR DESCRIPTION
Refactor str joining to work on generic sequences instead. Also add a subsequence replacement method as well.