### PR TITLE
Minor parser fixes

### DIFF
--- a/stdlib/mexpr/parser.mc
+++ b/stdlib/mexpr/parser.mc
@@ -8,60 +8,14 @@ include "ast.mc"
 include "ast-builder.mc"
 include "eq.mc"
 include "info.mc"
+include "parser/lexer.mc"
 
 type ParseResult a = {val : a, pos : Pos, str: String}
 type StrPos = {str : String, pos : Pos}
 
-let tabSpace = 2
-
--- Base language for whitespace and comments (WASC) parsing
-lang WSACParser
-  sem eatWSAC (p : Pos) =
-end
-
--- Eats whitespace
-lang WhitespaceParser = WSACParser
-  sem eatWSAC (p : Pos)  =
-  | " " ++ xs -> eatWSAC (advanceCol p 1)  xs
-  | "\t" ++ xs -> eatWSAC (advanceCol p tabSpace) xs
-  | "\n" ++ xs -> eatWSAC (advanceRow p 1) xs
-  | "\r" ++ xs -> eatWSAC p xs
-  | x -> {str = x, pos = p}
-end
-
--- Eat line comments of the form --
-lang LineCommentParser = WSACParser
-  sem eatWSAC (p : Pos)  =
-  | "--" ++ xs ->
-    recursive
-    let remove = lam p. lam str.
-      match str with "\n" ++ xs then eatWSAC (advanceRow p 1) xs else
-      match str with [x] ++ xs then remove (advanceCol p 1) xs else
-      eatWSAC p str
-    in remove p xs
-end
-
--- Eat multiline comment of the form *-  -*
-lang MultilineCommentParser = WSACParser
-  sem eatWSAC (p : Pos) =
-  | "/-" ++ xs ->
-    recursive
-    let remove = lam p. lam str. lam d.
-      match str with "/-" ++ xs then remove (advanceCol p 2) xs (addi d 1) else
-      match str with "\n" ++ xs then remove (advanceRow p 1) xs d else
-      match str with "-/" ++ xs then
-        if eqi d 1 then eatWSAC (advanceCol p 2) xs
-        else remove (advanceCol p 2) xs (subi d 1) else
-      match str with [_] ++ xs then remove (advanceCol p 1) xs d else
-      if eqi d 0 then eatWSAC p str else posErrorExit p "Unmatched multiline comments."
-    in remove (advanceCol p 2) xs 1
-end
-
 -- Commbined WSAC parser for MExpr
 lang MExprWSACParser = WhitespaceParser + LineCommentParser + MultilineCommentParser
 end
-
-
 
 -- Top of the expression parser. Connects WSAC with parsing of other non terminals
 lang ExprParser = WSACParser + Ast

--- a/stdlib/parser/ll1.mc
+++ b/stdlib/parser/ll1.mc
@@ -89,7 +89,7 @@ lang ParserSpec = ParserBase
   | str ->
     let res: NextTokenResult = nextToken {str = str, pos = posVal (concat "lit: " str) 1 1} in
     match (res.stream.str, res.lit) with ("", !"") then LitSpec {lit = str}
-    else error (join ["A literal token does not lex as a single token: \"", res.stream.str, "\""])
+    else error (join ["A literal token does not lex as a single token: \"", str,"\" leaves \"", res.stream.str, "\""])
   sem tokSym =
   | repr -> TokSpec repr
 end


### PR DESCRIPTION
This PR changes the manual `mexpr` parser to not duplicate definitions from `parser/lexer.mc`, and also makes `ll1.mc` produce a slightly better error message if a literal token doesn't lex as one token.