### PR TITLE
add beta-binomial support

### DIFF
--- a/stdlib/ext/dist-ext.mc
+++ b/stdlib/ext/dist-ext.mc
@@ -165,6 +165,21 @@ let lomaxLogPdf:Float -> Float -> Float -> Float = lam scale. lam shape. lam x.
 let lomaxPdf = lam scale: Float. lam shape: Float. lam x:Float.
   exp (lomaxLogPdf scale shape x)
 
+-- Beta binomial
+let betabinSample = lam n:Int. lam a: Float. lam b: Float.
+  let p = betaSample a b in
+  binomialSample p n
+
+let betabinLogPmf:Int -> Float -> Float -> Int -> Float = lam n. lam a. lam b. lam x.
+  if gti x n then negf inf else 
+  let lbeta1 = addf (subf (logGamma (addf a (int2float x))) (logGamma (addf (int2float n) (addf a b)))) (logGamma (addf b (int2float (subi n x))))  in
+  let lbeta2 = addf (subf (logGamma a) (logGamma (addf a b))) (logGamma b)  in
+  let lcomb = (logCombination n x) in
+  addf lcomb (subf lbeta1 lbeta2)
+
+let betabinPmf = lam n:Int. lam a: Float. lam b: Float. lam x:Float.
+  exp (betabinLogPmf n a b x)
+
 -- Seed
 external externalSetSeed ! : Int -> ()
 let setSeed : Int -> () = lam seed.
@@ -268,6 +283,11 @@ utest exp (geometricLogPmf 0.3 1) with 0.21 using _eqf in
 utest geometricPmf 0.3 2 with 0.147 using _eqf in
 utest exp (geometricLogPmf 0.3 3) with 0.1029 using _eqf in
 utest geometricSample 0.3 with 0 using geqi in
+
+-- Testing Beta-Binomial
+utest betabinLogPmf 5 1. 1. 2 with -1.79175946923 using _eqf in
+utest exp (betabinLogPmf 5 1. 1. 3) with 0.166666666667 using _eqf in
+utest betabinSample 20 1. 1. with 0 using intRange 0 20 in
 
 -- Testing seed
 utest setSeed 0; uniformSample (); uniformSample ()

--- a/stdlib/ext/math-ext.ext-ocaml.mc
+++ b/stdlib/ext/math-ext.ext-ocaml.mc
@@ -30,5 +30,19 @@ let mathExtMap =
     ]),
     ("externalSqrt", [
       impl { expr = "Float.sqrt", ty = tyarrow_ tyfloat_ tyfloat_ }
+    ]),
+    ("externalLogGamma", [
+      { expr = "Owl_maths.loggamma ",
+        ty = tyarrows_ [tyfloat_, tyfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
+    ]),
+    ("externalLogCombination", [
+      { expr = "Owl_maths.log_combination ",
+        ty = tyarrows_ [tyint_, tyint_, tyfloat_],
+        libraries = ["owl"],
+        cLibraries = []
+      }
     ])
   ]

--- a/stdlib/ext/math-ext.mc
+++ b/stdlib/ext/math-ext.mc
@@ -41,3 +41,11 @@ utest pow 3. 2. with 9. using eqf
 external externalSqrt : Float -> Float
 let sqrt: Float -> Float = lam x. externalSqrt x
 utest sqrt 9. with 3. using eqf
+
+external externalLogGamma : Float -> Float
+let logGamma: Float -> Float = lam x. externalLogGamma x
+utest logGamma 3. with log 2. using eqf
+
+external externalLogCombination : Int -> Int -> Float
+let logCombination: Int -> Int -> Float = lam n. lam c. externalLogCombination n c
+utest logCombination 4 2 with log 6. using _eqf


### PR DESCRIPTION
Adds beta binomial distribution to distribution support, as well as logGamma, and logCombination functions to `math-ext.mc` that are needed for it.