### PR TITLE
Add `allb` `someb` `tupleEq2` `setFilter` `strStartsWith` and `strEndsWith` to stdlib

### DIFF
--- a/stdlib/bool.mc
+++ b/stdlib/bool.mc
@@ -22,6 +22,14 @@ utest and true false with false
 utest and false true with false
 utest and false false with false
 
+-- Logical AND of sequence
+let allb : [Bool] -> Bool = foldl and true
+
+utest allb [true, true, true] with true
+utest allb [false, true, true] with false
+utest allb [true] with true
+utest allb [false] with false
+utest allb [] with true
 
 -- Logical OR
 let or: Bool -> Bool -> Bool =
@@ -31,6 +39,15 @@ utest or true true with true
 utest or true false with true
 utest or false true with true
 utest or false false with false
+
+-- Logical OR of sequence
+let someb : [Bool] -> Bool = foldl or false
+
+utest someb [false, false, false] with false
+utest someb [false, true, true] with true
+utest someb [true] with true
+utest someb [false] with false
+utest someb [] with false
 
 
 -- Logical XOR

--- a/stdlib/set.mc
+++ b/stdlib/set.mc
@@ -87,6 +87,17 @@ let setAny: all a. (a -> Bool) -> Set a -> Bool = lam p. lam s.
 -- `setOfKeys m` returns the keys of `m` as a set.
 let setOfKeys : all k. all v. Map k v -> Set k = lam m. mapMap (lam. ()) m
 
+-- `setFilter p s` creates a new set containing exactly those elements in set `s`
+-- that satisfy predicate `p`.
+let setFilter : all a. (a -> Bool) -> Set a -> Set a = 
+  lam p. lam s. 
+    mapFilterWithKey (lam k. lam. p k) s
+
+utest setFilter (lam. true) (setOfSeq subi [1,2,3]) with (setOfSeq subi [1,2,3]) using setEq 
+utest setIsEmpty (setFilter (lam. false) (setOfSeq subi [1,2,3])) with true 
+utest (setFilter (lam x. eqi (modi x 2) 0) (setOfSeq subi [1,2,3,4,5,6])) 
+  with (setOfSeq subi [2, 4, 6]) using setEq
+
 mexpr
 
 let s = setEmpty subi in

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -236,14 +236,7 @@ utest strTrim "   bbbbb  bbb " with "bbbbb  bbb"
 utest strTrim "ccccc c\t   \n" with "ccccc c"
 
 -- `strEndsWith str suffix` returns true if `str` ends with the provided `suffix`
-let strEndsWith : String -> String -> Bool
-  = lam str. lam suffix. 
-    let strLen = length str in 
-    let suffixLen = length suffix in 
-    if lti strLen suffixLen then
-      false
-    else
-      eqString (subsequence str (subi strLen suffixLen) strLen) suffix
+let strEndsWith : String -> String -> Bool = lam s1. lam s2. isSuffix eqChar s2 s1
 
 utest strEndsWith "Something" "thing" with true
 utest strEndsWith "Somethin" "thing" with false
@@ -254,14 +247,7 @@ utest strEndsWith "xs" "" with true
 
 
 -- `strStartswith str prefix` returns true if `str` starts with the provided `prefix`
-let strStartsWith : String -> String -> Bool
-  = lam str. lam prefix. 
-    let strLen = length str in 
-    let prefixLen = length prefix in 
-    if lti strLen prefixLen then
-      false
-    else
-      eqString (subsequence str 0 prefixLen) prefix
+let strStartsWith : String -> String -> Bool = lam s1. lam s2. isPrefix eqChar s2 s1
 
 utest strStartsWith "Something" "Some" with true
 utest strStartsWith "Somethin" "thing" with false

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -235,26 +235,26 @@ utest strTrim " aaaa   " with "aaaa"
 utest strTrim "   bbbbb  bbb " with "bbbbb  bbb"
 utest strTrim "ccccc c\t   \n" with "ccccc c"
 
--- `strEndsWith str suffix` returns true if `str` ends with the provided `suffix`
-let strEndsWith : String -> String -> Bool = lam s1. lam s2. isSuffix eqChar s2 s1
+-- `strEndsWith suffix str` returns true if `str` ends with the provided `suffix`
+let strEndsWith : String -> String -> Bool = isSuffix eqChar
 
-utest strEndsWith "Something" "thing" with true
-utest strEndsWith "Somethin" "thing" with false
-utest strEndsWith "Kunglinga Tekniska Hogskolan" "an" with true
-utest strEndsWith "short" "muchlonger" with false
-utest strEndsWith "" "xs" with false
-utest strEndsWith "xs" "" with true
+utest strEndsWith "thing" "Something" with true
+utest strEndsWith "thing" "Somethin" with false
+utest strEndsWith "an" "Kunglinga Tekniska Hogskolan" with true
+utest strEndsWith "muchlonger" "short" with false
+utest strEndsWith "" "xs" with true
+utest strEndsWith "xs" "" with false
 
 
--- `strStartswith str prefix` returns true if `str` starts with the provided `prefix`
-let strStartsWith : String -> String -> Bool = lam s1. lam s2. isPrefix eqChar s2 s1
+-- `strStartswith prefix str` returns true if `str` starts with the provided `prefix`
+let strStartsWith : String -> String -> Bool = isPrefix eqChar
 
-utest strStartsWith "Something" "Some" with true
-utest strStartsWith "Somethin" "thing" with false
-utest strStartsWith "Kunglinga Tekniska Hogskolan" "K" with true
-utest strStartsWith "short" "muchlonger" with false
-utest strStartsWith "" "xs" with false
-utest strStartsWith "xs" "" with true
+utest strStartsWith "Some" "Something" with true
+utest strStartsWith "thing" "Somethin" with false
+utest strStartsWith "K" "Kunglinga Tekniska Hogskolan" with true
+utest strStartsWith "muchlonger" "short" with false
+utest strStartsWith "" "xs" with true
+utest strStartsWith "xs" "" with false
 
 
 let stringIsInt = lam s.

--- a/stdlib/string.mc
+++ b/stdlib/string.mc
@@ -235,6 +235,40 @@ utest strTrim " aaaa   " with "aaaa"
 utest strTrim "   bbbbb  bbb " with "bbbbb  bbb"
 utest strTrim "ccccc c\t   \n" with "ccccc c"
 
+-- `strEndsWith str suffix` returns true if `str` ends with the provided `suffix`
+let strEndsWith : String -> String -> Bool
+  = lam str. lam suffix. 
+    let strLen = length str in 
+    let suffixLen = length suffix in 
+    if lti strLen suffixLen then
+      false
+    else
+      eqString (subsequence str (subi strLen suffixLen) strLen) suffix
+
+utest strEndsWith "Something" "thing" with true
+utest strEndsWith "Somethin" "thing" with false
+utest strEndsWith "Kunglinga Tekniska Hogskolan" "an" with true
+utest strEndsWith "short" "muchlonger" with false
+utest strEndsWith "" "xs" with false
+utest strEndsWith "xs" "" with true
+
+
+-- `strStartswith str prefix` returns true if `str` starts with the provided `prefix`
+let strStartsWith : String -> String -> Bool
+  = lam str. lam prefix. 
+    let strLen = length str in 
+    let prefixLen = length prefix in 
+    if lti strLen prefixLen then
+      false
+    else
+      eqString (subsequence str 0 prefixLen) prefix
+
+utest strStartsWith "Something" "Some" with true
+utest strStartsWith "Somethin" "thing" with false
+utest strStartsWith "Kunglinga Tekniska Hogskolan" "K" with true
+utest strStartsWith "short" "muchlonger" with false
+utest strStartsWith "" "xs" with false
+utest strStartsWith "xs" "" with true
 
 
 let stringIsInt = lam s.

--- a/stdlib/tuple.mc
+++ b/stdlib/tuple.mc
@@ -1,3 +1,5 @@
+include "bool.mc"
+
 /-
         This file contains utility functions that operate on tuples.
  -/
@@ -65,3 +67,19 @@ utest
   utest testCmp3 eqi (1, 1, 1) (1, 1, 1) with true in
   ()
   with ()
+
+let fst : all a. all b. (a, b) -> a = lam p. p.0
+utest fst (1, 2) with 1
+utest fst ("whatever", 2) with "whatever"
+
+let snd : all a. all b. (a, b) -> b = lam p. p.1
+utest snd (1, 2) with 2
+utest snd ([1, 2, 3], "whatever") with "whatever"
+
+let tupleEq2 : all a. all b. (a -> a -> Bool) -> (b -> b -> Bool) -> (a, b) -> (a, b) -> Bool
+  = lam eqFst. lam eqSnd. lam lhs. lam rhs. 
+    and (eqFst lhs.0 rhs.0) (eqSnd lhs.1 rhs.1)
+
+utest (tupleEq2 eqf eqi) (1.0, 1) (1.0, 1) with true 
+utest (tupleEq2 eqf eqi) (1.0, 1) (1.0, 12) with false
+utest (tupleEq2 eqf eqi) (1.2, 1) (1.0, 12) with false


### PR DESCRIPTION
Currently, we have `and` and `or` with arity 2. This leads to some rather ugly syntax when you have a list of conditions. E.g. `(and p1 (and p2 (and p3 p4)))`. With this pr, you'd be able to write `allb [p1, p2, p3, p4]`. The name comes from `all` (all must be true) and `b` for boolean.