### PR TITLE
Add basic mutable array externals and extend Sundials interface with Dense Matrix API

### DIFF
--- a/stdlib/ext/array-ext.ext-ocaml.mc
+++ b/stdlib/ext/array-ext.ext-ocaml.mc
@@ -1,0 +1,58 @@
+include "map.mc"
+include "ocaml/ast.mc"
+
+let impl = lam arg : { expr : String, ty : Type }.
+  { expr = arg.expr, ty = arg.ty, libraries = ["boot"], cLibraries = [] }
+
+let arrayExtMap =
+  use OCamlTypeAst in
+  mapFromSeq cmpString [
+    ("arrayCreateFloat", [
+      impl {
+        expr = "Array.create_float",
+        ty = tyarrow_ tyint_ otyopaque_
+      }
+    ]),
+    ("arrayLength", [
+      impl {
+        expr = "Array.length",
+        ty = tyarrow_ otyopaque_ tyint_
+      }
+    ]),
+    ("arrayGet", [
+      impl {
+        expr = "Array.get",
+        ty = tyarrows_ [otyopaque_, tyint_, otyopaque_]
+      }
+    ]),
+    ("arraySet", [
+      impl {
+        expr = "Array.set",
+        ty = tyarrows_ [otyopaque_, tyint_, otyopaque_, otyunit_]
+      }
+    ]),
+    ("cArray1CreateFloat", [
+      impl {
+        expr = "Bigarray.Array1.create Bigarray.float64 Bigarray.c_layout",
+        ty = tyarrow_ tyint_ otyopaque_
+      }
+    ]),
+    ("cArray1Dim", [
+      impl {
+        expr = "Bigarray.Array1.dim",
+        ty = tyarrow_ otyopaque_ tyint_
+      }
+    ]),
+    ("cArray1Get", [
+      impl {
+        expr = "Bigarray.Array1.get",
+        ty = tyarrows_ [otyopaque_, tyint_, otyopaque_]
+      }
+    ]),
+    ("cArray1Set", [
+      impl {
+        expr = "Bigarray.Array1.set",
+        ty = tyarrows_ [otyopaque_, tyint_, otyopaque_, otyunit_]
+      }
+    ])
+  ]

--- a/stdlib/ext/array-ext.mc
+++ b/stdlib/ext/array-ext.mc
@@ -1,0 +1,87 @@
+/-
+  This file contains a minimal interface to mutable arrays.
+-/
+
+type Array a
+type CArray1 a
+
+
+external arrayCreateFloat : Int -> Array Float
+
+-- Creates a float array of size `n` with uninitialized values.
+let arrayCreateFloat : Int -> Array Float = lam n. arrayCreateFloat n
+
+utest arrayCreateFloat 3; () with ()
+
+
+external arrayLength : all a. Array a -> Int
+
+-- The length of the array `a`.
+let arrayLength : all a. Array a -> Int = lam a. arrayLength a
+
+utest arrayLength (arrayCreateFloat 3) with 3
+
+
+external arrayGet : all a. Array a -> Int -> a
+
+-- Get the `i`th element from the array `a`.
+let arrayGet : all a. Array a -> Int -> a = lam a. lam i. arrayGet a i
+
+
+external arraySet ! : all a. Array a -> Int -> a -> ()
+
+-- Set, inplace, the `i`th element in the array `a` to the value `v`.
+let arraySet : all a. Array a -> Int -> a -> () = lam a. lam i. lam v. arraySet a i v
+
+
+utest
+  let a  = arrayCreateFloat 3 in
+  utest arraySet a 0 0. with () in
+  utest arraySet a 1 1. with () in
+  utest arraySet a 2 2. with () in
+  utest arrayGet a 0 with 0. in
+  utest arrayGet a 1 with 1. in
+  utest arrayGet a 2 with 2. in
+  ()
+  with ()
+
+
+external cArray1CreateFloat : Int -> CArray1 Float
+
+-- Creates a float array of size `n` with uninitialized values. This array can
+-- share data with external c-code.
+let cArray1CreateFloat : Int -> CArray1 Float = lam n. cArray1CreateFloat n
+
+utest cArray1CreateFloat 3; () with ()
+
+
+external cArray1Dim : all a. CArray1 a -> Int
+
+-- The length of the cArray1 `a`.
+let cArray1Dim : all a. CArray1 a -> Int = lam a. cArray1Dim a
+
+utest cArray1Dim (cArray1CreateFloat 3) with 3
+
+
+external cArray1Get : all a. CArray1 a -> Int -> a
+
+-- Get the `i`th element from the cArray1 `a`.
+let cArray1Get : all a. CArray1 a -> Int -> a = lam a. lam i. cArray1Get a i
+
+
+external cArray1Set ! : all a. CArray1 a -> Int -> a -> ()
+
+-- Set, inplace, the `i`th element in the cArray1 `a` to the value `v`.
+let cArray1Set : all a. CArray1 a -> Int -> a -> () = lam a. lam i. lam v. cArray1Set a i v
+
+
+utest
+  let a  = cArray1CreateFloat 3 in
+  utest cArray1Set a 0 0. with () in
+  utest cArray1Set a 1 1. with () in
+  utest cArray1Set a 2 2. with () in
+  utest cArray1Get a 0 with 0. in
+  utest cArray1Get a 1 with 1. in
+  utest cArray1Get a 2 with 2. in
+  ()
+  with ()

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -9,6 +9,7 @@ include "ext/file-ext.ext-ocaml.mc"
 include "ext/toml-ext.ext-ocaml.mc"
 include "ext/async-ext.ext-ocaml.mc"
 include "ext/rtppl-ext.ext-ocaml.mc"
+include "ext/array-ext.ext-ocaml.mc"
 include "sundials/sundials.ext-ocaml.mc"
 include "sundials/ida.ext-ocaml.mc"
 include "sundials/cvode.ext-ocaml.mc"
@@ -35,6 +36,7 @@ let globalExternalImplsMap : Map String [ExternalImpl] =
     [
       extTestMap,               -- For testing purposes
       mathExtMap,
+      arrayExtMap,
       sundialsExtMap,
       idaExtMap,
       cvodeExtMap,

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -34,6 +34,26 @@ let sundialsExtMap =
         ty = tyarrows_ [otyopaque_, (otybaarrayclayoutfloat_ 2)]
       }
     ]),
+    ("sundialsMatrixDenseGet", [
+      impl {
+        expr = "Sundials.Matrix.Dense.get",
+        ty = tyarrows_ [otyopaque_, tyint_, tyint_, tyfloat_]
+      }
+    ]),
+    ("sundialsMatrixDenseSet", [
+      impl {
+        expr = "Sundials.Matrix.Dense.set",
+        ty = tyarrows_ [otyopaque_, tyint_, tyint_, tyfloat_, otyunit_]
+      }
+    ]),
+    ("sundialsMatrixDenseUpdate", [
+      impl {
+        expr = "Sundials.Matrix.Dense.update",
+        ty = tyarrows_ [
+          otyopaque_, tyint_, tyint_, tyarrow_ tyfloat_ tyfloat_, otyunit_
+        ]
+      }
+    ]),
     ("sundialsNonlinearSolverNewtonMake", [
       impl {
         expr = "Sundials_NonlinearSolver.Newton.make",

--- a/stdlib/sundials/sundials.mc
+++ b/stdlib/sundials/sundials.mc
@@ -22,11 +22,31 @@ external sundialsMatrixDense : Int -> SundialsMatrixDense
 -- Sundials linear solvers, e.g. `idaDlsSolver`.
 let sundialsMatrixDense = lam n. sundialsMatrixDense n
 
-external sundialsMatrixDenseUnwrap ! : SundialsMatrixDense -> Tensor[Float]
+external sundialsMatrixDenseUnwrap : SundialsMatrixDense -> Tensor[Float]
 
 -- `sundialsMatrixDenseUnwrap m` unwraps the sundials dense matrix `m` to a rank
--- 2 tensor.
+-- 2 tensor. This tensor will be the transpose of the input matrix `m`.
 let sundialsMatrixDenseUnwrap = lam m. sundialsMatrixDenseUnwrap m
+
+external sundialsMatrixDenseGet : SundialsMatrixDense -> Int -> Int -> Float
+
+-- `sundialsMatrixDenseGet m i j` gets the `i`,`j`'th element in `m`.
+let sundialsMatrixDenseGet = lam m. lam i. lam j. sundialsMatrixDenseGet m i j
+
+external sundialsMatrixDenseSet ! : SundialsMatrixDense -> Int -> Int -> Float -> ()
+
+-- `sundialsMatrixDenseSet m i j v` sets, inplace, the `i`,`j`'th element in `m`
+-- to the value `v`.
+let sundialsMatrixDenseSet = lam m. lam i. lam j. lam v. sundialsMatrixDenseSet m i j v
+
+external sundialsMatrixDenseUpdate !
+  : SundialsMatrixDense -> Int -> Int -> (Float -> Float) -> ()
+
+-- `sundialsMatrixDenseUpdate m i j f` updates, inplace, the `i`,`j`'th element
+-- in `m` according to the function `f`, where the argument to this function is
+-- the current value at that index in `m`.
+let sundialsMatrixDenseUpdate = lam m. lam i. lam j. lam f.
+  sundialsMatrixDenseUpdate m i j f
 
 external sundialsNonlinearSolverNewtonMake
   : NvectorSerial -> SundialsNonlinearSolver


### PR DESCRIPTION
This PR:
- Adds externals for mutable arrays. These can be useful if you want arrays with minimal overhead.
- Adds interface to Sundials Dense Matrix for the same purpose.

If you know that you want an array data structure and do not need the more general Tensors, this interface might be useful.