### PR TITLE
Add fileReadBytes external

### DIFF
--- a/stdlib/ext/file-ext.ext-ocaml.mc
+++ b/stdlib/ext/file-ext.ext-ocaml.mc
@@ -69,6 +69,13 @@ let fileExtMap =
         cLibraries = []
       }
     ]),
+    ("externalReadBytes", [
+      { expr = "(fun rc len -> let buf = Bytes.create len in try really_input rc buf 0 len; (Bytes.to_string buf, false) with | End_of_file -> (\"\",true))",
+        ty = tyarrows_ [otyvarext_ "in_channel" [], tyint_, otytuple_ [otystring_, tybool_]],
+        libraries = [],
+        cLibraries = []
+      }
+    ]),
     ("externalReadString", [
       { expr = "(fun f -> try really_input_string f (in_channel_length f) with _ -> \"\")",
         ty = tyarrows_ [otyvarext_ "in_channel" [], otystring_],

--- a/stdlib/ext/file-ext.ext-ocaml.mc
+++ b/stdlib/ext/file-ext.ext-ocaml.mc
@@ -70,8 +70,8 @@ let fileExtMap =
       }
     ]),
     ("externalReadBytes", [
-      { expr = "(fun rc len -> let buf = Bytes.create len in try really_input rc buf 0 len; (Bytes.to_string buf, false) with | End_of_file -> (\"\",true))",
-        ty = tyarrows_ [otyvarext_ "in_channel" [], tyint_, otytuple_ [otystring_, tybool_]],
+      { expr = "(fun rc len -> try let buf = Bytes.create len in let actual_len = input rc buf 0 len in let reached_eof = actual_len < len in let had_error = false in let int_list = List.init actual_len (fun i -> int_of_char (Bytes.get buf i)) in (int_list, reached_eof, had_error) with | Sys_error err -> ([], false, true))",
+        ty = tyarrows_ [otyvarext_ "in_channel" [], tyint_, otytuple_ [otylist_ tyint_, tybool_, tybool_]],
         libraries = [],
         cLibraries = []
       }

--- a/stdlib/ext/file-ext.mc
+++ b/stdlib/ext/file-ext.mc
@@ -59,6 +59,12 @@ external externalReadLine ! : ReadChannel -> (String, Bool)
 let fileReadLine : ReadChannel -> Option String =
   lam rc. match externalReadLine rc with (s, false) then Some s else None ()
 
+-- Reads a given number of bytes from the file.
+-- Returns None if end of file or error.
+external externalReadBytes ! : ReadChannel -> Int -> (String, Bool)
+let fileReadBytes : ReadChannel -> Int -> Option String =
+  lam rc. lam len. match externalReadBytes rc len with (s, false) then Some s else None ()
+
 -- Reads everything in a file and returns the content as a string.
 -- Should support Unicode in the future.
 external externalReadString ! : ReadChannel -> String
@@ -111,6 +117,18 @@ utest
     (l1,l2,l3,l4)
   else ("Error reading file","","","")
 with ("Hello", "Next string", "Final", "EOF") in
+
+-- Test reading x amount of characters from the file
+utest
+  match fileReadOpen filename with Some rc then
+    let l1 = match fileReadBytes rc 3 with Some s then s else "" in
+    let l2 = match fileReadBytes rc 4 with Some s then s else "" in
+    let l3 = match fileReadBytes rc 0 with Some s then s else "" in
+    let l4 = match fileReadBytes rc 1 with Some s then s else "" in
+    fileReadClose rc;
+    (l1,l2,l3,l4)
+  else ("Error reading file","","","")
+with ("Hel", "lo\nN", "", "e") in
 
 -- Check that the file size is correct
 utest fileSize filename with 23 in

--- a/stdlib/ext/file-ext.mc
+++ b/stdlib/ext/file-ext.mc
@@ -60,10 +60,15 @@ let fileReadLine : ReadChannel -> Option String =
   lam rc. match externalReadLine rc with (s, false) then Some s else None ()
 
 -- Reads a given number of bytes from the file.
--- Returns None if end of file or error.
-external externalReadBytes ! : ReadChannel -> Int -> (String, Bool)
-let fileReadBytes : ReadChannel -> Int -> Option String =
-  lam rc. lam len. match externalReadBytes rc len with (s, false) then Some s else None ()
+-- Returns (bytes, eof, error) where bytes is the read bytes
+external externalReadBytes ! : ReadChannel -> Int -> ([Int], Bool, Bool)
+let fileReadBytes : ReadChannel -> Int -> Option [Int] =
+  lam rc. lam len.
+    switch externalReadBytes rc len
+      case ([], true, _) then None ()
+      case (s, _, false) then Some s
+      case _ then None ()
+    end
 
 -- Reads everything in a file and returns the content as a string.
 -- Should support Unicode in the future.
@@ -121,14 +126,16 @@ with ("Hello", "Next string", "Final", "EOF") in
 -- Test reading x amount of characters from the file
 utest
   match fileReadOpen filename with Some rc then
-    let l1 = match fileReadBytes rc 3 with Some s then s else "" in
-    let l2 = match fileReadBytes rc 4 with Some s then s else "" in
-    let l3 = match fileReadBytes rc 0 with Some s then s else "" in
-    let l4 = match fileReadBytes rc 1 with Some s then s else "" in
+    let l1 = match fileReadBytes rc 3   with Some s then map int2char s else "" in
+    let l2 = match fileReadBytes rc 4   with Some s then map int2char s else "" in
+    let l3 = match fileReadBytes rc 0   with Some s then map int2char s else "" in
+    let l4 = match fileReadBytes rc 1   with Some s then map int2char s else "" in
+    let l5 = match fileReadBytes rc 100 with Some s then map int2char s else "" in
+    let l6 = match fileReadBytes rc 100 with Some s then Some s else None () in
     fileReadClose rc;
-    (l1,l2,l3,l4)
-  else ("Error reading file","","","")
-with ("Hel", "lo\nN", "", "e") in
+    (l1,l2,l3,l4,l5,l6)
+  else ("Error reading file","","","","", None ())
+with ("Hel", "lo\nN", "", "e", "xt string\nFinal", None ()) in
 
 -- Check that the file size is correct
 utest fileSize filename with 23 in


### PR DESCRIPTION
Adds the ability to read X amount of characters from a `ReadChannel`. Commonly required in protocols such as JSON-RPC to read the required amount of characters as specified by a `Content-Length: X` header.