### PR TITLE
Add run_all, timeout, and constant folding to the microbenchmarks

### DIFF
--- a/test/microbenchmark/run
+++ b/test/microbenchmark/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-ocaml -I +unix unix.cma run.ml $1 $2 $3 $4 $5
+ocaml -I +unix unix.cma run.ml "$@"

--- a/test/microbenchmark/run
+++ b/test/microbenchmark/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-ocaml unix.cma run.ml $1 $2 $3 $4 $5
+ocaml -I +unix unix.cma run.ml $1 $2 $3 $4 $5

--- a/test/microbenchmark/run.ml
+++ b/test/microbenchmark/run.ml
@@ -2,14 +2,16 @@ open Printf
 
 let menu () =
   printf
-    "Usage: run <benchmark-name-without-postfix-name> <iteration> [excludes]\n\n" ;
+    "Usage: run <benchmark-name-without-postfix-name> <iteration> [excludes] \
+     [timeout]\n\n" ;
   printf "Example: run factorial 1000\n\n" ;
   printf "To exclude certain tests, add excluded numbers. For instance\n" ;
-  printf "command 'run factorial 1000 24' excludes the Miking interpreter\n" ;
-  printf "and OCaml byte code tests (test numbers 2 and 4).\n" ;
+  printf "command 'run factorial 1000 25' excludes the Miking interpreter\n" ;
+  printf "and OCaml byte code tests (test numbers 2 and 5).\n" ;
+  printf "The argument timeout give a timeout in seconds.\n" ;
   exit 1
 
-let measure excludes number str pre_cmd cmd post_cmd =
+let measure excludes number str pre_cmd cmd post_cmd timeout =
   (* printf "\n\npre_cmd: %s\ncmd: %s\npost_cmd: %s\n" pre_cmd cmd post_cmd ; *)
   if String.contains excludes (string_of_int number).[0] then ()
   else (
@@ -17,10 +19,19 @@ let measure excludes number str pre_cmd cmd post_cmd =
     let to_null = " 2>&1 >/dev/null" in
     let _ = Sys.command (pre_cmd ^ to_null) in
     let run () =
+      let command = cmd ^ to_null in
+      let command =
+        match timeout with
+        | Some timeout ->
+            "timeout " ^ string_of_int timeout ^ " " ^ command
+        | None ->
+            command
+      in
       let l1 = Unix.gettimeofday () in
-      let _ = Sys.command (cmd ^ to_null) in
+      let rc = Sys.command command in
       let l2 = Unix.gettimeofday () in
-      printf "%10fs" (l2 -. l1) ;
+      printf "%10f%s" (l2 -. l1)
+        (if rc = 124 && Option.is_some timeout then "s (timeout)" else "s") ;
       flush stdout
     in
     run () ;
@@ -52,28 +63,34 @@ let main =
     if len >= 3 then (Sys.argv.(1), Sys.argv.(2)) else menu ()
   in
   let excludes = if len >= 4 then Sys.argv.(3) else "" in
+  let timeout = if len >= 5 then Some (int_of_string Sys.argv.(4)) else None in
   let name_mc = name ^ ".mc" in
   let _ = Sys.command "rm -rf _build" in
   if Sys.file_exists name_mc then (
-    measure excludes 1 "Boot interpreter:  " ""
+    measure excludes 1 "Boot interpreter:     " ""
       ("boot eval " ^ name_mc ^ " -- " ^ iterations)
-      "" ;
-    measure excludes 2 "Miking interpreter:" ""
+      "" timeout ;
+    measure excludes 2 "Miking interpreter:   " ""
       ("mi eval " ^ name_mc ^ " -- " ^ iterations)
-      "" ;
-    measure excludes 3 "Miking compiler:   " ("mi compile " ^ name_mc)
+      "" timeout ;
+    measure excludes 3 "Miking compiler:      " ("mi compile " ^ name_mc)
       ("./" ^ name ^ " " ^ iterations)
-      ("rm -f " ^ name) ;
-    if Sys.file_exists (name ^ ".ml") then (
-      generate_dune name ;
-      generate_dune_project () ;
-      measure excludes 4 "Ocaml byte code    "
-        ("dune build --root ." ^ " " ^ name ^ ".bc")
-        ("ocamlrun _build/default/" ^ name ^ ".bc" ^ " " ^ iterations)
-        "rm -rf _build" ;
-      measure excludes 5 "OCaml native:      "
-        ("dune build --root ." ^ " " ^ name ^ ".exe")
-        ("./_build/default/" ^ name ^ ".exe" ^ " " ^ iterations)
-        "rm -rf _build && rm dune*" )
+      ("rm -f " ^ name) timeout ;
+    measure excludes 4 "Miking compiler (opt):"
+      ("mi compile --enable-constant-fold " ^ name_mc)
+      ("./" ^ name ^ " " ^ iterations)
+      ("rm -f " ^ name) timeout ;
+    if Sys.file_exists (name ^ ".ml") then
+      ( generate_dune name ;
+        generate_dune_project () ;
+        measure excludes 5 "Ocaml byte code       "
+          ("dune build --root ." ^ " " ^ name ^ ".bc")
+          ("ocamlrun _build/default/" ^ name ^ ".bc" ^ " " ^ iterations)
+          "rm -rf _build" timeout ;
+        measure excludes 6 "OCaml native:         "
+          ("dune build --root ." ^ " " ^ name ^ ".exe")
+          ("./_build/default/" ^ name ^ ".exe" ^ " " ^ iterations)
+          "rm -rf _build && rm dune*" )
+        timeout
     else () )
   else printf "ERROR: Cannot find file %s.mc\n" name

--- a/test/microbenchmark/run.ml
+++ b/test/microbenchmark/run.ml
@@ -1,15 +1,31 @@
 open Printf
 
-let menu () =
-  printf
-    "Usage: run <benchmark-name-without-postfix-name> <iteration> [excludes] \
-     [timeout]\n\n" ;
-  printf "Example: run factorial 1000\n\n" ;
-  printf "To exclude certain tests, add excluded numbers. For instance\n" ;
-  printf "command 'run factorial 1000 25' excludes the Miking interpreter\n" ;
-  printf "and OCaml byte code tests (test numbers 2 and 5).\n" ;
-  printf "The argument timeout give a timeout in seconds.\n" ;
-  exit 1
+let usage_msg =
+  "run [-i <iterations>] [-e <excludes>] [-t <timeout>] <BENCHMARK> \
+   [BENCHMARK] ...\n\n\
+  \ where BENCHMARK is the benchmark filename without file suffix."
+
+let iterations = ref 100
+
+let excludes = ref None
+
+let timeout = ref None
+
+let benchmarks = ref []
+
+let speclist =
+  [ ( "-i"
+    , Arg.Set_int iterations
+    , "Numer of iterations to run for each benchmark (default "
+      ^ string_of_int !iterations ^ ")" )
+  ; ( "-e"
+    , Arg.String (fun e -> excludes := Some e)
+    , "Tests to excludes,\n\
+      \ e.g. -e 25 exlcudes tests 2 and 5 (the Miking interpreter and OCaml \
+       byte code tests)" )
+  ; ( "-t"
+    , Arg.Int (fun t -> timeout := Some t)
+    , "Number of iterations to run for each benchmark" ) ]
 
 let measure excludes number str pre_cmd cmd post_cmd timeout =
   (* printf "\n\npre_cmd: %s\ncmd: %s\npost_cmd: %s\n" pre_cmd cmd post_cmd ; *)
@@ -58,39 +74,47 @@ let generate_dune_project () =
   close_out oc
 
 let main =
-  let len = Array.length Sys.argv in
-  let name, iterations =
-    if len >= 3 then (Sys.argv.(1), Sys.argv.(2)) else menu ()
-  in
-  let excludes = if len >= 4 then Sys.argv.(3) else "" in
-  let timeout = if len >= 5 then Some (int_of_string Sys.argv.(4)) else None in
-  let name_mc = name ^ ".mc" in
-  let _ = Sys.command "rm -rf _build" in
-  if Sys.file_exists name_mc then (
-    measure excludes 1 "Boot interpreter:     " ""
-      ("boot eval " ^ name_mc ^ " -- " ^ iterations)
-      "" timeout ;
-    measure excludes 2 "Miking interpreter:   " ""
-      ("mi eval " ^ name_mc ^ " -- " ^ iterations)
-      "" timeout ;
-    measure excludes 3 "Miking compiler:      " ("mi compile " ^ name_mc)
-      ("./" ^ name ^ " " ^ iterations)
-      ("rm -f " ^ name) timeout ;
-    measure excludes 4 "Miking compiler (opt):"
-      ("mi compile --enable-constant-fold " ^ name_mc)
-      ("./" ^ name ^ " " ^ iterations)
-      ("rm -f " ^ name) timeout ;
-    if Sys.file_exists (name ^ ".ml") then
-      ( generate_dune name ;
-        generate_dune_project () ;
-        measure excludes 5 "Ocaml byte code       "
-          ("dune build --root ." ^ " " ^ name ^ ".bc")
-          ("ocamlrun _build/default/" ^ name ^ ".bc" ^ " " ^ iterations)
-          "rm -rf _build" timeout ;
-        measure excludes 6 "OCaml native:         "
-          ("dune build --root ." ^ " " ^ name ^ ".exe")
-          ("./_build/default/" ^ name ^ ".exe" ^ " " ^ iterations)
-          "rm -rf _build && rm dune*" )
-        timeout
-    else () )
-  else printf "ERROR: Cannot find file %s.mc\n" name
+  Arg.parse speclist
+    (fun benchmark -> benchmarks := benchmark :: !benchmarks)
+    usage_msg ;
+  match !benchmarks with
+  | [] ->
+      Arg.usage speclist usage_msg
+  | _ ->
+      (let excludes = Option.value ~default:"" !excludes in
+       let iterations = string_of_int !iterations in
+       let timeout = !timeout in
+       let _ = Sys.command "rm -rf _build" in
+       List.iter (fun name ->
+           let name_mc = name ^ ".mc" in
+           if Sys.file_exists name_mc then (
+             measure excludes 1 "Boot interpreter:     " ""
+               ("boot eval " ^ name_mc ^ " -- " ^ iterations)
+               "" timeout ;
+             measure excludes 2 "Miking interpreter:   " ""
+               ("mi eval " ^ name_mc ^ " -- " ^ iterations)
+               "" timeout ;
+             measure excludes 3 "Miking compiler:      "
+               ("mi compile " ^ name_mc)
+               ("./" ^ name ^ " " ^ iterations)
+               ("rm -f " ^ name) timeout ;
+             measure excludes 4 "Miking compiler (opt):"
+               ("mi compile --enable-constant-fold " ^ name_mc)
+               ("./" ^ name ^ " " ^ iterations)
+               ("rm -f " ^ name) timeout ;
+             if Sys.file_exists (name ^ ".ml") then
+               ( generate_dune name ;
+                 generate_dune_project () ;
+                 measure excludes 5 "Ocaml byte code       "
+                   ("dune build --root ." ^ " " ^ name ^ ".bc")
+                   ( "ocamlrun _build/default/" ^ name ^ ".bc" ^ " "
+                   ^ iterations )
+                   "rm -rf _build" timeout ;
+                 measure excludes 6 "OCaml native:         "
+                   ("dune build --root ." ^ " " ^ name ^ ".exe")
+                   ("./_build/default/" ^ name ^ ".exe" ^ " " ^ iterations)
+                   "rm -rf _build && rm dune*" )
+                 timeout
+             else () )
+           else printf "ERROR: Cannot find file %s.mc\n" name ) )
+        !benchmarks

--- a/test/microbenchmark/run_all
+++ b/test/microbenchmark/run_all
@@ -1,0 +1,8 @@
+#!/bin/sh
+for f in *.mc
+do
+    b=$(basename -s .mc "$f")
+    echo "./run $b $@"
+    ./run "$b" "$@"
+    echo ""
+done

--- a/test/microbenchmark/split_rope.ml
+++ b/test/microbenchmark/split_rope.ml
@@ -5,6 +5,6 @@ let rec sum acc s =
     let t = Rope.sub_array s 1 (Rope.length_array s) in
     sum (acc + h) t
 
-let s = Rope.create 1000 (fun i -> i)
+let s = Rope.create_array 1000 (fun i -> i)
 
 let _ = Benchmarkcommon.repeat (fun () -> sum 0 s)


### PR DESCRIPTION
This PR adds the miking compiler with optimizations (currently only constant folding) to the micro-benchmark entries. Moreover, it adds an optional timeout and a script to run all micro-benchmarks conveniently. It also improves the argument parsing of the benchmark runner and fixes a minor bug.