### PR TITLE
Add flake for Sundials version of the compiler

### DIFF
--- a/misc/packaging/flake.nix
+++ b/misc/packaging/flake.nix
@@ -21,6 +21,7 @@
           ocaml
           findlib
           dune_3
+          ocamlformat_0_24_1
           pkgs.gdb
 
           lwt        # For async-ext.mc

--- a/misc/packaging/sundials/flake.lock
+++ b/misc/packaging/sundials/flake.lock
@@ -1,0 +1,218 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mirage-opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661959605,
+        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704282547,
+        "narHash": "sha256-GbTBdgQn0mYP106amm8+RUb1SrPRopeKlnArKXImh1c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "97f2135e6a6a3b85e323e3ede61fb9cec134ba93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-sundials-5_7_0": {
+      "locked": {
+        "lastModified": 1612715874,
+        "narHash": "sha256-VPKQpv/jU5cEpC2+unG9YilE/NsnSUXvDBfgnWWadPQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4953d87fcb07b258561320044f96a25e0754427d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4953d87fcb07b258561320044f96a25e0754427d",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1682362401,
+        "narHash": "sha256-/UMUHtF2CyYNl4b60Z2y4wwTTdIWGKhj9H301EDcT9M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "884ac294018409e0d1adc0cae185439a44bd6b0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "opam-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "mirage-opam-overlays": "mirage-opam-overlays",
+        "nixpkgs": "nixpkgs_2",
+        "opam-overlays": "opam-overlays",
+        "opam-repository": "opam-repository",
+        "opam2json": "opam2json"
+      },
+      "locked": {
+        "lastModified": 1703843211,
+        "narHash": "sha256-z7X1i2T1H37Lj9hEIJA5T0+sdE5E+PSWiiSyvYGyGSY=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "6a1d1802aec6bf4823c77b98512b269fa9927bf7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
+    "opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654162756,
+        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
+    "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701363371,
+        "narHash": "sha256-DeiPIuWNDSOxvlF41YPae7UpVGZLf7/E3qp2JMerovg=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "bc52affc41b55ff00c0d3ac9a376538d79695aaf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "opam2json": {
+      "inputs": {
+        "nixpkgs": [
+          "opam-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-sundials-5_7_0": "nixpkgs-sundials-5_7_0",
+        "opam-nix": "opam-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/misc/packaging/sundials/flake.nix
+++ b/misc/packaging/sundials/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Builds the Miking compiler with Sundials support";
+
+  inputs = {
+    opam-nix.url = "github:tweag/opam-nix";
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs";
+    nixpkgs-sundials-5_7_0.url = # SundialsML does not support Sundials after 6.1.1
+      "github:nixos/nixpkgs/4953d87fcb07b258561320044f96a25e0754427d";
+  };
+
+  outputs = { self, opam-nix, flake-utils, nixpkgs, nixpkgs-sundials-5_7_0 }:
+    let sundialsml = "sundialsml";
+    in flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs-sundials-5_7_0 = nixpkgs-sundials-5_7_0.legacyPackages.${system};
+      in {
+        legacyPackages = let
+          inherit (opam-nix.lib.${system}) queryToScope;
+          inherit pkgs;
+          # Build SundialsML from its OPAM package
+          scope = queryToScope { } {
+            ${sundialsml} = "*";
+            # The following line forces opam to choose the compiler from opam
+            # instead of the nixpkgs one
+            # ocaml-base-compiler = "*";
+          };
+          buildInputs = with pkgs.ocamlPackages; [
+            ocaml
+            findlib
+            (pkgs-sundials-5_7_0.sundials.override ({ kluSupport = false; }))
+          ];
+        in scope.overrideScope' (final: prev: {
+          ${sundialsml} = prev.${sundialsml}.overrideAttrs (_: {
+            buildInputs = buildInputs;
+            nativeBuildInputs = buildInputs;
+          });
+        });
+
+        devShells.default = pkgs.mkShell {
+          name = "Miking dev shell";
+          buildInputs = with pkgs.ocamlPackages; [
+            pkgs.coreutils # Miking currently requires mkdir to be able to run
+            ocaml
+            linenoise
+            pkgs.minizinc
+          ];
+          nativeBuildInputs = with pkgs.ocamlPackages; [
+            ocaml
+            findlib
+            dune_3
+            pkgs.gdb
+
+            lwt # For async-ext.mc
+            owl # For dist-ext.mc
+            toml # For toml-ext.mc
+            self.legacyPackages.${system}.${sundialsml} # for sundials-ext.mc
+          ];
+        };
+      });
+}

--- a/misc/packaging/sundials/flake.nix
+++ b/misc/packaging/sundials/flake.nix
@@ -50,6 +50,7 @@
             ocaml
             findlib
             dune_3
+            ocamlformat_0_24_1
             pkgs.gdb
 
             lwt # For async-ext.mc


### PR DESCRIPTION
This PR adds a Nix flake that produces a development shell for the Miking compiler including Sundials support. It also adds `ocamlformat 0.24.1` to the list of dependencies.