### PR TITLE
Make handling of names in mlang nominal

### DIFF
--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -104,10 +104,6 @@ let main =
       , Arg.Set Boot.Patterns.pat_example_gives_complete_pattern
       , " Make the pattern analysis in mlang print full patterns instead of \
          partial ones." )
-    ; ( "--subsumption-analysis"
-      , Arg.Set Boot.Mlang.enable_subsumption_analysis
-      , " Enables subsumption analysis of language fragments in mlang \
-         transformations." )
     ; ( "--disable-prune-utests"
       , Arg.Set disable_prune_external_utests
       , " Disables pruning of utests with missing external dependencies." )

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -231,7 +231,12 @@ and ptree =
   | PTreeInfo of info
 
 (* Terms in MLang *)
-and cdecl = CDecl of info * ustring list * ustring * ty (* info, type-parameters, constructor name, carried type *)
+and cdecl =
+  | CDecl of
+      info
+      * ustring list (* type-parameters *)
+      * ustring (* constructor name *)
+      * ty (* carried type *)
 
 and param = Param of info * ustring * ty
 
@@ -245,7 +250,8 @@ and with_kind = WithType | WithValue
 
 and lang_with = With of info * with_kind * ustring * (ustring * ustring) list
 
-and mlang = Lang of info * ustring * ustring list * lang_with list * decl list
+and mlang =
+  | Lang of info * ustring * ustring list * lang_with list * decl list
 
 and let_decl = Let of info * ustring * ty * tm
 
@@ -482,92 +488,134 @@ let smap_accum_left_tm_tm (f : 'a -> tm -> 'a * tm) (acc : 'a) : tm -> 'a * tm
   | TmBox (_, _) ->
       failwith "TmBox is a runtime value"
 
-let smap_accum_left_tm_ty (f : 'a -> ty -> 'a * ty) (acc : 'a) : tm -> 'a * tm = function
+let smap_accum_left_tm_ty (f : 'a -> ty -> 'a * ty) (acc : 'a) : tm -> 'a * tm
+    = function
   | TmLam (fi, id, sym, pesym, ty, tm) ->
-     let acc, ty = f acc ty in
-     (acc, TmLam (fi, id, sym, pesym, ty, tm))
+      let acc, ty = f acc ty in
+      (acc, TmLam (fi, id, sym, pesym, ty, tm))
   | TmLet (fi, id, sym, ty, body, inexpr) ->
-     let acc, ty = f acc ty in
-     (acc, TmLet (fi, id, sym, ty, body, inexpr))
+      let acc, ty = f acc ty in
+      (acc, TmLet (fi, id, sym, ty, body, inexpr))
   | TmRecLets (fi, lets, tm) ->
-     let f_bind acc (fi, id, sym, ty, tm) =
-       let acc, ty = f acc ty in
-       (acc, (fi, id, sym, ty, tm)) in
-     let acc, lets = List.fold_left_map f_bind acc lets in
-     (acc, TmRecLets (fi, lets, tm))
+      let f_bind acc (fi, id, sym, ty, tm) =
+        let acc, ty = f acc ty in
+        (acc, (fi, id, sym, ty, tm))
+      in
+      let acc, lets = List.fold_left_map f_bind acc lets in
+      (acc, TmRecLets (fi, lets, tm))
   | TmType (fi, name, params, rhs, inexpr) ->
-     let acc, rhs = f acc rhs in
-     (acc, TmType (fi, name, params, rhs, inexpr))
+      let acc, rhs = f acc rhs in
+      (acc, TmType (fi, name, params, rhs, inexpr))
   | TmConDef (fi, name, sym, ty, tm) ->
-     let acc, ty = f acc ty in
-     (acc, TmConDef (fi, name, sym, ty, tm))
+      let acc, ty = f acc ty in
+      (acc, TmConDef (fi, name, sym, ty, tm))
   | TmExt (fi, name, sym, side, ty, tm) ->
-     let acc, ty = f acc ty in
-     (acc, TmExt (fi, name, sym, side, ty, tm))
-  | (TmVar _ | TmApp _ | TmConst _ | TmSeq _ | TmRecord _ | TmRecordUpdate _ | TmConApp _ | TmMatch _ | TmUtest _ | TmNever _ | TmUse _ | TmClos _ | TmRef _ | TmTensor _ | TmDive _ | TmPreRun _ | TmBox _) as tm -> (acc, tm)
+      let acc, ty = f acc ty in
+      (acc, TmExt (fi, name, sym, side, ty, tm))
+  | ( TmVar _
+    | TmApp _
+    | TmConst _
+    | TmSeq _
+    | TmRecord _
+    | TmRecordUpdate _
+    | TmConApp _
+    | TmMatch _
+    | TmUtest _
+    | TmNever _
+    | TmUse _
+    | TmClos _
+    | TmRef _
+    | TmTensor _
+    | TmDive _
+    | TmPreRun _
+    | TmBox _ ) as tm ->
+      (acc, tm)
 
-let smap_accum_left_ty_ty (f : 'a -> ty -> 'a * ty) (acc : 'a) : ty -> 'a * ty = function
+let smap_accum_left_ty_ty (f : 'a -> ty -> 'a * ty) (acc : 'a) : ty -> 'a * ty
+    = function
   | TyArrow (fi, l, r) ->
-     let acc, l = f acc l in
-     let acc, r = f acc r in
-     (acc, TyArrow (fi, l, r))
+      let acc, l = f acc l in
+      let acc, r = f acc r in
+      (acc, TyArrow (fi, l, r))
   | TyAll (fi, id, ty) ->
-     let acc, ty = f acc ty in
-     (acc, TyAll (fi, id, ty))
+      let acc, ty = f acc ty in
+      (acc, TyAll (fi, id, ty))
   | TySeq (fi, ty) ->
-     let acc, ty = f acc ty in
-     (acc, TySeq (fi, ty))
+      let acc, ty = f acc ty in
+      (acc, TySeq (fi, ty))
   | TyTensor (fi, ty) ->
-     let acc, ty = f acc ty in
-     (acc, TyTensor (fi, ty))
+      let acc, ty = f acc ty in
+      (acc, TyTensor (fi, ty))
   | TyRecord (fi, tys) ->
-     let acc, tys = Record.to_seq tys
-                    |> List.of_seq
-                    |> List.fold_left_map (fun acc (k, v) -> let acc, v = f acc v in (acc, (k, v))) acc in
-     (acc, TyRecord (fi, Record.of_seq (List.to_seq tys)))
+      let acc, tys =
+        Record.to_seq tys |> List.of_seq
+        |> List.fold_left_map
+             (fun acc (k, v) ->
+               let acc, v = f acc v in
+               (acc, (k, v)) )
+             acc
+      in
+      (acc, TyRecord (fi, Record.of_seq (List.to_seq tys)))
   | TyApp (fi, l, r) ->
-     let acc, l = f acc l in
-     let acc, r = f acc r in
-     (acc, TyApp (fi, l, r))
+      let acc, l = f acc l in
+      let acc, r = f acc r in
+      (acc, TyApp (fi, l, r))
   | TyUse (fi, lang, ty) ->
-     let acc, ty = f acc ty in
-     (acc, TyUse (fi, lang, ty))
-  | (TyUnknown _ | TyBool _ | TyInt _ | TyFloat _ | TyChar _ | TyVariant _ | TyCon _ | TyVar _) as ty -> (acc, ty)
+      let acc, ty = f acc ty in
+      (acc, TyUse (fi, lang, ty))
+  | ( TyUnknown _
+    | TyBool _
+    | TyInt _
+    | TyFloat _
+    | TyChar _
+    | TyVariant _
+    | TyCon _
+    | TyVar _ ) as ty ->
+      (acc, ty)
 
-let smap_accum_left_tm_pat (f : 'a -> pat -> 'a * pat) (acc : 'a) : tm -> 'a * tm = function
+let smap_accum_left_tm_pat (f : 'a -> pat -> 'a * pat) (acc : 'a) :
+    tm -> 'a * tm = function
   | TmMatch (fi, scrut, pat, th, el) ->
-     let acc, pat = f acc pat in
-     (acc, TmMatch (fi, scrut, pat, th, el))
-  | tm -> (acc, tm)
+      let acc, pat = f acc pat in
+      (acc, TmMatch (fi, scrut, pat, th, el))
+  | tm ->
+      (acc, tm)
 
-let smap_accum_left_pat_pat (f : 'a -> pat -> 'a * pat) (acc : 'a) : pat -> 'a * pat = function
+let smap_accum_left_pat_pat (f : 'a -> pat -> 'a * pat) (acc : 'a) :
+    pat -> 'a * pat = function
   | PatSeqTot (fi, pats) ->
-     let acc, pats = Mseq.Helpers.map_accum_left f acc pats in
-     (acc, PatSeqTot (fi, pats))
+      let acc, pats = Mseq.Helpers.map_accum_left f acc pats in
+      (acc, PatSeqTot (fi, pats))
   | PatSeqEdge (fi, l, mid, r) ->
-     let acc, l = Mseq.Helpers.map_accum_left f acc l in
-     let acc, r = Mseq.Helpers.map_accum_left f acc r in
-     (acc, PatSeqEdge (fi, l, mid, r))
+      let acc, l = Mseq.Helpers.map_accum_left f acc l in
+      let acc, r = Mseq.Helpers.map_accum_left f acc r in
+      (acc, PatSeqEdge (fi, l, mid, r))
   | PatRecord (fi, pats) ->
-     let acc, pats = Record.to_seq pats
-                    |> List.of_seq
-                    |> List.fold_left_map (fun acc (k, v) -> let acc, v = f acc v in (acc, (k, v))) acc in
-     (acc, PatRecord (fi, Record.of_seq (List.to_seq pats)))
+      let acc, pats =
+        Record.to_seq pats |> List.of_seq
+        |> List.fold_left_map
+             (fun acc (k, v) ->
+               let acc, v = f acc v in
+               (acc, (k, v)) )
+             acc
+      in
+      (acc, PatRecord (fi, Record.of_seq (List.to_seq pats)))
   | PatCon (fi, id, sym, pat) ->
-     let acc, pat = f acc pat in
-     (acc, PatCon (fi, id, sym, pat))
+      let acc, pat = f acc pat in
+      (acc, PatCon (fi, id, sym, pat))
   | PatAnd (fi, l, r) ->
-     let acc, l = f acc l in
-     let acc, r = f acc r in
-     (acc, PatAnd (fi, l, r))
+      let acc, l = f acc l in
+      let acc, r = f acc r in
+      (acc, PatAnd (fi, l, r))
   | PatOr (fi, l, r) ->
-     let acc, l = f acc l in
-     let acc, r = f acc r in
-     (acc, PatOr (fi, l, r))
+      let acc, l = f acc l in
+      let acc, r = f acc r in
+      (acc, PatOr (fi, l, r))
   | PatNot (fi, pat) ->
-     let acc, pat = f acc pat in
-     (acc, PatNot (fi, pat))
-  | (PatNamed _ | PatInt _ | PatChar _ | PatBool _) as pat -> (acc, pat)
+      let acc, pat = f acc pat in
+      (acc, PatNot (fi, pat))
+  | (PatNamed _ | PatInt _ | PatChar _ | PatBool _) as pat ->
+      (acc, pat)
 
 (* smap and sfold variants of the smap_accum_lefts above *)
 
@@ -600,7 +648,9 @@ let smap_tm_pat (f : pat -> pat) (tm : tm) : tm =
   tm
 
 let sfold_tm_pat (f : 'a -> pat -> 'a) (acc : 'a) (tm : tm) : 'a =
-  let acc, _ = smap_accum_left_tm_pat (fun acc pat -> (f acc pat, pat)) acc tm in
+  let acc, _ =
+    smap_accum_left_tm_pat (fun acc pat -> (f acc pat, pat)) acc tm
+  in
   acc
 
 let smap_pat_pat (f : pat -> pat) (t : pat) : pat =

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -241,7 +241,11 @@ and decl =
   | Inter of info * ustring * ty * param list option * (pat * tm) list
   | Alias of info * ustring * ustring list * ty
 
-and mlang = Lang of info * ustring * ustring list * decl list
+and with_kind = WithType | WithValue
+
+and lang_with = With of info * with_kind * ustring * (ustring * ustring) list
+
+and mlang = Lang of info * ustring * ustring list * lang_with list * decl list
 
 and let_decl = Let of info * ustring * ty * tm
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -383,6 +383,8 @@ and ty =
   | TyVar of info * ustring
   (* Type application *)
   | TyApp of info * ty * ty
+  (* Type-level use *)
+  | TyUse of info * ustring * ty
 
 (* Kind of identifier *)
 and ident =
@@ -523,6 +525,9 @@ let smap_accum_left_ty_ty (f : 'a -> ty -> 'a * ty) (acc : 'a) : ty -> 'a * ty =
      let acc, l = f acc l in
      let acc, r = f acc r in
      (acc, TyApp (fi, l, r))
+  | TyUse (fi, lang, ty) ->
+     let acc, ty = f acc ty in
+     (acc, TyUse (fi, lang, ty))
   | (TyUnknown _ | TyBool _ | TyInt _ | TyFloat _ | TyChar _ | TyVariant _ | TyCon _ | TyVar _) as ty -> (acc, ty)
 
 let smap_accum_left_tm_pat (f : 'a -> pat -> 'a * pat) (acc : 'a) : tm -> 'a * tm = function
@@ -660,6 +665,7 @@ let ty_info = function
   | TyVariant (fi, _)
   | TyCon (fi, _)
   | TyVar (fi, _)
+  | TyUse (fi, _, _)
   | TyApp (fi, _, _) ->
       fi
 

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -231,7 +231,7 @@ and ptree =
   | PTreeInfo of info
 
 (* Terms in MLang *)
-and cdecl = CDecl of info * ustring list * ustring * ty
+and cdecl = CDecl of info * ustring list * ustring * ty (* info, type-parameters, constructor name, carried type *)
 
 and param = Param of info * ustring * ty
 
@@ -476,14 +476,130 @@ let smap_accum_left_tm_tm (f : 'a -> tm -> 'a * tm) (acc : 'a) : tm -> 'a * tm
   | TmBox (_, _) ->
       failwith "TmBox is a runtime value"
 
-(* smap for terms *)
+let smap_accum_left_tm_ty (f : 'a -> ty -> 'a * ty) (acc : 'a) : tm -> 'a * tm = function
+  | TmLam (fi, id, sym, pesym, ty, tm) ->
+     let acc, ty = f acc ty in
+     (acc, TmLam (fi, id, sym, pesym, ty, tm))
+  | TmLet (fi, id, sym, ty, body, inexpr) ->
+     let acc, ty = f acc ty in
+     (acc, TmLet (fi, id, sym, ty, body, inexpr))
+  | TmRecLets (fi, lets, tm) ->
+     let f_bind acc (fi, id, sym, ty, tm) =
+       let acc, ty = f acc ty in
+       (acc, (fi, id, sym, ty, tm)) in
+     let acc, lets = List.fold_left_map f_bind acc lets in
+     (acc, TmRecLets (fi, lets, tm))
+  | TmType (fi, name, params, rhs, inexpr) ->
+     let acc, rhs = f acc rhs in
+     (acc, TmType (fi, name, params, rhs, inexpr))
+  | TmConDef (fi, name, sym, ty, tm) ->
+     let acc, ty = f acc ty in
+     (acc, TmConDef (fi, name, sym, ty, tm))
+  | TmExt (fi, name, sym, side, ty, tm) ->
+     let acc, ty = f acc ty in
+     (acc, TmExt (fi, name, sym, side, ty, tm))
+  | (TmVar _ | TmApp _ | TmConst _ | TmSeq _ | TmRecord _ | TmRecordUpdate _ | TmConApp _ | TmMatch _ | TmUtest _ | TmNever _ | TmUse _ | TmClos _ | TmRef _ | TmTensor _ | TmDive _ | TmPreRun _ | TmBox _) as tm -> (acc, tm)
+
+let smap_accum_left_ty_ty (f : 'a -> ty -> 'a * ty) (acc : 'a) : ty -> 'a * ty = function
+  | TyArrow (fi, l, r) ->
+     let acc, l = f acc l in
+     let acc, r = f acc r in
+     (acc, TyArrow (fi, l, r))
+  | TyAll (fi, id, ty) ->
+     let acc, ty = f acc ty in
+     (acc, TyAll (fi, id, ty))
+  | TySeq (fi, ty) ->
+     let acc, ty = f acc ty in
+     (acc, TySeq (fi, ty))
+  | TyTensor (fi, ty) ->
+     let acc, ty = f acc ty in
+     (acc, TyTensor (fi, ty))
+  | TyRecord (fi, tys) ->
+     let acc, tys = Record.to_seq tys
+                    |> List.of_seq
+                    |> List.fold_left_map (fun acc (k, v) -> let acc, v = f acc v in (acc, (k, v))) acc in
+     (acc, TyRecord (fi, Record.of_seq (List.to_seq tys)))
+  | TyApp (fi, l, r) ->
+     let acc, l = f acc l in
+     let acc, r = f acc r in
+     (acc, TyApp (fi, l, r))
+  | (TyUnknown _ | TyBool _ | TyInt _ | TyFloat _ | TyChar _ | TyVariant _ | TyCon _ | TyVar _) as ty -> (acc, ty)
+
+let smap_accum_left_tm_pat (f : 'a -> pat -> 'a * pat) (acc : 'a) : tm -> 'a * tm = function
+  | TmMatch (fi, scrut, pat, th, el) ->
+     let acc, pat = f acc pat in
+     (acc, TmMatch (fi, scrut, pat, th, el))
+  | tm -> (acc, tm)
+
+let smap_accum_left_pat_pat (f : 'a -> pat -> 'a * pat) (acc : 'a) : pat -> 'a * pat = function
+  | PatSeqTot (fi, pats) ->
+     let acc, pats = Mseq.Helpers.map_accum_left f acc pats in
+     (acc, PatSeqTot (fi, pats))
+  | PatSeqEdge (fi, l, mid, r) ->
+     let acc, l = Mseq.Helpers.map_accum_left f acc l in
+     let acc, r = Mseq.Helpers.map_accum_left f acc r in
+     (acc, PatSeqEdge (fi, l, mid, r))
+  | PatRecord (fi, pats) ->
+     let acc, pats = Record.to_seq pats
+                    |> List.of_seq
+                    |> List.fold_left_map (fun acc (k, v) -> let acc, v = f acc v in (acc, (k, v))) acc in
+     (acc, PatRecord (fi, Record.of_seq (List.to_seq pats)))
+  | PatCon (fi, id, sym, pat) ->
+     let acc, pat = f acc pat in
+     (acc, PatCon (fi, id, sym, pat))
+  | PatAnd (fi, l, r) ->
+     let acc, l = f acc l in
+     let acc, r = f acc r in
+     (acc, PatAnd (fi, l, r))
+  | PatOr (fi, l, r) ->
+     let acc, l = f acc l in
+     let acc, r = f acc r in
+     (acc, PatOr (fi, l, r))
+  | PatNot (fi, pat) ->
+     let acc, pat = f acc pat in
+     (acc, PatNot (fi, pat))
+  | (PatNamed _ | PatInt _ | PatChar _ | PatBool _) as pat -> (acc, pat)
+
+(* smap and sfold variants of the smap_accum_lefts above *)
+
 let smap_tm_tm (f : tm -> tm) (t : tm) : tm =
   let _, t' = smap_accum_left_tm_tm (fun _ t -> ((), f t)) () t in
   t'
 
-(* sfold over terms *)
 let sfold_tm_tm (f : 'a -> tm -> 'a) (acc : 'a) (t : tm) : 'a =
   let acc', _ = smap_accum_left_tm_tm (fun acc t -> (f acc t, t)) acc t in
+  acc'
+
+let smap_tm_ty (f : ty -> ty) (tm : tm) : tm =
+  let _, tm = smap_accum_left_tm_ty (fun _ ty -> ((), f ty)) () tm in
+  tm
+
+let sfold_tm_ty (f : 'a -> ty -> 'a) (acc : 'a) (tm : tm) : 'a =
+  let acc, _ = smap_accum_left_tm_ty (fun acc ty -> (f acc ty, ty)) acc tm in
+  acc
+
+let smap_ty_ty (f : ty -> ty) (t : ty) : ty =
+  let _, t' = smap_accum_left_ty_ty (fun _ t -> ((), f t)) () t in
+  t'
+
+let sfold_ty_ty (f : 'a -> ty -> 'a) (acc : 'a) (t : ty) : 'a =
+  let acc', _ = smap_accum_left_ty_ty (fun acc t -> (f acc t, t)) acc t in
+  acc'
+
+let smap_tm_pat (f : pat -> pat) (tm : tm) : tm =
+  let _, tm = smap_accum_left_tm_pat (fun _ pat -> ((), f pat)) () tm in
+  tm
+
+let sfold_tm_pat (f : 'a -> pat -> 'a) (acc : 'a) (tm : tm) : 'a =
+  let acc, _ = smap_accum_left_tm_pat (fun acc pat -> (f acc pat, pat)) acc tm in
+  acc
+
+let smap_pat_pat (f : pat -> pat) (t : pat) : pat =
+  let _, t' = smap_accum_left_pat_pat (fun _ t -> ((), f t)) () t in
+  t'
+
+let sfold_pat_pat (f : 'a -> pat -> 'a) (acc : 'a) (t : pat) : 'a =
+  let acc', _ = smap_accum_left_pat_pat (fun acc t -> (f acc t, t)) acc t in
   acc'
 
 (* Returns arity given an type *)

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -19,8 +19,8 @@ let evalprog filename =
   if !utest then printf "%s: " filename ;
   utest_fail_local := 0 ;
   ( try
-      filename |> parse_mcore_file |> Mlang.flatten
-      |> Mlang.desugar_post_flatten |> debug_after_mlang
+      filename |> parse_mcore_file
+      |> Mlang.translate_program |> debug_after_mlang
       |> raise_parse_error_on_non_unique_external_id
       |> (fun t -> if !utest then t else remove_all_utests t)
       |> Symbolize.symbolize builtin_name2sym

--- a/src/boot/lib/eval.ml
+++ b/src/boot/lib/eval.ml
@@ -19,9 +19,8 @@ let evalprog filename =
   if !utest then printf "%s: " filename ;
   utest_fail_local := 0 ;
   ( try
-      filename |> parse_mcore_file
-      |> Mlang.translate_program |> debug_after_mlang
-      |> raise_parse_error_on_non_unique_external_id
+      filename |> parse_mcore_file |> Mlang.translate_program
+      |> debug_after_mlang |> raise_parse_error_on_non_unique_external_id
       |> (fun t -> if !utest then t else remove_all_utests t)
       |> Symbolize.symbolize builtin_name2sym
       |> debug_after_symbolize

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1049,7 +1049,7 @@ let rec parseMCoreFile
       PTreeTm
         ( filename |> Intrinsics.Mseq.Helpers.to_ustring |> Ustring.to_utf8
         |> Utils.normalize_path |> Parserutils.parse_mcore_file
-        |> Mlang.flatten |> Mlang.desugar_post_flatten
+        |> Mlang.translate_program
         |> Parserutils.raise_parse_error_on_non_unique_external_id
         |> Symbolize.symbolize name2sym
         |> Parserutils.raise_parse_error_on_partially_applied_external

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -169,7 +169,7 @@ type lang_data =
  * in the new fragment; this function is what makes it so. *)
 let pre_extend_lang : lang_data -> lang_data = fun lang ->
   let work_syn_case : syn_case -> syn_case = fun case ->
-    { case with def_here = true } in
+    { case with def_here = false } in
   let work_syn : syn_data -> syn_data = fun data ->
     { data with
       def_here = false

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -765,9 +765,9 @@ let wrap_cons : mlang_env -> lang_data -> tm -> tm = fun env lang tm ->
       TyAll (con.fi, tyvar, ty) in
     let wrap_app (ty : ty) (tyvar : ustring) =
       TyApp (con.fi, ty, TyVar (con.fi, tyvar)) in
-    let carried = List.fold_right wrap_all con.ty_params con.carried in
     let ret = List.fold_left wrap_app (TyCon (con.fi, name)) con.ty_params in
-    let ty = TyArrow (con.fi, carried, ret) in
+    let ty = TyArrow (con.fi, con.carried, ret) in
+    let ty = List.fold_right wrap_all con.ty_params ty in
     TmConDef
       ( con.fi
       , lang_con_mangle con.name

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -386,6 +386,12 @@ let rec translate_ty (env : mlang_env) : ty -> ty = function
      | Some id -> TyCon (fi, id)
      | None -> TyCon (fi, empty_mangle id)
      end
+  | TyUse (fi, lang, ty) ->
+     begin match Record.find_opt lang env.language_envs with
+     | Some new_env -> translate_ty (merge_env_prefer_right env new_env) ty
+     | None -> raise_error fi
+                 ( "Unbound language fragment '" ^ Ustring.to_utf8 lang ^ "'" )
+     end
   | ty ->
      let ty = smap_ty_ty (translate_ty env) ty in
      ty

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -434,6 +434,12 @@ module NoCap = struct
     It's worth noting that none of this would be an issue if we had
     symbols, so a potential fix would be to make symbolize in boot
     respect already placed symbols.
+
+    It's also worth noting that this would also not be an issue with
+    dot-notation (e.g., `X.foo` instead of `use X in foo`), because
+    the former makes it clear that we're using a name in `X` rather
+    than a name from `X` or the current scope.
+
      *)
 
     failwith "We don't presently support renaming `syn`s or `sem`s using `with`. See this error in the code for why."

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -51,248 +51,6 @@ let lookup_lang info prev_langs name =
   | Some l ->
       l
 
-type case =
-  { pat: pat
-  ; rhs: tm
-  ; (* We precompute the normpat corresponding to pat, as well as the one
-     * corresponding to not(pat) *)
-    pos_pat: normpat
-  ; neg_pat: normpat }
-
-type inter_data =
-  { info: info
-  ; ty: ty
-  ; params: param list option
-  ; (* We represent each case by the location of its pattern *)
-    cases: (info * case) list
-  ; (* We store the DAG of subset relations as a list of pairs (a, b),
-     * where a \subset b. Note proper subset, since equality
-     * means we should error because we can't order the patterns. *)
-    subsets: (info * info) list }
-
-type lang_data =
-  { inters: inter_data Record.t
-  ; syns: (info * int * cdecl list) Record.t
-  ; alias_defs: info Record.t
-  ; aliases_rev: (Ustring.t * info * ustring list * ty) list }
-
-let spprint_inter_data {info; cases; _} : ustring =
-  List.map
-    (fun (fi, {pat; _}) ->
-      us "  " ^. ustring_of_pat pat ^. us " at " ^. info2str fi )
-    cases
-  |> Ustring.concat (us "\n")
-  |> fun msg -> us "My location is " ^. info2str info ^. us "\n" ^. msg
-
-let spprint_lang_data {inters; _} : ustring =
-  Record.bindings inters
-  |> List.map (fun (name, data) -> name ^. us "\n" ^. spprint_inter_data data)
-  |> Ustring.concat (us "\n")
-
-let compute_order fi
-    ( (fi1, {pat= pat1; pos_pat= p1; neg_pat= n1; _})
-    , (fi2, {pat= pat2; pos_pat= p2; neg_pat= n2; _}) ) =
-  let string_of_pat pat = ustring_of_pat pat |> Ustring.to_utf8 in
-  let info2str fi = info2str fi |> Ustring.to_utf8 in
-  match order_query (p1, n1) (p2, n2) with
-  | Subset ->
-      [(fi1, fi2)]
-  | Superset ->
-      [(fi2, fi1)]
-  | Equal ->
-      raise_error fi
-        ( "Patterns at " ^ info2str fi1 ^ " and " ^ info2str fi2
-        ^ " cannot be ordered by specificity; they match exactly the same \
-           values." )
-  | Disjoint ->
-      []
-  | Overlapping (only1, both, only2) ->
-      "Two patterns in this semantic function cannot be ordered by \
-       specificity (neither is more specific than the other), but the order \
-       matters; they overlap." ^ "\n  " ^ info2str fi1 ^ ": "
-      ^ string_of_pat pat1 ^ "\n  " ^ info2str fi2 ^ ": " ^ string_of_pat pat2
-      ^ "\n Example:" ^ "\n  Only in the first: " ^ string_of_pat only1
-      ^ "\n  In both: " ^ string_of_pat both ^ "\n  Only in the other: "
-      ^ string_of_pat only2
-      |> raise_error fi
-
-let merge_inter fi name a b =
-  match (a, b) with
-  | None, None ->
-      None
-  | None, Some a ->
-      Some {a with info= fi}
-  | Some a, None ->
-      Some a
-  | ( Some ({info= fi1; ty= ty1; params= p1; cases= c1; subsets= s1} as data)
-    , Some {info= fi2; ty= ty2; params= p2; cases= c2; subsets= s2} ) ->
-      if eq_info fi1 fi2 then Some data
-      else
-        let param_lengths_differ =
-          match (p1, p2) with
-          | Some p1, Some p2 ->
-              List.length p1 <> List.length p2
-          | _ ->
-              false
-        in
-        if param_lengths_differ then
-          raise_error fi1
-            ( "Different number of parameters for interpreter '"
-            ^ Ustring.to_utf8 name ^ "' compared to previous definition at "
-            ^ Ustring.to_utf8 (info2str fi2) )
-        else
-          let c2 =
-            List.filter
-              (fun (fi, _) ->
-                List.exists (fun (fi2, _) -> eq_info fi fi2) c1 |> not )
-              c2
-          in
-          let subsets =
-            add_new_by
-              (fun (a1, a2) (b1, b2) -> eq_info a1 b1 && eq_info a2 b2)
-              s2 s1
-          in
-          let subsets =
-            liftA2 (fun a b -> (a, b)) c1 c2
-            |> fold_map
-                 ~fold:(fun a b -> List.rev_append b a)
-                 ~map:(compute_order fi1) subsets
-          in
-          let ty = match ty1 with TyUnknown _ -> ty2 | _ -> ty1 in
-          (* TODO(vipa, 2022-03-24): Perform capture avoiding substitution properly *)
-          let params =
-            match (p1, p2) with
-            | Some p1, Some p2 ->
-                if
-                  List.equal
-                    (fun (Param (_, n1, _)) (Param (_, n2, _)) -> n1 =. n2)
-                    p1 p2
-                then Some p1
-                else
-                  raise_error fi
-                    ( "Parameters are named differently for interpreter '"
-                    ^ Ustring.to_utf8 name
-                    ^ "' compared to previous definition at "
-                    ^ Ustring.to_utf8 (info2str fi2) )
-            | Some p1, None ->
-                Some p1
-            | None, Some p2 ->
-                Some p2
-            | None, None ->
-                None
-          in
-          Some {data with subsets; ty; params; cases= List.rev_append c2 c1}
-
-(* Check that a single language fragment is self-consistent; it has compatible patterns,
- * no duplicate definitions, etc. Does not consider included languages at all.
- *)
-let compute_lang_data (Lang (info, _, _, decls)) : lang_data =
-  let add_new_syn name ((fi, _, _) as data) = function
-    | None ->
-        Some data
-    | Some (old_fi, _, _) ->
-        raise_error fi
-          ( "Duplicate definition of '" ^ Ustring.to_utf8 name
-          ^ "', previously defined at "
-          ^ Ustring.to_utf8 (info2str old_fi) )
-  in
-  let add_new_sem name fi data = function
-    | None ->
-        Some data
-    | Some old_data ->
-        if Option.is_some old_data.params = Option.is_some data.params then
-          raise_error fi
-            ( "Duplicate definition of '" ^ Ustring.to_utf8 name
-            ^ "', previously defined at "
-            ^ Ustring.to_utf8 (info2str old_data.info) )
-        else merge_inter fi name (Some old_data) (Some data)
-  in
-  let add_decl lang_data = function
-    | Data (fi, name, params, cons) ->
-        { lang_data with
-          syns=
-            Record.update name
-              (add_new_syn name (fi, params, cons))
-              lang_data.syns }
-    | Inter (fi, name, ty, params, cases) ->
-        let mk_case (pat, rhs) =
-          let pos_pat = pat_to_normpat pat in
-          ( pat_info pat
-          , {pat; rhs; pos_pat; neg_pat= normpat_complement pos_pat} )
-        in
-        let cases = List.map mk_case cases in
-        let subsets =
-          pair_with_later cases
-          |> fold_map
-               ~fold:(fun a b -> List.rev_append b a)
-               ~map:(compute_order info) []
-        in
-        let inter_data = {info= fi; ty; params; cases; subsets} in
-        { lang_data with
-          inters=
-            Record.update name
-              (add_new_sem name fi inter_data)
-              lang_data.inters }
-    | Alias (fi, name, params, ty) -> (
-      match Record.find_opt name lang_data.alias_defs with
-      | Some old_fi ->
-          raise_error fi
-            ( "Duplicate definition of '" ^ Ustring.to_utf8 name
-            ^ "', previously defined at "
-            ^ Ustring.to_utf8 (info2str old_fi) )
-      | None ->
-          { lang_data with
-            aliases_rev= (name, fi, params, ty) :: lang_data.aliases_rev
-          ; alias_defs= Record.add name fi lang_data.alias_defs } )
-  in
-  List.fold_left add_decl
-    { inters= Record.empty
-    ; syns= Record.empty
-    ; alias_defs= Record.empty
-    ; aliases_rev= [] }
-    decls
-
-(* Merges the second language into the first, because the first includes the second *)
-let merge_lang_data fi {inters= i1; syns= s1; alias_defs= a1; aliases_rev= ar1}
-    {inters= i2; syns= s2; alias_defs= a2; aliases_rev= ar2} : lang_data =
-  let eq_cons (CDecl (_, _, c1, _)) (CDecl (_, _, c2, _)) = c1 =. c2 in
-  let merge_syn _ a b =
-    match (a, b) with
-    | None, None ->
-        None
-    | None, Some (fi, count, _) ->
-        Some (fi, count, [])
-    | Some a, None ->
-        Some a
-    | Some (fi, old_count, cons), Some (_, new_count, old_cons) ->
-        if old_count <> new_count then
-          raise_error fi
-            "This definition has the wrong number of type arguments"
-        else
-          Some
-            ( fi
-            , old_count
-            , List.filter
-                (fun c1 -> List.exists (eq_cons c1) old_cons |> not)
-                cons )
-  in
-  ignore
-    (Record.merge
-       (fun _ a b ->
-         match (a, b) with
-         | Some fi1, Some fi2 when fi1 <> fi2 ->
-             raise_error fi1
-               "This definition would shadow a previous definition in an \
-                included language fragment."
-         | _, _ ->
-             None )
-       a1 a2 ) ;
-  { inters= Record.merge (merge_inter fi) i1 i2
-  ; syns= Record.merge merge_syn s1 s2
-  ; alias_defs= Record.union (fun _ a _ -> Some a) a1 a2
-  ; aliases_rev=
-      List.filter (fun (name, _, _, _) -> Record.mem name a1) ar2 @ ar1 }
-
 (* TODO(vipa,?): this is likely fairly low hanging fruit when it comes to optimization *)
 let topo_sort (eq : 'a -> 'a -> bool) (edges : ('a * 'a) list)
     (vertices : 'a list) =
@@ -316,683 +74,1489 @@ let topo_sort (eq : 'a -> 'a -> bool) (edges : ('a * 'a) list)
   in
   recur [] edges vertices
 
-let data_to_lang info name includes {inters; syns; aliases_rev; _} : mlang =
-  let info_assoc fi l = List.find (fun (fi2, _) -> eq_info fi fi2) l |> snd in
-  let syns =
-    Record.bindings syns
-    |> List.map (fun (syn_name, (fi, count, cons)) ->
-           Data (fi, syn_name, count, cons) )
-  in
-  let sort_inter name {info; ty; params; cases; subsets} =
-    let mk_case fi =
-      let case = info_assoc fi cases in
-      (case.pat, case.rhs)
-    in
-    let cases =
-      List.map fst cases |> topo_sort eq_info subsets |> List.map mk_case
-    in
-    Inter (info, name, ty, params, cases)
-  in
-  let inters =
-    Record.bindings inters
-    |> List.map (fun (name, inter_data) -> sort_inter name inter_data)
-  in
-  let aliases =
-    aliases_rev
-    |> List.map (fun (name, fi, params, ty) -> Alias (fi, name, params, ty))
-  in
-  Lang
-    ( info
-    , name
-    , includes
-    , List.rev_append aliases (List.rev_append syns inters) )
+(* === Types for MLang language fragments and their contents === *)
 
-let flatten_lang (prev_langs : lang_data Record.t) :
-    top -> lang_data Record.t * top = function
-  | (TopLet _ | TopType _ | TopRecLet _ | TopCon _ | TopUtest _ | TopExt _) as
-    top ->
-      (prev_langs, top)
-  | TopLang (Lang (info, name, includes, _) as lang) ->
-      let self_data = compute_lang_data lang in
-      let included_data = List.map (lookup_lang info prev_langs) includes in
-      let merged_data =
-        List.fold_left (merge_lang_data info) self_data included_data
-      in
-      ( Record.add name merged_data prev_langs
-      , TopLang (data_to_lang info name includes merged_data) )
+type sem_case_id = Symb.t
+type sem_id = Symb.t
+type syn_case_id = Symb.t
+type syn_id = Symb.t
+type alias_id = Symb.t
 
-let flatten_with_env (prev_langs : lang_data Record.t)
-    (Program (includes, tops, e) : program) =
-  let new_langs, new_tops = accum_map flatten_lang prev_langs tops in
-  (new_langs, Program (includes, new_tops, e))
+type sem_case =
+  { id: sem_case_id
+  ; pat: pat
+  ; rhs: tm
+  ; (* We precompute the normpat corresponding to pat, as well as the one
+     * corresponding to not(pat) *)
+    pos_pat: normpat
+  ; neg_pat: normpat }
 
-(* Flatten top-level language definitions *)
-let flatten prg : program = snd (flatten_with_env Record.empty prg)
-
-(***************
- * Translation *
- ***************)
-
-module AstHelpers = struct
-  let var fi x = TmVar (fi, x, Symb.Helpers.nosym, false, false)
-
-  let app fi l r = TmApp (fi, l, r)
-
-  let let_ fi x s e body = TmLet (fi, x, s, TyUnknown fi, e, body)
+module SemCase = struct
+  type t = sem_case
+  let compare a b = Symb.compare a.id b.id
 end
+module SemCaseSet = Set.Make (SemCase)
 
-open AstHelpers
+module SubsetOrd = struct
+  type t = (sem_id * sem_id)
+  let compare (a1, a2) (b1, b2) =
+    let res = Symb.compare a1 b1 in
+    if res <> 0 then res else
+      Symb.compare a2 b2
+end
+module SubsetOrdSet = Set.Make (SubsetOrd)
 
-let translate_cases fi f target cases =
-  let translate_case (pat, handler) inner =
-    TmMatch (pat_info pat, target, pat, handler, inner)
-  in
-  let msg =
-    Mseq.map
-      (fun c -> TmConst (fi, CChar c))
-      (us "No matching case for function " ^. f |> Mseq.Helpers.of_ustring)
-  in
-  let no_match =
-    let_ fi (us "_") Symb.Helpers.nosym
-      (* TODO(?,?): we should probably have a special sort for let with wildcards *)
-      (app fi (TmConst (fi, Cdprint)) target)
-      (app fi (TmConst (fi, Cerror)) (TmSeq (fi, msg)))
-  in
-  List.fold_right translate_case cases no_match
+type sem_data =
+  { id: sem_id
+  ; fi: info
+  ; ty: ty
+  ; params: param list option
+  ; cases: SemCaseSet.t
+  ; (* We store the DAG of subset relations as a list of pairs (a, b),
+     * where a \subset b. Note proper subset, since equality
+     * means we should error because we can't order the patterns. *)
+    subsets: SubsetOrdSet.t }
 
-module USMap = Map.Make (Ustring)
+type syn_case =
+  { id: syn_case_id
+  ; fi: info
+  ; def_here: bool
+  ; ty_params: ustring list
+  ; name: (ustring * ustring) (* prefix, name *)
+  ; carried: ty
+  }
 
-type mlangEnv =
-  { constructors: ustring USMap.t
-  ; normals: ustring USMap.t
-  ; aliases: ustring USMap.t }
+type syn_data =
+  { id: syn_id
+  ; def_here: bool
+  ; ty: (ustring * ustring * int) (* prefix, name, number of parameters *)
+  ; cons: syn_case Record.t
+  ; fi: info
+  }
 
-let emptyMlangEnv =
-  {constructors= USMap.empty; normals= USMap.empty; aliases= USMap.empty}
+type alias_data =
+  { id: alias_id
+  ; def_here: bool
+  ; name: (ustring * ustring) (* prefix, name *)
+  ; params: ustring list
+  ; ty: ty
+  ; fi: info
+  }
 
-(* Compute the intersection of a and b, by overwriting names in a with the names
-   in b *)
-let intersect_env_overwrite fi a b =
-  let merger = function
-    | None, None ->
-        None
-    | Some _, Some r ->
-        Some r
-    | None, Some _ ->
-        None
-    | Some l, None ->
-        raise_error fi
-          ( "Binding '" ^ Ustring.to_utf8 l
-          ^ "' exists only in the subsumed language, which should be \
-             impossible.\n" )
-  in
-  { constructors=
-      USMap.merge (fun _ l r -> merger (l, r)) a.constructors b.constructors
-  ; normals= USMap.merge (fun _ l r -> merger (l, r)) a.normals b.normals
-  ; aliases= USMap.merge (fun _ l r -> merger (l, r)) a.aliases b.aliases }
+type ty_in_lang = (alias_data, syn_data) Either.t
+type lang_data =
+  { values: sem_data Record.t
+  ; types: ty_in_lang Record.t
+  }
 
-(* Adds the names from b to a, overwriting with the name from b when they overlap *)
-let merge_env_overwrite a b =
-  { constructors=
-      USMap.union (fun _ _ r -> Some r) a.constructors b.constructors
-  ; normals= USMap.union (fun _ _ r -> Some r) a.normals b.normals
-  ; aliases= USMap.union (fun _ _ r -> Some r) a.aliases b.aliases }
+(* let spprint_inter_data {info; cases; _} : ustring = *)
+(*   List.map *)
+(*     (fun (fi, {pat; _}) -> *)
+(*       us "  " ^. ustring_of_pat pat ^. us " at " ^. info2str fi ) *)
+(*     cases *)
+(*   |> Ustring.concat (us "\n") *)
+(*   |> fun msg -> us "My location is " ^. info2str info ^. us "\n" ^. msg *)
 
-let empty_mangle str = str
+(* let spprint_lang_data {inters; _} : ustring = *)
+(*   Record.bindings inters *)
+(*   |> List.map (fun (name, data) -> name ^. us "\n" ^. spprint_inter_data data) *)
+(*   |> Ustring.concat (us "\n") *)
 
-let resolve_con {constructors; _} ident =
-  match USMap.find_opt ident constructors with
-  | Some ident' ->
-      ident'
-  | None ->
-      empty_mangle ident
+(* === Functions relating to merging and extending fragments === *)
 
-let resolve_id {normals; _} ident =
-  match USMap.find_opt ident normals with
-  | Some ident' ->
-      ident'
-  | None ->
-      empty_mangle ident
+(* NOTE(vipa, 2023-11-14): When we extend a language most components
+ * of the old language are simply in scope, they should not be re-defined
+ * in the new fragment; this function is what makes it so. *)
+let pre_extend_lang : lang_data -> lang_data = fun lang ->
+  let work_syn_case : syn_case -> syn_case = fun case ->
+    { case with def_here = true } in
+  let work_syn : syn_data -> syn_data = fun data ->
+    { data with
+      def_here = false
+    ; cons = Record.map work_syn_case data.cons
+    } in
+  let work_alias : alias_data -> alias_data = fun data ->
+    { data with
+      def_here = false
+    } in
+  { lang with
+    types = Record.map (Either.map ~left:work_alias ~right:work_syn) lang.types
+  }
 
-let resolve_alias {aliases; _} ident =
-  match USMap.find_opt ident aliases with
-  | Some ident' ->
-      ident'
-  | None ->
-      empty_mangle ident
+(* NOTE(vipa, 2023-11-14): Compute the order between two sem cases
+based on the specificity of their patterns *)
+let compute_order (fi : info)
+    ({id= id1; pat= pat1; pos_pat= p1; neg_pat= n1; _} : sem_case)
+    ({id= id2; pat= pat2; pos_pat= p2; neg_pat= n2; _} : sem_case) : (sem_case_id * sem_case_id) option =
+  let string_of_pat pat = ustring_of_pat pat |> Ustring.to_utf8 in
+  let info2str fi = info2str fi |> Ustring.to_utf8 in
+  match order_query (p1, n1) (p2, n2) with
+  | Subset ->
+     Some (id1, id2)
+  | Superset ->
+     Some (id2, id1)
+  | Equal ->
+      raise_error fi
+        ( "Patterns at " ^ info2str (pat_info pat1) ^ " and " ^ info2str (pat_info pat2)
+        ^ " cannot be ordered by specificity; they match exactly the same \
+           values." )
+  | Disjoint ->
+      None
+  | Overlapping (only1, both, only2) ->
+      "Two patterns in this semantic function cannot be ordered by \
+       specificity (neither is more specific than the other), but the order \
+       matters; they overlap." ^ "\n  " ^ info2str (pat_info pat1) ^ ": "
+      ^ string_of_pat pat1 ^ "\n  " ^ info2str (pat_info pat2) ^ ": " ^ string_of_pat pat2
+      ^ "\n Example:" ^ "\n  Only in the first: " ^ string_of_pat only1
+      ^ "\n  In both: " ^ string_of_pat both ^ "\n  Only in the other: "
+      ^ string_of_pat only2
+      |> raise_error fi
 
-let delete_id ({normals; _} as env) ident =
-  {env with normals= USMap.remove ident normals}
-
-let delete_con ({constructors; _} as env) ident =
-  {env with constructors= USMap.remove ident constructors}
-
-let delete_alias ({aliases; _} as env) ident =
-  {env with aliases= USMap.remove ident aliases}
-
-(* Maintains a subsumption relation among the languages (a reflexive and
-   transitive relation). A subsumes B if any call to a semantic function in A
-   can be replaced by a call to a semantic function in B with unchanged result.
-   Subsumption is only checked for language composition (lang A = B + C).
-   Subsumption implies inclusion, but not the other way around.
-
-   subsumer: Maintains the current subsumer of each language. If the binding (A,
-   B) is in 'subsumer', then the language B subsumes the language A, and B is
-   not subsumed by any other language (B is a "maximal" subsumer of A). If A is
-   not bound in 'subsumer', then A is subsumed by itself only.
-
-   subsumes: Maintains the set of languages that a language subsumes (excluding
-   self-subsumption). *)
-type subsumeEnv = {subsumer: ustring USMap.t; subsumes: USSet.t USMap.t}
-
-let emptySubsumeEnv = {subsumer= USMap.empty; subsumes= USMap.empty}
-
-let enable_subsumption_analysis = ref false
-
-(* Check if the first language is subsumed by the second *)
-let lang_is_subsumed_by l1 l2 =
-  match (l1, l2) with
-  | Lang (fi, _, _, decls1), Lang (_, _, _, decls2) ->
-      let decl_is_subsumed_by = function
-        | Inter (_, n1, _, _, cases1), Inter (_, n2, _, _, cases2)
-          when n1 =. n2 ->
-            let mk_pos_neg (pat, _) =
-              let pos_pat = pat_to_normpat pat in
-              let neg_pat = normpat_complement pos_pat in
-              (pos_pat, neg_pat)
-            in
-            let cases1 = List.map mk_pos_neg cases1 in
-            let cases2 = List.map mk_pos_neg cases2 in
-            (* First, filter out cases in B that are equal to A; those are
-               included from A *)
-            let cases2 =
-              List.filter
-                (fun (p2, n2) ->
-                  let is_equal =
-                    List.fold_left
-                      (fun is_equal (p1, n1) ->
-                        is_equal
-                        ||
-                        match order_query (p1, n1) (p2, n2) with
-                        | Equal ->
-                            true
-                        | _ ->
-                            false )
-                      false cases1
-                  in
-                  not is_equal )
-                cases2
-            in
-            (* Then, check if all patterns in A are smaller than remaining
-               patterns in B *)
-            List.for_all
-              (fun (p1, n1) ->
-                List.fold_left
-                  (fun is_smaller (p2, n2) ->
-                    if not is_smaller then is_smaller
-                    else
-                      match order_query (p1, n1) (p2, n2) with
-                      | Subset | Disjoint ->
-                          true
-                      | Superset ->
-                          false
-                      | Equal | Overlapping _ ->
-                          raise_error fi
-                            "Two patterns in this semantic function are \
-                             either equal or overlapping, which should be \
-                             impossible" )
-                  true cases2 )
-              cases1
-        | Data _, Data _
-        | Inter _, Inter _
-        | Data _, Inter _
-        | Inter _, Data _
-        | Alias _, Data _
-        | Alias _, Inter _
-        | Alias _, Alias _
-        | Data _, Alias _
-        | Inter _, Alias _ ->
-            true
-      in
-      List.for_all
-        (fun d1 -> List.for_all (fun d2 -> decl_is_subsumed_by (d1, d2)) decls2)
-        decls1
-
-(* Compute the resulting subsumption environment for a language declaration *)
-let handle_subsumption env langs lang includes =
-  if !enable_subsumption_analysis then
-    (* Find a subsumer for a language, if any exists. *)
-    let find_subsumer env x =
-      (* y is a subsumer of x if y has no subsumer and it subsumes x *)
-      let is_subsumer y =
-        match USMap.find_opt y env.subsumer with
-        | Some _ ->
-            false
-        | None -> (
-          match USMap.find_opt y env.subsumes with
-          | None ->
-              false
-          | Some set ->
-              USSet.mem x set )
-      in
-      (* Set b as the subsumer where currently a is *)
-      let replace_subsumer subsumer_map a b =
-        USMap.map (fun x -> if x =. a then b else x) subsumer_map
-      in
-      let found_subsumer, subsumer =
-        USMap.fold
-          (fun k _ acc ->
-            match acc with true, _ -> acc | _ -> (is_subsumer k, k) )
-          env.subsumes (false, x)
-      in
-      if found_subsumer then
-        { {env with subsumer= replace_subsumer env.subsumer x subsumer} with
-          subsumer= USMap.add x subsumer env.subsumer }
-      else env
+(* NOTE(vipa, 2023-11-14): Merge two sems with the same name, failing
+if they originate from different root sems. *)
+let merge_sems_in_lang : info -> ustring -> sem_data -> sem_data -> sem_data = fun fi name a b ->
+  let su = Ustring.to_utf8 in
+  if Symb.eqsym a.id b.id then
+    let inconsistent_parameter_lists =
+      match a.params, b.params with
+      | Some p1, Some p2 -> Bool.not (List.equal (fun (Param (_, a, _)) (Param (_, b, _)) -> a =. b) p1 p2)
+      | _ -> false
     in
-    (* Finds new subsumers for languages that were previously subsumed by lang *)
-    let del_lang env =
-      let subsumed_langs = USMap.find_opt lang env.subsumes in
-      let env = {env with subsumes= USMap.remove lang env.subsumes} in
-      match subsumed_langs with
-      | Some set ->
-          let env =
-            { env with
-              subsumer=
-                USMap.filter (fun k _ -> not (USSet.mem k set)) env.subsumer }
-          in
-          let env = USSet.fold (fun x acc -> find_subsumer acc x) set env in
-          env
-      | None ->
-          env
-    in
-    (* Subsume the language, and recursively subsume the languages that were
-       previously subsumed by it *)
-    let rec add_lang to_be_subsumed env =
-      let env =
-        {env with subsumer= USMap.add to_be_subsumed lang env.subsumer}
-      in
-      let env =
-        match USMap.find_opt to_be_subsumed env.subsumes with
-        | Some set ->
-            USSet.fold add_lang set env
-        | None ->
-            env
-      in
-      { env with
-        subsumes=
-          USMap.update lang
-            (function
-              | None ->
-                  Some (USSet.singleton to_be_subsumed)
-              | Some set ->
-                  Some (USSet.add to_be_subsumed set) )
-            env.subsumes }
-    in
-    List.fold_left
-      (fun acc included ->
-        if
-          lang_is_subsumed_by
-            (USMap.find included langs)
-            (USMap.find lang langs)
-        then add_lang included acc
-        else acc )
-      (del_lang env) includes
-  else env
+    if inconsistent_parameter_lists then
+      raise_error fi
+        ( "Trying to merge two 'sem's with inconsistent parameter lists (length or names) into '"
+        ^ su name ^ "' (previous definitions: "
+        ^ su (info2str a.fi) ^ " and " ^ su (info2str b.fi) ^ ")" )
+    else
+      let new_subsets =
+        let new_a = List.of_seq (SemCaseSet.to_seq (SemCaseSet.diff a.cases b.cases)) in
+        let new_b = List.of_seq (SemCaseSet.to_seq (SemCaseSet.diff b.cases a.cases)) in
+        liftA2 (compute_order fi) new_a new_b
+        |> List.filter_map (fun x -> x)
+        |> List.to_seq
+        |> SubsetOrdSet.of_seq in
+      { a with
+        fi = fi
+      ; params = if Option.is_some a.params then a.params else b.params
+      ; cases = SemCaseSet.union a.cases b.cases
+      ; subsets =
+          SubsetOrdSet.union
+            (SubsetOrdSet.union a.subsets b.subsets)
+            new_subsets
+      }
+  else
+    raise_error fi
+      ( "'sem' name conflict, found two definitions of '"
+      ^ su name ^ "', one at " ^ su (info2str a.fi)
+      ^ "and one at " ^ su (info2str b.fi) )
 
-let rec desugar_ty env = function
-  | TyArrow (fi, lty, rty) ->
-      TyArrow (fi, desugar_ty env lty, desugar_ty env rty)
-  | TyAll (fi, id, ty) ->
-      TyAll (fi, id, desugar_ty env ty)
-  | TySeq (fi, ty) ->
-      TySeq (fi, desugar_ty env ty)
-  | TyTensor (fi, ty) ->
-      TyTensor (fi, desugar_ty env ty)
-  | TyRecord (fi, bindings) ->
-      TyRecord (fi, Record.map (desugar_ty env) bindings)
-  | TyVariant (fi, constrs) ->
-      TyVariant (fi, constrs)
+let merge_aliases_in_lang : info -> ustring -> alias_data -> alias_data -> alias_data = fun fi name a b ->
+  let su = Ustring.to_utf8 in
+  if Symb.eqsym a.id b.id then a
+  else
+    raise_error fi
+      ( "Name conflict, there are two type aliases named '" ^ su name ^ "'" )
+
+let merge_syn_cases_in_lang : info -> ustring -> syn_case -> syn_case -> syn_case = fun fi name a b ->
+  let su = Ustring.to_utf8 in
+  if Symb.eqsym a.id b.id then a else
+    raise_error fi
+      ( "Conflicting definitions of constructor '"
+      ^ su name ^ "', at " ^ su (info2str a.fi)
+      ^ " and " ^ su (info2str b.fi) )
+
+let merge_syns_in_lang : info -> ustring -> syn_data -> syn_data -> syn_data = fun fi name a b ->
+  let su = Ustring.to_utf8 in
+  if Symb.eqsym a.id b.id then
+    match a.ty, b.ty with
+    | (_, _, a_count), (_, _, b_count) when a_count <> b_count ->
+      raise_error fi
+        ( "Trying to merge two 'syn's with different number of parameters into '"
+          ^ su name ^ "' (previous definitions: " ^ su (info2str a.fi)
+          ^ " and " ^ su (info2str b.fi) ^ ")")
+    | _ ->
+      { a with
+        cons = Record.union (fun name a b -> Some (merge_syn_cases_in_lang fi name a b)) a.cons b.cons
+      }
+  else
+    raise_error fi
+      ( "'syn' name conflict, found two definitions of '"
+        ^ su name ^ "', one at " ^ su (info2str a.fi)
+        ^ " and one at " ^ su (info2str b.fi) )
+
+let merge_types_in_lang : info -> ustring -> ty_in_lang -> ty_in_lang -> ty_in_lang = fun fi name a b ->
+  let su = Ustring.to_utf8 in
+  match a, b with
+  | (Left _, Right _) | (Right _, Left _) ->
+     raise_error fi
+       ( "Name conflict, a type alias and a syn are named '" ^ su name ^ "'" )
+  | Left a, Left b -> Left (merge_aliases_in_lang fi name a b)
+  | Right a, Right b -> Right (merge_syns_in_lang fi name a b)
+
+let merge_langs : info -> lang_data -> lang_data -> lang_data = fun fi a b ->
+  { values = Record.union (fun name a b -> Some (merge_sems_in_lang fi name a b)) a.values b.values
+  ; types = Record.union (fun name a b -> Some (merge_types_in_lang fi name a b)) a.types b.types
+  }
+
+(* === Functions that facilitate renaming types and values, and thus merging them after the fact === *)
+
+let rec_add_with : ('a -> 'a -> 'a) -> ustring -> 'a -> 'a Record.t -> 'a Record.t = fun f k v m ->
+  let f = function
+    | Some v1 -> Some (f v1 v)
+    | None -> Some v in
+  Record.update k f m
+
+let rename_type
+    : info -> ustring -> (ustring * ustring * syn_id) -> lang_data -> lang_data
+  = fun fi orig_name (new_prefix, new_name, new_id) data ->
+  let update_alias (alias : alias_data) =
+    { alias with
+      id = new_id
+    ; def_here = true
+    ; name = (new_prefix, new_name)
+    } in
+  let update_syn (syn : syn_data) =
+    let (_, _, param_count) = syn.ty in
+    let update_syn_case (c : syn_case) =
+      { c with
+        name = (new_prefix, snd c.name)
+      ; def_here = true
+      } in
+    { syn with
+      id = new_id
+    ; def_here = true
+    ; ty = (new_prefix, new_name, param_count)
+    ; cons = Record.map update_syn_case syn.cons
+    } in
+  match Record.find_opt orig_name data.types with
+  | Some ty_content ->
+     let types = Record.remove orig_name data.types in
+     let ty_content = Either.map ~left:update_alias ~right:update_syn ty_content in
+     let types = rec_add_with (merge_types_in_lang fi new_name) new_name ty_content types in
+     (* TODO(vipa, 2023-11-14): rename all references to the old type *)
+     { data with types = types }
+  | None -> data
+
+let rename_value
+    : info -> ustring -> (ustring * ustring * sem_id) -> lang_data -> lang_data
+  = fun fi orig_name (_new_prefix, new_name, new_id) data ->
+  match Record.find_opt orig_name data.values with
+  | Some val_content ->
+     let values = Record.remove orig_name data.values in
+     let update_sem (sem : sem_data) = {sem with id = new_id} in
+     let val_content = update_sem val_content in
+     let values = rec_add_with (merge_sems_in_lang fi new_name) new_name val_content values in
+     (* TODO(vipa, 2023-11-14): rename all references to the old value *)
+     { data with values = values }
+  | None -> data
+
+(* === Translating from MLang (list of top-declarations, including lang) to MExpr (single tm) === *)
+
+type mlang_env =
+  { values : ustring Record.t
+  ; ty_cons : ustring Record.t
+  ; constructors : ustring Record.t
+  ; languages : lang_data Record.t
+  ; language_envs : mlang_env Record.t
+  }
+
+let empty_mlang_env =
+  { values = Record.empty
+  ; ty_cons = Record.empty
+  ; constructors = Record.empty
+  ; languages = Record.empty
+  ; language_envs = Record.empty
+  }
+
+let empty_mangle : ustring -> ustring = fun x -> x
+let lang_value_mangle : (ustring * ustring) -> ustring = fun (prefix, name) -> us"v" ^. prefix ^. us"_" ^. name
+let lang_con_mangle : (ustring * ustring) -> ustring = fun (prefix, name) -> prefix ^. us"_" ^. name
+
+let merge_env_prefer_right : mlang_env -> mlang_env -> mlang_env = fun a b ->
+  { values = Record.union (fun _ _a b -> Some b) a.values b.values
+  ; ty_cons = Record.union (fun _ _a b -> Some b) a.ty_cons b.ty_cons
+  ; constructors = Record.union (fun _ _a b -> Some b) a.constructors b.constructors
+  ; languages = Record.union (fun _ _a b -> Some b) a.languages b.languages
+  ; language_envs = Record.union (fun _ _a b -> Some b) a.language_envs b.language_envs
+  }
+
+let rec translate_ty (env : mlang_env) : ty -> ty = function
   | TyCon (fi, id) ->
-      TyCon (fi, resolve_alias env id)
-  | TyVar (fi, id) ->
-      TyVar (fi, id)
-  | TyApp (fi, lty, rty) ->
-      TyApp (fi, desugar_ty env lty, desugar_ty env rty)
-  | (TyUnknown _ | TyBool _ | TyInt _ | TyFloat _ | TyChar _) as ty ->
-      ty
+     begin match Record.find_opt id env.ty_cons with
+     | Some id -> TyCon (fi, id)
+     | None -> TyCon (fi, empty_mangle id)
+     end
+  | ty ->
+     let ty = smap_ty_ty (translate_ty env) ty in
+     ty
 
-let rec desugar_tm nss env subs =
-  let map_right f (a, b) = (a, f b) in
-  function
-  (* Referencing things *)
-  | TmVar (fi, name, i, pes, frozen) ->
-      TmVar (fi, resolve_id env name, i, pes, frozen)
-  (* Introducing things *)
-  | TmLam (fi, name, s, pes, ty, body) ->
-      TmLam
-        ( fi
-        , empty_mangle name
-        , s
-        , pes
-        , desugar_ty env ty
-        , desugar_tm nss (delete_id env name) subs body )
-  | TmLet (fi, name, s, ty, e, body) ->
-      TmLet
-        ( fi
-        , empty_mangle name
-        , s
-        , desugar_ty env ty
-        , desugar_tm nss env subs e
-        , desugar_tm nss (delete_id env name) subs body )
-  | TmType (fi, name, params, ty, body) ->
-      TmType
-        ( fi
-        , name
-        , params
-        , desugar_ty env ty
-        , desugar_tm nss (delete_alias env name) subs body )
-  | TmRecLets (fi, bindings, body) ->
-      let env' =
-        List.fold_left
-          (fun env' (_, name, _, _, _) -> delete_id env' name)
-          env bindings
-      in
-      TmRecLets
-        ( fi
-        , List.map
-            (fun (fi, name, s, ty, e) ->
-              ( fi
-              , empty_mangle name
-              , s
-              , desugar_ty env ty
-              , desugar_tm nss env' subs e ) )
-            bindings
-        , desugar_tm nss env' subs body )
-  | TmConDef (fi, name, s, ty, body) ->
-      TmConDef
-        ( fi
-        , empty_mangle name
-        , s
-        , desugar_ty env ty
-        , desugar_tm nss (delete_con env name) subs body )
-  | TmConApp (fi, x, s, t) ->
-      TmConApp (fi, resolve_con env x, s, desugar_tm nss env subs t)
-  | TmClos _ as tm ->
-      tm
-  (* Both introducing and referencing *)
-  | TmMatch (fi, target, pat, thn, els) ->
-      let desugar_pname env = function
-        | NameStr (n, s) ->
-            (delete_id env n, NameStr (empty_mangle n, s))
-        | NameWildcard ->
-            (env, NameWildcard)
-      in
-      let rec desugar_pat_seq env pats =
-        Mseq.Helpers.fold_right
-          (fun p (env, pats) ->
-            desugar_pat env p |> map_right (fun p -> Mseq.cons p pats) )
-          (env, Mseq.empty) pats
-      and desugar_pat env = function
-        | PatNamed (fi, name) ->
-            name |> desugar_pname env |> map_right (fun n -> PatNamed (fi, n))
-        | PatSeqTot (fi, pats) ->
-            let env, pats = desugar_pat_seq env pats in
-            (env, PatSeqTot (fi, pats))
-        | PatSeqEdge (fi, l, x, r) ->
-            let env, l = desugar_pat_seq env l in
-            let env, x = desugar_pname env x in
-            let env, r = desugar_pat_seq env r in
-            (env, PatSeqEdge (fi, l, x, r))
-        | PatRecord (fi, pats) ->
-            let env = ref env in
-            let pats =
-              pats
-              |> Record.map (fun p ->
-                     let env', p = desugar_pat !env p in
-                     env := env' ;
-                     p )
-            in
-            (!env, PatRecord (fi, pats))
-        | PatAnd (fi, l, r) ->
-            let env, l = desugar_pat env l in
-            let env, r = desugar_pat env r in
-            (env, PatAnd (fi, l, r))
-        | PatOr (fi, l, r) ->
-            let env, l = desugar_pat env l in
-            let env, r = desugar_pat env r in
-            (env, PatOr (fi, l, r))
-        | PatNot (fi, p) ->
-            let env, p = desugar_pat env p in
-            (env, PatNot (fi, p))
-        | PatCon (fi, name, sym, p) ->
-            desugar_pat env p
-            |> map_right (fun p -> PatCon (fi, resolve_con env name, sym, p))
-        | (PatInt _ | PatChar _ | PatBool _) as pat ->
-            (env, pat)
-      in
-      let env', pat' = desugar_pat env pat in
-      TmMatch
-        ( fi
-        , desugar_tm nss env subs target
-        , pat'
-        , desugar_tm nss env' subs thn
-        , desugar_tm nss env subs els )
-  (* Use *)
-  | TmUse (fi, name, body) -> (
-    match USMap.find_opt name nss with
-    | None ->
-        raise_error fi
-          ("Unknown language fragment '" ^ Ustring.to_utf8 name ^ "'")
-    | Some ns ->
-        let intersected_ns =
-          match USMap.find_opt name subs.subsumer with
-          | None ->
-              ns
-          | Some subsumer ->
-              (* Use namespace from subsumer, but prune bindings that are not
-                 defined in the subsumed namespace *)
-              intersect_env_overwrite fi ns (USMap.find subsumer nss)
-        in
-        desugar_tm nss (merge_env_overwrite env intersected_ns) subs body )
-  (* Simple recursions *)
-  | TmApp (fi, a, b) ->
-      TmApp (fi, desugar_tm nss env subs a, desugar_tm nss env subs b)
-  | TmSeq (fi, tms) ->
-      TmSeq (fi, Mseq.map (desugar_tm nss env subs) tms)
-  | TmRecord (fi, r) ->
-      TmRecord (fi, Record.map (desugar_tm nss env subs) r)
-  | TmRecordUpdate (fi, a, lab, b) ->
-      TmRecordUpdate
-        (fi, desugar_tm nss env subs a, lab, desugar_tm nss env subs b)
-  | TmUtest (fi, a, b, using, onfail, body) ->
-      let using_desugared = Option.map (desugar_tm nss env subs) using in
-      let onfail_desugared = Option.map (desugar_tm nss env subs) onfail in
-      TmUtest
-        ( fi
-        , desugar_tm nss env subs a
-        , desugar_tm nss env subs b
-        , using_desugared
-        , onfail_desugared
-        , desugar_tm nss env subs body )
-  | TmNever fi ->
-      TmNever fi
-  | TmDive (fi, l, a) ->
-      TmDive (fi, l, desugar_tm nss env subs a)
-  | TmPreRun (fi, l, a) ->
-      TmPreRun (fi, l, desugar_tm nss env subs a)
-  | TmBox (_, _) ->
-      failwith "Box is a runtime value"
-  (* Non-recursive *)
-  | (TmConst _ | TmRef _ | TmTensor _ | TmExt _) as tm ->
-      tm
+let rec translate_pat (env : mlang_env) : pat -> mlang_env * pat = function
+  | PatNamed (_, NameStr(id, _)) as pat ->
+     ({env with values = Record.remove id env.values}, pat)
+  | PatCon (fi, id, sym, pat) ->
+     let id, sym = match Record.find_opt id env.constructors with
+       | Some id -> (id, Symb.Helpers.nosym)
+       | None -> (id, sym) in
+     let env, pat = translate_pat env pat in
+     (env, PatCon (fi, id, sym, pat))
+  | pat ->
+     smap_accum_left_pat_pat translate_pat env pat
 
-(* add namespace to nss (overwriting) if relevant, prepend a tm -> tm function to stack, return updated tuple. Should use desugar_tm, as well as desugar both sem and syn *)
-let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function
-  | TopLang (Lang (fi, langName, includes, decls) as lang) ->
-      let default d = function Some x -> x | None -> d in
-      let add_lang ns lang =
-        USMap.find_opt lang nss |> default emptyMlangEnv
-        |> merge_env_overwrite ns
-      in
-      let previous_ns = List.fold_left add_lang emptyMlangEnv includes in
-      (* compute the namespace *)
-      let mangle str = langName ^. us "_" ^. str in
-      let cdecl_names (CDecl (_, _, name, _)) = (name, mangle name) in
-      let add_decl ({constructors; normals; aliases}, syns) = function
-        | Data (fi, name, count, cdecls) ->
-            let new_constructors = List.to_seq cdecls |> Seq.map cdecl_names in
-            ( { constructors= USMap.add_seq new_constructors constructors
-              ; aliases
-              ; normals }
-            , USMap.add name (fi, count) syns )
-        | Inter (_, name, _, _, _) ->
-            ( { normals= USMap.add name (mangle name) normals
-              ; aliases
-              ; constructors }
-            , syns )
-        | Alias (_, name, _, _) ->
-            ( { aliases= USMap.add name (mangle name) aliases
-              ; normals
-              ; constructors }
-            , syns )
-      in
-      let ns, new_syns = List.fold_left add_decl (previous_ns, syns) decls in
-      (* wrap in "con"s *)
-      let wrap_con ty_name (CDecl (fi, params, cname, ty)) tm =
-        let app_param ty param = TyApp (fi, ty, TyVar (fi, param)) in
-        let all_param param ty = TyAll (fi, param, ty) in
-        let con = List.fold_left app_param (TyCon (fi, ty_name)) params in
-        TmConDef
-          ( fi
-          , mangle cname
-          , Symb.Helpers.nosym
-          , List.fold_right all_param params
-              (TyArrow (fi, desugar_ty ns ty, con))
-          , tm )
-      in
-      (* TODO(vipa,?): the type will likely be incorrect once we start doing product extensions of constructors *)
-      let wrap_data decl tm =
-        match decl with
-        | Data (_, name, _, cdecls) ->
-            List.fold_right (wrap_con name) cdecls tm
-        | Alias (fi, name, params, ty) ->
-            TmType (fi, mangle name, params, desugar_ty ns ty, tm)
-        | _ ->
-            tm
-      in
-      (* translate "Inter"s into (info * ustring * tm) *)
-      let inter_to_tm fname fi params cases =
-        let target = us "__sem_target" in
-        let wrap_param (Param (fi, name, ty)) tm =
-          TmLam (fi, name, Symb.Helpers.nosym, false, desugar_ty ns ty, tm)
-        in
-        TmLam
-          ( fi
-          , target
-          , Symb.Helpers.nosym
-          , false
-          , TyUnknown fi
-          , translate_cases fi fname (var fi target) cases )
-        |> List.fold_right wrap_param params
-        |> desugar_tm nss ns subs
-        (* TODO: pass new subs here? *)
-      in
-      let translate_inter = function
-        | Inter (fi, name, ty, params, cases) ->
-            let params =
-              match params with Some params -> params | None -> []
-            in
+let rec translate_tm (env : mlang_env) : tm -> tm = function
+  | TmVar (fi, name, sym, pesym, frozen) ->
+     let name, sym =
+       match Record.find_opt name env.values with
+       | Some name -> (name, Symb.Helpers.nosym)
+       | None -> (name, sym) in
+     (* TODO(vipa, 2023-11-14): is it correct to do nothing about pesym? *)
+     TmVar (fi, name, sym, pesym, frozen)
+  | TmLam (fi, name, sym, pesym, ty, tm) ->
+     let new_env = {env with values = Record.remove name env.values} in
+     TmLam (fi, empty_mangle name, sym, pesym, translate_ty env ty, translate_tm new_env tm)
+  | TmLet (fi, name, sym, ty, body, inexpr) ->
+     let new_env = {env with values = Record.remove name env.values} in
+     TmLet
+       ( fi
+       , empty_mangle name
+       , sym
+       , translate_ty env ty
+       , translate_tm env body
+       , translate_tm new_env inexpr
+       )
+  | TmRecLets (fi, lets, inexpr) ->
+     let rem_value values (_, id, _, _, _) = Record.remove id values in
+     let new_env = {env with values = List.fold_left rem_value env.values lets} in
+     let translate_let (fi, id, sym, ty, tm) = (fi, empty_mangle id, sym, translate_ty new_env ty, translate_tm new_env tm) in
+     TmRecLets (fi, List.map translate_let lets, translate_tm new_env inexpr)
+  | TmType (fi, name, params, ty, tm) ->
+     let new_env = {env with ty_cons = Record.remove name env.ty_cons} in
+     TmType (fi, empty_mangle name, params, translate_ty env ty, translate_tm new_env tm)
+  | TmConDef (fi, name, sym, ty, tm) ->
+     let new_env = {env with constructors = Record.remove name env.constructors} in
+     TmConDef (fi, empty_mangle name, sym, translate_ty env ty, translate_tm new_env tm)
+  | TmConApp (fi, name, sym, tm) ->
+     let name, sym =
+       match Record.find_opt name env.constructors with
+       | Some name -> (name, Symb.Helpers.nosym)
+       | None -> (name, sym) in
+     TmConApp (fi, name, sym, translate_tm env tm)
+  | TmUse (fi, lang, tm) ->
+     begin match Record.find_opt lang env.language_envs with
+     | Some lang_env -> translate_tm (merge_env_prefer_right env lang_env) tm
+     | None -> raise_error fi
+                 ( "Unbound language fragment '" ^ Ustring.to_utf8 lang ^ "'" )
+     end
+  | TmExt (fi, name, sym, side, ty, tm) ->
+     let new_env = {env with values = Record.add name name env.values} in
+     TmExt (fi, name, sym, side, translate_ty env ty, translate_tm new_env tm)
+  | TmMatch (fi, scrut, pat, th, el) ->
+     let new_env, pat = translate_pat env pat in
+     TmMatch (fi, translate_tm env scrut, pat, translate_tm new_env th, translate_tm env el)
+  | (TmApp _ | TmConst _ | TmSeq _ | TmRecord _ | TmRecordUpdate _ | TmUtest _| TmNever _ | TmClos _ | TmRef _ | TmTensor _ | TmDive _ | TmPreRun _ | TmBox _) as tm ->
+     let tm = smap_tm_ty (translate_ty env) tm in
+     let tm = smap_tm_tm (translate_tm env) tm in
+     tm
+
+let add_decl_to_lang (lang_fi : info) (lang_name : ustring) (data : lang_data) : decl -> lang_data = function
+  | Data (fi, name, param_count, constructors) ->
+     let syn =
+       match Record.find_opt name data.types with
+       | Some (Right syn) -> syn
+       | Some _ -> raise_error fi
+                     ( "Trying to define a 'syn' that's already defined as an alias ('"
+                     ^ Ustring.to_utf8 name ^ "')." )
+       | None ->
+          { id = Symb.gensym ()
+          ; def_here = true
+          ; ty = (lang_name, name, param_count)
+          ; cons = Record.empty
+          ; fi
+          } in
+     let add_con : syn_case Record.t -> cdecl -> syn_case Record.t = fun syn (CDecl(fi, ty_params, name, carried)) ->
+       let f : syn_case option -> syn_case option = function
+         | Some con ->
+            raise_error fi
+              ( "Redefinition of constructor '" ^ Ustring.to_utf8 name
+              ^ "', previously defined at " ^ Ustring.to_utf8 (info2str con.fi) )
+         | None ->
             Some
-              ( fi
-              , mangle name
-              , Symb.Helpers.nosym
-              , desugar_ty ns ty
-              , inter_to_tm name fi params cases )
-        | _ ->
-            None
-      in
-      (* put translated inters in a single letrec, then wrap in cons, then done *)
-      let wrap tm =
-        TmRecLets (fi, List.filter_map translate_inter decls, tm)
-        |> List.fold_right wrap_data decls
-      in
-      let new_langs = USMap.add langName lang langs in
-      ( USMap.add langName ns nss
-      , new_langs
-      , handle_subsumption subs new_langs langName includes
-      , new_syns
-      , wrap :: stack )
-  (* The other tops are trivial translations *)
+              { id = Symb.gensym ()
+              ; fi
+              ; def_here = true
+              ; ty_params
+              ; name = (lang_name, name)
+              ; carried
+              } in
+       Record.update name f syn in
+     let syn = {syn with cons = List.fold_left add_con syn.cons constructors} in
+     {data with types = Record.add name (Either.Right syn) data.types}
+  | Inter (fi, name, ty, params, cases) ->
+     let sem =
+       match Record.find_opt name data.values with
+       | Some sem ->
+          { sem with
+            params = if Option.is_some sem.params then sem.params else params
+          }
+       | None ->
+          { id = Symb.gensym ()
+          ; fi
+          ; ty
+          ; params
+          ; cases = SemCaseSet.empty
+          ; subsets = SubsetOrdSet.empty
+          } in
+     let add_case sem (pat, rhs) =
+       let id = Symb.gensym () in
+       let pos_pat = pat_to_normpat pat in
+       let neg_pat = normpat_complement pos_pat in
+       let case = {id; pat; rhs; pos_pat; neg_pat} in
+       let subsets =
+         SemCaseSet.to_seq sem.cases
+         |> Seq.filter_map (compute_order lang_fi case)
+         |> Seq.fold_left (fun acc x -> SubsetOrdSet.add x acc) sem.subsets in
+       {sem with subsets; cases = SemCaseSet.add case sem.cases} in
+     let sem = List.fold_left add_case sem cases in
+     {data with values = Record.add name sem data.values}
+  | Alias (fi, name, params, ty) ->
+     if Record.mem name data.types then
+       raise_error fi
+         ( "Duplicate definition, a type with name '"
+         ^ Ustring.to_utf8 name ^ "' is already defined." )
+     else
+       let alias =
+         { id = Symb.gensym ()
+         ; def_here = true
+         ; name = (lang_name, name)
+         ; params
+         ; ty
+         ; fi
+         } in
+       {data with types = Record.add name (Either.Left alias) data.types}
+
+let lang_to_env : ustring -> lang_data -> mlang_env = fun name lang ->
+  let values =
+    Record.to_seq lang.values
+    |> Seq.map (fun (n, _) -> (n, lang_value_mangle (name, n)))
+    |> Record.of_seq in
+  let mk_type_pair : (ustring * ty_in_lang) -> (ustring * ustring) = function
+    | (n, Either.Left alias) -> (n, lang_con_mangle alias.name)
+    | (n, Either.Right {ty = (pre, name, _); _}) -> (n, lang_con_mangle (pre, name)) in
+  let ty_cons =
+    Record.to_seq lang.types
+    |> Seq.map mk_type_pair
+    |> Record.of_seq in
+  let constructors =
+    Record.to_seq lang.types
+    |> Seq.map snd
+    |> Seq.filter_map Either.find_right
+    |> Seq.flat_map (fun x -> Record.to_seq x.cons)
+    |> Seq.map (fun (n, (case : syn_case)) -> (n, lang_con_mangle case.name))
+    |> Record.of_seq in
+  { values
+  ; ty_cons
+  ; constructors
+  ; languages = Record.empty
+  ; language_envs = Record.empty
+  }
+
+let wrap_syn_types : lang_data -> tm -> tm = fun lang tm ->
+  let wrap_syn (tm : tm) (syn : syn_data) =
+    let (pre, name, param_count) = syn.ty in
+    TmType
+      ( syn.fi
+      , lang_con_mangle (pre, name)
+      , List.init param_count (fun _ -> us"a")
+      , TyVariant (syn.fi, [])
+      , tm
+      ) in
+  Record.to_seq lang.types
+  |> Seq.map snd
+  |> Seq.filter_map Either.find_right
+  |> Seq.filter (fun (syn : syn_data) -> syn.def_here)
+  |> Seq.fold_left wrap_syn tm
+
+let wrap_aliases : mlang_env -> lang_data -> tm -> tm = fun env lang tm ->
+  let wrap_alias (alias : alias_data) (tm : tm) =
+    TmType
+      ( alias.fi
+      , lang_con_mangle alias.name
+      , alias.params
+      , translate_ty env alias.ty
+      , tm
+      ) in
+  Record.to_seq lang.types
+  |> Seq.map snd
+  |> Seq.filter_map Either.find_left
+  |> Seq.filter (fun (alias : alias_data) -> alias.def_here)
+  |> List.of_seq
+  |> List.sort (fun (a : alias_data) (b : alias_data) -> Symb.compare a.id b.id)
+  |> fun aliases -> List.fold_right wrap_alias aliases tm
+
+let wrap_cons : mlang_env -> lang_data -> tm -> tm = fun env lang tm ->
+  let wrap_con (tm : tm) (con : syn_case) =
+    TmConDef
+      ( con.fi
+      , lang_con_mangle con.name
+      , Symb.Helpers.nosym
+      , translate_ty env con.carried
+      , tm
+      ) in
+  Record.to_seq lang.types
+  |> Seq.map snd
+  |> Seq.filter_map Either.find_right
+  |> Seq.flat_map (fun x -> Record.to_seq x.cons)
+  |> Seq.map snd
+  |> Seq.filter (fun (con : syn_case) -> con.def_here)
+  |> Seq.fold_left wrap_con tm
+
+let wrap_sems : mlang_env -> ustring -> lang_data -> tm -> tm = fun env lang_name lang tm ->
+  let sem_to_binding ((name : ustring), (sem : sem_data)) : (info * ustring * Symb.t * ty * tm) =
+    let mk_with_body body =
+      ( sem.fi
+      , lang_value_mangle (lang_name, name)
+      , Symb.Helpers.nosym
+      , translate_ty env sem.ty
+      , body
+      ) in
+    if SemCaseSet.is_empty sem.cases then
+      mk_with_body (TmLam (sem.fi, us"x", Symb.Helpers.nosym, false, TyUnknown sem.fi, TmNever sem.fi))
+    else
+      let scrut = TmVar (sem.fi, us"__sem_target", Symb.Helpers.nosym, false, false) in
+      let cases =
+        let vertices =
+          SemCaseSet.to_seq sem.cases
+          |> Seq.map (fun (case : sem_case) -> case.id)
+          |> List.of_seq in
+        let edges = SubsetOrdSet.elements sem.subsets in
+        let find_by_id id =
+          (* NOTE(vipa, 2023-11-15): The compare function for
+          SemCaseSet only looks at `id`, thus this is ok *)
+          SemCaseSet.find
+            {id; pat = Obj.magic (); rhs = Obj.magic (); pos_pat = Obj.magic (); neg_pat = Obj.magic ()}
+            sem.cases in
+        topo_sort Symb.eqsym edges vertices
+        |> List.map find_by_id in
+      let wrap_case (case : sem_case) (tm : tm) =
+        TmMatch (pat_info case.pat, scrut, case.pat, case.rhs, tm) in
+      let wrap_param (Param (fi, name, ty)) (tm : tm) =
+        TmLam (fi, name, Symb.Helpers.nosym, false, ty, tm) in
+      let body = List.fold_right wrap_case cases (TmNever sem.fi) in
+      let body = TmLam (sem.fi, us"__sem_target", Symb.Helpers.nosym, false, TyUnknown sem.fi, body) in
+      let body = List.fold_right wrap_param (Option.value ~default:[] sem.params) body in
+      ( sem.fi
+      , lang_value_mangle (lang_name, name)
+      , Symb.Helpers.nosym
+      , translate_ty env sem.ty
+      , translate_tm env body
+      ) in
+  if Record.is_empty lang.values then tm
+  else
+    TmRecLets
+      ( NoInfo
+      , Record.to_seq lang.values
+        |> Seq.map sem_to_binding
+        |> List.of_seq
+      , tm
+      )
+
+let lang_gen : mlang_env -> ustring -> lang_data -> mlang_env * (tm -> tm) = fun env lang_name lang ->
+  let lang_env = lang_to_env lang_name lang in
+  let wrap tm =
+    let env = merge_env_prefer_right env lang_env in
+    wrap_syn_types lang
+      (wrap_aliases env lang
+         (wrap_cons env lang
+            (wrap_sems env lang_name lang tm))) in
+  (lang_env, wrap)
+
+let translate_lang (env : mlang_env) (Lang(fi, name, includes, decls)) : mlang_env * (tm -> tm) =
+  let su = Ustring.to_utf8 in
+  let fetch_include inc =
+    match Record.find_opt inc env.languages with
+    | Some lang -> lang
+    | None -> raise_error fi ("Unknown language '" ^ su inc ^ "' in include list.") in
+  let includes = List.map fetch_include includes in
+  (* TODO(vipa, 2023-11-14): Apply renames via `where` here once the syntax is in *)
+  let lang =
+    { values = Record.empty
+    ; types = Record.empty
+    } in
+  let lang = List.fold_left (merge_langs fi) lang includes in
+  let lang = List.fold_left (add_decl_to_lang fi name) lang decls in
+  let lang_env, wrap = lang_gen env name lang in
+  let new_env =
+    { env with
+      languages = Record.add name (pre_extend_lang lang) env.languages
+    ; language_envs = Record.add name lang_env env.language_envs
+    } in
+  (new_env, wrap)
+
+let translate_top (env : mlang_env) : top -> mlang_env * (tm -> tm) = function
+  | TopLang lang -> translate_lang env lang
   | TopLet (Let (fi, id, ty, tm)) ->
-      let wrap tm' =
-        TmLet
-          ( fi
-          , empty_mangle id
-          , Symb.Helpers.nosym
-          , ty
-          , desugar_tm nss emptyMlangEnv subs tm
-          , tm' )
-      in
-      (nss, langs, subs, syns, wrap :: stack)
+     let new_env = {env with values = Record.remove id env.values} in
+     let wrap inexpr =
+       TmLet
+         ( fi
+         , empty_mangle id
+         , Symb.Helpers.nosym
+         , translate_ty new_env ty
+         , translate_tm new_env tm
+         , inexpr
+         ) in
+     (new_env, wrap)
   | TopType (Type (fi, id, params, ty)) ->
-      let wrap tm' = TmType (fi, id, params, ty, tm') in
-      (nss, langs, subs, syns, wrap :: stack)
+     let new_env = {env with ty_cons = Record.remove id env.ty_cons} in
+     let wrap inexpr =
+       TmType
+         ( fi
+         , empty_mangle id
+         , params
+         , translate_ty env ty
+         , inexpr
+         ) in
+     (new_env, wrap)
   | TopRecLet (RecLet (fi, lets)) ->
-      let wrap tm' =
-        TmRecLets
-          ( fi
-          , List.map
-              (fun (fi', id, ty, tm) ->
-                ( fi'
-                , empty_mangle id
-                , Symb.Helpers.nosym
-                , ty
-                , desugar_tm nss emptyMlangEnv subs tm ) )
-              lets
-          , tm' )
-      in
-      (nss, langs, subs, syns, wrap :: stack)
+     let rem_value values (_, id, _, _) = Record.remove id values in
+     let new_env = {env with values = List.fold_left rem_value env.values lets} in
+     let translate_binding (fi', id, ty, tm) =
+       ( fi'
+       , empty_mangle id
+       , Symb.Helpers.nosym
+       , translate_ty new_env ty
+       , translate_tm new_env tm
+       ) in
+     let wrap inexpr =
+       TmRecLets (fi, List.map translate_binding lets, inexpr) in
+     (new_env, wrap)
   | TopCon (Con (fi, id, ty)) ->
-      let wrap tm' =
-        TmConDef (fi, empty_mangle id, Symb.Helpers.nosym, ty, tm')
-      in
-      (nss, langs, subs, syns, wrap :: stack)
+     let new_env = {env with constructors = Record.remove id env.constructors} in
+     let wrap inexpr =
+       TmConDef (fi, empty_mangle id, Symb.Helpers.nosym, translate_ty env ty, inexpr) in
+     (new_env, wrap)
   | TopUtest (Utest (fi, lhs, rhs, using, onfail)) ->
-      let wrap tm' = TmUtest (fi, lhs, rhs, using, onfail, tm') in
-      (nss, langs, subs, syns, wrap :: stack)
+     let wrap inexpr =
+       TmUtest
+         ( fi
+         , translate_tm env lhs
+         , translate_tm env rhs
+         , Option.map (translate_tm env) using
+         , Option.map (translate_tm env) onfail
+         , inexpr
+         ) in
+     (env, wrap)
   | TopExt (Ext (fi, id, e, ty)) ->
-      let wrap tm' =
-        TmExt (fi, empty_mangle id, Symb.Helpers.nosym, e, ty, tm')
-      in
-      (nss, langs, subs, syns, wrap :: stack)
+     (* NOTE(vipa, 2023-11-14): Externals must have exactly the given
+     name, thus we leave them unchanged, which we do by recording them
+     in `values` (otherwise bindings would be `empty_mangle`d). *)
+     let new_env = {env with values = Record.add id id env.values} in
+     let wrap inexpr =
+       TmExt (fi, id, Symb.Helpers.nosym, e, translate_ty env ty, inexpr) in
+     (new_env, wrap)
 
-let desugar_post_flatten_with_nss nss (Program (_, tops, t)) =
-  let acc_start = (nss, USMap.empty, emptySubsumeEnv, USMap.empty, []) in
-  let new_nss, _langs, subs, syns, stack =
-    List.fold_left desugar_top acc_start tops
-  in
-  (* TODO(vipa, 2022-05-06): This allows `syn` types to be used before
-     their fragment is declared, and also makes them mostly global; they
-     can be used without `use`ing any language fragment. A proper
-     solution would be to mangle them as well *)
-  let syntydecl =
-    List.map
-      (fun (syn, (fi, count)) tm' ->
-        TmType
-          ( fi
-          , syn
-          , List.init count (fun i -> us "a" ^. ustring_of_int i)
-          , TyVariant (fi, [])
-          , tm' ) )
-      (USMap.bindings syns)
-  in
-  let stack = stack @ syntydecl in
-  let desugared_tm =
-    List.fold_left ( |> ) (desugar_tm new_nss emptyMlangEnv subs t) stack
-  in
-  (new_nss, desugared_tm)
+let translate_tops_with_env (env : mlang_env) (tops : top list) (bot : tm) : mlang_env * tm =
+  let rec work env = function
+    | [] -> (env, translate_tm env bot)
+    | top :: tops ->
+       let (env, wrap) = translate_top env top in
+       let (env, bot) = work env tops in
+       (env, wrap bot) in
+  work env tops
 
-(* Desugar top level statements after flattening language fragments. *)
-let desugar_post_flatten prg =
-  snd (desugar_post_flatten_with_nss USMap.empty prg)
+let translate_program_with_env (env : mlang_env) (Program (_includes, tops, bot)) : mlang_env * tm =
+  translate_tops_with_env env tops bot
+
+let translate_program (p : program) : tm =
+  snd (translate_program_with_env empty_mlang_env p)
+
+(* (\* Check that a single language fragment is self-consistent; it has compatible patterns, *)
+(*  * no duplicate definitions, etc. Does not consider included languages at all. *)
+(*  *\) *)
+(* let compute_lang_data (Lang (info, _, _, decls)) : lang_data = *)
+(*   let add_new_syn name ((fi, _, _) as data) = function *)
+(*     | None -> *)
+(*         Some data *)
+(*     | Some (old_fi, _, _) -> *)
+(*         raise_error fi *)
+(*           ( "Duplicate definition of '" ^ Ustring.to_utf8 name *)
+(*           ^ "', previously defined at " *)
+(*           ^ Ustring.to_utf8 (info2str old_fi) ) *)
+(*   in *)
+(*   let add_new_sem name fi data = function *)
+(*     | None -> *)
+(*         Some data *)
+(*     | Some old_data -> *)
+(*         if Option.is_some old_data.params = Option.is_some data.params then *)
+(*           raise_error fi *)
+(*             ( "Duplicate definition of '" ^ Ustring.to_utf8 name *)
+(*             ^ "', previously defined at " *)
+(*             ^ Ustring.to_utf8 (info2str old_data.info) ) *)
+(*         else merge_inter fi name (Some old_data) (Some data) *)
+(*   in *)
+(*   let add_decl lang_data = function *)
+(*     | Data (fi, name, params, cons) -> *)
+(*         { lang_data with *)
+(*           syns= *)
+(*             Record.update name *)
+(*               (add_new_syn name (fi, params, cons)) *)
+(*               lang_data.syns } *)
+(*     | Inter (fi, name, ty, params, cases) -> *)
+(*         let mk_case (pat, rhs) = *)
+(*           let pos_pat = pat_to_normpat pat in *)
+(*           ( pat_info pat *)
+(*           , {pat; rhs; pos_pat; neg_pat= normpat_complement pos_pat} ) *)
+(*         in *)
+(*         let cases = List.map mk_case cases in *)
+(*         let subsets = *)
+(*           pair_with_later cases *)
+(*           |> fold_map *)
+(*                ~fold:(fun a b -> List.rev_append b a) *)
+(*                ~map:(compute_order info) [] *)
+(*         in *)
+(*         let inter_data = {info= fi; ty; params; cases; subsets} in *)
+(*         { lang_data with *)
+(*           inters= *)
+(*             Record.update name *)
+(*               (add_new_sem name fi inter_data) *)
+(*               lang_data.inters } *)
+(*     | Alias (fi, name, params, ty) -> ( *)
+(*       match Record.find_opt name lang_data.alias_defs with *)
+(*       | Some old_fi -> *)
+(*           raise_error fi *)
+(*             ( "Duplicate definition of '" ^ Ustring.to_utf8 name *)
+(*             ^ "', previously defined at " *)
+(*             ^ Ustring.to_utf8 (info2str old_fi) ) *)
+(*       | None -> *)
+(*           { lang_data with *)
+(*             aliases_rev= (name, fi, params, ty) :: lang_data.aliases_rev *)
+(*           ; alias_defs= Record.add name fi lang_data.alias_defs } ) *)
+(*   in *)
+(*   List.fold_left add_decl *)
+(*     { inters= Record.empty *)
+(*     ; syns= Record.empty *)
+(*     ; alias_defs= Record.empty *)
+(*     ; aliases_rev= [] } *)
+(*     decls *)
+
+(* (\* Merges the second language into the first, because the first includes the second *\) *)
+(* let merge_lang_data fi {inters= i1; syns= s1; alias_defs= a1; aliases_rev= ar1} *)
+(*     {inters= i2; syns= s2; alias_defs= a2; aliases_rev= ar2} : lang_data = *)
+(*   let eq_cons (CDecl (_, _, c1, _)) (CDecl (_, _, c2, _)) = c1 =. c2 in *)
+(*   let merge_syn _ a b = *)
+(*     match (a, b) with *)
+(*     | None, None -> *)
+(*         None *)
+(*     | None, Some (fi, count, _) -> *)
+(*         Some (fi, count, []) *)
+(*     | Some a, None -> *)
+(*         Some a *)
+(*     | Some (fi, old_count, cons), Some (_, new_count, old_cons) -> *)
+(*         if old_count <> new_count then *)
+(*           raise_error fi *)
+(*             "This definition has the wrong number of type arguments" *)
+(*         else *)
+(*           Some *)
+(*             ( fi *)
+(*             , old_count *)
+(*             , List.filter *)
+(*                 (fun c1 -> List.exists (eq_cons c1) old_cons |> not) *)
+(*                 cons ) *)
+(*   in *)
+(*   ignore *)
+(*     (Record.merge *)
+(*        (fun _ a b -> *)
+(*          match (a, b) with *)
+(*          | Some fi1, Some fi2 when fi1 <> fi2 -> *)
+(*              raise_error fi1 *)
+(*                "This definition would shadow a previous definition in an \ *)
+(*                 included language fragment." *)
+(*          | _, _ -> *)
+(*              None ) *)
+(*        a1 a2 ) ; *)
+(*   { inters= Record.merge (merge_inter fi) i1 i2 *)
+(*   ; syns= Record.merge merge_syn s1 s2 *)
+(*   ; alias_defs= Record.union (fun _ a _ -> Some a) a1 a2 *)
+(*   ; aliases_rev= *)
+(*       List.filter (fun (name, _, _, _) -> Record.mem name a1) ar2 @ ar1 } *)
+
+
+(* let data_to_lang info name includes {inters; syns; aliases_rev; _} : mlang = *)
+(*   let info_assoc fi l = List.find (fun (fi2, _) -> eq_info fi fi2) l |> snd in *)
+(*   let syns = *)
+(*     Record.bindings syns *)
+(*     |> List.map (fun (syn_name, (fi, count, cons)) -> *)
+(*            Data (fi, syn_name, count, cons) ) *)
+(*   in *)
+(*   let sort_inter name {info; ty; params; cases; subsets} = *)
+(*     let mk_case fi = *)
+(*       let case = info_assoc fi cases in *)
+(*       (case.pat, case.rhs) *)
+(*     in *)
+(*     let cases = *)
+(*       List.map fst cases |> topo_sort eq_info subsets |> List.map mk_case *)
+(*     in *)
+(*     Inter (info, name, ty, params, cases) *)
+(*   in *)
+(*   let inters = *)
+(*     Record.bindings inters *)
+(*     |> List.map (fun (name, inter_data) -> sort_inter name inter_data) *)
+(*   in *)
+(*   let aliases = *)
+(*     aliases_rev *)
+(*     |> List.map (fun (name, fi, params, ty) -> Alias (fi, name, params, ty)) *)
+(*   in *)
+(*   Lang *)
+(*     ( info *)
+(*     , name *)
+(*     , includes *)
+(*     , List.rev_append aliases (List.rev_append syns inters) ) *)
+
+(* let flatten_lang (prev_langs : lang_data Record.t) : *)
+(*     top -> lang_data Record.t * top = function *)
+(*   | (TopLet _ | TopType _ | TopRecLet _ | TopCon _ | TopUtest _ | TopExt _) as *)
+(*     top -> *)
+(*       (prev_langs, top) *)
+(*   | TopLang (Lang (info, name, includes, _) as lang) -> *)
+(*       let self_data = compute_lang_data lang in *)
+(*       let included_data = List.map (lookup_lang info prev_langs) includes in *)
+(*       let merged_data = *)
+(*         List.fold_left (merge_lang_data info) self_data included_data *)
+(*       in *)
+(*       ( Record.add name merged_data prev_langs *)
+(*       , TopLang (data_to_lang info name includes merged_data) ) *)
+
+(* let flatten_with_env (prev_langs : lang_data Record.t) *)
+(*     (Program (includes, tops, e) : program) = *)
+(*   let new_langs, new_tops = accum_map flatten_lang prev_langs tops in *)
+(*   (new_langs, Program (includes, new_tops, e)) *)
+
+(* (\* Flatten top-level language definitions *\) *)
+(* let flatten prg : program = snd (flatten_with_env Record.empty prg) *)
+
+(* (\*************** *)
+(*  * Translation * *)
+(*  ***************\) *)
+
+(* module AstHelpers = struct *)
+(*   let var fi x = TmVar (fi, x, Symb.Helpers.nosym, false, false) *)
+
+(*   let app fi l r = TmApp (fi, l, r) *)
+
+(*   let let_ fi x s e body = TmLet (fi, x, s, TyUnknown fi, e, body) *)
+(* end *)
+
+(* open AstHelpers *)
+
+(* let translate_cases fi f target cases = *)
+(*   let translate_case (pat, handler) inner = *)
+(*     TmMatch (pat_info pat, target, pat, handler, inner) *)
+(*   in *)
+(*   let msg = *)
+(*     Mseq.map *)
+(*       (fun c -> TmConst (fi, CChar c)) *)
+(*       (us "No matching case for function " ^. f |> Mseq.Helpers.of_ustring) *)
+(*   in *)
+(*   let no_match = *)
+(*     let_ fi (us "_") Symb.Helpers.nosym *)
+(*       (\* TODO(?,?): we should probably have a special sort for let with wildcards *\) *)
+(*       (app fi (TmConst (fi, Cdprint)) target) *)
+(*       (app fi (TmConst (fi, Cerror)) (TmSeq (fi, msg))) *)
+(*   in *)
+(*   List.fold_right translate_case cases no_match *)
+
+(* module USMap = Map.Make (Ustring) *)
+
+(* type mlangEnv = *)
+(*   { constructors: ustring USMap.t *)
+(*   ; normals: ustring USMap.t *)
+(*   ; aliases: ustring USMap.t } *)
+
+(* let emptyMlangEnv = *)
+(*   {constructors= USMap.empty; normals= USMap.empty; aliases= USMap.empty} *)
+
+(* (\* Compute the intersection of a and b, by overwriting names in a with the names *)
+(*    in b *\) *)
+(* let intersect_env_overwrite fi a b = *)
+(*   let merger = function *)
+(*     | None, None -> *)
+(*         None *)
+(*     | Some _, Some r -> *)
+(*         Some r *)
+(*     | None, Some _ -> *)
+(*         None *)
+(*     | Some l, None -> *)
+(*         raise_error fi *)
+(*           ( "Binding '" ^ Ustring.to_utf8 l *)
+(*           ^ "' exists only in the subsumed language, which should be \ *)
+(*              impossible.\n" ) *)
+(*   in *)
+(*   { constructors= *)
+(*       USMap.merge (fun _ l r -> merger (l, r)) a.constructors b.constructors *)
+(*   ; normals= USMap.merge (fun _ l r -> merger (l, r)) a.normals b.normals *)
+(*   ; aliases= USMap.merge (fun _ l r -> merger (l, r)) a.aliases b.aliases } *)
+
+(* (\* Adds the names from b to a, overwriting with the name from b when they overlap *\) *)
+(* let merge_env_overwrite a b = *)
+(*   { constructors= *)
+(*       USMap.union (fun _ _ r -> Some r) a.constructors b.constructors *)
+(*   ; normals= USMap.union (fun _ _ r -> Some r) a.normals b.normals *)
+(*   ; aliases= USMap.union (fun _ _ r -> Some r) a.aliases b.aliases } *)
+
+(* let empty_mangle str = str *)
+
+(* let resolve_con {constructors; _} ident = *)
+(*   match USMap.find_opt ident constructors with *)
+(*   | Some ident' -> *)
+(*       ident' *)
+(*   | None -> *)
+(*       empty_mangle ident *)
+
+(* let resolve_id {normals; _} ident = *)
+(*   match USMap.find_opt ident normals with *)
+(*   | Some ident' -> *)
+(*       ident' *)
+(*   | None -> *)
+(*       empty_mangle ident *)
+
+(* let resolve_alias {aliases; _} ident = *)
+(*   match USMap.find_opt ident aliases with *)
+(*   | Some ident' -> *)
+(*       ident' *)
+(*   | None -> *)
+(*       empty_mangle ident *)
+
+(* let delete_id ({normals; _} as env) ident = *)
+(*   {env with normals= USMap.remove ident normals} *)
+
+(* let delete_con ({constructors; _} as env) ident = *)
+(*   {env with constructors= USMap.remove ident constructors} *)
+
+(* let delete_alias ({aliases; _} as env) ident = *)
+(*   {env with aliases= USMap.remove ident aliases} *)
+
+(* (\* Maintains a subsumption relation among the languages (a reflexive and *)
+(*    transitive relation). A subsumes B if any call to a semantic function in A *)
+(*    can be replaced by a call to a semantic function in B with unchanged result. *)
+(*    Subsumption is only checked for language composition (lang A = B + C). *)
+(*    Subsumption implies inclusion, but not the other way around. *)
+
+(*    subsumer: Maintains the current subsumer of each language. If the binding (A, *)
+(*    B) is in 'subsumer', then the language B subsumes the language A, and B is *)
+(*    not subsumed by any other language (B is a "maximal" subsumer of A). If A is *)
+(*    not bound in 'subsumer', then A is subsumed by itself only. *)
+
+(*    subsumes: Maintains the set of languages that a language subsumes (excluding *)
+(*    self-subsumption). *\) *)
+(* type subsumeEnv = {subsumer: ustring USMap.t; subsumes: USSet.t USMap.t} *)
+
+(* let emptySubsumeEnv = {subsumer= USMap.empty; subsumes= USMap.empty} *)
+
+(* let enable_subsumption_analysis = ref false *)
+
+(* (\* Check if the first language is subsumed by the second *\) *)
+(* let lang_is_subsumed_by l1 l2 = *)
+(*   match (l1, l2) with *)
+(*   | Lang (fi, _, _, decls1), Lang (_, _, _, decls2) -> *)
+(*       let decl_is_subsumed_by = function *)
+(*         | Inter (_, n1, _, _, cases1), Inter (_, n2, _, _, cases2) *)
+(*           when n1 =. n2 -> *)
+(*             let mk_pos_neg (pat, _) = *)
+(*               let pos_pat = pat_to_normpat pat in *)
+(*               let neg_pat = normpat_complement pos_pat in *)
+(*               (pos_pat, neg_pat) *)
+(*             in *)
+(*             let cases1 = List.map mk_pos_neg cases1 in *)
+(*             let cases2 = List.map mk_pos_neg cases2 in *)
+(*             (\* First, filter out cases in B that are equal to A; those are *)
+(*                included from A *\) *)
+(*             let cases2 = *)
+(*               List.filter *)
+(*                 (fun (p2, n2) -> *)
+(*                   let is_equal = *)
+(*                     List.fold_left *)
+(*                       (fun is_equal (p1, n1) -> *)
+(*                         is_equal *)
+(*                         || *)
+(*                         match order_query (p1, n1) (p2, n2) with *)
+(*                         | Equal -> *)
+(*                             true *)
+(*                         | _ -> *)
+(*                             false ) *)
+(*                       false cases1 *)
+(*                   in *)
+(*                   not is_equal ) *)
+(*                 cases2 *)
+(*             in *)
+(*             (\* Then, check if all patterns in A are smaller than remaining *)
+(*                patterns in B *\) *)
+(*             List.for_all *)
+(*               (fun (p1, n1) -> *)
+(*                 List.fold_left *)
+(*                   (fun is_smaller (p2, n2) -> *)
+(*                     if not is_smaller then is_smaller *)
+(*                     else *)
+(*                       match order_query (p1, n1) (p2, n2) with *)
+(*                       | Subset | Disjoint -> *)
+(*                           true *)
+(*                       | Superset -> *)
+(*                           false *)
+(*                       | Equal | Overlapping _ -> *)
+(*                           raise_error fi *)
+(*                             "Two patterns in this semantic function are \ *)
+(*                              either equal or overlapping, which should be \ *)
+(*                              impossible" ) *)
+(*                   true cases2 ) *)
+(*               cases1 *)
+(*         | Data _, Data _ *)
+(*         | Inter _, Inter _ *)
+(*         | Data _, Inter _ *)
+(*         | Inter _, Data _ *)
+(*         | Alias _, Data _ *)
+(*         | Alias _, Inter _ *)
+(*         | Alias _, Alias _ *)
+(*         | Data _, Alias _ *)
+(*         | Inter _, Alias _ -> *)
+(*             true *)
+(*       in *)
+(*       List.for_all *)
+(*         (fun d1 -> List.for_all (fun d2 -> decl_is_subsumed_by (d1, d2)) decls2) *)
+(*         decls1 *)
+
+(* (\* Compute the resulting subsumption environment for a language declaration *\) *)
+(* let handle_subsumption env langs lang includes = *)
+(*   if !enable_subsumption_analysis then *)
+(*     (\* Find a subsumer for a language, if any exists. *\) *)
+(*     let find_subsumer env x = *)
+(*       (\* y is a subsumer of x if y has no subsumer and it subsumes x *\) *)
+(*       let is_subsumer y = *)
+(*         match USMap.find_opt y env.subsumer with *)
+(*         | Some _ -> *)
+(*             false *)
+(*         | None -> ( *)
+(*           match USMap.find_opt y env.subsumes with *)
+(*           | None -> *)
+(*               false *)
+(*           | Some set -> *)
+(*               USSet.mem x set ) *)
+(*       in *)
+(*       (\* Set b as the subsumer where currently a is *\) *)
+(*       let replace_subsumer subsumer_map a b = *)
+(*         USMap.map (fun x -> if x =. a then b else x) subsumer_map *)
+(*       in *)
+(*       let found_subsumer, subsumer = *)
+(*         USMap.fold *)
+(*           (fun k _ acc -> *)
+(*             match acc with true, _ -> acc | _ -> (is_subsumer k, k) ) *)
+(*           env.subsumes (false, x) *)
+(*       in *)
+(*       if found_subsumer then *)
+(*         { {env with subsumer= replace_subsumer env.subsumer x subsumer} with *)
+(*           subsumer= USMap.add x subsumer env.subsumer } *)
+(*       else env *)
+(*     in *)
+(*     (\* Finds new subsumers for languages that were previously subsumed by lang *\) *)
+(*     let del_lang env = *)
+(*       let subsumed_langs = USMap.find_opt lang env.subsumes in *)
+(*       let env = {env with subsumes= USMap.remove lang env.subsumes} in *)
+(*       match subsumed_langs with *)
+(*       | Some set -> *)
+(*           let env = *)
+(*             { env with *)
+(*               subsumer= *)
+(*                 USMap.filter (fun k _ -> not (USSet.mem k set)) env.subsumer } *)
+(*           in *)
+(*           let env = USSet.fold (fun x acc -> find_subsumer acc x) set env in *)
+(*           env *)
+(*       | None -> *)
+(*           env *)
+(*     in *)
+(*     (\* Subsume the language, and recursively subsume the languages that were *)
+(*        previously subsumed by it *\) *)
+(*     let rec add_lang to_be_subsumed env = *)
+(*       let env = *)
+(*         {env with subsumer= USMap.add to_be_subsumed lang env.subsumer} *)
+(*       in *)
+(*       let env = *)
+(*         match USMap.find_opt to_be_subsumed env.subsumes with *)
+(*         | Some set -> *)
+(*             USSet.fold add_lang set env *)
+(*         | None -> *)
+(*             env *)
+(*       in *)
+(*       { env with *)
+(*         subsumes= *)
+(*           USMap.update lang *)
+(*             (function *)
+(*               | None -> *)
+(*                   Some (USSet.singleton to_be_subsumed) *)
+(*               | Some set -> *)
+(*                   Some (USSet.add to_be_subsumed set) ) *)
+(*             env.subsumes } *)
+(*     in *)
+(*     List.fold_left *)
+(*       (fun acc included -> *)
+(*         if *)
+(*           lang_is_subsumed_by *)
+(*             (USMap.find included langs) *)
+(*             (USMap.find lang langs) *)
+(*         then add_lang included acc *)
+(*         else acc ) *)
+(*       (del_lang env) includes *)
+(*   else env *)
+
+(* let rec desugar_ty env = function *)
+(*   | TyArrow (fi, lty, rty) -> *)
+(*       TyArrow (fi, desugar_ty env lty, desugar_ty env rty) *)
+(*   | TyAll (fi, id, ty) -> *)
+(*       TyAll (fi, id, desugar_ty env ty) *)
+(*   | TySeq (fi, ty) -> *)
+(*       TySeq (fi, desugar_ty env ty) *)
+(*   | TyTensor (fi, ty) -> *)
+(*       TyTensor (fi, desugar_ty env ty) *)
+(*   | TyRecord (fi, bindings) -> *)
+(*       TyRecord (fi, Record.map (desugar_ty env) bindings) *)
+(*   | TyVariant (fi, constrs) -> *)
+(*       TyVariant (fi, constrs) *)
+(*   | TyCon (fi, id) -> *)
+(*       TyCon (fi, resolve_alias env id) *)
+(*   | TyVar (fi, id) -> *)
+(*       TyVar (fi, id) *)
+(*   | TyApp (fi, lty, rty) -> *)
+(*       TyApp (fi, desugar_ty env lty, desugar_ty env rty) *)
+(*   | (TyUnknown _ | TyBool _ | TyInt _ | TyFloat _ | TyChar _) as ty -> *)
+(*       ty *)
+
+(* let rec desugar_tm nss env subs = *)
+(*   let map_right f (a, b) = (a, f b) in *)
+(*   function *)
+(*   (\* Referencing things *\) *)
+(*   | TmVar (fi, name, i, pes, frozen) -> *)
+(*       TmVar (fi, resolve_id env name, i, pes, frozen) *)
+(*   (\* Introducing things *\) *)
+(*   | TmLam (fi, name, s, pes, ty, body) -> *)
+(*       TmLam *)
+(*         ( fi *)
+(*         , empty_mangle name *)
+(*         , s *)
+(*         , pes *)
+(*         , desugar_ty env ty *)
+(*         , desugar_tm nss (delete_id env name) subs body ) *)
+(*   | TmLet (fi, name, s, ty, e, body) -> *)
+(*       TmLet *)
+(*         ( fi *)
+(*         , empty_mangle name *)
+(*         , s *)
+(*         , desugar_ty env ty *)
+(*         , desugar_tm nss env subs e *)
+(*         , desugar_tm nss (delete_id env name) subs body ) *)
+(*   | TmType (fi, name, params, ty, body) -> *)
+(*       TmType *)
+(*         ( fi *)
+(*         , name *)
+(*         , params *)
+(*         , desugar_ty env ty *)
+(*         , desugar_tm nss (delete_alias env name) subs body ) *)
+(*   | TmRecLets (fi, bindings, body) -> *)
+(*       let env' = *)
+(*         List.fold_left *)
+(*           (fun env' (_, name, _, _, _) -> delete_id env' name) *)
+(*           env bindings *)
+(*       in *)
+(*       TmRecLets *)
+(*         ( fi *)
+(*         , List.map *)
+(*             (fun (fi, name, s, ty, e) -> *)
+(*               ( fi *)
+(*               , empty_mangle name *)
+(*               , s *)
+(*               , desugar_ty env ty *)
+(*               , desugar_tm nss env' subs e ) ) *)
+(*             bindings *)
+(*         , desugar_tm nss env' subs body ) *)
+(*   | TmConDef (fi, name, s, ty, body) -> *)
+(*       TmConDef *)
+(*         ( fi *)
+(*         , empty_mangle name *)
+(*         , s *)
+(*         , desugar_ty env ty *)
+(*         , desugar_tm nss (delete_con env name) subs body ) *)
+(*   | TmConApp (fi, x, s, t) -> *)
+(*       TmConApp (fi, resolve_con env x, s, desugar_tm nss env subs t) *)
+(*   | TmClos _ as tm -> *)
+(*       tm *)
+(*   (\* Both introducing and referencing *\) *)
+(*   | TmMatch (fi, target, pat, thn, els) -> *)
+(*       let desugar_pname env = function *)
+(*         | NameStr (n, s) -> *)
+(*             (delete_id env n, NameStr (empty_mangle n, s)) *)
+(*         | NameWildcard -> *)
+(*             (env, NameWildcard) *)
+(*       in *)
+(*       let rec desugar_pat_seq env pats = *)
+(*         Mseq.Helpers.fold_right *)
+(*           (fun p (env, pats) -> *)
+(*             desugar_pat env p |> map_right (fun p -> Mseq.cons p pats) ) *)
+(*           (env, Mseq.empty) pats *)
+(*       and desugar_pat env = function *)
+(*         | PatNamed (fi, name) -> *)
+(*             name |> desugar_pname env |> map_right (fun n -> PatNamed (fi, n)) *)
+(*         | PatSeqTot (fi, pats) -> *)
+(*             let env, pats = desugar_pat_seq env pats in *)
+(*             (env, PatSeqTot (fi, pats)) *)
+(*         | PatSeqEdge (fi, l, x, r) -> *)
+(*             let env, l = desugar_pat_seq env l in *)
+(*             let env, x = desugar_pname env x in *)
+(*             let env, r = desugar_pat_seq env r in *)
+(*             (env, PatSeqEdge (fi, l, x, r)) *)
+(*         | PatRecord (fi, pats) -> *)
+(*             let env = ref env in *)
+(*             let pats = *)
+(*               pats *)
+(*               |> Record.map (fun p -> *)
+(*                      let env', p = desugar_pat !env p in *)
+(*                      env := env' ; *)
+(*                      p ) *)
+(*             in *)
+(*             (!env, PatRecord (fi, pats)) *)
+(*         | PatAnd (fi, l, r) -> *)
+(*             let env, l = desugar_pat env l in *)
+(*             let env, r = desugar_pat env r in *)
+(*             (env, PatAnd (fi, l, r)) *)
+(*         | PatOr (fi, l, r) -> *)
+(*             let env, l = desugar_pat env l in *)
+(*             let env, r = desugar_pat env r in *)
+(*             (env, PatOr (fi, l, r)) *)
+(*         | PatNot (fi, p) -> *)
+(*             let env, p = desugar_pat env p in *)
+(*             (env, PatNot (fi, p)) *)
+(*         | PatCon (fi, name, sym, p) -> *)
+(*             desugar_pat env p *)
+(*             |> map_right (fun p -> PatCon (fi, resolve_con env name, sym, p)) *)
+(*         | (PatInt _ | PatChar _ | PatBool _) as pat -> *)
+(*             (env, pat) *)
+(*       in *)
+(*       let env', pat' = desugar_pat env pat in *)
+(*       TmMatch *)
+(*         ( fi *)
+(*         , desugar_tm nss env subs target *)
+(*         , pat' *)
+(*         , desugar_tm nss env' subs thn *)
+(*         , desugar_tm nss env subs els ) *)
+(*   (\* Use *\) *)
+(*   | TmUse (fi, name, body) -> ( *)
+(*     match USMap.find_opt name nss with *)
+(*     | None -> *)
+(*         raise_error fi *)
+(*           ("Unknown language fragment '" ^ Ustring.to_utf8 name ^ "'") *)
+(*     | Some ns -> *)
+(*         let intersected_ns = *)
+(*           match USMap.find_opt name subs.subsumer with *)
+(*           | None -> *)
+(*               ns *)
+(*           | Some subsumer -> *)
+(*               (\* Use namespace from subsumer, but prune bindings that are not *)
+(*                  defined in the subsumed namespace *\) *)
+(*               intersect_env_overwrite fi ns (USMap.find subsumer nss) *)
+(*         in *)
+(*         desugar_tm nss (merge_env_overwrite env intersected_ns) subs body ) *)
+(*   (\* Simple recursions *\) *)
+(*   | TmApp (fi, a, b) -> *)
+(*       TmApp (fi, desugar_tm nss env subs a, desugar_tm nss env subs b) *)
+(*   | TmSeq (fi, tms) -> *)
+(*       TmSeq (fi, Mseq.map (desugar_tm nss env subs) tms) *)
+(*   | TmRecord (fi, r) -> *)
+(*       TmRecord (fi, Record.map (desugar_tm nss env subs) r) *)
+(*   | TmRecordUpdate (fi, a, lab, b) -> *)
+(*       TmRecordUpdate *)
+(*         (fi, desugar_tm nss env subs a, lab, desugar_tm nss env subs b) *)
+(*   | TmUtest (fi, a, b, using, onfail, body) -> *)
+(*       let using_desugared = Option.map (desugar_tm nss env subs) using in *)
+(*       let onfail_desugared = Option.map (desugar_tm nss env subs) onfail in *)
+(*       TmUtest *)
+(*         ( fi *)
+(*         , desugar_tm nss env subs a *)
+(*         , desugar_tm nss env subs b *)
+(*         , using_desugared *)
+(*         , onfail_desugared *)
+(*         , desugar_tm nss env subs body ) *)
+(*   | TmNever fi -> *)
+(*       TmNever fi *)
+(*   | TmDive (fi, l, a) -> *)
+(*       TmDive (fi, l, desugar_tm nss env subs a) *)
+(*   | TmPreRun (fi, l, a) -> *)
+(*       TmPreRun (fi, l, desugar_tm nss env subs a) *)
+(*   | TmBox (_, _) -> *)
+(*       failwith "Box is a runtime value" *)
+(*   (\* Non-recursive *\) *)
+(*   | (TmConst _ | TmRef _ | TmTensor _ | TmExt _) as tm -> *)
+(*       tm *)
+
+(* (\* add namespace to nss (overwriting) if relevant, prepend a tm -> tm function to stack, return updated tuple. Should use desugar_tm, as well as desugar both sem and syn *\) *)
+(* let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function *)
+(*   | TopLang (Lang (fi, langName, includes, decls) as lang) -> *)
+(*       let default d = function Some x -> x | None -> d in *)
+(*       let add_lang ns lang = *)
+(*         USMap.find_opt lang nss |> default emptyMlangEnv *)
+(*         |> merge_env_overwrite ns *)
+(*       in *)
+(*       let previous_ns = List.fold_left add_lang emptyMlangEnv includes in *)
+(*       (\* compute the namespace *\) *)
+(*       let mangle str = langName ^. us "_" ^. str in *)
+(*       let cdecl_names (CDecl (_, _, name, _)) = (name, mangle name) in *)
+(*       let add_decl ({constructors; normals; aliases}, syns) = function *)
+(*         | Data (fi, name, count, cdecls) -> *)
+(*             let new_constructors = List.to_seq cdecls |> Seq.map cdecl_names in *)
+(*             ( { constructors= USMap.add_seq new_constructors constructors *)
+(*               ; aliases *)
+(*               ; normals } *)
+(*             , USMap.add name (fi, count) syns ) *)
+(*         | Inter (_, name, _, _, _) -> *)
+(*             ( { normals= USMap.add name (mangle name) normals *)
+(*               ; aliases *)
+(*               ; constructors } *)
+(*             , syns ) *)
+(*         | Alias (_, name, _, _) -> *)
+(*             ( { aliases= USMap.add name (mangle name) aliases *)
+(*               ; normals *)
+(*               ; constructors } *)
+(*             , syns ) *)
+(*       in *)
+(*       let ns, new_syns = List.fold_left add_decl (previous_ns, syns) decls in *)
+(*       (\* wrap in "con"s *\) *)
+(*       let wrap_con ty_name (CDecl (fi, params, cname, ty)) tm = *)
+(*         let app_param ty param = TyApp (fi, ty, TyVar (fi, param)) in *)
+(*         let all_param param ty = TyAll (fi, param, ty) in *)
+(*         let con = List.fold_left app_param (TyCon (fi, ty_name)) params in *)
+(*         TmConDef *)
+(*           ( fi *)
+(*           , mangle cname *)
+(*           , Symb.Helpers.nosym *)
+(*           , List.fold_right all_param params *)
+(*               (TyArrow (fi, desugar_ty ns ty, con)) *)
+(*           , tm ) *)
+(*       in *)
+(*       (\* TODO(vipa,?): the type will likely be incorrect once we start doing product extensions of constructors *\) *)
+(*       let wrap_data decl tm = *)
+(*         match decl with *)
+(*         | Data (_, name, _, cdecls) -> *)
+(*             List.fold_right (wrap_con name) cdecls tm *)
+(*         | Alias (fi, name, params, ty) -> *)
+(*             TmType (fi, mangle name, params, desugar_ty ns ty, tm) *)
+(*         | _ -> *)
+(*             tm *)
+(*       in *)
+(*       (\* translate "Inter"s into (info * ustring * tm) *\) *)
+(*       let inter_to_tm fname fi params cases = *)
+(*         let target = us "__sem_target" in *)
+(*         let wrap_param (Param (fi, name, ty)) tm = *)
+(*           TmLam (fi, name, Symb.Helpers.nosym, false, desugar_ty ns ty, tm) *)
+(*         in *)
+(*         TmLam *)
+(*           ( fi *)
+(*           , target *)
+(*           , Symb.Helpers.nosym *)
+(*           , false *)
+(*           , TyUnknown fi *)
+(*           , translate_cases fi fname (var fi target) cases ) *)
+(*         |> List.fold_right wrap_param params *)
+(*         |> desugar_tm nss ns subs *)
+(*         (\* TODO: pass new subs here? *\) *)
+(*       in *)
+(*       let translate_inter = function *)
+(*         | Inter (fi, name, ty, params, cases) -> *)
+(*             let params = *)
+(*               match params with Some params -> params | None -> [] *)
+(*             in *)
+(*             Some *)
+(*               ( fi *)
+(*               , mangle name *)
+(*               , Symb.Helpers.nosym *)
+(*               , desugar_ty ns ty *)
+(*               , inter_to_tm name fi params cases ) *)
+(*         | _ -> *)
+(*             None *)
+(*       in *)
+(*       (\* put translated inters in a single letrec, then wrap in cons, then done *\) *)
+(*       let wrap tm = *)
+(*         TmRecLets (fi, List.filter_map translate_inter decls, tm) *)
+(*         |> List.fold_right wrap_data decls *)
+(*       in *)
+(*       let new_langs = USMap.add langName lang langs in *)
+(*       ( USMap.add langName ns nss *)
+(*       , new_langs *)
+(*       , handle_subsumption subs new_langs langName includes *)
+(*       , new_syns *)
+(*       , wrap :: stack ) *)
+(*   (\* The other tops are trivial translations *\) *)
+(*   | TopLet (Let (fi, id, ty, tm)) -> *)
+(*       let wrap tm' = *)
+(*         TmLet *)
+(*           ( fi *)
+(*           , empty_mangle id *)
+(*           , Symb.Helpers.nosym *)
+(*           , ty *)
+(*           , desugar_tm nss emptyMlangEnv subs tm *)
+(*           , tm' ) *)
+(*       in *)
+(*       (nss, langs, subs, syns, wrap :: stack) *)
+(*   | TopType (Type (fi, id, params, ty)) -> *)
+(*       let wrap tm' = TmType (fi, id, params, ty, tm') in *)
+(*       (nss, langs, subs, syns, wrap :: stack) *)
+(*   | TopRecLet (RecLet (fi, lets)) -> *)
+(*       let wrap tm' = *)
+(*         TmRecLets *)
+(*           ( fi *)
+(*           , List.map *)
+(*               (fun (fi', id, ty, tm) -> *)
+(*                 ( fi' *)
+(*                 , empty_mangle id *)
+(*                 , Symb.Helpers.nosym *)
+(*                 , ty *)
+(*                 , desugar_tm nss emptyMlangEnv subs tm ) ) *)
+(*               lets *)
+(*           , tm' ) *)
+(*       in *)
+(*       (nss, langs, subs, syns, wrap :: stack) *)
+(*   | TopCon (Con (fi, id, ty)) -> *)
+(*       let wrap tm' = *)
+(*         TmConDef (fi, empty_mangle id, Symb.Helpers.nosym, ty, tm') *)
+(*       in *)
+(*       (nss, langs, subs, syns, wrap :: stack) *)
+(*   | TopUtest (Utest (fi, lhs, rhs, using, onfail)) -> *)
+(*       let wrap tm' = TmUtest (fi, lhs, rhs, using, onfail, tm') in *)
+(*       (nss, langs, subs, syns, wrap :: stack) *)
+(*   | TopExt (Ext (fi, id, e, ty)) -> *)
+(*       let wrap tm' = *)
+(*         TmExt (fi, empty_mangle id, Symb.Helpers.nosym, e, ty, tm') *)
+(*       in *)
+(*       (nss, langs, subs, syns, wrap :: stack) *)
+
+(* let desugar_post_flatten_with_nss nss (Program (_, tops, t)) = *)
+(*   let acc_start = (nss, USMap.empty, emptySubsumeEnv, USMap.empty, []) in *)
+(*   let new_nss, _langs, subs, syns, stack = *)
+(*     List.fold_left desugar_top acc_start tops *)
+(*   in *)
+(*   (\* TODO(vipa, 2022-05-06): This allows `syn` types to be used before *)
+(*      their fragment is declared, and also makes them mostly global; they *)
+(*      can be used without `use`ing any language fragment. A proper *)
+(*      solution would be to mangle them as well *\) *)
+(*   let syntydecl = *)
+(*     List.map *)
+(*       (fun (syn, (fi, count)) tm' -> *)
+(*         TmType *)
+(*           ( fi *)
+(*           , syn *)
+(*           , List.init count (fun i -> us "a" ^. ustring_of_int i) *)
+(*           , TyVariant (fi, []) *)
+(*           , tm' ) ) *)
+(*       (USMap.bindings syns) *)
+(*   in *)
+(*   let stack = stack @ syntydecl in *)
+(*   let desugared_tm = *)
+(*     List.fold_left ( |> ) (desugar_tm new_nss emptyMlangEnv subs t) stack *)
+(*   in *)
+(*   (new_nss, desugared_tm) *)
+
+(* (\* Desugar top level statements after flattening language fragments. *\) *)
+(* let desugar_post_flatten prg = *)
+(*   snd (desugar_post_flatten_with_nss USMap.empty prg) *)

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -77,9 +77,13 @@ let topo_sort (eq : 'a -> 'a -> bool) (edges : ('a * 'a) list)
 (* === Types for MLang language fragments and their contents === *)
 
 type sem_case_id = Symb.t
+
 type sem_id = Symb.t
+
 type syn_case_id = Symb.t
+
 type syn_id = Symb.t
+
 type alias_id = Symb.t
 
 type sem_case =
@@ -93,17 +97,20 @@ type sem_case =
 
 module SemCase = struct
   type t = sem_case
+
   let compare a b = Symb.compare a.id b.id
 end
+
 module SemCaseSet = Set.Make (SemCase)
 
 module SubsetOrd = struct
-  type t = (sem_id * sem_id)
+  type t = sem_id * sem_id
+
   let compare (a1, a2) (b1, b2) =
     let res = Symb.compare a1 b1 in
-    if res <> 0 then res else
-      Symb.compare a2 b2
+    if res <> 0 then res else Symb.compare a2 b2
 end
+
 module SubsetOrdSet = Set.Make (SubsetOrd)
 
 type sem_data =
@@ -122,32 +129,27 @@ type syn_case =
   ; fi: info
   ; def_here: bool
   ; ty_params: ustring list
-  ; name: (ustring * ustring) (* prefix, name *)
-  ; carried: ty
-  }
+  ; name: ustring * ustring (* prefix, name *)
+  ; carried: ty }
 
 type syn_data =
   { id: syn_id
   ; def_here: bool
-  ; ty: (ustring * ustring * int) (* prefix, name, number of parameters *)
+  ; ty: ustring * ustring * int (* prefix, name, number of parameters *)
   ; cons: syn_case Record.t
-  ; fi: info
-  }
+  ; fi: info }
 
 type alias_data =
   { id: alias_id
   ; def_here: bool
-  ; name: (ustring * ustring) (* prefix, name *)
+  ; name: ustring * ustring (* prefix, name *)
   ; params: ustring list
   ; ty: ty
-  ; fi: info
-  }
+  ; fi: info }
 
 type ty_in_lang = (alias_data, syn_data) Either.t
-type lang_data =
-  { values: sem_data Record.t
-  ; types: ty_in_lang Record.t
-  }
+
+type lang_data = {values: sem_data Record.t; types: ty_in_lang Record.t}
 
 (* let spprint_inter_data {info; cases; _} : ustring = *)
 (*   List.map *)
@@ -167,37 +169,41 @@ type lang_data =
 (* NOTE(vipa, 2023-11-14): When we extend a language most components
  * of the old language are simply in scope, they should not be re-defined
  * in the new fragment; this function is what makes it so. *)
-let pre_extend_lang : lang_data -> lang_data = fun lang ->
-  let work_syn_case : syn_case -> syn_case = fun case ->
-    { case with def_here = false } in
-  let work_syn : syn_data -> syn_data = fun data ->
-    { data with
-      def_here = false
-    ; cons = Record.map work_syn_case data.cons
-    } in
-  let work_alias : alias_data -> alias_data = fun data ->
-    { data with
-      def_here = false
-    } in
+let pre_extend_lang : lang_data -> lang_data =
+ fun lang ->
+  let work_syn_case : syn_case -> syn_case =
+   fun case -> {case with def_here= false}
+  in
+  let work_syn : syn_data -> syn_data =
+   fun data ->
+    {data with def_here= false; cons= Record.map work_syn_case data.cons}
+  in
+  let work_alias : alias_data -> alias_data =
+   fun data -> {data with def_here= false}
+  in
   { lang with
-    types = Record.map (Either.map ~left:work_alias ~right:work_syn) lang.types
+    types= Record.map (Either.map ~left:work_alias ~right:work_syn) lang.types
   }
 
 (* NOTE(vipa, 2023-11-14): Compute the order between two sem cases
-based on the specificity of their patterns *)
+   based on the specificity of their patterns *)
 let compute_order (fi : info)
     ({id= id1; pat= pat1; pos_pat= p1; neg_pat= n1; _} : sem_case)
-    ({id= id2; pat= pat2; pos_pat= p2; neg_pat= n2; _} : sem_case) : (sem_case_id * sem_case_id) option =
+    ({id= id2; pat= pat2; pos_pat= p2; neg_pat= n2; _} : sem_case) :
+    (sem_case_id * sem_case_id) option =
   let string_of_pat pat = ustring_of_pat pat |> Ustring.to_utf8 in
   let info2str fi = info2str fi |> Ustring.to_utf8 in
   match order_query (p1, n1) (p2, n2) with
   | Subset ->
-     Some (id1, id2)
+      Some (id1, id2)
   | Superset ->
-     Some (id2, id1)
+      Some (id2, id1)
   | Equal ->
       raise_error fi
-        ( "Patterns at " ^ info2str (pat_info pat1) ^ " and " ^ info2str (pat_info pat2)
+        ( "Patterns at "
+        ^ info2str (pat_info pat1)
+        ^ " and "
+        ^ info2str (pat_info pat2)
         ^ " cannot be ordered by specificity; they match exactly the same \
            values." )
   | Disjoint ->
@@ -205,566 +211,686 @@ let compute_order (fi : info)
   | Overlapping (only1, both, only2) ->
       "Two patterns in this semantic function cannot be ordered by \
        specificity (neither is more specific than the other), but the order \
-       matters; they overlap." ^ "\n  " ^ info2str (pat_info pat1) ^ ": "
-      ^ string_of_pat pat1 ^ "\n  " ^ info2str (pat_info pat2) ^ ": " ^ string_of_pat pat2
-      ^ "\n Example:" ^ "\n  Only in the first: " ^ string_of_pat only1
-      ^ "\n  In both: " ^ string_of_pat both ^ "\n  Only in the other: "
-      ^ string_of_pat only2
+       matters; they overlap." ^ "\n  "
+      ^ info2str (pat_info pat1)
+      ^ ": " ^ string_of_pat pat1 ^ "\n  "
+      ^ info2str (pat_info pat2)
+      ^ ": " ^ string_of_pat pat2 ^ "\n Example:" ^ "\n  Only in the first: "
+      ^ string_of_pat only1 ^ "\n  In both: " ^ string_of_pat both
+      ^ "\n  Only in the other: " ^ string_of_pat only2
       |> raise_error fi
 
 (* NOTE(vipa, 2023-11-14): Merge two sems with the same name, failing
-if they originate from different root sems. *)
-let merge_sems_in_lang : info -> ustring -> sem_data -> sem_data -> sem_data = fun fi name a b ->
+   if they originate from different root sems. *)
+let merge_sems_in_lang : info -> ustring -> sem_data -> sem_data -> sem_data =
+ fun fi name a b ->
   let su = Ustring.to_utf8 in
   if Symb.eqsym a.id b.id then
     let inconsistent_parameter_lists =
-      match a.params, b.params with
-      | Some p1, Some p2 -> Bool.not (List.equal (fun (Param (_, a, _)) (Param (_, b, _)) -> a =. b) p1 p2)
-      | _ -> false
+      match (a.params, b.params) with
+      | Some p1, Some p2 ->
+          Bool.not
+            (List.equal
+               (fun (Param (_, a, _)) (Param (_, b, _)) -> a =. b)
+               p1 p2 )
+      | _ ->
+          false
     in
     if inconsistent_parameter_lists then
       raise_error fi
-        ( "Trying to merge two 'sem's with inconsistent parameter lists (length or names) into '"
-        ^ su name ^ "' (previous definitions: "
-        ^ su (info2str a.fi) ^ " and " ^ su (info2str b.fi) ^ ")" )
+        ( "Trying to merge two 'sem's with inconsistent parameter lists \
+           (length or names) into '" ^ su name ^ "' (previous definitions: "
+        ^ su (info2str a.fi)
+        ^ " and "
+        ^ su (info2str b.fi)
+        ^ ")" )
     else
       let new_subsets =
-        let new_a = List.of_seq (SemCaseSet.to_seq (SemCaseSet.diff a.cases b.cases)) in
-        let new_b = List.of_seq (SemCaseSet.to_seq (SemCaseSet.diff b.cases a.cases)) in
+        let new_a =
+          List.of_seq (SemCaseSet.to_seq (SemCaseSet.diff a.cases b.cases))
+        in
+        let new_b =
+          List.of_seq (SemCaseSet.to_seq (SemCaseSet.diff b.cases a.cases))
+        in
         liftA2 (compute_order fi) new_a new_b
         |> List.filter_map (fun x -> x)
-        |> List.to_seq
-        |> SubsetOrdSet.of_seq in
+        |> List.to_seq |> SubsetOrdSet.of_seq
+      in
       { a with
-        params = if Option.is_some a.params then a.params else b.params
-      ; cases = SemCaseSet.union a.cases b.cases
-      ; subsets =
+        params= (if Option.is_some a.params then a.params else b.params)
+      ; cases= SemCaseSet.union a.cases b.cases
+      ; subsets=
           SubsetOrdSet.union
             (SubsetOrdSet.union a.subsets b.subsets)
-            new_subsets
-      }
+            new_subsets }
   else
     raise_error fi
-      ( "'sem' name conflict, found two definitions of '"
-      ^ su name ^ "', one at " ^ su (info2str a.fi)
-      ^ "and one at " ^ su (info2str b.fi) )
+      ( "'sem' name conflict, found two definitions of '" ^ su name
+      ^ "', one at "
+      ^ su (info2str a.fi)
+      ^ "and one at "
+      ^ su (info2str b.fi) )
 
-let merge_aliases_in_lang : info -> ustring -> alias_data -> alias_data -> alias_data = fun fi name a b ->
+let merge_aliases_in_lang :
+    info -> ustring -> alias_data -> alias_data -> alias_data =
+ fun fi name a b ->
   let su = Ustring.to_utf8 in
   if Symb.eqsym a.id b.id then a
   else
     raise_error fi
-      ( "Name conflict, there are two type aliases named '" ^ su name ^ "'" )
+      ("Name conflict, there are two type aliases named '" ^ su name ^ "'")
 
-let merge_syn_cases_in_lang : info -> ustring -> syn_case -> syn_case -> syn_case = fun fi name a b ->
+let merge_syn_cases_in_lang :
+    info -> ustring -> syn_case -> syn_case -> syn_case =
+ fun fi name a b ->
   let su = Ustring.to_utf8 in
-  if Symb.eqsym a.id b.id then a else
-    raise_error fi
-      ( "Conflicting definitions of constructor '"
-      ^ su name ^ "', at " ^ su (info2str a.fi)
-      ^ " and " ^ su (info2str b.fi) )
-
-let merge_syns_in_lang : info -> ustring -> syn_data -> syn_data -> syn_data = fun fi name a b ->
-  let su = Ustring.to_utf8 in
-  if Symb.eqsym a.id b.id then
-    match a.ty, b.ty with
-    | (_, _, a_count), (_, _, b_count) when a_count <> b_count ->
-      raise_error fi
-        ( "Trying to merge two 'syn's with different number of parameters into '"
-          ^ su name ^ "' (previous definitions: " ^ su (info2str a.fi)
-          ^ " and " ^ su (info2str b.fi) ^ ")")
-    | _ ->
-      { a with
-        cons = Record.union (fun name a b -> Some (merge_syn_cases_in_lang fi name a b)) a.cons b.cons
-      }
+  if Symb.eqsym a.id b.id then a
   else
     raise_error fi
-      ( "'syn' name conflict, found two definitions of '"
-        ^ su name ^ "', one at " ^ su (info2str a.fi)
-        ^ " and one at " ^ su (info2str b.fi) )
+      ( "Conflicting definitions of constructor '" ^ su name ^ "', at "
+      ^ su (info2str a.fi)
+      ^ " and "
+      ^ su (info2str b.fi) )
 
-let merge_types_in_lang : info -> ustring -> ty_in_lang -> ty_in_lang -> ty_in_lang = fun fi name a b ->
+let merge_syns_in_lang : info -> ustring -> syn_data -> syn_data -> syn_data =
+ fun fi name a b ->
   let su = Ustring.to_utf8 in
-  match a, b with
-  | (Left _, Right _) | (Right _, Left _) ->
-     raise_error fi
-       ( "Name conflict, a type alias and a syn are named '" ^ su name ^ "'" )
-  | Left a, Left b -> Left (merge_aliases_in_lang fi name a b)
-  | Right a, Right b -> Right (merge_syns_in_lang fi name a b)
+  if Symb.eqsym a.id b.id then
+    match (a.ty, b.ty) with
+    | (_, _, a_count), (_, _, b_count) when a_count <> b_count ->
+        raise_error fi
+          ( "Trying to merge two 'syn's with different number of parameters \
+             into '" ^ su name ^ "' (previous definitions: "
+          ^ su (info2str a.fi)
+          ^ " and "
+          ^ su (info2str b.fi)
+          ^ ")" )
+    | _ ->
+        { a with
+          cons=
+            Record.union
+              (fun name a b -> Some (merge_syn_cases_in_lang fi name a b))
+              a.cons b.cons }
+  else
+    raise_error fi
+      ( "'syn' name conflict, found two definitions of '" ^ su name
+      ^ "', one at "
+      ^ su (info2str a.fi)
+      ^ " and one at "
+      ^ su (info2str b.fi) )
 
-let merge_langs : info -> lang_data -> lang_data -> lang_data = fun fi a b ->
-  { values = Record.union (fun name a b -> Some (merge_sems_in_lang fi name a b)) a.values b.values
-  ; types = Record.union (fun name a b -> Some (merge_types_in_lang fi name a b)) a.types b.types
-  }
+let merge_types_in_lang :
+    info -> ustring -> ty_in_lang -> ty_in_lang -> ty_in_lang =
+ fun fi name a b ->
+  let su = Ustring.to_utf8 in
+  match (a, b) with
+  | Left _, Right _ | Right _, Left _ ->
+      raise_error fi
+        ("Name conflict, a type alias and a syn are named '" ^ su name ^ "'")
+  | Left a, Left b ->
+      Left (merge_aliases_in_lang fi name a b)
+  | Right a, Right b ->
+      Right (merge_syns_in_lang fi name a b)
+
+let merge_langs : info -> lang_data -> lang_data -> lang_data =
+ fun fi a b ->
+  { values=
+      Record.union
+        (fun name a b -> Some (merge_sems_in_lang fi name a b))
+        a.values b.values
+  ; types=
+      Record.union
+        (fun name a b -> Some (merge_types_in_lang fi name a b))
+        a.types b.types }
 
 (* === Functions that facilitate renaming types and values, and thus merging them after the fact === *)
 
 module NoCap = struct
   (* NOTE(vipa, 2023-11-15): This only supportrs renaming type
-  constructors and values, not type variabels nor constructors *)
-  type small_env =
-    { subst : ustring Record.t
-    ; avoid : USSet.t
-    }
-  let empty_small =
-    { subst = Record.empty
-    ; avoid = USSet.empty
-    }
-  type big_env =
-    { values : small_env
-    ; ty_cons : small_env
-    }
-  let empty_big =
-    { values = empty_small
-    ; ty_cons = empty_small
-    }
+     constructors and values, not type variabels nor constructors *)
+  type small_env = {subst: ustring Record.t; avoid: USSet.t}
 
-  let subst_name : ustring -> small_env -> ustring = fun name env ->
-    Option.value ~default:name (Record.find_opt name env.subst)
+  let empty_small = {subst= Record.empty; avoid= USSet.empty}
 
-  let add_subst : ustring -> ustring -> small_env -> small_env = fun before now env ->
-    { subst = Record.add before now env.subst
-    ; avoid = USSet.add now env.avoid
-    }
+  type big_env = {values: small_env; ty_cons: small_env}
+
+  let empty_big = {values= empty_small; ty_cons= empty_small}
+
+  let subst_name : ustring -> small_env -> ustring =
+   fun name env -> Option.value ~default:name (Record.find_opt name env.subst)
+
+  let add_subst : ustring -> ustring -> small_env -> small_env =
+   fun before now env ->
+    {subst= Record.add before now env.subst; avoid= USSet.add now env.avoid}
 
   let subst_ty_con_env (before : ustring) (now : ustring) : big_env =
-    {empty_big with ty_cons = add_subst before now empty_big.ty_cons}
+    {empty_big with ty_cons= add_subst before now empty_big.ty_cons}
 
   let subst_value_env (before : ustring) (now : ustring) : big_env =
-    {empty_big with values = add_subst before now empty_big.values}
+    {empty_big with values= add_subst before now empty_big.values}
 
-  let process_binding : small_env -> ustring -> small_env * ustring = fun env name ->
+  let process_binding : small_env -> ustring -> small_env * ustring =
+   fun env name ->
     if USSet.mem name env.avoid then
-      let new_name = name ^. us"_new" in
+      let new_name = name ^. us "_new" in
       (add_subst name new_name env, new_name)
     else (env, name)
 
   let rec subst_ty (env : big_env) : ty -> ty = function
     | TyCon (fi, name) ->
-       TyCon (fi, subst_name name env.ty_cons)
-    | TyUse (fi, _, _) -> raise_error fi
-                   ( "Compiler limitation: we can't easily rename syns or sems if 'use' is somewhere in the language fragment." )
-    | ty -> smap_ty_ty (subst_ty env) ty
+        TyCon (fi, subst_name name env.ty_cons)
+    | TyUse (fi, _, _) ->
+        raise_error fi
+          "Compiler limitation: we can't easily rename syns or sems if 'use' \
+           is somewhere in the language fragment."
+    | ty ->
+        smap_ty_ty (subst_ty env) ty
 
   let rec subst_pat (env : big_env) : pat -> big_env * pat = function
     | PatNamed (fi, NameStr (id, sym)) ->
-       let values, id = process_binding env.values id in
-       ({env with values}, PatNamed (fi, NameStr (id, sym)))
+        let values, id = process_binding env.values id in
+        ({env with values}, PatNamed (fi, NameStr (id, sym)))
     | PatSeqEdge (fi, l, NameStr (id, sym), r) ->
-       let env, l = Mseq.Helpers.map_accum_left subst_pat env l in
-       let values, id = process_binding env.values id in
-       let env = {env with values} in
-       let env, r = Mseq.Helpers.map_accum_left subst_pat env r in
-       (env, PatSeqEdge (fi, l, NameStr (id, sym), r))
-    | _ -> failwith "todo"
+        let env, l = Mseq.Helpers.map_accum_left subst_pat env l in
+        let values, id = process_binding env.values id in
+        let env = {env with values} in
+        let env, r = Mseq.Helpers.map_accum_left subst_pat env r in
+        (env, PatSeqEdge (fi, l, NameStr (id, sym), r))
+    | _ ->
+        failwith "todo"
 
   let rec subst_tm (env : big_env) : tm -> tm = function
     | TmVar (fi, name, sym, pesym, frozen) ->
-       let name = subst_name name env.values in
-       TmVar (fi, name, sym, pesym, frozen)
+        let name = subst_name name env.values in
+        TmVar (fi, name, sym, pesym, frozen)
     | TmLam (fi, name, sym, pesym, ty, tm) ->
-       let ty = subst_ty env ty in
-       let values, name = process_binding env.values name in
-       let env = {env with values} in
-       let tm = subst_tm env tm in
-       TmLam (fi, name, sym, pesym, ty, tm)
+        let ty = subst_ty env ty in
+        let values, name = process_binding env.values name in
+        let env = {env with values} in
+        let tm = subst_tm env tm in
+        TmLam (fi, name, sym, pesym, ty, tm)
     | TmLet (fi, name, sym, ty, body, inexpr) ->
-       let ty = subst_ty env ty in
-       let body = subst_tm env body in
-       let values, name = process_binding env.values name in
-       let env = {env with values} in
-       let inexpr = subst_tm env inexpr in
-       TmLet (fi, name, sym, ty, body, inexpr)
+        let ty = subst_ty env ty in
+        let body = subst_tm env body in
+        let values, name = process_binding env.values name in
+        let env = {env with values} in
+        let inexpr = subst_tm env inexpr in
+        TmLet (fi, name, sym, ty, body, inexpr)
     | TmRecLets (fi, lets, inexpr) ->
-       let process values (fi, id, sym, ty, tm) =
-         let values, id = process_binding values id in
-         (values, (fi, id, sym, ty, tm)) in
-       let values, lets = List.fold_left_map process env.values lets in
-       let env = {env with values} in
-       let subst_let (fi, id, sym, ty, tm) =
-         (fi, id, sym, subst_ty env ty, subst_tm env tm) in
-       let lets = List.map subst_let lets in
-       TmRecLets (fi, lets, subst_tm env inexpr)
+        let process values (fi, id, sym, ty, tm) =
+          let values, id = process_binding values id in
+          (values, (fi, id, sym, ty, tm))
+        in
+        let values, lets = List.fold_left_map process env.values lets in
+        let env = {env with values} in
+        let subst_let (fi, id, sym, ty, tm) =
+          (fi, id, sym, subst_ty env ty, subst_tm env tm)
+        in
+        let lets = List.map subst_let lets in
+        TmRecLets (fi, lets, subst_tm env inexpr)
     | TmType (fi, name, params, ty, tm) ->
-       let ty = subst_ty env ty in
-       let ty_cons, name = process_binding env.ty_cons name in
-       let env = {env with ty_cons} in
-       TmType (fi, name, params, ty, subst_tm env tm)
-    | TmUse (fi, _, _) -> raise_error fi
-                   ( "Compiler limitation: we can't easily rename syns or sems if 'use' is somewhere in the language fragment." )
+        let ty = subst_ty env ty in
+        let ty_cons, name = process_binding env.ty_cons name in
+        let env = {env with ty_cons} in
+        TmType (fi, name, params, ty, subst_tm env tm)
+    | TmUse (fi, _, _) ->
+        raise_error fi
+          "Compiler limitation: we can't easily rename syns or sems if 'use' \
+           is somewhere in the language fragment."
     | TmExt (fi, name, sym, side, ty, tm) ->
-       let ty = subst_ty env ty in
-       let values, name = process_binding env.values name in
-       let tm = subst_tm {env with values} tm in
-       TmExt (fi, name, sym, side, ty, tm)
+        let ty = subst_ty env ty in
+        let values, name = process_binding env.values name in
+        let tm = subst_tm {env with values} tm in
+        TmExt (fi, name, sym, side, ty, tm)
     | TmMatch (fi, scrut, pat, th, el) ->
-       let scrut = subst_tm env scrut in
-       let new_env, pat = subst_pat env pat in
-       let th = subst_tm new_env th in
-       let el = subst_tm env el in
-       TmMatch (fi, scrut, pat, th, el)
-    | tm -> smap_tm_tm (subst_tm env) tm
+        let scrut = subst_tm env scrut in
+        let new_env, pat = subst_pat env pat in
+        let th = subst_tm new_env th in
+        let el = subst_tm env el in
+        TmMatch (fi, scrut, pat, th, el)
+    | tm ->
+        smap_tm_tm (subst_tm env) tm
 
   let subst_lang (_env : big_env) (_lang : lang_data) : lang_data =
     (* NOTE(vipa, 2023-11-15):
 
-    I'm not sure we can actually do full and proper capture avoiding
-    substitution here, because of `use`. Consider:
+       I'm not sure we can actually do full and proper capture avoiding
+       substitution here, because of `use`. Consider:
 
-    lang X
-      sem bar =
-    end
+       lang X
+         sem bar =
+       end
 
-    lang A
-      sem foo =
-      | _ -> use X in (foo, bar)
-    end
+       lang A
+         sem foo =
+         | _ -> use X in (foo, bar)
+       end
 
-    lang B = A
-      with bar = A.foo
-    end
+       lang B = A
+         with bar = A.foo
+       end
 
-    Here we cannot rename `foo` to `bar` without capture, because we
-    cannot also rename `bar` in `X`.
+       Here we cannot rename `foo` to `bar` without capture, because we
+       cannot also rename `bar` in `X`.
 
-    For this reason I'm waiting with actually using the machinery
-    above, that should otherwise do decent capture-avoiding
-    substitution.
+       For this reason I'm waiting with actually using the machinery
+       above, that should otherwise do decent capture-avoiding
+       substitution.
 
-    It's worth noting that none of this would be an issue if we had
-    symbols, so a potential fix would be to make symbolize in boot
-    respect already placed symbols.
+       It's worth noting that none of this would be an issue if we had
+       symbols, so a potential fix would be to make symbolize in boot
+       respect already placed symbols.
 
-    It's also worth noting that this would also not be an issue with
-    dot-notation (e.g., `X.foo` instead of `use X in foo`), because
-    the former makes it clear that we're using a name in `X` rather
-    than a name from `X` or the current scope.
-
-     *)
-
-    failwith "We don't presently support renaming `syn`s or `sem`s using `with`. See this error in the code for why."
+       It's also worth noting that this would also not be an issue with
+       dot-notation (e.g., `X.foo` instead of `use X in foo`), because
+       the former makes it clear that we're using a name in `X` rather
+       than a name from `X` or the current scope.
+    *)
+    failwith
+      "We don't presently support renaming `syn`s or `sem`s using `with`. See \
+       this error in the code for why."
 end
 
-let rec_add_with : ('a -> 'a -> 'a) -> ustring -> 'a -> 'a Record.t -> 'a Record.t = fun f k v m ->
-  let f = function
-    | Some v1 -> Some (f v1 v)
-    | None -> Some v in
+let rec_add_with :
+    ('a -> 'a -> 'a) -> ustring -> 'a -> 'a Record.t -> 'a Record.t =
+ fun f k v m ->
+  let f = function Some v1 -> Some (f v1 v) | None -> Some v in
   Record.update k f m
 
-let rename_type
-    : info -> ustring -> (ustring * ustring * syn_id) -> lang_data -> lang_data
-  = fun fi orig_name (new_prefix, new_name, new_id) data ->
+let rename_type :
+    info -> ustring -> ustring * ustring * syn_id -> lang_data -> lang_data =
+ fun fi orig_name (new_prefix, new_name, new_id) data ->
   let update_alias (alias : alias_data) =
-    { alias with
-      id = new_id
-    ; def_here = true
-    ; name = (new_prefix, new_name)
-    } in
+    {alias with id= new_id; def_here= true; name= (new_prefix, new_name)}
+  in
   let update_syn (syn : syn_data) =
-    let (_, _, param_count) = syn.ty in
+    let _, _, param_count = syn.ty in
     let update_syn_case (c : syn_case) =
-      { c with
-        name = (new_prefix, snd c.name)
-      ; def_here = true
-      } in
+      {c with name= (new_prefix, snd c.name); def_here= true}
+    in
     { syn with
-      id = new_id
-    ; def_here = true
-    ; ty = (new_prefix, new_name, param_count)
-    ; cons = Record.map update_syn_case syn.cons
-    } in
+      id= new_id
+    ; def_here= true
+    ; ty= (new_prefix, new_name, param_count)
+    ; cons= Record.map update_syn_case syn.cons }
+  in
   match Record.find_opt orig_name data.types with
   | Some ty_content ->
-     let types = Record.remove orig_name data.types in
-     let ty_content = Either.map ~left:update_alias ~right:update_syn ty_content in
-     let types = rec_add_with (merge_types_in_lang fi new_name) new_name ty_content types in
-     let data = {data with types} in
-     if orig_name =. new_name then data
-     else
-       let subst = NoCap.subst_ty_con_env orig_name new_name in
-       NoCap.subst_lang subst data
-  | None -> data
+      let types = Record.remove orig_name data.types in
+      let ty_content =
+        Either.map ~left:update_alias ~right:update_syn ty_content
+      in
+      let types =
+        rec_add_with
+          (merge_types_in_lang fi new_name)
+          new_name ty_content types
+      in
+      let data = {data with types} in
+      if orig_name =. new_name then data
+      else
+        let subst = NoCap.subst_ty_con_env orig_name new_name in
+        NoCap.subst_lang subst data
+  | None ->
+      data
 
-let rename_value
-    : info -> ustring -> (ustring * ustring * sem_id) -> lang_data -> lang_data
-  = fun fi orig_name (_new_prefix, new_name, new_id) data ->
+let rename_value :
+    info -> ustring -> ustring * ustring * sem_id -> lang_data -> lang_data =
+ fun fi orig_name (_new_prefix, new_name, new_id) data ->
   match Record.find_opt orig_name data.values with
   | Some val_content ->
-     let values = Record.remove orig_name data.values in
-     let update_sem (sem : sem_data) = {sem with id = new_id} in
-     let val_content = update_sem val_content in
-     let values = rec_add_with (merge_sems_in_lang fi new_name) new_name val_content values in
-     let data = {data with values} in
-     if orig_name =. new_name then data
-     else
-       let subst = NoCap.subst_value_env orig_name new_name in
-       NoCap.subst_lang subst data
-  | None -> data
+      let values = Record.remove orig_name data.values in
+      let update_sem (sem : sem_data) = {sem with id= new_id} in
+      let val_content = update_sem val_content in
+      let values =
+        rec_add_with
+          (merge_sems_in_lang fi new_name)
+          new_name val_content values
+      in
+      let data = {data with values} in
+      if orig_name =. new_name then data
+      else
+        let subst = NoCap.subst_value_env orig_name new_name in
+        NoCap.subst_lang subst data
+  | None ->
+      data
 
 (* === Translating from MLang (list of top-declarations, including lang) to MExpr (single tm) === *)
 
 type mlang_env =
-  { values : ustring Record.t
-  ; ty_cons : ustring Record.t
-  ; constructors : ustring Record.t
-  ; languages : lang_data Record.t
-  ; language_envs : mlang_env Record.t
-  }
+  { values: ustring Record.t
+  ; ty_cons: ustring Record.t
+  ; constructors: ustring Record.t
+  ; languages: lang_data Record.t
+  ; language_envs: mlang_env Record.t }
 
 let empty_mlang_env =
-  { values = Record.empty
-  ; ty_cons = Record.empty
-  ; constructors = Record.empty
-  ; languages = Record.empty
-  ; language_envs = Record.empty
-  }
+  { values= Record.empty
+  ; ty_cons= Record.empty
+  ; constructors= Record.empty
+  ; languages= Record.empty
+  ; language_envs= Record.empty }
 
 let empty_mangle : ustring -> ustring = fun x -> x
-let lang_value_mangle : (ustring * ustring) -> ustring = fun (prefix, name) -> us"v" ^. prefix ^. us"_" ^. name
-let lang_con_mangle : (ustring * ustring) -> ustring = fun (prefix, name) -> prefix ^. us"_" ^. name
 
-let merge_env_prefer_right : mlang_env -> mlang_env -> mlang_env = fun a b ->
-  { values = Record.union (fun _ _a b -> Some b) a.values b.values
-  ; ty_cons = Record.union (fun _ _a b -> Some b) a.ty_cons b.ty_cons
-  ; constructors = Record.union (fun _ _a b -> Some b) a.constructors b.constructors
-  ; languages = Record.union (fun _ _a b -> Some b) a.languages b.languages
-  ; language_envs = Record.union (fun _ _a b -> Some b) a.language_envs b.language_envs
-  }
+let lang_value_mangle : ustring * ustring -> ustring =
+ fun (prefix, name) -> us "v" ^. prefix ^. us "_" ^. name
+
+let lang_con_mangle : ustring * ustring -> ustring =
+ fun (prefix, name) -> prefix ^. us "_" ^. name
+
+let merge_env_prefer_right : mlang_env -> mlang_env -> mlang_env =
+ fun a b ->
+  { values= Record.union (fun _ _a b -> Some b) a.values b.values
+  ; ty_cons= Record.union (fun _ _a b -> Some b) a.ty_cons b.ty_cons
+  ; constructors=
+      Record.union (fun _ _a b -> Some b) a.constructors b.constructors
+  ; languages= Record.union (fun _ _a b -> Some b) a.languages b.languages
+  ; language_envs=
+      Record.union (fun _ _a b -> Some b) a.language_envs b.language_envs }
 
 let rec translate_ty (env : mlang_env) : ty -> ty = function
-  | TyCon (fi, id) ->
-     begin match Record.find_opt id env.ty_cons with
-     | Some id -> TyCon (fi, id)
-     | None -> TyCon (fi, empty_mangle id)
-     end
-  | TyUse (fi, lang, ty) ->
-     begin match Record.find_opt lang env.language_envs with
-     | Some new_env -> translate_ty (merge_env_prefer_right env new_env) ty
-     | None -> raise_error fi
-                 ( "Unbound language fragment '" ^ Ustring.to_utf8 lang ^ "'" )
-     end
+  | TyCon (fi, id) -> (
+    match Record.find_opt id env.ty_cons with
+    | Some id ->
+        TyCon (fi, id)
+    | None ->
+        TyCon (fi, empty_mangle id) )
+  | TyUse (fi, lang, ty) -> (
+    match Record.find_opt lang env.language_envs with
+    | Some new_env ->
+        translate_ty (merge_env_prefer_right env new_env) ty
+    | None ->
+        raise_error fi
+          ("Unbound language fragment '" ^ Ustring.to_utf8 lang ^ "'") )
   | ty ->
-     let ty = smap_ty_ty (translate_ty env) ty in
-     ty
+      let ty = smap_ty_ty (translate_ty env) ty in
+      ty
 
 let rec translate_pat (env : mlang_env) : pat -> mlang_env * pat = function
-  | PatNamed (_, NameStr(id, _)) as pat ->
-     ({env with values = Record.remove id env.values}, pat)
+  | PatNamed (_, NameStr (id, _)) as pat ->
+      ({env with values= Record.remove id env.values}, pat)
   | PatSeqEdge (fi, l, (NameStr (id, _) as name), r) ->
-     let env, l = Mseq.Helpers.map_accum_left translate_pat env l in
-     let env, r = Mseq.Helpers.map_accum_left translate_pat env r in
-     ( {env with values = Record.remove id env.values}
-     , PatSeqEdge (fi, l, name, r)
-     )
+      let env, l = Mseq.Helpers.map_accum_left translate_pat env l in
+      let env, r = Mseq.Helpers.map_accum_left translate_pat env r in
+      ( {env with values= Record.remove id env.values}
+      , PatSeqEdge (fi, l, name, r) )
   | PatCon (fi, id, sym, pat) ->
-     let id, sym = match Record.find_opt id env.constructors with
-       | Some id -> (id, Symb.Helpers.nosym)
-       | None -> (id, sym) in
-     let env, pat = translate_pat env pat in
-     (env, PatCon (fi, id, sym, pat))
+      let id, sym =
+        match Record.find_opt id env.constructors with
+        | Some id ->
+            (id, Symb.Helpers.nosym)
+        | None ->
+            (id, sym)
+      in
+      let env, pat = translate_pat env pat in
+      (env, PatCon (fi, id, sym, pat))
   | pat ->
-     smap_accum_left_pat_pat translate_pat env pat
+      smap_accum_left_pat_pat translate_pat env pat
 
 let rec translate_tm (env : mlang_env) : tm -> tm = function
   | TmVar (fi, name, sym, pesym, frozen) ->
-     let name, sym =
-       match Record.find_opt name env.values with
-       | Some name -> (name, Symb.Helpers.nosym)
-       | None -> (name, sym) in
-     (* TODO(vipa, 2023-11-14): is it correct to do nothing about pesym? *)
-     TmVar (fi, name, sym, pesym, frozen)
+      let name, sym =
+        match Record.find_opt name env.values with
+        | Some name ->
+            (name, Symb.Helpers.nosym)
+        | None ->
+            (name, sym)
+      in
+      (* TODO(vipa, 2023-11-14): is it correct to do nothing about pesym? *)
+      TmVar (fi, name, sym, pesym, frozen)
   | TmLam (fi, name, sym, pesym, ty, tm) ->
-     let new_env = {env with values = Record.remove name env.values} in
-     TmLam (fi, empty_mangle name, sym, pesym, translate_ty env ty, translate_tm new_env tm)
+      let new_env = {env with values= Record.remove name env.values} in
+      TmLam
+        ( fi
+        , empty_mangle name
+        , sym
+        , pesym
+        , translate_ty env ty
+        , translate_tm new_env tm )
   | TmLet (fi, name, sym, ty, body, inexpr) ->
-     let new_env = {env with values = Record.remove name env.values} in
-     TmLet
-       ( fi
-       , empty_mangle name
-       , sym
-       , translate_ty env ty
-       , translate_tm env body
-       , translate_tm new_env inexpr
-       )
+      let new_env = {env with values= Record.remove name env.values} in
+      TmLet
+        ( fi
+        , empty_mangle name
+        , sym
+        , translate_ty env ty
+        , translate_tm env body
+        , translate_tm new_env inexpr )
   | TmRecLets (fi, lets, inexpr) ->
-     let rem_value values (_, id, _, _, _) = Record.remove id values in
-     let new_env = {env with values = List.fold_left rem_value env.values lets} in
-     let translate_let (fi, id, sym, ty, tm) = (fi, empty_mangle id, sym, translate_ty new_env ty, translate_tm new_env tm) in
-     TmRecLets (fi, List.map translate_let lets, translate_tm new_env inexpr)
+      let rem_value values (_, id, _, _, _) = Record.remove id values in
+      let new_env =
+        {env with values= List.fold_left rem_value env.values lets}
+      in
+      let translate_let (fi, id, sym, ty, tm) =
+        ( fi
+        , empty_mangle id
+        , sym
+        , translate_ty new_env ty
+        , translate_tm new_env tm )
+      in
+      TmRecLets (fi, List.map translate_let lets, translate_tm new_env inexpr)
   | TmType (fi, name, params, ty, tm) ->
-     let new_env = {env with ty_cons = Record.remove name env.ty_cons} in
-     TmType (fi, empty_mangle name, params, translate_ty env ty, translate_tm new_env tm)
+      let new_env = {env with ty_cons= Record.remove name env.ty_cons} in
+      TmType
+        ( fi
+        , empty_mangle name
+        , params
+        , translate_ty env ty
+        , translate_tm new_env tm )
   | TmConDef (fi, name, sym, ty, tm) ->
-     let new_env = {env with constructors = Record.remove name env.constructors} in
-     TmConDef (fi, empty_mangle name, sym, translate_ty env ty, translate_tm new_env tm)
+      let new_env =
+        {env with constructors= Record.remove name env.constructors}
+      in
+      TmConDef
+        ( fi
+        , empty_mangle name
+        , sym
+        , translate_ty env ty
+        , translate_tm new_env tm )
   | TmConApp (fi, name, sym, tm) ->
-     let name, sym =
-       match Record.find_opt name env.constructors with
-       | Some name -> (name, Symb.Helpers.nosym)
-       | None -> (name, sym) in
-     TmConApp (fi, name, sym, translate_tm env tm)
-  | TmUse (fi, lang, tm) ->
-     begin match Record.find_opt lang env.language_envs with
-     | Some lang_env -> translate_tm (merge_env_prefer_right env lang_env) tm
-     | None -> raise_error fi
-                 ( "Unbound language fragment '" ^ Ustring.to_utf8 lang ^ "'" )
-     end
+      let name, sym =
+        match Record.find_opt name env.constructors with
+        | Some name ->
+            (name, Symb.Helpers.nosym)
+        | None ->
+            (name, sym)
+      in
+      TmConApp (fi, name, sym, translate_tm env tm)
+  | TmUse (fi, lang, tm) -> (
+    match Record.find_opt lang env.language_envs with
+    | Some lang_env ->
+        translate_tm (merge_env_prefer_right env lang_env) tm
+    | None ->
+        raise_error fi
+          ("Unbound language fragment '" ^ Ustring.to_utf8 lang ^ "'") )
   | TmExt (fi, name, sym, side, ty, tm) ->
-     let new_env = {env with values = Record.add name name env.values} in
-     TmExt (fi, name, sym, side, translate_ty env ty, translate_tm new_env tm)
+      let new_env = {env with values= Record.add name name env.values} in
+      TmExt (fi, name, sym, side, translate_ty env ty, translate_tm new_env tm)
   | TmMatch (fi, scrut, pat, th, el) ->
-     let new_env, pat = translate_pat env pat in
-     TmMatch (fi, translate_tm env scrut, pat, translate_tm new_env th, translate_tm env el)
-  | (TmApp _ | TmConst _ | TmSeq _ | TmRecord _ | TmRecordUpdate _ | TmUtest _| TmNever _ | TmClos _ | TmRef _ | TmTensor _ | TmDive _ | TmPreRun _ | TmBox _) as tm ->
-     let tm = smap_tm_ty (translate_ty env) tm in
-     let tm = smap_tm_tm (translate_tm env) tm in
-     tm
+      let new_env, pat = translate_pat env pat in
+      TmMatch
+        ( fi
+        , translate_tm env scrut
+        , pat
+        , translate_tm new_env th
+        , translate_tm env el )
+  | ( TmApp _
+    | TmConst _
+    | TmSeq _
+    | TmRecord _
+    | TmRecordUpdate _
+    | TmUtest _
+    | TmNever _
+    | TmClos _
+    | TmRef _
+    | TmTensor _
+    | TmDive _
+    | TmPreRun _
+    | TmBox _ ) as tm ->
+      let tm = smap_tm_ty (translate_ty env) tm in
+      let tm = smap_tm_tm (translate_tm env) tm in
+      tm
 
-let add_decl_to_lang (lang_fi : info) (lang_name : ustring) (data : lang_data) : decl -> lang_data = function
+let add_decl_to_lang (lang_fi : info) (lang_name : ustring) (data : lang_data)
+    : decl -> lang_data = function
   | Data (fi, name, param_count, constructors) ->
-     let syn =
-       match Record.find_opt name data.types with
-       | Some (Right syn) -> syn
-       | Some _ -> raise_error fi
-                     ( "Trying to define a 'syn' that's already defined as an alias ('"
-                     ^ Ustring.to_utf8 name ^ "')." )
-       | None ->
-          { id = Symb.gensym ()
-          ; def_here = true
-          ; ty = (lang_name, name, param_count)
-          ; cons = Record.empty
-          ; fi
-          } in
-     let add_con : syn_case Record.t -> cdecl -> syn_case Record.t = fun syn (CDecl(fi, ty_params, name, carried)) ->
-       let f : syn_case option -> syn_case option = function
-         | Some con ->
+      let syn =
+        match Record.find_opt name data.types with
+        | Some (Right syn) ->
+            syn
+        | Some _ ->
             raise_error fi
-              ( "Redefinition of constructor '" ^ Ustring.to_utf8 name
-              ^ "', previously defined at " ^ Ustring.to_utf8 (info2str con.fi) )
-         | None ->
-            Some
-              { id = Symb.gensym ()
-              ; fi
-              ; def_here = true
-              ; ty_params
-              ; name = (lang_name, name)
-              ; carried
-              } in
-       Record.update name f syn in
-     let syn = {syn with cons = List.fold_left add_con syn.cons constructors} in
-     {data with types = Record.add name (Either.Right syn) data.types}
+              ( "Trying to define a 'syn' that's already defined as an alias ('"
+              ^ Ustring.to_utf8 name ^ "')." )
+        | None ->
+            { id= Symb.gensym ()
+            ; def_here= true
+            ; ty= (lang_name, name, param_count)
+            ; cons= Record.empty
+            ; fi }
+      in
+      let add_con : syn_case Record.t -> cdecl -> syn_case Record.t =
+       fun syn (CDecl (fi, ty_params, name, carried)) ->
+        let f : syn_case option -> syn_case option = function
+          | Some con ->
+              raise_error fi
+                ( "Redefinition of constructor '" ^ Ustring.to_utf8 name
+                ^ "', previously defined at "
+                ^ Ustring.to_utf8 (info2str con.fi) )
+          | None ->
+              Some
+                { id= Symb.gensym ()
+                ; fi
+                ; def_here= true
+                ; ty_params
+                ; name= (lang_name, name)
+                ; carried }
+        in
+        Record.update name f syn
+      in
+      let syn =
+        {syn with cons= List.fold_left add_con syn.cons constructors}
+      in
+      {data with types= Record.add name (Either.Right syn) data.types}
   | Inter (fi, name, ty, params, cases) ->
-     let sem =
-       match Record.find_opt name data.values with
-       | Some sem ->
-          { sem with
-            params = if Option.is_some sem.params then sem.params else params
-          }
-       | None ->
-          { id = Symb.gensym ()
-          ; fi
-          ; ty
-          ; params
-          ; cases = SemCaseSet.empty
-          ; subsets = SubsetOrdSet.empty
-          } in
-     let add_case sem (pat, rhs) =
-       let id = Symb.gensym () in
-       let pos_pat = pat_to_normpat pat in
-       let neg_pat = normpat_complement pos_pat in
-       let case = {id; pat; rhs; pos_pat; neg_pat} in
-       let subsets =
-         SemCaseSet.to_seq sem.cases
-         |> Seq.filter_map (compute_order lang_fi case)
-         |> Seq.fold_left (fun acc x -> SubsetOrdSet.add x acc) sem.subsets in
-       {sem with subsets; cases = SemCaseSet.add case sem.cases} in
-     let sem = List.fold_left add_case sem cases in
-     {data with values = Record.add name sem data.values}
+      let sem =
+        match Record.find_opt name data.values with
+        | Some sem ->
+            { sem with
+              params= (if Option.is_some sem.params then sem.params else params)
+            }
+        | None ->
+            { id= Symb.gensym ()
+            ; fi
+            ; ty
+            ; params
+            ; cases= SemCaseSet.empty
+            ; subsets= SubsetOrdSet.empty }
+      in
+      let add_case sem (pat, rhs) =
+        let id = Symb.gensym () in
+        let pos_pat = pat_to_normpat pat in
+        let neg_pat = normpat_complement pos_pat in
+        let case = {id; pat; rhs; pos_pat; neg_pat} in
+        let subsets =
+          SemCaseSet.to_seq sem.cases
+          |> Seq.filter_map (compute_order lang_fi case)
+          |> Seq.fold_left (fun acc x -> SubsetOrdSet.add x acc) sem.subsets
+        in
+        {sem with subsets; cases= SemCaseSet.add case sem.cases}
+      in
+      let sem = List.fold_left add_case sem cases in
+      {data with values= Record.add name sem data.values}
   | Alias (fi, name, params, ty) ->
-     if Record.mem name data.types then
-       raise_error fi
-         ( "Duplicate definition, a type with name '"
-         ^ Ustring.to_utf8 name ^ "' is already defined." )
-     else
-       let alias =
-         { id = Symb.gensym ()
-         ; def_here = true
-         ; name = (lang_name, name)
-         ; params
-         ; ty
-         ; fi
-         } in
-       {data with types = Record.add name (Either.Left alias) data.types}
+      if Record.mem name data.types then
+        raise_error fi
+          ( "Duplicate definition, a type with name '" ^ Ustring.to_utf8 name
+          ^ "' is already defined." )
+      else
+        let alias =
+          { id= Symb.gensym ()
+          ; def_here= true
+          ; name= (lang_name, name)
+          ; params
+          ; ty
+          ; fi }
+        in
+        {data with types= Record.add name (Either.Left alias) data.types}
 
-let lang_to_env : ustring -> lang_data -> mlang_env = fun name lang ->
+let lang_to_env : ustring -> lang_data -> mlang_env =
+ fun name lang ->
   let values =
     Record.to_seq lang.values
     |> Seq.map (fun (n, _) -> (n, lang_value_mangle (name, n)))
-    |> Record.of_seq in
-  let mk_type_pair : (ustring * ty_in_lang) -> (ustring * ustring) = function
-    | (n, Either.Left alias) -> (n, lang_con_mangle alias.name)
-    | (n, Either.Right {ty = (pre, name, _); _}) -> (n, lang_con_mangle (pre, name)) in
+    |> Record.of_seq
+  in
+  let mk_type_pair : ustring * ty_in_lang -> ustring * ustring = function
+    | n, Either.Left alias ->
+        (n, lang_con_mangle alias.name)
+    | n, Either.Right {ty= pre, name, _; _} ->
+        (n, lang_con_mangle (pre, name))
+  in
   let ty_cons =
-    Record.to_seq lang.types
-    |> Seq.map mk_type_pair
-    |> Record.of_seq in
+    Record.to_seq lang.types |> Seq.map mk_type_pair |> Record.of_seq
+  in
   let constructors =
-    Record.to_seq lang.types
-    |> Seq.map snd
+    Record.to_seq lang.types |> Seq.map snd
     |> Seq.filter_map Either.find_right
     |> Seq.flat_map (fun x -> Record.to_seq x.cons)
     |> Seq.map (fun (n, (case : syn_case)) -> (n, lang_con_mangle case.name))
-    |> Record.of_seq in
+    |> Record.of_seq
+  in
   { values
   ; ty_cons
   ; constructors
-  ; languages = Record.empty
-  ; language_envs = Record.empty
-  }
+  ; languages= Record.empty
+  ; language_envs= Record.empty }
 
-let wrap_syn_types : lang_data -> tm -> tm = fun lang tm ->
+let wrap_syn_types : lang_data -> tm -> tm =
+ fun lang tm ->
   let wrap_syn (tm : tm) (syn : syn_data) =
-    let (pre, name, param_count) = syn.ty in
+    let pre, name, param_count = syn.ty in
     TmType
       ( syn.fi
       , lang_con_mangle (pre, name)
-      , List.init param_count (fun _ -> us"a")
+      , List.init param_count (fun _ -> us "a")
       , TyVariant (syn.fi, [])
-      , tm
-      ) in
-  Record.to_seq lang.types
-  |> Seq.map snd
+      , tm )
+  in
+  Record.to_seq lang.types |> Seq.map snd
   |> Seq.filter_map Either.find_right
   |> Seq.filter (fun (syn : syn_data) -> syn.def_here)
   |> Seq.fold_left wrap_syn tm
 
-let wrap_aliases : mlang_env -> lang_data -> tm -> tm = fun env lang tm ->
+let wrap_aliases : mlang_env -> lang_data -> tm -> tm =
+ fun env lang tm ->
   let wrap_alias (alias : alias_data) (tm : tm) =
     TmType
       ( alias.fi
       , lang_con_mangle alias.name
       , alias.params
       , translate_ty env alias.ty
-      , tm
-      ) in
-  Record.to_seq lang.types
-  |> Seq.map snd
+      , tm )
+  in
+  Record.to_seq lang.types |> Seq.map snd
   |> Seq.filter_map Either.find_left
   |> Seq.filter (fun (alias : alias_data) -> alias.def_here)
   |> List.of_seq
-  |> List.sort (fun (a : alias_data) (b : alias_data) -> Symb.compare a.id b.id)
+  |> List.sort (fun (a : alias_data) (b : alias_data) ->
+         Symb.compare a.id b.id )
   |> fun aliases -> List.fold_right wrap_alias aliases tm
 
-let wrap_cons : mlang_env -> lang_data -> tm -> tm = fun env lang tm ->
+let wrap_cons : mlang_env -> lang_data -> tm -> tm =
+ fun env lang tm ->
   let cons_with_syn_name (syn : syn_data) : (ustring * syn_case) Seq.t =
     let _, name, _ = syn.ty in
-    Record.to_seq syn.cons
-    |> Seq.map (fun (_, c) -> (name, c)) in
+    Record.to_seq syn.cons |> Seq.map (fun (_, c) -> (name, c))
+  in
   let wrap_con (tm : tm) ((name : ustring), (con : syn_case)) =
-    let wrap_all (tyvar : ustring) (ty : ty) =
-      TyAll (con.fi, tyvar, ty) in
+    let wrap_all (tyvar : ustring) (ty : ty) = TyAll (con.fi, tyvar, ty) in
     let wrap_app (ty : ty) (tyvar : ustring) =
-      TyApp (con.fi, ty, TyVar (con.fi, tyvar)) in
+      TyApp (con.fi, ty, TyVar (con.fi, tyvar))
+    in
     let ret = List.fold_left wrap_app (TyCon (con.fi, name)) con.ty_params in
     let ty = TyArrow (con.fi, con.carried, ret) in
     let ty = List.fold_right wrap_all con.ty_params ty in
@@ -773,980 +899,229 @@ let wrap_cons : mlang_env -> lang_data -> tm -> tm = fun env lang tm ->
       , lang_con_mangle con.name
       , Symb.Helpers.nosym
       , translate_ty env ty
-      , tm
-      ) in
-  Record.to_seq lang.types
-  |> Seq.map snd
+      , tm )
+  in
+  Record.to_seq lang.types |> Seq.map snd
   |> Seq.filter_map Either.find_right
   |> Seq.flat_map cons_with_syn_name
   |> Seq.filter (fun (_, (con : syn_case)) -> con.def_here)
   |> Seq.fold_left wrap_con tm
 
-let wrap_sems : mlang_env -> ustring -> lang_data -> tm -> tm = fun env lang_name lang tm ->
-  let sem_to_binding ((name : ustring), (sem : sem_data)) : (info * ustring * Symb.t * ty * tm) =
+let wrap_sems : mlang_env -> ustring -> lang_data -> tm -> tm =
+ fun env lang_name lang tm ->
+  let sem_to_binding ((name : ustring), (sem : sem_data)) :
+      info * ustring * Symb.t * ty * tm =
     let mk_with_body body =
       ( sem.fi
       , lang_value_mangle (lang_name, name)
       , Symb.Helpers.nosym
       , translate_ty env sem.ty
-      , body
-      ) in
+      , body )
+    in
     if SemCaseSet.is_empty sem.cases then
-      mk_with_body (TmLam (sem.fi, us"x", Symb.Helpers.nosym, false, TyUnknown sem.fi, TmNever sem.fi))
+      mk_with_body
+        (TmLam
+           ( sem.fi
+           , us "x"
+           , Symb.Helpers.nosym
+           , false
+           , TyUnknown sem.fi
+           , TmNever sem.fi ) )
     else
-      let scrut = TmVar (sem.fi, us"__sem_target", Symb.Helpers.nosym, false, false) in
+      let scrut =
+        TmVar (sem.fi, us "__sem_target", Symb.Helpers.nosym, false, false)
+      in
       let cases =
         let vertices =
           SemCaseSet.to_seq sem.cases
           |> Seq.map (fun (case : sem_case) -> case.id)
-          |> List.of_seq in
+          |> List.of_seq
+        in
         let edges = SubsetOrdSet.elements sem.subsets in
         let find_by_id id =
           (* NOTE(vipa, 2023-11-15): The compare function for
-          SemCaseSet only looks at `id`, thus this is ok *)
+             SemCaseSet only looks at `id`, thus this is ok *)
           SemCaseSet.find
-            {id; pat = Obj.magic (); rhs = Obj.magic (); pos_pat = Obj.magic (); neg_pat = Obj.magic ()}
-            sem.cases in
-        topo_sort Symb.eqsym edges vertices
-        |> List.map find_by_id in
+            { id
+            ; pat= Obj.magic ()
+            ; rhs= Obj.magic ()
+            ; pos_pat= Obj.magic ()
+            ; neg_pat= Obj.magic () }
+            sem.cases
+        in
+        topo_sort Symb.eqsym edges vertices |> List.map find_by_id
+      in
       let wrap_case (case : sem_case) (tm : tm) =
-        TmMatch (pat_info case.pat, scrut, case.pat, case.rhs, tm) in
+        TmMatch (pat_info case.pat, scrut, case.pat, case.rhs, tm)
+      in
       let wrap_param (Param (fi, name, ty)) (tm : tm) =
-        TmLam (fi, name, Symb.Helpers.nosym, false, ty, tm) in
+        TmLam (fi, name, Symb.Helpers.nosym, false, ty, tm)
+      in
       let body = List.fold_right wrap_case cases (TmNever sem.fi) in
-      let body = TmLam (sem.fi, us"__sem_target", Symb.Helpers.nosym, false, TyUnknown sem.fi, body) in
-      let body = List.fold_right wrap_param (Option.value ~default:[] sem.params) body in
+      let body =
+        TmLam
+          ( sem.fi
+          , us "__sem_target"
+          , Symb.Helpers.nosym
+          , false
+          , TyUnknown sem.fi
+          , body )
+      in
+      let body =
+        List.fold_right wrap_param (Option.value ~default:[] sem.params) body
+      in
       ( sem.fi
       , lang_value_mangle (lang_name, name)
       , Symb.Helpers.nosym
       , translate_ty env sem.ty
-      , translate_tm env body
-      ) in
+      , translate_tm env body )
+  in
   if Record.is_empty lang.values then tm
   else
     TmRecLets
       ( NoInfo
-      , Record.to_seq lang.values
-        |> Seq.map sem_to_binding
-        |> List.of_seq
-      , tm
-      )
+      , Record.to_seq lang.values |> Seq.map sem_to_binding |> List.of_seq
+      , tm )
 
-let lang_gen : mlang_env -> ustring -> lang_data -> mlang_env * (tm -> tm) = fun env lang_name lang ->
+let lang_gen : mlang_env -> ustring -> lang_data -> mlang_env * (tm -> tm) =
+ fun env lang_name lang ->
   let lang_env = lang_to_env lang_name lang in
   let wrap tm =
     let env = merge_env_prefer_right env lang_env in
     wrap_syn_types lang
       (wrap_aliases env lang
-         (wrap_cons env lang
-            (wrap_sems env lang_name lang tm))) in
+         (wrap_cons env lang (wrap_sems env lang_name lang tm)) )
+  in
   (lang_env, wrap)
 
-let translate_lang (env : mlang_env) (Lang(fi, name, includes, renames, decls)) : mlang_env * (tm -> tm) =
+let translate_lang (env : mlang_env) (Lang (fi, name, includes, renames, decls))
+    : mlang_env * (tm -> tm) =
   let su = Ustring.to_utf8 in
   let fetch_include inc =
     match Record.find_opt inc env.languages with
-    | Some lang -> (inc, lang)
-    | None -> raise_error fi ("Unknown language '" ^ su inc ^ "' in include list.") in
+    | Some lang ->
+        (inc, lang)
+    | None ->
+        raise_error fi ("Unknown language '" ^ su inc ^ "' in include list.")
+  in
   let apply_rename includes (With (fi, kind, new_name, inputs)) =
-    let f = match kind with WithType -> rename_type | WithValue -> rename_value in
+    let f =
+      match kind with WithType -> rename_type | WithValue -> rename_value
+    in
     let id = Symb.gensym () in
     let f lang orig_name = f fi orig_name (name, new_name, id) lang in
     let process_input includes (lang_name, orig_name) =
       let f = function
-        | Some lang -> Some (f lang orig_name)
-        | None -> raise_error fi
-                    ( "Unknown language '" ^ su lang_name ^ "' in 'with' clause." ) in
-      Record.update lang_name f includes in
-    List.fold_left process_input includes inputs in
+        | Some lang ->
+            Some (f lang orig_name)
+        | None ->
+            raise_error fi
+              ("Unknown language '" ^ su lang_name ^ "' in 'with' clause.")
+      in
+      Record.update lang_name f includes
+    in
+    List.fold_left process_input includes inputs
+  in
   let includes =
-    List.to_seq includes
-    |> Seq.map fetch_include
-    |> Record.of_seq in
+    List.to_seq includes |> Seq.map fetch_include |> Record.of_seq
+  in
   let includes = List.fold_left apply_rename includes renames in
+  let lang = {values= Record.empty; types= Record.empty} in
   let lang =
-    { values = Record.empty
-    ; types = Record.empty
-    } in
-  let lang =
-    Record.to_seq includes
-    |> Seq.map snd
-    |> Seq.fold_left (merge_langs fi) lang in
+    Record.to_seq includes |> Seq.map snd
+    |> Seq.fold_left (merge_langs fi) lang
+  in
   let lang = List.fold_left (add_decl_to_lang fi name) lang decls in
   let lang_env, wrap = lang_gen env name lang in
   let new_env =
     { env with
-      languages = Record.add name (pre_extend_lang lang) env.languages
-    ; language_envs = Record.add name lang_env env.language_envs
-    } in
+      languages= Record.add name (pre_extend_lang lang) env.languages
+    ; language_envs= Record.add name lang_env env.language_envs }
+  in
   (new_env, wrap)
 
 let translate_top (env : mlang_env) : top -> mlang_env * (tm -> tm) = function
-  | TopLang lang -> translate_lang env lang
+  | TopLang lang ->
+      translate_lang env lang
   | TopLet (Let (fi, id, ty, tm)) ->
-     let new_env = {env with values = Record.remove id env.values} in
-     let wrap inexpr =
-       TmLet
-         ( fi
-         , empty_mangle id
-         , Symb.Helpers.nosym
-         , translate_ty new_env ty
-         , translate_tm new_env tm
-         , inexpr
-         ) in
-     (new_env, wrap)
+      let new_env = {env with values= Record.remove id env.values} in
+      let wrap inexpr =
+        TmLet
+          ( fi
+          , empty_mangle id
+          , Symb.Helpers.nosym
+          , translate_ty new_env ty
+          , translate_tm new_env tm
+          , inexpr )
+      in
+      (new_env, wrap)
   | TopType (Type (fi, id, params, ty)) ->
-     let new_env = {env with ty_cons = Record.remove id env.ty_cons} in
-     let wrap inexpr =
-       TmType
-         ( fi
-         , empty_mangle id
-         , params
-         , translate_ty env ty
-         , inexpr
-         ) in
-     (new_env, wrap)
+      let new_env = {env with ty_cons= Record.remove id env.ty_cons} in
+      let wrap inexpr =
+        TmType (fi, empty_mangle id, params, translate_ty env ty, inexpr)
+      in
+      (new_env, wrap)
   | TopRecLet (RecLet (fi, lets)) ->
-     let rem_value values (_, id, _, _) = Record.remove id values in
-     let new_env = {env with values = List.fold_left rem_value env.values lets} in
-     let translate_binding (fi', id, ty, tm) =
-       ( fi'
-       , empty_mangle id
-       , Symb.Helpers.nosym
-       , translate_ty new_env ty
-       , translate_tm new_env tm
-       ) in
-     let wrap inexpr =
-       TmRecLets (fi, List.map translate_binding lets, inexpr) in
-     (new_env, wrap)
+      let rem_value values (_, id, _, _) = Record.remove id values in
+      let new_env =
+        {env with values= List.fold_left rem_value env.values lets}
+      in
+      let translate_binding (fi', id, ty, tm) =
+        ( fi'
+        , empty_mangle id
+        , Symb.Helpers.nosym
+        , translate_ty new_env ty
+        , translate_tm new_env tm )
+      in
+      let wrap inexpr =
+        TmRecLets (fi, List.map translate_binding lets, inexpr)
+      in
+      (new_env, wrap)
   | TopCon (Con (fi, id, ty)) ->
-     let new_env = {env with constructors = Record.remove id env.constructors} in
-     let wrap inexpr =
-       TmConDef (fi, empty_mangle id, Symb.Helpers.nosym, translate_ty env ty, inexpr) in
-     (new_env, wrap)
+      let new_env =
+        {env with constructors= Record.remove id env.constructors}
+      in
+      let wrap inexpr =
+        TmConDef
+          (fi, empty_mangle id, Symb.Helpers.nosym, translate_ty env ty, inexpr)
+      in
+      (new_env, wrap)
   | TopUtest (Utest (fi, lhs, rhs, using, onfail)) ->
-     let wrap inexpr =
-       TmUtest
-         ( fi
-         , translate_tm env lhs
-         , translate_tm env rhs
-         , Option.map (translate_tm env) using
-         , Option.map (translate_tm env) onfail
-         , inexpr
-         ) in
-     (env, wrap)
+      let wrap inexpr =
+        TmUtest
+          ( fi
+          , translate_tm env lhs
+          , translate_tm env rhs
+          , Option.map (translate_tm env) using
+          , Option.map (translate_tm env) onfail
+          , inexpr )
+      in
+      (env, wrap)
   | TopExt (Ext (fi, id, e, ty)) ->
-     (* NOTE(vipa, 2023-11-14): Externals must have exactly the given
-     name, thus we leave them unchanged, which we do by recording them
-     in `values` (otherwise bindings would be `empty_mangle`d). *)
-     let new_env = {env with values = Record.add id id env.values} in
-     let wrap inexpr =
-       TmExt (fi, id, Symb.Helpers.nosym, e, translate_ty env ty, inexpr) in
-     (new_env, wrap)
+      (* NOTE(vipa, 2023-11-14): Externals must have exactly the given
+         name, thus we leave them unchanged, which we do by recording them
+         in `values` (otherwise bindings would be `empty_mangle`d). *)
+      let new_env = {env with values= Record.add id id env.values} in
+      let wrap inexpr =
+        TmExt (fi, id, Symb.Helpers.nosym, e, translate_ty env ty, inexpr)
+      in
+      (new_env, wrap)
 
-let translate_tops_with_env (env : mlang_env) (tops : top list) (bot : tm) : mlang_env * tm =
+let translate_tops_with_env (env : mlang_env) (tops : top list) (bot : tm) :
+    mlang_env * tm =
   let rec work env = function
-    | [] -> (env, translate_tm env bot)
+    | [] ->
+        (env, translate_tm env bot)
     | top :: tops ->
-       let (env, wrap) = translate_top env top in
-       let (env, bot) = work env tops in
-       (env, wrap bot) in
+        let env, wrap = translate_top env top in
+        let env, bot = work env tops in
+        (env, wrap bot)
+  in
   work env tops
 
-let translate_program_with_env (env : mlang_env) (Program (_includes, tops, bot)) : mlang_env * tm =
+let translate_program_with_env (env : mlang_env)
+    (Program (_includes, tops, bot)) : mlang_env * tm =
   translate_tops_with_env env tops bot
 
 let translate_program (p : program) : tm =
   snd (translate_program_with_env empty_mlang_env p)
-
-(* (\* Check that a single language fragment is self-consistent; it has compatible patterns, *)
-(*  * no duplicate definitions, etc. Does not consider included languages at all. *)
-(*  *\) *)
-(* let compute_lang_data (Lang (info, _, _, decls)) : lang_data = *)
-(*   let add_new_syn name ((fi, _, _) as data) = function *)
-(*     | None -> *)
-(*         Some data *)
-(*     | Some (old_fi, _, _) -> *)
-(*         raise_error fi *)
-(*           ( "Duplicate definition of '" ^ Ustring.to_utf8 name *)
-(*           ^ "', previously defined at " *)
-(*           ^ Ustring.to_utf8 (info2str old_fi) ) *)
-(*   in *)
-(*   let add_new_sem name fi data = function *)
-(*     | None -> *)
-(*         Some data *)
-(*     | Some old_data -> *)
-(*         if Option.is_some old_data.params = Option.is_some data.params then *)
-(*           raise_error fi *)
-(*             ( "Duplicate definition of '" ^ Ustring.to_utf8 name *)
-(*             ^ "', previously defined at " *)
-(*             ^ Ustring.to_utf8 (info2str old_data.info) ) *)
-(*         else merge_inter fi name (Some old_data) (Some data) *)
-(*   in *)
-(*   let add_decl lang_data = function *)
-(*     | Data (fi, name, params, cons) -> *)
-(*         { lang_data with *)
-(*           syns= *)
-(*             Record.update name *)
-(*               (add_new_syn name (fi, params, cons)) *)
-(*               lang_data.syns } *)
-(*     | Inter (fi, name, ty, params, cases) -> *)
-(*         let mk_case (pat, rhs) = *)
-(*           let pos_pat = pat_to_normpat pat in *)
-(*           ( pat_info pat *)
-(*           , {pat; rhs; pos_pat; neg_pat= normpat_complement pos_pat} ) *)
-(*         in *)
-(*         let cases = List.map mk_case cases in *)
-(*         let subsets = *)
-(*           pair_with_later cases *)
-(*           |> fold_map *)
-(*                ~fold:(fun a b -> List.rev_append b a) *)
-(*                ~map:(compute_order info) [] *)
-(*         in *)
-(*         let inter_data = {info= fi; ty; params; cases; subsets} in *)
-(*         { lang_data with *)
-(*           inters= *)
-(*             Record.update name *)
-(*               (add_new_sem name fi inter_data) *)
-(*               lang_data.inters } *)
-(*     | Alias (fi, name, params, ty) -> ( *)
-(*       match Record.find_opt name lang_data.alias_defs with *)
-(*       | Some old_fi -> *)
-(*           raise_error fi *)
-(*             ( "Duplicate definition of '" ^ Ustring.to_utf8 name *)
-(*             ^ "', previously defined at " *)
-(*             ^ Ustring.to_utf8 (info2str old_fi) ) *)
-(*       | None -> *)
-(*           { lang_data with *)
-(*             aliases_rev= (name, fi, params, ty) :: lang_data.aliases_rev *)
-(*           ; alias_defs= Record.add name fi lang_data.alias_defs } ) *)
-(*   in *)
-(*   List.fold_left add_decl *)
-(*     { inters= Record.empty *)
-(*     ; syns= Record.empty *)
-(*     ; alias_defs= Record.empty *)
-(*     ; aliases_rev= [] } *)
-(*     decls *)
-
-(* (\* Merges the second language into the first, because the first includes the second *\) *)
-(* let merge_lang_data fi {inters= i1; syns= s1; alias_defs= a1; aliases_rev= ar1} *)
-(*     {inters= i2; syns= s2; alias_defs= a2; aliases_rev= ar2} : lang_data = *)
-(*   let eq_cons (CDecl (_, _, c1, _)) (CDecl (_, _, c2, _)) = c1 =. c2 in *)
-(*   let merge_syn _ a b = *)
-(*     match (a, b) with *)
-(*     | None, None -> *)
-(*         None *)
-(*     | None, Some (fi, count, _) -> *)
-(*         Some (fi, count, []) *)
-(*     | Some a, None -> *)
-(*         Some a *)
-(*     | Some (fi, old_count, cons), Some (_, new_count, old_cons) -> *)
-(*         if old_count <> new_count then *)
-(*           raise_error fi *)
-(*             "This definition has the wrong number of type arguments" *)
-(*         else *)
-(*           Some *)
-(*             ( fi *)
-(*             , old_count *)
-(*             , List.filter *)
-(*                 (fun c1 -> List.exists (eq_cons c1) old_cons |> not) *)
-(*                 cons ) *)
-(*   in *)
-(*   ignore *)
-(*     (Record.merge *)
-(*        (fun _ a b -> *)
-(*          match (a, b) with *)
-(*          | Some fi1, Some fi2 when fi1 <> fi2 -> *)
-(*              raise_error fi1 *)
-(*                "This definition would shadow a previous definition in an \ *)
-(*                 included language fragment." *)
-(*          | _, _ -> *)
-(*              None ) *)
-(*        a1 a2 ) ; *)
-(*   { inters= Record.merge (merge_inter fi) i1 i2 *)
-(*   ; syns= Record.merge merge_syn s1 s2 *)
-(*   ; alias_defs= Record.union (fun _ a _ -> Some a) a1 a2 *)
-(*   ; aliases_rev= *)
-(*       List.filter (fun (name, _, _, _) -> Record.mem name a1) ar2 @ ar1 } *)
-
-
-(* let data_to_lang info name includes {inters; syns; aliases_rev; _} : mlang = *)
-(*   let info_assoc fi l = List.find (fun (fi2, _) -> eq_info fi fi2) l |> snd in *)
-(*   let syns = *)
-(*     Record.bindings syns *)
-(*     |> List.map (fun (syn_name, (fi, count, cons)) -> *)
-(*            Data (fi, syn_name, count, cons) ) *)
-(*   in *)
-(*   let sort_inter name {info; ty; params; cases; subsets} = *)
-(*     let mk_case fi = *)
-(*       let case = info_assoc fi cases in *)
-(*       (case.pat, case.rhs) *)
-(*     in *)
-(*     let cases = *)
-(*       List.map fst cases |> topo_sort eq_info subsets |> List.map mk_case *)
-(*     in *)
-(*     Inter (info, name, ty, params, cases) *)
-(*   in *)
-(*   let inters = *)
-(*     Record.bindings inters *)
-(*     |> List.map (fun (name, inter_data) -> sort_inter name inter_data) *)
-(*   in *)
-(*   let aliases = *)
-(*     aliases_rev *)
-(*     |> List.map (fun (name, fi, params, ty) -> Alias (fi, name, params, ty)) *)
-(*   in *)
-(*   Lang *)
-(*     ( info *)
-(*     , name *)
-(*     , includes *)
-(*     , List.rev_append aliases (List.rev_append syns inters) ) *)
-
-(* let flatten_lang (prev_langs : lang_data Record.t) : *)
-(*     top -> lang_data Record.t * top = function *)
-(*   | (TopLet _ | TopType _ | TopRecLet _ | TopCon _ | TopUtest _ | TopExt _) as *)
-(*     top -> *)
-(*       (prev_langs, top) *)
-(*   | TopLang (Lang (info, name, includes, _) as lang) -> *)
-(*       let self_data = compute_lang_data lang in *)
-(*       let included_data = List.map (lookup_lang info prev_langs) includes in *)
-(*       let merged_data = *)
-(*         List.fold_left (merge_lang_data info) self_data included_data *)
-(*       in *)
-(*       ( Record.add name merged_data prev_langs *)
-(*       , TopLang (data_to_lang info name includes merged_data) ) *)
-
-(* let flatten_with_env (prev_langs : lang_data Record.t) *)
-(*     (Program (includes, tops, e) : program) = *)
-(*   let new_langs, new_tops = accum_map flatten_lang prev_langs tops in *)
-(*   (new_langs, Program (includes, new_tops, e)) *)
-
-(* (\* Flatten top-level language definitions *\) *)
-(* let flatten prg : program = snd (flatten_with_env Record.empty prg) *)
-
-(* (\*************** *)
-(*  * Translation * *)
-(*  ***************\) *)
-
-(* module AstHelpers = struct *)
-(*   let var fi x = TmVar (fi, x, Symb.Helpers.nosym, false, false) *)
-
-(*   let app fi l r = TmApp (fi, l, r) *)
-
-(*   let let_ fi x s e body = TmLet (fi, x, s, TyUnknown fi, e, body) *)
-(* end *)
-
-(* open AstHelpers *)
-
-(* let translate_cases fi f target cases = *)
-(*   let translate_case (pat, handler) inner = *)
-(*     TmMatch (pat_info pat, target, pat, handler, inner) *)
-(*   in *)
-(*   let msg = *)
-(*     Mseq.map *)
-(*       (fun c -> TmConst (fi, CChar c)) *)
-(*       (us "No matching case for function " ^. f |> Mseq.Helpers.of_ustring) *)
-(*   in *)
-(*   let no_match = *)
-(*     let_ fi (us "_") Symb.Helpers.nosym *)
-(*       (\* TODO(?,?): we should probably have a special sort for let with wildcards *\) *)
-(*       (app fi (TmConst (fi, Cdprint)) target) *)
-(*       (app fi (TmConst (fi, Cerror)) (TmSeq (fi, msg))) *)
-(*   in *)
-(*   List.fold_right translate_case cases no_match *)
-
-(* module USMap = Map.Make (Ustring) *)
-
-(* type mlangEnv = *)
-(*   { constructors: ustring USMap.t *)
-(*   ; normals: ustring USMap.t *)
-(*   ; aliases: ustring USMap.t } *)
-
-(* let emptyMlangEnv = *)
-(*   {constructors= USMap.empty; normals= USMap.empty; aliases= USMap.empty} *)
-
-(* (\* Compute the intersection of a and b, by overwriting names in a with the names *)
-(*    in b *\) *)
-(* let intersect_env_overwrite fi a b = *)
-(*   let merger = function *)
-(*     | None, None -> *)
-(*         None *)
-(*     | Some _, Some r -> *)
-(*         Some r *)
-(*     | None, Some _ -> *)
-(*         None *)
-(*     | Some l, None -> *)
-(*         raise_error fi *)
-(*           ( "Binding '" ^ Ustring.to_utf8 l *)
-(*           ^ "' exists only in the subsumed language, which should be \ *)
-(*              impossible.\n" ) *)
-(*   in *)
-(*   { constructors= *)
-(*       USMap.merge (fun _ l r -> merger (l, r)) a.constructors b.constructors *)
-(*   ; normals= USMap.merge (fun _ l r -> merger (l, r)) a.normals b.normals *)
-(*   ; aliases= USMap.merge (fun _ l r -> merger (l, r)) a.aliases b.aliases } *)
-
-(* (\* Adds the names from b to a, overwriting with the name from b when they overlap *\) *)
-(* let merge_env_overwrite a b = *)
-(*   { constructors= *)
-(*       USMap.union (fun _ _ r -> Some r) a.constructors b.constructors *)
-(*   ; normals= USMap.union (fun _ _ r -> Some r) a.normals b.normals *)
-(*   ; aliases= USMap.union (fun _ _ r -> Some r) a.aliases b.aliases } *)
-
-(* let empty_mangle str = str *)
-
-(* let resolve_con {constructors; _} ident = *)
-(*   match USMap.find_opt ident constructors with *)
-(*   | Some ident' -> *)
-(*       ident' *)
-(*   | None -> *)
-(*       empty_mangle ident *)
-
-(* let resolve_id {normals; _} ident = *)
-(*   match USMap.find_opt ident normals with *)
-(*   | Some ident' -> *)
-(*       ident' *)
-(*   | None -> *)
-(*       empty_mangle ident *)
-
-(* let resolve_alias {aliases; _} ident = *)
-(*   match USMap.find_opt ident aliases with *)
-(*   | Some ident' -> *)
-(*       ident' *)
-(*   | None -> *)
-(*       empty_mangle ident *)
-
-(* let delete_id ({normals; _} as env) ident = *)
-(*   {env with normals= USMap.remove ident normals} *)
-
-(* let delete_con ({constructors; _} as env) ident = *)
-(*   {env with constructors= USMap.remove ident constructors} *)
-
-(* let delete_alias ({aliases; _} as env) ident = *)
-(*   {env with aliases= USMap.remove ident aliases} *)
-
-(* (\* Maintains a subsumption relation among the languages (a reflexive and *)
-(*    transitive relation). A subsumes B if any call to a semantic function in A *)
-(*    can be replaced by a call to a semantic function in B with unchanged result. *)
-(*    Subsumption is only checked for language composition (lang A = B + C). *)
-(*    Subsumption implies inclusion, but not the other way around. *)
-
-(*    subsumer: Maintains the current subsumer of each language. If the binding (A, *)
-(*    B) is in 'subsumer', then the language B subsumes the language A, and B is *)
-(*    not subsumed by any other language (B is a "maximal" subsumer of A). If A is *)
-(*    not bound in 'subsumer', then A is subsumed by itself only. *)
-
-(*    subsumes: Maintains the set of languages that a language subsumes (excluding *)
-(*    self-subsumption). *\) *)
-(* type subsumeEnv = {subsumer: ustring USMap.t; subsumes: USSet.t USMap.t} *)
-
-(* let emptySubsumeEnv = {subsumer= USMap.empty; subsumes= USMap.empty} *)
-
-(* let enable_subsumption_analysis = ref false *)
-
-(* (\* Check if the first language is subsumed by the second *\) *)
-(* let lang_is_subsumed_by l1 l2 = *)
-(*   match (l1, l2) with *)
-(*   | Lang (fi, _, _, decls1), Lang (_, _, _, decls2) -> *)
-(*       let decl_is_subsumed_by = function *)
-(*         | Inter (_, n1, _, _, cases1), Inter (_, n2, _, _, cases2) *)
-(*           when n1 =. n2 -> *)
-(*             let mk_pos_neg (pat, _) = *)
-(*               let pos_pat = pat_to_normpat pat in *)
-(*               let neg_pat = normpat_complement pos_pat in *)
-(*               (pos_pat, neg_pat) *)
-(*             in *)
-(*             let cases1 = List.map mk_pos_neg cases1 in *)
-(*             let cases2 = List.map mk_pos_neg cases2 in *)
-(*             (\* First, filter out cases in B that are equal to A; those are *)
-(*                included from A *\) *)
-(*             let cases2 = *)
-(*               List.filter *)
-(*                 (fun (p2, n2) -> *)
-(*                   let is_equal = *)
-(*                     List.fold_left *)
-(*                       (fun is_equal (p1, n1) -> *)
-(*                         is_equal *)
-(*                         || *)
-(*                         match order_query (p1, n1) (p2, n2) with *)
-(*                         | Equal -> *)
-(*                             true *)
-(*                         | _ -> *)
-(*                             false ) *)
-(*                       false cases1 *)
-(*                   in *)
-(*                   not is_equal ) *)
-(*                 cases2 *)
-(*             in *)
-(*             (\* Then, check if all patterns in A are smaller than remaining *)
-(*                patterns in B *\) *)
-(*             List.for_all *)
-(*               (fun (p1, n1) -> *)
-(*                 List.fold_left *)
-(*                   (fun is_smaller (p2, n2) -> *)
-(*                     if not is_smaller then is_smaller *)
-(*                     else *)
-(*                       match order_query (p1, n1) (p2, n2) with *)
-(*                       | Subset | Disjoint -> *)
-(*                           true *)
-(*                       | Superset -> *)
-(*                           false *)
-(*                       | Equal | Overlapping _ -> *)
-(*                           raise_error fi *)
-(*                             "Two patterns in this semantic function are \ *)
-(*                              either equal or overlapping, which should be \ *)
-(*                              impossible" ) *)
-(*                   true cases2 ) *)
-(*               cases1 *)
-(*         | Data _, Data _ *)
-(*         | Inter _, Inter _ *)
-(*         | Data _, Inter _ *)
-(*         | Inter _, Data _ *)
-(*         | Alias _, Data _ *)
-(*         | Alias _, Inter _ *)
-(*         | Alias _, Alias _ *)
-(*         | Data _, Alias _ *)
-(*         | Inter _, Alias _ -> *)
-(*             true *)
-(*       in *)
-(*       List.for_all *)
-(*         (fun d1 -> List.for_all (fun d2 -> decl_is_subsumed_by (d1, d2)) decls2) *)
-(*         decls1 *)
-
-(* (\* Compute the resulting subsumption environment for a language declaration *\) *)
-(* let handle_subsumption env langs lang includes = *)
-(*   if !enable_subsumption_analysis then *)
-(*     (\* Find a subsumer for a language, if any exists. *\) *)
-(*     let find_subsumer env x = *)
-(*       (\* y is a subsumer of x if y has no subsumer and it subsumes x *\) *)
-(*       let is_subsumer y = *)
-(*         match USMap.find_opt y env.subsumer with *)
-(*         | Some _ -> *)
-(*             false *)
-(*         | None -> ( *)
-(*           match USMap.find_opt y env.subsumes with *)
-(*           | None -> *)
-(*               false *)
-(*           | Some set -> *)
-(*               USSet.mem x set ) *)
-(*       in *)
-(*       (\* Set b as the subsumer where currently a is *\) *)
-(*       let replace_subsumer subsumer_map a b = *)
-(*         USMap.map (fun x -> if x =. a then b else x) subsumer_map *)
-(*       in *)
-(*       let found_subsumer, subsumer = *)
-(*         USMap.fold *)
-(*           (fun k _ acc -> *)
-(*             match acc with true, _ -> acc | _ -> (is_subsumer k, k) ) *)
-(*           env.subsumes (false, x) *)
-(*       in *)
-(*       if found_subsumer then *)
-(*         { {env with subsumer= replace_subsumer env.subsumer x subsumer} with *)
-(*           subsumer= USMap.add x subsumer env.subsumer } *)
-(*       else env *)
-(*     in *)
-(*     (\* Finds new subsumers for languages that were previously subsumed by lang *\) *)
-(*     let del_lang env = *)
-(*       let subsumed_langs = USMap.find_opt lang env.subsumes in *)
-(*       let env = {env with subsumes= USMap.remove lang env.subsumes} in *)
-(*       match subsumed_langs with *)
-(*       | Some set -> *)
-(*           let env = *)
-(*             { env with *)
-(*               subsumer= *)
-(*                 USMap.filter (fun k _ -> not (USSet.mem k set)) env.subsumer } *)
-(*           in *)
-(*           let env = USSet.fold (fun x acc -> find_subsumer acc x) set env in *)
-(*           env *)
-(*       | None -> *)
-(*           env *)
-(*     in *)
-(*     (\* Subsume the language, and recursively subsume the languages that were *)
-(*        previously subsumed by it *\) *)
-(*     let rec add_lang to_be_subsumed env = *)
-(*       let env = *)
-(*         {env with subsumer= USMap.add to_be_subsumed lang env.subsumer} *)
-(*       in *)
-(*       let env = *)
-(*         match USMap.find_opt to_be_subsumed env.subsumes with *)
-(*         | Some set -> *)
-(*             USSet.fold add_lang set env *)
-(*         | None -> *)
-(*             env *)
-(*       in *)
-(*       { env with *)
-(*         subsumes= *)
-(*           USMap.update lang *)
-(*             (function *)
-(*               | None -> *)
-(*                   Some (USSet.singleton to_be_subsumed) *)
-(*               | Some set -> *)
-(*                   Some (USSet.add to_be_subsumed set) ) *)
-(*             env.subsumes } *)
-(*     in *)
-(*     List.fold_left *)
-(*       (fun acc included -> *)
-(*         if *)
-(*           lang_is_subsumed_by *)
-(*             (USMap.find included langs) *)
-(*             (USMap.find lang langs) *)
-(*         then add_lang included acc *)
-(*         else acc ) *)
-(*       (del_lang env) includes *)
-(*   else env *)
-
-(* let rec desugar_ty env = function *)
-(*   | TyArrow (fi, lty, rty) -> *)
-(*       TyArrow (fi, desugar_ty env lty, desugar_ty env rty) *)
-(*   | TyAll (fi, id, ty) -> *)
-(*       TyAll (fi, id, desugar_ty env ty) *)
-(*   | TySeq (fi, ty) -> *)
-(*       TySeq (fi, desugar_ty env ty) *)
-(*   | TyTensor (fi, ty) -> *)
-(*       TyTensor (fi, desugar_ty env ty) *)
-(*   | TyRecord (fi, bindings) -> *)
-(*       TyRecord (fi, Record.map (desugar_ty env) bindings) *)
-(*   | TyVariant (fi, constrs) -> *)
-(*       TyVariant (fi, constrs) *)
-(*   | TyCon (fi, id) -> *)
-(*       TyCon (fi, resolve_alias env id) *)
-(*   | TyVar (fi, id) -> *)
-(*       TyVar (fi, id) *)
-(*   | TyApp (fi, lty, rty) -> *)
-(*       TyApp (fi, desugar_ty env lty, desugar_ty env rty) *)
-(*   | (TyUnknown _ | TyBool _ | TyInt _ | TyFloat _ | TyChar _) as ty -> *)
-(*       ty *)
-
-(* let rec desugar_tm nss env subs = *)
-(*   let map_right f (a, b) = (a, f b) in *)
-(*   function *)
-(*   (\* Referencing things *\) *)
-(*   | TmVar (fi, name, i, pes, frozen) -> *)
-(*       TmVar (fi, resolve_id env name, i, pes, frozen) *)
-(*   (\* Introducing things *\) *)
-(*   | TmLam (fi, name, s, pes, ty, body) -> *)
-(*       TmLam *)
-(*         ( fi *)
-(*         , empty_mangle name *)
-(*         , s *)
-(*         , pes *)
-(*         , desugar_ty env ty *)
-(*         , desugar_tm nss (delete_id env name) subs body ) *)
-(*   | TmLet (fi, name, s, ty, e, body) -> *)
-(*       TmLet *)
-(*         ( fi *)
-(*         , empty_mangle name *)
-(*         , s *)
-(*         , desugar_ty env ty *)
-(*         , desugar_tm nss env subs e *)
-(*         , desugar_tm nss (delete_id env name) subs body ) *)
-(*   | TmType (fi, name, params, ty, body) -> *)
-(*       TmType *)
-(*         ( fi *)
-(*         , name *)
-(*         , params *)
-(*         , desugar_ty env ty *)
-(*         , desugar_tm nss (delete_alias env name) subs body ) *)
-(*   | TmRecLets (fi, bindings, body) -> *)
-(*       let env' = *)
-(*         List.fold_left *)
-(*           (fun env' (_, name, _, _, _) -> delete_id env' name) *)
-(*           env bindings *)
-(*       in *)
-(*       TmRecLets *)
-(*         ( fi *)
-(*         , List.map *)
-(*             (fun (fi, name, s, ty, e) -> *)
-(*               ( fi *)
-(*               , empty_mangle name *)
-(*               , s *)
-(*               , desugar_ty env ty *)
-(*               , desugar_tm nss env' subs e ) ) *)
-(*             bindings *)
-(*         , desugar_tm nss env' subs body ) *)
-(*   | TmConDef (fi, name, s, ty, body) -> *)
-(*       TmConDef *)
-(*         ( fi *)
-(*         , empty_mangle name *)
-(*         , s *)
-(*         , desugar_ty env ty *)
-(*         , desugar_tm nss (delete_con env name) subs body ) *)
-(*   | TmConApp (fi, x, s, t) -> *)
-(*       TmConApp (fi, resolve_con env x, s, desugar_tm nss env subs t) *)
-(*   | TmClos _ as tm -> *)
-(*       tm *)
-(*   (\* Both introducing and referencing *\) *)
-(*   | TmMatch (fi, target, pat, thn, els) -> *)
-(*       let desugar_pname env = function *)
-(*         | NameStr (n, s) -> *)
-(*             (delete_id env n, NameStr (empty_mangle n, s)) *)
-(*         | NameWildcard -> *)
-(*             (env, NameWildcard) *)
-(*       in *)
-(*       let rec desugar_pat_seq env pats = *)
-(*         Mseq.Helpers.fold_right *)
-(*           (fun p (env, pats) -> *)
-(*             desugar_pat env p |> map_right (fun p -> Mseq.cons p pats) ) *)
-(*           (env, Mseq.empty) pats *)
-(*       and desugar_pat env = function *)
-(*         | PatNamed (fi, name) -> *)
-(*             name |> desugar_pname env |> map_right (fun n -> PatNamed (fi, n)) *)
-(*         | PatSeqTot (fi, pats) -> *)
-(*             let env, pats = desugar_pat_seq env pats in *)
-(*             (env, PatSeqTot (fi, pats)) *)
-(*         | PatSeqEdge (fi, l, x, r) -> *)
-(*             let env, l = desugar_pat_seq env l in *)
-(*             let env, x = desugar_pname env x in *)
-(*             let env, r = desugar_pat_seq env r in *)
-(*             (env, PatSeqEdge (fi, l, x, r)) *)
-(*         | PatRecord (fi, pats) -> *)
-(*             let env = ref env in *)
-(*             let pats = *)
-(*               pats *)
-(*               |> Record.map (fun p -> *)
-(*                      let env', p = desugar_pat !env p in *)
-(*                      env := env' ; *)
-(*                      p ) *)
-(*             in *)
-(*             (!env, PatRecord (fi, pats)) *)
-(*         | PatAnd (fi, l, r) -> *)
-(*             let env, l = desugar_pat env l in *)
-(*             let env, r = desugar_pat env r in *)
-(*             (env, PatAnd (fi, l, r)) *)
-(*         | PatOr (fi, l, r) -> *)
-(*             let env, l = desugar_pat env l in *)
-(*             let env, r = desugar_pat env r in *)
-(*             (env, PatOr (fi, l, r)) *)
-(*         | PatNot (fi, p) -> *)
-(*             let env, p = desugar_pat env p in *)
-(*             (env, PatNot (fi, p)) *)
-(*         | PatCon (fi, name, sym, p) -> *)
-(*             desugar_pat env p *)
-(*             |> map_right (fun p -> PatCon (fi, resolve_con env name, sym, p)) *)
-(*         | (PatInt _ | PatChar _ | PatBool _) as pat -> *)
-(*             (env, pat) *)
-(*       in *)
-(*       let env', pat' = desugar_pat env pat in *)
-(*       TmMatch *)
-(*         ( fi *)
-(*         , desugar_tm nss env subs target *)
-(*         , pat' *)
-(*         , desugar_tm nss env' subs thn *)
-(*         , desugar_tm nss env subs els ) *)
-(*   (\* Use *\) *)
-(*   | TmUse (fi, name, body) -> ( *)
-(*     match USMap.find_opt name nss with *)
-(*     | None -> *)
-(*         raise_error fi *)
-(*           ("Unknown language fragment '" ^ Ustring.to_utf8 name ^ "'") *)
-(*     | Some ns -> *)
-(*         let intersected_ns = *)
-(*           match USMap.find_opt name subs.subsumer with *)
-(*           | None -> *)
-(*               ns *)
-(*           | Some subsumer -> *)
-(*               (\* Use namespace from subsumer, but prune bindings that are not *)
-(*                  defined in the subsumed namespace *\) *)
-(*               intersect_env_overwrite fi ns (USMap.find subsumer nss) *)
-(*         in *)
-(*         desugar_tm nss (merge_env_overwrite env intersected_ns) subs body ) *)
-(*   (\* Simple recursions *\) *)
-(*   | TmApp (fi, a, b) -> *)
-(*       TmApp (fi, desugar_tm nss env subs a, desugar_tm nss env subs b) *)
-(*   | TmSeq (fi, tms) -> *)
-(*       TmSeq (fi, Mseq.map (desugar_tm nss env subs) tms) *)
-(*   | TmRecord (fi, r) -> *)
-(*       TmRecord (fi, Record.map (desugar_tm nss env subs) r) *)
-(*   | TmRecordUpdate (fi, a, lab, b) -> *)
-(*       TmRecordUpdate *)
-(*         (fi, desugar_tm nss env subs a, lab, desugar_tm nss env subs b) *)
-(*   | TmUtest (fi, a, b, using, onfail, body) -> *)
-(*       let using_desugared = Option.map (desugar_tm nss env subs) using in *)
-(*       let onfail_desugared = Option.map (desugar_tm nss env subs) onfail in *)
-(*       TmUtest *)
-(*         ( fi *)
-(*         , desugar_tm nss env subs a *)
-(*         , desugar_tm nss env subs b *)
-(*         , using_desugared *)
-(*         , onfail_desugared *)
-(*         , desugar_tm nss env subs body ) *)
-(*   | TmNever fi -> *)
-(*       TmNever fi *)
-(*   | TmDive (fi, l, a) -> *)
-(*       TmDive (fi, l, desugar_tm nss env subs a) *)
-(*   | TmPreRun (fi, l, a) -> *)
-(*       TmPreRun (fi, l, desugar_tm nss env subs a) *)
-(*   | TmBox (_, _) -> *)
-(*       failwith "Box is a runtime value" *)
-(*   (\* Non-recursive *\) *)
-(*   | (TmConst _ | TmRef _ | TmTensor _ | TmExt _) as tm -> *)
-(*       tm *)
-
-(* (\* add namespace to nss (overwriting) if relevant, prepend a tm -> tm function to stack, return updated tuple. Should use desugar_tm, as well as desugar both sem and syn *\) *)
-(* let desugar_top (nss, langs, subs, syns, (stack : (tm -> tm) list)) = function *)
-(*   | TopLang (Lang (fi, langName, includes, decls) as lang) -> *)
-(*       let default d = function Some x -> x | None -> d in *)
-(*       let add_lang ns lang = *)
-(*         USMap.find_opt lang nss |> default emptyMlangEnv *)
-(*         |> merge_env_overwrite ns *)
-(*       in *)
-(*       let previous_ns = List.fold_left add_lang emptyMlangEnv includes in *)
-(*       (\* compute the namespace *\) *)
-(*       let mangle str = langName ^. us "_" ^. str in *)
-(*       let cdecl_names (CDecl (_, _, name, _)) = (name, mangle name) in *)
-(*       let add_decl ({constructors; normals; aliases}, syns) = function *)
-(*         | Data (fi, name, count, cdecls) -> *)
-(*             let new_constructors = List.to_seq cdecls |> Seq.map cdecl_names in *)
-(*             ( { constructors= USMap.add_seq new_constructors constructors *)
-(*               ; aliases *)
-(*               ; normals } *)
-(*             , USMap.add name (fi, count) syns ) *)
-(*         | Inter (_, name, _, _, _) -> *)
-(*             ( { normals= USMap.add name (mangle name) normals *)
-(*               ; aliases *)
-(*               ; constructors } *)
-(*             , syns ) *)
-(*         | Alias (_, name, _, _) -> *)
-(*             ( { aliases= USMap.add name (mangle name) aliases *)
-(*               ; normals *)
-(*               ; constructors } *)
-(*             , syns ) *)
-(*       in *)
-(*       let ns, new_syns = List.fold_left add_decl (previous_ns, syns) decls in *)
-(*       (\* wrap in "con"s *\) *)
-(*       let wrap_con ty_name (CDecl (fi, params, cname, ty)) tm = *)
-(*         let app_param ty param = TyApp (fi, ty, TyVar (fi, param)) in *)
-(*         let all_param param ty = TyAll (fi, param, ty) in *)
-(*         let con = List.fold_left app_param (TyCon (fi, ty_name)) params in *)
-(*         TmConDef *)
-(*           ( fi *)
-(*           , mangle cname *)
-(*           , Symb.Helpers.nosym *)
-(*           , List.fold_right all_param params *)
-(*               (TyArrow (fi, desugar_ty ns ty, con)) *)
-(*           , tm ) *)
-(*       in *)
-(*       (\* TODO(vipa,?): the type will likely be incorrect once we start doing product extensions of constructors *\) *)
-(*       let wrap_data decl tm = *)
-(*         match decl with *)
-(*         | Data (_, name, _, cdecls) -> *)
-(*             List.fold_right (wrap_con name) cdecls tm *)
-(*         | Alias (fi, name, params, ty) -> *)
-(*             TmType (fi, mangle name, params, desugar_ty ns ty, tm) *)
-(*         | _ -> *)
-(*             tm *)
-(*       in *)
-(*       (\* translate "Inter"s into (info * ustring * tm) *\) *)
-(*       let inter_to_tm fname fi params cases = *)
-(*         let target = us "__sem_target" in *)
-(*         let wrap_param (Param (fi, name, ty)) tm = *)
-(*           TmLam (fi, name, Symb.Helpers.nosym, false, desugar_ty ns ty, tm) *)
-(*         in *)
-(*         TmLam *)
-(*           ( fi *)
-(*           , target *)
-(*           , Symb.Helpers.nosym *)
-(*           , false *)
-(*           , TyUnknown fi *)
-(*           , translate_cases fi fname (var fi target) cases ) *)
-(*         |> List.fold_right wrap_param params *)
-(*         |> desugar_tm nss ns subs *)
-(*         (\* TODO: pass new subs here? *\) *)
-(*       in *)
-(*       let translate_inter = function *)
-(*         | Inter (fi, name, ty, params, cases) -> *)
-(*             let params = *)
-(*               match params with Some params -> params | None -> [] *)
-(*             in *)
-(*             Some *)
-(*               ( fi *)
-(*               , mangle name *)
-(*               , Symb.Helpers.nosym *)
-(*               , desugar_ty ns ty *)
-(*               , inter_to_tm name fi params cases ) *)
-(*         | _ -> *)
-(*             None *)
-(*       in *)
-(*       (\* put translated inters in a single letrec, then wrap in cons, then done *\) *)
-(*       let wrap tm = *)
-(*         TmRecLets (fi, List.filter_map translate_inter decls, tm) *)
-(*         |> List.fold_right wrap_data decls *)
-(*       in *)
-(*       let new_langs = USMap.add langName lang langs in *)
-(*       ( USMap.add langName ns nss *)
-(*       , new_langs *)
-(*       , handle_subsumption subs new_langs langName includes *)
-(*       , new_syns *)
-(*       , wrap :: stack ) *)
-(*   (\* The other tops are trivial translations *\) *)
-(*   | TopLet (Let (fi, id, ty, tm)) -> *)
-(*       let wrap tm' = *)
-(*         TmLet *)
-(*           ( fi *)
-(*           , empty_mangle id *)
-(*           , Symb.Helpers.nosym *)
-(*           , ty *)
-(*           , desugar_tm nss emptyMlangEnv subs tm *)
-(*           , tm' ) *)
-(*       in *)
-(*       (nss, langs, subs, syns, wrap :: stack) *)
-(*   | TopType (Type (fi, id, params, ty)) -> *)
-(*       let wrap tm' = TmType (fi, id, params, ty, tm') in *)
-(*       (nss, langs, subs, syns, wrap :: stack) *)
-(*   | TopRecLet (RecLet (fi, lets)) -> *)
-(*       let wrap tm' = *)
-(*         TmRecLets *)
-(*           ( fi *)
-(*           , List.map *)
-(*               (fun (fi', id, ty, tm) -> *)
-(*                 ( fi' *)
-(*                 , empty_mangle id *)
-(*                 , Symb.Helpers.nosym *)
-(*                 , ty *)
-(*                 , desugar_tm nss emptyMlangEnv subs tm ) ) *)
-(*               lets *)
-(*           , tm' ) *)
-(*       in *)
-(*       (nss, langs, subs, syns, wrap :: stack) *)
-(*   | TopCon (Con (fi, id, ty)) -> *)
-(*       let wrap tm' = *)
-(*         TmConDef (fi, empty_mangle id, Symb.Helpers.nosym, ty, tm') *)
-(*       in *)
-(*       (nss, langs, subs, syns, wrap :: stack) *)
-(*   | TopUtest (Utest (fi, lhs, rhs, using, onfail)) -> *)
-(*       let wrap tm' = TmUtest (fi, lhs, rhs, using, onfail, tm') in *)
-(*       (nss, langs, subs, syns, wrap :: stack) *)
-(*   | TopExt (Ext (fi, id, e, ty)) -> *)
-(*       let wrap tm' = *)
-(*         TmExt (fi, empty_mangle id, Symb.Helpers.nosym, e, ty, tm') *)
-(*       in *)
-(*       (nss, langs, subs, syns, wrap :: stack) *)
-
-(* let desugar_post_flatten_with_nss nss (Program (_, tops, t)) = *)
-(*   let acc_start = (nss, USMap.empty, emptySubsumeEnv, USMap.empty, []) in *)
-(*   let new_nss, _langs, subs, syns, stack = *)
-(*     List.fold_left desugar_top acc_start tops *)
-(*   in *)
-(*   (\* TODO(vipa, 2022-05-06): This allows `syn` types to be used before *)
-(*      their fragment is declared, and also makes them mostly global; they *)
-(*      can be used without `use`ing any language fragment. A proper *)
-(*      solution would be to mangle them as well *\) *)
-(*   let syntydecl = *)
-(*     List.map *)
-(*       (fun (syn, (fi, count)) tm' -> *)
-(*         TmType *)
-(*           ( fi *)
-(*           , syn *)
-(*           , List.init count (fun i -> us "a" ^. ustring_of_int i) *)
-(*           , TyVariant (fi, []) *)
-(*           , tm' ) ) *)
-(*       (USMap.bindings syns) *)
-(*   in *)
-(*   let stack = stack @ syntydecl in *)
-(*   let desugared_tm = *)
-(*     List.fold_left ( |> ) (desugar_tm new_nss emptyMlangEnv subs t) stack *)
-(*   in *)
-(*   (new_nss, desugared_tm) *)
-
-(* (\* Desugar top level statements after flattening language fragments. *\) *)
-(* let desugar_post_flatten prg = *)
-(*   snd (desugar_post_flatten_with_nss USMap.empty prg) *)

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -236,8 +236,7 @@ let merge_sems_in_lang : info -> ustring -> sem_data -> sem_data -> sem_data = f
         |> List.to_seq
         |> SubsetOrdSet.of_seq in
       { a with
-        fi = fi
-      ; params = if Option.is_some a.params then a.params else b.params
+        params = if Option.is_some a.params then a.params else b.params
       ; cases = SemCaseSet.union a.cases b.cases
       ; subsets =
           SubsetOrdSet.union

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -555,6 +555,9 @@ ty:
   | ALL var_ident DOT ty
       { let fi = mkinfo $1.i (ty_info $4) in
         TyAll(fi, $2.v, $4) }
+  | USE ident IN ty
+      { let fi = mkinfo $1.i $3.i in
+        TyUse(fi, $2.v, $4) }
 
 ty_left:
   | ty_atom

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -216,12 +216,13 @@ toputest:
 
 mlang:
   | LANG ident lang_includes decls END
-    { let fi = if List.length $3 > 0 then
-                 mkinfo $1.i (List.nth $3 (List.length $3 - 1)).i
+    { let incs, withs = $3 in
+      let fi = if List.length incs > 0 then
+                 mkinfo $1.i (List.nth incs (List.length incs - 1)).i
                else
                  mkinfo $1.i $2.i
       in
-      Lang (fi, $2.v, List.map (fun l -> l.v) $3, $4) }
+      Lang (fi, $2.v, List.map (fun l -> l.v) incs, withs, $4) }
 
 topext:
   | EXTERNAL ident COLON ty
@@ -232,15 +233,34 @@ topext:
       Ext (fi, $2.v, true, $5) }
 
 lang_includes:
-  | EQ lang_list
-    { $2 }
+  | EQ lang_list with_list
+    { $2, List.rev $3 }
   |
-    { [] }
+    { [], [] }
 lang_list:
   | ident ADD lang_list
     { $1 :: $3 }
   | ident
     { [$1] }
+with_list:
+  |
+    { [] }
+  | with_list WITH type_ident EQ with_type_list
+    { let fi = mkinfo $2.i $4.i in
+      With (fi, WithType, $3.v, List.rev $5) :: $1 }
+  | with_list WITH var_ident EQ with_var_list
+    { let fi = mkinfo $2.i $4.i in
+      With (fi, WithValue, $3.v, List.rev $5) :: $1 }
+with_type_list:
+  | with_type_list ADD ident DOT type_ident
+    { ($3.v, $5.v) :: $1 }
+  | ident DOT type_ident
+    { [($1.v, $3.v)] }
+with_var_list:
+  | with_var_list ADD ident DOT var_ident
+    { ($3.v, $5.v) :: $1 }
+  | ident DOT var_ident
+    { [($1.v, $3.v)] }
 
 decls:
   | decl decls

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -209,7 +209,7 @@ let rec ustring_of_ty = function
   | TyVar (_, x) ->
       pprint_var_str x
   | TyUse (_, lang, ty) ->
-     us"use " ^. lang ^. us" in " ^. ustring_of_ty ty
+      us "use " ^. lang ^. us " in " ^. ustring_of_ty ty
   | TyApp (_, ty1, ty2) ->
       us "(" ^. ustring_of_ty ty1 ^. us " " ^. ustring_of_ty ty2 ^. us ")"
 

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -208,6 +208,8 @@ let rec ustring_of_ty = function
       pprint_type_str x
   | TyVar (_, x) ->
       pprint_var_str x
+  | TyUse (_, lang, ty) ->
+     us"use " ^. lang ^. us" in " ^. ustring_of_ty ty
   | TyApp (_, ty1, ty2) ->
       us "(" ^. ustring_of_ty ty1 ^. us " " ^. ustring_of_ty ty2 ^. us ")"
 

--- a/src/boot/lib/repl.ml
+++ b/src/boot/lib/repl.ml
@@ -154,8 +154,7 @@ let wrap_mexpr (Program (inc, tops, tm)) =
 
 let repl_merge_includes = merge_includes (Sys.getcwd ()) []
 
-let repl_envs =
-  ref (empty_mlang_env, builtin_name2sym, builtin_sym2term)
+let repl_envs = ref (empty_mlang_env, builtin_name2sym, builtin_sym2term)
 
 let initialize_envs () =
   let initial_envs, _ =
@@ -204,7 +203,8 @@ let keywords_and_identifiers () =
   let replace_name name mangled_name names =
     names |> USSet.add name |> USSet.remove mangled_name
   in
-  let rec process_mlang_env : 'a. 'a -> mlang_env -> USSet.t -> USSet.t = fun _ mlang_env names ->
+  let rec process_mlang_env : 'a. 'a -> mlang_env -> USSet.t -> USSet.t =
+   fun _ mlang_env names ->
     Record.fold replace_name mlang_env.values names
     |> Record.fold replace_name mlang_env.ty_cons
     |> Record.fold replace_name mlang_env.constructors

--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -110,7 +110,7 @@ let pprintCudaAst = use CudaPrettyPrint in
   lam ast : CudaProg.
   printCudaProg cCompilerNames ast
 
-let futharkTranslation : Set Name -> Expr -> FutProg =
+let futharkTranslation : use MExprFutharkCompile in Set Name -> Expr -> FutProg =
   lam entryPoints. lam ast.
   use MExprFutharkCompile in
   let ast = generateProgram entryPoints ast in
@@ -140,7 +140,7 @@ let cudaTranslation =
                                         options.accelerateTensorMaxRank ccEnv in
   (CuPProg { includes = cudaIncludes, tops = cudaTops }, wrapperProg)
 
-let mergePrograms : CudaProg -> CudaProg -> CudaProg =
+let mergePrograms : use CudaAst in CudaProg -> CudaProg -> CudaProg =
   lam cudaProg. lam wrapperProg.
   use MExprCudaCompile in
   -- NOTE(larshum, 2022-04-01): We split up the tops such that the types

--- a/src/main/parse.mc
+++ b/src/main/parse.mc
@@ -22,26 +22,27 @@ type ParseOptions = {
   keywords : [String]
 }
 
-let parseParseMCoreFile : ParseOptions -> String -> Expr = lam opt. lam file.
-  use BootParser in
-  if opt.pruneExternalUtests then
-    let externalsExclude =
-      if opt.findExternalsExclude then
-        mapKeys (externalGetSupportedExternalImpls ())
-      else []
-    in
-    parseMCoreFile {{{{{{ defaultBootParserParseMCoreFileArg
-      with keepUtests = opt.keepUtests }
-      with pruneExternalUtests = true }
-      with externalsExclude = externalsExclude }
-      with pruneExternalUtestsWarning = opt.pruneExternalUtestsWarning }
-      with eliminateDeadCode = opt.eliminateDeadCode }
-      with keywords = opt.keywords } file
-  else
-    parseMCoreFile {{{{{{ defaultBootParserParseMCoreFileArg
-      with keepUtests = opt.keepUtests }
-      with pruneExternalUtests = false }
-      with externalsExclude = [] }
-      with pruneExternalUtestsWarning = false }
-      with eliminateDeadCode = opt.eliminateDeadCode }
-      with keywords = opt.keywords } file
+let parseParseMCoreFile : ParseOptions -> String -> use Ast in Expr =
+  lam opt. lam file.
+    use BootParser in
+    if opt.pruneExternalUtests then
+      let externalsExclude =
+        if opt.findExternalsExclude then
+          mapKeys (externalGetSupportedExternalImpls ())
+        else []
+      in
+      parseMCoreFile {{{{{{ defaultBootParserParseMCoreFileArg
+        with keepUtests = opt.keepUtests }
+        with pruneExternalUtests = true }
+        with externalsExclude = externalsExclude }
+        with pruneExternalUtestsWarning = opt.pruneExternalUtestsWarning }
+        with eliminateDeadCode = opt.eliminateDeadCode }
+        with keywords = opt.keywords } file
+    else
+      parseMCoreFile {{{{{{ defaultBootParserParseMCoreFileArg
+        with keepUtests = opt.keepUtests }
+        with pruneExternalUtests = false }
+        with externalsExclude = [] }
+        with pruneExternalUtestsWarning = false }
+        with eliminateDeadCode = opt.eliminateDeadCode }
+        with keywords = opt.keywords } file

--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -23,7 +23,7 @@ let tableFromFile = lam file.
   else error (join ["Tune file ", file, " does not exist"])
 
 let dependencyAnalysis
-  : Options -> CallCtxEnv -> Expr -> (DependencyGraph, Expr) =
+  : use MCoreTune in Options -> CallCtxEnv -> Expr -> (DependencyGraph, Expr) =
   lam options : Options. lam env : CallCtxEnv. lam ast.
     use MCoreTune in
     if options.tuneOptions.dependencyAnalysis then

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -65,7 +65,7 @@ let _lookupTypeName = use MExprAst in
   work (None ()) ty
 
 -- C assignment shorthand
-let _assign: CExpr -> CExpr -> CExpr = use CAst in
+let _assign: use CAst in CExpr -> CExpr -> CExpr = use CAst in
   lam lhs. lam rhs.
     CEBinOp { op = COAssign {}, lhs = lhs, rhs = rhs }
 

--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -1379,7 +1379,8 @@ let printCompiledCProg = use CProgPrettyPrint in
 lang Test =
   MExprCCompileAlloc + MExprPrettyPrint + MExprTypeCheck +
   MExprRemoveTypeAscription + MExprANF + MExprSym + BootParser +
-  MExprTypeLift + SeqTypeNoStringTypeLift + TensorTypeTypeLift
+  MExprTypeLift + SeqTypeNoStringTypeLift + TensorTypeTypeLift +
+  CProgAst
 end
 
 mexpr

--- a/stdlib/cp/pprint.mc
+++ b/stdlib/cp/pprint.mc
@@ -113,15 +113,20 @@ end
 -- OBJECTIVES --
 ----------------
 
-lang COPObjectiveDeclPrettyPrint = COPPrettyPrintBase + COPObjectiveDeclAst
+lang COPObjectivePrettyPrint
   sem pprintCOPObjective: PprintEnv -> COPObjective -> (PprintEnv, String)
+end
+
+lang COPObjectiveDeclPrettyPrint =
+  COPPrettyPrintBase + COPObjectivePrettyPrint + COPObjectiveDeclAst
   sem pprintCOPDecl env =
   | COPObjectiveDecl { objective = objective } ->
     match pprintCOPObjective env objective with (env, obj) in
     (env, join ["solve ", obj, ";"])
 end
 
-lang COPObjectiveMinimizePrettyPrint = COPPrettyPrintBase + COPObjectiveMinimizeAst
+lang COPObjectiveMinimizePrettyPrint =
+  COPPrettyPrintBase + COPObjectivePrettyPrint + COPObjectiveMinimizeAst
   sem pprintCOPObjective env =
   | COPObjectiveMinimize { expr = expr } ->
     match pprintCOPExpr env expr with (env, expr) in

--- a/stdlib/cuda/intrinsics/intrinsic.mc
+++ b/stdlib/cuda/intrinsics/intrinsic.mc
@@ -5,6 +5,11 @@ include "cuda/ast.mc"
 include "cuda/compile.mc"
 
 lang CudaIntrinsic = CudaAst + CudaCompile
+  sem generateCudaIntrinsicFunction : CompileCEnv -> CExpr -> (Name, CuTop)
+
+  sem generateCudaIntrinsicCall : CompileCEnv -> [CuTop] -> CExpr -> CExpr
+                               -> ([CuTop], CStmt)
+
   sem _getSequenceElemType (env : CompileCEnv) =
   | ty ->
     -- TODO(larshum, 2022-02-08): Assumes 1d sequence

--- a/stdlib/cuda/kernel-translate.mc
+++ b/stdlib/cuda/kernel-translate.mc
@@ -18,11 +18,19 @@ include "cuda/intrinsics/tensor-slice.mc"
 include "cuda/intrinsics/tensor-sub.mc"
 include "pmexpr/extract.mc"
 
+lang CudaTranslate
+  sem generateIntrinsicExpr : CompileCEnv -> [CuTop] -> CExpr -> CExpr
+                           -> ([CuTop], CStmt)
+
+  sem generateIntrinsicExprNoRet : CompileCEnv -> [CuTop] -> CExpr
+                                -> ([CuTop], CStmt)
+end
+
 -- Translates non-kernel intrinsics, which could run either in CPU or GPU code,
 -- to looping constructs.
 lang CudaCpuTranslate =
-  CudaFoldlIntrinsic + CudaTensorSliceIntrinsic + CudaTensorSubIntrinsic +
-  CudaLoopIntrinsic + CudaLoopAccIntrinsic
+  CudaTranslate + CudaFoldlIntrinsic + CudaTensorSliceIntrinsic +
+  CudaTensorSubIntrinsic + CudaLoopIntrinsic + CudaLoopAccIntrinsic
 
   sem generateIntrinsicExpr : CompileCEnv -> [CuTop] -> CExpr -> CExpr
                            -> ([CuTop], CStmt)
@@ -39,7 +47,7 @@ end
 
 -- Translates kernel expressions to GPU kernel calls.
 lang CudaGpuTranslate =
-  CudaLoopKernelIntrinsic
+  CudaTranslate + CudaLoopKernelIntrinsic
 
   -- NOTE(larshum, 2022-03-22): At the moment, no kernels returning a value are
   -- supported.

--- a/stdlib/ext/array-ext.ext-ocaml.mc
+++ b/stdlib/ext/array-ext.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = ["boot"], cLibraries = [] }
 
 let arrayExtMap =

--- a/stdlib/ext/ext-test.ext-ocaml.mc
+++ b/stdlib/ext/ext-test.ext-ocaml.mc
@@ -1,10 +1,11 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let implWithLibs = lam arg : { expr : String, ty : Type, libraries : [String] }.
-  { expr = arg.expr, ty = arg.ty, libraries = arg.libraries, cLibraries = [] }
+let implWithLibs =
+  lam arg : { expr : String, ty : use Ast in Type, libraries : [String] }.
+    { expr = arg.expr, ty = arg.ty, libraries = arg.libraries, cLibraries = [] }
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   implWithLibs { expr = arg.expr, ty = arg.ty, libraries = [] }
 
 let myrecty1 = otyrecordext_

--- a/stdlib/ext/local-search.mc
+++ b/stdlib/ext/local-search.mc
@@ -387,6 +387,9 @@ end
 
 mexpr
 
+type SearchState = use LocalSearchBase in SearchState in
+type MetaState = use LocalSearchBase in MetaState in
+
 let debug = false in
 
 let nIters = lam n. lam state : SearchState.

--- a/stdlib/ext/local-search.mc
+++ b/stdlib/ext/local-search.mc
@@ -19,8 +19,11 @@ include "string.mc"
 include "digraph.mc"
 include "iterator.mc"
 
--- TODO(Linnea, 2022-04-22): These type declarations should be put inside the
--- language fragment, but gives a type error right now.
+----------------------------
+-- Base language fragment --
+----------------------------
+
+lang LocalSearchBase
 
   -- A local search solution: an assignment with a cost.
   type Solution = {assignment : Assignment, cost : Cost}
@@ -31,17 +34,11 @@ include "iterator.mc"
     inc : Solution,                               -- incumbent (best solution thus far)
     iter : Int,                                   -- number of iterations thus far
     stuck : Bool,                                 -- whether the search is stuck
-                                                  -- (no local moves possible)
+    -- (no local moves possible)
     cost : Option Solution -> Assignment -> Cost, -- cost of an assignment
     cmp : Cost -> Cost -> Int,                    -- comparison of costs
     data : Option LSData                          -- any custom data
   }
-
-----------------------------
--- Base language fragment --
-----------------------------
-
-lang LocalSearchBase
 
   -- Maintains meta-information between search iterations.
   syn MetaState =

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let mathExtMap =

--- a/stdlib/ext/rtppl-ext.ext-ocaml.mc
+++ b/stdlib/ext/rtppl-ext.ext-ocaml.mc
@@ -2,7 +2,7 @@ include "map.mc"
 include "ocaml/ast.mc"
 
 let tyts_ = tytuple_ [tyint_, tyunknown_]
-let impl = lam arg : {expr : String, ty : Type }.
+let impl = lam arg : {expr : String, ty : use Ast in Type }.
   [ { expr = arg.expr, ty = arg.ty, libraries = ["rtppl-support"], cLibraries = [] } ]
 
 let timespec = otytuple_ [tyint_, tyint_]

--- a/stdlib/ext/toml-ext.ext-ocaml.mc
+++ b/stdlib/ext/toml-ext.ext-ocaml.mc
@@ -4,7 +4,7 @@ include "ocaml/ast.mc"
 let tyTomlTable_ = otyvarext_ "Toml.Types.table" []
 let tyTomlValue_ = otyvarext_ "Toml.Types.value" []
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = ["toml"], cLibraries = [] }
 
 let tomlExtMap =

--- a/stdlib/futhark/generate.mc
+++ b/stdlib/futhark/generate.mc
@@ -116,8 +116,13 @@ lang FutharkPatternGenerate = MExprAst + FutharkAst + FutharkTypeGenerate
     errorSingle [infoPat p] "Pattern is not supported by Futhark backend"
 end
 
+lang FutharkGenerate
+  sem generateExpr : FutharkGenerateEnv -> Expr -> FutExpr
+end
+
 lang FutharkMatchGenerate = MExprAst + FutharkAst + FutharkPatternGenerate +
-                            FutharkTypeGenerate + FutharkTypePrettyPrint
+                            FutharkTypeGenerate + FutharkTypePrettyPrint +
+                            FutharkGenerate
   sem defaultGenerateMatch (env : FutharkGenerateEnv) =
   | TmMatch t ->
     errorSingle [t.info] (join ["Match expression not supported by the Futhark backend"])
@@ -214,7 +219,7 @@ lang FutharkMatchGenerate = MExprAst + FutharkAst + FutharkPatternGenerate +
 end
 
 lang FutharkAppGenerate = MExprAst + FutharkAst + FutharkTypeGenerate +
-                          PMExprVariableSub
+                          PMExprVariableSub + FutharkGenerate
   sem defaultGenerateApp (env : FutharkGenerateEnv) =
   | TmApp t -> FEApp {lhs = generateExpr env t.lhs, rhs = generateExpr env t.rhs,
                       ty = generateType env t.ty, info = t.info}
@@ -363,7 +368,7 @@ end
 
 lang FutharkExprGenerate = FutharkConstGenerate + FutharkTypeGenerate +
                            FutharkMatchGenerate + FutharkAppGenerate +
-                           PMExprAst
+                           PMExprAst + FutharkGenerate
   sem generateExpr (env : FutharkGenerateEnv) =
   | TmVar t ->
     -- NOTE(larshum, 2022-08-15): Special-case handling of external functions.

--- a/stdlib/futhark/generate.mc
+++ b/stdlib/futhark/generate.mc
@@ -15,7 +15,7 @@ include "pmexpr/utils.mc"
 let extMap = mapFromSeq cmpString
   [("externalSin", "f64.sin"), ("externalCos", "f64.cos")]
 
-type FutharkGenerateEnv = {
+type FutharkGenerateEnv = use Ast in {
   entryPoints : Set Name,
   boundNames : Map Name Expr
 }

--- a/stdlib/futhark/pprint.mc
+++ b/stdlib/futhark/pprint.mc
@@ -158,7 +158,8 @@ lang FutharkTypePrettyPrint = FutharkAst
 end
 
 lang FutharkExprPrettyPrint = FutharkAst + FutharkConstPrettyPrint +
-                              FutharkPatPrettyPrint + FutharkTypePrettyPrint
+                              FutharkPatPrettyPrint + FutharkTypePrettyPrint +
+                              PrettyPrint
   sem isAtomic =
   | FEVar _ -> true
   | FEVarExt _ -> true

--- a/stdlib/futhark/size-parameterize.mc
+++ b/stdlib/futhark/size-parameterize.mc
@@ -11,7 +11,7 @@ include "futhark/pprint.mc"
 -- A size parameter represents the size of one dimension of an array. As an
 -- array may be multi-dimensional, we distinguish the size parameters using a
 -- dimension index.
-lang FutharkSizeType
+lang FutharkSizeType = FutharkAst
   type SizeParam = {
     id : Name,
     dim : Int

--- a/stdlib/ipopt/ipopt.ext-ocaml.mc
+++ b/stdlib/ipopt/ipopt.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   {
     expr = arg.expr,
     ty = arg.ty,

--- a/stdlib/javascript/compile.mc
+++ b/stdlib/javascript/compile.mc
@@ -416,16 +416,16 @@ let filepathWithoutExtension = lam filename.
 
 -- Compile a Miking AST to a JavaScript program AST.
 -- Walk the AST and convert it to a JavaScript AST.
-let javascriptCompile : CompileJSOptions -> Expr -> JSProg =
-  lam opts : CompileJSOptions. lam ast : Expr.
+let javascriptCompile : use MExprJSCompile in CompileJSOptions -> Expr -> JSProg =
+  lam opts : CompileJSOptions. lam ast : use Ast in Expr.
   use MExprJSCompile in
   let ctx = { compileJSCtxEmpty with options = opts } in
   compileProg ctx ast
 
 
-let javascriptCompileFile : CompileJSOptions -> Expr -> String -> String =
+let javascriptCompileFile : use Ast in CompileJSOptions -> Expr -> String -> String =
   lam opts : CompileJSOptions.
-  lam ast : Expr.
+  lam ast : use Ast in Expr.
   lam sourcePath: String.
   use JSProgPrettyPrint in
   let targetPath = concat (filepathWithoutExtension sourcePath) ".js" in

--- a/stdlib/javascript/mcore.mc
+++ b/stdlib/javascript/mcore.mc
@@ -9,7 +9,7 @@ let platformMapJS = mapFromSeq cmpString
   ,("bun", CompileJSTP_Bun ())
   ,("web", CompileJSTP_Web ())]
 
-let compileMCoreToJS : CompileJSOptions -> Expr -> String -> String =
+let compileMCoreToJS : use Ast in CompileJSOptions -> Expr -> String -> String =
   lam opts. lam ast. lam sourcePath.
   let outfile = javascriptCompileFile opts ast sourcePath in
   printLn (concat "Successfully compiled file to: " outfile);

--- a/stdlib/javascript/optimizations.mc
+++ b/stdlib/javascript/optimizations.mc
@@ -79,7 +79,7 @@ lang JSOptimizeBlocks = JSExprAst
 
 end
 
-type JSTCOContext = {
+type JSTCOContext = use JSExprAst in {
   expr: JSExpr,
   foundTailCall: Bool
 }

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -11,7 +11,7 @@ include "string.mc"
 -- NOTE(larshum, 2023-03-05): Below follows the implementation of the (as of
 -- writing) intrinsic functions of the map data type, making use of the native
 -- AVL tree implementation.
-type Map k v = {cmp : k -> k -> Int, root : AVL k v}
+type Map k v = use AVLTreeImpl in {cmp : k -> k -> Int, root : AVL k v}
 
 let mapEmpty : all k. all v. (k -> k -> Int) -> Map k v = lam cmp.
   use AVLTreeImpl in

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -90,8 +90,12 @@ lang AppANFAll = ANF + AppAst
 
 end
 
+lang NormalizeLams
+  sem normalizeLams =
+end
+
 -- Version analogous to AppANF, where each individual lambda is not name-bound.
-lang LamANF = ANF + LamAst
+lang LamANF = ANF + NormalizeLams + LamAst
 
   sem normalize (k : Expr -> Expr) =
   | TmLam _ & t -> k (normalizeLams t)
@@ -103,7 +107,7 @@ lang LamANF = ANF + LamAst
 end
 
 -- Version where each individual lambda is name-bound.
-lang LamANFAll = ANF + LamAst
+lang LamANFAll = ANF + NormalizeLams + LamAst
 
   sem normalize (k : Expr -> Expr) =
   | TmLam _ & t -> k (normalizeLams t)
@@ -153,10 +157,7 @@ lang TypeANF = ANF + TypeAst
     TmType {t with inexpr = normalizeName k t.inexpr}
 end
 
-lang RecLetsANFBase = ANF + RecLetsAst + LamAst
-
-  sem normalizeLams =
-  -- Intentionally left blank
+lang RecLetsANFBase = ANF + NormalizeLams + RecLetsAst + LamAst
 
   sem normalize (k : Expr -> Expr) =
   -- We do not allow lifting things outside of reclets, since they might

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -277,7 +277,7 @@ let patRecord : [(String, use Ast in Pat)] -> Info -> use Ast in Pat =
 
 let prec_ = lam bindings. patRecord bindings (NoInfo ())
 
-let patTuple = lam ps : [Pat]. lam info : Info.
+let patTuple = lam ps : use Ast in [Pat]. lam info : Info.
   patRecord (mapi (lam i. lam p. (int2string i, p)) ps) info
 
 let ptuple_ = lam ps. patTuple ps (NoInfo ())
@@ -580,7 +580,7 @@ let record_add = use MExprAst in
   else
       errorSingle [infoTm record] "record is not a TmRecord construct"
 
-let record_add_bindings : [(String, Expr)] -> Expr -> Expr =
+let record_add_bindings : use Ast in [(String, Expr)] -> Expr -> Expr =
   lam bindings. lam record.
   foldl (lam recacc. lam b : (String, Expr). record_add b.0 b.1 recacc) record bindings
 

--- a/stdlib/mexpr/ast-builder.mc
+++ b/stdlib/mexpr/ast-builder.mc
@@ -58,7 +58,8 @@ let tyarrows_ = use FunTypeAst in
   lam tys.
   foldr1 (lam e. lam acc. TyArrow {from = e, to = acc, info = NoInfo ()}) tys
 
-let tyRecord : Info -> [(String, Type)] -> Type = use RecordTypeAst in
+let tyRecord : Info -> [(String, use Ast in Type)] -> use Ast in Type =
+  use RecordTypeAst in
   lam info. lam fields.
   let fieldMapFunc = lam b : (String, Type). (stringToSid b.0, b.1) in
   TyRecord {
@@ -113,7 +114,7 @@ let nstyall_ = use AllTypeAst in
 
 let styall_ = lam s. nstyall_ (nameNoSym s)
 
-let ntyall_ : Name -> Type -> Type  = use KindAst in
+let ntyall_ : Name -> use Ast in Type -> Type  = use KindAst in
   lam n.
   nstyall_ n (Poly ())
 
@@ -263,7 +264,7 @@ let pcon_ = use MExprAst in
   lam cs. lam cp.
   npcon_ (nameNoSym cs) cp
 
-let patRecord : [(String, Pat)] -> Info -> Pat =
+let patRecord : [(String, use Ast in Pat)] -> Info -> use Ast in Pat =
   use MExprAst in
   lam bindings : [(String, Pat)].
   lam info : Info.

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -852,7 +852,7 @@ lang CmpSymbAst = SymbAst + BoolAst
   | CEqsym {}
 end
 
-lang SeqOpAst = SeqAst
+lang SeqOpAst = SeqAst + ConstAst
   syn Const =
   | CSet {}
   | CGet {}

--- a/stdlib/mexpr/ast.mc
+++ b/stdlib/mexpr/ast.mc
@@ -1420,7 +1420,7 @@ lang VarTypeAst = Ast
   | TyVar t -> t.info
 end
 
-lang KindAst
+lang KindAst = Ast
   syn Kind =
   | Poly ()
   | Mono ()

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -276,6 +276,8 @@ lang CFA = CFABase
 
   sem propagateConstraint: (IName,AbsVal) -> CFAGraph -> Constraint -> CFAGraph
 
+  sem propagateConstraintConst: ConstPropFun
+
   -- Returns both the new graph, and a Boolean that is true iff the new edge was
   -- added to the graph.
   -- NOTE(Linnea, 2022-06-21): Updates the graph by a side effect
@@ -698,8 +700,6 @@ lang AppCFA = CFA + ConstCFA + BaseConstraint + LamCFA + AppAst + MExprArity
         { graph with cstrs = concat cstrs graph.cstrs }
       else errorSingle [infoTm app.rhs] "Not a TmVar in application"
     else errorSingle [infoTm app.lhs] "Not a TmVar in application"
-
-  sem propagateConstraintConst: ConstPropFun
 end
 
 lang RecordCFA = CFA + BaseConstraint + RecordAst

--- a/stdlib/mexpr/const-transformer.mc
+++ b/stdlib/mexpr/const-transformer.mc
@@ -12,7 +12,8 @@ include "ast.mc"
 include "option.mc"
 
 -- Add info for both term and type in const tms
-let _constWithInfos: Info -> Expr -> Expr = use MExprAst in
+let _constWithInfos: Info -> use Ast in Expr -> use Ast in Expr =
+  use MExprAst in
   lam i: Info. lam tm: Expr.
     match tm with
       TmConst ({ info = NoInfo _, ty = TyUnknown ({ info = NoInfo _ } & ty)} & t)

--- a/stdlib/mexpr/const-types.mc
+++ b/stdlib/mexpr/const-types.mc
@@ -11,12 +11,16 @@ let tybootparsetree_ = tycon_ "BootParseTree"
 
 let tyvarseq_ = lam id. tyseq_ (tyvar_ id)
 
-lang UnsafeCoerceTypeAst = UnsafeCoerceAst
+lang TyConst
+  sem tyConst =
+end
+
+lang UnsafeCoerceTypeAst = TyConst + UnsafeCoerceAst
   sem tyConst =
   | CUnsafeCoerce _ -> tyall_ "a" (tyall_ "b" (tyarrow_ (tyvar_ "a") (tyvar_ "b")))
 end
 
-lang LiteralTypeAst = IntAst + FloatAst + BoolAst + CharAst
+lang LiteralTypeAst = TyConst + IntAst + FloatAst + BoolAst + CharAst
   sem tyConst =
   | CInt _ -> tyint_
   | CFloat _ -> tyfloat_
@@ -24,7 +28,7 @@ lang LiteralTypeAst = IntAst + FloatAst + BoolAst + CharAst
   | CChar _ -> tychar_
 end
 
-lang ArithIntTypeAst = ArithIntAst
+lang ArithIntTypeAst = TyConst + ArithIntAst
   sem tyConst =
   | CAddi _ -> tyarrows_ [tyint_, tyint_, tyint_]
   | CSubi _ -> tyarrows_ [tyint_, tyint_, tyint_]
@@ -34,14 +38,14 @@ lang ArithIntTypeAst = ArithIntAst
   | CModi _ -> tyarrows_ [tyint_, tyint_, tyint_]
 end
 
-lang ShiftIntTypeAst = ShiftIntAst
+lang ShiftIntTypeAst = TyConst + ShiftIntAst
   sem tyConst =
   | CSlli _ -> tyarrows_ [tyint_, tyint_, tyint_]
   | CSrli _ -> tyarrows_ [tyint_, tyint_, tyint_]
   | CSrai _ -> tyarrows_ [tyint_, tyint_, tyint_]
 end
 
-lang ArithFloatTypeAst = ArithFloatAst
+lang ArithFloatTypeAst = TyConst + ArithFloatAst
   sem tyConst =
   | CAddf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
   | CSubf _ -> tyarrows_ [tyfloat_, tyfloat_, tyfloat_]
@@ -50,7 +54,7 @@ lang ArithFloatTypeAst = ArithFloatAst
   | CNegf _ -> tyarrow_ tyfloat_ tyfloat_
 end
 
-lang FloatIntConversionTypeAst = FloatIntConversionAst
+lang FloatIntConversionTypeAst = TyConst + FloatIntConversionAst
   sem tyConst =
   | CFloorfi _ -> tyarrow_ tyfloat_ tyint_
   | CCeilfi _ -> tyarrow_ tyfloat_ tyint_
@@ -58,7 +62,7 @@ lang FloatIntConversionTypeAst = FloatIntConversionAst
   | CInt2float _ -> tyarrow_ tyint_ tyfloat_
 end
 
-lang CmpIntTypeAst = CmpIntAst
+lang CmpIntTypeAst = TyConst + CmpIntAst
   sem tyConst =
   | CEqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
   | CNeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
@@ -68,7 +72,7 @@ lang CmpIntTypeAst = CmpIntAst
   | CGeqi _ -> tyarrows_ [tyint_, tyint_, tybool_]
 end
 
-lang CmpFloatTypeAst = CmpFloatAst
+lang CmpFloatTypeAst = TyConst + CmpFloatAst
   sem tyConst =
   | CEqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
   | CLtf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
@@ -78,37 +82,37 @@ lang CmpFloatTypeAst = CmpFloatAst
   | CNeqf _ -> tyarrows_ [tyfloat_, tyfloat_, tybool_]
 end
 
-lang CmpCharTypeAst = CmpCharAst
+lang CmpCharTypeAst = TyConst + CmpCharAst
   sem tyConst =
   | CEqc _ -> tyarrows_ [tychar_, tychar_, tybool_]
 end
 
-lang IntCharConversionTypeAst = IntCharConversionAst
+lang IntCharConversionTypeAst = TyConst + IntCharConversionAst
   sem tyConst =
   | CInt2Char _ -> tyarrow_ tyint_ tychar_
   | CChar2Int _ -> tyarrow_ tychar_ tyint_
 end
 
-lang FloatStringConversionTypeAst = FloatStringConversionAst
+lang FloatStringConversionTypeAst = TyConst + FloatStringConversionAst
   sem tyConst =
   | CStringIsFloat _ -> tyarrow_ tystr_ tybool_
   | CString2float _ -> tyarrow_ tystr_ tyfloat_
   | CFloat2string _ -> tyarrow_ tyfloat_ tystr_
 end
 
-lang SymbTypeAst = SymbAst
+lang SymbTypeAst = TyConst + SymbAst
   sem tyConst =
   | CSymb _ -> tysym_
   | CGensym _ -> tyarrow_ tyunit_ tysym_
   | CSym2hash _ -> tyarrow_ tysym_ tyint_
 end
 
-lang CmpSymbTypeAst = CmpSymbAst
+lang CmpSymbTypeAst = TyConst + CmpSymbAst
   sem tyConst =
   | CEqsym _ -> tyarrows_ [tysym_, tysym_, tybool_]
 end
 
-lang SeqOpTypeAst = SeqOpAst
+lang SeqOpTypeAst = TyConst + SeqOpAst
   sem tyConst =
   | CSet _ ->
     tyall_ "a" (tyarrows_ [ tyvarseq_ "a", tyint_, tyvar_ "a", tyvarseq_ "a"])
@@ -155,7 +159,7 @@ lang SeqOpTypeAst = SeqOpAst
     tyall_ "a" (tyarrows_ [ tyvarseq_ "a", tyint_, tyint_, tyvarseq_ "a"])
 end
 
-lang FileOpTypeAst = FileOpAst
+lang FileOpTypeAst = TyConst + FileOpAst
   sem tyConst =
   | CFileRead _ -> tyarrow_ tystr_ tystr_
   | CFileWrite _ -> tyarrows_ [tystr_, tystr_, tyunit_]
@@ -163,7 +167,7 @@ lang FileOpTypeAst = FileOpAst
   | CFileDelete _ -> tyarrow_ tystr_ tyunit_
 end
 
-lang IOTypeAst = IOAst
+lang IOTypeAst = TyConst + IOAst
   sem tyConst =
   | CPrint _ -> tyarrow_ tystr_ tyunit_
   | CPrintError _ -> tyarrow_ tystr_ tyunit_
@@ -174,13 +178,13 @@ lang IOTypeAst = IOAst
   | CReadBytesAsString _ -> tyarrow_ tyint_ (tytuple_ [tystr_, tystr_])
 end
 
-lang RandomNumberGeneratorTypeAst = RandomNumberGeneratorAst
+lang RandomNumberGeneratorTypeAst = TyConst + RandomNumberGeneratorAst
   sem tyConst =
   | CRandIntU _ -> tyarrows_ [tyint_, tyint_, tyint_]
   | CRandSetSeed _ -> tyarrow_ tyint_ tyunit_
 end
 
-lang SysTypeAst = SysAst
+lang SysTypeAst = TyConst + SysAst
   sem tyConst =
   | CExit _ -> tyall_ "a" (tyarrow_ tyint_ (tyvar_ "a"))
   | CError _ -> tyall_ "a" (tyarrow_ tystr_ (tyvar_ "a"))
@@ -188,25 +192,25 @@ lang SysTypeAst = SysAst
   | CCommand _ -> tyarrow_ tystr_ tyint_
 end
 
-lang TimeTypeAst = TimeAst
+lang TimeTypeAst = TyConst + TimeAst
   sem tyConst =
   | CWallTimeMs _ -> tyarrow_ tyunit_ tyfloat_
   | CSleepMs _ -> tyarrow_ tyint_ tyunit_
 end
 
-lang RefOpTypeAst = RefOpAst
+lang RefOpTypeAst = TyConst + RefOpAst
   sem tyConst =
   | CRef _ -> tyall_ "a" (tyarrow_ (tyvar_ "a") (tyref_ (tyvar_ "a")))
   | CModRef _ -> tyall_ "a" (tyarrows_ [tyref_ (tyvar_ "a"), tyvar_ "a", tyunit_])
   | CDeRef _ -> tyall_ "a" (tyarrow_ (tyref_ (tyvar_ "a")) (tyvar_ "a"))
 end
 
-lang ConTagTypeAst = ConTagAst
+lang ConTagTypeAst = TyConst + ConTagAst
   sem tyConst =
   | CConstructorTag _ -> tyall_ "a" (tyarrow_ (tyvar_ "a") tyint_)
 end
 
-lang TensorOpTypeAst = TensorOpAst
+lang TensorOpTypeAst = TyConst + TensorOpAst
   sem tyConst =
   | CTensorCreateUninitInt _ -> tytensorcreateuninitint_
   | CTensorCreateUninitFloat _ -> tytensorcreateuninitfloat_
@@ -229,7 +233,7 @@ lang TensorOpTypeAst = TensorOpAst
   | CTensorToString _ -> tyall_ "a" (tytensortostring_ (tyvar_ "a"))
 end
 
-lang BootParserTypeAst = BootParserAst
+lang BootParserTypeAst = TyConst + BootParserAst
   sem tyConst =
   | CBootParserParseMExprString _ -> tyarrows_ [
       tytuple_ [tybool_],

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -206,9 +206,7 @@ let wrapDirect = use MExprAst in
         i (nulam_ v.1 (i (nulam_ v.0 (app_ (i (nvar_ v.1)) acc))))
       ) inner varNames
 
-lang ConstCPS = CPS + ConstAst + MExprArity
-  sem tyConst: Const -> Type
-
+lang ConstCPS = CPS + ConstAst + MExprArity + TyConst
   sem exprCps env k =
   | TmLet ({ ident = ident, body = TmConst { val = c } & body} & t) ->
     if not (transform env ident) then

--- a/stdlib/mexpr/cse.mc
+++ b/stdlib/mexpr/cse.mc
@@ -35,13 +35,13 @@ type ExprStatus
 con Once : ProgramPos -> ExprStatus
 con Multiple : ProgramPos -> ExprStatus
 
-type CSESearchEnv = {
+type CSESearchEnv = use Ast in {
   index : PosIndex,
   subexprs : Map Expr ExprStatus,
   recursiveIdents : Set Name
 }
 
-type CSEApplyEnv = {
+type CSEApplyEnv = use Ast in {
   index : PosIndex,
   posToSubexpr : Map PosIndex [(Name, Expr)],
   exprIdent : Map Expr Name

--- a/stdlib/mexpr/eq.mc
+++ b/stdlib/mexpr/eq.mc
@@ -351,27 +351,27 @@ end
 -- CONSTANTS --
 ---------------
 
-lang IntEq = IntAst
+lang IntEq = Eq + IntAst
   sem eqConstH =
   | (CInt l, CInt r) -> eqi l.val r.val
 end
 
-lang FloatEq = FloatAst
+lang FloatEq = Eq + FloatAst
   sem eqConstH =
   | (CFloat l, CFloat r) -> eqf l.val r.val
 end
 
-lang BoolEq = BoolAst
+lang BoolEq = Eq + BoolAst
   sem eqConstH =
   | (CBool l, CBool r) -> eqBool l.val r.val
 end
 
-lang CharEq = CharAst
+lang CharEq = Eq + CharAst
   sem eqConstH =
   | (CChar l, CChar r) -> eqChar l.val r.val
 end
 
-lang SymbEq = SymbAst
+lang SymbEq = Eq + SymbAst
   sem eqConstH =
   | (CSymb l, CSymb r) -> eqsym l.val r.val
 end
@@ -394,7 +394,7 @@ let _eqpatname : BiNameMap -> EqEnv -> PatName -> PatName -> Option (EqEnv, BiNa
     else match (p1,p2) with (PWildcard _,PWildcard _) then Some (free,penv)
     else None ()
 
-lang NamedPatEq = NamedPat
+lang NamedPatEq = MatchEq + NamedPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatNamed {ident = p2} ->
     match lhs with PatNamed {ident = p1} then
@@ -402,7 +402,7 @@ lang NamedPatEq = NamedPat
     else None ()
 end
 
-lang SeqTotPatEq = SeqTotPat
+lang SeqTotPatEq = MatchEq + SeqTotPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatSeqTot {pats = ps2} ->
     match lhs with PatSeqTot {pats = ps1} then
@@ -417,7 +417,7 @@ lang SeqTotPatEq = SeqTotPat
     else None ()
 end
 
-lang SeqEdgePatEq = SeqEdgePat
+lang SeqEdgePatEq = MatchEq + SeqEdgePat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatSeqEdge {prefix = pre2, middle = mid2, postfix = post2} ->
     match lhs with PatSeqEdge {prefix = pre1, middle = mid1, postfix = post1} then
@@ -446,7 +446,7 @@ lang SeqEdgePatEq = SeqEdgePat
     else None ()
 end
 
-lang RecordPatEq = RecordPat
+lang RecordPatEq = MatchEq + RecordPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatRecord {bindings = bs2} ->
     match lhs with PatRecord {bindings = bs1} then
@@ -463,7 +463,7 @@ lang RecordPatEq = RecordPat
     else None ()
 end
 
-lang DataPatEq = DataPat
+lang DataPatEq = MatchEq + DataPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatCon {ident = i2, subpat = s2} ->
     match lhs with PatCon {ident = i1, subpat = s1} then
@@ -475,7 +475,7 @@ lang DataPatEq = DataPat
     else None ()
 end
 
-lang IntPatEq = IntPat
+lang IntPatEq = MatchEq + IntPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatInt {val = i2} ->
     match lhs with PatInt {val = i1} then
@@ -483,7 +483,7 @@ lang IntPatEq = IntPat
     else None ()
 end
 
-lang CharPatEq = CharPat
+lang CharPatEq = MatchEq + CharPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatChar {val = c2} ->
     match lhs with PatChar {val = c1} then
@@ -491,7 +491,7 @@ lang CharPatEq = CharPat
     else None ()
 end
 
-lang BoolPatEq = BoolPat
+lang BoolPatEq = MatchEq + BoolPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatBool {val = b2} ->
     match lhs with PatBool {val = b1} then
@@ -499,7 +499,7 @@ lang BoolPatEq = BoolPat
     else None ()
 end
 
-lang AndPatEq = AndPat
+lang AndPatEq = MatchEq + AndPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatAnd {lpat = l2, rpat = r2} ->
     match lhs with PatAnd {lpat = l1, rpat = r1} then
@@ -512,7 +512,7 @@ lang AndPatEq = AndPat
     else None ()
 end
 
-lang OrPatEq = OrPat
+lang OrPatEq = MatchEq + OrPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatOr {lpat = l2, rpat = r2} ->
     match lhs with PatOr {lpat = l1, rpat = r1} then
@@ -525,7 +525,7 @@ lang OrPatEq = OrPat
     else None ()
 end
 
-lang NotPatEq = NotPat
+lang NotPatEq = MatchEq + NotPat
   sem eqPat (env : EqEnv) (free : EqEnv) (patEnv : BiNameMap) (lhs : Pat) =
   | PatNot {subpat = p2} ->
     match lhs with PatNot {subpat = p1} then

--- a/stdlib/mexpr/eval.mc
+++ b/stdlib/mexpr/eval.mc
@@ -288,7 +288,7 @@ end
 type T
 con TInt : Tensor[Int] -> T
 con TFloat : Tensor[Float] -> T
-con TExpr : Tensor[Expr] -> T
+con TExpr : use Ast in Tensor[Expr] -> T
 
 lang TensorEval = Eval + Eq + PrettyPrint
   syn Expr =

--- a/stdlib/mexpr/index.mc
+++ b/stdlib/mexpr/index.mc
@@ -123,12 +123,12 @@ end
 -- PATTERNS --
 --------------
 
-lang NamedPatIndex = Index + NamedPat
+lang NamedPatIndex = MatchIndex + NamedPat
   sem patIndexAdd (acc: IndexAcc) =
   | PatNamed { ident = PName name } -> addKey name acc
 end
 
-lang SeqEdgePatIndex = Index + SeqEdgePat
+lang SeqEdgePatIndex = MatchIndex + SeqEdgePat
   sem patIndexAdd (acc: IndexAcc) =
   | PatSeqEdge { middle = PName name } & p ->
     sfold_Pat_Pat patIndexAdd (addKey name acc) p

--- a/stdlib/mexpr/infix.mc
+++ b/stdlib/mexpr/infix.mc
@@ -73,11 +73,11 @@ lang MExprExt = MExprAst + MExprParserExt + MExprEval + MExprPrettyPrint + MExpr
 end
 
 -- Evaluate an expression into a value expression
-let evalExpr : Expr -> Expr =
+let evalExpr : use MExprExt in Expr -> Expr =
   use MExprExt in lam t. eval (evalCtxEmpty ()) (symbolize t)
 
 -- Parse a string and then evaluate into a value expression
-let evalStr : String -> Expr =
+let evalStr : use MExprExt in String -> Expr =
   lam str. use MExprExt in evalExpr (parseExpr (initPos "") str)
 
 -- Parse a string and then evaluate into a value, and pretty print

--- a/stdlib/mexpr/kcfa.mc
+++ b/stdlib/mexpr/kcfa.mc
@@ -492,6 +492,9 @@ lang KBaseConstraint = KCFA
     if isDirect av then
       addData graph (directTransition graph rhs av) rhs
     else graph
+
+  sem propagateConstraintConst
+  : (IName,Ctx) -> [(IName,Ctx)] -> CFAGraph -> Const -> CFAGraph
 end
 
 -----------
@@ -723,9 +726,6 @@ lang AppKCFA = KCFA + ConstKCFA + KBaseConstraint + LamKCFA + AppAst + MExprArit
         (ctxEnvAdd ident ctx env, cstrs)
       else errorSingle [infoTm app.rhs] "Not a TmVar in application"
     else errorSingle [infoTm app.lhs] "Not a TmVar in application"
-
-  sem propagateConstraintConst
-  : (IName,Ctx) -> [(IName,Ctx)] -> CFAGraph -> Const -> CFAGraph
 end
 
 lang RecordKCFA = KCFA + KBaseConstraint + RecordAst

--- a/stdlib/mexpr/lamlift.mc
+++ b/stdlib/mexpr/lamlift.mc
@@ -11,7 +11,7 @@ include "mexpr/symbolize.mc"
 include "mexpr/type-check.mc"
 include "mexpr/utils.mc"
 
-type LambdaLiftState = {
+type LambdaLiftState = use Ast in {
   -- Variables in the current scope that can occur as free variables in the
   -- current expression.
   vars : Set Name,

--- a/stdlib/mexpr/mexpr.mc
+++ b/stdlib/mexpr/mexpr.mc
@@ -14,11 +14,11 @@ lang MExpr = MExprAst + MExprParser + MExprEval + MExprPrettyPrint + MExprSym
 end
 
 -- Evaluate an expression into a value expression
-let evalExpr : Expr -> Expr =
+let evalExpr : use MExpr in Expr -> Expr =
   use MExpr in lam t. eval (evalCtxEmpty ()) (symbolize t)
 
 -- Parse a string and then evaluate into a value expression
-let evalStr : String -> Expr =
+let evalStr : use MExpr in String -> Expr =
   lam str. use MExpr in evalExpr (parseExpr (initPos "") str)
 
 -- Parse a string and then evaluate into a value, and pretty print

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -914,8 +914,9 @@ lang NamedPatPrettyPrint = PrettyPrint + NamedPat + PatNamePrettyPrint
   | PatNamed {ident = patname} -> _pprint_patname env patname
 end
 
-let _pprint_patseq: (Int -> PprintEnv -> Pat -> (PprintEnv, String)) -> Int ->
-                    PprintEnv -> [Pat] -> (PprintEnv, String) =
+let _pprint_patseq
+  : use Ast in (Int -> PprintEnv -> Pat -> (PprintEnv, String)) -> Int
+            -> PprintEnv -> [Pat] -> (PprintEnv, String) =
 lam recur. lam indent. lam env. lam pats.
   use CharPat in
   let extract_char = lam e.

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -257,7 +257,7 @@ lang PrettyPrint = IdentifierPrettyPrint
     else (env, join ["(", str, ")"])
 end
 
-lang VarPrettyPrint = MExprIdentifierPrettyPrint + VarAst
+lang VarPrettyPrint = PrettyPrint + MExprIdentifierPrettyPrint + VarAst
   sem isAtomic =
   | TmVar _ -> true
 
@@ -906,7 +906,7 @@ lang PatNamePrettyPrint = IdentifierPrettyPrint
   | PWildcard () -> (env, "_")
 end
 
-lang NamedPatPrettyPrint = NamedPat + PatNamePrettyPrint
+lang NamedPatPrettyPrint = PrettyPrint + NamedPat + PatNamePrettyPrint
   sem patIsAtomic =
   | PatNamed _ -> true
 
@@ -929,7 +929,7 @@ lam recur. lam indent. lam env. lam pats.
     strJoin (concat "," (pprintNewline (pprintIncr indent))) pats in
   (env, join ["[ ", merged, " ]"])
 
-lang SeqTotPatPrettyPrint = SeqTotPat + CharPat
+lang SeqTotPatPrettyPrint = PrettyPrint + SeqTotPat + CharPat
   sem patIsAtomic =
   | PatSeqTot _ -> true
 
@@ -937,7 +937,7 @@ lang SeqTotPatPrettyPrint = SeqTotPat + CharPat
   | PatSeqTot {pats = pats} -> _pprint_patseq getPatStringCode indent env pats
 end
 
-lang SeqEdgePatPrettyPrint = SeqEdgePat + PatNamePrettyPrint
+lang SeqEdgePatPrettyPrint = PrettyPrint + SeqEdgePat + PatNamePrettyPrint
   sem patIsAtomic =
   | PatSeqEdge _ -> false
 
@@ -949,7 +949,7 @@ lang SeqEdgePatPrettyPrint = SeqEdgePat + PatNamePrettyPrint
       (env, join [pre, " ++ ", pname, " ++ ", post])
 end
 
-lang RecordPatPrettyPrint = RecordPat + IdentifierPrettyPrint
+lang RecordPatPrettyPrint = PrettyPrint + RecordPat + IdentifierPrettyPrint
   sem patIsAtomic =
   | PatRecord _ -> true
 
@@ -974,7 +974,7 @@ lang RecordPatPrettyPrint = RecordPat + IdentifierPrettyPrint
     (env,join ["{", strJoin ", " (mapValues bindMap), "}"])
 end
 
-lang DataPatPrettyPrint = DataPat + IdentifierPrettyPrint
+lang DataPatPrettyPrint = PrettyPrint + DataPat
   sem patIsAtomic =
   | PatCon _ -> false
 
@@ -987,7 +987,7 @@ lang DataPatPrettyPrint = DataPat + IdentifierPrettyPrint
     in (env, join [str, " ", subpat])
 end
 
-lang IntPatPrettyPrint = IntPat
+lang IntPatPrettyPrint = PrettyPrint + IntPat
   sem patIsAtomic =
   | PatInt _ -> true
 
@@ -995,7 +995,7 @@ lang IntPatPrettyPrint = IntPat
   | PatInt t -> (env, int2string t.val)
 end
 
-lang CharPatPrettyPrint = CharPat
+lang CharPatPrettyPrint = PrettyPrint + CharPat
   sem patIsAtomic =
   | PatChar _ -> true
 
@@ -1003,7 +1003,7 @@ lang CharPatPrettyPrint = CharPat
   | PatChar t -> (env, join ["\'", escapeChar t.val, "\'"])
 end
 
-lang BoolPatPrettyPrint = BoolPat
+lang BoolPatPrettyPrint = PrettyPrint + BoolPat
   sem patIsAtomic =
   | PatBool _ -> true
 
@@ -1037,7 +1037,7 @@ lang NotPatPrettyPrint = PrettyPrint + NotPat
   sem patIsAtomic =
   | PatNot _ -> false  -- OPT(vipa, 2020-09-23): this could possibly be true, just because it binds stronger than everything else
 
-  sem getPatStringCode (indent : Int) (env : PprintEnv) =
+  sem getPatStringCode (indent : Int) (env: PprintEnv) =
   | PatNot {subpat = p} ->
     match printPatParen indent env p with (env, p2) in
     (env, join ["!", p2])
@@ -1047,27 +1047,27 @@ end
 -- TYPES --
 -----------
 
-lang UnknownTypePrettyPrint = UnknownTypeAst
+lang UnknownTypePrettyPrint = PrettyPrint + UnknownTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyUnknown _ -> (env,"Unknown")
 end
 
-lang BoolTypePrettyPrint = BoolTypeAst
+lang BoolTypePrettyPrint = PrettyPrint + BoolTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyBool _ -> (env,"Bool")
 end
 
-lang IntTypePrettyPrint = IntTypeAst
+lang IntTypePrettyPrint = PrettyPrint + IntTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyInt _ -> (env,"Int")
 end
 
-lang FloatTypePrettyPrint = FloatTypeAst
+lang FloatTypePrettyPrint = PrettyPrint + FloatTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyFloat _ -> (env,"Float")
 end
 
-lang CharTypePrettyPrint = CharTypeAst
+lang CharTypePrettyPrint = PrettyPrint + CharTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyChar _ -> (env,"Char")
 end
@@ -1083,21 +1083,21 @@ lang FunTypePrettyPrint = PrettyPrint + FunTypeAst
     (env, join [from, " -> ", to])
 end
 
-lang SeqTypePrettyPrint = SeqTypeAst
+lang SeqTypePrettyPrint = PrettyPrint + SeqTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TySeq t ->
     match getTypeStringCode indent env t.ty with (env, ty) in
     (env, join ["[", ty, "]"])
 end
 
-lang TensorTypePrettyPrint = TensorTypeAst
+lang TensorTypePrettyPrint = PrettyPrint + TensorTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyTensor t ->
     match getTypeStringCode indent env t.ty with (env, ty) in
     (env, join ["Tensor[", ty, "]"])
 end
 
-lang RecordTypePrettyPrint = IdentifierPrettyPrint + RecordTypeAst
+lang RecordTypePrettyPrint = PrettyPrint + RecordTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | (TyRecord t) & ty ->
     if mapIsEmpty t.fields then (env,"()") else
@@ -1134,7 +1134,7 @@ lang RecordTypePrettyPrint = IdentifierPrettyPrint + RecordTypeAst
         (env,join ["{", strJoin ", " (map conventry fields), "}"])
 end
 
-lang VariantTypePrettyPrint = VariantTypeAst
+lang VariantTypePrettyPrint = PrettyPrint + VariantTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyVariant t ->
     if eqi (mapLength t.constrs) 0 then (env,"<>")
@@ -1144,13 +1144,13 @@ lang VariantTypePrettyPrint = VariantTypeAst
     -- still use TyVariant in the AST and might get compilation errors for it.
 end
 
-lang ConTypePrettyPrint = IdentifierPrettyPrint + ConTypeAst
+lang ConTypePrettyPrint = PrettyPrint + ConTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyCon t ->
     pprintTypeName env t.ident
 end
 
-lang VarTypePrettyPrint = IdentifierPrettyPrint + VarTypeAst
+lang VarTypePrettyPrint = PrettyPrint + VarTypeAst
   sem getTypeStringCode (indent : Int) (env: PprintEnv) =
   | TyVar t ->
     pprintVarName env t.ident

--- a/stdlib/mexpr/side-effect.mc
+++ b/stdlib/mexpr/side-effect.mc
@@ -56,7 +56,11 @@ lang SideEffect
   | t -> exprHasSideEffect (sideEffectEnvEmpty ()) t
 end
 
-lang ConstSideEffect = MExprAst
+lang ConstSideEffectBase = ConstAst
+  sem constHasSideEffect : Const -> Bool
+end
+
+lang ConstSideEffect = ConstSideEffectBase + MExprAst
   sem constHasSideEffect =
   | CInt _ | CFloat _ | CBool _ | CChar _ -> false
   | CAddi _ | CSubi _ | CMuli _ | CDivi _ | CNegi _ | CModi _ -> false

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -627,7 +627,7 @@ end
 -- PATTERN TYPE ANNOTATE --
 ---------------------------
 
-lang NamedPatTypeAnnot = TypeAnnot + NamedPat
+lang NamedPatTypeAnnot = MatchTypeAnnot + NamedPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatNamed t ->
     let env =
@@ -637,7 +637,8 @@ lang NamedPatTypeAnnot = TypeAnnot + NamedPat
     (env, PatNamed {t with ty = expectedTy})
 end
 
-lang SeqTotPatTypeAnnot = TypeAnnot + SeqTotPat + UnknownTypeAst + SeqTypeAst
+lang SeqTotPatTypeAnnot = MatchTypeAnnot + SeqTotPat + UnknownTypeAst +
+                          SeqTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatSeqTot t ->
     let elemTy =
@@ -649,7 +650,8 @@ lang SeqTotPatTypeAnnot = TypeAnnot + SeqTotPat + UnknownTypeAst + SeqTypeAst
     else never
 end
 
-lang SeqEdgePatTypeAnnot = TypeAnnot + SeqEdgePat + UnknownTypeAst + SeqTypeAst
+lang SeqEdgePatTypeAnnot = MatchTypeAnnot + SeqEdgePat + UnknownTypeAst +
+                           SeqTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatSeqEdge t ->
     let elemTy =
@@ -671,7 +673,8 @@ lang SeqEdgePatTypeAnnot = TypeAnnot + SeqEdgePat + UnknownTypeAst + SeqTypeAst
     else never
 end
 
-lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
+lang RecordPatTypeAnnot = MatchTypeAnnot + RecordPat + UnknownTypeAst +
+                          RecordTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatRecord t ->
     let expectedTy = unwrapType expectedTy in
@@ -700,7 +703,7 @@ lang RecordPatTypeAnnot = TypeAnnot + RecordPat + UnknownTypeAst + RecordTypeAst
     else never
 end
 
-lang DataPatTypeAnnot = TypeAnnot + DataPat + VariantTypeAst + ConTypeAst +
+lang DataPatTypeAnnot = MatchTypeAnnot + DataPat + VariantTypeAst + ConTypeAst +
                         FunTypeAst + AllTypeAst
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatCon t ->
@@ -712,22 +715,22 @@ lang DataPatTypeAnnot = TypeAnnot + DataPat + VariantTypeAst + ConTypeAst +
     else (env, PatCon t)
 end
 
-lang IntPatTypeAnnot = TypeAnnot + IntPat
+lang IntPatTypeAnnot = MatchTypeAnnot + IntPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatInt r -> (env, PatInt {r with ty = tyint_})
 end
 
-lang CharPatTypeAnnot = TypeAnnot + CharPat
+lang CharPatTypeAnnot = MatchTypeAnnot + CharPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatChar r -> (env, PatChar {r with ty = tychar_})
 end
 
-lang BoolPatTypeAnnot = TypeAnnot + BoolPat
+lang BoolPatTypeAnnot = MatchTypeAnnot + BoolPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatBool r -> (env, PatBool {r with ty = tybool_})
 end
 
-lang AndPatTypeAnnot = TypeAnnot + AndPat
+lang AndPatTypeAnnot = MatchTypeAnnot + AndPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatAnd t ->
     match typeAnnotPat env expectedTy t.lpat with (env, lpat) then
@@ -737,7 +740,7 @@ lang AndPatTypeAnnot = TypeAnnot + AndPat
     else never
 end
 
-lang OrPatTypeAnnot = TypeAnnot + OrPat
+lang OrPatTypeAnnot = MatchTypeAnnot + OrPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatOr t ->
     match typeAnnotPat env expectedTy t.lpat with (env, lpat) then
@@ -747,7 +750,7 @@ lang OrPatTypeAnnot = TypeAnnot + OrPat
     else never
 end
 
-lang NotPatTypeAnnot = TypeAnnot + NotPat
+lang NotPatTypeAnnot = MatchTypeAnnot + NotPat
   sem typeAnnotPat (env : TypeEnv) (expectedTy : Type) =
   | PatNot t ->
     match typeAnnotPat env expectedTy t.subpat with (env, subpat) then

--- a/stdlib/mexpr/type-annot.mc
+++ b/stdlib/mexpr/type-annot.mc
@@ -17,9 +17,9 @@ include "builtin.mc"
 include "type.mc"
 
 type TypeEnv = {
-  varEnv: Map Name Type,
-  conEnv: Map Name Type,
-  tyEnv : Map Name Type
+  varEnv: Map Name (use Ast in Type),
+  conEnv: Map Name (use Ast in Type),
+  tyEnv : Map Name (use Ast in Type)
 }
 
 let _typeEnvEmpty = {

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -30,10 +30,10 @@ include "mexpr/unify.mc"
 include "mexpr/value.mc"
 
 type TCEnv = {
-  varEnv: Map Name Type,
-  conEnv: Map Name Type,
+  varEnv: Map Name (use Ast in Type),
+  conEnv: Map Name (use Ast in Type),
   tyVarEnv: Map Name Level,
-  tyConEnv: Map Name (Level, [Name], Type),
+  tyConEnv: Map Name (Level, [Name], use Ast in Type),
   currentLvl: Level,
   disableRecordPolymorphism: Bool
 }

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -449,6 +449,9 @@ lang TypeCheck = TCUnify + Generalize + RemoveMetaVar
   -- Type check `expr' under the type environment `env'. The resulting
   -- type may contain unification variables and links.
   sem typeCheckExpr : TCEnv -> Expr -> Expr
+  sem typeCheckExpr env =
+  | tm ->
+    dprint tm; print "\n"; error ""
 end
 
 lang PatTypeCheck = TCUnify

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -25,7 +25,7 @@ include "cmp.mc"
 -- This type is added specifically for the type lifting to allow distinguishing
 -- between variant types in the type environment before their constructors have
 -- been added.
-lang VariantNameTypeAst = Eq
+lang VariantNameTypeAst = Ast + Eq
   syn Type =
   | TyVariantName {ident : Name,
                    info : Info}

--- a/stdlib/mexpr/type-lift.mc
+++ b/stdlib/mexpr/type-lift.mc
@@ -82,25 +82,6 @@ lang TypeLiftBase = MExprAst + VariantNameTypeAst
     assocSeqMap f env.typeEnv
 end
 
-lang TypeLiftAddRecordToEnv = TypeLiftBase + RecordTypeAst
-  sem addRecordToEnv (env : TypeLiftEnv) =
-  | TyRecord {fields = fields, info = info} & ty ->
-    switch mapLookup fields env.records
-    case Some name then
-      let tycon = TyCon {ident = name, info = info} in
-      (env, tycon)
-    case None _ then
-      let name = nameSym "Rec" in
-      let tycon = TyCon {ident = name, info = info} in
-      let env = {{env
-                  with records = mapInsert fields name env.records}
-                  with typeEnv = assocSeqInsert name ty env.typeEnv}
-      in
-      (env, tycon)
-    end
-  -- | ty -> (env, ty) -- NOTE(dlunde,2021-10-06): I commented this out, so that it gives an error if a TyRecord is not supplied (less error-prone)
-end
-
 -- Define function for adding sequence types to environment
 lang TypeLiftAddSeqToEnv = TypeLiftBase + SeqTypeAst + ConTypeAst
   sem addSeqToEnv (env: TypeLiftEnv) =
@@ -185,6 +166,25 @@ lang TypeLift = TypeLiftBase + Cmp
       let typeEnv = _replaceVariantNamesInTypeEnv env in
       (typeEnv, t)
     else never
+end
+
+lang TypeLiftAddRecordToEnv = TypeLift + RecordTypeAst
+  sem addRecordToEnv (env : TypeLiftEnv) =
+  | TyRecord {fields = fields, info = info} & ty ->
+    switch mapLookup fields env.records
+    case Some name then
+      let tycon = TyCon {ident = name, info = info} in
+      (env, tycon)
+    case None _ then
+      let name = nameSym "Rec" in
+      let tycon = TyCon {ident = name, info = info} in
+      let env = {{env
+                  with records = mapInsert fields name env.records}
+                  with typeEnv = assocSeqInsert name ty env.typeEnv}
+      in
+      (env, tycon)
+    end
+  -- | ty -> (env, ty) -- NOTE(dlunde,2021-10-06): I commented this out, so that it gives an error if a TyRecord is not supplied (less error-prone)
 end
 
 lang TypeTypeLift = TypeLift + TypeAst + VariantTypeAst + UnknownTypeAst +

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -14,7 +14,7 @@ include "mexpr/type.mc"
 -- TYPE UNIFICATION --
 ----------------------
 
-lang Unify = Ast
+lang Unify = KindAst
   type UnifyEnv = {
     wrappedLhs: Type,  -- The currently examined left-hand subtype, before resolving aliases
     wrappedRhs: Type,  -- The currently examined right-hand subtype, before resolving aliases

--- a/stdlib/mexpr/value.mc
+++ b/stdlib/mexpr/value.mc
@@ -24,7 +24,7 @@ lang IsValue = Ast
       if v then isValue (Val ()) tm else false) true t
 end
 
-lang VarIsValue = VarAst
+lang VarIsValue = IsValue + VarAst
   sem isValue (guarded : Guarded) =
   | TmVar t ->
     switch guarded
@@ -33,41 +33,41 @@ lang VarIsValue = VarAst
     end
 end
 
-lang AppIsValue = AppAst
+lang AppIsValue = IsValue + AppAst
   sem isValue (guarded : Guarded) =
   | TmApp t -> false
 end
 
-lang LamIsValue = LamAst
+lang LamIsValue = IsValue + LamAst
   sem isValue (guarded : Guarded) =
   | TmLam t -> true
 end
 
-lang LetIsValue = LetAst
+lang LetIsValue = IsValue + LetAst
   sem isValue (guarded : Guarded) =
   | TmLet t ->
     if isValue (Val ()) t.body then isValue guarded t.inexpr
     else false
 end
 
-lang RecLetsIsValue = RecLetsAst
+lang RecLetsIsValue = IsValue + RecLetsAst
   sem isValue (guarded : Guarded) =
   | TmRecLets t ->
     if forAll (lam b. isValue (Val ()) b.body) t.bindings then isValue guarded t.inexpr
     else false
 end
 
-lang TypeIsValue = TypeAst
+lang TypeIsValue = IsValue + TypeAst
   sem isValue (guarded : Guarded) =
   | TmType t -> isValue guarded t.inexpr
 end
 
-lang DataIsValue = DataAst
+lang DataIsValue = IsValue + DataAst
   sem isValue (guarded : Guarded) =
   | TmConDef t -> isValue guarded t.inexpr
 end
 
-lang MatchIsValue = MatchAst
+lang MatchIsValue = IsValue + MatchAst
   sem isValue (guarded : Guarded) =
   | TmMatch t ->
     if isValue (Val ()) t.target then
@@ -76,12 +76,12 @@ lang MatchIsValue = MatchAst
     else false
 end
 
-lang UtestIsValue = UtestAst
+lang UtestIsValue = IsValue + UtestAst
   sem isValue (guarded : Guarded) =
   | TmUtest t -> isValue guarded t.next
 end
 
-lang ExtIsValue = ExtAst
+lang ExtIsValue = IsValue + ExtAst
   sem isValue (guarded : Guarded) =
   | TmExt t -> isValue guarded t.inexpr
 end

--- a/stdlib/multicore/atomic.ext-ocaml.mc
+++ b/stdlib/multicore/atomic.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let tyaref_ = lam. tyunknown_

--- a/stdlib/multicore/cond.ext-ocaml.mc
+++ b/stdlib/multicore/cond.ext-ocaml.mc
@@ -2,7 +2,7 @@ include "map.mc"
 include "ocaml/ast.mc"
 include "mutex.ext-ocaml.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let tycond_ = tyunknown_

--- a/stdlib/multicore/mutex.ext-ocaml.mc
+++ b/stdlib/multicore/mutex.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let tymutex_ = tyunknown_

--- a/stdlib/multicore/thread.ext-ocaml.mc
+++ b/stdlib/multicore/thread.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
 
 let tyathread_ = lam. tyunknown_

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -3,11 +3,11 @@ include "mexpr/ast-builder.mc"
 
 type OCamlTopBinding =
   { ident : Name
-    , tyBody : Type
-    , body : Expr
+  , tyBody : use Ast in Type
+  , body : use Ast in Expr
   }
 
-lang OCamlTopAst
+lang OCamlTopAst = Ast
   syn Top =
   | OTopTypeDecl { ident : Name, ty : Type }
   | OTopVariantTypeDecl { ident : Name, constrs : Map Name Type }

--- a/stdlib/ocaml/ast.mc
+++ b/stdlib/ocaml/ast.mc
@@ -19,7 +19,7 @@ lang OCamlTopAst
   | OTopTryWith { try : Expr, arms : [(Pat, Expr)] }
 end
 
-lang OCamlRecord
+lang OCamlRecord = Ast
   syn Expr =
   | OTmRecord {bindings : [(String, Expr)], tyident : Type}
   | OTmProject {field : String, tm : Expr}
@@ -53,7 +53,7 @@ lang OCamlRecord
     else never
 end
 
-lang OCamlRecordUpdate
+lang OCamlRecordUpdate = Ast
   syn Expr =
   | OTmRecordUpdate {rec : Expr, updates : [(SID, Expr)]}
 
@@ -71,7 +71,7 @@ lang OCamlRecordUpdate
     (acc, OTmRecordUpdate {t with rec = rec, updates = updates})
 end
 
-lang OCamlMatch
+lang OCamlMatch = Ast
   syn Expr =
   | OTmMatch
     { target : Expr
@@ -96,7 +96,7 @@ lang OCamlMatch
     else never
 end
 
-lang OCamlArray
+lang OCamlArray = Ast
   syn Expr =
   | OTmArray {tms : [Expr]}
 
@@ -109,7 +109,7 @@ lang OCamlArray
     else never
 end
 
-lang OCamlTuple
+lang OCamlTuple = Ast
   syn Expr =
   | OTmTuple { values : [Expr] }
 
@@ -133,7 +133,7 @@ lang OCamlTuple
     else never
 end
 
-lang OCamlData
+lang OCamlData = Ast
   syn Expr =
   | OTmConApp { ident : Name, args : [Expr] }
 
@@ -157,7 +157,7 @@ lang OCamlData
     else never
 end
 
-lang OCamlString
+lang OCamlString = Ast
   syn Expr =
   | OTmString { text : String }
 end
@@ -170,7 +170,7 @@ end
 -- *cannot* overlap with other names. An easy way to do that is to
 -- always use fully qualified names, since normal names cannot contain
 -- dots.
-lang OCamlExternal
+lang OCamlExternal = Ast
   syn Expr =
   | OTmVarExt { ident : String }
   | OTmConAppExt { ident : String, args : [Expr] }
@@ -196,7 +196,7 @@ lang OCamlExternal
     else never
 end
 
-lang OCamlLabel
+lang OCamlLabel = Ast
   syn Expr =
   | OTmLabel { label : String, arg : Expr }
 
@@ -209,7 +209,7 @@ lang OCamlLabel
     else never
 end
 
-lang OCamlLam
+lang OCamlLam = Ast
   syn Expr =
   | OTmLam {label : Option String, ident : Name, body : Expr}
 

--- a/stdlib/ocaml/external-includes.mc
+++ b/stdlib/ocaml/external-includes.mc
@@ -23,7 +23,7 @@ include "ipopt/ipopt.ext-ocaml.mc"
 
 type ExternalImpl = {
   expr : String,
-  ty : Type,
+  ty : use Ast in Type,
   libraries : [String],
   cLibraries : [String]
 }

--- a/stdlib/ocaml/generate-env.mc
+++ b/stdlib/ocaml/generate-env.mc
@@ -4,8 +4,8 @@ include "ocaml/external-includes.mc"
 include "mexpr/cmp.mc"
 
 type GenerateEnv = {
-  constrs : Map Name Type,
-  records : Map (Map SID Type) Name,
+  constrs : Map Name (use Ast in Type),
+  records : Map (Map SID (use Ast in Type)) Name,
   exts : Map Name [ExternalImpl]
 }
 
@@ -20,5 +20,5 @@ let objRepr = use OCamlAst in
 let objMagic = use OCamlAst in
   lam t. app_ (OTmVarExt {ident = "Obj.magic"}) t
 
-let ocamlTypedFields = lam fields : Map SID Type.
+let ocamlTypedFields = lam fields : Map SID (use Ast in Type).
   mapMap (lam. tyunknown_) fields

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -63,8 +63,14 @@ let lookupRecordFields = use MExprAst in
     else None ()
   else None ()
 
-type MatchRecord = {target : Expr, pat : Pat, thn : Expr,
-                    els : Expr, ty : Type, info : Info}
+type MatchRecord = {
+  target : use Ast in Expr,
+  pat : use Ast in Pat,
+  thn : use Ast in Expr,
+  els : use Ast in Expr,
+  ty : use Ast in Type,
+  info : Info
+}
 
 lang OCamlTopGenerate = MExprAst + OCamlAst + OCamlGenerateExternalNaive
   sem generateTops (env : GenerateEnv) =

--- a/stdlib/ocaml/generate.mc
+++ b/stdlib/ocaml/generate.mc
@@ -113,7 +113,7 @@ end
 -- match-expressions, for different kinds of patterns. We assume pattern
 -- lowering has been applied on the provided AST, which guarantees absence of
 -- AND, OR, and NOT patterns as well as nested patterns.
-lang OCamlMatchGenerate = MExprAst + OCamlAst
+lang OCamlMatchGenerate = MExprAst + OCamlAst + OCamlTopGenerate
   sem getPatName : PatName -> Option Name
   sem getPatName =
   | PWildcard _ -> None ()

--- a/stdlib/ocaml/mcore.mc
+++ b/stdlib/ocaml/mcore.mc
@@ -8,10 +8,10 @@ include "ocaml/pprint.mc"
 include "sys.mc"
 
 type Hooks a =
-  { debugTypeAnnot : Expr -> ()
+  { debugTypeAnnot : use Ast in Expr -> ()
   , debugGenerate : String -> ()
   , exitBefore : () -> ()
-  , postprocessOcamlTops : [Top] -> [Top]
+  , postprocessOcamlTops : [use OCamlTopAst in Top] -> [use OCamlTopAst in Top]
   , compileOcaml : [String] -> [String] -> String -> a
   }
 

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -168,14 +168,21 @@ changed.
 
 -/
 
-type Constructor =
+lang CarriedTypeBase
+  syn CarriedType =
+
+  sem carriedRepr : CarriedType -> Type
+  sem carriedSMapAccumL : (Expr -> Expr -> Expr) -> Type -> CarriedType -> Option (Name -> Name -> Expr)
+end
+
+type Constructor = use CarriedTypeBase in
   { name : Name
   , fragment : Name
   , synType : Name
   , carried : CarriedType
   }
 
-type SFuncRequest =
+type SFuncRequest = use Ast in
   { synName : Name
   , target : Type
   , names :
@@ -185,7 +192,7 @@ type SFuncRequest =
     }
   }
 
-type FieldAccessorRequest =
+type FieldAccessorRequest = use Ast in
   { synName : Name
   , field : String
   , resTy : Type
@@ -204,13 +211,6 @@ type GenInput =
   , sfunctions : [SFuncRequest]
   , fieldAccessors : [FieldAccessorRequest]
   }
-
-lang CarriedTypeBase
-  syn CarriedType =
-
-  sem carriedRepr : CarriedType -> Type
-  sem carriedSMapAccumL : (Expr -> Expr -> Expr) -> Type -> CarriedType -> Option (Name -> Name -> Expr)
-end
 
 let _nulet_ = lam n. lam body. lam inexpr. use LetAst in TmLet
   { ident = n
@@ -366,7 +366,7 @@ lang CarriedTypeHelpers = CarriedTypeBase + SemDeclAst + PrettyPrint
 end
 
 let _mkFieldStubs
-  : FieldAccessorRequest -> [Decl]
+  : use SelfhostBaseAst in FieldAccessorRequest -> [Decl]
   = lam request.
     use SemDeclAst in
     let synTy = ntycon_ request.synName in
@@ -440,7 +440,7 @@ let _mkFieldStubs
       } in
     [getf, setf, mapAccumf, mapf]
 
-lang CarriedTarget = CarriedTypeBase + Eq
+lang CarriedTarget = CarriedTypeBase + Eq + Ast
   syn CarriedType =
   | TargetType {targetable : Bool, ty : Type}
 
@@ -555,32 +555,32 @@ lang CarriedRecord = CarriedTypeBase
 end
 
 let targetableType
-  : Type
-  -> CarriedType
+  : use Ast in Type
+  -> use CarriedTypeBase in CarriedType
   = lam ty. use CarriedTarget in TargetType {targetable = true, ty = ty}
 
 let untargetableType
-  : Type
-  -> CarriedType
+  : use Ast in Type
+  -> use CarriedTypeBase in CarriedType
   = lam ty. use CarriedTarget in TargetType {targetable = false, ty = ty}
 
 let seqType
-  : CarriedType
+  : use CarriedTypeBase in CarriedType
   -> CarriedType
   = lam ty. use CarriedSeq in SeqType ty
 
 let optionType
-  : CarriedType
+  : use CarriedTypeBase in CarriedType
   -> CarriedType
   = lam ty. use CarriedOption in OptionType ty
 
 let recordType
-  : [(String, CarriedType)]
+  : use CarriedTypeBase in [(String, CarriedType)]
   -> CarriedType
   = lam fields. use CarriedRecord in RecordType fields
 
 let tupleType
-  : [CarriedType]
+  : use CarriedTypeBase in  [CarriedType]
   -> CarriedType
   = lam fields. recordType (mapi (lam i. lam field. (int2string i, field)) fields)
 

--- a/stdlib/parser/gen-ast.mc
+++ b/stdlib/parser/gen-ast.mc
@@ -366,7 +366,7 @@ lang CarriedTypeHelpers = CarriedTypeBase + SemDeclAst + PrettyPrint
 end
 
 let _mkFieldStubs
-  : use SelfhostBaseAst in FieldAccessorRequest -> [Decl]
+  : use DeclAst in FieldAccessorRequest -> [Decl]
   = lam request.
     use SemDeclAst in
     let synTy = ntycon_ request.synName in

--- a/stdlib/parser/gen-op-ast.mc
+++ b/stdlib/parser/gen-op-ast.mc
@@ -1,13 +1,13 @@
 include "gen-ast.mc"
 
 type OperatorUnsplitter
-con AtomUnsplit :
+con AtomUnsplit : use Ast in
   ({record : Expr, info : Expr} -> Expr) -> OperatorUnsplitter
-con PrefixUnsplit :
+con PrefixUnsplit : use Ast in
   ({record : Expr, info : Expr, right : Expr} -> Expr) -> OperatorUnsplitter
-con PostfixUnsplit :
+con PostfixUnsplit : use Ast in
   ({record : Expr, info : Expr, left : Expr} -> Expr) -> OperatorUnsplitter
-con InfixUnsplit :
+con InfixUnsplit : use Ast in
   ({record : Expr, info : Expr, left : Expr, right : Expr} -> Expr) -> OperatorUnsplitter
 
 type Ordering
@@ -26,7 +26,7 @@ con NAssoc : () -> Assoc
 con LAssoc : () -> Assoc
 con RAssoc : () -> Assoc
 
-type GenOperator =
+type GenOperator = use Ast in
   { requiredFragments : [Name]
   , opConstructorName : Name
   , precedenceKey : Option Name
@@ -131,28 +131,28 @@ let _geither = nconapp_ _incNames.c.geither unit_
 let _infoTy = ntycon_ _incNames.t.infoTy
 let _permanentNode_ = lam ty. tyapp_ (ntycon_ _incNames.t.permanentNode) ty
 
-let _mergeInfos_ : [Expr] -> Expr = lam exprs. switch exprs
+let _mergeInfos_ : use Ast in [Expr] -> Expr = lam exprs. switch exprs
   case [] then nconapp_ _incNames.c.noInfo unit_
   case [x] then x
   case [a, b] then appf2_ (nvar_ _incNames.v.mergeInfo) a b
   case [first] ++ exprs then appf3_ (nvar_ _incNames.v.foldl) (nvar_ _incNames.v.mergeInfo) first (seq_ exprs)
   end
 
-let _nletin_ : Name -> Type -> Expr -> Expr -> Expr
+let _nletin_ : use Ast in Name -> Type -> Expr -> Expr -> Expr
   = lam name. lam ty. lam val. lam body.
     use MExprAst in
     TmLet {ident = name, tyAnnot = ty, tyBody = tyunknown_, body = val, inexpr = body, ty = tyunknown_, info = NoInfo ()}
 
-let _nuletin_ : Name -> Expr -> Expr -> Expr
+let _nuletin_ : use Ast in Name -> Expr -> Expr -> Expr
   = lam name. lam val. lam body.
     _nletin_ name tyunknown_ val body
 
-let _uletin_ : String -> Expr -> Expr -> Expr
+let _uletin_ : use Ast in String -> Expr -> Expr -> Expr
   = lam name. lam val. lam body.
     _nletin_ (nameNoSym name) tyunknown_ val body
 
 let _mkBaseFragment
-  : (Name, InternalSynDesc) -> Decl
+  : use LangDeclAst in (Name, InternalSynDesc) -> Decl
   = lam names.
     use SemDeclAst in
     use SynDeclAst in
@@ -416,7 +416,7 @@ lang GenOpAstLang = SynDeclAst + SemDeclAst + LangDeclAst
 end
 
 let _mkGroupingSem
-  : Map Name {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
+  : use SemDeclAst in Map Name {canBeLeft : Bool, canBeRight : Bool, assoc : Assoc, conName : Name}
   -> InternalSynDesc
   -> Decl
   = lam opMap. lam desc.
@@ -459,7 +459,7 @@ let _mkGroupingSem
     }
 
 let _mkComposedFragment
-  : GenOpInput -> Map Name InternalSynDesc -> [Decl] -> Decl
+  : use LangDeclAst in GenOpInput -> Map Name InternalSynDesc -> [Decl] -> Decl
   = lam config. lam synDescs. lam fragments.
     use LangDeclAst in
     let opFragments : [Name] = mapOption
@@ -490,7 +490,7 @@ let _mkComposedFragment
     , info = NoInfo ()
     }
 
-type WrapperInfo =
+type WrapperInfo = use Ast in
   { addAtom_ : Expr -> Expr -> Expr -> Expr
   , addInfix_ : Expr -> Expr -> Expr -> Expr
   , addPrefix_ : Expr -> Expr -> Expr -> Expr
@@ -601,7 +601,7 @@ let _mkBrWrappersFor
     , finalize_ = appf2_ (nvar_ finalizeName)
     }
 
-type GenOpResult =
+type GenOpResult = use LangDeclAst in use Ast in
   { fragments : [Decl]
   -- NOTE(vipa, 2022-04-12): This function wraps an expression such
   -- that the remaining functions (`addAtomFor`, etc.) can be used.

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -15,11 +15,11 @@ lang WSACParser
   | x -> {str = x, pos = p}
 end
 
-type Stream = {pos : Pos, str : String}
-type NextTokenResult = {token : Token, lit : String, info : Info, stream : Stream}
-
 -- Base language for parsing tokens preceeded by WSAC
 lang TokenParser = WSACParser + TokenReprBase
+  type Stream = {pos : Pos, str : String}
+  type NextTokenResult = {token : Token, lit : String, info : Info, stream : Stream}
+
   syn Token =
   sem nextToken /- : Stream -> NextTokenResult -/ =
   | stream ->

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -169,7 +169,7 @@ let _iterateUntilFixpoint : all a. (a -> a -> Bool) -> (a -> a) -> a -> a =
       if eq a next then a else work next
     in work
 
-type GenError prodLabel state = Map Name (Map (SpecSymbol Token TokenRepr state prodLabel) [prodLabel])
+type GenError prodLabel state = use Lexer in Map Name (Map (SpecSymbol Token TokenRepr state prodLabel) [prodLabel])
 
 lang ParserGeneration = ParserSpec + ParserConcrete
   -- NOTE(vipa, 2022-03-02): The type signature is a bit weird here,

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -102,8 +102,8 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   con ProdTop : {v: Name, i: Info} -> GenLabel in
   con ProdInternal : {name: {v: Name, i: Info}, info: Info} -> GenLabel in
 
-  let asDyn_ : Expr -> Expr = app_ (var_ "asDyn") in
-  let fromDyn_ : Expr -> Expr = app_ (var_ "fromDyn") in
+  let asDyn_ : use Ast in Expr -> Expr = app_ (var_ "asDyn") in
+  let fromDyn_ : use Ast in Expr -> Expr = app_ (var_ "fromDyn") in
 
   let filename = args.synFile in
   let destinationFile = args.outFile in
@@ -143,7 +143,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   -- needs a bit of conversion to create proper MExpr code (though most
   -- of it is just switching from XExpr to TmX).
   recursive let exprToMExpr
-    : Expr -> Res Expr
+    : Expr -> Res (use Ast in Expr)
     = lam e. switch e
       case AppExpr (x & {left = ConExpr c}) then
         result.map

--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -119,7 +119,11 @@ lang PEval = PEvalCtx + Eval + PrettyPrint
   sem pevalReadbackH ctx =| t -> smapAccumL_Expr_Expr pevalReadbackH ctx t
 end
 
-lang AppPEval = PEval + AppAst
+lang PEvalApply = Ast
+  sem pevalApply : Info -> PEvalCtx -> (Expr -> Expr) -> (Expr, Expr) -> Expr
+end
+
+lang AppPEval = PEval + PEvalApply + AppAst
   sem pevalBindThis =
   | TmApp _ -> true
 
@@ -165,7 +169,7 @@ lang ClosPAst = ClosAst
   | TmClosP r -> TmClosP { r with cls = { r.cls with info = info } }
 end
 
-lang LamPEval = PEval + VarAst + LamAst + ClosPAst + AppEval
+lang LamPEval = PEval + PEvalApply + VarAst + LamAst + ClosPAst + AppEval
   sem pevalBindThis =
   | TmClosP _ -> false
 
@@ -400,7 +404,7 @@ lang SeqPEval = PEval + SeqAst
       (lam tms. k (TmSeq { r with tms = tms }))
 end
 
-lang ConstPEval = PEval + ConstEvalNoDefault
+lang ConstPEval = PEval + PEvalApply + ConstEvalNoDefault
   sem pevalReadbackH ctx =
   | TmConstApp r ->
     match mapAccumL pevalReadbackH ctx r.args with (ctx, args) in
@@ -500,7 +504,7 @@ lang UtestPEval = PEval + UtestAst
       t.test
 end
 
-lang NeverPEval = PEval + NeverAst
+lang NeverPEval = PEval + PEvalApply + NeverAst
   sem pevalBindThis =
   | TmNever _ -> false
 
@@ -574,7 +578,7 @@ lang ArithIntPEval = ArithIntEval + VarAst
     end
 end
 
-lang ArithFloatPEval = ArithFloatEval + VarAst
+lang ArithFloatPEval = PEval + ArithFloatEval + VarAst
   sem pevalReadbackH ctx =
   | t & TmConst (r & { val = CFloat v }) ->
     if ltf v.val 0. then
@@ -631,7 +635,7 @@ lang CmpCharPEval = CmpCharEval + VarAst end
 
 lang IOPEval = IOAst + SeqAst + IOArity end
 
-lang SeqOpPEval = PEval + SeqOpEvalFirstOrder + AppAst + ConstAst + VarAst
+lang SeqOpPEval = PEval + PEvalApply + SeqOpEvalFirstOrder + AppAst + ConstAst + VarAst
   sem pevalBindThis =
   | TmApp {
     lhs = TmApp {

--- a/stdlib/pmexpr/build.mc
+++ b/stdlib/pmexpr/build.mc
@@ -21,7 +21,9 @@ let filenameWithoutExtension = lam filename.
     subsequence filename 0 idx
   else filename
 
-lang PMExprBuildBase = PMExprClassify
+lang PMExprBuildBase =
+  PMExprClassify + FutharkAst + CudaAst + OCamlTopAst + CProgAst
+
   -- TODO(larshum, 2022-06-06): Move this to separate file defining the
   -- compilation process (in standard library).
   syn GpuCompileResult =

--- a/stdlib/pmexpr/demote.mc
+++ b/stdlib/pmexpr/demote.mc
@@ -124,7 +124,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
     bindall_ [aExpr, bExpr, tExpr, mapExpr]
 end
 
-lang PMExprDemoteReduce = PMExprAst
+lang PMExprDemoteReduce = PMExprDemoteBase + PMExprAst
   sem demoteParallel =
   | TmParallelReduce t ->
     let tyuk = TyUnknown {info = t.info} in
@@ -137,7 +137,7 @@ lang PMExprDemoteReduce = PMExprAst
       rhs = demoteParallel t.as, ty = tyuk, info = t.info}
 end
 
-lang PMExprDemoteLoop = PMExprAst
+lang PMExprDemoteLoop = PMExprDemoteBase + PMExprAst
   sem demoteParallel =
   | TmLoop t | TmParallelLoop t ->
     let unitTy = TyRecord {fields = mapEmpty cmpSID, info = t.info} in

--- a/stdlib/pmexpr/parallel-patterns.mc
+++ b/stdlib/pmexpr/parallel-patterns.mc
@@ -42,14 +42,14 @@ let varPatString : VarPattern -> String = lam pat.
   else never
 
 type AtomicPattern
-con AppPattern : {id : Int, fn : Expr, vars : [VarPattern]} -> AtomicPattern
+con AppPattern : use Ast in {id : Int, fn : Expr, vars : [VarPattern]} -> AtomicPattern
 con UnknownOpPattern : {id : Int, vars : [VarPattern]} -> AtomicPattern
 con BranchPattern : {id : Int, cond : VarPattern, thn : [AtomicPattern],
                         els : [AtomicPattern]} -> AtomicPattern
 con RecursionPattern : {id : Int, binds : [(Name, VarPattern)]} -> AtomicPattern
 con ReturnPattern : {id : Int, var : VarPattern} -> AtomicPattern
 
-type Pattern = {
+type Pattern = use Ast in {
   atomicPatternMap : Map Int AtomicPattern,
   activePatterns : [Int],
   dependencies : Map Int (Set Int),
@@ -126,7 +126,7 @@ let getPatternDependencies : [AtomicPattern] -> ([Int], Map Int (Set Int)) =
 -- Add the dependencies to the ParallelPattern structure. We add them to the
 -- structure to avoid having to recompute them every time an atomic pattern is
 -- checked.
-let withDependencies :
+let withDependencies : use Ast in
      {atomicPatterns : [AtomicPattern],
       replacement : Info -> Map VarPattern (Name, Expr) -> Expr} -> Pattern = lam pat.
   recursive let work = lam acc. lam pat.
@@ -144,7 +144,7 @@ let withDependencies :
   , dependencies = dependencies
   , replacement = pat.replacement }
 
-let getMatch : String -> VarPattern -> Map VarPattern (Name, Expr)
+let getMatch : use Ast in String -> VarPattern -> Map VarPattern (Name, Expr)
             -> (Name, Expr) =
   lam parallelPattern. lam varPat. lam matches.
   match mapLookup varPat matches with Some (id, expr) then
@@ -154,7 +154,7 @@ let getMatch : String -> VarPattern -> Map VarPattern (Name, Expr)
       "Pattern replacement function for ", parallelPattern,
       " referenced unmatched variable pattern ", varPatString varPat])
 
-let eliminateUnusedLetExpressions : Expr -> Expr =
+let eliminateUnusedLetExpressions : use Ast in Expr -> Expr =
   use PMExprAst in
   lam e.
   recursive let collectVariables = lam acc. lam expr.

--- a/stdlib/pmexpr/tailrecursion.mc
+++ b/stdlib/pmexpr/tailrecursion.mc
@@ -17,7 +17,7 @@ include "pmexpr/ast.mc"
 include "pmexpr/function-properties.mc"
 include "pmexpr/utils.mc"
 
-type TailRecursiveEnv = {
+type TailRecursiveEnv = use Ast in {
   binop : Expr,
   ne : Expr,
   leftArgRecursion : Bool
@@ -53,7 +53,7 @@ let compatibleSide : Option Side -> Option Side -> Option Side =
 
 -- Determines whether a given expression is a recursive call to a function with
 -- the given identifier.
-let isRecursiveCall : Expr -> Name -> Bool =
+let isRecursiveCall : use Ast in Expr -> Name -> Bool =
   use MExprAst in
   lam expr. lam ident.
   match collectAppArguments expr with (TmVar {ident = functionId}, _) then
@@ -65,8 +65,8 @@ let isRecursiveCall : Expr -> Name -> Bool =
 -- If no such binary operator is found, None is returned. If no recursive call
 -- takes place within either of the arguments of the binary operator, then the
 -- result is None.
-type TailPosInfo = {binop : Expr, side : Option Side}
-let tailPositionExpressionInfo : Name -> Expr -> Option TailPosInfo =
+type TailPosInfo = use Ast in {binop : Expr, side : Option Side}
+let tailPositionExpressionInfo : use Ast in Name -> Expr -> Option TailPosInfo =
   lam ident. lam expr.
   use MExprAst in
   match expr with TmApp {lhs = TmApp {lhs = binop, rhs = arg1}, rhs = arg2} then

--- a/stdlib/pmexpr/utils.mc
+++ b/stdlib/pmexpr/utils.mc
@@ -7,7 +7,7 @@ include "mexpr/type-check.mc"
 include "pmexpr/ast.mc"
 
 -- Gets the return type of the body of a function.
-recursive let functionBodyReturnType : Expr -> Type =
+recursive let functionBodyReturnType : use Ast in Expr -> Type =
   use PMExprAst in
   lam expr.
   match expr with TmLam {body = body} then
@@ -17,7 +17,7 @@ end
 
 -- Replaces the body of a functiion body, excluding its top-level parameters,
 -- with a new expression.
-recursive let replaceFunctionBody : Expr -> Expr -> Expr =
+recursive let replaceFunctionBody : use Ast in Expr -> Expr -> Expr =
   use PMExprAst in
   lam funcExpr. lam newExpr.
   match funcExpr with TmLam t then
@@ -41,7 +41,7 @@ end
 
 -- Takes a function expression and produces a tuple containing a list of the
 -- arguments and the function body without the lambdas.
-let functionParametersAndBody : Expr -> ([(Name, Type, Info)], Expr) =
+let functionParametersAndBody : use Ast in Expr -> ([(Name, Type, Info)], Expr) =
   use MExprAst in
   lam functionExpr.
   recursive let work = lam acc. lam e.
@@ -52,7 +52,7 @@ let functionParametersAndBody : Expr -> ([(Name, Type, Info)], Expr) =
 
 -- Collects the parameters of an application and returns them in a tuple
 -- together with the target expression (the function being called).
-let collectAppArguments : Expr -> (Expr, [Expr]) =
+let collectAppArguments : use Ast in Expr -> (Expr, [Expr]) =
   use MExprAst in
   lam e.
   recursive let work = lam acc. lam e.

--- a/stdlib/sundials/cvode.ext-ocaml.mc
+++ b/stdlib/sundials/cvode.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
 
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []

--- a/stdlib/sundials/ida.ext-ocaml.mc
+++ b/stdlib/sundials/ida.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
 
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []

--- a/stdlib/sundials/kinsol.ext-ocaml.mc
+++ b/stdlib/sundials/kinsol.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
 
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []

--- a/stdlib/sundials/sundials.ext-ocaml.mc
+++ b/stdlib/sundials/sundials.ext-ocaml.mc
@@ -1,7 +1,7 @@
 include "map.mc"
 include "ocaml/ast.mc"
 
-let impl = lam arg : { expr : String, ty : Type }.
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
   { expr = arg.expr, ty = arg.ty, libraries = ["sundialsml"], cLibraries = [] }
 
 let tyrealarray = otyvarext_ "Sundials.RealArray.t" []

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -335,7 +335,7 @@ lang IndependentAst = HoleAnnotation + KeywordMaker + ANF + PrettyPrint
     (env, join ["independent ", lhs, pprintNewline aindent, rhs])
 end
 
-let holeBool_ : Bool -> Int -> Expr =
+let holeBool_ : use Ast in Bool -> Int -> Expr =
   use HoleBoolAst in
   lam default. lam depth.
   TmHole { default = bool_ default
@@ -344,7 +344,7 @@ let holeBool_ : Bool -> Int -> Expr =
          , info = NoInfo ()
          , inner = BoolHole {}}
 
-let holeIntRange_ : Int -> Int -> Int -> Int -> Expr =
+let holeIntRange_ : use Ast in Int -> Int -> Int -> Int -> Expr =
   use HoleIntRangeAst in
   lam default. lam depth. lam min. lam max.
   TmHole { default = int_ default

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -10,7 +10,7 @@ let _lookupExit : all a. Info -> String -> Map String a -> a =
   lam info : Info. lam s : String. lam m : Map String a.
     mapLookupOrElse (lam. errorSingle [info] (concat s " not found")) s m
 
-let _expectConstInt : Info -> String -> Expr -> Int =
+let _expectConstInt : use Ast in Info -> String -> Expr -> Int =
   lam info : Info. lam s. lam i.
     use IntAst in
     match i with TmConst {val = CInt {val = i}} then i

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -16,7 +16,7 @@ let _expectConstInt : Info -> String -> Expr -> Int =
     match i with TmConst {val = CInt {val = i}} then i
     else errorSingle [info] (concat "Expected a constant integer: " s)
 
-lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeCheck
+lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeCheck + Sym
   syn Hole =
 
   syn Expr =

--- a/stdlib/tuning/call-graph.mc
+++ b/stdlib/tuning/call-graph.mc
@@ -26,7 +26,7 @@ let callGraphEdgeNames = lam cg.
 -- The top of the call graph, has no incoming edges.
 let callGraphTop = (nameSym "top", NoInfo ())
 
-type Binding = {ident : Name, body : Expr, info : Info}
+type Binding = use Ast in {ident : Name, body : Expr, info : Info}
 let _handleLetVertex = use LamAst in
   lam f. lam letexpr : Binding.
     match letexpr.body with TmLam lm then

--- a/stdlib/tuning/const-dep.mc
+++ b/stdlib/tuning/const-dep.mc
@@ -8,12 +8,16 @@ let _constDepExe = (false,true)
 let _constDepBoth = (true,true)
 let _constDepNone = (false,false)
 
-lang IntDep = IntAst
+lang ConstDep
+  sem constDep =
+end
+
+lang IntDep = ConstDep + IntAst
   sem constDep =
   | CInt _ -> []
 end
 
-lang ArithIntDep = ArithIntAst
+lang ArithIntDep = ConstDep + ArithIntAst
   sem constDep =
   | CAddi _ -> [_constDepData, _constDepData]
   | CSubi _ -> [_constDepData, _constDepData]
@@ -23,19 +27,19 @@ lang ArithIntDep = ArithIntAst
   | CModi _ -> [_constDepData]
 end
 
-lang ShiftIntDep = ShiftIntAst
+lang ShiftIntDep = ConstDep + ShiftIntAst
   sem constDep =
   | CSlli _ -> [_constDepData]
   | CSrli _ -> [_constDepData]
   | CSrai _ -> [_constDepData]
 end
 
-lang FloatDep = FloatAst
+lang FloatDep = ConstDep + FloatAst
   sem constDep =
   | CFloat _ -> []
 end
 
-lang ArithFloatDep = ArithFloatAst
+lang ArithFloatDep = ConstDep + ArithFloatAst
   sem constDep =
   | CAddf _ -> [_constDepData, _constDepData]
   | CSubf _ -> [_constDepData, _constDepData]
@@ -44,7 +48,7 @@ lang ArithFloatDep = ArithFloatAst
   | CNegf _ -> [_constDepData]
 end
 
-lang FloatIntConversionDep = FloatIntConversionAst
+lang FloatIntConversionDep = ConstDep + FloatIntConversionAst
   sem constDep =
   | CFloorfi _ -> [_constDepData]
   | CCeilfi _ -> [_constDepData]
@@ -52,12 +56,12 @@ lang FloatIntConversionDep = FloatIntConversionAst
   | CInt2float _ -> [_constDepData]
 end
 
-lang BoolDep = BoolAst
+lang BoolDep = ConstDep + BoolAst
   sem constDep =
   | CBool _ -> []
 end
 
-lang CmpIntDep = CmpIntAst
+lang CmpIntDep = ConstDep + CmpIntAst
   sem constDep =
   | CEqi _ -> [_constDepData, _constDepData]
   | CNeqi _ -> [_constDepData, _constDepData]
@@ -67,7 +71,7 @@ lang CmpIntDep = CmpIntAst
   | CGeqi _ -> [_constDepData, _constDepData]
 end
 
-lang CmpFloatDep = CmpFloatAst
+lang CmpFloatDep = ConstDep + CmpFloatAst
   sem constDep =
   | CEqf _ -> [_constDepData, _constDepData]
   | CLtf _ -> [_constDepData, _constDepData]
@@ -77,23 +81,23 @@ lang CmpFloatDep = CmpFloatAst
   | CNeqf _ -> [_constDepData, _constDepData]
 end
 
-lang CharDep = CharAst
+lang CharDep = ConstDep + CharAst
   sem constDep =
   | CChar _ -> []
 end
 
-lang CmpCharDep = CmpCharAst
+lang CmpCharDep = ConstDep + CmpCharAst
   sem constDep =
   | CEqc _ -> [_constDepData, _constDepData]
 end
 
-lang IntCharConversionDep = IntCharConversionAst
+lang IntCharConversionDep = ConstDep + IntCharConversionAst
   sem constDep =
   | CInt2Char _ -> [_constDepData]
   | CChar2Int _ -> [_constDepData]
 end
 
-lang FloatStringConversionDep = FloatStringConversionAst
+lang FloatStringConversionDep = ConstDep + FloatStringConversionAst
   sem constDep =
   -- NOTE(Linnea,2021-11-19): technically, the execution times of these
   -- conversions depend on the length of the strings, but we ignore that for
@@ -103,19 +107,19 @@ lang FloatStringConversionDep = FloatStringConversionAst
   | CFloat2string _ -> [_constDepData]
 end
 
-lang SymbDep = SymbAst
+lang SymbDep = ConstDep + SymbAst
   sem constDep =
   | CSymb _ -> []
   | CGensym _ -> [_constDepNone]
   | CSym2hash _ -> [_constDepData]
 end
 
-lang CmpSymbDep = CmpSymbAst
+lang CmpSymbDep = ConstDep + CmpSymbAst
   sem constDep =
   | CEqsym _ -> [_constDepData, _constDepData]
 end
 
-lang SeqOpDep = SeqOpAst
+lang SeqOpDep = ConstDep + SeqOpAst
   -- TODO(Linnea,2021-11-22): Does not handle different behaviors for Rope and
   -- List. E.g., concat is linear for list but not for Rope. Moreover,
   -- operations that are O(1) for both might have different constants. E.g.,
@@ -148,7 +152,7 @@ lang SeqOpDep = SeqOpAst
   | CSubsequence _ -> [_constDepBoth, _constDepBoth, _constDepBoth]
 end
 
-lang FileOpDep = FileOpAst
+lang FileOpDep = ConstDep + FileOpAst
   sem constDep =
   | CFileRead _ -> [_constDepBoth]
   | CFileWrite _ -> [_constDepNone, _constDepExe]
@@ -156,7 +160,7 @@ lang FileOpDep = FileOpAst
   | CFileDelete _ -> [_constDepNone]
 end
 
-lang IODep = IOAst
+lang IODep = ConstDep + IOAst
   sem constDep =
   | CPrint _ -> [_constDepNone]
   | CPrintError _ -> [_constDepNone]
@@ -167,13 +171,13 @@ lang IODep = IOAst
   | CReadBytesAsString _ -> [_constDepData]
 end
 
-lang RandomNumberGeneratorDep = RandomNumberGeneratorAst
+lang RandomNumberGeneratorDep = ConstDep + RandomNumberGeneratorAst
   sem constDep =
   | CRandIntU _ -> [_constDepData,_constDepData]
   | CRandSetSeed _ -> [_constDepNone]
 end
 
-lang SysDep = SysAst
+lang SysDep = ConstDep + SysAst
   sem constDep =
   | CExit _ -> [_constDepNone]
   | CError _ -> [_constDepNone]
@@ -181,13 +185,13 @@ lang SysDep = SysAst
   | CCommand _ -> [_constDepBoth]
 end
 
-lang TimeDep = TimeAst
+lang TimeDep = ConstDep + TimeAst
   sem constDep =
   | CWallTimeMs _ -> [_constDepNone]
   | CSleepMs _ -> [_constDepExe]
 end
 
-lang ConTagDep = ConTagAst
+lang ConTagDep = ConstDep + ConTagAst
   sem constDep =
   | CConstructorTag _ -> [_constDepData]
 end
@@ -198,14 +202,14 @@ end
 --   let r2 = r in
 --   modref r2 <data2> in
 --   let x = deref r in  <-- {data1} ⊆ x, {data2} ⊈ x
-lang RefOpDep = RefOpAst
+lang RefOpDep = ConstDep + RefOpAst
   sem constDep =
   | CRef _ -> [_constDepData]
   | CModRef _ -> [_constDepNone,_constDepNone]
   | CDeRef _ -> [_constDepData]
 end
 
-lang TensorOpDep = TensorOpAst
+lang TensorOpDep = ConstDep + TensorOpAst
   sem constDep =
   | CTensorCreateInt _ -> error "TensorOpDep not implemented yet"
   | CTensorCreateFloat _ -> error "TensorOpDep not implemented yet"
@@ -226,7 +230,7 @@ lang TensorOpDep = TensorOpAst
   | CTensorToString _ -> error "TensorOpDep not implemented yet"
 end
 
-lang BootParserDep = BootParserAst
+lang BootParserDep = ConstDep + BootParserAst
   sem constDep =
   | CBootParserParseMExprString _ -> []
   | CBootParserParseMCoreFile _ -> []

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -12,7 +12,7 @@ include "graph-coloring.mc"
 
 -- Implements context expansion for a program with holes.
 
-type LookupTable = [Expr]
+type LookupTable = [use Ast in Expr]
 
 type ContextExpanded =
 { table : LookupTable    -- The initial lookup table

--- a/stdlib/tuning/graph-coloring.mc
+++ b/stdlib/tuning/graph-coloring.mc
@@ -30,7 +30,7 @@ let _threadPoolNbrThreadsStr = "threadPoolNbrThreads"
 let _threadPoolId2idxStr = "threadPoolId2idx"
 
 -- Maintains call context information necessary for program transformations.
-type CallCtxEnv = {
+type CallCtxEnv = use Ast in {
 
   -- Call graph of the program. Functions are nodes, function calls are edges.
   callGraph: CallGraph,
@@ -68,7 +68,7 @@ type CallCtxEnv = {
   -- sets of 'hole2idx'.
   -- OPT(Linnea, 2021-05-19): Consider other representations, as the same
   -- expression may be repeated many times.
-  idx2hole: [use Ast in Expr],
+  idx2hole: [Expr],
 
   -- Maps a hole to the function in which it is defined
   hole2fun: Map NameInfo NameInfo,

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -542,7 +542,7 @@ let tuneEntry =
     -- Set the random seed?
     (match options.seed with Some seed then randSetSeed seed else ());
 
-    let holes : [Expr] = env.idx2hole in
+    let holes : use Ast in [Expr] = env.idx2hole in
     let hole2idx : Map NameInfo (Map [NameInfo] Int) = env.hole2idx in
 
     -- Runs the program with a given command-line input and optional timeout

--- a/test/mlang/catchall.mc
+++ b/test/mlang/catchall.mc
@@ -1,7 +1,7 @@
 lang Nat
   syn Nat =
   | Z ()
-  | S Dyn
+  | S Nat
 
   sem is_zero =
   | Z _ -> true
@@ -11,7 +11,7 @@ lang Nat
   | Z _ -> Z ()
   | S n -> n
 
-  sem plus (n2 : Dyn) =
+  sem plus (n2 : Nat) =
   | Z _ -> n2
   | S n1 -> S (plus n1 n2)
 end

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -6,8 +6,8 @@ end
 
 lang Arith = Base
   syn Expr =
-  | Num Dyn
-  | Add (Dyn, Dyn)
+  | Num Int
+  | Add (Int, Int)
 
   sem eval =
   | Num n -> n
@@ -21,7 +21,7 @@ lang MyBool = Base
   syn Expr =
   | True ()
   | False ()
-  | If(Dyn, Dyn, Dyn)
+  | If(Expr, Expr, Expr)
 
   sem eval =
   | True _ -> true
@@ -39,7 +39,7 @@ lang ArithBool = Arith + MyBool end
 
 lang ArithBool2 = Arith + MyBool
   syn Expr =
-  | IsZero(Dyn)
+  | IsZero Int
 
   sem eval =
   | IsZero n ->
@@ -55,13 +55,13 @@ lang User
   | Unit _ ->
     use Arith in
     eval (Add (Num 1, Num 2))
-  sem bump (x : Dyn) =
+  sem bump (x : Int) =
   | Unit _ -> addi x 1
 end
 
 lang A
   syn ATy =
-  | ACon {afield : Dyn}
+  | ACon {afield : Int}
 end
 
 lang Overlap = ArithBool + ArithBool2 + Arith end

--- a/test/mlang/mlang.mc
+++ b/test/mlang/mlang.mc
@@ -1,4 +1,10 @@
-lang Arith
+lang Base
+  syn Expr =
+
+  sem eval =
+end
+
+lang Arith = Base
   syn Expr =
   | Num Dyn
   | Add (Dyn, Dyn)
@@ -11,7 +17,7 @@ lang Arith
     addi (eval e1) (eval e2)
 end
 
-lang MyBool
+lang MyBool = Base
   syn Expr =
   | True ()
   | False ()
@@ -58,14 +64,15 @@ lang A
   | ACon {afield : Dyn}
 end
 
-lang AExtend = A
-  syn ATy =
-  | ACon {aextfield : Dyn}
-end
-
 lang Overlap = ArithBool + ArithBool2 + Arith end
 
-lang FooA
+lang FooBase
+  syn Val =
+
+  sem foo =
+end
+
+lang FooA = FooBase
   syn Val =
   | A {}
 
@@ -73,7 +80,7 @@ lang FooA
   | A _ -> "A"
 end
 
-lang FooB
+lang FooB = FooBase
   syn Val =
   | B {}
 
@@ -131,11 +138,6 @@ mexpr
 
 let e1 = use ArithBool in If(True(), Num 1, Num 2) in
 let e2 = use ArithBool2 in If(True(), Num 1, Num 2) in
-utest e1 with e2 in
-
-
-let e1 = use A in ACon{afield = 1, aextfield = 2} in -- TODO(vipa,?): this should break once we start typechecking product extensions of a constructor
-let e2 = use AExtend in ACon{afield = 1, aextfield = 2} in
 utest e1 with e2 in
 
 

--- a/test/mlang/nestedpatterns.mc
+++ b/test/mlang/nestedpatterns.mc
@@ -156,7 +156,6 @@ utest use OrderIndependentA in foo (true, false) with use OrderIndependentB in f
 utest use OrderIndependentA in foo (false, true) with use OrderIndependentB in foo (false, true) in
 
 utest use RecordsWithNegation in foo {blue = true} with 4 in
-utest use RecordsWithNegation in foo {red = true} with 2 in
 utest use RecordsWithNegation in foo {blue = false} with 3 in
 
 use Lexer in

--- a/test/mlang/sharedcons.mc
+++ b/test/mlang/sharedcons.mc
@@ -34,16 +34,13 @@ utest fooAC with fooA in
 
 use A in
   utest isA (TmFoo ()) with true in
-  utest isB (TmFoo ()) with false in
   ();
 
 use AC in
   utest isA (TmFoo ()) with true in
-  utest isB (TmFoo ()) with false in
   ();
 
 
 use B in
-  utest isA (TmFoo ()) with false in
   utest isB (TmFoo ()) with true in
   ()

--- a/test/mlang/sharedcons.mc
+++ b/test/mlang/sharedcons.mc
@@ -1,6 +1,10 @@
 -- Remembering constructors from individual language fragments
 
-lang A
+lang ExprDef
+  syn Expr =
+end
+
+lang A = ExprDef
     syn Expr =
     | TmFoo ()
 end
@@ -13,7 +17,7 @@ end
 let isA = use A in lam x. match x with TmFoo () then true else false
 let isB = use B in lam x. match x with TmFoo () then true else false
 
-lang C
+lang C = ExprDef
     syn Expr =
     | TmBar ()
 end

--- a/test/mlang/strformat.mc
+++ b/test/mlang/strformat.mc
@@ -4,7 +4,15 @@ include "char.mc"
 include "seq.mc"
 include "string.mc"
 
-lang FormatInteger
+lang Format
+  syn Fmt =
+
+  sem toString =
+
+  sem toFormat fmtstr =
+end
+
+lang FormatInteger = Format
   syn Fmt =
   | FmtInt (Int)
 
@@ -19,7 +27,7 @@ lang FormatInteger
       error (concat "FormatInteger: toFormat: Unrecognized format: " fmtstr)
 end
 
-lang FormatFloat
+lang FormatFloat = Format
   syn Fmt =
   | FmtFloat (Float)
 
@@ -34,7 +42,7 @@ lang FormatFloat
       error (concat "FormatFloat: toFormat: Unrecognized format: " fmtstr)
 end
 
-lang FormatString
+lang FormatString = Format
   syn Fmt =
   | FmtStr (String)
 
@@ -53,7 +61,7 @@ lang FormatString
       error (concat "FormatString: toFormat: Unrecognized format: " fmtstr)
 end
 
-lang FormatChar
+lang FormatChar = Format
   syn Fmt =
   | FmtChar (Char)
 
@@ -68,7 +76,7 @@ lang FormatChar
       error (concat "FormatChar: toFormat: Unrecognized format: " fmtstr)
 end
 
-lang StrFormatBase
+lang StrFormatBase = Format
   syn Fmt =
   -- Intentionally left blank
 

--- a/test/mlang/type-alias.mc
+++ b/test/mlang/type-alias.mc
@@ -3,7 +3,13 @@
 --
 -- Type-aliases defined within language fragments.
 
-lang L1
+lang Base
+  syn T1 =
+
+  syn T2 =
+end
+
+lang L1 = Base
   syn T1 =
 
   type A1 = {a1 : T1, a2 : T2}
@@ -13,7 +19,7 @@ lang L1
   | X ()
 end
 
-lang L2
+lang L2 = Base
   syn T2 =
   | Y ()
 


### PR DESCRIPTION
This PR replaces #809, to be able to separately merge the nominal changes without the updates because of the new type-checker.

In this PR:
- Nominal handling
- Merging of definitions using `with`, though this excludes renaming presently; it's only allowed if all things getting merged have the same original string name.
- Fixing the compiler and the test suite such that it compiles under this slightly more strict handling of things.

Not included, but previously discussed:
- Typechecker-related changes, these will be presented in a separate PR
- Renaming of declarations/definitions from extended language fragments (as mentioned above; merging things with different string names requires a rename along the way).

**Important:** The changes here should be checked against the other dependent repositories as well. We believe we found and fixed everything before the paper deadline, but those PRs haven't necessarily been merged yet:
- https://github.com/miking-lang/miking-dppl/pull/148
- [TreePPL](https://github.com/treeppl/treeppl/pulls) doesn't seem to have a PR, so it might not need fixes, but this should be confirmed.
- Same for [ProbTime](https://github.com/miking-lang/ProbTime/pulls)

Finally, it's worth mentioning that the PRs in the dependent repos can be merged before this one; the required changes should be fully backwards-compatible. 