### PR TITLE
Added support for inf, -inf and nan in json2string.

### DIFF
--- a/stdlib/json.mc
+++ b/stdlib/json.mc
@@ -2,6 +2,12 @@
 -- https://www.json.org/json-en.html
 -- Only divergence from the spec is the distinction between floats and integers
 
+-- The JSON specification does not support the special float values `nan`, `inf` and `-inf`.
+-- These are therefore encoded using the following objects:
+-- - `inf` is encoded as `{"__float__": "inf"}`
+-- - `-inf` is encoded as `{"__float__": "-inf"}`
+-- - `nan` is encoded as `{"__float__": "nan"}`
+
 include "either.mc"
 include "map.mc"
 include "string.mc"


### PR DESCRIPTION
JSON format does not support the representation of `inf`, `-inf`, and `nan`. When encoding these values using the `json2string` function, they are preserved in their original form (e.g., `inf` remains as `inf`), resulting in an invalid JSON output.

To address this limitation, this pull request introduces a smart encoding mechanism for handling these special values, enabling their inclusion while generating a valid JSON string. The encoding scheme is as follows:

- `inf` is encoded as `{"__float__": "inf"}`
- `-inf` is encoded as `{"__float__": "-inf"}`
- `nan` is encoded as `{"__float__": "nan"}`