### PR TITLE
Workaround for a Failing Test in TreePPL

### DIFF
--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -569,7 +569,7 @@ let tensorFind : all a. (a -> Bool) -> Tensor[a] -> Option a =
   lam p. lam t.
     let x = tensorFindi p t in
     -- NOTE(vsenderov, 2024-03-21) Workaround for a failing test in TreePPL
-    -- see https://github.com/treeppl/treeppl/pull/67
+    -- see https://github.com/treeppl/treeppl/pull/67, https://github.com/treeppl/treeppl/issues/69
     match x with Some (y, _) then Some y
     else match x with None _ then None ()
     else never

--- a/stdlib/tensor.mc
+++ b/stdlib/tensor.mc
@@ -568,7 +568,9 @@ with (3, [0, 2])
 let tensorFind : all a. (a -> Bool) -> Tensor[a] -> Option a =
   lam p. lam t.
     let x = tensorFindi p t in
-    match x with Some (x, _) then Some x
+    -- NOTE(vsenderov, 2024-03-21) Workaround for a failing test in TreePPL
+    -- see https://github.com/treeppl/treeppl/pull/67
+    match x with Some (y, _) then Some y
     else match x with None _ then None ()
     else never
 


### PR DESCRIPTION
Without this fix we get with the current miking/ miking-dppl stack

```
viktor@yggy:~/Sync/Workspaces/TreePPL/treeppl$ make test
mi compile src/treeppl-to-coreppl/compile.mc --test
./compile | sed 's/\.\{10,\}//g'
NOTE: Zero-argument function, `hello`, converted to Int. Potential type errors might refer to Int type.

ERROR </home/viktor/Sync/Workspaces/Miking/miking/stdlib/tensor.mc 572:15-572:28>:
* Expected an expression of type: Option a
*    Found an expression of type: a1
* where
*   a :: Poly
* (errors: types Option a != a1)
* When type checking the expression
    else match x with None _ then None ()

.mi compile src/lib/standard.mc --test
./standard | sed 's/\.\{10,\}//g'

rm -f compile standard
```

See also

https://github.com/treeppl/treeppl/pull/67