### PR TITLE
Max over floats and transformation of selected constants to variables 

### DIFF
--- a/stdlib/math.mc
+++ b/stdlib/math.mc
@@ -4,11 +4,16 @@ include "bool.mc"
 -- Float stuff
 let inf = divf 1.0 0.0
 let nan = mulf 0. inf
-let minf: Float -> Float -> Float = lam r. lam l. if ltf r l then r else l
 
+let minf: Float -> Float -> Float = lam r. lam l. if ltf r l then r else l
 utest minf 0. 0. with 0. using eqf
 utest minf 1. 0. with 0. using eqf
 utest minf 0. 1. with 0. using eqf
+
+let maxf: Float -> Float -> Float = lam r. lam l. if gtf r l then r else l
+utest maxf 0. 0. with 0. using eqf
+utest maxf 1. 0. with 1. using eqf
+utest maxf 0. 1. with 1. using eqf
 
 utest absf 0. with 0. using eqf
 utest absf 1. with 1. using eqf


### PR DESCRIPTION
This PR constains:
1. A `maxf` library function that takes the maximum of two floats.
2. A new semantic function `constTransformConstToVars` that transforms a subset of constants into variables in a program. This is useful when you want to extend the set of constants in your transformations, e.g., adding more elementary functions, but these need to be associated with for example externals in the output program.