### PR TITLE
Improve pretty printing of negative numbers for OCaml backend

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -598,7 +598,9 @@ module FloatConversion = struct
 
   let string2float s = s |> Mseq.Helpers.to_ustring |> float_of_ustring
 
-  let float2string r = r |> ustring_of_float |> Mseq.Helpers.of_ustring
+  let float2string r =
+    (if Float.is_nan r then us "nan" else r |> ustring_of_float)
+    |> Mseq.Helpers.of_ustring
 end
 
 module IO = struct

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -546,7 +546,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
   -- can be any type, and the result type can be any type, it's thus
   -- very economical
     TmApp {{t with lhs = objMagic (generate env lhs)}
-              with rhs = generate env rhs}
+           with rhs = generate env rhs}
   | TmNever t ->
     let msg = "Reached a never term, which should be impossible in a well-typed program." in
     TmApp {

--- a/stdlib/ocaml/pprint.mc
+++ b/stdlib/ocaml/pprint.mc
@@ -170,14 +170,29 @@ lang OCamlPrettyPrint =
 
   sem getConstStringCode (indent : Int) =
   | CUnsafeCoerce _ -> "(fun x -> x)"
-  | CInt {val = i} -> int2string i
+  -- NOTE(oerikss, 2023-10-06): Integer and float constant can here be both
+  -- negative and positive. Note that -0 = 0, which is the reason for the
+  -- condition on grouping below.
+  | CInt {val = n} ->
+    if eqi n 0 then "0"
+    else
+      let str = int2string n in
+      if leqi n 0 then join ["(", str, ")"] else str
+  | CFloat {val = f} ->
+    if eqf f 0. then "0."
+    else
+      if eqf f (divf 1. 0.) then "infinity"
+      else
+        if eqf f (negf (divf 1. 0.)) then "neg_infinity"
+        else
+          let str = float2string f in
+          if leqf f 0. then join ["(", str, ")"] else str
   | CAddi _ -> "Int.add"
   | CSubi _ -> "Int.sub"
   | CMuli _ -> "Int.mul"
   | CDivi _ -> "Int.div"
   | CModi _ -> "Int.rem"
   | CNegi _ -> "Int.neg"
-  | CFloat {val = f} -> float2string f
   | CAddf _ -> "Float.add"
   | CSubf _ -> "Float.sub"
   | CMulf _ -> "Float.mul"


### PR DESCRIPTION
This PR adds support for pretty printing of negative numbers for the OCaml backend. Note that `float2string` is changed so that NaNs are never printed with a negative sign since these have no different meaning than NaN without a negative sign.