### PR TITLE
Updates to built-in types interface, fixes to problematic dependencies, and improved matching in peval

### DIFF
--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -79,7 +79,7 @@ lang MExprCudaCompile =
 end
 
 let keywordsSymEnv =
-  {symEnvEmpty with varEnv =
+  {symEnvDefault with varEnv =
     mapFromSeq
       cmpString
       (map (lam s. (s, nameSym s)) mexprExtendedKeywords)}

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -1387,7 +1387,7 @@ use Test in
 let compile: CompileCOptions -> Expr -> CProg = lam opts. lam prog.
 
   -- Symbolize with empty environment
-  let prog = symbolizeExpr symEnvEmpty prog in
+  let prog = symbolizeExpr symEnvDefault prog in
 
   -- Type check and annotate
   let prog = typeCheck prog in

--- a/stdlib/mexpr/keyword-maker.mc
+++ b/stdlib/mexpr/keyword-maker.mc
@@ -11,7 +11,6 @@
 include "ast.mc"
 include "info.mc"
 include "error.mc"
-include "mexpr.mc"
 include "ast-builder.mc"
 include "eq.mc"
 
@@ -163,7 +162,7 @@ end
 
 -- A test fragment that is used to test the approach. This
 -- fragment can be used as a template when using the keyword maker.
-lang _testKeywordMaker = KeywordMaker + MExpr + MExprEq
+lang _testKeywordMaker = KeywordMaker + MExprEq
 
   -- Example terms that will be used to represent the values of the
   -- the keyword expressions (the new language constructs). The term

--- a/stdlib/mexpr/symbolize.mc
+++ b/stdlib/mexpr/symbolize.mc
@@ -31,7 +31,7 @@ type SymEnv = {
   ignoreExternals: Bool
 }
 
-let symEnvEmpty = {
+let _symEnvEmpty = {
   varEnv = mapEmpty cmpString,
   conEnv = mapEmpty cmpString,
   tyVarEnv = mapEmpty cmpString,
@@ -47,7 +47,12 @@ let symEnvAddBuiltinTypes : all a. SymEnv -> [(String, a)] -> SymEnv
   }
 
 let symEnvDefault =
-  symEnvAddBuiltinTypes symEnvEmpty builtinTypes
+  symEnvAddBuiltinTypes _symEnvEmpty builtinTypes
+
+-- TODO(oerikss, 2023-11-14): Change all DSLs that use this name for the
+-- symbolize environment to instead point to `symEnvDefault` and then
+-- remove this alias and rename `_symEnvEmpty` to `symEnvEmpty`.
+let symEnvEmpty = symEnvDefault
 
 lang SymLookup
   type LookupParams = {kind : String, info : [Info], allowFree : Bool}

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -60,6 +60,11 @@ let typecheckEnvAddBuiltinTypes : TCEnv -> [(String, [String])] -> TCEnv
 let typcheckEnvDefault =
   typecheckEnvAddBuiltinTypes typcheckEnvEmpty builtinTypes
 
+-- TODO(oerikss, 2023-11-14): Change all DSLs that use this name for the
+-- type-check environment to instead point to `typcheckEnvDefault` and then
+-- remove this alias.
+let _tcEnvEmpty = typcheckEnvDefault
+
 let _insertVar = lam name. lam ty. lam env : TCEnv.
   {env with varEnv = mapInsert name ty env.varEnv}
 

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -38,18 +38,27 @@ type TCEnv = {
   disableRecordPolymorphism: Bool
 }
 
-let _tcEnvEmpty = {
+let typcheckEnvEmpty = {
   varEnv = mapEmpty nameCmp,
   conEnv = mapEmpty nameCmp,
   tyVarEnv = mapEmpty nameCmp,
-  tyConEnv =
-  mapFromSeq nameCmp
-    (map (lam t: (String, [String]).
-      (nameNoSym t.0, (0, map nameSym t.1, tyvariant_ []))) builtinTypes),
-
+  tyConEnv = mapEmpty nameCmp,
   currentLvl = 0,
   disableRecordPolymorphism = true
 }
+
+let typecheckEnvAddBuiltinTypes : TCEnv -> [(String, [String])] -> TCEnv
+  = lam env. lam tys. {
+    env with
+    tyConEnv =
+      foldl
+        (lam env. lam t.
+          mapInsert (nameNoSym t.0) (0, map nameSym t.1, tyvariant_ []) env)
+        env.tyConEnv tys
+  }
+
+let typcheckEnvDefault =
+  typecheckEnvAddBuiltinTypes typcheckEnvEmpty builtinTypes
 
 let _insertVar = lam name. lam ty. lam env : TCEnv.
   {env with varEnv = mapInsert name ty env.varEnv}
@@ -444,7 +453,7 @@ lang TypeCheck = TCUnify + Generalize + RemoveMetaVar
   sem typeCheck : Expr -> Expr
   sem typeCheck =
   | tm ->
-    removeMetaVarExpr (typeCheckExpr _tcEnvEmpty tm)
+    removeMetaVarExpr (typeCheckExpr typcheckEnvDefault tm)
 
   -- Type check `expr' under the type environment `env'. The resulting
   -- type may contain unification variables and links.
@@ -994,8 +1003,8 @@ let typeOf = lam test : TypeTest.
   let tyEnv = mapFromSeq nameCmp bindings in
   unwrapTypes
     (tyTm
-       (typeCheckExpr {_tcEnvEmpty with varEnv = tyEnv}
-          (symbolizeExpr {symEnvEmpty with varEnv = symEnv} test.tm)))
+       (typeCheckExpr {typcheckEnvDefault with varEnv = tyEnv}
+          (symbolizeExpr {symEnvDefault with varEnv = symEnv} test.tm)))
 in
 
 let runTest =

--- a/stdlib/peval/ast.mc
+++ b/stdlib/peval/ast.mc
@@ -5,6 +5,7 @@ include "mexpr/type-check.mc"
 include "mexpr/eval.mc"
 include "mexpr/info.mc"
 include "mexpr/eq.mc"
+include "mexpr/mexpr.mc"
 
 include "peval/peval.mc"
 include "error.mc"

--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -434,7 +434,8 @@ lang ConstPEval = PEval + ConstEvalNoDefault
 end
 
 lang MatchPEval =
-  PEval + MatchEval + RecordAst + ConstAst + DataAst + SeqAst + NeverAst + VarAst
+  PEval + MatchEval + RecordAst + ConstAst + DataAst + SeqAst + NeverAst +
+  VarAst + NamedPat
 
   sem pevalBindThis =
   | TmMatch _ -> true
@@ -443,23 +444,36 @@ lang MatchPEval =
   | TmMatch r ->
     pevalBind ctx
       (lam target.
-        switch target
-        case t & TmNever _ then k t
-          -- TODO(oerikss, 2023-07-07): This check is not exhaustive, we must
-          -- probably redefine tryMatch and handle each particular pattern type.
-        case TmRecord _ | TmConst _ | TmConApp _ | TmSeq _ then
-          match tryMatch ctx.env target r.pat with Some env then
-            pevalBind { ctx with env = env } k r.thn
-          else pevalBind ctx k r.els
+        switch (target, tryMatch ctx.env target r.pat)
+        case (TmNever r, _) then TmNever r
+        case (_, Some env) then
+          pevalBind { ctx with env = env } k r.thn
+        case (!TmVar _, None _) then
+          pevalBind ctx k r.els
         case _ then
+          match freshPattern ctx.env r.pat with (env, pat) in
           let ctx = { ctx with recFlag = false } in
-          k (TmMatch {r with
-                      target = target,
-                      thn = pevalBind ctx (lam x. x) r.thn,
-                      els = pevalBind ctx (lam x. x) r.els
-          })
+          k (TmMatch { r with
+                       target = target,
+                       pat = pat,
+                       thn = pevalBind { ctx with env = env } (lam x. x) r.thn,
+                       els = pevalBind ctx (lam x. x) r.els })
         end)
       r.target
+
+  sem freshPattern : EvalEnv -> Pat -> (EvalEnv, Pat)
+  sem freshPattern env =
+  | PatNamed (r & {ident = PName name}) ->
+    let newname = nameSetNewSym name in
+    let newvar = TmVar {
+      ident = newname,
+      ty = r.ty,
+      info = r.info,
+      frozen = false
+    } in
+    (evalEnvInsert name newvar env,
+     PatNamed { r with ident = PName newname })
+  | p -> smapAccumL_Pat_Pat freshPattern env p
 end
 
 lang UtestPEval = PEval + UtestAst

--- a/stdlib/pmexpr/utils.mc
+++ b/stdlib/pmexpr/utils.mc
@@ -77,7 +77,7 @@ let typeCheckEnv = lam env : [(Name, Type)]. lam expr.
       (lam env. lam x : (Name, Type).
         match x with (id, ty) in
         _insertVar id ty env)
-      _tcEnvEmpty env in
+      typcheckEnvDefault env in
   removeMetaVarExpr (typeCheckExpr tcEnv expr)
 in
 


### PR DESCRIPTION
This PR:
- Changes the interface of the default symbolize and type-check environments so that it is easier to extend the built-in types. A change that might affect other projects using the miking compiler is that `symEnvEmpty` is now called `symEnvDefault` to reflect that the default environment contains the built-in types in MExpr. Similarly,  `_tcEnvEmpty` is renamed to `typcheckEnvDefault` to also indicate that it is public. Fore each environment there is a empty version that is truly empty and there is a function `{sym,typcheck}EnvAddBuiltinTypes` to more conveniently add builtin types to the environments.
- Removes an unused include in `keyword-maker.mc` that broke the the lexer when including both `parser/lexer.mc` and `keyword-maker.mc`. It is typically a bad idea to duplicate the names of language fragments with different implementations as is the case for `parser/lexer.mc` and `mexpr/parser.mc` when the include order is hard to control/foresee.
- Improves matching in `peval.mc` and fixes a possible bug with incorrect name capturing.