### PR TITLE
Add support for negative numbers

### DIFF
--- a/src/boot/lib/lexer.mll
+++ b/src/boot/lib/lexer.mll
@@ -144,7 +144,6 @@ let string_buf = Buffer.create 80
 let parse_error_message() =
   (PARSE_ERROR,ERROR,!last_info,[])
 
-
 }
 
 let utf8_1byte = ['\x00'-'\x7F']
@@ -173,10 +172,10 @@ let symtok =  "="  | "+" |  "-" | "*"  | "/" | "%"  | "<"  | "<=" | ">" | ">=" |
 
 let line_comment = "--" [^ '\013' '\010']*
 let unsigned_integer = digit+
-let signed_integer = unsigned_integer  | '-' unsigned_integer
+let signed_integer = '-' unsigned_integer | unsigned_integer
 let unsigned_number = unsigned_integer ('.' (unsigned_integer)?)?
                       (('e'|'E') ("+"|"-")? unsigned_integer)?
-
+let signed_number = unsigned_number | '-' unsigned_number
 
 (* Main lexing *)
 rule main = parse
@@ -195,10 +194,10 @@ rule main = parse
       { add_colno !tabsize; main lexbuf }
   | newline
       { newrow(); main lexbuf }
-  | (unsigned_integer as str)
-      { Parser.UINT{i=mkinfo_fast str; v=int_of_string str} }
-  | unsigned_number as str
-      { Parser.UFLOAT{i=mkinfo_fast str; v=float_of_string str} }
+  | (signed_integer as str)
+      { Parser.INT{i=mkinfo_fast str; v=int_of_string str} }
+  | signed_number as str
+      { Parser.FLOAT{i=mkinfo_fast str; v=float_of_string str} }
   | ident | symtok as s
       { mklcid s }
   | uident as s

--- a/src/boot/lib/parser.mly
+++ b/src/boot/lib/parser.mly
@@ -43,8 +43,8 @@
 %token <Ustring.ustring Ast.tokendata> LC_IDENT  /* An identifier that starts with "_" or a lower-case letter */
 %token <Ustring.ustring Ast.tokendata> STRING
 %token <Ustring.ustring Ast.tokendata> CHAR
-%token <int Ast.tokendata> UINT
-%token <float Ast.tokendata> UFLOAT
+%token <int Ast.tokendata> INT
+%token <float Ast.tokendata> FLOAT
 
 
 /* Keywords */
@@ -432,8 +432,8 @@ atom:
   | var_ident            { TmVar($1.i,$1.v,Symb.Helpers.nosym, false, false) }
   | frozen_ident         { TmVar($1.i,$1.v,Symb.Helpers.nosym, false, true) }
   | CHAR                 { TmConst($1.i, CChar(List.hd (ustring2list $1.v))) }
-  | UINT                 { TmConst($1.i,CInt($1.v)) }
-  | UFLOAT               { TmConst($1.i,CFloat($1.v)) }
+  | INT                  { TmConst($1.i,CInt($1.v)) }
+  | FLOAT                { TmConst($1.i,CFloat($1.v)) }
   | TRUE                 { TmConst($1.i,CBool(true)) }
   | FALSE                { TmConst($1.i,CBool(false)) }
   | NEVER                { TmNever($1.i) }
@@ -451,7 +451,7 @@ atom:
         ) $2 $4}
 
 proj_label:
-  | UINT
+  | INT
     { ($1.i, ustring_of_int $1.v) }
   | label_ident
     { ($1.i,$1.v) }
@@ -541,7 +541,7 @@ pat_atom:
   | LBRACKET pat_labels RBRACKET
       { PatRecord(mkinfo $1.i $3.i, $2 |> List.fold_left
                   (fun acc (k,v) -> Record.add k v acc) Record.empty) }
-  | UINT /* TODO(?,?): enable matching against negative ints */
+  | INT
       { PatInt($1.i, $1.v) }
   | CHAR
       { PatChar($1.i, List.hd (ustring2list $1.v)) }

--- a/test/mexpr/float-test.mc
+++ b/test/mexpr/float-test.mc
@@ -10,6 +10,7 @@ mexpr
 
 -- Floating-point number literals
 utest 32.1 with 32.1 using eqf in
+utest -32.1 with -32.1 using eqf in
 utest 0.01 with 1e-2 using eqf in
 utest 0.032 with 3.2e-2 using eqf in
 utest 320.0 with 3.2e+2 using eqf in
@@ -32,7 +33,8 @@ utest divf 6.0 3.0 with 2.0 using eqf in
 
 -- Negation
 -- Float -> Float
-utest negf 2.2 with negf 2.2 using eqf in
+utest negf 2.2 with -2.2 using eqf in
+utest negf -2.2 with 2.2 using eqf in
 
 -- Floating-point operations
 -- Float -> Float -> Bool

--- a/test/mexpr/int-test.mc
+++ b/test/mexpr/int-test.mc
@@ -9,6 +9,7 @@ mexpr
 -- Ingerger literals
 utest 1 with 1 in
 utest 35 with 35 in
+utest -35 with -35 in
 
 -- Integer operations: add sub mul div mod
 -- int -> int -> int
@@ -21,7 +22,8 @@ utest 1 with modi 9 2 in              -- modulo
 -- Integer negations
 -- int -> int
 utest 15 with addi 20 (negi 5) in
-utest negi 1 with negi 1 in
+utest negi 1 with -1 in
+utest negi -1 with 1 in
 -- Integer comparison operators
 -- int -> int -> bool
 let neg = lam f. lam x. lam y. not (f x y) in

--- a/test/mexpr/match.mc
+++ b/test/mexpr/match.mc
@@ -12,6 +12,20 @@ mexpr
 utest () with () in
 utest () with {} in
 
+-- Matching integers
+utest
+  match 1 with 1 then true else false
+  with true
+in
+utest
+  match -1 with -1 then true else false
+  with true
+in
+utest
+  match negi 1 with -1 then true else false
+  with true
+in
+
 -- Constructor with arguments
 type T a in
 con K1 : all a. a -> T a in
@@ -116,8 +130,6 @@ utest count tree3 with 23 in
 utest
   match {foo=7,bar={more="hello"}} with {foo=_,bar={more=str}} then str else ""
 with "hello" in
-
-
 
 -- Wildcard
 utest match (1,2,3) with (_,2,_) then true else false with true in


### PR DESCRIPTION
This PR adds support for negative numbers (ints and floats) in the boot parser. The motivation for this addition follows.

1. We can then match on negative integers (right now we can only match on positive integers).
2. We do not have to re-discover negative numbers after transformations, such as constant folding or partial evaluation, and translate these to applications of `negi` or `negf` on positive numbers before, e.g., pretty printing.
3. There is no ambiguity between negative number literals and applications of negation operations `negi` and `negf`.

An effect of this change is that it is allowed to project from records with, e.g., `t.-1`, which is well typed if `t : all a. { #label"-1" : a, ... }`.

This PR solves https://github.com/miking-lang/miking/issues/796, except that it does not make any changes to `mexpr/parser.mc`.