### PR TITLE
Effect library

### DIFF
--- a/stdlib/effect.mc
+++ b/stdlib/effect.mc
@@ -141,7 +141,7 @@ lang Writer = Effect
   syn Response =
   | WriterTellR ()
 
-  sem tell : all a. Log -> Eff ()
+  sem tell : Log -> Eff ()
   sem tell =
   | l -> perform (WriterTellQ l) (lam. ())
 

--- a/stdlib/effect.mc
+++ b/stdlib/effect.mc
@@ -1,0 +1,22 @@
+lang Effect
+  syn Eff a =
+  | Return a
+  | Bind (Eff a, a -> Eff b)
+
+  sem return : a -> Eff a
+  sem return =
+  | a -> Return a
+
+  sem bind : Eff a -> (a -> Eff b) -> Eff b
+  sem bind e =
+  | f -> Bind (e, f)
+end
+
+lang Reader = Effect
+  syn Eff a =
+  | Get ()
+
+  sem get =
+  | () -> Get ()
+
+end

--- a/stdlib/effect.mc
+++ b/stdlib/effect.mc
@@ -177,10 +177,10 @@ mexpr
 
 use TestLang in
 
+con ICtx : Int -> Ctx in
 let intCtx : Iso Int Ctx =
-  con Ctx : Int -> Ctx in
-  { fwd = lam i. Ctx i
-  , bwd = lam c. match c with Ctx i in i }
+  { fwd = lam i. ICtx i
+  , bwd = lam c. match c with ICtx i in i }
 in
 
 let effProg : Eff Int =

--- a/stdlib/effect.mc
+++ b/stdlib/effect.mc
@@ -1,6 +1,48 @@
 include "option.mc"
 include "either.mc"
 
+/- This file implements an extensible effects library inspired by
+   algebraic effects / free(er) monads.  To learn more, see e.g.,
+   [1,2,3].
+
+   The main part of the library is the `Effect` fragment, which defines
+   a type `Eff a` representing generic effectful computations.  Users
+   may extend `Eff` with their own effectful operations along with
+   handlers for those operations.  See the fragments below for
+   examples.
+
+   Effects interact well with language fragment composition.  To use a
+   given effect, simply include the corresponding fragment and start
+   using the effectful operations.  A `sem` clause in one language
+   fragment may use a given effect (e.g., a read-only context) without
+   interfering with the definitions of other clauses (e.g., without
+   having to add an extra parameter even in clauses where the context
+   is unused).  The only requirement is that the `sem` returns an
+   `Eff`-type.
+
+   There are two main limitations of the implementation at current.
+   The first is that there is no static check that all effects have
+   been handled.  Trying to extract a value from an effectful
+   computation without handling all effects will give a runtime error.
+   This could potentially be solved by constructor types or an
+   extension of them using row polymorphism.  The second limitation is
+   that the runtime performance is not very good.  There are
+   techniques for improving the efficiency (e.g., [3]), but these are
+   not implemented currently, and achieving very good performance in
+   an in-language implementation may take a lot of effort.
+
+   To get optimal support for this kind of effect system, integrating
+   it into the language somehow seems like the best solution.  For
+   example, we could consider adding primitives piggybacking on OCaml
+   5's effect handlers and adding a static check based on some
+   variation of effect rows.
+
+   [1]: https://v2.ocaml.org/manual/effects.html
+   [2]: https://okmij.org/ftp/Haskell/extensible/more.pdf
+   [3]: https://okmij.org/ftp/Computation/free-monad.html
+
+-/
+
 lang Effect
   -- NOTE(aathn, 2024-02-06): If we had GADTs, we could remove the
   -- Response type in favor of having a parameterized Query type where

--- a/stdlib/effect.mc
+++ b/stdlib/effect.mc
@@ -1,8 +1,14 @@
 include "option.mc"
 
 lang Effect
+  -- NOTE(aathn, 2024-02-06): If we had GADTs, we could remove the
+  -- Response type in favor of having a Query type with a type
+  -- parameter indicating the return type.
   syn Query =
   syn Response =
+
+  type Iso a b =
+    { fwd : a -> b, bwd : b -> a }
 
   syn Eff a =
   | Pure a
@@ -12,14 +18,25 @@ lang Effect
   sem return =
   | a -> Pure a
 
-  sem flatMap : all a. all b. (a -> Eff b) -> Eff a -> Eff b
-  sem flatMap f =
+  sem bind : all a. all b. Eff a -> (a -> Eff b) -> Eff b
+  sem bind e = | f -> effJoinMap f e
+
+  sem effJoinMap : all a. all b. (a -> Eff b) -> Eff a -> Eff b
+  sem effJoinMap f =
   | Pure x -> f x
   | Impure (q, k) ->
-    Impure (q, lam x. flatMap f (k x))
+    Impure (q, lam x. effJoinMap f (k x))
 
-  sem bind : all a. all b. Eff a -> (a -> Eff b) -> Eff b
-  sem bind e = | f -> flatMap f e
+  sem effMap : all a. all b. (a -> b) -> Eff a -> Eff b
+  sem effMap f = | e -> effJoinMap (lam x. return (f x)) e
+
+  sem effMap2 : all a. all b. all c. (a -> b -> c) -> Eff a -> Eff b -> Eff c
+  sem effMap2 f e1 = | e2 ->
+    effJoinMap (lam g. effMap g e2) (effMap f e1)
+
+  sem effMapM : all a. all b. (a -> Eff b) -> [a] -> Eff [b]
+  sem effMapM f = | l ->
+    foldl (lam acc. lam x. effMap2 snoc acc (f x)) (return []) l
 
   sem perform : all a. Query -> (Response -> a) -> Eff a
   sem perform q =
@@ -51,15 +68,17 @@ lang Reader = Effect
   syn Response =
   | ReaderGetR Ctx
 
+  sem ask : all a. Iso a Ctx -> Eff a
   sem ask =
-  | () -> perform (ReaderGetQ ()) (lam x. match x with ReaderGetR c in c)
+  | i -> perform (ReaderGetQ ()) (lam x. match x with ReaderGetR c in i.bwd c)
 
-  sem handleReader : all a. Ctx -> Eff a -> Eff a
-  sem handleReader ctx =
+  sem handleReader : all b. all a. Iso b Ctx -> b -> Eff a -> Eff a
+  sem handleReader i ctx =
   | e ->
+    let c = i.fwd ctx in
     let handler = lam continue. lam q.
       match q with ReaderGetQ () then
-        Some (continue (ReaderGetR ctx))
+        Some (continue (ReaderGetR c))
       else None ()
     in
     handleEff return handler e
@@ -74,15 +93,16 @@ lang Writer = Effect
   syn Response =
   | WriterPutR ()
 
-  sem tell =
-  | l -> perform (WriterPutQ l) (lam. ())
+  sem tell : all a. Iso a Log -> a -> Eff ()
+  sem tell i =
+  | l -> perform (WriterPutQ (i.fwd l)) (lam. ())
 
-  sem handleWriter : all a. Eff a -> Eff (a, [Log])
-  sem handleWriter =
+  sem handleWriter : all a. all b. Iso b Log -> Eff a -> Eff (a, [b])
+  sem handleWriter i =
   | e ->
     let handler = lam continue. lam q.
       match q with WriterPutQ l then
-        Some (bind (continue (WriterPutR ())) (lam al. (al.0, concat l al.1)))
+        Some (effMap (lam al. (al.0, cons (i.bwd l) al.1)) (continue (WriterPutR ())))
       else None ()
     in
     handleEff (lam x. return (x, [])) handler e
@@ -99,23 +119,76 @@ lang State = Effect
   | StateGetR State
   | StatePutR ()
 
-  sem ask =
-  | () -> perform (StateGetQ ()) (lam x. match x with StateGetQ s in s)
+  sem get : all a. Iso a State -> Eff a
+  sem get =
+  | i -> perform (StateGetQ ()) (lam x. match x with StateGetR s in i.bwd s)
 
-  sem put =
-  | s -> perform (StatePutQ s) (lam. ())
+  sem put : all a. Iso a State -> a -> Eff ()
+  sem put i =
+  | s -> perform (StatePutQ (i.fwd s)) (lam. ())
 
-  sem handleState : all a. State -> Eff a -> Eff (a, State)
-  sem handleState s =
+  sem handleState : all a. all b. Iso b State -> b -> Eff a -> Eff (a, b)
+  sem handleState i s =
   | Pure x -> return (x, s)
   | Impure (q, k) ->
-    let continue = lam s. lam r. handleState s (k r) in
+    let continue = lam s. lam r. handleState i s (k r) in
     switch q
     case StateGetQ () then
-      continue s (StateGetR s)
+      continue s (StateGetR (i.fwd s))
     case StatePutQ s then
-      continue s (StatePutR ())
+      continue (i.bwd s) (StatePutR ())
     case _ then
       Impure (q, continue s)
     end
 end
+
+lang NonDet = Effect
+  syn NDItem =
+
+  syn Query =
+  | NDChooseQ [NDItem]
+
+  syn Response =
+  | NDChooseR NDItem
+
+  sem choose : all a. [a] -> Eff a
+  sem choose =
+  | is ->
+    con Item : a -> NDItem in
+    perform
+      (NDChooseQ (map (lam i. Item i) is))
+      (lam x. match x with NDChooseR (Item i) in i)
+
+  sem handleND : all a. Eff a -> Eff [a]
+  sem handleND =
+  | e ->
+    let handler = lam continue. lam q.
+      match q with NDChooseQ is then
+        let f = lam acc. lam i. effMap2 concat acc (continue (NDChooseR i)) in
+        Some (foldl f (return []) is)
+      else None ()
+    in
+    handleEff (lam x. return [x]) handler e
+end
+
+lang TestLang = Reader + NonDet end
+
+mexpr
+
+use TestLang in
+
+let intCtx : Iso Int Ctx =
+  con Ctx : Int -> Ctx in
+  { fwd = lam i. Ctx i
+  , bwd = lam c. match c with Ctx i in i }
+in
+
+let effProg : Eff Int =
+  bind (choose [0,1]) (lam i.
+  bind (choose [2,3]) (lam j.
+  bind (ask intCtx) (lam k.
+  return (addi (addi i j) k))))
+in
+
+utest runEff (handleND (handleReader intCtx 7 effProg)) with [9,10,10,11] in
+()

--- a/stdlib/effect.mc
+++ b/stdlib/effect.mc
@@ -1,19 +1,53 @@
 lang Effect
+  syn Req a =
+
   syn Eff a =
-  | Return a
-  | Bind (Eff a, a -> Eff b)
+  | Pure a
+  -- Encoding existentials using forall
+  | Impure (all r. (all b. (Req b, b -> Eff a) -> r) -> r)
 
-  sem return : a -> Eff a
+  sem return : all a. a -> Eff a
   sem return =
-  | a -> Return a
+  | a -> Pure a
 
-  sem bind : Eff a -> (a -> Eff b) -> Eff b
-  sem bind e =
-  | f -> Bind (e, f)
+  sem flatMap : all a. all b. (a -> Eff b) -> Eff a -> Eff b
+  sem flatMap f =
+  | Pure x -> f x
+  | Impure content ->
+    let newContent : all r. (all c. (Req c, c -> Eff b) -> r) -> r =
+      lam k.
+        let compute : all d. (Req d, d -> Eff a) -> r = lam input.
+          match input with (u, g) in
+          k (u, lam x. bind (g x) f)
+        in
+        content #frozen"compute"
+    in
+    Impure #frozen"newContent"
+
+  sem bind : all a. all b. Eff a -> (a -> Eff b) -> Eff b
+  sem bind e = | f -> flatMap f e
+
+  sem send : all a. Req a -> Eff a
+  sem send =
+  | req ->
+    let content : all r. (all c. (Req c, c -> Eff a) -> r) -> r =
+      lam k. k (req, return)
+    in
+    Impure #frozen"content"
+
+  sem runEffect : all a. all b. (a -> Eff b) -> (all v. (v -> Eff b) -> Req v -> Eff b) -> Eff a -> Eff b
+  sem runEffect ret h =
+  | Pure x -> ret x
+  | Impure content ->
+    let compute : all c. (Req c, c -> Eff a) -> b = lam input.
+      match input with (u, q) in
+      h u (lam x. runEffect ret h (q x))
+    in
+    content #frozen"compute"
 end
 
 lang Reader = Effect
-  syn Eff a =
+  syn Req a =
   | Get ()
 
   sem get =

--- a/stdlib/effect.mc
+++ b/stdlib/effect.mc
@@ -1,10 +1,12 @@
+include "option.mc"
+
 lang Effect
-  syn Req a =
+  syn Query =
+  syn Response =
 
   syn Eff a =
   | Pure a
-  -- Encoding existentials using forall
-  | Impure (all r. (all b. (Req b, b -> Eff a) -> r) -> r)
+  | Impure (Query, Response -> Eff a)
 
   sem return : all a. a -> Eff a
   sem return =
@@ -13,44 +15,107 @@ lang Effect
   sem flatMap : all a. all b. (a -> Eff b) -> Eff a -> Eff b
   sem flatMap f =
   | Pure x -> f x
-  | Impure content ->
-    let newContent : all r. (all c. (Req c, c -> Eff b) -> r) -> r =
-      lam k.
-        let compute : all d. (Req d, d -> Eff a) -> r = lam input.
-          match input with (u, g) in
-          k (u, lam x. bind (g x) f)
-        in
-        content #frozen"compute"
-    in
-    Impure #frozen"newContent"
+  | Impure (q, k) ->
+    Impure (q, lam x. flatMap f (k x))
 
   sem bind : all a. all b. Eff a -> (a -> Eff b) -> Eff b
   sem bind e = | f -> flatMap f e
 
-  sem send : all a. Req a -> Eff a
-  sem send =
-  | req ->
-    let content : all r. (all c. (Req c, c -> Eff a) -> r) -> r =
-      lam k. k (req, return)
-    in
-    Impure #frozen"content"
+  sem perform : all a. Query -> (Response -> a) -> Eff a
+  sem perform q =
+  | k ->
+    Impure (q, lam r. return (k r))
 
-  sem runEffect : all a. all b. (a -> Eff b) -> (all v. (v -> Eff b) -> Req v -> Eff b) -> Eff a -> Eff b
-  sem runEffect ret h =
+  sem handleEff
+    : all a. all b. (a -> Eff b)
+    -> ((Response -> Eff b) -> Query -> Option (Eff b))
+    -> Eff a
+    -> Eff b
+  sem handleEff ret h =
   | Pure x -> ret x
-  | Impure content ->
-    let compute : all c. (Req c, c -> Eff a) -> b = lam input.
-      match input with (u, q) in
-      h u (lam x. runEffect ret h (q x))
-    in
-    content #frozen"compute"
+  | Impure (q, k) ->
+    let continue = lam r. handleEff ret h (k r) in
+    optionGetOr (Impure (q, continue)) (h continue q)
+
+  sem runEff : all a. Eff a -> a
+  sem runEff =
+  | Pure x -> x
 end
 
 lang Reader = Effect
-  syn Req a =
-  | Get ()
+  syn Ctx =
 
-  sem get =
-  | () -> Get ()
+  syn Query =
+  | ReaderGetQ ()
 
+  syn Response =
+  | ReaderGetR Ctx
+
+  sem ask =
+  | () -> perform (ReaderGetQ ()) (lam x. match x with ReaderGetR c in c)
+
+  sem handleReader : all a. Ctx -> Eff a -> Eff a
+  sem handleReader ctx =
+  | e ->
+    let handler = lam continue. lam q.
+      match q with ReaderGetQ () then
+        Some (continue (ReaderGetR ctx))
+      else None ()
+    in
+    handleEff return handler e
+end
+
+lang Writer = Effect
+  syn Log =
+
+  syn Query =
+  | WriterPutQ Log
+
+  syn Response =
+  | WriterPutR ()
+
+  sem tell =
+  | l -> perform (WriterPutQ l) (lam. ())
+
+  sem handleWriter : all a. Eff a -> Eff (a, [Log])
+  sem handleWriter =
+  | e ->
+    let handler = lam continue. lam q.
+      match q with WriterPutQ l then
+        Some (bind (continue (WriterPutR ())) (lam al. (al.0, concat l al.1)))
+      else None ()
+    in
+    handleEff (lam x. return (x, [])) handler e
+end
+
+lang State = Effect
+  syn State =
+
+  syn Query =
+  | StateGetQ ()
+  | StatePutQ State
+
+  syn Response =
+  | StateGetR State
+  | StatePutR ()
+
+  sem ask =
+  | () -> perform (StateGetQ ()) (lam x. match x with StateGetQ s in s)
+
+  sem put =
+  | s -> perform (StatePutQ s) (lam. ())
+
+  sem handleState : all a. State -> Eff a -> Eff (a, State)
+  sem handleState s =
+  | Pure x -> return (x, s)
+  | Impure (q, k) ->
+    let continue = lam s. lam r. handleState s (k r) in
+    switch q
+    case StateGetQ () then
+      continue s (StateGetR s)
+    case StatePutQ s then
+      continue s (StatePutR ())
+    case _ then
+      Impure (q, continue s)
+    end
 end

--- a/stdlib/mexpr/ast-effect.mc
+++ b/stdlib/mexpr/ast-effect.mc
@@ -1,0 +1,164 @@
+include "effect.mc"
+
+-- MExpr
+include "ast.mc"
+include "eq.mc"
+include "boot-parser.mc"
+
+/-
+
+  This file implements shallow mapping/folding with `Eff a` from
+  `effect.mc` over `Expr`s.
+
+  -/
+
+lang AstEffect = Ast + Effect
+
+  -- Perform a computation on the the immediate sub-expressions of an
+  -- expression.  Note that this function is capable of emulating
+  -- smapAccumL through use of the State effect.
+  sem smapEff_Expr_Expr : all a. (Expr -> Eff Expr) -> Expr -> Eff Expr
+  sem smapEff_Expr_Expr f =
+  | e ->
+    let getChildren : Expr -> [Expr] = sfold_Expr_Expr snoc [] in
+    let updateChildren : Expr -> [Expr] -> Expr =
+      lam e. lam children.
+      let f =
+        lam acc. lam e.
+        match acc with [h] ++ t then (t, h) else ([], e)
+      in
+      (smapAccumL_Expr_Expr f children e).1
+    in
+    effMap (updateChildren e)
+      (effMapM f (getChildren e))
+
+end
+
+lang TestLang = AstEffect + Writer + Failure + BootParser + MExprEq end
+
+mexpr
+
+use TestLang in
+
+let parse =
+  parseMExprString
+    { _defaultBootParserParseMExprStringArg () with allowFree = true }
+in
+
+con CLog : Char -> Log in
+let cLog : Iso Char Log =
+  { fwd = lam c. CLog c
+  , bwd = lam w. match w with CLog c in c}
+in
+
+con IFail : Int -> Failure in
+let iFail : Iso Int Failure =
+  { fwd = lam i. IFail i
+  , bwd = lam w. match w with IFail i in i}
+in
+
+-- The order of warnings and errors is not significant, thus we call
+-- this function on a result to be compared in a utest to get a stable
+-- ordering.
+let prepTest
+  : all a. Eff a -> ([Char], Either Int a)
+  = lam x.
+    match runEff (handleWriter cLog (handleFail iFail x)) with (r, w) in
+    (sort cmpChar w, r)
+in
+
+---------------------------------------
+-- Test smapEff_Expr_Expr --
+---------------------------------------
+
+let _prepTest = lam e1. lam e2. prepTest (effMap (eqExpr e1) e2) in
+
+-- Renames variables by concatenating its name to itself. variables with names
+-- 'y' gives a warning 'b' and variables with names 'z' gives an error 1.
+recursive let f : Expr -> Eff Expr
+  = lam e.
+    match e with TmVar r then
+      let name = nameGetStr r.ident in
+      let e =
+        match name with "z" then fail iFail 1
+        else
+          return
+            (TmVar { r with ident = nameSetStr r.ident (concat name name) })
+      in
+      match name with "y" then
+        bind (tell cLog 'b') (lam. e)
+      else e
+    else
+      smapEff_Expr_Expr f e
+in
+
+
+-- Test 1
+let e = parse "
+  let f = lam x. y x in
+  (lam u. f u)
+  "
+in
+
+let expected = parse "
+  let f = lam x. yy xx in
+  (lam u. ff uu)
+  "
+in
+
+utest _prepTest expected (f e) with (['b'], Right true) in
+---
+
+-- Test 2
+let e = parse "
+  let f = lam x. y y x in
+  (lam u. f)
+  "
+in
+
+let expected = parse "
+  let f = lam x. yy yy xx in
+  (lam u. ff)
+  "
+in
+
+utest _prepTest expected (f e) with (['b', 'b'], Right true) in
+---
+
+-- Test 3
+let e = parse "
+  let f = lam x. z x in
+  (lam u. z)
+  "
+in
+
+utest _prepTest e (f e) with ([], Left 1) in
+---
+
+-- Test 4
+let e = parse "
+  let f = lam x. y z x in
+  (lam u. z z z)
+  "
+in
+
+utest _prepTest e (f e) with (['b'], Left 1) in
+---
+
+-- Test 5
+let e = parse "
+  let f = lam x. x x in
+  (lam u. y x x)
+  "
+in
+
+let expected = parse "
+  let f = lam x. xx xx in
+  (lam u. yy xx xx)
+  "
+in
+
+utest _prepTest expected (f e) with (['b'], Right true) in
+---
+
+()


### PR DESCRIPTION
This file implements an extensible effects library `stdlib/effect.mc`, inspired by algebraic effects / free(er) monads.  To learn more, see e.g., [^1],[^2],[^3].

The main part of the library is the `Effect` fragment, which defines a type `Eff a` representing generic effectful computations.  Users may extend `Eff` with their own effectful operations along with handlers for those operations.

Effects interact well with language fragment composition.  To use a given effect, simply include the corresponding fragment and start using the effectful operations.  A `sem` clause in one language fragment may use a given effect (e.g., a read-only context) without interfering with the definitions of other clauses (e.g., without having to add an extra parameter even in clauses where the context is unused).  The only requirement is that the `sem` returns an `Eff`-type.

For example, consider the following fragment:
```
lang TestLang = Reader + NonDet
  sem getInt : Ctx -> Int

  sem effProg : () -> Eff Int
  sem effProg = | () ->
    bind (choose [0,1]) (lam i.
    bind (choose [2,3]) (lam j.
    bind (ask getInt) (lam k.
    return (addi (addi i j) k))))

end
```

The fragment `TestLang` imports two effects: read-only context (`Reader`) and non-determinism (`NonDet`).  `effProg` defines an effectful program which uses both effects.  The program first chooses two numbers `i \in [0,1]` and `j \in [2,3]`, then reads a number `k` from the context, and then returns the sum of the three.  Note that the context type is kept abstract, we only declare a sem `getInt : Ctx -> Int` for extracting an integer from it.

To run the program, we provide a concrete implementation of `getInt` and a value for the context:

```
lang TestLangImpl = TestLang
  syn Ctx = | ICtx Int
  sem getInt = | ICtx i -> i
end

mexpr

use TestLangImpl in

utest runEff (handleND (handleReader (ICtx 7) (effProg ()))) 
with [9,10,10,11] in ()
```

Here, the `Reader` effect is first handled using `handleReader` with a context `ICtx 7`, and then the nondeterminism effect is resolved using `handleND`.  When all effects are handled, `runEff` can be used to extract the final value, in this case `[9,10,10,11]`.

There is also `stdlib/mexpr/ast-effect.mc`, which contains variations of an `smapEff`-function which can be used to map effectful operations over MExpr AST nodes.  The utest part of the file is derived from `ast-result.mc`, and demonstrates how the `Result` effect of `result.mc` can be emulated by `Eff` using the `Writer` and `Failure` effects (although it will not accumulate more than one error, as opposed to `Result`).

There are two main limitations of the implementation at current. The first is that there is no static check that all effects have been handled.  Trying to extract a value from an effectful computation without handling all effects will give a runtime error. This could potentially be solved by constructor types or an extension of them using row polymorphism.  The second limitation is that the runtime performance is not very good.  There are techniques for improving the efficiency (e.g., [^3]), but these are not implemented currently, and achieving very good performance in an in-language implementation may take a lot of effort.

To get optimal support for this kind of effect system, integrating it into the language somehow seems like the best solution.  For example, we could consider adding primitives piggybacking on OCaml 5's effect handlers and adding a static check based on some variation of effect rows.

[^1]: https://v2.ocaml.org/manual/effects.html
[^2]: https://okmij.org/ftp/Haskell/extensible/more.pdf
[^3]: https://okmij.org/ftp/Computation/free-monad.html