### PR TITLE
Unify updates

### DIFF
--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -108,18 +108,18 @@ let tyvar_ =
   ntyvar_ (nameNoSym s)
 
 let nstyall_ = use AllTypeAst in
-  lam n. lam sort. lam ty.
-  TyAll {ident = n, info = NoInfo (), ty = ty, sort = sort}
+  lam n. lam kind. lam ty.
+  TyAll {ident = n, info = NoInfo (), ty = ty, kind = kind}
 
 let styall_ = lam s. nstyall_ (nameNoSym s)
 
-let ntyall_ : Name -> Type -> Type  = use VarSortAst in
+let ntyall_ : Name -> Type -> Type  = use KindAst in
   lam n.
-  nstyall_ n (PolyVar ())
+  nstyall_ n (Poly ())
 
-let tyall_ = use VarSortAst in
+let tyall_ = use KindAst in
   lam s.
-  styall_ s (PolyVar ())
+  styall_ s (Poly ())
 
 let tyalls_ =
   lam strs. lam ty.

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -289,7 +289,7 @@ lang BootParser = MExprAst + ConstTransformer
     TyAll {info = ginfo t 0,
            ident = gname t 0,
            ty = gtype t 0,
-           sort = PolyVar ()}
+           kind = Poly ()}
 
 
   -- Get constant help function

--- a/stdlib/mexpr/cmp.mc
+++ b/stdlib/mexpr/cmp.mc
@@ -413,23 +413,23 @@ lang VarTypeCmp = Cmp + VarTypeAst
   | (TyVar t1, TyVar t2) -> nameCmp t1.ident t2.ident
 end
 
-lang VarSortCmp = Cmp + VarSortAst
-  sem cmpVarSort =
-  | (RecordVar l, RecordVar r) ->
+lang KindCmp = Cmp + KindAst
+  sem cmpKind =
+  | (Row l, Row r) ->
     mapCmp cmpType l.fields r.fields
   | (lhs, rhs) ->
     subi (constructorTag lhs) (constructorTag rhs)
 end
 
-lang AllTypeCmp = VarSortCmp + AllTypeAst
+lang AllTypeCmp = KindCmp + AllTypeAst
   sem cmpTypeH =
   | (TyAll t1, TyAll t2) ->
     let identDiff = nameCmp t1.ident t2.ident in
     if eqi identDiff 0 then
-      let sortDiff = cmpVarSort (t1.sort, t2.sort) in
-      if eqi sortDiff 0 then
+      let kindDiff = cmpKind (t1.kind, t2.kind) in
+      if eqi kindDiff 0 then
         cmpType t1.ty t2.ty
-      else sortDiff
+      else kindDiff
     else identDiff
 end
 

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -646,9 +646,9 @@ lang VarTypeEq = Eq + VarTypeAst
     else None ()
 end
 
-lang VarSortEq = Eq + VarSortAst
-  sem eqVarSort (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) =
-  | (RecordVar l, RecordVar r) ->
+lang KindEq = Eq + KindAst
+  sem eqKind (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) =
+  | (Row l, Row r) ->
       if eqi (mapSize l.fields) (mapSize r.fields) then
         mapFoldlOption
           (lam free. lam k1. lam v1.
@@ -662,11 +662,11 @@ lang VarSortEq = Eq + VarSortAst
     else None ()
 end
 
-lang AllTypeEq = VarSortEq + AllTypeAst
+lang AllTypeEq = KindEq + AllTypeAst
   sem eqTypeH (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) (lhs : Type) =
   | TyAll r ->
     match unwrapType lhs with TyAll l then
-      optionBind (eqVarSort typeEnv free (l.sort, r.sort))
+      optionBind (eqKind typeEnv free (l.kind, r.kind))
         (lam free.
           eqTypeH
             {typeEnv with tyVarEnv = biInsert (l.ident, r.ident) typeEnv.tyVarEnv}

--- a/stdlib/mexpr/generate-json-serializers.mc
+++ b/stdlib/mexpr/generate-json-serializers.mc
@@ -6,6 +6,7 @@ include "cmp.mc"
 include "boot-parser.mc"
 include "pprint.mc"
 include "symbolize.mc"
+include "type.mc"
 include "utils.mc"
 include "duplicate-code-elimination.mc"
 

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -451,7 +451,7 @@ lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
 end
 
 lang LambdaLiftTyAlls = MExprAst
-  type TyAllData = (VarSort, Info)
+  type TyAllData = (Kind, Info)
 
   sem liftTyAlls : Expr -> (Map Name TyAllData, Expr)
   sem liftTyAlls =
@@ -478,7 +478,7 @@ lang LambdaLiftTyAlls = MExprAst
   sem liftTyAllsType : Map Name TyAllData -> Type -> (Map Name TyAllData, Type)
   sem liftTyAllsType tyAlls =
   | TyAll t ->
-    let tyAlls = mapInsert t.ident (t.sort, t.info) tyAlls in
+    let tyAlls = mapInsert t.ident (t.kind, t.info) tyAlls in
     liftTyAllsType tyAlls t.ty
   | ty -> smapAccumL_Type_Type liftTyAllsType tyAlls ty
 
@@ -545,8 +545,8 @@ lang LambdaLiftTyAlls = MExprAst
     let ty = eraseUnboundTypesType vars ty in
     ( mapFoldWithKey
         (lam accTy. lam tyId. lam tyAllData.
-          match tyAllData with (varSort, info) in
-          TyAll {ident = tyId, sort = varSort, ty = accTy, info = info})
+          match tyAllData with (kind, info) in
+          TyAll {ident = tyId, kind = kind, ty = accTy, info = info})
         ty vars
     , vars )
 

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -1156,23 +1156,23 @@ lang VarTypePrettyPrint = IdentifierPrettyPrint + VarTypeAst
     pprintVarName env t.ident
 end
 
-lang VarSortPrettyPrint = PrettyPrint + RecordTypeAst + VarSortAst
-  sem getVarSortStringCode (indent : Int) (env : PprintEnv) (idstr : String) =
-  | RecordVar r ->
+lang KindPrettyPrint = PrettyPrint + RecordTypeAst + KindAst
+  sem getKindStringCode (indent : Int) (env : PprintEnv) (idstr : String) =
+  | Row r ->
     let recty = TyRecord {info = NoInfo (), fields = r.fields} in
     match getTypeStringCode indent env recty with (env, recstr) in
     (env, join [init recstr, " ... ", [last recstr]])
   | _ -> (env, idstr)
 end
 
-lang AllTypePrettyPrint = IdentifierPrettyPrint + AllTypeAst + VarSortPrettyPrint
+lang AllTypePrettyPrint = IdentifierPrettyPrint + AllTypeAst + KindPrettyPrint
   sem typePrecedence =
   | TyAll _ -> 0
 
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyAll t ->
     match pprintVarName env t.ident with (env, idstr) in
-    match getVarSortStringCode indent env idstr t.sort with (env, varstr) in
+    match getKindStringCode indent env idstr t.kind with (env, varstr) in
     match getTypeStringCode indent env t.ty with (env, tystr) in
     (env, join ["all ", varstr, ". ", tystr])
 end

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -183,7 +183,7 @@ lang LetSym = Sym + LetAst + AllTypeAst
     match mapAccumL setSymbolFirst env.tyVarEnv vars with (tyVarEnv, vars) in
     (tyVarEnv,
      foldr (lam vs. lam ty. TyAll {info = infoTy tyAnnot,
-                                   ident = vs.0, sort = vs.1, ty = ty})
+                                   ident = vs.0, kind = vs.1, ty = ty})
        (symbolizeType {env with tyVarEnv = tyVarEnv} stripped) vars)
 
   sem addTopNames (env : SymEnv) =
@@ -320,14 +320,14 @@ lang VarTypeSym = Sym + VarTypeAst + UnknownTypeAst
     TyVar {t with ident = ident}
 end
 
-lang AllTypeSym = Sym + AllTypeAst + VarSortAst
+lang AllTypeSym = Sym + AllTypeAst + KindAst
   sem symbolizeType env =
   | TyAll t ->
-    let sort = smap_VarSort_Type (symbolizeType env) t.sort in
+    let kind = smap_Kind_Type (symbolizeType env) t.kind in
     match setSymbol env.tyVarEnv t.ident with (tyVarEnv, ident) in
     TyAll {t with ident = ident,
                   ty = symbolizeType {env with tyVarEnv = tyVarEnv} t.ty,
-                  sort = sort}
+                  kind = kind}
 end
 
 --------------

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -15,7 +15,6 @@ include "builtin.mc"
 include "info.mc"
 include "error.mc"
 include "pprint.mc"
-include "type.mc"
 
 ---------------------------
 -- SYMBOLIZE ENVIRONMENT --

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -1,16 +1,162 @@
 include "map.mc"
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
+include "mexpr/cmp.mc"
 include "mexpr/const-types.mc"
+include "mexpr/eq.mc"
+include "mexpr/pprint.mc"
+
+---------------------------
+-- UNIFICATION VARIABLES --
+---------------------------
+
+-- A level denotes the level in the AST that a type was introduced at
+type Level = Int
+
+-- Unification meta variables.  These variables represent some
+-- specific but as-of-yet undetermined type.
+lang MetaVarTypeAst = KindAst + Ast
+  type MetaVarRec = {ident  : Name,
+                     level  : Level,
+    -- The level indicates at what depth of let-binding the variable
+    -- was introduced, which is used to determine which variables can
+    -- be generalized and to check that variables stay in their scope.
+                     kind   : Kind}
+
+  syn MetaVar =
+  | Unbound MetaVarRec
+  | Link Type
+
+  syn Type =
+  -- Meta type variable
+  | TyMetaVar {info     : Info,
+               contents : Ref MetaVar}
+
+  sem tyWithInfo (info : Info) =
+  | TyMetaVar t ->
+    switch deref t.contents
+    case Unbound _ then
+      TyMetaVar {t with info = info}
+    case Link ty then
+      tyWithInfo info ty
+    end
+
+  sem infoTy =
+  | TyMetaVar {info = info} -> info
+
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
+  | TyMetaVar t ->
+    switch deref t.contents
+    case Unbound r then
+      match smapAccumL_Kind_Type f acc r.kind with (acc, kind) in
+      modref t.contents (Unbound {r with kind = kind});
+      (acc, TyMetaVar t)
+    case Link ty then
+      f acc ty
+    end
+
+  sem rappAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
+  | TyMetaVar t & ty ->
+    recursive let work = lam ty.
+      match ty with TyMetaVar x then
+        switch deref x.contents
+        case Link l then
+          let new = work l in
+          modref x.contents (Link new);
+          new
+        case Unbound _ then
+          ty
+        end
+      else ty in
+    switch work ty
+    case TyMetaVar _ & ty1 then (acc, ty1)
+    case ty1 then f acc ty1
+    end
+end
+
+lang MetaVarTypeCmp = Cmp + MetaVarTypeAst
+  sem cmpTypeH =
+  | (TyMetaVar l, TyMetaVar r) ->
+    -- NOTE(vipa, 2023-04-19): Any non-link TyMetaVar should have been
+    -- unwrapped already, thus we can assume `Unbound` here.
+    match (deref l.contents, deref r.contents) with (Unbound l, Unbound r) in
+    nameCmp l.ident r.ident
+end
+
+lang MetaVarTypePrettyPrint = IdentifierPrettyPrint + KindPrettyPrint + MetaVarTypeAst
+  sem typePrecedence =
+  | TyMetaVar t ->
+    switch deref t.contents
+    case Unbound _ then
+      100000
+    case Link ty then
+      typePrecedence ty
+    end
+  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
+  | TyMetaVar t ->
+    switch deref t.contents
+    case Unbound t then
+      match pprintVarName env t.ident with (env, idstr) in
+      match getKindStringCode indent env idstr t.kind with (env, str) in
+      let monoPrefix =
+        match t.kind with Mono _ then "_" else "" in
+      (env, concat monoPrefix str)
+    case Link ty then
+      getTypeStringCode indent env ty
+    end
+end
+
+lang MetaVarTypeEq = KindEq + MetaVarTypeAst
+  sem eqTypeH (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) (lhs : Type) =
+  | TyMetaVar _ & rhs ->
+    switch (unwrapType lhs, unwrapType rhs)
+    case (TyMetaVar l, TyMetaVar r) then
+      match (deref l.contents, deref r.contents) with (Unbound n1, Unbound n2) in
+      optionBind
+        (_eqCheck n1.ident n2.ident biEmpty free.freeTyFlex)
+        (lam freeTyFlex.
+          eqKind typeEnv {free with freeTyFlex = freeTyFlex} (n1.kind, n2.kind))
+    case (! TyMetaVar _, ! TyMetaVar _) then
+      eqTypeH typeEnv free lhs rhs
+    case _ then None ()
+    end
+end
+
+let newmetavar =
+  lam kind. lam level. lam info. use MetaVarTypeAst in
+  TyMetaVar {info = info,
+             contents = ref (Unbound {ident = nameSym "a",
+                                      level = level,
+                                      kind  = kind})}
+
+let newmonovar = use KindAst in
+  newmetavar (Mono ())
+let newpolyvar = use KindAst in
+  newmetavar (Poly ())
+let newrowvar = use KindAst in
+  lam fields. newmetavar (Row {fields = fields})
+
+let newvar = newpolyvar
 
 -- Substitutes type variables
-lang VarTypeSubstitute = VarTypeAst
+lang VarTypeSubstitute = VarTypeAst + MetaVarTypeAst
   sem substituteVars (subst : Map Name Type) =
   | TyVar t & ty ->
     match mapLookup t.ident subst with Some tyvar then tyvar
     else ty
   | ty ->
     smap_Type_Type (substituteVars subst) ty
+
+  sem substituteMetaVars (subst : Map Name Type) =
+  | TyMetaVar t & ty ->
+    switch deref t.contents
+    case Unbound r then
+      match mapLookup r.ident subst with Some tyvar then tyvar else ty
+    case Link to then
+      substituteMetaVars subst to
+    end
+  | ty ->
+    smap_Type_Type (substituteMetaVars subst) ty
 end
 
 -- Returns the argument list in a type application

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -1,0 +1,371 @@
+-- Unification of MExpr types.  See type-check.mc for an overview of
+-- the type checker.
+
+include "result.mc"
+
+include "mexpr/ast.mc"
+include "mexpr/cmp.mc"
+include "mexpr/eq.mc"
+include "mexpr/info.mc"
+include "mexpr/pprint.mc"
+
+---------------------------
+-- UNIFICATION VARIABLES --
+---------------------------
+
+-- A level denotes the level in the AST that a type was introduced at
+type Level = Int
+
+-- Unification (or 'flexible') variables.  These variables represent some
+-- specific but as-of-yet undetermined type, and are used only in type checking.
+lang FlexTypeAst = VarSortAst + Ast
+  type FlexVarRec = {ident  : Name,
+                     level  : Level,
+    -- The level indicates at what depth the variable was bound introduced,
+    -- which is used to determine which variables can be generalized.
+                     sort   : VarSort}
+    -- The sort of a variable can be polymorphic, monomorphic or a record.
+
+  syn FlexVar =
+  | Unbound FlexVarRec
+  | Link Type
+
+  syn Type =
+  -- Flexible type variable
+  | TyFlex {info     : Info,
+            contents : Ref FlexVar}
+
+  sem tyWithInfo (info : Info) =
+  | TyFlex t ->
+    switch deref t.contents
+    case Unbound _ then
+      TyFlex {t with info = info}
+    case Link ty then
+      tyWithInfo info ty
+    end
+
+  sem infoTy =
+  | TyFlex {info = info} -> info
+
+  sem smapAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
+  | TyFlex t ->
+    switch deref t.contents
+    case Unbound r then
+      match smapAccumL_VarSort_Type f acc r.sort with (acc, sort) in
+      modref t.contents (Unbound {r with sort = sort});
+      (acc, TyFlex t)
+    case Link ty then
+      f acc ty
+    end
+
+  sem rappAccumL_Type_Type (f : acc -> Type -> (acc, Type)) (acc : acc) =
+  | TyFlex t & ty ->
+    match deref t.contents with Link inner then f acc inner
+    else (acc, ty)
+end
+
+lang FlexTypeCmp = Cmp + FlexTypeAst
+  sem cmpTypeH =
+  | (TyFlex l, TyFlex r) ->
+    -- NOTE(vipa, 2023-04-19): Any non-link TyFlex should have been
+    -- unwrapped already, thus we can assume `Unbound` here.
+    match (deref l.contents, deref r.contents) with (Unbound l, Unbound r) in
+    nameCmp l.ident r.ident
+end
+
+lang FlexTypePrettyPrint = IdentifierPrettyPrint + VarSortPrettyPrint + FlexTypeAst
+  sem typePrecedence =
+  | TyFlex t ->
+    switch deref t.contents
+    case Unbound _ then
+      100000
+    case Link ty then
+      typePrecedence ty
+    end
+  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
+  | TyFlex t ->
+    switch deref t.contents
+    case Unbound t then
+      match pprintVarName env t.ident with (env, idstr) in
+      match getVarSortStringCode indent env idstr t.sort with (env, str) in
+      let monoPrefix =
+        match t.sort with MonoVar _ then "_" else "" in
+      (env, concat monoPrefix str)
+    case Link ty then
+      getTypeStringCode indent env ty
+    end
+end
+
+lang FlexTypeEq = VarSortEq + FlexTypeAst
+  sem eqTypeH (typeEnv : EqTypeEnv) (free : EqTypeFreeEnv) (lhs : Type) =
+  | TyFlex _ & rhs ->
+    switch (unwrapType lhs, unwrapType rhs)
+    case (TyFlex l, TyFlex r) then
+      match (deref l.contents, deref r.contents) with (Unbound n1, Unbound n2) in
+      optionBind
+        (_eqCheck n1.ident n2.ident biEmpty free.freeTyFlex)
+        (lam freeTyFlex.
+          eqVarSort typeEnv {free with freeTyFlex = freeTyFlex} (n1.sort, n2.sort))
+    case (! TyFlex _, ! TyFlex _) then
+      eqTypeH typeEnv free lhs rhs
+    case _ then None ()
+    end
+end
+
+
+----------------------
+-- TYPE UNIFICATION --
+----------------------
+
+lang Unifier = FlexTypeAst
+  syn TCError =
+  | TypeUnificationError (Type, Type)
+
+  type TCResult a = Result () TCError a
+
+  syn Unifier =
+  -- Intentionally left blank
+
+  sem uempty : () -> Unifier
+
+  sem uconcat : Unifier -> Unifier -> TCResult Unifier
+
+  sem uinsert : FlexVarRec -> Type -> Unifier -> TCResult Unifier
+end
+
+lang Unify = Unifier + AliasTypeAst + PrettyPrint + Cmp + FlexTypeCmp
+  syn UnifyExt =
+  -- Intentionally left blank
+
+  type UnifyEnv =
+    { wrappedLhs : Type
+    , wrappedRhs : Type
+    , boundNames : BiNameMap
+    , ext        : UnifyExt
+    }
+
+  -- Unify the types `ty1' and `ty2', where
+  -- `ty1' is the expected type of an expression, and
+  -- `ty2' is the inferred type of the expression,
+  -- under the assumptions of `env'.
+  sem unifyTypes : UnifyEnv -> (Type, Type) -> TCResult Unifier
+  sem unifyTypes env =
+  | (ty1, ty2) ->
+    unifyBase
+      {env with wrappedLhs = ty1, wrappedRhs = ty2}
+      (unwrapType ty1, unwrapType ty2)
+
+  -- unifyBase env (ty1, ty2) unifies ty1 and ty2 under the
+  -- assumptions of env.
+  -- IMPORTANT: Assumes that ty1 = unwrapType env.wrappedLhs and
+  -- ty2 = unwrapType env.wrappedRhs.
+  sem unifyBase : UnifyEnv -> (Type, Type) -> TCResult Unifier
+  sem unifyBase env =
+  | (ty1, ty2) ->
+    result.err (TypeUnificationError (ty1, ty2))
+
+  -- unifyCheck is called before a variable `tv' is unified with another type.
+  sem unifyCheck : UnifyEnv -> FlexVarRec -> Type -> TCResult ()
+end
+
+-- Helper language providing functions to unify fields of record-like types
+lang UnifyRows = Unify
+
+  -- Check that 'm1' is a subset of 'm2'
+  sem unifyRowsSubset : UnifyEnv -> Map SID Type -> Map SID Type -> TCResult Unifier
+  sem unifyRowsSubset env m1 =
+  | m2 ->
+    let f = lam b.
+      match b with (k, tyfield1) in
+      match mapLookup k m2 with Some tyfield2 then
+        unifyTypes env (tyfield1, tyfield2)
+      else
+        result.err (RowUnificationError (m1, m2))
+    in
+    let g = lam acc. lam b. result.bind (result.map2 uconcat acc (f b)) (lam x. x) in
+    (result.mapAccumLM g (mapBindings m1)).0
+
+  -- Check that 'm1' and 'm2' contain the same fields
+  sem unifyRowsStrict : UnifyEnv -> Map SID Type -> Map SID Type -> TCResult Unifier
+  sem unifyRowsStrict env m1 =
+  | m2 ->
+    if eqi (mapSize m1) (mapSize m2) then
+      unifyRowsSubset env m1 m2
+    else
+      result.err (RowUnificationError (m1, m2))
+end
+
+lang VarTypeUnify = Unify + VarTypeAst
+  sem unifyBase env =
+  | (TyVar t1 & ty1, TyVar t2 & ty2) ->
+    if nameEq t1.ident t2.ident then result.ok (uempty ())
+    else if biMem (t1.ident, t2.ident) env.boundNames then result.ok (uempty ())
+    else result.err (TypeUnificationError (ty1, ty2))
+end
+
+lang FlexTypeUnify = UnifyRows + FlexTypeAst + RecordTypeAst
+  sem addSorts : UnifyEnv -> (VarSort, VarSort) -> TCResult (Unifier, VarSort)
+  sem addSorts env =
+  | (RecordVar r1, RecordVar r2) ->
+    let f = lam acc. lam b.
+      match b with (k, tyfield1) in
+      match mapLookup k acc.1 with Some tyfield2 then
+        let res =
+          result.bind
+            (result.map2 uconcat acc.0 (unifyTypes env (tyfield1, tyfield2) b))
+            (lam x. x)
+        in
+        (res, acc.1)
+      else
+        (acc.0, mapInsert k tyfield1 acc.1)
+    in
+    match foldl f (result.ok (uempty ()), r2.fields) (mapBindings r1.fields)
+      with (unifier, fields)
+    in (unifier, RecordVar {r1 with fields = fields})
+  | (RecordVar _ & rv, ! RecordVar _ & tv)
+  | (! RecordVar _ & tv, RecordVar _ & rv) ->
+    (uempty (), rv)
+  | (PolyVar _, PolyVar _) -> (uempty (), PolyVar ())
+  | (s1, s2) -> (uempty (), MonoVar ())
+
+  sem unifyBase env =
+  | (TyFlex t1 & ty1, TyFlex t2 & ty2) ->
+    match (deref t1.contents, deref t2.contents) with (Unbound r1, Unbound r2) in
+    if not (nameEq r1.ident r2.ident) then
+      unifyCheck env r1 ty2;
+      unifyCheck env r2 ty1;
+      let updated =
+        Unbound {r1 with level = mini r1.level r2.level,
+                         sort = addSorts env (r1.sort, r2.sort)} in
+      modref t1.contents updated;
+      modref t2.contents (Link ty1)
+    else ()
+  | (TyFlex t1 & ty1, !TyFlex _ & ty2) ->
+    match deref t1.contents with Unbound tv in
+    unifyCheck env tv ty2;
+    (match (tv.sort, ty2) with (RecordVar r1, TyRecord r2) then
+      unifyRowsSubset env r1.fields r2.fields
+    else match tv.sort with RecordVar _ then
+      unificationError env
+    else ());
+    modref t1.contents (Link env.rhsName)
+  | (!TyFlex _ & ty1, TyFlex _ & ty2) ->
+    unifyBase {env with lhsName = env.rhsName, rhsName = env.lhsName} (ty2, ty1)
+
+  sem unifyCheckBase env boundVars tv =
+  | TyFlex t ->
+    match deref t.contents with Unbound r in
+    if nameEq r.ident tv.ident then
+      let msg = join [
+        "* Encountered a type occurring within itself.\n",
+        "* Recursive types are only permitted using data constructors.\n",
+        "* When type checking the expression\n"
+      ] in
+      errorSingle env.info msg
+    else
+      let sort =
+        match (tv.sort, r.sort) with (MonoVar _, PolyVar _) then MonoVar ()
+        else
+          sfold_VarSort_Type
+            (lam. lam ty. unifyCheckType env boundVars tv ty) () r.sort;
+          r.sort
+      in
+      let updated = Unbound {r with level = mini r.level tv.level,
+                                    sort  = sort} in
+      modref t.contents updated
+end
+
+lang FunTypeUnify = Unify + FunTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyArrow {from = from1, to = to1}, TyArrow {from = from2, to = to2}) ->
+    unifyTypes env (from1, from2);
+    unifyTypes env (to1, to2)
+end
+
+lang AppTypeUnify = Unify + AppTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyApp t1, TyApp t2) ->
+    unifyTypes env (t1.lhs, t2.lhs);
+    unifyTypes env (t1.rhs, t2.rhs)
+end
+
+lang AllTypeUnify = UnifyRows + AllTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyAll t1, TyAll t2) ->
+    (match (t1.sort, t2.sort) with (RecordVar r1, RecordVar r2) then
+      unifyRowsStrict env r1.fields r2.fields
+    else if eqi (constructorTag t1.sort) (constructorTag t2.sort) then ()
+    else unificationError env);
+    let env = {env with names = biInsert (t1.ident, t2.ident) env.names} in
+    unifyTypes env (t1.ty, t2.ty)
+
+  sem unifyCheckBase env boundVars tv =
+  | TyAll t ->
+    match tv.sort with MonoVar _ then
+      let msg = join [
+        "* Encountered a monomorphic type used in a polymorphic position.\n",
+        "* Perhaps you encountered the value restriction, or need a type annotation?\n",
+        "* When type checking the expression\n"
+      ] in
+      errorSingle env.info msg
+    else
+      sfold_VarSort_Type (lam. lam ty. unifyCheckType env boundVars tv ty) () t.sort;
+      unifyCheckType env (setInsert t.ident boundVars) tv t.ty
+end
+
+lang ConTypeUnify = Unify + ConTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyCon t1 & ty1, TyCon t2 & ty2) ->
+    if nameEq t1.ident t2.ident then ()
+    else unificationError env
+
+  sem unifyCheckBase env boundVars tv =
+  | TyCon t ->
+    match optionMap (lam r. lti tv.level r.0) (mapLookup t.ident env.tyConEnv) with
+      !Some false then
+      let msg = join [
+        "* Encountered a type constructor escaping its scope: ",
+        nameGetStr t.ident, "\n",
+        "* When type checking the expression\n"
+      ] in
+      errorSingle env.info msg
+    else ()
+end
+
+lang BoolTypeUnify = Unify + BoolTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyBool _, TyBool _) -> ()
+end
+
+lang IntTypeUnify = Unify + IntTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyInt _, TyInt _) -> ()
+end
+
+lang FloatTypeUnify = Unify + FloatTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyFloat _, TyFloat _) -> ()
+end
+
+lang CharTypeUnify = Unify + CharTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyChar _, TyChar _) -> ()
+end
+
+lang SeqTypeUnify = Unify + SeqTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TySeq t1, TySeq t2) ->
+    unifyTypes env (t1.ty, t2.ty)
+end
+
+lang TensorTypeUnify = Unify + TensorTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyTensor t1, TyTensor t2) ->
+    unifyTypes env (t1.ty, t2.ty)
+end
+
+lang RecordTypeUnify = UnifyRows + RecordTypeAst
+  sem unifyBase (env : UnifyEnv) =
+  | (TyRecord t1, TyRecord t2) ->
+    unifyRowsStrict env t1.fields t2.fields
+end

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -26,20 +26,21 @@ lang Unify = Ast
   | Rows (Map SID Type, Map SID Type)
   | Kinds (Kind, Kind)
 
-  type UnifyResult a = Result () UnifyError a
-  type Unifier = [(UnifyEnv, Type, Type)]
+  type Unifier u = {
+    empty : u,
+    combine : u -> u -> u,
+    unify : UnifyEnv -> Type -> Type -> u,
+    err   : UnifyError -> u
+  }
 
   -- Unify the types `ty1` and `ty2` under the assumptions of `env`.
-  -- Returns a list of unification obligations `(env, TyMetaVar m, ty)`, where the
-  -- variable of the left-hand side should be unified with the type `ty`.  Note that
-  -- this function can return a non-error result even for two incompatible types.
-  -- For instance, it could return `[(env, varA, Int), (env, varA, Bool)]`, which gives
-  -- two incompatible types to `varA`.
-  -- For a full unification which errors in this scenario, see `unifyPure` below.
-  sem unifyTypes : UnifyEnv -> (Type, Type) -> UnifyResult Unifier
-  sem unifyTypes env =
+  -- Takes an abstract type `u` satisfying the interface `Unifier` to
+  -- perform the actual variable unifications.
+  -- For an example usage, see `unifyPure` below.
+  sem unifyTypes : all u. Unifier u -> UnifyEnv -> (Type, Type) -> u
+  sem unifyTypes u env =
   | (ty1, ty2) ->
-    unifyBase
+    unifyBase u
       {env with wrappedLhs = ty1, wrappedRhs = ty2}
       (unwrapType ty1, unwrapType ty2)
 
@@ -47,191 +48,190 @@ lang Unify = Ast
   -- assumptions of env.
   -- IMPORTANT: Assumes that ty1 = unwrapType env.wrappedLhs and
   -- ty2 = unwrapType env.wrappedRhs.
-  sem unifyBase : UnifyEnv -> (Type, Type) -> UnifyResult Unifier
-  sem unifyBase env =
+  sem unifyBase : all u. Unifier u -> UnifyEnv -> (Type, Type) -> u
+  sem unifyBase u env =
   | (ty1, ty2) ->
-    result.err (Types (ty1, ty2))
+    u.err (Types (ty1, ty2))
 end
 
 -- Helper language providing functions to unify fields of record-like types
 lang UnifyRows = Unify
   -- Check that 'm1' is a subset of 'm2'
-  sem unifyRowsSubset : UnifyEnv -> Map SID Type -> Map SID Type -> UnifyResult Unifier
-  sem unifyRowsSubset env m1 =
+  sem unifyRowsSubset : all u. Unifier u -> UnifyEnv -> Map SID Type -> Map SID Type -> u
+  sem unifyRowsSubset u env m1 =
   | m2 ->
     let f = lam acc. lam b.
       let unifier =
         match b with (k, tyfield1) in
         match mapLookup k m2 with Some tyfield2 then
-          unifyTypes env (tyfield1, tyfield2)
+          unifyTypes u env (tyfield1, tyfield2)
         else
-          result.err (Rows (m1, m2))
+          u.err (Rows (m1, m2))
       in
-      result.map2 concat acc unifier
+      u.combine acc unifier
     in
-    foldl f (result.ok []) (mapBindings m1)
+    foldl f u.empty (mapBindings m1)
 
   -- Check that 'm1' and 'm2' contain the same fields
-  sem unifyRowsStrict : UnifyEnv -> Map SID Type -> Map SID Type -> UnifyResult Unifier
-  sem unifyRowsStrict env m1 =
+  sem unifyRowsStrict : all u. Unifier u -> UnifyEnv -> Map SID Type -> Map SID Type -> u
+  sem unifyRowsStrict u env m1 =
   | m2 ->
     if eqi (mapSize m1) (mapSize m2) then
-      unifyRowsSubset env m1 m2
+      unifyRowsSubset u env m1 m2
     else
-      result.err (Rows (m1, m2))
+      u.err (Rows (m1, m2))
 
   -- Check that the intersection of 'm1' and 'm2' unifies, then return their union
-  sem unifyRowsUnion : UnifyEnv -> Map SID Type -> Map SID Type -> (UnifyResult Unifier, Map SID Type)
-  sem unifyRowsUnion env m1 =
+  sem unifyRowsUnion : all u. Unifier u -> UnifyEnv -> Map SID Type -> Map SID Type -> (u, Map SID Type)
+  sem unifyRowsUnion u env m1 =
   | m2 ->
     let f = lam acc. lam b.
       match b with (k, tyfield1) in
       match mapLookup k acc.1 with Some tyfield2 then
-        (result.map2 concat acc.0 (unifyTypes env (tyfield1, tyfield2)), acc.1)
+        (u.combine acc.0 (unifyTypes u env (tyfield1, tyfield2)), acc.1)
       else
         (acc.0, mapInsert k tyfield1 acc.1)
     in
-    foldl f (result.ok [], m2) (mapBindings m1)
+    foldl f (u.empty, m2) (mapBindings m1)
 end
 
 lang VarTypeUnify = Unify + VarTypeAst
-  sem unifyBase env =
+  sem unifyBase u env =
   | (TyVar t1 & ty1, TyVar t2 & ty2) ->
-    if nameEq t1.ident t2.ident then result.ok []
-    else if biMem (t1.ident, t2.ident) env.boundNames then result.ok []
-    else result.err (Types (ty1, ty2))
+    if nameEq t1.ident t2.ident then u.empty
+    else if biMem (t1.ident, t2.ident) env.boundNames then u.empty
+    else u.err (Types (ty1, ty2))
 end
 
-lang MetaVarTypeUnify = Unify + UnifyRows + MetaVarTypeAst
-  sem addKinds : UnifyEnv -> (Kind, Kind) -> (UnifyResult Unifier, Kind)
-  sem addKinds env =
-  | (Row r1, Row r2) ->
-    match unifyRowsUnion env r1.fields r2.fields with (unifier, fields) in
-    (unifier, Row {r1 with fields = fields})
-  | (Row _ & rv, ! Row _ & tv)
-  | (! Row _ & tv, Row _ & rv) ->
-    (result.ok [], rv)
-  | (Poly _, Poly _) -> (result.ok [], Poly ())
-  | (s1, s2) -> (result.ok [], Mono ())
-
-  sem unifyBase env =
-  | (TyMetaVar _ & ty1, ty2) ->
-    result.ok [(env, ty1, ty2)]
+lang MetaVarTypeUnify = Unify + MetaVarTypeAst
+  sem unifyBase u env =
+  | (TyMetaVar _ & ty1, ty2) -> u.unify env ty1 ty2
   | (!TyMetaVar _ & ty1, TyMetaVar _ & ty2) ->
-    unifyBase {env with wrappedLhs = env.wrappedRhs, wrappedRhs = env.wrappedLhs} (ty2, ty1)
+    unifyBase u {env with wrappedLhs = env.wrappedRhs, wrappedRhs = env.wrappedLhs} (ty2, ty1)
 end
 
 lang FunTypeUnify = Unify + FunTypeAst
-  sem unifyBase (env : UnifyEnv) =
+  sem unifyBase u env =
   | (TyArrow t1, TyArrow t2) ->
-    result.map2 concat
-      (unifyTypes env (t1.from, t2.from))
-      (unifyTypes env (t1.to, t2.to))
+    u.combine
+      (unifyTypes u env (t1.from, t2.from))
+      (unifyTypes u env (t1.to, t2.to))
 end
 
 lang AppTypeUnify = Unify + AppTypeAst
-  sem unifyBase (env : UnifyEnv) =
+  sem unifyBase u env =
   | (TyApp t1, TyApp t2) ->
-    result.map2 concat
-      (unifyTypes env (t1.lhs, t2.lhs))
-      (unifyTypes env (t1.rhs, t2.rhs))
+    u.combine
+      (unifyTypes u env (t1.lhs, t2.lhs))
+      (unifyTypes u env (t1.rhs, t2.rhs))
 end
 
 lang AllTypeUnify = UnifyRows + AllTypeAst
-  sem unifyBase (env : UnifyEnv) =
+  sem unifyBase u env =
   | (TyAll t1, TyAll t2) ->
-    result.map2 concat
+    u.combine
       (match (t1.kind, t2.kind) with (Row r1, Row r2) then
-        unifyRowsStrict env r1.fields r2.fields
-       else if eqi (constructorTag t1.kind) (constructorTag t2.kind) then result.ok []
-            else result.err (Kinds (t1.kind, t2.kind)))
+        unifyRowsStrict u env r1.fields r2.fields
+       else if eqi (constructorTag t1.kind) (constructorTag t2.kind) then u.empty
+            else u.err (Kinds (t1.kind, t2.kind)))
       (let env = {env with boundNames = biInsert (t1.ident, t2.ident) env.boundNames} in
-       unifyTypes env (t1.ty, t2.ty))
+       unifyTypes u env (t1.ty, t2.ty))
 end
 
 lang ConTypeUnify = Unify + ConTypeAst
-  sem unifyBase (env : UnifyEnv) =
+  sem unifyBase u env =
   | (TyCon t1 & ty1, TyCon t2 & ty2) ->
-    if nameEq t1.ident t2.ident then result.ok []
-    else result.err (Types (ty1, ty2))
+    if nameEq t1.ident t2.ident then u.empty
+    else u.err (Types (ty1, ty2))
 end
 
 lang BoolTypeUnify = Unify + BoolTypeAst
-  sem unifyBase (env : UnifyEnv) =
-  | (TyBool _, TyBool _) -> result.ok []
+  sem unifyBase u env =
+  | (TyBool _, TyBool _) -> u.empty
 end
 
 lang IntTypeUnify = Unify + IntTypeAst
-  sem unifyBase (env : UnifyEnv) =
-  | (TyInt _, TyInt _) -> result.ok []
+  sem unifyBase u env =
+  | (TyInt _, TyInt _) -> u.empty
 end
 
 lang FloatTypeUnify = Unify + FloatTypeAst
-  sem unifyBase (env : UnifyEnv) =
-  | (TyFloat _, TyFloat _) -> result.ok []
+  sem unifyBase u env =
+  | (TyFloat _, TyFloat _) -> u.empty
 end
 
 lang CharTypeUnify = Unify + CharTypeAst
-  sem unifyBase (env : UnifyEnv) =
-  | (TyChar _, TyChar _) -> result.ok []
+  sem unifyBase u env =
+  | (TyChar _, TyChar _) -> u.empty
 end
 
 lang SeqTypeUnify = Unify + SeqTypeAst
-  sem unifyBase (env : UnifyEnv) =
+  sem unifyBase u env =
   | (TySeq t1, TySeq t2) ->
-    unifyTypes env (t1.ty, t2.ty)
+    unifyTypes u env (t1.ty, t2.ty)
 end
 
 lang TensorTypeUnify = Unify + TensorTypeAst
-  sem unifyBase (env : UnifyEnv) =
+  sem unifyBase u env =
   | (TyTensor t1, TyTensor t2) ->
-    unifyTypes env (t1.ty, t2.ty)
+    unifyTypes u env (t1.ty, t2.ty)
 end
 
 lang RecordTypeUnify = UnifyRows + RecordTypeAst
-  sem unifyBase (env : UnifyEnv) =
+  sem unifyBase u env =
   | (TyRecord t1, TyRecord t2) ->
-    unifyRowsStrict env t1.fields t2.fields
+    unifyRowsStrict u env t1.fields t2.fields
 end
 
 
 lang UnifyPure = Unify + MetaVarTypeAst + VarTypeSubstitute
+
+  type UnifyPureResult a = Result () UnifyError a
+  type UnifyPureUnifier = [(UnifyEnv, Type, Type)]
+
   -- Unify types `ty1` and `ty2`, returning a map of variable substitutions
   -- equating the two, or giving an error if the types are incompatible.
   -- This function does not perform any occurs checks, scope checking, or
   -- level updates, and accepts cyclic equations.
-  sem unifyPure : Type -> Type -> UnifyResult (Map Name Type)
+  sem unifyPure : Type -> Type -> UnifyPureResult (Map Name Type)
   sem unifyPure ty1 = | ty2 ->
-  recursive let work = lam acc. lam unifier.
-    switch unifier
-    case [] then result.ok acc
-    case [ (env, meta, ty) ] ++ rest then
-      switch unwrapType meta
-      case TyMetaVar t then
-        match deref t.contents with Unbound r in
-        let isEqual =
-          match unwrapType ty with TyMetaVar t2 then
-            match deref t2.contents with Unbound r2 in nameEq r.ident r2.ident
-          else false
-        in
-        if isEqual then work acc rest else
-          if mapMem r.ident acc then work acc rest else
-            let subst = mapInsert r.ident ty (mapEmpty nameCmp) in
-            let f = substituteMetaVars subst in
-            let g = lam x. (x.0, f x.1, f x.2) in
-            work (mapUnion (mapMap f acc) subst) (map g rest)
-      case other then
-        result.bind (unifyTypes env (other, ty))
-          (lam newUnifier. work acc (concat newUnifier rest))
+    let u : Unifier (UnifyPureResult UnifyPureUnifier) = {
+      empty = result.ok [],
+      combine = result.map2 concat,
+      unify = lam env. lam ty1. lam ty2. result.ok [(env, ty1, ty2)],
+      err = result.err
+    }
+    in
+    recursive let work = lam acc. lam unifier.
+      switch unifier
+      case [] then result.ok acc
+      case [ (env, meta, ty) ] ++ rest then
+        switch unwrapType meta
+        case TyMetaVar t then
+          match deref t.contents with Unbound r in
+          let isEqual =
+            match unwrapType ty with TyMetaVar t2 then
+              match deref t2.contents with Unbound r2 in nameEq r.ident r2.ident
+            else false
+          in
+          if isEqual then work acc rest else
+            if mapMem r.ident acc then work acc rest else
+              let subst = mapInsert r.ident ty (mapEmpty nameCmp) in
+              let f = substituteMetaVars subst in
+              let g = lam x. (x.0, f x.1, f x.2) in
+              work (mapUnion (mapMap f acc) subst) (map g rest)
+        case other then
+          result.bind (unifyTypes u env (other, ty))
+            (lam newUnifier. work acc (concat newUnifier rest))
+        end
       end
-    end
-  in
-  let env : UnifyEnv = {
-    boundNames = biEmpty,
-    wrappedLhs = ty1,
-    wrappedRhs = ty2
-  } in
-  result.bind (unifyTypes env (ty1, ty2)) (work (mapEmpty nameCmp))
+    in
+    let env : UnifyEnv = {
+      boundNames = biEmpty,
+      wrappedLhs = ty1,
+      wrappedRhs = ty2
+    } in
+    result.bind (unifyTypes u env (ty1, ty2)) (work (mapEmpty nameCmp))
 end
 
 

--- a/stdlib/mexpr/utest-generate.mc
+++ b/stdlib/mexpr/utest-generate.mc
@@ -104,7 +104,7 @@ let _tyalls = lam vars. lam ty.
   if null vars then error "" else
   foldr
     (lam tyvar. lam acc.
-      TyAll {ident = tyvar, sort = PolyVar (), ty = acc,
+      TyAll {ident = tyvar, kind = Poly (), ty = acc,
              info = _utestInfo})
     ty vars
 recursive let _pprintTy = lam ty.

--- a/stdlib/peval/include.mc
+++ b/stdlib/peval/include.mc
@@ -169,7 +169,7 @@ let includeTyConsNames =
    "FloatTypeAst_TyFloat","CharTypeAst_TyChar", "FunTypeAst_TyArrow",
    "SeqTypeAst_TySeq", "TensorTypeAst_TyTensor", "RecordTypeAst_TyRecord",
    "VariantTypeAst_TyVariant", "ConTypeAst_TyCon", "VarTypeAst_TyVar",
-   "VarSortAst_PolyVar","VarSortAst_MonoVar", "VarSortAst_RecordVar",
+   "KindAst_Poly", "KindAst_Mono", "KindAst_Row",
    "AllTypeAst_TyAll", "AppTypeAst_TyApp","AliasTypeAst_TyAlias"]
 
 let includeOtherFuncs =

--- a/stdlib/pmexpr/tailrecursion.mc
+++ b/stdlib/pmexpr/tailrecursion.mc
@@ -39,7 +39,7 @@ let combineOptions : all a. (a -> a -> Option a) -> Option a -> Option a -> Opti
   else never
 
 -- Finds a compatible side which agrees with both given side values. The value
--- None represents neither side (the minimal element), while Some (Both ())
+-- None represents neither side (the minimal element), while Some (BothSides ())
 -- represents either side (the maximal element).
 let compatibleSide : Option Side -> Option Side -> Option Side =
   combineOptions

--- a/stdlib/pmexpr/utils.mc
+++ b/stdlib/pmexpr/utils.mc
@@ -78,7 +78,7 @@ let typeCheckEnv = lam env : [(Name, Type)]. lam expr.
         match x with (id, ty) in
         _insertVar id ty env)
       _tcEnvEmpty env in
-  removeFlexExpr (typeCheckExpr tcEnv expr)
+  removeMetaVarExpr (typeCheckExpr tcEnv expr)
 in
 
 let t = typeCheck (symbolize (lam_ "x" tyint_ (char_ 'c'))) in


### PR DESCRIPTION
This PR separates out the unification machinery from `type-check.mc` to its own file `unify.mc`.  The functions in `unify.mc` are non-side-effecting, and `type-check.mc` wrap them with side-effects to achieve the same behavior as before.

`unify.mc` now provides language fragments defining the semantic function
```
unifyTypes : UnifyEnv -> (Type, Type) -> Result () UnifyError [(UnifyEnv, Type, Type)]
```
whose result is either a list of `UnifyError` indicating which parts of the type fail to unify, or a list `[(UnifyEnv, Type, Type)]` of variable unifications to be made.  In other words, each element is on the form `(env, var, ty)`, where `var` should be unified with `ty` under `env` in order to unify the original two types given.  Note that the success of `unifyTypes` does not necessarily mean that two types can unify, as it can return, e.g., lists like `[(_, varA, tyA), (_, varA, tyB)]`, where `tyA` and `tyB` are incompatible.

The PR also renames `TyFlex` to `TyMetaVar` and `VarSort` to `Kind`, as I think these names are more appropriate.  I also rename the `RecordVar` kind to `Row` in anticipation to adding actual row kinds.

An unrelated change is that I needed to rename the constructors of the `Side` type of `pmexpr/tailrecursion.mc` as they were conflicting with those of `Either`, giving me an error when I tried to use `Either` in `type-check.mc`.  I vaguely recall someone else encountered the same problem in a previous PR, but I can't seem to find that one now.

**EDIT:**
This PR is now updated to contain a full 'pure' unification function based on `unifyTypes` in `unify.mc`, along with utests checking it behaves as expected.

I also measured the bootstrap times with and without these changes, and it seems there is a noticable impact, mainly in the first step of bootstrapping.

Bootstrapping times **without** these changes (on `develop@a80f0fd`) on my machine:
```
Bootstrapping the Miking compiler (1st round, might take a few minutes)

real    1m45.855s
user    1m45.508s
sys     0m0.309s
Bootstrapping the Miking compiler (2nd round, might take some more time)

real    0m32.152s
user    0m31.414s
sys     0m0.728s
Bootstrapping the Miking compiler (3rd round, might take some more time)

real    0m33.122s
user    0m32.361s
sys     0m0.764s
```

Times **with** these changes:
```
Bootstrapping the Miking compiler (1st round, might take a few minutes)

real    1m54.480s
user    1m54.128s
sys     0m0.320s
Bootstrapping the Miking compiler (2nd round, might take some more time)

real    0m32.415s
user    0m31.738s
sys     0m0.689s
Bootstrapping the Miking compiler (3rd round, might take some more time)

real    0m33.698s
user    0m33.014s
sys     0m0.673s
```

In addition, here is the output of `mi compile --debug-phases src/main/mi.mc` **without** the changes.
```
parsing
  Ast size: 1181346 (Traversal takes ~95.5649414062ms)
  Phase duration: 11775.3520508
make-keywords
  Ast size: 1181346 (Traversal takes ~95.4069824219ms)
  Phase duration: 149.673828125
accelerate
  Ast size: 1181346 (Traversal takes ~95.3259277344ms)
  Phase duration: 42.6911621094
tuning
  Ast size: 1181346 (Traversal takes ~95.8549804688ms)
  Phase duration: 94.6882324219
instrument-profiling
  Ast size: 1181346 (Traversal takes ~88.1550292969ms)
  Phase duration: 0.0009765625
symbolize
  Ast size: 1181346 (Traversal takes ~89.3630371094ms)
  Phase duration: 322.765869141
typecheck
  Ast size: 10641092 (Traversal takes ~413.844238281ms)
  Phase duration: 1683.71411133
runtime-checks
  Ast size: 10641092 (Traversal takes ~403.499023438ms)
  Phase duration: 33.1420898438
pattern-lowering
  Ast size: 10620736 (Traversal takes ~413.074951172ms)
  Phase duration: 384.356933594
backend
  Ast size: 10620736 (Traversal takes ~411.910888672ms)
  Phase duration: 18526.7709961
```

And again, **with** these changes:
```
parsing
  Ast size: 1186280 (Traversal takes ~133.729003906ms)
  Phase duration: 12160.9389648
make-keywords
  Ast size: 1186280 (Traversal takes ~131.163818359ms)
  Phase duration: 234.313964844
accelerate
  Ast size: 1186280 (Traversal takes ~124.016113281ms)
  Phase duration: 61.6220703125
tuning
  Ast size: 1186280 (Traversal takes ~121.324951172ms)
  Phase duration: 141.681884766
instrument-profiling
  Ast size: 1186280 (Traversal takes ~111.20703125ms)
  Phase duration: 0.0009765625
symbolize
  Ast size: 1186280 (Traversal takes ~104.211669922ms)
  Phase duration: 381.483154297
typecheck
  Ast size: 10805293 (Traversal takes ~458.098876953ms)
  Phase duration: 1931.31494141
runtime-checks
  Ast size: 10805293 (Traversal takes ~446.711914062ms)
  Phase duration: 36.1391601562
pattern-lowering
  Ast size: 10777857 (Traversal takes ~452.55078125ms)
  Phase duration: 425.315917969
backend
  Ast size: 10777857 (Traversal takes ~443.486083984ms)
  Phase duration: 19151.2380371
```