### PR TITLE
Add constructor type validation

### DIFF
--- a/stdlib/cuda/well-formed.mc
+++ b/stdlib/cuda/well-formed.mc
@@ -294,12 +294,14 @@ utest checkWellFormedExpr recUpdate with [CudaExprError recordUpdateExpr]
 using eqSeq eqCudaError in
 
 let t = nameSym "Tree" in
-let recursiveConstructorExpr = condef_ "Con" (tyarrow_ (ntyvar_ t) (ntyvar_ t)) in
+let recursiveConstructorExpr =
+  ncondef_ (nameSym "Con") (tyarrow_ (tytuple_ [ntycon_ t, ntycon_ t]) (ntycon_ t))
+in
 let conDef = bindall_ [
   ntype_ t [] (tyvariant_ []),
   recursiveConstructorExpr,
   int_ 0] in
-let expectedExpr = preprocess (bind_ recursiveConstructorExpr (int_ 0)) in
+let expectedExpr = bind_ recursiveConstructorExpr (int_ 0) in
 -- NOTE(larshum, 2022-07-12): Skip the first expression (a type) since we
 -- cannot compare those.
 utest tail (checkWellFormedExpr conDef) with [CudaExprError expectedExpr]

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -909,9 +909,41 @@ lang TypeTypeCheck = TypeCheck + TypeAst + VariantTypeAst + ResolveType
 end
 
 lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + ResolveType
+  -- NOTE(larshum, 2023-09-07): Verify that the annotated type of a constructor
+  -- is of the form we expect, and provide understandable error messages
+  -- otherwise.
+  sem _checkConstructorType : Type -> ()
+  sem _checkConstructorType =
+  | ty ->
+    recursive let isValidConstructorType = lam ty.
+      switch ty
+      case TyCon _ then true
+      case TyApp {lhs = lhs} then isConstructorType lhs
+      case _ then false
+      end
+    in
+    match inspectType ty with TyArrow {to = to & (TyCon _ | TyApp _)} then
+      if isValidConstructorType to then ()
+      else
+        let msg = join [
+          "* Invalid type of constructor: ", nameGetStr t.ident, "\n",
+          "* The right-hand side should refer to a constructor type.\n",
+          "* When type checking the expression\n"
+        ] in
+        errorSingle [t.info] msg
+    else
+      let msg = join [
+        "* Invalid type of constructor: ", nameGetStr t.ident, "\n",
+        "* The constructor should be given a type A -> B such that B\n",
+        "  determines the constructor type.\n",
+        "* When type checking the expression\n"
+      ] in
+      errorSingle [t.info] msg
+
   sem typeCheckExpr env =
   | TmConDef t ->
     let tyIdent = resolveType t.info env.tyConEnv t.tyIdent in
+    _checkConstructorType tyIdent;
     let inexpr = typeCheckExpr (_insertCon t.ident tyIdent env) t.inexpr in
     TmConDef {t with tyIdent = tyIdent, inexpr = inexpr, ty = tyTm inexpr}
   | TmConApp t ->

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -934,8 +934,8 @@ lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + ResolveType
     else
       let msg = join [
         "* Invalid type of constructor: ", nameGetStr ident, "\n",
-        "* The constructor should be given a type A -> B such that B\n",
-        "  determines the constructor type.\n",
+        "* The constructor should be given type A -> B, where B\n",
+        "  is a fully applied datatype in scope.\n",
         "* When type checking the expression\n"
       ] in
       errorSingle [info] msg


### PR DESCRIPTION
This PR adds a validation step in the type-checker to ensure that the type annotated to a constructor is of the form `A -> B`, where `B` is a fully applied constructor type. Previously, a program such as
```
type A
con B : Int
mexpr
B 2
```
would result in the type-checker reaching a never-term because of an assumption on the shape of the constructor type annotation. Similarly, had B been annotated with a type `Int -> Int`, it would have been accepted by the type-checker but may result in cryptic errors later on in the code.

After this PR, the type-checker will catch such errors with a message that clearly points to the source of the problem.