### PR TITLE
Improve pretty printing of negative numbers for OCaml backend

### DIFF
--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -170,14 +170,25 @@ lang OCamlPrettyPrint =
 
   sem getConstStringCode (indent : Int) =
   | CUnsafeCoerce _ -> "(fun x -> x)"
-  | CInt {val = i} -> int2string i
+  -- NOTE(oerikss, 2023-10-06): Integer and float constant can here be both
+  -- negative and positive. Note that -0 = 0, which is the reason for the
+  -- condition on grouping below.
+  | CInt {val = n} ->
+    if eqi n 0 then "0"
+    else
+      let str = int2string n in
+      if leqi n 0 then join ["(", str, ")"] else str
+  | CFloat {val = f} ->
+    if eqf f 0. then "0."
+    else
+      let str = float2string f in
+      if leqf f 0. then join ["(", str, ")"] else str
   | CAddi _ -> "Int.add"
   | CSubi _ -> "Int.sub"
   | CMuli _ -> "Int.mul"
   | CDivi _ -> "Int.div"
   | CModi _ -> "Int.rem"
   | CNegi _ -> "Int.neg"
-  | CFloat {val = f} -> float2string f
   | CAddf _ -> "Float.add"
   | CSubf _ -> "Float.sub"
   | CMulf _ -> "Float.mul"


### PR DESCRIPTION
This PR optimizes the code generation of negative integer and float literals in that these are pretty printed as negative number literals rather than applications of `neg` on positive numbers. Experience with partial evaluation of large numerical expressions, which simplified to expressions with a large number of negative numbers, decreased performance due to the introduction of a large number of applications of `neg` in some cases.  It seems that OCaml does not always simplify these for us. Another small benefit is that the code generation for negative numbers is slightly less verbose with this PR.