### PR TITLE
Updates necessary for supporting tuning in mi-ocaml

### DIFF
--- a/src/main/tune-config.mc
+++ b/src/main/tune-config.mc
@@ -102,12 +102,6 @@ let tuneOptionsConfig : ParseConfig Options = concat optionsConfig [
       let o: Options = p.options in
       let to : TuneOptions = o.tuneOptions in
       {o with tuneOptions = {to with debugExpansion = true}}),
-  ([("--seq-transform", "", "")],
-    "Transform sequence literals into create function choosing between rope and list",
-    lam p: ArgPart Options.
-      let o: Options = p.options in
-      let to : TuneOptions = o.tuneOptions in
-      {o with tuneOptions = {to with seqTransform = true}}),
   ([("--reduce-dependencies", " ", "<t>")],
     join ["Reduce the dependency graph by filtering out measuring points with runtimes below this threshold value (default ",
           float2string tuneOptionsDefault.reduceDependencies, ")"],

--- a/src/main/tune.mc
+++ b/src/main/tune.mc
@@ -93,7 +93,7 @@ let tune = lam files. lam options : Options. lam args.
       {options with output = Some (sysJoinPath r.tempDir "tune")} file ast in
 
     -- Do the tuning
-    let result = tuneEntry binary tuneOptions env dep instRes r ast in
+    let result = tune binary tuneOptions env dep instRes r ast in
 
     -- Write the best found values to filename.tune
     tuneFileDumpTable (tuneFileName file) env result true;

--- a/stdlib/ext/toml-ext.ext-ocaml.mc
+++ b/stdlib/ext/toml-ext.ext-ocaml.mc
@@ -58,6 +58,14 @@ let tomlExtMap =
       ",
       ty = tyarrows_ [tyTomlValue_, tyfloat_] }
     ]),
+    ("externalTomlValueToBoolExn", [
+      impl { expr =
+      "fun v -> match v with
+         | Toml.Types.TBool v -> v
+         | _ -> raise (Invalid_argument (\"tomlValueToBoolExn: \" ^ (Toml.Printer.string_of_value v)))
+      ",
+      ty = tyarrows_ [tyTomlValue_, tybool_] }
+    ]),
     ("externalTomlValueToTableExn", [
       impl { expr =
       "fun v -> match v with

--- a/stdlib/ext/toml-ext.mc
+++ b/stdlib/ext/toml-ext.mc
@@ -8,11 +8,12 @@ include "map.mc"
   and each value is one of:
   - integer
   - float
+  - bool
   - string
   - TOML table
   - a sequence of values
 
-  Boolean and date data types are currently not supported.
+  Date data types are currently not supported.
 -/
 
 type TomlTable
@@ -83,6 +84,12 @@ external externalTomlValueToFloatExn ! : TomlValue -> Float
 let tomlValueToFloatExn = lam v. externalTomlValueToFloatExn v
 
 utest tomlValueToFloatExn (tomlFindExn "key" (tomlFromStringExn "key=3.14")) with 3.14
+
+-- 'tomlValueToBoolExn v' converts a toml value to a bool.
+external externalTomlValueToBoolExn ! : TomlValue -> Bool
+let tomlValueToBoolExn = lam v. externalTomlValueToBoolExn v
+
+utest tomlValueToFloatExn (tomlFindExn "key" (tomlFromStringExn "key=true")) with true
 
 -- 'tomlValueToTableExn v' converts a toml value to a toml table.
 external externalTomlValueToTableExn ! : TomlValue -> TomlTable

--- a/stdlib/ext/toml-ext.mc
+++ b/stdlib/ext/toml-ext.mc
@@ -89,7 +89,7 @@ utest tomlValueToFloatExn (tomlFindExn "key" (tomlFromStringExn "key=3.14")) wit
 external externalTomlValueToBoolExn ! : TomlValue -> Bool
 let tomlValueToBoolExn = lam v. externalTomlValueToBoolExn v
 
-utest tomlValueToFloatExn (tomlFindExn "key" (tomlFromStringExn "key=true")) with true
+utest tomlValueToBoolExn (tomlFindExn "key" (tomlFromStringExn "key=true")) with true
 
 -- 'tomlValueToTableExn v' converts a toml value to a toml table.
 external externalTomlValueToTableExn ! : TomlValue -> TomlTable

--- a/stdlib/tuning/tune-options.mc
+++ b/stdlib/tuning/tune-options.mc
@@ -1,4 +1,6 @@
+include "assoc.mc"
 include "option.mc"
+include "ext/toml-ext.mc"
 
 type SearchMethod
 con Exhaustive         : () -> SearchMethod
@@ -26,7 +28,6 @@ type TuneOptions =
 , debugInstrumentation : Bool
 , debugExpansion : Bool
 , reduceDependencies : Float
-, seqTransform : Bool
 , printStats : Bool
 }
 
@@ -43,12 +44,93 @@ let tuneOptionsDefault : TuneOptions =
 , ignoreErrors = false
 , exitEarly = true
 , seed = None ()
-, dependencyAnalysis = false
+, dependencyAnalysis = true
 , debugDependencyAnalysis = false
 , debugInstrumentation = false
 , debugExpansion = false
-, seqTransform = false
 , reduceDependencies = 0.0
 , cleanup = false
 , printStats = false
 }
+
+let tuneOptionsFromToml: TuneOptions -> String -> TuneOptions =
+  lam default. lam tomlString.
+    let toml = tomlBindings (tomlFromStringExn tomlString) in
+    foldl (lam acc. lam bind: (String, TomlValue).
+      match bind with (k,v) in
+      switch k
+      case "verbose" then {acc with verbose = tomlValueToBoolExn v}
+      case "iters" then {acc with iters = tomlValueToIntExn v}
+      case "timeoutMs" then {acc with timeoutMs = Some (tomlValueToFloatExn v)}
+      case "warmups" then {acc with warmups = tomlValueToIntExn v}
+      case "method" then
+        let method = tomlValueToStringExn v in
+        {acc with method = optionGetOrElse
+          (lam. error (concat "Unknown method: " method))
+          (assocLookup {eq=eqString} method tuneSearchMethodMap)}
+      case "args" then {acc with args = tomlValueToStringSeqExn v}
+      case "epsilonMs" then {acc with epsilonMs = tomlValueToFloatExn v}
+      case "stepSize" then {acc with stepSize = tomlValueToIntExn v}
+      case "ignoreErrors" then {acc with ignoreErrors = tomlValueToBoolExn v}
+      case "exitEarly" then {acc with exitEarly = tomlValueToBoolExn v}
+      case "seed" then {acc with seed = Some (tomlValueToIntExn v)}
+      case "dependencyAnalysis" then
+        {acc with dependencyAnalysis = tomlValueToBoolExn v}
+      case "debugDependencyAnalysis" then
+        {acc with debugDependencyAnalysis = tomlValueToBoolExn v}
+      case "debugInstrumentation" then
+        {acc with debugInstrumentation = tomlValueToBoolExn v}
+      case "debugExpansion" then
+        {acc with debugExpansion = tomlValueToBoolExn v}
+      case "reduceDependencies" then
+        {acc with reduceDependencies = tomlValueToFloatExn v}
+      case "cleanup" then {acc with cleanup = tomlValueToBoolExn v}
+      case "printStats" then {acc with printStats = tomlValueToBoolExn v}
+      case key then error (concat "Unknown option: " key)
+      end
+    ) default toml
+
+mexpr
+
+utest tuneOptionsFromToml tuneOptionsDefault
+"
+verbose = true
+iters = 3
+timeoutMs = 0.1
+method = \"exhaustive\"
+args = [\"3000 3 1\", \"20000 3 2\"]
+epsilonMs = 1.0
+stepSize = 102
+ignoreErrors = true
+exitEarly = false
+seed = 42
+dependencyAnalysis = false
+debugDependencyAnalysis = true
+debugInstrumentation = true
+debugExpansion = false
+reduceDependencies = 10.0
+cleanup = true
+printStats = true
+"
+with
+{ verbose = true
+, iters = 3
+, timeoutMs = Some 0.1
+, warmups = 1
+, method = Exhaustive ()
+, args = ["3000 3 1", "20000 3 2"]
+, epsilonMs = 1.0
+, stepSize = 102
+, ignoreErrors = true
+, exitEarly = false
+, seed = Some 42
+, dependencyAnalysis = false
+, debugDependencyAnalysis = true
+, debugInstrumentation = true
+, debugExpansion = false
+, reduceDependencies = 10.0
+, cleanup = true
+, printStats = true
+}
+in
+()


### PR DESCRIPTION
* Refactors `tune.mc` so that the language fragments become extensible, so that that tuning can be used from within the `mi-ocaml` compiler.
* Adds a function for parsing tune options from a toml file.
* Adds a `tomlValueToBoolExn` to `toml-ext.mc`