### PR TITLE
Fix issues in the GitHub Actions runner for MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Cache opam packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.opam
-          key: ${{ runner.os }}-opam-build
-
       - name: Install opam packages
         run: |
           # Install dependencies of owl
@@ -66,12 +60,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: Cache opam packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.opam
-          key: ${{ runner.os }}-opam-build
 
       - name: Install opam packages
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OCaml and opam for Miking
         uses: ocaml/setup-ocaml@v2
@@ -19,7 +19,7 @@ jobs:
           ocaml-compiler: ocaml-base-compiler.5.0.0
 
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -48,7 +48,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OCaml and opam for Miking
         uses: ocaml/setup-ocaml@v2
@@ -56,7 +56,7 @@ jobs:
           ocaml-compiler: ocaml-base-compiler.5.0.0
 
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
           opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.24.1
 
       - name: Build Miking
-        timeout-minutes: 10
+        timeout-minutes: 30
         run: |
           eval $(opam env)
           make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           make test-all
 
   build-and-test-mac-os:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
       - name: Install opam packages
         run: |
           # Install dependencies of owl
-          brew install pkg-config
+          brew install pkg-config autoconf openblas
 
           # Export environment variable needed by openblas
           export PKG_CONFIG_PATH=$(brew --prefix openblas)/lib/pkgconfig


### PR DESCRIPTION
This PR fixes a couple of issues in the GitHub Actions for the MacOS runner, causing all tests to fail:
* Forces the MacOS runner to use version 13, as version 14 uses ARM (which I couldn't figure out how to get working).
* Increases the timeout of the build step in the MacOS runner, as it's started timing out.

Also, it updates the versions of existing actions to get rid of deprecation warnings and removes the cache step (it is never used in practice).