### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default rules
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf                # Use Unix line endings
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 80            # A line should not have more than this amount
+                                # of chars (not supported by all plugins)
+
+# Makefiles require tabs
+[{Makefile,**.mk}]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,14 +5,16 @@ root = true
 
 # Default rules
 [*]
-indent_style = space
-indent_size = 2
 end_of_line = lf                # Use Unix line endings
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 80            # A line should not have more than this amount
                                 # of chars (not supported by all plugins)
+
+[*.mc]
+indent_style = space
+indent_size = 2
 
 # Makefiles require tabs
 [{Makefile,**.mk}]


### PR DESCRIPTION
Rather than just specify code formating in the wiki I suggest that we add an https://editorconfig.org/ configuration with our specification. The benefit is that many editors has builtin support for editorconfig (and even more have optional plugins), meaning that they will automatically indent code etc. according to our specification when editing files in this repo. 