### PR TITLE
Fixes to conform to the JSON standard

### DIFF
--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -313,7 +313,7 @@ recursive let json2string: JsonValue -> String = lam value.
     in
     (snoc (foldl escape "\"" s) '\"')
   case JsonFloat f then
-    -- NOTE(vsenderov, 2022-09-14): Need to append/prepend 0 to conform to the
+    -- NOTE(vsenderov, 2023-09-14): Need to append/prepend 0 to conform to the
     -- JSON standard.  What is the situation in locales that don't use a dot
     -- to delimit decimals?
     let str = float2string f in
@@ -415,8 +415,8 @@ utest json2string (JsonFloat (negf 1e-5)) with "-1e-05" in
 utest jsonParse "1.0" with Left (JsonFloat 1.) using eitherEq jsonEq eqString in
 utest json2string (JsonFloat 1.) with "1.0" in
 
-utest jsonParse "0.1" with Left (JsonFloat 0.1) using eitherEq jsonEq eqString in
-utest json2string (JsonFloat 0.1) with "0.1" in
+utest jsonParse "0.25" with Left (JsonFloat 0.25) using eitherEq jsonEq eqString in
+utest json2string (JsonFloat 0.25) with "0.25" in
 
 utest jsonParse "1233" with Left (JsonInt 1233) using eitherEq jsonEq eqString in
 utest json2string (JsonInt 1233) with "1233" in

--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -313,9 +313,16 @@ recursive let json2string: JsonValue -> String = lam value.
     in
     (snoc (foldl escape "\"" s) '\"')
   case JsonFloat f then
-    -- TODO(johnwikman, 2022-05-13): Verify that this 2string method actually
-    -- conforms to JSON. ".01" and "13." are not valid floats in JSON.
-    float2string f
+    -- NOTE(vsenderov, 2022-09-14): Need to append/prepend 0 to conform to the
+    -- JSON standard.  What is the situation in locales that don't use a dot
+    -- to delimit decimals?
+    let str = float2string f in
+    switch str
+        case _ ++ "." then snoc str '0'
+        case "." ++ _ then cons '0' str
+        case _ then str
+    end
+
   case JsonInt i then
     int2string i
   case JsonBool b then
@@ -404,6 +411,12 @@ utest json2string (JsonFloat 123.45) with "123.45" in
 
 utest jsonParse "-1e-5" with Left (JsonFloat (negf 1e-5)) using eitherEq jsonEq eqString in
 utest json2string (JsonFloat (negf 1e-5)) with "-1e-05" in
+
+utest jsonParse "1.0" with Left (JsonFloat 1.) using eitherEq jsonEq eqString in
+utest json2string (JsonFloat 1.) with "1.0" in
+
+utest jsonParse "0.1" with Left (JsonFloat 0.1) using eitherEq jsonEq eqString in
+utest json2string (JsonFloat 0.1) with "0.1" in
 
 utest jsonParse "1233" with Left (JsonInt 1233) using eitherEq jsonEq eqString in
 utest json2string (JsonInt 1233) with "1233" in


### PR DESCRIPTION
The JSON specification does not allow for trailing or leading 0's such as `1.` or `.1`.  For this reason I have changed the `json2string` function on the string level and added tests.

Caveats:
- a better fix may be to write a new intrinsic to use instead of `float2string` that makes use of the OCaml Printf module and specify the required output there;
-  unsure if this works for locales that do not have dot as the decimal separator and use `,` instead.

This is an urgent PR as JSON compatibility is critical for TreePPL.