### PR TITLE
Direnv and a nix-flake for a developer environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ tags
 .tags
 .ctags.d/
 .ctags
+.envrc
+.direnv/
 .DS_Store
 *.install
 

--- a/misc/direnv/README.md
+++ b/misc/direnv/README.md
@@ -1,0 +1,13 @@
+This folder contains `.envrc` files that are suitable to start from if you would like to use [direnv](https://direnv.net/) to manage your environment. To use one of them, issue the following command from the root of the repository:
+
+```bash
+# Copy one of the .envrc files to the root
+cp misc/direnv/<envrc-file> .envrc
+
+# Allow the .envrc to execute
+direnv allow
+```
+
+Note that `.envrc` in the root of the repository is in `.gitignore`, meaning that you can change this file freely without affecting the git history. These files are available:
+
+- `nix.envrc` use a Nix flake to install enter a devshell with all Miking dependencies.

--- a/misc/direnv/nix.envrc
+++ b/misc/direnv/nix.envrc
@@ -1,0 +1,18 @@
+# Use a nix flake if nix is installed
+if has nix; then
+  if declare -F nix_direnv_watch_file > /dev/null; then
+    # nix-direnv has a different way of specifying where the flake files are
+    # https://github.com/nix-community/nix-direnv/blob/master/README.md
+    nix_direnv_watch_file ./misc/packaging/flake.nix
+    nix_direnv_watch_file ./misc/packaging/flake.lock
+  fi
+  use flake ./misc/packaging/
+fi
+
+# ADD the 'boot' build location to OCAMLPATH
+path_add OCAMLPATH ./build/lib
+
+# OVERWRITE the variable controlling mcore libraries, the compiler has
+# no external mcore dependencies, and we don't want conflicts with an
+# installed stdlib
+export MCORE_LIBS=stdlib=$(expand_path ./stdlib)

--- a/misc/packaging/flake.lock
+++ b/misc/packaging/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1690640159,
+        "narHash": "sha256-5DZUYnkeMOsVb/eqPYb9zns5YsnQXRJRC8Xx/nPMcno=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6ab46982debeab9831236869539a507f670a129",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/misc/packaging/flake.nix
+++ b/misc/packaging/flake.nix
@@ -1,0 +1,32 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let pkgs = nixpkgs.legacyPackages.x86_64-linux.pkgs;
+    in {
+      devShells.x86_64-linux.default = pkgs.mkShell {
+        name = "Miking dev shell";
+        # NOTE(vipa, 2023-09-21): The dependencies below are mirrored
+        # from miking.nix. Normally we would like to use miking.nix
+        # directly via inputsFrom, but miking.nix is presently not
+        # written to work in pure mode so we can't use it here.
+        buildInputs = with pkgs.ocaml-ng.ocamlPackages_5_0; [
+          pkgs.coreutils  # Miking currently requires mkdir to be able to run
+          linenoise
+          pkgs.minizinc
+        ];
+        nativeBuildInputs = with pkgs.ocaml-ng.ocamlPackages_5_0; [
+          ocaml
+          findlib
+          dune_3
+          pkgs.gdb
+
+          lwt        # For async-ext.mc
+          owl        # For dist-ext.mc
+          toml       # For toml-ext.mc
+        ];
+      };
+    };
+}


### PR DESCRIPTION
This PR adds a `.envrc` file, meant to be used by [direnv](https://direnv.net/) to set a reasonable environment for developing the Miking compiler. Presently this means three things:
- Adding `build/lib` to `OCAMLPATH`, so we can run `ocaml` commands that need the `boot` library without extra hassle.
- _Overwriting_ `MCORE_LIBS`, setting the stdlib location to the in-repo version. This throws away any previously set values, which seems correct because a) the compiler has no external mcore dependencies, and b) it's an annoying error when you accidentally forget to point to the correct location when running some `mi` command directly.
- If Nix is installed we use it (via a flake) to provide an environment with all Miking dependencies.

I'm using this locally and figured it was worth seeing if it's interesting to others.