### PR TITLE
Extend MiniZinc API with better solution parsing and options

### DIFF
--- a/stdlib/cp/ast.mc
+++ b/stdlib/cp/ast.mc
@@ -20,7 +20,7 @@ lang COPAst
 
   sem isOptimizationModel: COPModel -> Bool
   sem isOptimizationModel =
-  | m -> isOptimization m.solveItem
+  | m -> isOptimization m.objective
 
   sem isOptimization: COPObjective -> Bool
   sem isOptimization =

--- a/stdlib/cp/ast.mc
+++ b/stdlib/cp/ast.mc
@@ -8,11 +8,23 @@ include "name.mc"
 ----------------------------
 
 lang COPAst
-  type COPModel = [COPDecl]
+  type COPModel = {
+    decls: [COPDecl],
+    objective: COPObjective
+  }
 
   syn COPDecl =
   syn COPDomain =
   syn COPExpr =
+  syn COPObjective =
+
+  sem isOptimizationModel: COPModel -> Bool
+  sem isOptimizationModel =
+  | m -> isOptimization m.solveItem
+
+  sem isOptimization: COPObjective -> Bool
+  sem isOptimization =
+  | _ -> false
 end
 
 -------------
@@ -84,15 +96,25 @@ end
 -- OBJECTIVES --
 ----------------
 
-lang COPObjectiveDeclAst = COPAst
+lang COPObjectiveMinimizeAst = COPAst
   syn COPObjective =
-  syn COPDecl =
-  | COPObjectiveDecl { objective: COPObjective }
+  | COPMinimize { expr: COPExpr }
+
+  sem isOptimization =
+  | COPMinimize _ -> true
 end
 
-lang COPObjectiveMinimizeAst = COPObjectiveDeclAst
+lang COPObjectiveMaximizeAst = COPAst
   syn COPObjective =
-  | COPObjectiveMinimize { expr: COPExpr }
+  | COPMaximize { expr: COPExpr }
+
+  sem isOptimization =
+  | COPMaximize _ -> true
+end
+
+lang COPObjectiveSatisfyAst = COPAst
+  syn COPObjective =
+  | COPSatisfy {}
 end
 
 -----------------
@@ -142,7 +164,7 @@ lang COP =
   COPConstraintDeclAst + COPConstraintTableAst + COPConstraintTableReifAst +
   COPConstraintLEAst + COPConstraintLTAst +
   -- Objectives --
-  COPObjectiveDeclAst + COPObjectiveMinimizeAst +
+  COPObjectiveMinimizeAst + COPObjectiveMaximizeAst + COPObjectiveSatisfyAst +
   -- Expressions --
   COPExprSumAst + COPExprVarAst + COPExprVarAccessAst + COPExprIntAst +
   COPExprArrayAst + COPExprArray2dAst

--- a/stdlib/tuning/ast.mc
+++ b/stdlib/tuning/ast.mc
@@ -282,6 +282,7 @@ end
 
 -- Independency annotation
 lang IndependentAst = HoleAnnotation + KeywordMaker + ANF + PrettyPrint
+                    + TypeCheck
   syn Expr =
   | TmIndependent {lhs : Expr,
                    rhs : Expr,
@@ -333,6 +334,15 @@ lang IndependentAst = HoleAnnotation + KeywordMaker + ANF + PrettyPrint
     let aindent = pprintIncr indent in
     match printParen aindent env t.rhs with (env, rhs) in
     (env, join ["independent ", lhs, pprintNewline aindent, rhs])
+
+  sem typeCheckExpr (env: TCEnv) =
+  | TmIndependent t ->
+    let lhs = typeCheckExpr env t.lhs in
+    let rhs = typeCheckExpr env t.rhs in
+    TmIndependent {{{t with lhs = lhs}
+                       with rhs = rhs}
+                       with ty = tyTm lhs}
+
 end
 
 let holeBool_ : use Ast in Bool -> Int -> Expr =

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -21,6 +21,8 @@ type ContextExpanded =
 , cleanup : () -> ()     -- Removes all temporary files from the disk
 }
 
+let contextExpansionTableName = nameSym "table"
+
 -- Generate code for looking up a value of a hole depending on its call history
 let contextExpansionLookupCallCtx =
   use Ast in
@@ -71,7 +73,7 @@ lang ContextExpand = HoleAst
   sem contextExpand (env : CallCtxEnv) =
   | t ->
     let lookup = _lookupFromInt env (lam i.
-      tensorGetExn_ tyint_ (nvar_ _table) (seq_ [int_ i]))
+      tensorGetExn_ tyint_ (nvar_ contextExpansionTableName) (seq_ [int_ i]))
     in
     let ast = _contextExpandWithLookup env lookup t in
     let tempDir = sysTempDirMake () in
@@ -251,9 +253,9 @@ lang ContextExpand = HoleAst
         (get_ (appf2_ (nvar_ strSplitName) (str_ ": ") (nvar_ x)) (int_ 1)))
         (nvar_ strVals))
     -- Convert strings into values
-    , nulet_ _table (map_ (nvar_ string2intName) (nvar_ strVals))
+    , nulet_ contextExpansionTableName (map_ (nvar_ string2intName) (nvar_ strVals))
     -- Convert table into a tensor (for constant-time lookups)
-    , nulet_ _table (app_ (nvar_ seq2TensorName) (nvar_ _table))
+    , nulet_ contextExpansionTableName (app_ (nvar_ seq2TensorName) (nvar_ contextExpansionTableName))
     , tm
     ]
 end

--- a/stdlib/tuning/graph-coloring.mc
+++ b/stdlib/tuning/graph-coloring.mc
@@ -413,8 +413,6 @@ let _forwardCall
                           with body = f bind.body}
     in (localFun, {bind with body = _lamWithBody newBody bind.body})
 
-let _table = nameSym "table"
-
 -- Graph coloring proper --
 
 lang GraphColoring = HoleAst + HoleCallGraph

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -147,6 +147,8 @@ lang NestedMeasuringPoints = MExprHoleCFA
       in concat res acc
     else errorSingle [infoTm t.lhs] "Not a TmVar in application"
 
+  | TmExt t -> acc
+
   | t ->
     sfold_Expr_Expr (_callGraphEdges im data avLams cur) acc t
 

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -615,6 +615,9 @@ let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchSta
     -- Run pattern lowering
     let ast = lowerAll ast in
 
+    -- Strip annotations before compiling
+    let ast = stripTuneAnnotations ast in
+
     -- Compile the program
     let compileOCaml = lam libs. lam clibs. lam ocamlProg.
       let opt = {optimize = true, libraries = libs, cLibraries = clibs} in
@@ -912,6 +915,19 @@ if h then sleepMs 100 else ()
 utest test debug true opt t with {
   finalTable = [false_],
   nbrRuns = 2
+} using eqTest in
+
+-- Independence annotation
+let t = parse
+"
+let h = hole (Boolean {default = true}) in
+let hh = independent h h in
+if hh then sleepMs 100 else ()
+" in
+
+utest test debug false opt t with {
+  finalTable = [],
+  nbrRuns = 0
 } using eqTest in
 
 ()


### PR DESCRIPTION
This PR extends the MiniZinc API so that 
* all status codes ("unsatisfiable", "satisfied", etc.) are parsed, not only "optimal solution"
* all intermediate solutions are parsed and returned, not only the last solution like before
* it's possible to pass options to the solving process, e.g. to choose solver and timeout
* satisfaction and maximization problems are directly supported (not just minimization problems)

Additionally, I have included some minor fixes for tuning:
* Renamed a variable that could potentially become a name conflict
* Fixed a bug that gave a crash on externals
* Added type checking and test cases for independence annotations