### PR TITLE
Do not allow partial evaluation of non-top-level rec bindings

### DIFF
--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -301,17 +301,9 @@ lang RecLetsPEval = PEval + RecLetsAst + ClosPAst + LamAst
     }
 
   sem pevalEval ctx k =
-  | TmRecLets r ->
-    let bindings =
-      map
-        (lam bind. { bind with body = pevalBind ctx (lam x. x) bind.body })
-        r.bindings
-    in
-    TmRecLets {
-      r with
-      bindings = bindings,
-      inexpr = pevalBind ctx k r.inexpr
-    }
+  | TmRecLets _ ->
+    error
+      "Partial evaluation of non-top-level recursive let bindings is not safe"
 
   sem pevalReadbackH ctx =
   | TmRecLets r ->
@@ -1475,27 +1467,29 @@ lam n.
   using eqExpr else _toString
 in
 
-let prog = _parse "
-let pow =
-  recursive let recur = lam n. lam x.
-    if eqi n 0 then 1.
-    else
-      if eqi n 1 then x
-      else mulf (recur (subi n 1) x) x
-  in recur
-in lam x. (pow 10 x, pow 9 x)
-  "
-in
-utest pevalInlineLets (_test prog) with _parse "
-recursive let recur = lam n. lam x.
-  if eqi n 0 then 1.
-  else
-    if eqi n 1 then x
-    else mulf (recur (subi n 1) x) x
-in lam x. (recur 10 x, recur 9 x)
-  "
-  using eqExpr else _toString
-in
+-- -- Give error since the a non-top-level recursive binding can escape its
+-- -- scope
+-- let prog = _parse "
+-- let pow =
+--   recursive let recur = lam n. lam x.
+--     if eqi n 0 then 1.
+--     else
+--       if eqi n 1 then x
+--       else mulf (recur (subi n 1) x) x
+--   in recur
+-- in lam x. (pow 10 x, pow 9 x)
+--   "
+-- in
+-- utest pevalInlineLets (_test prog) with _parse "
+-- recursive let recur = lam n. lam x.
+--   if eqi n 0 then 1.
+--   else
+--     if eqi n 1 then x
+--     else mulf (recur (subi n 1) x) x
+-- in lam x. (recur 10 x, recur 9 x)
+--   "
+--   using eqExpr else _toString
+-- in
 
 let prog = _parse "
 recursive let pow = lam n. lam x.


### PR DESCRIPTION
This PR changes `peval` so that it gives an error when partially evaluating a recursive let-bindings that is not defined at the "top-level" of an expression. The problem with partially evaluating these recursive let-bindings is that variables bound in these recursive definitions can sometimes escape their scope. 

To partially evaluate expression with recursive definitions not at the top-level you can, e.g., perform a lambda-lifting (`lamlift.mc`) prior to partial evaluation.