### PR TITLE
Adds a mapFindLower and mapFindUpper to map.mc

### DIFF
--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -247,6 +247,18 @@ let mapFilterWithKey : all k. all v. (k -> v -> Bool) -> Map k v -> Map k v
 let mapFilter : all k. all v. (v -> Bool) -> Map k v -> Map k v
   = lam p. mapFilterWithKey (lam. p)
 
+-- `mapFindUpper k m` returns the value in the map `m` associated with k',
+-- where k' is the minimum key in `m` and k≤k'. Returns `None ()` if no such key
+-- k' exists in `m`.
+let mapFindUpper : all k. all v. k -> Map k v -> Option (k, v)
+  = lam k. lam m. use AVLTreeImpl in avlFindUpper m.cmp k m.root
+
+-- `mapFindLower k m` returns the value in the map `m` associated with k',
+-- where k' is the maximum key in `m` and k≥k'. Returns `None ()` if no such key
+-- k' exists in `m`.
+let mapFindLower : all k. all v. k -> Map k v -> Option (k, v)
+  = lam k. lam m. use AVLTreeImpl in avlFindLower m.cmp k m.root
+
 mexpr
 
 let m = mapEmpty subi in
@@ -402,5 +414,29 @@ utest
   mapBindings (mapFilter (lam v. or (eqString v "1") (eqString v "3")) m)
   with [(1, "1"), (3, "3")]
 in
+
+let cmp = lam a. lam b. if ltf a b then -1 else if gtf a b then 1 else 0 in
+let m = mapFromSeq cmp [(0., 0), (1., 1), (2., 2), (3., 3), (4., 4)] in
+utest mapFindUpper 4.5 m with None () in
+utest mapFindUpper 4. m with Some (4., 4) in
+utest mapFindUpper 3.5 m with Some (4., 4) in
+utest mapFindUpper 3. m with Some (3., 3) in
+utest mapFindUpper 2.5 m with Some (3., 3) in
+utest mapFindUpper 2. m with Some (2., 2) in
+utest mapFindUpper 1.5 m with Some (2., 2) in
+utest mapFindUpper 1. m with Some (1., 1) in
+utest mapFindUpper 0.5 m with Some (1., 1) in
+utest mapFindUpper 0. m with Some (0., 0) in
+utest mapFindLower 4.5 m with Some (4., 4) in
+utest mapFindLower 4. m with Some (4., 4) in
+utest mapFindLower 3.5 m with Some (3., 3) in
+utest mapFindLower 3. m with Some (3., 3) in
+utest mapFindLower 2.5 m with Some (2., 2) in
+utest mapFindLower 2. m with Some (2., 2) in
+utest mapFindLower 1.5 m with Some (1., 1) in
+utest mapFindLower 1. m with Some (1., 1) in
+utest mapFindLower 0.5 m with Some (0., 0) in
+utest mapFindLower 0. m with Some (0., 0) in
+utest mapFindLower -1. m with None () in
 
 ()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -82,13 +82,13 @@ let mapLookupOr : all k. all v. v -> k -> Map k v -> v =
   lam dv. lam k. lam m.
   mapLookupOrElse (lam. dv) k m
 
--- `mapFindUpper k m` returns the value-value pair (k', v) in the map `m`,
+-- `mapFindUpper k m` returns the key-value pair (k', v) in the map `m`,
 -- where k' is the minimum key in `m` and k≤k'. Returns `None ()` if no such key
 -- k' exists in `m`. Time complexity is O(log n).
 let mapFindUpper : all k. all v. k -> Map k v -> Option (k, v)
   = lam k. lam m. use AVLTreeImpl in avlFindUpper m.cmp k m.root
 
--- `mapFindLower k m` returns the value-value pair (k', v) in the map `m`,
+-- `mapFindLower k m` returns the key-value pair (k', v) in the map `m`,
 -- where k' is the maximum key in `m` and k≥k'. Returns `None ()` if no such key
 -- k' exists in `m`. Time complexity is O(log n).
 let mapFindLower : all k. all v. k -> Map k v -> Option (k, v)

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -124,6 +124,16 @@ let mapUpdate : all k. all v. k -> (Option v -> Option v) -> Map k v -> Map k v
     end
 
 
+-- ┌───────────┐
+-- │ Singleton │
+-- └───────────┘
+
+-- `mapSingleton cmp k v` creates a singleton map with key-value `k, v` and
+-- comparision function `cmp`.
+let mapSingleton : all k. all v. (k -> k -> Int) -> k -> v -> Map k v
+  = lam cmp. lam k. lam v. mapInsert k v (mapEmpty cmp)
+
+
 -- ┌────────┐
 -- │ Choose │
 -- └────────┘
@@ -513,5 +523,9 @@ utest mapFindLower 1. m with Some (1., 1) in
 utest mapFindLower 0.5 m with Some (0., 0) in
 utest mapFindLower 0. m with Some (0., 0) in
 utest mapFindLower -1. m with None () in
+
+let m = mapSingleton subi 1 1 in
+utest mapSize m with 1 in
+utest mapLookup 1 m with Some 1 in
 
 ()

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -84,13 +84,13 @@ let mapLookupOr : all k. all v. v -> k -> Map k v -> v =
 
 -- `mapFindUpper k m` returns the value-value pair (k', v) in the map `m`,
 -- where k' is the minimum key in `m` and k≤k'. Returns `None ()` if no such key
--- k' exists in `m`.
+-- k' exists in `m`. Time complexity is O(log n).
 let mapFindUpper : all k. all v. k -> Map k v -> Option (k, v)
   = lam k. lam m. use AVLTreeImpl in avlFindUpper m.cmp k m.root
 
 -- `mapFindLower k m` returns the value-value pair (k', v) in the map `m`,
 -- where k' is the maximum key in `m` and k≥k'. Returns `None ()` if no such key
--- k' exists in `m`.
+-- k' exists in `m`. Time complexity is O(log n).
 let mapFindLower : all k. all v. k -> Map k v -> Option (k, v)
   = lam k. lam m. use AVLTreeImpl in avlFindLower m.cmp k m.root
 

--- a/stdlib/map.mc
+++ b/stdlib/map.mc
@@ -220,10 +220,6 @@ let mapFoldlOption : all k. all v. all acc.
   lam f. lam acc. lam m.
     optionFoldlM (lam acc. lam t : (k, v). f acc t.0 t.1) acc (mapBindings m)
 
-let mapAllWithKey : all k. all v. (k -> v -> Bool) -> Map k v -> Bool =
-  lam f. lam m.
-  mapFoldWithKey (lam acc. lam k. lam v. and acc (f k v)) true m
-
 let mapMapAccum : all k. all v1. all v2. all acc.
   (acc -> k -> v1 -> (acc, v2)) -> acc -> Map k v1 -> (acc, Map k v2) =
   lam f. lam acc. lam m.
@@ -266,6 +262,10 @@ let mapAny : all k. all v. (k -> v -> Bool) -> Map k v -> Bool =
 
 let mapAll : all k. all v. (v -> Bool) -> Map k v -> Bool = lam f. lam m.
   mapFoldWithKey (lam acc. lam. lam v. and acc (f v)) true m
+
+let mapAllWithKey : all k. all v. (k -> v -> Bool) -> Map k v -> Bool =
+  lam f. lam m.
+  mapFoldWithKey (lam acc. lam k. lam v. and acc (f k v)) true m
 
 
 -- ┌─────────┐


### PR DESCRIPTION
This PR:
- Adds two new functions to `map.mc`, `mapFindLower`, and `mapFindUpper` that find the nearest upper/lower key and associated value w.r.t. to a given key.
- Adds a new function, `mapSingleton`, which creates a singleton map.
- Re-organizes `map.mc` to clarify the map interface.