### PR TITLE
More stuff for repr-types

### DIFF
--- a/stdlib/heap.mc
+++ b/stdlib/heap.mc
@@ -23,6 +23,9 @@ type Heap a
 con HNil : all a. () -> Heap a
 con HNode : all a. (a, [Heap a]) -> Heap a
 
+let heapEmpty : all a. Heap a
+  = HNil ()
+
 let heapSingleton : all a. a -> Heap a
   = lam a. HNode (a, [])
 

--- a/stdlib/lazy.mc
+++ b/stdlib/lazy.mc
@@ -31,6 +31,9 @@ type LStream a = Lazy (StreamNode a)
 let lazyStreamEmpty : all a. () -> LStream a
   = lam. ref (LazyVal (SNil ()))
 
+let lazyStreamSingleton : all a. a -> LStream a
+  = lam a. ref (LazyVal (SCons (a, lazyStreamEmpty ())))
+
 let lazyStream : all acc. all a. (acc -> Option (acc, a)) -> acc -> LStream a
   = lam f. lam acc.
     recursive let goNext = lam acc.

--- a/stdlib/lazy.mc
+++ b/stdlib/lazy.mc
@@ -122,3 +122,11 @@ let lazyStreamStatefulFilterMap : all a. all b. all acc. (acc -> a -> (acc, Opti
 let lazyStreamStatefulFilter : all a. all acc. (acc -> a -> (acc, Bool)) -> acc -> LStream a -> LStream a
   = lam f. lam acc. lam s.
     lazyStreamStatefulFilterMap (lam acc. lam a. match f acc a with (acc, keep) in (acc, if keep then Some a else None ())) acc s
+
+let lazyStreamForceAll : all a. LStream a -> [a]
+  = lam s.
+    recursive let work = lam acc. lam s.
+      match lazyStreamUncons s with Some (x, s)
+      then work (snoc acc x) s
+      else acc
+    in work [] s

--- a/stdlib/lazy.mc
+++ b/stdlib/lazy.mc
@@ -166,3 +166,24 @@ let iterUncons : all a. Iter a -> Option (a, Iter a)
     case INNil _ then None ()
     case INCons (x, xs) then Some (x, xs)
     end
+
+recursive let iterTake : all a. Int -> Iter a -> Iter a
+  = lam limit. lam it. lam.
+    if leqi limit 0 then INNil () else
+    switch it ()
+    case INNil _ then INNil ()
+    case INCons (x, xs) then INCons (x, iterTake (subi limit 1) xs)
+    end
+end
+
+let iterMin : all a. (a -> a -> Int) -> Iter a -> Option a
+  = lam cmp. lam it.
+    recursive let work = lam acc. lam it. switch it ()
+      case INNil _ then acc
+      case INCons (x, xs) then
+        work (if lti (cmp acc x) 0 then acc else x) xs
+      end in
+    switch it ()
+    case INNil _ then None ()
+    case INCons (x, xs) then Some (work x xs)
+    end

--- a/stdlib/lazy.mc
+++ b/stdlib/lazy.mc
@@ -160,3 +160,9 @@ recursive let iterConcatMap : all a. all b. (a -> Iter b) -> Iter a -> Iter b
     case INCons (x, xs) then iterConcat (f x) (iterConcatMap f xs) ()
     end
 end
+
+let iterUncons : all a. Iter a -> Option (a, Iter a)
+  = lam it. switch it ()
+    case INNil _ then None ()
+    case INCons (x, xs) then Some (x, xs)
+    end

--- a/stdlib/mexpr/repr-ast.mc
+++ b/stdlib/mexpr/repr-ast.mc
@@ -99,7 +99,7 @@ end
 
 type ImplId = Int
 lang OpImplAst = Ast
-  type TmOpImplRec =
+  type TmOpImplRec = use Ast in
     { ident : Name
     , implId : ImplId
     , reprScope : Int

--- a/stdlib/mexpr/reptypes.mc
+++ b/stdlib/mexpr/reptypes.mc
@@ -1125,7 +1125,6 @@ lang LazyTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHe
             pufFold
               (lam a. lam. lam. a)
               (lam acc. lam pair. lam repr. mapInsertWith (mapUnionWith concat) pair.0 (singleton repr [idx]) acc)
-              (lam a. lam. lam. a)
               acc
               sol.uni.reprs in
           let potentialConflicts = foldli collectIdxes

--- a/stdlib/mexpr/reptypes.mc
+++ b/stdlib/mexpr/reptypes.mc
@@ -5641,10 +5641,13 @@ lang TreeSolverPartIndep = ComposableSolver
       , s.pickBestOr
       ]) x in
     let largeSolver = lam tree. s.try
-      (s.onTopHomogeneousAlts (s.seq s.propagate (s.sizeBranches
-         [ (100000, bottomUp)
-         ]
-         (s.seq (s.debug "homogeneous top") s.oneHomogeneous))))
+      (s.bestDoneOf
+        [ s.consistent
+        , s.onTopHomogeneousAlts (s.seq s.propagate (s.sizeBranches
+          [ (100000, bottomUp)
+          ]
+          (s.seq (s.debug "homogeneous top") s.oneHomogeneous)))
+        ])
       (s.enumBest (Some 1))
       tree in
     let inner = lam tree. s.chain
@@ -5659,6 +5662,7 @@ lang TreeSolverPartIndep = ComposableSolver
       , s.propagate
       , s.debug "post-propagate"
       , s.flattenAnds
+      , s.debug "post-flatten"
       , s.partitionIndep
       , s.debug "post-partition-indep"
       , s.perIndep #frozen"inner"

--- a/stdlib/mexpr/reptypes.mc
+++ b/stdlib/mexpr/reptypes.mc
@@ -171,7 +171,6 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
       then any (lam b. containsRepr b.tyBody) t.bindings
       else false in
     if not shouldBeOp then TmRecLets (typeCheckRecLets env t) else
-    let env = {env with reptypes = {env.reptypes with inImpl = true}} in
     let bindingToBindingPair = lam b.
       ( stringToSid (nameGetStr b.ident)
       , TmVar
@@ -186,7 +185,8 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
       , ty = tyunknown_
       , info = t.info
       } in
-    match withNewReprScope env (lam env. typeCheckRecLets env {t with inexpr = opRecord})
+    let implEnv = {env with reptypes = {env.reptypes with inImpl = true}} in
+    match withNewReprScope implEnv (lam env. typeCheckRecLets env {t with inexpr = opRecord})
       with (newT, reprScope, delayedReprUnifications) in
     let recordName =
       let ident = (head newT.bindings).ident in
@@ -2841,7 +2841,7 @@ lang MemoedTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypes
 
   sem addOpUse debug global branch query = | opUse ->
     (if debug then
-      printLn "\n# Solving process:"
+      printLn (join ["\n# Solving process", info2str opUse.info, ":"])
      else ());
     match branch with SBContent branch in
     match query with STQContent query in

--- a/stdlib/mexpr/reptypes.mc
+++ b/stdlib/mexpr/reptypes.mc
@@ -1718,7 +1718,7 @@ lang SolTreeSoloSolver = SolTreeSolver
     in propagate 0 tree
 end
 
-lang SATishSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers + PrettyPrint + Cmp + Generalize + VarAccessHelpers + LocallyNamelessStuff + SolTreeSolver
+lang SATishSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers + PrettyPrint + Cmp + Generalize + VarAccessHelpers + LocallyNamelessStuff + SolTreeSolver + WildToMeta
   type ProcOpImpl a  =
     { implId : ImplId
     , op : Name
@@ -2197,6 +2197,7 @@ lang SATishSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers
 
     let perImpl : SBContent a -> ProcOpImpl a -> (SBContent a, Option (Map Symbol Int, SolTreeInput (Constraint a) (ChildInfo a) (SolContent a)))
       = lam branch. lam impl.
+        let ty = wildToMeta impl.metaLevel ty in
         match instAndSubst (infoTy impl.specType) impl.metaLevel impl.specType
           with (specType, subst) in
         match unifyPure impl.uni (removeReprSubsts specType) ty with Some uni then
@@ -2267,7 +2268,7 @@ lang SATishSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers
     (branch, {reprLevels = reprLevels, tree = STIOr {alternatives = impls}})
 end
 
-lang LazyTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers + PrettyPrint + Cmp + Generalize + VarAccessHelpers + LocallyNamelessStuff
+lang LazyTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers + PrettyPrint + Cmp + Generalize + VarAccessHelpers + LocallyNamelessStuff + WildToMeta
   type ProcOpImpl a  =
     { implId : ImplId
     , op : Name
@@ -2472,6 +2473,7 @@ lang LazyTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHe
 
     let perImpl : SBContent a -> ProcOpImpl a -> (SBContent a, LStream (SolContentRec a))
       = lam branch. lam impl.
+        let ty = wildToMeta impl.metaLevel ty in
         match instAndSubst (infoTy impl.specType) impl.metaLevel impl.specType
           with (specType, subst) in
         match unifyPure impl.uni (removeReprSubsts specType) ty with Some uni then
@@ -2636,7 +2638,7 @@ lang LazyTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHe
     else lazyStreamEmpty ()
 end
 
-lang MemoedTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers + PrettyPrint + Cmp + Generalize + VarAccessHelpers + LocallyNamelessStuff
+lang MemoedTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypesHelpers + PrettyPrint + Cmp + Generalize + VarAccessHelpers + LocallyNamelessStuff + WildToMeta
   -- NOTE(vipa, 2023-11-28): We pre-process impls to merge repr vars,
   -- meta vars, and opUses, split the problem into disjoint
   -- sub-problems, and re-order opUses such that we can drop internal
@@ -2942,6 +2944,7 @@ lang MemoedTopDownSolver = RepTypesShallowSolverInterface + UnifyPure + RepTypes
       end in
 
     let perImpl = lam acc : {branch : SBContent a, sols : [SolContentRec a]}. lam impl.
+      let ty = wildToMeta impl.metaLevel ty in
       let debugIndent = optionMap (concat " ") debugIndent in
       (match debugIndent with Some indent then
         print (join [indent, "trying impl with ", int2string (length impl.problem), " commands"])

--- a/stdlib/mexpr/type-check.mc
+++ b/stdlib/mexpr/type-check.mc
@@ -228,7 +228,10 @@ lang TCUnify = Unify + AliasTypeAst + MetaVarTypeAst + DataKindAst + PrettyPrint
     match getTypeStringCode 0 env l with (env, l) in
     match getTypeStringCode 0 env r with (env, r) in
     (env, join ["types ", l, " != ", r])
-  | Records _ -> (env, "record inequality (pprint todo)")
+  | Records (l, r) ->
+    let lExclusive = strJoin ", " (map sidToString (mapKeys (mapDifference l r))) in
+    let rExclusive = strJoin ", " (map sidToString (mapKeys (mapDifference r l))) in
+    (env, join ["record inequality (only in left: ", lExclusive, ", only in right: ", rExclusive, ")"])
   | Kinds (Data d1, Data d2) ->
     let getDiff = lam ks1. lam ks2.
       match ks2.upper with Some upper then

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -84,7 +84,7 @@ lang MetaVarTypeCmp = Cmp + MetaVarTypeAst
     else error "cmpTypeH reached non-unwrapped MetaVar!"
 end
 
-lang MetaVarTypePrettyPrint = PrettyPrint + MetaVarTypeAst
+lang MetaVarTypePrettyPrint = PrettyPrint + MetaVarTypeAst + MonoKindAst
   sem typePrecedence =
   | TyMetaVar t ->
     switch deref t.contents
@@ -98,10 +98,7 @@ lang MetaVarTypePrettyPrint = PrettyPrint + MetaVarTypeAst
     switch deref t.contents
     case Unbound t then
       match pprintVarName env t.ident with (env, idstr) in
-      match getKindStringCode indent env idstr t.kind with (env, str) in
-      let monoPrefix =
-        match t.kind with Mono _ then "_m" else "_p" in
-      (env, concat monoPrefix str)
+      (env, cons '_' idstr)
     case Link ty then
       getTypeStringCode indent env ty
     end

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -96,8 +96,14 @@ lang MetaVarTypePrettyPrint = PrettyPrint + MetaVarTypeAst
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
   | TyMetaVar t ->
     switch deref t.contents
-    case Unbound t then pprintVarName env t.ident
-    case Link ty then getTypeStringCode indent env ty
+    case Unbound t then
+      match pprintVarName env t.ident with (env, idstr) in
+      match getKindStringCode indent env idstr t.kind with (env, str) in
+      let monoPrefix =
+        match t.kind with Mono _ then "_m" else "_p" in
+      (env, concat monoPrefix str)
+    case Link ty then
+      getTypeStringCode indent env ty
     end
 end
 

--- a/stdlib/mexpr/type.mc
+++ b/stdlib/mexpr/type.mc
@@ -153,7 +153,9 @@ lang VarTypeSubstitute = VarTypeAst + MetaVarTypeAst
   | TyMetaVar t & ty ->
     switch deref t.contents
     case Unbound r then
-      match mapLookup r.ident subst with Some tyvar then tyvar else ty
+      match mapLookup r.ident subst with Some tyvar
+      then tyvar
+      else smap_Type_Type (substituteMetaVars subst) ty
     case Link to then
       substituteMetaVars subst to
     end

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -544,6 +544,25 @@ let pufMapAll
       (pufEmptyResults (mapEmpty cmp))
       puf
 
+let pufFilterFunction
+  : all k. all out
+  . ((k, Int) -> Bool)
+  -> PureUnionFind k out
+  -> PureUnionFind k out
+  = lam shouldKeep. lam puf.
+    -- NOTE(vipa, 2023-10-14): Here we know, by construction, that the
+    -- extra outputs in PUFResult are empty, so we just access `puf`
+    -- and call it a day.
+    pufFold
+      (lam acc. lam from. lam to. if shouldKeep from
+       then (pufUnify (lam. lam. error "compiler error in pufFilter unify") from to acc).puf
+       else acc)
+      (lam acc. lam from. lam out. if shouldKeep from
+       then (pufSetOut (lam. lam. error "compiler error in pufFilter setOut") from out acc).puf
+       else acc)
+      (pufEmpty (mapGetCmpFun puf))
+      puf
+
 let pufFilter
   : all k. all out
   . Int

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -757,8 +757,8 @@ lang UnifyPure = Unify + MetaVarTypeAst + VarTypeSubstitute + ReprTypeAst + Cmp 
 
   sem unificationToDebug : String -> PprintEnv -> Unification -> (PprintEnv, String)
   sem unificationToDebug indent env = | uni ->
-    match pufToDebug (cons ' ' indent) (lam env. lam sym. (env, int2string (sym2hash sym))) (lam env. lam. (env, "")) pprintVarName env uni.reprs with (env, reprs) in
-    match pufToDebug (cons ' ' indent) pprintVarName (lam env. lam. (env, "")) (getTypeStringCode 2) env uni.types with (env, types) in
+    match pufToDebug (cons ' ' indent) (lam env. lam sym. (env, int2string (sym2hash sym))) "<unknown>" pprintVarName env uni.reprs with (env, reprs) in
+    match pufToDebug (cons ' ' indent) pprintVarName "<unknown>" (getTypeStringCode 2) env uni.types with (env, types) in
     (env, join [indent, "reprs:\n", reprs, indent, "types:\n", types])
 end
 

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -757,8 +757,8 @@ lang UnifyPure = Unify + MetaVarTypeAst + VarTypeSubstitute + ReprTypeAst + Cmp 
 
   sem unificationToDebug : String -> PprintEnv -> Unification -> (PprintEnv, String)
   sem unificationToDebug indent env = | uni ->
-    match pufToDebug (cons ' ' indent) (lam env. lam sym. (env, int2string (sym2hash sym))) "<unknown>" pprintVarName env uni.reprs with (env, reprs) in
-    match pufToDebug (cons ' ' indent) pprintVarName "<unknown>" (getTypeStringCode 2) env uni.types with (env, types) in
+    match pufToDebug (snoc indent ' ') (lam env. lam sym. (env, int2string (sym2hash sym))) "<unknown>" pprintVarName env uni.reprs with (env, reprs) in
+    match pufToDebug (snoc indent ' ') pprintVarName "<unknown>" (getTypeStringCode 2) env uni.types with (env, types) in
     (env, join [indent, "reprs:\n", reprs, indent, "types:\n", types])
 end
 

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -366,6 +366,21 @@ con PUFOut : all k. all out. out -> PUFContent k out
 type PureUnionFind k out =
   Map k {level : Int, content : PUFContent k out}
 
+let pufPhysicalCmp : all k. all out. (out -> out -> Int) -> PureUnionFind k out -> PureUnionFind k out -> Int
+  = lam outCmp. lam a. lam b.
+    let cmp = mapGetCmpFun a in
+    let ceq = lam a. lam b. switch (a, b)
+      case (PUFLink a, PUFLink b) then cmp a b
+      case (PUFEmpty _, PUFEmpty _) then 0
+      case (PUFOut a, PUFOut b) then outCmp a b
+      case _ then subi (constructorTag a) (constructorTag b)
+      end in
+    let f = lam a. lam b.
+      let res = subi a.level b.level in
+      if neqi 0 res then res else
+      ceq a.content b.content in
+    mapCmp f a b
+
 let pufToDebug
   : all k. all out. all env.
   String

--- a/stdlib/mexpr/unify.mc
+++ b/stdlib/mexpr/unify.mc
@@ -516,6 +516,19 @@ let pufFold
       acc
       puf
 
+let pufMerge
+  : all k. all out. all side
+  . (out -> out -> (side, out))
+  -> PureUnionFind k out
+  -> PureUnionFind k out
+  -> PUFResults k out side
+  = lam combine. lam a. lam b.
+    pufFold
+      (lam acc. lam l. lam r. pufBind acc (pufUnify combine l r))
+      (lam acc. lam l. lam out. pufBind acc (pufSetOut combine l out))
+      (pufEmptyResults a)
+      b
+
 let pufMapAll
   : all k1. all out1. all k2. all out2. all side
   . (k2 -> k2 -> Int)

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -18,6 +18,15 @@ utest optionEq eqi (Some 10) (Some 11) with false
 utest optionEq eqi (Some 10) (None ()) with false
 utest optionEq eqi (None ()) (None ()) with true
 
+let optionCmp : all a. (a -> a -> Int) -> Option a -> Option a -> Int =
+  lam cmp. lam o1. lam o2.
+    switch (o1, o2)
+    case (None _, None _) then 0
+    case (None _, Some _) then negi 1
+    case (Some _, None _) then 1
+    case (Some a, Some b) then cmp a b
+    end
+
 -- Applies a function to the contained value (if any).
 let optionMap: all a. all b. (a -> b) -> Option a -> Option b = lam f. lam o.
   match o with Some t then
@@ -173,6 +182,21 @@ let optionMapAccumLM : all a. all b. all acc.
         else None ()
       else Some (acc, prefix)
     in work []
+
+
+let optionMapiAccumLM : all a. all b. all acc.
+  (acc -> Int -> a -> Option (acc, b))
+  -> acc
+  -> [a]
+  -> Option (acc, [b])
+  = lam f.
+    recursive let work = lam prefix. lam idx. lam acc. lam l.
+      match l with [x] ++ l then
+        match f acc idx x with Some (acc, x) then
+          work (snoc prefix x) (addi idx 1) acc l
+        else None ()
+      else Some (acc, prefix)
+    in work [] 0
 
 -- 'optionFoldlM f acc list' folds over 'list' using 'f', starting with the value 'acc'.
 -- This is foldlM in the Option monad, i.e., if 'f' returns 'None' at any point the entire

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -306,6 +306,14 @@ utest optionOr (Some 1) (None ()) with (Some 1) using optionEq eqi
 utest optionOr (None ()) (Some 2) with (Some 2) using optionEq eqi
 utest optionOr (None ()) (None ()) with (None ()) using optionEq eqi
 
+-- Return the option if it contains a value, otherwise use the
+-- function to compute a value to return.
+let optionOrElse : all a. (() -> Option a) -> Option a -> Option a = lam f. lam o.
+  match o with Some _ then o else f ()
+
+utest optionOrElse (lam. Some 2) (Some 1) with (Some 1) using optionEq eqi
+utest optionOrElse (lam. Some 2) (None ()) with (Some 2) using optionEq eqi
+
 -- If exactly one option is `Some`, that option is returned,
 -- otherwise returns `None`.
 let optionXor : all a. Option a -> Option a -> Option a = lam o1. lam o2.

--- a/stdlib/option.mc
+++ b/stdlib/option.mc
@@ -160,6 +160,20 @@ let optionMapM: all a. all b. (a -> Option b) -> [a] -> Option [b] = lam f. lam 
 utest optionMapM (lam x. if gti x 2 then Some x else None ()) [3, 4, 5] with Some [3, 4, 5]
 utest optionMapM (lam x. if gti x 2 then Some x else None ()) [2, 3, 4] with None ()
 
+let optionMapAccumLM : all a. all b. all acc.
+  (acc -> a -> Option (acc, b))
+  -> acc
+  -> [a]
+  -> Option (acc, [b])
+  = lam f.
+    recursive let work = lam prefix. lam acc. lam l.
+      match l with [x] ++ l then
+        match f acc x with Some (acc, x) then
+          work (snoc prefix x) acc l
+        else None ()
+      else Some (acc, prefix)
+    in work []
+
 -- 'optionFoldlM f acc list' folds over 'list' using 'f', starting with the value 'acc'.
 -- This is foldlM in the Option monad, i.e., if 'f' returns 'None' at any point the entire
 -- result is 'None'.

--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -76,6 +76,38 @@ end
 lang MExprWSACParser = WhitespaceParser + LineCommentParser + MultilineCommentParser
 end
 
+lang ErrorTokenParser = TokenParser
+  syn Token =
+  | ErrorTok {char : Char, info : Info}
+  syn TokenRepr =
+  | ErrorRepr ()
+
+  sem parseToken pos =
+  | [c] ++ str ->
+    let pos2 = advanceCol pos 1 in
+    let info = makeInfo pos pos2 in
+    { token = ErrorTok {char = c, info = info}
+    , lit = [c]
+    , info = info
+    , stream = {pos = pos2, str = str}
+    }
+
+  sem tokKindEq tokRepr =
+  | ErrorTok _ -> match tokRepr with ErrorRepr _ then true else false
+
+  sem tokInfo =
+  | ErrorTok x -> x.info
+
+  sem tokToStr =
+  | ErrorTok x -> join ["<Lexing error: '", x.char, "'"]
+
+  sem tokToRepr =
+  | ErrorTok _ -> ErrorRepr ()
+
+  sem tokReprToStr =
+  | ErrorRepr _ -> "<Error>"
+end
+
 lang EOFTokenParser = TokenParser + TokenReprEOF
   syn Token =
   | EOFTok {info : Info}

--- a/stdlib/seq.mc
+++ b/stdlib/seq.mc
@@ -78,6 +78,20 @@ with [] using eqSeq eqi
 utest mapOption (lam a. if gti a 3 then Some (addi a 30) else None ()) []
 with [] using eqSeq eqi
 
+let mapiOption
+  : all a. all b.
+     (Int -> a -> Option b)
+  -> [a]
+  -> [b]
+  = lam f.
+    recursive let work = lam idx. lam as.
+      match as with [a] ++ as then
+        match f idx a with Some b
+        then cons b (work (addi idx 1) as)
+        else work (addi idx 1) as
+      else []
+    in work 0
+
 let for_
   : all a.
      [a]


### PR DESCRIPTION
This PR contains the current state of repr-types, as a follow-up to #811.

Other changes relevant to the project at large:
- Some added functions to `heap` and `lazy`.
- Added an iterator type in the vein of `Seq` in OCaml, as `Iter` in `lazy.mc`.
- Basic error printing for type errors with record shapes, it now prints `record inequality (only in left: <list of labels>, only in right: <list of labels>)` rather than `record inequality (pprint todo)`.
- `optionMapAccumLM` and `optionMapiAccumLM` in `option.mc`.
- `mapiOption` in `seq.mc`