### PR TITLE
fix external names

### DIFF
--- a/stdlib/ext/file-ext.ext-ocaml.mc
+++ b/stdlib/ext/file-ext.ext-ocaml.mc
@@ -5,21 +5,21 @@ let fileExtMap =
   use OCamlTypeAst in
   mapFromSeq cmpString
   [
-    ("fileExists", [
+    ("externalFileExists", [
       { expr = "(fun s -> try Sys.file_exists s with _ -> false)",
         ty = tyarrows_ [otystring_, tybool_],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("deleteFile", [
+    ("externalDeleteFile", [
       { expr = "(fun s -> try Sys.remove s with _ -> ())",
         ty = tyarrows_ [otystring_, otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("fileSize", [
+    ("externalFileSize", [
       { expr = concat "(fun n -> try let f = open_in_bin n in let s = in_channel_length "
                        "f in let _ = close_in_noerr f in s with _ -> 0)",
         ty = tyarrows_ [otystring_, tyint_],
@@ -27,77 +27,77 @@ let fileExtMap =
         cLibraries = []
       }
     ]),
-    ("writeOpen", [
+    ("externalWriteOpen", [
       { expr = "(fun s -> try (open_out_bin s, true) with _ -> (stdout, false))",
         ty = tyarrows_ [otystring_, otytuple_ [otyvarext_ "out_channel" [], tybool_]],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("writeString", [
+    ("externalWriteString", [
       { expr = "output_string",
         ty = tyarrows_ [otyvarext_ "out_channel" [], otystring_, otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("writeFlush", [
+    ("externalWriteFlush", [
       { expr = "flush",
         ty = tyarrows_ [otyvarext_ "out_channel" [], otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("writeClose", [
+    ("externalWriteClose", [
       { expr = "close_out_noerr",
         ty = tyarrows_ [otyvarext_ "out_channel" [], otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("readOpen", [
+    ("externalReadOpen", [
       { expr = "(fun s -> try (open_in_bin s, true) with _ -> (stdin, false))",
         ty = tyarrows_ [otystring_, otytuple_ [otyvarext_ "in_channel" [], tybool_]],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("readLine", [
+    ("externalReadLine", [
       { expr = "(fun rc -> try (input_line rc, false) with | End_of_file -> (\"\",true))",
         ty = tyarrows_ [otyvarext_ "in_channel" [], otytuple_ [otystring_, tybool_]],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("readString", [
+    ("externalReadString", [
       { expr = "(fun f -> try really_input_string f (in_channel_length f) with _ -> \"\")",
         ty = tyarrows_ [otyvarext_ "in_channel" [], otystring_],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("readClose", [
+    ("externalReadClose", [
       { expr = "close_in_noerr",
         ty = tyarrows_ [otyvarext_ "in_channel" [], otyunit_],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("stdin", [
+    ("externalStdin", [
       { expr = "stdin",
         ty = otyvarext_ "in_channel" [],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("stdout", [
+    ("externalStdout", [
       { expr = "stdout",
         ty = otyvarext_ "out_channel" [],
         libraries = [],
         cLibraries = []
       }
     ]),
-    ("stderr", [
+    ("externalStderr", [
       { expr = "stderr",
         ty = otyvarext_ "out_channel" [],
         libraries = [],

--- a/stdlib/ext/file-ext.mc
+++ b/stdlib/ext/file-ext.mc
@@ -6,72 +6,79 @@ type ReadChannel
 
 
 -- Returns true if the give file exists, else false
-external fileExists ! : String -> Bool
+external externalFileExists ! : String -> Bool
+let fileExists = lam s. externalFileExists s
 
 -- Deletes the file from the file system. If the file does not
 -- exist, no error is reported. Use function fileExists to check
 -- if the file exists.
-external deleteFile ! : String -> ()
-let deleteFile = lam s. if fileExists s then deleteFile s else ()
+external externalDeleteFile ! : String -> ()
+let deleteFile = lam s. if externalFileExists s then externalDeleteFile s else ()
 
 -- Returns the size in bytes of a given file
 -- If the file does not exist, 0 is returned.
 -- Use function fileExists to check if a file exists.
-external fileSize ! : String -> Int
+external externalFileSize ! : String -> Int
+let fileSize : String -> Int =
+  lam name. externalFileSize name
 
 -- Open a file for writing. Note that we
 -- always open binary channels.
 -- Note: the external function is shadowed. Use the second signature
-external writeOpen ! : String -> (WriteChannel, Bool)
+external externalWriteOpen ! : String -> (WriteChannel, Bool)
 let writeOpen : String -> Option WriteChannel =
-  lam name. match writeOpen name with (wc, true) then Some wc else None ()
+  lam name. match externalWriteOpen name with (wc, true) then Some wc else None ()
 
 -- Write a text string to the output channel
 -- Right now, it does not handle Unicode correctly
 -- It should default to UTF-8
-external writeString ! : WriteChannel -> String -> ()
+external externalWriteString ! : WriteChannel -> String -> ()
 let writeString : WriteChannel -> String -> () =
-  lam c. lam s. writeString c s
+  lam c. lam s. externalWriteString c s
 
 -- Flush output channel
-external writeFlush ! : WriteChannel -> ()
+external externalWriteFlush ! : WriteChannel -> ()
+let writeFlush = lam c. externalWriteFlush c
 
 -- Close a write channel
-external writeClose ! : WriteChannel -> ()
+external externalWriteClose ! : WriteChannel -> ()
+let writeClose = lam c. externalWriteClose c
 
 -- Open a file for reading. Read open either return
 -- Note: the external function is shadowed. Use the second signature
-external readOpen ! : String -> (ReadChannel, Bool)
+external externalReadOpen ! : String -> (ReadChannel, Bool)
 let readOpen : String -> Option ReadChannel =
-  lam name. match readOpen name with (rc, true) then Some rc else None ()
+  lam name. match externalReadOpen name with (rc, true) then Some rc else None ()
 
 -- Reads one line of text. Returns None if end of file.
 -- If a successful line is read, it is returned without
 -- the end-of-line character.
 -- Should support Unicode in the future.
 -- Note: the external function is shadowed. Use the second signature
-external readLine ! : ReadChannel -> (String, Bool)
+external externalReadLine ! : ReadChannel -> (String, Bool)
 let readLine : ReadChannel -> Option String =
-  lam rc. match readLine rc with (s, false) then Some s else None ()
+  lam rc. match externalReadLine rc with (s, false) then Some s else None ()
 
 -- Reads everything in a file and returns the content as a string.
 -- Should support Unicode in the future.
-external readString ! : ReadChannel -> String
+external externalReadString ! : ReadChannel -> String
+let readString = lam c. externalReadString c
 
 -- Closes a channel that was opened for reading
-external readClose ! : ReadChannel -> ()
+external externalReadClose ! : ReadChannel -> ()
+let readClose = lam c. externalReadClose c
 
 -- Standard in read channel
-external stdin ! : ReadChannel
+external externalStdin ! : ReadChannel
+let stdin = externalStdin
 
 -- Standard out write channel
-external stdout ! : WriteChannel
+external externalStdout ! : WriteChannel
+let stdout = externalStdout
 
 -- Standard error write channel
-external stderr ! : WriteChannel
-
-
-
+external externalStderr ! : WriteChannel
+let stderr = externalStderr
 
 mexpr
 

--- a/stdlib/ext/file-ext.mc
+++ b/stdlib/ext/file-ext.mc
@@ -13,7 +13,7 @@ let fileExists = lam s. externalFileExists s
 -- exist, no error is reported. Use function fileExists to check
 -- if the file exists.
 external externalDeleteFile ! : String -> ()
-let deleteFile = lam s. if externalFileExists s then externalDeleteFile s else ()
+let fileDeleteFile = lam s. if externalFileExists s then externalDeleteFile s else ()
 
 -- Returns the size in bytes of a given file
 -- If the file does not exist, 0 is returned.
@@ -26,28 +26,28 @@ let fileSize : String -> Int =
 -- always open binary channels.
 -- Note: the external function is shadowed. Use the second signature
 external externalWriteOpen ! : String -> (WriteChannel, Bool)
-let writeOpen : String -> Option WriteChannel =
+let fileWriteOpen : String -> Option WriteChannel =
   lam name. match externalWriteOpen name with (wc, true) then Some wc else None ()
 
 -- Write a text string to the output channel
 -- Right now, it does not handle Unicode correctly
 -- It should default to UTF-8
 external externalWriteString ! : WriteChannel -> String -> ()
-let writeString : WriteChannel -> String -> () =
+let fileWriteString : WriteChannel -> String -> () =
   lam c. lam s. externalWriteString c s
 
 -- Flush output channel
 external externalWriteFlush ! : WriteChannel -> ()
-let writeFlush = lam c. externalWriteFlush c
+let fileWriteFlush = lam c. externalWriteFlush c
 
 -- Close a write channel
 external externalWriteClose ! : WriteChannel -> ()
-let writeClose = lam c. externalWriteClose c
+let fileWriteClose = lam c. externalWriteClose c
 
 -- Open a file for reading. Read open either return
 -- Note: the external function is shadowed. Use the second signature
 external externalReadOpen ! : String -> (ReadChannel, Bool)
-let readOpen : String -> Option ReadChannel =
+let fileReadOpen : String -> Option ReadChannel =
   lam name. match externalReadOpen name with (rc, true) then Some rc else None ()
 
 -- Reads one line of text. Returns None if end of file.
@@ -56,29 +56,29 @@ let readOpen : String -> Option ReadChannel =
 -- Should support Unicode in the future.
 -- Note: the external function is shadowed. Use the second signature
 external externalReadLine ! : ReadChannel -> (String, Bool)
-let readLine : ReadChannel -> Option String =
+let fileReadLine : ReadChannel -> Option String =
   lam rc. match externalReadLine rc with (s, false) then Some s else None ()
 
 -- Reads everything in a file and returns the content as a string.
 -- Should support Unicode in the future.
 external externalReadString ! : ReadChannel -> String
-let readString = lam c. externalReadString c
+let fileReadString = lam c. externalReadString c
 
 -- Closes a channel that was opened for reading
 external externalReadClose ! : ReadChannel -> ()
-let readClose = lam c. externalReadClose c
+let fileReadClose = lam c. externalReadClose c
 
 -- Standard in read channel
 external externalStdin ! : ReadChannel
-let stdin = externalStdin
+let fileStdin = externalStdin
 
 -- Standard out write channel
 external externalStdout ! : WriteChannel
-let stdout = externalStdout
+let fileStdout = externalStdout
 
 -- Standard error write channel
 external externalStderr ! : WriteChannel
-let stderr = externalStderr
+let fileStderr = externalStderr
 
 mexpr
 
@@ -86,13 +86,13 @@ let filename = "___testfile___.txt" in
 
 -- Test to open a file and write some lines of text
 utest
-  match writeOpen filename with Some wc then
-    let write = writeString wc in
+  match fileWriteOpen filename with Some wc then
+    let write = fileWriteString wc in
     write "Hello\n";
     write "Next string\n";
     write "Final";
-    writeFlush wc; -- Not needed here, just testing the API
-    writeClose wc;
+    fileWriteFlush wc; -- Not needed here, just testing the API
+    fileWriteClose wc;
     ""
   else "Error writing to file."
 with "" in
@@ -102,12 +102,12 @@ utest fileExists filename with true in
 
 -- Test to open and read the file created above (line by line)
 utest
-  match readOpen filename with Some rc then
-    let l1 = match readLine rc with Some s then s else "" in
-    let l2 = match readLine rc with Some s then s else "" in
-    let l3 = match readLine rc with Some s then s else "" in
-    let l4 = match readLine rc with Some s then s else "EOF" in
-    readClose rc;
+  match fileReadOpen filename with Some rc then
+    let l1 = match fileReadLine rc with Some s then s else "" in
+    let l2 = match fileReadLine rc with Some s then s else "" in
+    let l3 = match fileReadLine rc with Some s then s else "" in
+    let l4 = match fileReadLine rc with Some s then s else "EOF" in
+    fileReadClose rc;
     (l1,l2,l3,l4)
   else ("Error reading file","","","")
 with ("Hello", "Next string", "Final", "EOF") in
@@ -117,38 +117,38 @@ utest fileSize filename with 23 in
 
 -- Reads the content of the file using function readString()
 utest
-  match readOpen filename with Some rc then
-    let s = readString rc in
+  match fileReadOpen filename with Some rc then
+    let s = fileReadString rc in
     (s, length s)
   else ("",0)
 with ("Hello\nNext string\nFinal", 23) in
 
 -- Delete the newly created file and check that it does not exist anymore
 utest
-  deleteFile filename;
+  fileDeleteFile filename;
   fileExists filename
 with false in
 
 -- Delete the file, even if it does not exist, and make sure that we do not get an error
-utest deleteFile filename with () in
+utest fileDeleteFile filename with () in
 
 -- Check that we get file size 0 if the file does not exist
 utest fileSize filename with 0 in
 
 -- Test to open a file (for reading) that should not exist
 utest
-  match readOpen "__should_not_exist__.txt" with Some _ then true else false
+  match fileReadOpen "__should_not_exist__.txt" with Some _ then true else false
 with false in
 
 -- Test to open a file (for writing) with an illegal file name
 utest
-  match writeOpen "////" with Some _ then true else false
+  match fileWriteOpen "////" with Some _ then true else false
 with false in
 
 -- Tests that stdin, stdout, and stderr are available.
 -- Uncomment the lines below to test the echo function in interactive mode.
 utest
-  let skip = (stdin, stdout, stderr) in
+  let skip = (fileStdin, fileStdout, fileStderr) in
   --match readLine stdin with Some s in
   --writeString stdout s;
   --writeString stderr s;

--- a/stdlib/ext/file-ext.mc
+++ b/stdlib/ext/file-ext.mc
@@ -115,7 +115,7 @@ with ("Hello", "Next string", "Final", "EOF") in
 -- Check that the file size is correct
 utest fileSize filename with 23 in
 
--- Reads the content of the file using function readString()
+-- Reads the content of the file using function fileReadString()
 utest
   match fileReadOpen filename with Some rc then
     let s = fileReadString rc in
@@ -149,9 +149,9 @@ with false in
 -- Uncomment the lines below to test the echo function in interactive mode.
 utest
   let skip = (fileStdin, fileStdout, fileStderr) in
-  --match readLine stdin with Some s in
-  --writeString stdout s;
-  --writeString stderr s;
+  --match fileReadLine stdin with Some s in
+  --fileWriteString stdout s;
+  --fileWriteString stderr s;
   ()
 with () in
 

--- a/test-files.mk
+++ b/test-files.mk
@@ -104,6 +104,9 @@ run_files_exclude += stdlib/parser-combinators.mc
 run_files_exclude += test/mlang/catchall.mc
 run_files_exclude += test/mlang/mlang.mc
 
+# Programs that we currently cannot interpret/test since externals cannot be tested by interpreter currently.
+external_files_exclude += stdlib/ext/file-ext.mc
+
 # Programs that we should be able to compile/test if we prune utests.
 compile_files_prune =\
 	$(filter-out $(python_files) $(typecheck_files_exclude) $(compile_files_exclude), $(src_files_all))
@@ -116,7 +119,7 @@ compile_files =\
 
 # Programs that we should be able to interpret/test with the interpreter.
 run_files =\
-	$(filter-out $(python_files) $(run_files_exclude) $(typecheck_files_exclude),\
+	$(filter-out $(python_files) $(run_files_exclude) $(typecheck_files_exclude) $(external_files_exclude),\
 		$(src_files_all))
 
 

--- a/test/examples/parser/lrk-calclang.mc
+++ b/test/examples/parser/lrk-calclang.mc
@@ -191,8 +191,8 @@ end
     ""
   ] in
   let fname = "lrk-calclang-gen.mc" in
-  match writeOpen fname with Some wc then
-    writeString wc program;
+  match fileWriteOpen fname with Some wc then
+    fileWriteString wc program;
     printLn (join ["Generated parser as \"", fname, "\""])
   else
     printLn (join ["Could not open the file \"", fname, "\""])

--- a/test/examples/parser/lrk-nonll.mc
+++ b/test/examples/parser/lrk-nonll.mc
@@ -100,8 +100,8 @@ case ResultOk {value = lrtable} then
     ""
   ] in
   let fname = "lrk-nonll-gen.mc" in
-  match writeOpen fname with Some wc then
-    writeString wc program;
+  match fileWriteOpen fname with Some wc then
+    fileWriteString wc program;
     printLn (join ["Generated parser as \"", fname, "\""])
   else
     printLn (join ["Could not open the file \"", fname, "\""])

--- a/test/examples/parser/lrk-parenlang.mc
+++ b/test/examples/parser/lrk-parenlang.mc
@@ -89,8 +89,8 @@ case ResultOk {value = lrtable} then
     ""
   ] in
   let fname = "lrk-parenlang-gen.mc" in
-  match writeOpen fname with Some wc then
-    writeString wc program;
+  match fileWriteOpen fname with Some wc then
+    fileWriteString wc program;
     printLn (join ["Generated parser as \"", fname, "\""])
   else
     printLn (join ["Could not open the file \"", fname, "\""])


### PR DESCRIPTION
This PR fixes external names in `file-ext.mc` since it causes a conflict in Miking CorePPL with `readFile` built-in due to how externals are handled.
There is an intrinsic called readLines so the external 'readLine' shadows that intrinsic and causes the external's name to change in Miking CorePPL.
@br4sco suggested the best option is that before printing, we could go through all externals and add their symbols to the pretty print environment before we start pretty printing (though not sure how to integrate that in the CorePPL compiler currently). A temporary solution Oscar suggested for now is to rename externals to prevent this.