### PR TITLE
Make local-search.mc test deterministic

### DIFF
--- a/stdlib/ext/local-search.mc
+++ b/stdlib/ext/local-search.mc
@@ -387,6 +387,12 @@ end
 
 mexpr
 
+-- NOTE(johnwikman, 2024-09-11): Test cases below make use of randIntU within
+-- simulated annealing. Had one of those tests below randomly fail in a manner
+-- which I cannot reproduce, so explicitly setting seed to 0 to make tests
+-- below deterministic.
+setRandSeed 0;
+
 type SearchState = use LocalSearchBase in SearchState in
 type MetaState = use LocalSearchBase in MetaState in
 

--- a/stdlib/ext/local-search.mc
+++ b/stdlib/ext/local-search.mc
@@ -391,7 +391,7 @@ mexpr
 -- simulated annealing. Had one of those tests below randomly fail in a manner
 -- which I cannot reproduce, so explicitly setting seed to 0 to make tests
 -- below deterministic.
-setRandSeed 0;
+randSetSeed 0;
 
 type SearchState = use LocalSearchBase in SearchState in
 type MetaState = use LocalSearchBase in MetaState in


### PR DESCRIPTION
Had the simulated annealing test case in `stdlib/ext/local-search.mc` randomly fail when building one of the docker images. It worked fine in all other build and also when I again rebuilt the image, so assuming it had to do with the randomness in the implementation.