### PR TITLE
Make parseMExprString total

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -229,6 +229,7 @@ and ptree =
   | PTreePat of pat
   | PTreeConst of const
   | PTreeInfo of info
+  | PTreeError of (info * ustring) list
 
 (* Terms in MLang *)
 and cdecl =

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -8,15 +8,19 @@ open Symbutils
 (* Tab length when calculating the info field *)
 let tablength = 8
 
-let error_to_ustring e =
-  match e with
-  | Lexer.Lex_error m ->
-      message2str m
+let error_to_error_message = function
+  | Lexer.Lex_error m | Error m ->
+      Some m
   | Parsing.Parse_error ->
-      message2str (Lexer.parse_error_message ())
-  | Error m ->
-      message2str m
+      Some (Lexer.parse_error_message ())
   | _ ->
+      None
+
+let error_to_ustring e =
+  match error_to_error_message e with
+  | Some m ->
+      message2str m
+  | None ->
       us (Printexc.to_string e)
 
 module ExtIdMap = Map.Make (Ustring)

--- a/stdlib/mexpr/anf.mc
+++ b/stdlib/mexpr/anf.mc
@@ -390,7 +390,7 @@ in
 use TestANF in
 
 let _test = _testConstr normalizeTerm in
-let _parse = parseMExprStringKeywords [] in
+let _parse = parseMExprStringKeywordsExn [] in
 
 let basic = _parse "
   let f = (lam x. x) in

--- a/stdlib/mexpr/ast-effect.mc
+++ b/stdlib/mexpr/ast-effect.mc
@@ -104,7 +104,7 @@ mexpr
 use TestLangImpl in
 
 let parse =
-  parseMExprString
+  parseMExprStringExn
     { _defaultBootParserParseMExprStringArg () with allowFree = true }
 in
 

--- a/stdlib/mexpr/ast-result.mc
+++ b/stdlib/mexpr/ast-result.mc
@@ -54,7 +54,7 @@ mexpr
 use TestLang in
 
 let parse =
-  parseMExprString
+  parseMExprStringExn
     { _defaultBootParserParseMExprStringArg () with allowFree = true }
 in
 

--- a/stdlib/mexpr/boot-parser.mc
+++ b/stdlib/mexpr/boot-parser.mc
@@ -440,7 +440,8 @@ use BootParserTest in
 -- Tests where strings of MExpr text is parsed and then pretty printed again.
 -- All terms are tested in this way.
 let norm : String -> String = lam str.
-  filter (lam x. not (or (or (eqChar x ' ') (eqChar x '\n')) (eqChar x '\t'))) str in
+  filter (lam x. not (or (or (eqChar x ' ') (eqChar x '\n')) (eqChar x '\t'))) str
+in
 
 -- Test the combination of parsing and pretty printing
 let parse = lam ks. lam s. expr2str (parseMExprStringKeywordsExn ks s) in
@@ -453,7 +454,8 @@ let l_info : [String] -> String -> Info = lam ks. lam s.
   infoTm (parseMExprStringKeywordsExn ks s) in
 let l_infoClosed = l_info [] in
 let r_info : Int -> Int -> Int -> Int -> Info = lam r1. lam c1. lam r2. lam c2.
-      Info {filename = "internal", row1 = r1, col1 = c1, row2 = r2, col2 = c2} in
+  Info {filename = "internal", row1 = r1, col1 = c1, row2 = r2, col2 = c2}
+in
 
 -- TmVar
 let s = "_asdXA123" in
@@ -477,7 +479,9 @@ utest l_info ["_aas_12"] "  _aas_12 " with r_info 1 2 1 9 in
 let s = "let y = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest l_infoClosed "  \n lam x.x" with r_info 2 1 2 8 in
-utest match parseMExprStringKeywordsExn [] s with TmLet r then infoTm r.body else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet r
+  then infoTm r.body else NoInfo ()
 with r_info 1 8 1 15 in
 utest l_info ["y"] "  let x = 4 in y  " with r_info 1 2 1 14 in
 let s = "(printLn x); 10" in
@@ -540,12 +544,14 @@ utest l_infoClosed " {foo = 123} " with r_info 1 1 1 12 in
 let s = "{a with foo = 5}" in
 utest lside ["a"] s with rside s in
 let s = "{{bar='a', foo=7} with bar = 'b'}" in
-let t = recordupdate_ (urecord_ [("bar", char_ 'a'), ("foo", int_ 7)]) "bar" (char_ 'b') in
+let t =
+  recordupdate_
+    (urecord_ [("bar", char_ 'a'), ("foo", int_ 7)]) "bar" (char_ 'b') in
 utest parseMExprStringKeywordsExn [] s with t using eqExpr in
 utest l_info ["foo"] " {foo with a = 18 } " with r_info 1 1 1 19 in
 
--- NOTE(caylak, 2021-03-17): Commented out because test fails since parsing of TyVariant is not supported yet
--- TmType
+-- NOTE(caylak, 2021-03-17): Commented out because test fails since parsing of
+-- TyVariant is not supported yet TmType
 let s = "type Foo=<> in x" in
 --utest lsideClosed s with rside s in
 utest l_infoClosed "  type Bar in () " with r_info 1 2 1 13 in
@@ -569,7 +575,9 @@ let s = "match foo with _ then 7 else 2" in
 utest lside ["foo"] s with rside s in
 utest l_infoClosed "match [4] with x then x else [] " with r_info 1 0 1 31 in
 let s = " match bar with Foo {a = x} then x else 2" in
-utest match parseMExprStringKeywordsExn ["Foo", "bar"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["Foo", "bar"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 16 1 27 in
 
 -- TmMatch, PatSeqTot, PatSeqEdge
@@ -577,70 +585,98 @@ let s = "match x with \"\" then x else 2" in
 utest lside ["x"] s with rside s in
 let s = "match x with [x,y,z] then x else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 20 in
 let s = " match x with [a] ++ v ++ [x,y,z] then x else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 14 1 33 in
 let s = "match x with \"\" ++ x ++ [y] then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 27 in
 let s = "match x with [z] ++ x ++ \"\" then z else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 27 in
 
 --TmMatch, PatRecord
 let s = "match x with {} then x else 2" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 15 in
 let s = "match x with {bar=_, foo=x} then x else 2" in
 let t = match_ (var_ "x")
                (prec_ [("bar", pvarw_), ("foo", pvar_ "x")])
                (var_ "x") (int_ 2) in
 utest parseMExprStringKeywordsExn ["x"] s with t using eqExpr in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 27 in
 
 --TmMatch, PatCon
 let s = "match x with Foo {foo = x} then x else 100" in
 utest lside ["x", "Foo"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x", "Foo"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x", "Foo"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 26 in
 
 --TmMatch, PatInt, PatBool, PatChar
 let s = "match x with [1,2,12] then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 21 in
 let s = "match x with 'A' then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 16 in
 let s = "match x with [true,false] then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 25 in
 
 -- TmMatch, PatAnd, PatOr, PatNot
 let s = "match x with 1 & x then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 18 in
 let s = "match x with 1 | x then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 18 in
 let s = "match x with !y then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 13 1 15 in
 let s = "match 1 with (a & b) | (!c) then x else x" in
 utest lside ["x"] s with rside s in
-utest match parseMExprStringKeywordsExn ["x"] s with TmMatch r then infoPat r.pat else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn ["x"] s with TmMatch r
+  then infoPat r.pat else NoInfo ()
 with r_info 1 14 1 26 in
 
 -- TmUtest
@@ -665,51 +701,70 @@ utest l_infoClosed "   \n  external y! : Int in 1" with r_info 2 2 2 24 in
 -- TyUnknown
 let s = "let y:Unknown = lam x.x in y" in
 utest lsideClosed s with rside "let y = lam x.x in y" in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 13 in
 let s = "lam x:Int. lam y:Char. x" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] " \n lam x:Int. lam y:Char. x" with TmLam l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] " \n lam x:Int. lam y:Char. x"
+    with TmLam l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 2 7 2 10 in
 
 -- TyInt
 let s = "let y:Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 9 in
 
 -- TyFloat
 let s = "let y:Float = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 11 in
 
 -- TyChar
 let s = "let y:Char = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 10 in
 
 -- TyArrow
 let s = "let y:Int->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 14 in
 
 -- Nested TyArrow
 let s = "let y:[Float]->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 18 in
 
 -- TySeq
 let s = "let y:[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 11 in
 
 -- Nested TySeq
-let s = "let y:[{a:{a_1:Int,a_2:Float},b:{b_1:[Char],b_2:Float}}]= lam x.x in y" in
+let s =
+  "let y:[{a:{a_1:Int,a_2:Float},b:{b_1:[Char],b_2:Float}}]= lam x.x in y"
+in
 let recTy = tyseq_ (tyrecord_ [
   ("a", tyrecord_ [
     ("a_1", tyint_),
@@ -721,13 +776,17 @@ let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 56 in
 
 -- TyTensor
 let s = "let y:Tensor[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 17 in
 
 -- Nested TyTensor
@@ -741,18 +800,24 @@ let typedLet = lam letTy.
   bind_ (let_ "y" letTy (ulam_ "x" (var_ "x")))
         (var_ "y") in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 30 in
 
 -- TyRecord
 let s = "let y:{a:Int,b:[Char]} = lam x.x in y" in
 let recTy = tyrecord_ [("a", tyint_), ("b", tystr_)] in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 22 in
 
 -- Nested TyRecord
-let s = "let y:{a:{a_1:Int,a_2:Float},b:{b_1:[Char],b_2:Float}} = lam x.x in y" in
+let s =
+  "let y:{a:{a_1:Int,a_2:Float},b:{b_1:[Char],b_2:Float}} = lam x.x in y"
+in
 let recTy = tyrecord_ [
   ("a", tyrecord_ [
     ("a_1", tyint_),
@@ -761,50 +826,66 @@ let recTy = tyrecord_ [
     ("b_1", tystr_),
     ("b_2", tyfloat_)])] in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 54 in
 
 -- TyVariant
 let s = "let y:<> = lam x.x in y" in
 -- NOTE(caylak,2021-03-17): Parsing of TyVariant is not supported yet
 --utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 8 in
 
 -- TyVar
 let s = "let y:_asd = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 10 in
 
 -- TyAll
 let s = "let y:all x.x = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 13 in
 
 -- Nested TyAll
 let s = "let y:all x.(all y.all z.z)->all w.w = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 36 in
 
 -- TyCon
 let s = "let y:Foo = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 9 in
 
 -- TyApp
 let s = "let y:(Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 7 1 19 in
 
 -- Nested TyApp
 let s = "let y:((Int->Int)Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest
+  match parseMExprStringKeywordsExn [] s with TmLet l
+  then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 8 1 29 in
 
 -- Allow free variables

--- a/stdlib/mexpr/cfa.mc
+++ b/stdlib/mexpr/cfa.mc
@@ -1754,7 +1754,7 @@ mexpr
 use Test in
 
 -- Test functions --
-let _parse = parseMExprStringKeywords [] in
+let _parse = parseMExprStringKeywordsExn [] in
 let _testBase: Option PprintEnv -> Expr -> (Option PprintEnv, CFAGraph) =
   lam env: Option PprintEnv. lam t: Expr.
     match env with Some env then

--- a/stdlib/mexpr/constant-fold.mc
+++ b/stdlib/mexpr/constant-fold.mc
@@ -338,7 +338,7 @@ use TestLang in
 let _parse = lam prog.
   typeCheck
     (symbolize
-       (parseMExprString
+       (parseMExprStringExn
           { _defaultBootParserParseMExprStringArg () with allowFree = false }
           prog))
 in

--- a/stdlib/mexpr/cps.mc
+++ b/stdlib/mexpr/cps.mc
@@ -387,7 +387,7 @@ mexpr
 use Test in
 
 let _parse =
-  parseMExprString { defaultBootParserParseMExprStringArg with allowFree = true }
+  parseMExprStringExn { defaultBootParserParseMExprStringArg with allowFree = true }
 in
 
 -------------------------

--- a/stdlib/mexpr/externals.mc
+++ b/stdlib/mexpr/externals.mc
@@ -41,7 +41,7 @@ end
 mexpr
 use Test in
 
-let parse = parseMExprString
+let parse = parseMExprStringExn
   { defaultBootParserParseMExprStringArg with allowFree = true } in
 let ast1 = parse "
   external a: Int -> Int in

--- a/stdlib/mexpr/free-vars.mc
+++ b/stdlib/mexpr/free-vars.mc
@@ -79,7 +79,7 @@ let parseProgram : String -> Expr =
     let parseArgs =
       {defaultBootParserParseMExprStringArg with allowFree = true}
     in
-    let ast = parseMExprString parseArgs str in
+    let ast = parseMExprStringExn parseArgs str in
     symbolizeExpr {symEnvEmpty with allowFree = true} ast
 in
 

--- a/stdlib/mexpr/generate-json-serializers.mc
+++ b/stdlib/mexpr/generate-json-serializers.mc
@@ -398,7 +398,7 @@ end
 mexpr
 use Test in
 
-let parseTest = parseMExprString {
+let parseTest = parseMExprStringExn {
   defaultBootParserParseMExprStringArg with
     allowFree = true
 } in

--- a/stdlib/mexpr/index.mc
+++ b/stdlib/mexpr/index.mc
@@ -154,7 +154,7 @@ mexpr
 use Test in
 
 let test: String -> IndexMap = lam s.
-  let t = parseMExprStringKeywords [] s in
+  let t = parseMExprStringKeywordsExn [] s in
   indexGen t
 in
 

--- a/stdlib/mexpr/kcfa.mc
+++ b/stdlib/mexpr/kcfa.mc
@@ -1803,7 +1803,7 @@ mexpr
 use KTest in
 
 -- Test functions --
-let _parse = parseMExprStringKeywords [] in
+let _parse = parseMExprStringKeywordsExn [] in
 let _testBase: Option PprintEnv -> Int -> Expr -> (Option PprintEnv, CFAGraph) =
   lam env: Option PprintEnv. lam k. lam t: Expr.
     match env with Some env then

--- a/stdlib/mexpr/profiling.mc
+++ b/stdlib/mexpr/profiling.mc
@@ -191,7 +191,7 @@ let getProfilerReportCode = lam.
   match deref _profilerReportCodeRef with Some t then t
   else
     use BootParser in
-    let code = parseMExprStringKeywords ["functionProfileData"] _profilerReportStr in
+    let code = parseMExprStringKeywordsExn ["functionProfileData"] _profilerReportStr in
     modref _profilerReportCodeRef (Some code);
     code
 
@@ -252,7 +252,7 @@ lang MExprProfileInstrument = MExprAst + BootParser
     let emptyEnv = mapEmpty nameCmp in
     let env = collectToplevelFunctions emptyEnv t in
     bindall_ [
-      parseMExprStringKeywords [] (_profilerInitStr env),
+      parseMExprStringKeywordsExn [] (_profilerInitStr env),
       ulet_ "" (instrumentProfilingH env t),
       getProfilerReportCode ()]
 end

--- a/stdlib/mexpr/utils.mc
+++ b/stdlib/mexpr/utils.mc
@@ -178,7 +178,7 @@ utest pp (substituteIdentifiers replace (expr "x")) with pp (expr "y") using eqS
 let parseProgram : String -> Expr =
   lam str.
   let parseArgs = {defaultBootParserParseMExprStringArg with allowFree = true} in
-  let ast = parseMExprString parseArgs str in
+  let ast = parseMExprStringExn parseArgs str in
   symbolizeAllowFree ast
 in
 

--- a/stdlib/parser/tool.mc
+++ b/stdlib/parser/tool.mc
@@ -1867,7 +1867,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
       use LetDeclAst in
       use UseAst in
       use BootParser in
-      let parse = parseMExprString {_defaultBootParserParseMExprStringArg () with allowFree = true} in
+      let parse = parseMExprStringExn {_defaultBootParserParseMExprStringArg () with allowFree = true} in
       let body = parse
         (strJoin "\n"
           [ "  let config = {errors = ref [], content = content} in"

--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -779,7 +779,7 @@ in
 let _toString = utestDefaultToString expr2str expr2str in
 
 let _parse =
-  parseMExprString
+  parseMExprStringExn
     { _defaultBootParserParseMExprStringArg () with allowFree = true }
 in
 

--- a/stdlib/tuning/context-expansion.mc
+++ b/stdlib/tuning/context-expansion.mc
@@ -131,7 +131,7 @@ lang ContextExpand = HoleAst
   sem _wrapReadFile (env : CallCtxEnv) (tuneFile : String) =
   | tm ->
     use BootParser in
-    let impl = parseMExprStringKeywords [] "
+    let impl = parseMExprStringKeywordsExn [] "
     let eqSeq = lam eq. lam s1. lam s2.
       recursive let work = lam s1. lam s2.
         match (s1, s2) with ([h1] ++ t1, [h2] ++ t2) then
@@ -277,7 +277,7 @@ let anf = compose normalizeTerm symbolize in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprStringKeywords holeKeywords str in
+  let ast = parseMExprStringKeywordsExn holeKeywords str in
   let ast = makeKeywords ast in
   symbolize ast
 in

--- a/stdlib/tuning/dependency-analysis.mc
+++ b/stdlib/tuning/dependency-analysis.mc
@@ -232,7 +232,7 @@ use TestLang in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprStringKeywords holeKeywords str in
+  let ast = parseMExprStringKeywordsExn holeKeywords str in
   let ast = makeKeywords ast in
   symbolize ast
 in

--- a/stdlib/tuning/hole-cfa.mc
+++ b/stdlib/tuning/hole-cfa.mc
@@ -458,7 +458,7 @@ use Test in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprStringKeywords holeKeywords str in
+  let ast = parseMExprStringKeywordsExn holeKeywords str in
   let ast = makeKeywords ast in
   symbolize ast
 in

--- a/stdlib/tuning/instrumentation.mc
+++ b/stdlib/tuning/instrumentation.mc
@@ -220,7 +220,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
        in\n"
     , "()\n"
     ] in
-    let ex = use BootParser in parseMExprStringKeywords [] str in
+    let ex = use BootParser in parseMExprStringKeywordsExn [] str in
     let str2name = lam str.
       use MExprFindSym in
       match findName str ex with Some n then n
@@ -325,7 +325,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
       in"
     , "()\n"
     ] in
-    let ex = use BootParser in parseMExprStringKeywords [] str in
+    let ex = use BootParser in parseMExprStringKeywordsExn [] str in
     let fun = use MExprFindSym in
       match findName "dumpLog" ex with Some n then n else error "impossible" in
     (ex, fun)
@@ -372,7 +372,7 @@ let debugPrintLn = lam debug.
 in
 
 let parse = lam str.
-  let ast = parseMExprStringKeywords holeKeywords str in
+  let ast = parseMExprStringKeywordsExn holeKeywords str in
   let ast = makeKeywords ast in
   symbolize ast
 in

--- a/stdlib/tuning/nested.mc
+++ b/stdlib/tuning/nested.mc
@@ -352,7 +352,7 @@ use TestLang in
 
 let debug = false in
 let parse = lam str.
-  let ast = parseMExprStringKeywords holeKeywords str in
+  let ast = parseMExprStringKeywordsExn holeKeywords str in
   let ast = makeKeywords ast in
   symbolize ast
 in

--- a/stdlib/tuning/tail-positions.mc
+++ b/stdlib/tuning/tail-positions.mc
@@ -137,7 +137,7 @@ use TestLang in
 let debug = false in
 
 let parse = lam str.
-  let ast = parseMExprStringKeywords [] str in
+  let ast = parseMExprStringKeywordsExn [] str in
   symbolize ast
 in
 

--- a/stdlib/tuning/tune-file.mc
+++ b/stdlib/tuning/tune-file.mc
@@ -146,4 +146,4 @@ let tuneFileReadTable : String -> LookupTable = lam file.
   let n = string2int (head rows) in
   let strVals = subsequence rows 1 n in
   let strVals = map (lam x. get (strSplit ": " x) 1) strVals in
-  map (parseMExprStringKeywords []) strVals
+  map (parseMExprStringKeywordsExn []) strVals

--- a/stdlib/tuning/tune-stats.mc
+++ b/stdlib/tuning/tune-stats.mc
@@ -314,7 +314,7 @@ use TestLang in
 let debug = true in
 
 let parse = lam str.
-  let ast = parseMExprStringKeywords holeKeywords str in
+  let ast = parseMExprStringKeywordsExn holeKeywords str in
   let ast = makeKeywords ast in
   symbolize ast
 in

--- a/stdlib/tuning/tune.mc
+++ b/stdlib/tuning/tune.mc
@@ -550,7 +550,7 @@ let debug = false in
 let timeSensitive = false in
 
 let parse = lam str.
-  let ast = parseMExprStringKeywords holeKeywords str in
+  let ast = parseMExprStringKeywordsExn holeKeywords str in
   let ast = makeKeywords ast in
   symbolize ast
 in


### PR DESCRIPTION
This PR makes the semantic function `parseMExprString` total so that parser errors are no longer thrown as exceptions in boot. 
Previously, any parse error would kill the program with an uninformative error on the form: 

```
<internal 1:0-1:1>:
Parse error
```

With this change, `parseMExprString` now has the signature:

```
all a. BootParserParseMExprStringArg -> String -> Result a (Info, String) Expr
```

which allows you to handle the error at the place of its application. There is also a new semantic function

```
parseMExprStringExn : BootParserParseMExprStringArg -> String -> Expr
```

with the same semantics as the old `parseMExprString` but where `error` is called in `mexpr` rather than in boot so that you can pin down the error using, e.g., `--debug-stack-trace`, which was not possible before.

Note, this change may affect the satellite projects using  `parseMExprString`.