### PR TITLE
Partial evaluation improvements and regressions

### DIFF
--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -483,11 +483,11 @@ utest _test data with _parse "
 
 let seq = _parse " [1 (2 3), 4, 5 6] " in
 utest _test seq with _parse "
-  let t = 5 6 in
   let t1 = 2 3 in
   let t2 = 1 t1 in
-  let t3 = [t2, 4, t] in
-  t3
+  let t3 = 5 6 in
+  let t4 = [t2, 4, t3] in
+  t4
 " using eqExpr in
 
 let smatch = _parse "

--- a/stdlib/mexpr/constant-fold.mc
+++ b/stdlib/mexpr/constant-fold.mc
@@ -176,16 +176,20 @@ lang ArithFloatConstantFold = ConstantFold + ArithFloatEval + AppAst
       if eqf f.val 0. then Some b else None ()
     case (_, _) then None ()
     end
-  | TmApp {
-    lhs = TmApp {
+  | TmApp (appr1 & {
+    lhs = TmApp (appr2 & {
       lhs = TmConst {val = c & CMulf _},
-      rhs = a},
+      rhs = a}),
     rhs = b,
     info = info
-  } ->
+  }) ->
     switch (a, b)
     case (TmConst {val = CFloat f1}, TmConst {val = CFloat f2}) then
       Some (delta info (c, [a, b]))
+    case (TmApp {lhs = TmConst {val = CNegf _}, rhs = a},
+          TmApp {lhs = TmConst {val = CNegf _}, rhs = b})
+    then
+      Some (TmApp { appr1 with lhs = TmApp { appr2 with rhs = a }, rhs = b })
     case
       (TmApp (appr1 & {
         lhs = TmApp (appr2 & {
@@ -516,6 +520,9 @@ utest _test prog with _parse "mulf x 6." using eqExpr in
 
 let prog = _parse "mulf 2. (mulf x 3.)" in
 utest _test prog with _parse "mulf x 6." using eqExpr in
+
+let prog = _parse "mulf (negf x) (negf y)" in
+utest _test prog with _parse "mulf x y" using eqExpr in
 
 let prog = _parse "divf x 1." in
 utest _test prog with _parse "x" using eqExpr in

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -460,13 +460,44 @@ lang CmpSymbEval = CmpSymbAst + ConstEvalNoDefault + CmpSymbArity
     TmConst {t with val = CBool {val = eqsym s1.val s2.val}}
 end
 
-lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEvalNoDefault + SeqOpArity
+lang SeqOpEvalFirstOrder =
+  SeqOpAst + IntAst + BoolAst + ConstEvalNoDefault + SeqOpArity
+
   sem delta info =
   | (CHead _, [TmSeq s]) -> head s.tms
   | (CTail _, [TmSeq s]) -> TmSeq {s with tms = tail s.tms}
   | (CNull _, [TmSeq s]) -> TmConst {
     val = CBool {val = null s.tms}, ty = tyunknown_, info = NoInfo ()
   }
+  | (CGet _, [TmSeq s, TmConst {val = CInt n}]) -> get s.tms n.val
+  | (CSet _, [TmSeq s, TmConst {val = CInt n}, val]) ->
+    TmSeq {s with tms = set s.tms n.val val}
+  | (CCons _, [tm, TmSeq s]) -> TmSeq {s with tms = cons tm s.tms}
+  | (CSnoc _, [TmSeq s, tm]) -> TmSeq {s with tms = snoc s.tms tm}
+  | (CConcat _, [TmSeq s1, TmSeq s2]) ->
+    TmSeq {s2 with tms = concat s1.tms s2.tms}
+  | (CLength _, [TmSeq s]) ->
+    TmConst {val = CInt {val = length s.tms}, ty = tyunknown_, info = NoInfo ()}
+  | (CReverse _, [TmSeq s]) -> TmSeq {s with tms = reverse s.tms}
+  | (CSplitAt _, [TmSeq s, TmConst {val = CInt n}]) ->
+    let t = splitAt s.tms n.val in
+    utuple_ [TmSeq {s with tms = t.0}, TmSeq {s with tms = t.1}]
+  | (CIsList _, [TmSeq s]) ->
+    TmConst {
+      val = CBool {val = isList s.tms}, ty = tyunknown_, info = NoInfo ()
+    }
+  | (CIsRope _, [TmSeq s]) ->
+    TmConst {
+      val = CBool {val = isRope s.tms}, ty = tyunknown_, info = NoInfo ()
+    }
+  | (CSubsequence _, [
+    TmSeq s, TmConst {val = CInt ofs}, TmConst {val = CInt len}
+  ]) ->
+    TmSeq {s with tms = subsequence s.tms ofs.val len.val}
+end
+
+lang SeqOpEval = SeqOpEvalFirstOrder
+  sem delta info =
   | (CMap _, [f, TmSeq s]) ->
     let f = lam x. apply (evalCtxEmpty ()) info (f, x) in
     TmSeq {s with tms = map f s.tms}
@@ -496,19 +527,6 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEvalNoDefault + SeqOpArity
       apply (evalCtxEmpty ()) info (apply (evalCtxEmpty ()) info (f, x), acc)
     in
     foldr f acc s.tms
-  | (CGet _, [TmSeq s, TmConst {val = CInt n}]) -> get s.tms n.val
-  | (CSet _, [TmSeq s, TmConst {val = CInt n}, val]) ->
-    TmSeq {s with tms = set s.tms n.val val}
-  | (CCons _, [tm, TmSeq s]) -> TmSeq {s with tms = cons tm s.tms}
-  | (CSnoc _, [TmSeq s, tm]) -> TmSeq {s with tms = snoc s.tms tm}
-  | (CConcat _, [TmSeq s1, TmSeq s2]) ->
-    TmSeq {s2 with tms = concat s1.tms s2.tms}
-  | (CLength _, [TmSeq s]) ->
-    TmConst {val = CInt {val = length s.tms}, ty = tyunknown_, info = NoInfo ()}
-  | (CReverse _, [TmSeq s]) -> TmSeq {s with tms = reverse s.tms}
-  | (CSplitAt _, [TmSeq s, TmConst {val = CInt n}]) ->
-    let t = splitAt s.tms n.val in
-    utuple_ [TmSeq {s with tms = t.0}, TmSeq {s with tms = t.1}]
   | (CCreate _, [TmConst {val = CInt n}, f]) ->
     let f = lam i. apply (evalCtxEmpty ()) info (f, int_ i) in
     TmSeq {tms = create n.val f, ty = tyunknown_, info = NoInfo ()}
@@ -518,18 +536,6 @@ lang SeqOpEval = SeqOpAst + IntAst + BoolAst + ConstEvalNoDefault + SeqOpArity
   | (CCreateRope _, [TmConst {val = CInt n}, f]) ->
     let f = lam i. apply (evalCtxEmpty ()) info (f, int_ i) in
     TmSeq {tms = createRope n.val f, ty = tyunknown_, info = NoInfo ()}
-  | (CIsList _, [TmSeq s]) ->
-    TmConst {
-      val = CBool {val = isList s.tms}, ty = tyunknown_, info = NoInfo ()
-    }
-  | (CIsRope _, [TmSeq s]) ->
-    TmConst {
-      val = CBool {val = isRope s.tms}, ty = tyunknown_, info = NoInfo ()
-    }
-  | (CSubsequence _, [
-    TmSeq s, TmConst {val = CInt ofs}, TmConst {val = CInt len}
-  ]) ->
-    TmSeq {s with tms = subsequence s.tms ofs.val len.val}
 end
 
 lang FloatStringConversionEval =

--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -144,6 +144,34 @@ lang VarPEval = PEval + VarAst + AppPEval
   | t & TmVar r -> ({ ctx with freeVar = setInsert r.ident ctx.freeVar }, t)
 end
 
+lang LamPEval = PEval + VarAst + LamAst + ClosAst + AppEval
+  sem pevalBindThis =
+  | TmClos _ -> false
+
+  sem pevalApply info ctx k =
+  | (TmClos r, arg) ->
+    let env = evalEnvInsert r.ident arg (r.env ()) in
+    pevalEval { ctx with env = env } k r.body
+
+  sem pevalEval ctx k =
+  | TmLam r ->
+    k (TmClos {
+      ident = r.ident, body = r.body, env = lam. ctx.env, info = r.info
+    })
+  | TmClos r -> k (TmClos r)
+
+  sem pevalReadbackH ctx =
+  | TmClos r ->
+    let b = astBuilder r.info in
+    let newident = nameSetNewSym r.ident in
+    let env = evalEnvInsert r.ident (b.var newident) (r.env ()) in
+    match
+      pevalReadbackH ctx (pevalBind { ctx with env = env } (lam x. x) r.body)
+      with (ctx, body)
+    in
+    (ctx, b.nulam newident body)
+end
+
 lang ClosPAst = ClosAst
   syn Expr =
   | TmClosP {
@@ -157,45 +185,6 @@ lang ClosPAst = ClosAst
 
   sem withInfo info =
   | TmClosP r -> TmClosP { r with cls = { r.cls with info = info } }
-end
-
-lang LamPEval = PEval + VarAst + LamAst + ClosPAst + AppEval
-  sem pevalBindThis =
-  | TmClosP _ -> false
-
-  sem pevalApply info ctx k =
-  | (TmClosP r, arg) ->
-    if and (not ctx.recFlag) r.isRecursive then
-      let b = astBuilder r.cls.info in k (b.app (b.var r.ident) arg)
-    else
-      let env = evalEnvInsert r.cls.ident arg (r.cls.env ()) in
-      pevalEval { ctx with env = env } k r.cls.body
-
-  sem pevalEval ctx k =
-  | TmLam r ->
-    let b = astBuilder r.info in
-    let cls =
-      { ident = r.ident, body = r.body, env = lam. ctx.env, info = r.info }
-    in
-    let newident = nameSetNewSym r.ident in
-    let env = evalEnvInsert r.ident (b.var newident) ctx.env in
-    -- match
-    --   pevalReadbackH
-    let body =
-      -- ctx
-        (pevalBind { ctx with env = env } (lam x. x) r.body)
-      -- with (_, body)
-    in
-    let ident = nameSym "t" in
-    bind_
-      (b.nulet ident (TmLam { r with ident = newident, body = body }))
-      (k (TmClosP { cls = cls, ident = ident, isRecursive = false }))
-  | TmClosP r -> k (TmClosP r)
-
-  sem pevalReadbackH ctx =
-  | TmClosP r ->
-    let b = astBuilder r.cls.info in
-    ({ ctx with freeVar = setInsert r.ident ctx.freeVar }, b.var r.ident)
 end
 
 lang LetPEval = PEval + LetAst
@@ -226,40 +215,14 @@ lang LetPEval = PEval + LetAst
         (inexprCtx, inexpr)
 end
 
+-- NOTE(oerikss, 2023-08-14): We currently do not partially evaluate recursive
+-- calls.
 lang RecLetsPEval = PEval + RecLetsAst + ClosPAst + LamAst
   sem pevalBindThis =
   | TmRecLets _ -> true
 
   sem pevalEval ctx k =
   | TmRecLets r ->
-    recursive let envPrime : Int -> Lazy EvalEnv = lam n. lam.
-      let wraplambda = lam bind.
-        if geqi n ctx.maxRecDepth then TmVar {
-          ident = bind.ident,
-          info = bind.info,
-          ty = bind.tyBody,
-          frozen = false
-        }
-        else
-          match bind.body with TmLam r then TmClosP {
-            cls = {
-              ident = r.ident,
-              body = r.body,
-              env = envPrime (succ n),
-              info = r.info
-            },
-            ident = bind.ident,
-            isRecursive = true
-          }
-          else
-            errorSingle [infoTm bind.body]
-              "Right-hand side of recursive let must be a lambda"
-      in
-      foldl
-        (lam env. lam bind.
-          evalEnvInsert bind.ident (wraplambda bind) env)
-        ctx.env r.bindings
-    in
     let bindings =
       map
         (lam bind. { bind with body = pevalBind ctx (lam x. x) bind.body })
@@ -268,10 +231,10 @@ lang RecLetsPEval = PEval + RecLetsAst + ClosPAst + LamAst
     TmRecLets {
       r with
       bindings = bindings,
-      inexpr = pevalBind { ctx with env = envPrime 0 () } k r.inexpr
+      inexpr = pevalBind ctx k r.inexpr
     }
 
-  sem pevalReadbackH ctx =
+    sem pevalReadbackH ctx =
   | TmRecLets r ->
     let fv = setOfSeq nameCmp (map (lam bind. bind.ident) r.bindings) in
     match pevalReadbackH ctx r.inexpr with (inexprCtx, inexpr) in
@@ -607,6 +570,104 @@ lang SeqOpPEval = PEval + SeqOpEvalFirstOrder + AppAst + ConstAst + VarAst
     foldlK f acc s.tms k
 end
 
+-- NOTE(oerikss, 2023-08-14): WIP handling of recursion and better handling of
+-- closures. It avoids code-swell due to closure inlineing. This fragment is not
+-- correct for functions returning functions.
+lang LamRecLetsPEval = PEval + VarAst + LamAst + RecLetsAst + ClosPAst + AppEval
+  sem pevalBindThis =
+  | TmClosP _ -> false
+  | TmRecLets _ -> true
+
+  sem pevalApply info ctx k =
+  | (TmClosP r, arg) ->
+    if and (not ctx.recFlag) r.isRecursive then
+      let b = astBuilder r.cls.info in k (b.app (b.var r.ident) arg)
+    else
+      let env = evalEnvInsert r.cls.ident arg (r.cls.env ()) in
+      pevalEval { ctx with env = env } k r.cls.body
+
+  sem pevalEval ctx k =
+  | TmLam r ->
+    let b = astBuilder r.info in
+    let cls =
+      { ident = r.ident, body = r.body, env = lam. ctx.env, info = r.info }
+    in
+    let newident = nameSetNewSym r.ident in
+    let env = evalEnvInsert r.ident (b.var newident) ctx.env in
+    let body =
+      (pevalBind { ctx with env = env } (lam x. x) r.body)
+    in
+    let ident = nameSym "t" in
+    bind_
+      (b.nulet ident (TmLam { r with ident = newident, body = body }))
+      (k (TmClosP { cls = cls, ident = ident, isRecursive = false }))
+  | TmClosP r -> k (TmClosP r)
+  | TmRecLets r ->
+    recursive let envPrime : Int -> Lazy EvalEnv = lam n. lam.
+      let wraplambda = lam bind.
+        if geqi n ctx.maxRecDepth then TmVar {
+          ident = bind.ident,
+          info = bind.info,
+          ty = bind.tyBody,
+          frozen = false
+        }
+        else
+          match bind.body with TmLam r then TmClosP {
+            cls = {
+              ident = r.ident,
+              body = r.body,
+              env = envPrime (succ n),
+              info = r.info
+            },
+            ident = bind.ident,
+            isRecursive = true
+          }
+          else
+            errorSingle [infoTm bind.body]
+              "Right-hand side of recursive let must be a lambda"
+      in
+      foldl
+        (lam env. lam bind.
+          evalEnvInsert bind.ident (wraplambda bind) env)
+        ctx.env r.bindings
+    in
+    let bindings =
+      map
+        (lam bind. { bind with body = pevalBind ctx (lam x. x) bind.body })
+        r.bindings
+    in
+    TmRecLets {
+      r with
+      bindings = bindings,
+      inexpr = pevalBind { ctx with env = envPrime 0 () } k r.inexpr
+    }
+
+  sem pevalReadbackH ctx =
+  | TmClosP r ->
+    let b = astBuilder r.cls.info in
+    ({ ctx with freeVar = setInsert r.ident ctx.freeVar }, b.var r.ident)
+  | TmRecLets r ->
+    let fv = setOfSeq nameCmp (map (lam bind. bind.ident) r.bindings) in
+    match pevalReadbackH ctx r.inexpr with (inexprCtx, inexpr) in
+    if
+      forAll (lam bind. not (setMem bind.ident inexprCtx.freeVar)) r.bindings
+    then
+      (inexprCtx, inexpr)
+    else
+      let ctx = { inexprCtx with freeVar = setUnion inexprCtx.freeVar fv } in
+    match
+      mapAccumL
+        (lam ctx. lam bind.
+          match pevalReadbackH ctx bind.body with (bodyCtx, body) in
+          (bodyCtx, { bind with body = body }))
+        ctx
+        r.bindings
+      with (ctx, bindings)
+    in
+    (ctx, TmRecLets { r with bindings = bindings, inexpr = inexpr })
+end
+
+
 lang MExprPEval =
   -- Terms
   VarPEval + LamPEval + AppPEval + RecordPEval + ConstPEval + LetPEval +
@@ -629,921 +690,1024 @@ lang TestLang =
   MExprPEval + MExprPrettyPrint + MExprEq + BootParser + MExprConstantFold
 end
 
+-- NOTE(oerikss, 2023-08-14): This new language supports recursion and tries to
+-- to avoid code-swell from substitution of closures.
+lang MExprPEvalNew =
+  -- Terms
+  VarPEval + LamRecLetsPEval + AppPEval + RecordPEval + ConstPEval + LetPEval +
+  MatchPEval + NeverPEval + DataPEval + TypePEval + SeqPEval +
+  UtestPEval + ExtPEval + SeqOpPEval +
+
+  -- Constants
+  ArithIntPEval + ArithFloatPEval + CmpIntPEval + CmpFloatPEval + IOPEval +
+  CmpCharPEval +
+
+  -- Patterns
+  NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +
+  IntPatEval + CharPatEval + BoolPatEval + AndPatEval + OrPatEval + NotPatEval +
+
+  -- Side effects
+  MExprSideEffect
+end
+
+lang TestLangNew =
+  MExprPEvalNew + MExprPrettyPrint + MExprEq + BootParser + MExprConstantFold
+end
+
 mexpr
 
-use TestLang in
+utest
+  ----------------------------------
+  -- Test standard implementation --
+  ----------------------------------
+  use TestLang in
 
-let _test = lam expr.
-  logMsg logLevel.debug (lam.
-    strJoin "\n" [
-      "Before peval",
-      expr2str expr
-    ]);
-  let expr = symbolizeAllowFree expr in
-  match pevalExpr { pevalCtxEmpty () with maxRecDepth = 10 } expr with expr in
-  logMsg logLevel.debug (lam.
-    strJoin "\n" [
-      "After peval",
-      expr2str expr
-    ]);
-  logMsg logLevel.debug (lam.
-    strJoin "\n" [
-      "After peval (folded)",
-      expr2str (constantfoldLets expr)
-    ]);
-  expr
-in
-
-let _parse =
-  parseMExprString
-    { _defaultBootParserParseMExprStringArg () with allowFree = true }
-in
-
-
-------------------------------
--- Test closure application --
-------------------------------
-
-let prog = _parse "lam x. x" in
-utest _test prog with _parse "let f = lam x. x in f" using eqExpr in
-
-let prog = _parse "(lam x. x) (lam z. z)" in
-utest _test prog with _parse "let f = lam z. z in f" using eqExpr in
-
-let prog = _parse "(lam x. x y) (lam z. z)" in
-utest _test prog with _parse "y" using eqExpr in
-
-let prog = _parse "(lam x. y y x) (lam z. z)" in
-utest _test prog with _parse "
-let t =  lam z. z in
-let t1 =
-  y
-    y
-in
-let t2 =
-  t1
-    t
-in
-t2
-  "
-  using eqExpr
-in
-
-let prog = _parse "(lam f. (f, f)) (lam z. z)" in
-utest _test prog with _parse "
-let t =
-  lam z.
-    z
-in
-(t, t)
-  " using eqExpr in
-
------------------------------
--- Test integer arithmetic --
------------------------------
-
-let prog = _parse "lam x. addi x 0" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. addi x 1" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    addi
-      1
-      x
+  let _test = lam expr.
+    logMsg logLevel.debug (lam.
+      strJoin "\n" [
+        "Before peval",
+        expr2str expr
+      ]);
+    let expr = symbolizeAllowFree expr in
+    match pevalExpr (pevalCtxEmpty ()) expr with expr in
+    logMsg logLevel.debug (lam.
+      strJoin "\n" [
+        "After peval",
+        expr2str expr
+      ]);
+    logMsg logLevel.debug (lam.
+      strJoin "\n" [
+        "After peval (folded)",
+        expr2str (constantfoldLets expr)
+      ]);
+    expr
   in
-  t
-in f
-  "
-  using eqExpr
-in
 
-let prog = _parse "lam x. addi 0 x" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. addi 1 x" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    addi
-      1
-      x
+  let _parse =
+    parseMExprString
+      { _defaultBootParserParseMExprStringArg () with allowFree = true }
   in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. addi x x" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    muli
-      2
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. muli x 0" in
-utest _test prog with _parse "let f = lam x. 0 in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. muli 0 x" in
-utest _test prog with _parse "let f = lam x. 0 in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. muli 1 x" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. muli x 1" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "let f = lam x. muli 2 x in f" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    muli
-      2
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. muli x 2" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    muli
-      2
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. divi x 1" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. divi 0 x" in
-utest _test prog with _parse "let f = lam x. 0 in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. modi x 1" in
-utest _test prog with _parse "let f = lam x. 0 in f" using eqExpr in
-
-let prog = _parse "lam x. modi 0 x" in
-utest _test prog with _parse "let f = lam x. 0 in f" using eqExpr in
-
-------------------------------------
--- Test floating point arithmetic --
-------------------------------------
-
-let prog = _parse "lam x. addf x 0." in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. addf x 1." in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    addf
-      1.
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. addf 0. x" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. addf 1. x" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    addf
-      1.
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. addf x x" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    mulf
-      2.
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. mulf x 0." in
-utest _test prog with _parse "let f = lam x. 0. in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. mulf 0. x" in
-utest _test prog with _parse "let f = lam x. 0. in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. mulf 1. x" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. mulf x 1." in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. mulf 2. x" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    mulf
-      2.
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. mulf x 2." in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    mulf
-      2.
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "lam x. divf x 1." in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "lam x. divf 0. x" in
-utest _test prog with _parse "let f = lam x. 0. in f"
-  using eqExpr
-in
 
 
--------------------------------------------
--- Test Composite Arithmetic Expressions --
--------------------------------------------
+  ------------------------------
+  -- Test closure application --
+  ------------------------------
 
-let prog = _parse "lam x. mulf (addf 1. x) 1." in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    addf
-      1.
-      x
-  in
-  t
-in f
-  "
-  using eqExpr
-in
+  let prog = _parse "lam x. x" in
+  utest _test prog with _parse "lam x. x" using eqExpr in
 
-let prog = _parse "lam y. (lam x. mulf x x) (mulf (mulf 2. y) y)" in
-utest _test prog with _parse "
-let f = lam y.
-  let t =
-    mulf
-      2.
-      y
-  in
+  let prog = _parse "(lam x. x) (lam z. z)" in
+  utest _test prog with _parse "lam z. z" using eqExpr in
+
+  let prog = _parse "(lam x. x y) (lam z. z)" in
+  utest _test prog with _parse "y" using eqExpr in
+
+  let prog = _parse "(lam x. y y x) (lam z. z)" in
+  utest _test prog with _parse "
   let t1 =
-    mulf
-      t
+    y
       y
   in
   let t2 =
-    mulf
-      t1
-      t1
+    t1
+      (lam z. z)
   in
   t2
-in f
-  "
-  using eqExpr
-in
-
-----------------------------------------
--- Test Record Updates and Projection --
-----------------------------------------
-
-let prog = _parse "{ a = 1, b = 2}.b" in
-utest _test prog with _parse "2"
-  using eqExpr
-in
-
-let prog = _parse "{ a = 1, b = 2}.a" in
-utest _test prog with _parse "1"
-  using eqExpr
-in
-
-let prog = _parse "lam x. x.a" in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    x.a
+    "
+    using eqExpr
   in
-  t
-in f
-  "
-  using eqExpr
-in
 
-let prog = _parse "{{ a = 1, b = 2} with a = 3}.a" in
-utest _test prog with _parse "3"
-  using eqExpr
-in
+  let prog = _parse "(lam f. (f, f)) (lam z. z)" in
+  utest _test prog with _parse "
+  (lam z. z, lam z. z)
+    " using eqExpr in
 
-let prog = _parse "{x with a = 3}.a" in
-utest _test prog with _parse "
-let t =
-  { x
-    with
-    a =
-      3 }
-in
-let t1 =
-  t.a
-in
-t1
-  "
-  using eqExpr
-in
+  -----------------------------
+  -- Test integer arithmetic --
+  -----------------------------
 
----------------------------
--- Test Pattern Matching --
----------------------------
-
-let prog = _parse "lam x. match (lam z. (1, z)) x with (u, v) in v" in
-utest _test prog with _parse "let f = lam x. x in f"
-  using eqExpr
-in
-
-let prog = _parse "
-lam x. match x with (f, g) then (lam x. x) (f, g) else (lam x. x) (lam z. z)
-  " in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    match
-      x
-    with
-      (f, g)
-    then
-      (f, g)
-    else
-      let f = lam z. z in f
+  let prog = _parse "lam x. addi x 0" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
   in
-  t
-in f
-  "
-  using eqExpr
-in
 
----------------
--- Test Lets --
----------------
+  let prog = _parse "lam x. addi x 1" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      addi
+        1
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
 
-let prog = _parse "
-  lam y. let f = lam x. x in f y
-  " in
-utest _test prog with _parse "
-  let f = lam y. y in f
-  "
-  using eqExpr
-in
+  let prog = _parse "lam x. addi 0 x" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
 
-let prog = _parse "
-  lam y. let f = y (lam x. x) in f (lam x. x)
-  " in
-utest _test prog with _parse "
-  let f = lam y.
-    let t1 = lam x. x in
-    let t2 = y t1 in
-    let t3 = lam x. x in
-    let t4 = t2 t3 in
-    t4
-  in f
-  "
-  using eqExpr
-in
+  let prog = _parse "lam x. addi 1 x" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      addi
+        1
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
 
-let prog = _parse "
-  (lam f. (f, f)) (lam x. x)
-  " in
-utest _test prog with _parse "
+  let prog = _parse "lam x. addi x x" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      muli
+        2
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. muli x 0" in
+  utest _test prog with _parse "lam x. 0"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. muli 0 x" in
+  utest _test prog with _parse "lam x. 0"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. muli 1 x" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. muli x 1" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. muli 2 x" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      muli
+        2
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. muli x 2" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      muli
+        2
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. divi x 1" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. divi 0 x" in
+  utest _test prog with _parse "lam x. 0"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. modi x 1" in
+  utest _test prog with _parse "lam x. 0" using eqExpr in
+
+  let prog = _parse "lam x. modi 0 x" in
+  utest _test prog with _parse "lam x. 0" using eqExpr in
+
+  ------------------------------------
+  -- Test floating point arithmetic --
+  ------------------------------------
+
+  let prog = _parse "lam x. addf x 0." in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. addf x 1." in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      addf
+        1.
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. addf 0. x" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. addf 1. x" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      addf
+        1.
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. addf x x" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      mulf
+        2.
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. mulf x 0." in
+  utest _test prog with _parse "lam x. 0."
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. mulf 0. x" in
+  utest _test prog with _parse "lam x. 0."
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. mulf 1. x" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. mulf x 1." in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. mulf 2. x" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      mulf
+        2.
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. mulf x 2." in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      mulf
+        2.
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. divf x 1." in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. divf 0. x" in
+  utest _test prog with _parse "lam x. 0."
+    using eqExpr
+  in
+
+
+  -------------------------------------------
+  -- Test Composite Arithmetic Expressions --
+  -------------------------------------------
+
+  let prog = _parse "lam x. mulf (addf 1. x) 1." in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      addf
+        1.
+        x
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "lam y. (lam x. mulf x x) (mulf (mulf 2. y) y)" in
+  utest _test prog with _parse "
+  lam y.
+    let t =
+      mulf
+        2.
+        y
+    in
+    let t1 =
+      mulf
+        t
+        y
+    in
+    let t2 =
+      mulf
+        t1
+        t1
+    in
+    t2
+    "
+    using eqExpr
+  in
+
+  ----------------------------------------
+  -- Test Record Updates and Projection --
+  ----------------------------------------
+
+  let prog = _parse "{ a = 1, b = 2}.b" in
+  utest _test prog with _parse "2"
+    using eqExpr
+  in
+
+  let prog = _parse "{ a = 1, b = 2}.a" in
+  utest _test prog with _parse "1"
+    using eqExpr
+  in
+
+  let prog = _parse "lam x. x.a" in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      x.a
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "{{ a = 1, b = 2} with a = 3}.a" in
+  utest _test prog with _parse "3"
+    using eqExpr
+  in
+
+  let prog = _parse "{x with a = 3}.a" in
+  utest _test prog with _parse "
   let t =
+    { x
+      with
+      a =
+        3 }
+  in
+  let t1 =
+    t.a
+  in
+  t1
+    "
+    using eqExpr
+  in
+
+  ---------------------------
+  -- Test Pattern Matching --
+  ---------------------------
+
+  let prog = _parse "lam x. match (lam z. (1, z)) x with (u, v) in v" in
+  utest _test prog with _parse "lam x. x"
+    using eqExpr
+  in
+
+  let prog = _parse "
+  lam x. match x with (f, g) then (lam x. x) (f, g) else (lam x. x) (lam z. z)
+    " in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      match
+        x
+      with
+        (f, g)
+      then
+        (f, g)
+      else
+        lam z. z
+    in
+    t
+    "
+    using eqExpr
+  in
+
+  ---------------
+  -- Test Lets --
+  ---------------
+
+  let prog = _parse "
+    lam y. let f = lam x. x in f y
+    " in
+  utest _test prog with _parse "
+    lam y. y
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "
+    lam y. let f = y (lam x. x) in f (lam x. x)
+    " in
+  utest _test prog with _parse "
+    lam y.
+      let t1 = y (lam x. x) in
+      let t2 = t1 (lam x. x) in
+      t2
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "
+    (lam f. (f, f)) (lam x. x)
+    " in
+  utest _test prog with _parse "
+    (lam x. x, lam x. x)
+    "
+    using eqExpr
+  in
+
+  --------------------------------
+  -- Test Dead Code Elimination --
+  --------------------------------
+
+  let prog = _parse "
+  lam y. (lam x. mulf x 0.) (addf y y)
+    " in
+  utest _test prog with _parse "lam y. 0."
+    using eqExpr
+  in
+
+  let prog = _parse "
+  lam y. (lam x. mulf x 0.) (addf (print \"hello\"; y) y)
+    " in
+  utest _test prog with _parse "
+  lam t.
+    let t = print \"hello\" in
+    0.
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "
+  lam x.
+      (lam x1. lam x2. addf x1 x2)
+        ((lam y. addf y y) x)
+        ((lam z. addf z z) x)
+    " in
+  utest _test prog with _parse "
+  lam x.
+    let t =
+      mulf
+        2.
+        x
+    in
+    let t1 =
+      mulf
+        2.
+        x
+    in
+    let t2 =
+      addf
+        t
+        t1
+    in
+    t2
+    "
+    using eqExpr
+  in
+
+  --------------------------
+  -- Test Char Comparison --
+  --------------------------
+
+  let prog = _parse "
+  lam x.
+    eqc 'v' x
+  " in
+
+  utest _test prog with _parse "
+  lam x.
+    let t = eqc 'v' x in
+    t
+  "
+    using eqExpr in
+
+  let prog = _parse "
+    eqc 'v' 'a'" in
+
+  utest _test prog with _parse "false" using eqExpr in
+
+  -------------------------
+  -- Test Seq Operations --
+  -------------------------
+
+  let prog = _parse "map (addi 1) [1, 2, 3]" in
+  utest _test prog with _parse "[2, 3, 4]" using eqExpr in
+
+  let prog = _parse "lam x. map (addi x) [1, 2, 3]" in
+  utest _test prog with _parse "
+  lam x.
+    let t1 = addi 1 x in
+    let t2 = addi 2 x in
+    let t3 = addi 3 x in
+    [t1, t2, t3]
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "mapi addi [1, 2, 3]" in
+  utest _test prog with _parse "[1, 3, 5]" using eqExpr in
+
+  let prog = _parse "lam x. mapi (lam i. lam y. muli i (addi x y)) [1, 2, 3]" in
+  utest _test prog with
+    _parse "
+  lam x.
+    let t1 = addi 2 x in
+    let t2 = addi 3 x in
+    let t3 = muli 2 t2 in
+    [0, t1, t3]
+      "
+    using eqExpr
+  in
+
+  let prog = _parse "foldl addi 0 [1, 2, 3]" in
+  utest _test prog with _parse "6" using eqExpr in
+
+  let prog = _parse "lam x. foldl addi x [1, 2, 3]" in
+  utest _test prog with _parse "
+  lam x.
+    let t = addi 1 x in
+    let t1 = addi 2 t in
+    let t2 = addi 3 t1 in
+    t2
+    " using eqExpr in
+
+  let prog = _parse "lam x. lam y. [get x y, get x 1, get x 2]" in
+  utest _test prog with _parse "
     lam x.
-      x
+      lam y. [get x y, get x 1, get x 2]
+    "
+    using eqExpr
+  in
+
+  -------------------------
+  -- Test Recursive Lets --
+  -------------------------
+
+  let prog = _parse "
+  recursive let pow = lam n. lam x.
+    if eqi n 0 then 1.
+    else
+      if eqi n 1 then x
+      else mulf (pow (subi n 1) x) x
+  in lam x. pow 10 x
+    " in
+  utest constantfoldLets (_test prog) with _parse "
+  recursive let pow = lam n. lam x.
+    if eqi n 0 then 1.
+    else
+      if eqi n 1 then x
+      else mulf (pow (subi n 1) x) x
+  in lam x. pow 10 x
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "
+  recursive let pow = lam n. lam x.
+    if eqi n 0 then 1.
+    else
+      if eqi n 1 then x
+      else mulf (pow (subi n 1) x) x
+  in lam x. x
+    " in
+  utest constantfoldLets (_test prog) with _parse "
+    lam x. x
+    "
+    using eqExpr
+  in
+  ()
+  with () in
+
+utest
+  -----------------------------
+  -- Test new implementation --
+  -----------------------------
+  use TestLangNew in
+
+  let _test = lam expr.
+    logMsg logLevel.debug (lam.
+      strJoin "\n" [
+        "Before peval",
+        expr2str expr
+      ]);
+    let expr = symbolizeAllowFree expr in
+    match pevalExpr { pevalCtxEmpty () with maxRecDepth = 10 } expr with expr in
+    logMsg logLevel.debug (lam.
+      strJoin "\n" [
+        "After peval",
+        expr2str expr
+      ]);
+    logMsg logLevel.debug (lam.
+      strJoin "\n" [
+        "After peval (folded)",
+        expr2str (constantfoldLets expr)
+      ]);
+    expr
+  in
+
+  let _parse =
+    parseMExprString
+      { _defaultBootParserParseMExprStringArg () with allowFree = true }
+  in
+
+  ----------------------------------
+  -- Test new closure application --
+  ----------------------------------
+
+  let prog = _parse "lam x. x" in
+  utest _test prog with _parse "let f = lam x. x in f" using eqExpr in
+
+  let prog = _parse "(lam x. x) (lam z. z)" in
+  utest _test prog with _parse "let f = lam z. z in f" using eqExpr in
+
+  let prog = _parse "(lam x. x y) (lam z. z)" in
+  utest _test prog with _parse "y" using eqExpr in
+
+  let prog = _parse "(lam x. y y x) (lam z. z)" in
+  utest _test prog with _parse "
+  let t =  lam z. z in
+  let t1 =
+    y
+      y
+  in
+  let t2 =
+    t1
+      t
+  in
+  t2
+    "
+    using eqExpr
+  in
+
+  let prog = _parse "(lam f. (f, f)) (lam z. z)" in
+  utest _test prog with _parse "
+  let t =
+    lam z.
+      z
   in
   (t, t)
-  "
-  using eqExpr
-in
+    " using eqExpr in
 
--------------------------
--- Test Recursive Lets --
--------------------------
+  -------------------------
+  -- Test Recursive Lets --
+  -------------------------
 
+  let prog = _parse "
+  recursive let pow = lam n. lam x.
+    if eqi n 0 then 1.
+    else
+      if eqi n 1 then x
+      else mulf (pow (subi n 1) x) x
+  in lam x. pow 10 x
+    " in
+  utest constantfoldLets (_test prog) with _parse "
+  lam x.
+    mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf x x) x) x) x) x) x) x) x) x
+    "
+    using eqExpr
+  in
 
+  let prog = _parse "
+  recursive let pow = lam n. lam x.
+    if eqi n 0 then 1.
+    else
+      if eqi n 1 then x
+      else mulf (pow (subi n 1) x) x
+  in lam x. lam n. (pow 10 x, pow n x)
+    " in
+  utest constantfoldLets (_test prog) with _parse "
+  recursive let pow = lam n. lam x.
+    match eqi n 0 with true then 1.
+    else match eqi n 1 with true then x
+         else mulf (pow (subi n 1) x) x
+  in
+  lam x. lam n.
+    (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf x x) x) x) x) x) x) x) x) x,
+     match eqi n 0 with true then 1.
+     else
+       match eqi n 1 with true then x
+       else mulf (pow (subi n 1) x) x)
+    "
+    using eqExpr
+  in
 
-let prog = _parse "
-recursive let pow = lam n. lam x.
-  if eqi n 0 then 1.
-  else
-    if eqi n 1 then x
-    else mulf (pow (subi n 1) x) x
-in lam x. pow 10 x
-  " in
-utest constantfoldLets (_test prog) with _parse "
-lam x.
-  mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf x x) x) x) x) x) x) x) x) x
-  "
-  using eqExpr
-in
+  let prog = _parse "
+  recursive let pow = lam n. lam x.
+    if eqi n 0 then 1.
+    else
+      if eqi n 1 then x
+      else mulf (pow (subi n 1) x) x
+  in lam x. pow 2 x
+    " in
+  utest _test prog with _parse "
+  let f = lam x. let t = mulf x x in t in f
+    "
+    using eqExpr
+  in
 
-let prog = _parse "
-recursive let pow = lam n. lam x.
-  if eqi n 0 then 1.
-  else
-    if eqi n 1 then x
-    else mulf (pow (subi n 1) x) x
-in lam x. lam n. (pow 10 x, pow n x)
-  " in
-utest constantfoldLets (_test prog) with _parse "
-recursive let pow = lam n. lam x.
-  match eqi n 0 with true then 1.
-  else match eqi n 1 with true then x
-       else mulf (pow (subi n 1) x) x
-in
-lam x. lam n.
-  (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf x x) x) x) x) x) x) x) x) x,
-   match eqi n 0 with true then 1.
-   else
-     match eqi n 1 with true then x
-     else mulf (pow (subi n 1) x) x)
-  "
-  using eqExpr
-in
+  let prog = _parse "
+  recursive
+  let odd = lam n.
+      if eqi n 1 then true
+      else if lti n 1 then false
+      else even (subi n 1)
+  let even = lam n.
+      if eqi n 0 then true
+      else if lti n 0 then false
+      else odd (subi n 1)
+  in
+  odd 9
+    " in
+  utest constantfoldLets (_test prog) with _parse "
+  true
+    "
+    using eqExpr
+  in
 
-let prog = _parse "
-recursive let pow = lam n. lam x.
-  if eqi n 0 then 1.
-  else
-    if eqi n 1 then x
-    else mulf (pow (subi n 1) x) x
-in lam x. pow 2 x
-  " in
-utest _test prog with _parse "
-let f = lam x. let t = mulf x x in t in f
-  "
-  using eqExpr
-in
+  let prog = _parse "
+  recursive
+  let odd = lam n.
+      if eqi n 1 then true
+      else if lti n 1 then false
+      else even (subi n 1)
+  let even = lam n.
+      if eqi n 0 then true
+      else if lti n 0 then false
+      else odd (subi n 1)
+  in
+  odd 10
+    " in
+  utest constantfoldLets (_test prog) with _parse "
+  recursive
+  let odd = lam n.
+      if eqi n 1 then true
+      else if lti n 1 then false
+      else even (subi n 1)
+  let even = lam n.
+      if eqi n 0 then true
+      else if lti n 0 then false
+      else odd (subi n 1)
+  in
+  odd 0
+    "
+    using eqExpr
+  in
 
-let prog = _parse "
-recursive
-let odd = lam n.
-    if eqi n 1 then true
-    else if lti n 1 then false
-    else even (subi n 1)
-let even = lam n.
-    if eqi n 0 then true
-    else if lti n 0 then false
-    else odd (subi n 1)
-in
-odd 9
-  " in
-utest constantfoldLets (_test prog) with _parse "
-true
-  "
-  using eqExpr
-in
+  let prog = _parse "
+  recursive let pow = lam x. lam n.
+    if eqi n 0 then 1.
+    else mulf x (pow x (subi n 1))
+  in
+  lam x. [
+    pow x 0,
+    pow x 1,
+    pow x 2,
+    pow x 3,
+    pow x 4,
+    pow x 5,
+    pow x 6,
+    pow x 7,
+    pow x 8,
+    pow x 9,
+    pow x 10
+  ]
+    " in
 
-let prog = _parse "
-recursive
-let odd = lam n.
-    if eqi n 1 then true
-    else if lti n 1 then false
-    else even (subi n 1)
-let even = lam n.
-    if eqi n 0 then true
-    else if lti n 0 then false
-    else odd (subi n 1)
-in
-odd 10
-  " in
-utest constantfoldLets (_test prog) with _parse "
-recursive
-let odd = lam n.
-    if eqi n 1 then true
-    else if lti n 1 then false
-    else even (subi n 1)
-let even = lam n.
-    if eqi n 0 then true
-    else if lti n 0 then false
-    else odd (subi n 1)
-in
-odd 0
-  "
-  using eqExpr
-in
-
-let prog = _parse "
-recursive let pow = lam x. lam n.
-  if eqi n 0 then 1.
-  else mulf x (pow x (subi n 1))
-in
-lam x. [
-  pow x 0,
-  pow x 1,
-  pow x 2,
-  pow x 3,
-  pow x 4,
-  pow x 5,
-  pow x 6,
-  pow x 7,
-  pow x 8,
-  pow x 9,
-  pow x 10
-]
-  " in
-
-utest constantfoldLets (_test prog) with _parse "
-recursive let pow = lam x. lam n.
-  if eqi n 0 then 1.
-  else mulf x (pow x (subi n 1))
-in
-lam x.
-  [ 1.,
-    x,
-    mulf
-      x
+  utest constantfoldLets (_test prog) with _parse "
+  recursive let pow = lam x. lam n.
+    if eqi n 0 then 1.
+    else mulf x (pow x (subi n 1))
+  in
+  lam x.
+    [ 1.,
       x,
-    mulf
-      x
-      (mulf
-         x
-         x),
-    mulf
-      x
-      (mulf
-         x
-         (mulf
-            x
-            x)),
-    mulf
-      x
-      (mulf
-         x
-         (mulf
-            x
-            (mulf
-               x
-               x))),
-    mulf
-      x
-      (mulf
-         x
-         (mulf
-            x
-            (mulf
-               x
-               (mulf
-                  x
-                  x)))),
-    mulf
-      x
-      (mulf
-         x
-         (mulf
-            x
-            (mulf
-               x
-               (mulf
-                  x
-                  (mulf
-                     x
-                     x))))),
-    mulf
-      x
-      (mulf
-         x
-         (mulf
-            x
-            (mulf
-               x
-               (mulf
-                  x
-                  (mulf
-                     x
-                     (mulf
-                        x
-                        x)))))),
-    mulf
-      x
-      (mulf
-         x
-         (mulf
-            x
-            (mulf
-               x
-               (mulf
-                  x
-                  (mulf
-                     x
-                     (mulf
-                        x
-                        (mulf
-                           x
-                           x))))))),
-    mulf
-      x
-      (mulf
-         x
-         (mulf
-            x
-            (mulf
-               x
-               (mulf
-                  x
-                  (mulf
-                     x
-                     (mulf
-                        x
-                        (mulf
-                           x
-                           (mulf
-                              x
-                              (mulf
-                                 x
-                                 (pow
-                                    x
-                                    0)))))))))) ]
-  "
-  using eqExpr
-in
+      mulf
+        x
+        x,
+      mulf
+        x
+        (mulf
+           x
+           x),
+      mulf
+        x
+        (mulf
+           x
+           (mulf
+              x
+              x)),
+      mulf
+        x
+        (mulf
+           x
+           (mulf
+              x
+              (mulf
+                 x
+                 x))),
+      mulf
+        x
+        (mulf
+           x
+           (mulf
+              x
+              (mulf
+                 x
+                 (mulf
+                    x
+                    x)))),
+      mulf
+        x
+        (mulf
+           x
+           (mulf
+              x
+              (mulf
+                 x
+                 (mulf
+                    x
+                    (mulf
+                       x
+                       x))))),
+      mulf
+        x
+        (mulf
+           x
+           (mulf
+              x
+              (mulf
+                 x
+                 (mulf
+                    x
+                    (mulf
+                       x
+                       (mulf
+                          x
+                          x)))))),
+      mulf
+        x
+        (mulf
+           x
+           (mulf
+              x
+              (mulf
+                 x
+                 (mulf
+                    x
+                    (mulf
+                       x
+                       (mulf
+                          x
+                          (mulf
+                             x
+                             x))))))),
+      mulf
+        x
+        (mulf
+           x
+           (mulf
+              x
+              (mulf
+                 x
+                 (mulf
+                    x
+                    (mulf
+                       x
+                       (mulf
+                          x
+                          (mulf
+                             x
+                             (mulf
+                                x
+                                (mulf
+                                   x
+                                   (pow
+                                      x
+                                      0)))))))))) ]
+    "
+    using eqExpr
+  in
 
-let prog = _parse "
-lam p.
-recursive let pow = lam x. lam n.
-  if eqi n 0 then 1.
-  else mulf x (pow x (subi n 1))
-in
-recursive let powpp = lam xpp. lam npp.
-    match lti npp 1 with true then (1., 0., 0.)
-    else
-      let t = powpp xpp (subi npp 1) in
-      (mulf xpp.0 t.0
-      ,addf (mulf xpp.0 t.1) (mulf xpp.1 t.0)
-      ,addf
-         (addf (mulf xpp.0 t.2) (mulf 2. (mulf xpp.1 t.1)))
-         (mulf xpp.2 t.0))
-in
-lam y. lam yp. {
-  r0 = subf (get yp 1) (mulf (get y 0) (get y 4)),
-  r1 = subf (get yp 3) (subf (mulf (get y 2) (get y 4)) 1.),
-  r2 = addf
-    (powpp (get y 0, get y 1, get yp 1) p).2
-    (powpp (get y 2, get y 3, get yp 3) p).2,
-  r3 =
-    subf
-      (get y 5)
-      (addf
-        (pow x 2)
-        (pow x 3)),
-  r4 = subf (get y 1) (get yp 0),
-  r5 = subf (get y 3) (get yp 2)
-}
-  " in
-
-utest constantfoldLets (_test prog) with _parse "
-lam p.
+  let prog = _parse "
+  lam p.
+  recursive let pow = lam x. lam n.
+    if eqi n 0 then 1.
+    else mulf x (pow x (subi n 1))
+  in
   recursive let powpp = lam xpp. lam npp.
-    match lti npp 1 with true then (1., 0., 0.)
-    else
-      let t2 = powpp xpp (subi npp 1) in
-      (mulf xpp.0 t2.0
-      ,addf (mulf xpp.0 t2.1) (mulf xpp.1 t2.0)
-      ,addf
-         (addf (mulf xpp.0 t2.2) (mulf 2. (mulf xpp.1 t2.1)))
-         (mulf xpp.2 t2.0))
+      match lti npp 1 with true then (1., 0., 0.)
+      else
+        let t = powpp xpp (subi npp 1) in
+        (mulf xpp.0 t.0
+        ,addf (mulf xpp.0 t.1) (mulf xpp.1 t.0)
+        ,addf
+           (addf (mulf xpp.0 t.2) (mulf 2. (mulf xpp.1 t.1)))
+           (mulf xpp.2 t.0))
   in
   lam y. lam yp. {
     r0 = subf (get yp 1) (mulf (get y 0) (get y 4)),
     r1 = subf (get yp 3) (subf (mulf (get y 2) (get y 4)) 1.),
-    r2 =
-    addf
-      (match lti p 1 with true then (1., 0., 0.)
-       else
-        let t = powpp (get y 0, get y 1, get yp 1) (subi p 1) in
-        (mulf (get y 0) t.0
-        ,addf (mulf (get y 0) t.1) (mulf (get y 1) t.0)
-        ,addf
-           (addf
-              (mulf (get y 0) t.2)
-              (mulf 2. (mulf (get y 1) t.1)))
-           (mulf (get yp 1) t.0))).2
-      (match lti p 1 with true then (1., 0., 0.)
-       else
-        let t1 = powpp (get y 2, get y 3, get yp 3) (subi p 1) in
-        (mulf (get y 2) t1.0
-        ,addf
-           (mulf (get y 2) t1.1)
-           (mulf (get y 3) t1.0)
-        ,addf
-           (addf
-              (mulf (get y 2) t1.2)
-              (mulf 2. (mulf (get y 3) t1.1)))
-           (mulf (get yp 3) t1.0))).2,
-    r3 = subf (get y 5) (addf (mulf x x) (mulf x (mulf x x))),
+    r2 = addf
+      (powpp (get y 0, get y 1, get yp 1) p).2
+      (powpp (get y 2, get y 3, get yp 3) p).2,
+    r3 =
+      subf
+        (get y 5)
+        (addf
+          (pow x 2)
+          (pow x 3)),
     r4 = subf (get y 1) (get yp 0),
     r5 = subf (get y 3) (get yp 2)
   }
-  "
-  using eqExpr
-in
+    " in
 
---------------------------------
--- Test Dead Code Elimination --
---------------------------------
-
-let prog = _parse "
-lam y. (lam x. mulf x 0.) (addf y y)
-  " in
-utest _test prog with _parse "let f = lam y. 0. in f"
-  using eqExpr
-in
-
-let prog = _parse "
-lam y. (lam x. mulf x 0.) (addf (print \"hello\"; y) y)
-  " in
-utest _test prog with _parse "
-let f = lam t.
-  let t = print \"hello\" in
-  0.
-in f
-  "
-  using eqExpr
-in
-
--- logSetLogLevel logLevel.debug;
-
-let prog = _parse "
-lam x.
-    (lam x1. lam x2. addf x1 x2)
-      ((lam y. addf y y) x)
-      ((lam z. addf z z) x)
-  " in
-utest _test prog with _parse "
-let f = lam x.
-  let t =
-    mulf
-      2.
-      x
-  in
-  let t1 =
-    mulf
-      2.
-      x
-  in
-  let t2 =
-    addf
-      t
-      t1
-  in
-  t2
-in f
-  "
-  using eqExpr
-in
-
---------------------------
--- Test Char Comparison --
---------------------------
-
-let prog = _parse "
-lam x.
-  eqc 'v' x
-" in
-
-utest _test prog with _parse "
-let f = lam x.
-  let t = eqc 'v' x in
-  t
-in f"
-  using eqExpr in
-
-let prog = _parse "
-  eqc 'v' 'a'" in
-
-utest _test prog with _parse "false" using eqExpr in
-
--------------------------
--- Test Seq Operations --
--------------------------
-
-let prog = _parse "map (addi 1) [1, 2, 3]" in
-utest _test prog with _parse "[2, 3, 4]" using eqExpr in
-
-let prog = _parse "lam x. map (addi x) [1, 2, 3]" in
-utest _test prog with _parse "
-let f = lam x.
-  let t1 = addi 1 x in
-  let t2 = addi 2 x in
-  let t3 = addi 3 x in
-  [t1, t2, t3]
-in f
-  "
-  using eqExpr
-in
-
-let prog = _parse "mapi addi [1, 2, 3]" in
-utest _test prog with _parse "[1, 3, 5]" using eqExpr in
-
-let prog = _parse "lam x. mapi (lam i. lam y. muli i (addi x y)) [1, 2, 3]" in
-utest _test prog with
-  _parse "
-let f = lam x.
-  let t1 = addi 2 x in
-  let t2 = addi 3 x in
-  let t3 = muli 2 t2 in
-  [0, t1, t3]
-in f
+  utest constantfoldLets (_test prog) with _parse "
+  lam p.
+    recursive let powpp = lam xpp. lam npp.
+      match lti npp 1 with true then (1., 0., 0.)
+      else
+        let t2 = powpp xpp (subi npp 1) in
+        (mulf xpp.0 t2.0
+        ,addf (mulf xpp.0 t2.1) (mulf xpp.1 t2.0)
+        ,addf
+           (addf (mulf xpp.0 t2.2) (mulf 2. (mulf xpp.1 t2.1)))
+           (mulf xpp.2 t2.0))
+    in
+    lam y. lam yp. {
+      r0 = subf (get yp 1) (mulf (get y 0) (get y 4)),
+      r1 = subf (get yp 3) (subf (mulf (get y 2) (get y 4)) 1.),
+      r2 =
+      addf
+        (match lti p 1 with true then (1., 0., 0.)
+         else
+          let t = powpp (get y 0, get y 1, get yp 1) (subi p 1) in
+          (mulf (get y 0) t.0
+          ,addf (mulf (get y 0) t.1) (mulf (get y 1) t.0)
+          ,addf
+             (addf
+                (mulf (get y 0) t.2)
+                (mulf 2. (mulf (get y 1) t.1)))
+             (mulf (get yp 1) t.0))).2
+        (match lti p 1 with true then (1., 0., 0.)
+         else
+          let t1 = powpp (get y 2, get y 3, get yp 3) (subi p 1) in
+          (mulf (get y 2) t1.0
+          ,addf
+             (mulf (get y 2) t1.1)
+             (mulf (get y 3) t1.0)
+          ,addf
+             (addf
+                (mulf (get y 2) t1.2)
+                (mulf 2. (mulf (get y 3) t1.1)))
+             (mulf (get yp 3) t1.0))).2,
+      r3 = subf (get y 5) (addf (mulf x x) (mulf x (mulf x x))),
+      r4 = subf (get y 1) (get yp 0),
+      r5 = subf (get y 3) (get yp 2)
+    }
     "
-  using eqExpr
-in
-
-let prog = _parse "foldl addi 0 [1, 2, 3]" in
-utest _test prog with _parse "6" using eqExpr in
-
-let prog = _parse "lam x. foldl addi x [1, 2, 3]" in
-utest _test prog with _parse "
-let f = lam x.
-  let t = addi 1 x in
-  let t1 = addi 2 t in
-  let t2 = addi 3 t1 in
-  t2
-in f
-  " using eqExpr in
-
-let prog = _parse "lam x. lam y. [get x y, get x 1, get x 2]" in
-utest _test prog with _parse "
-  let f = lam x.
-    let f = lam y. [get x y, get x 1, get x 2] in f
-  in f"
-  using eqExpr
-in
+    using eqExpr
+  in
+  () with () in
 
 ()

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -80,16 +80,6 @@ let mapReverse : all a. all b. (a -> b) -> [a] -> [b] = lam f. lam lst.
 
 utest toRope (mapReverse (lam x. addi x 1) [10,20,30]) with [31,21,11]
 
--- `mapK f seq k` maps the continuation passing function `f` over the sequence
--- `seq`, passing the result of the mapping to the continuation `k`.
-let mapK : all a. all b. all c. (a -> (b -> c) -> c) -> [a] -> ([b] -> c) -> c =
-  lam f. lam seq. lam k.
-    foldl (lam k. lam x. (lam xs. f x (lam x. k (cons x xs)))) k seq []
-
-utest mapK (lam x. lam k. k (addi x 1)) [] (lam seq. reverse seq) with []
-utest mapK (lam x. lam k. k (addi x 1)) [1,2,3] (lam seq. reverse seq) with [4,3,2]
-utest mapK (lam x. lam k. k (addi x 1)) [1,2,3] (lam seq. foldl addi 0 seq) with 9
-
 -- Folds
 let foldl1 : all a. (a -> a -> a) -> [a] -> a = lam f. lam l. foldl f (head l) (tail l)
 
@@ -165,6 +155,72 @@ utest foldli (lam acc. lam i. lam e. snoc acc (i, e)) [] [5.0]
 with [(0, 5.0)]
 utest foldli (lam acc. lam i. lam e. snoc acc (i, e)) [] ["foo", "bar", "babar"]
 with [(0, "foo"), (1, "bar"), (2, "babar")]
+
+-- CPS style maps and folds
+
+-- `mapK f seq k` maps the continuation passing function `f` over the sequence
+-- `seq`, passing the result of the mapping to the continuation `k`.
+let mapK : all a. all b. all c. (a -> (b -> c) -> c) -> [a] -> ([b] -> c) -> c =
+  lam f. lam seq. lam k.
+    foldl (lam k. lam x. (lam xs. f x (lam x. k (snoc xs x)))) k (reverse seq) []
+
+utest mapK (lam x. lam k. k (addi x 1)) [] (lam seq. reverse seq) with []
+utest mapK (lam x. lam k. k (addi x 1)) [1,2,3] (lam seq. reverse seq) with [4,3,2]
+utest mapK (lam x. lam k. k (addi x 1)) [1,2,3] (lam seq. foldl addi 0 seq) with 9
+
+-- `mapiK f seq k` maps the continuation passing function `f` with the index
+-- over the sequence `seq`, passing the result of the mapping to the
+-- continuation `k`.
+let mapiK : all a. all b. all c. (Int -> a -> (b -> c) -> c) -> [a] -> ([b] -> c) -> c =
+  lam f. lam seq. lam k.
+    (foldl
+       (lam ik. match ik with (i, k) in
+              lam x. (subi i 1, lam xs. f i x (lam x. k (snoc xs x))))
+       (subi (length seq) 1, k) (reverse seq)).1 []
+
+utest mapiK (lam i. lam x. lam k. k (muli x i)) [] (lam seq. reverse seq) with []
+utest mapiK (lam i. lam x. lam k. k (muli x i)) [1,2,3] (lam seq. reverse seq)
+  with [6,2,0]
+utest mapiK (lam i. lam x. lam k. k (muli x i)) [1,2,3] (lam seq. foldl addi 0 seq)
+  with 8
+
+-- `foldlK f acc seq k` fold the continuation passing function `f` over the
+-- sequence `seq`, from the left, with the initial accumulator `acc` and
+-- continuation `k`. (from
+-- https://leastfixedpoint.com/tonyg/kcbbs/lshift_archive/folds-and-continuation-passing-style-20070611.html)
+let foldlK
+  = lam f. lam acc. lam seq. lam k.
+    recursive let recur = lam acc. lam seq. lam k.
+      if null seq then k acc
+      else f acc (head seq) (lam acc. recur acc (tail seq) k)
+    in
+    recur acc seq k
+
+utest
+  let acc : [Int] = [] in
+  utest
+    foldlK (lam acc. lam x. lam k. k (cons (addi x 1) acc)) acc [] (lam x. reverse x)
+    with []
+  in
+  utest
+    foldlK
+      (lam acc. lam x. lam k. k (cons (addi x 1) acc))
+      acc
+      [1, 2, 3]
+      (lam x. reverse x)
+    with [2, 3, 4]
+  in
+  utest
+    foldlK
+      (lam acc. lam x. lam k.
+        if geqi (length acc) 2 then acc -- short circuit
+        else k (cons (addi x 1) acc))
+      acc
+      [1, 2, 3]
+      (lam x. reverse x)          -- which also skips this computation
+    with [3, 2]
+  in
+  () with ()
 
 -- zips
 let zipWith : all a. all b. all c. (a -> b -> c) -> [a] -> [b] -> [c] =


### PR DESCRIPTION
This PR adds the following:
1. It adds partial evaluation of map and fold operations over sequences. This includes additional sequence library functions for CPS-style maps and folds.
2. PEval no longer let-binds `get s i` and `set s i v` if  `s` is a variable and `i` is either a literal integer or a variable. The reason for this is that for programs with many accesses into large sequences (see below for an example), the partially evaluated program may become quite large and I believe that the data cache should be able to give good performance for subsequent accesses into the same sequence in most practical applications. I'm not sure we should keep this change as the output program is then not necessarily on ANF (if this is of value in itself?). We could use common subexpression elimination to make sure that the number of these type of let-bindings are bound by the size of the sequence. There is a work-in-progress CSE in `cse.mc` by @larshum.
3. Some constant applications in PEval are simplified/changed to leverage that the default case is to keep the application dynamic. This also includes a renaming of the semantic function `pevalIsValue` to `pevalBindThis` that better reflects that the function now defines which expressions should be let-bound and that these do not necessarily have to be all non-values.
4. A regression on partial evaluation of recursion and a work in progress improved implementation of partial evaluation of closures. There is a bug in the current implementation that allows variables binding to recursive functions to escape their scopes. Therefore recursion is no longer partially evaluated. There is a new language fragment, `MExprPEvalNew` (the standard fragment is `MExprPEval`), that contains a work-in-progress implementation of recursion and better handling of closures. Note however that this implementation is not correct for functions returning functions. These two implementations are described below.

**get, set**

To illustrate the problem with partially evaluating sequence accesses before this PR consider the snippet

```
addf (mulf (get x 0) (get x 0)) (get x 0)
```

Partial evaluation of this program resulted in

```
let t0 = get x 0 in
let t1 = get x 0 in
let t2 = get x 0 in
let t3 = mulf t0 t1 in
let t4 = mulf t3 t2 in
t4
```

where PEval produces a number of identical let bindings for `get x 0` since they occur multiple times in the input program. In this PR, the resulting program is instead:

```
let t1 = mulf (get x 0) (get x 0)  in
let t2 = mulf t1 (get x 0) in
t2
```

**Unapplied abstractions**

Now, a program

```
let f = lam x. x in (f, f)
```

partially evaluates to 

```
(lam x. x, lam x. x)
``` 
which typically results in code swell for larger programs without any gain in runtime performance.

In `MExprPEvalNew`, partial evaluation instead results in 

```
let f = lam x. x in (f, f)
```

However, this also means that `lam x. x` will partially evaluate to `let t = lam x. x in t` (See  4. for how these let-bindings can be eliminated).

**Recursion**

Consider a recursive power function and the program

```
recursive let pow = lam n. lam x.
  if eqi n 0 then 1.
  else
    if eqi n 1 then x
    else mulf (pow (subi n 1) x) x
in lam x. lam n. (pow 10 x, pow n x)
```

In the tuple in the final lambda it is beneficial to unroll the first element since `n` is statically known to be `10` while unrolling the second element just gives us more code. `peval` in `MExprPEvalNew` produces

```
recursive let pow = lam n. lam x.
  match eqi n 0 with true then 1.
  else match eqi n 1 with true then x
       else mulf (pow (subi n 1) x) x
in
lam x. lam n.
  (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf (mulf x x) x) x) x) x) x) x) x) x,
   match eqi n 0 with true then 1.
   else
     match eqi n 1 with true then x
     else mulf (pow (subi n 1) x) x)
```

After `constantfoldLets` (see 4.). The first element of the tuple is expanded into an appropriate number of multiplications while in the second element, the recursive call is dynamic in the else branch.

As a note, we still need to bound recursion as we can otherwise define divergent programs, e.g,

```
recursive let f = lam x. if x then f x else x in f true
```

