### PR TITLE
Fixes to code deduplication in order to enable JSON serialization

### DIFF
--- a/stdlib/mexpr/duplicate-code-elimination.mc
+++ b/stdlib/mexpr/duplicate-code-elimination.mc
@@ -61,7 +61,8 @@ lang MExprEliminateDuplicateCode = MExprAst
     -- NOTE(larshum, 2022-10-28): All definitions containing NoInfo are
     -- considered not to be equal. This prevents eliminating code generated as
     -- part of the compilation.
-    match (info, mapLookup definition env.defIds) with (!NoInfo _, Some prevId) then
+    match info with NoInfo _ then elsfn env else
+    match mapLookup definition env.defIds with Some prevId then
       let env = {env with replace = mapInsert id prevId env.replace} in
       let replaced = mapInsert id prevId replaced in
       eliminateDuplicateCodeExpr env replaced inexpr
@@ -135,6 +136,7 @@ lang MExprEliminateDuplicateCode = MExprAst
     let eliminateDuplicateBinding = lam acc. lam binding.
       match acc with (replaced, env) in
       let defn = (binding.info, nameGetStr binding.ident) in
+      match binding.info with NoInfo _ then ((replaced, env), Some binding) else
       match mapLookup defn env.defIds with Some id then
         let env = {env with replace = mapInsert binding.ident id env.replace} in
         let replaced = mapInsert binding.ident id replaced in


### PR DESCRIPTION
I found this bug, but @elegios fixed it.  I am submitting this PR as this is vital for the TreePPL compiler, but if @elegios  wants to submit it instead, feel free to delete this.

In a nutshell the issue was that the JSON serialization routines that Daniel wrote could not handle user-defined types:

```
type MyType = MyType {
    a: Real,
    b: Real
}

model function tensors():MyType {
    let x = [1.0, 2.0, 3.0, 4.0, 5.0];
    let y = rvecCreate(5, x); // Creates a row vector
    let z = cvecCreate(5, x); // Creates a column vector
    let r = MyType {a = 1.0, b= 2.1};
    return r;
}
```

```
$ tpplc models/lang/tensors.tppl 
NOTE: Zero-argument function, `tensors`, converted to Int. Potential type errors might refer to Int type.
ERROR: Compilation of generated MExpr code failed
stdout:

stderr:

ERROR </tmp/miking-tmp.TfmrJbTxoh0 86734:8-86736:21>:
* Expected an expression of type: JsonValue
* Found an expression of type: [Char] -> [Char] -> Int
* When type checking the expression
        jr1
      with
        JsonObject m3
```

The issue happened to be located in the duplicate code elimination: 

> the json de-/serialization code all gets NoInfo (), lambda lifting gives a name to each anonymous lambda (nameSym "t"), then duplicate code elimination sees two bindings with the same string name ("t") and the same info (NoInfo ()), whereby they're deduplicated

Eventually @elegios found out how to get deduplication not to deduplicated `NoInfo` things, as this was the intended behavior anyway.