### PR TITLE
Peval improvements

### DIFF
--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -188,7 +188,7 @@ utest mapiK (lam i. lam x. lam k. k (muli x i)) [1,2,3] (lam seq. foldl addi 0 s
 -- sequence `seq`, from the left, with the initial accumulator `acc` and
 -- continuation `k`. (from
 -- https://leastfixedpoint.com/tonyg/kcbbs/lshift_archive/folds-and-continuation-passing-style-20070611.html)
-let foldlK
+let foldlK : all a. all b. all c. all d. (a -> b -> (a -> c) -> c) -> a -> [b] -> (a -> c) -> c
   = lam f. lam acc. lam seq. lam k.
     recursive let recur = lam acc. lam seq. lam k.
       if null seq then k acc


### PR DESCRIPTION
This PR adds improvement to `peval`. In particular, it adds the following changes:
- A semantic function `pevalInlineLets` to inline let bindings that are referenced at most once in a program.
- Partial evaluation of the `iter` intrinsic
- For functions bound at the top-level, `peval` will no longer substitute unapplied closures to avoid code swell. The fact that these are bound at the top-level ensures the binding is in scope.
- Similarly, recursive functions at the top-level are unrolled during partial evaluation but not other recursive functions. The unroll heuristics stop the unrolling if a guard is dynamic.
- Improvements to test printouts.