### PR TITLE
Json debug in phase stats

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -41,7 +41,8 @@ lang MCoreCompile =
   MExprConstantFold +
   OCamlTryWithWrap + MCoreCompileLang + PhaseStats +
   SpecializeCompile +
-  PprintTyAnnot + HtmlAnnotator
+  PprintTyAnnot + HtmlAnnotator +
+  MExprToJson
 end
 
 lang TyAnnotFull = MExprPrettyPrint + TyAnnot + HtmlAnnotator + MetaVarTypePrettyPrint
@@ -63,7 +64,7 @@ let insertTunedOrDefaults = lam options : Options. lam ast. lam file.
 
 let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
   use MCoreCompile in
-    let log = mkPhaseLogState options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
 
     -- If option --debug-profile, insert instrumented profiling expressions
     -- in AST
@@ -151,7 +152,7 @@ let compile = lam files. lam options : Options. lam args.
     iter (compileExtendedMLangToOcaml options compileWithUtests) files
   else
     let compileFile = lam file.
-      let log = mkPhaseLogState options.debugPhases in
+      let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
       let ast = parseParseMCoreFile {
         keepUtests = options.runTests,
         pruneExternalUtests = not options.disablePruneExternalUtests,

--- a/src/main/options-config.mc
+++ b/src/main/options-config.mc
@@ -39,6 +39,10 @@ let optionsConfig : ParseConfig Options = [
     "Show debug and profiling information about each pass",
     lam p: ArgPart Options.
       let o: Options = p.options in {o with debugPhases = true}),
+  ([("--debug-phase", " ", "<phase>")],
+    "Print a json representation of the AST after the given pass. Can be given multiple times.",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with debugDumpPhases = setInsert (argToString p) o.debugDumpPhases}),
   ([("--exit-before", "", "")],
     "Exit before evaluation or compilation",
     lam p: ArgPart Options.

--- a/src/main/options-type.mc
+++ b/src/main/options-type.mc
@@ -1,4 +1,5 @@
 include "tuning/tune-options.mc"
+include "set.mc"
 
 -- Options type
 type Options = {
@@ -11,6 +12,7 @@ type Options = {
   debugShallow : Bool,
   debugConstantFold : Bool,
   debugPhases : Bool,
+  debugDumpPhases : Set String,
   exitBefore : Bool,
   disablePruneExternalUtests : Bool,
   disablePruneExternalUtestsWarning : Bool,

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -14,6 +14,7 @@ let optionsDefault : Options = {
   debugShallow = false,
   debugConstantFold = false,
   debugPhases = false,
+  debugDumpPhases = setEmpty cmpString,
   exitBefore = false,
   disablePruneExternalUtests = false,
   disablePruneExternalUtestsWarning = false,

--- a/src/stdlib/extrec/main.mc
+++ b/src/stdlib/extrec/main.mc
@@ -185,7 +185,7 @@ lang BigPipeline = BigIncludeHandler +
     smap_Expr_Expr stripTypes e
 
   sem compileExtendedMLangToOcaml options runner =| filepath ->
-    let log = mkPhaseLogState options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
 
     let p = parseAndHandleIncludes filepath in
     endPhaseStatsProg log "parsing-include-handling" p;

--- a/src/stdlib/json.mc
+++ b/src/stdlib/json.mc
@@ -14,6 +14,7 @@ include "string.mc"
 include "option.mc"
 include "tensor.mc"
 include "math.mc"
+include "common.mc"
 
 type JsonValue
 con JsonObject: Map String JsonValue -> JsonValue
@@ -345,6 +346,87 @@ recursive let json2string: JsonValue -> String = lam value.
     "null"
   end
 end
+
+recursive let _printJson: JsonValue -> () = lam value.
+  switch value
+  case JsonObject properties then
+    print "{";
+    mapFoldWithKey (lam comma. lam k. lam v.
+      (if comma then print "," else ());
+      _printJson (JsonString k);
+      print ":";
+      _printJson v;
+      true
+    ) false properties;
+    print "}"
+  case JsonArray values then
+    print "[";
+    (match values with [h] ++ t then
+      _printJson h;
+      iter (lam v. print ","; _printJson v) t
+     else ());
+    print "]"
+  case JsonString s then
+    let escape: Char -> () = lam c.
+      let cval: Int = char2int c in
+      if eqi cval 8 then
+        print "\\b"
+      else if eqi cval 12 then
+        print "\\f"
+      else if or (lti cval 32) (eqi cval 127) then
+        let tohex: Int -> Char = lam x.
+          if lti x 10 then
+            int2char (addi x (char2int '0'))
+          else
+            int2char (addi (subi x 10) (char2int 'a'))
+        in
+        print ['\\', 'u', '0', '0', tohex (divi cval 16), tohex (modi cval 16)]
+      else
+        switch c
+        case '\"' then print "\\\""
+        case '\\' then print "\\\\"
+        case '/' then print "\\/"
+        case '\n' then print "\\n"
+        case '\r' then print "\\r"
+        case '\t' then print "\\t"
+        case _ then
+          -- NOTE(johnwikman, 2022-05-13): Ignoring the upper bound on JSON
+          -- character size here.
+          print [c]
+        end
+    in
+    print "\"";
+    iter escape s;
+    print "\""
+  case JsonFloat f then
+    if neqf f f then
+      print "{\"__float__\": \"nan\"}"
+    else if eqf f inf then
+      print "{\"__float__\": \"inf\"}"
+    else if eqf f (negf inf) then
+      print "{\"__float__\": \"-inf\"}"
+    else
+      -- NOTE(vsenderov, 2023-09-14): Need to append/prepend 0 to conform to the
+      -- JSON standard.  What is the situation in locales that don't use a dot
+      -- to delimit decimals?
+      let str = float2string f in
+      switch str
+        case _ ++ "." then print str; print "0"
+        case "." ++ _ then print "0"; print str
+        case _ then print str
+      end
+
+  case JsonInt i then
+    print (int2string i)
+  case JsonBool b then
+    print (if b then "true" else "false")
+  case JsonNull () then
+    print "null"
+  end
+end
+let printJsonLn : JsonValue -> () = lam v.
+  _printJson v;
+  printLn ""
 
 recursive let jsonEq: JsonValue -> JsonValue -> Bool =
   lam lhs. lam rhs.

--- a/src/stdlib/mexpr/json-debug.mc
+++ b/src/stdlib/mexpr/json-debug.mc
@@ -10,10 +10,18 @@ include "mlang/ast.mc"
 
 lang AstToJson = Ast + DeclAst
   sem exprToJson : Expr -> JsonValue
+  sem exprToJson =
+  | tm -> error (join ["Missing case in exprToJson ", info2str (infoTm tm)])
   sem typeToJson : Type -> JsonValue
+  sem typeToJson =
+  | ty -> error (join ["Missing case in typeToJson ", info2str (infoTy ty)])
   sem kindToJson : Kind -> JsonValue
   sem patToJson : Pat -> JsonValue
+  sem patToJson =
+  | pat -> error (join ["Missing case in patToJson ", info2str (infoPat pat)])
   sem declToJson : Decl -> JsonValue
+  sem declToJson =
+  | decl -> error (join ["Missing case in declToJson ", info2str (infoDecl decl)])
 
   sem optToNull : Option JsonValue -> JsonValue
   sem optToNull =
@@ -555,6 +563,14 @@ lang ExtToJson = ExtDeclAst + AstToJson
     , ("tyIdent", typeToJson x.tyIdent)
     , ("effect", JsonBool x.effect)
     , ("info", infoToJson x.info)
+    ] )
+end
+
+lang MLangProgramToJson = MLangTopLevel + AstToJson
+  sem progToJson =
+  | x -> JsonObject (mapFromSeq cmpString
+    [ ("decls", JsonArray (map declToJson x.decls))
+    , ("expr", exprToJson x.expr)
     ] )
 end
 

--- a/src/stdlib/mexpr/phase-stats.mc
+++ b/src/stdlib/mexpr/phase-stats.mc
@@ -1,13 +1,16 @@
 include "common.mc"
 include "ast.mc"
 include "basic-types.mc"
+include "either.mc"
+include "json-debug.mc"
 
 include "mlang/ast.mc"
 
-lang PhaseStats = Ast + MLangTopLevel
+lang PhaseStats = Ast + MLangTopLevel + AstToJson + MLangProgramToJson
   type StatState =
     { lastPhaseEnd : Ref Float
     , log : Bool
+    , jsonDumpPhases : Set String
     }
 
   sem endPhaseStatsExpr : StatState -> String -> Expr -> ()
@@ -20,22 +23,35 @@ lang PhaseStats = Ast + MLangTopLevel
 
   sem endPhaseStats : StatState -> String -> Either Expr MLangProgram -> ()
   sem endPhaseStats state phaseLabel = | e ->
-    if state.log then
-      let before = deref state.lastPhaseEnd in
-      let now = wallTimeMs () in
+    let before = deref state.lastPhaseEnd in
+    let now = wallTimeMs () in
+
+    (if state.log then
       printLn phaseLabel;
       printLn (join ["  Phase duration: ", float2string (subf now before), "ms"]);
       let preTraverse = wallTimeMs () in
-      let size = (switch e 
+      let size = (switch e
         case Left expr then countExprNodes 0 expr
         case Right prog then countProgNodes prog
-      end) in 
+      end) in
       let postTraverse = wallTimeMs () in
-      printLn (join ["  Ast size: ", int2string size, " (Traversal takes ~", float2string (subf postTraverse preTraverse), "ms)"]);
-      let newNow = wallTimeMs () in
-      modref state.lastPhaseEnd newNow
-    else ()
+      printLn (join ["  Ast size: ", int2string size, " (Traversal takes ~", float2string (subf postTraverse preTraverse), "ms)"])
+     else ());
 
-  sem mkPhaseLogState : Bool -> StatState
-  sem mkPhaseLogState = | log -> { lastPhaseEnd = ref (wallTimeMs ()), log = log }
+    (if setMem phaseLabel state.jsonDumpPhases then
+      printJsonLn (JsonString (concat "Computing AST after " phaseLabel));
+      let e = eitherEither exprToJson progToJson e in
+      printJsonLn (JsonString (concat "Printing AST after " phaseLabel));
+      printJsonLn e
+     else ());
+
+    let newNow = wallTimeMs () in
+    modref state.lastPhaseEnd newNow
+
+  sem mkPhaseLogState : Set String -> Bool -> StatState
+  sem mkPhaseLogState jsonDumpPhases = | log ->
+    { lastPhaseEnd = ref (wallTimeMs ())
+    , jsonDumpPhases = jsonDumpPhases
+    , log = log
+    }
 end

--- a/src/stdlib/mlang/main.mc
+++ b/src/stdlib/mlang/main.mc
@@ -1,5 +1,5 @@
 -- The main file of the MLang pipline.
--- The semantic function `compileMLangToOcaml`, takes a filepath as input. 
+-- The semantic function `compileMLangToOcaml`, takes a filepath as input.
 -- It then puts the program at this file through the MLang pipeline and then
 -- compiles it to OCaml.
 
@@ -26,54 +26,54 @@ include "mexpr/ast-builder.mc"
 include "mexpr/phase-stats.mc"
 include "mexpr/pprint.mc"
 
-lang MLangPipeline = MLangCompiler + BootParserMLang + 
+lang MLangPipeline = MLangCompiler + BootParserMLang +
                      MLangSym + MLangCompositionCheck +
-                     MExprPrettyPrint + MExprEval + MExprEq + 
+                     MExprPrettyPrint + MExprEval + MExprEq +
                      MLangConstTransformer + MLangIncludeHandler +
                      PhaseStats + LanguageComposer + PostProcess
 
   sem myEval : Expr -> Expr
   sem myEval =| e ->
-    eval (evalCtxEmpty ()) e 
+    eval (evalCtxEmpty ()) e
 
   -- TODO: re-add 'eval' through mlang-pipelineO
 
   -- TODO: add node count for MLang programs to phase-stats
   sem compileMLangToOcaml options runner =| filepath ->
-    let log = mkPhaseLogState options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
 
-    let p = parseAndHandleIncludes filepath in 
+    let p = parseAndHandleIncludes filepath in
     endPhaseStatsProg log "parsing-include-handling" p;
 
     let p = constTransformProgram builtin p in
     endPhaseStatsProg log "const-transformation" p;
 
-    let p = composeProgram p in 
+    let p = composeProgram p in
     endPhaseStatsProg log "language-inclusion-generation" p;
 
-    match symbolizeMLang symEnvDefault p with (_, p) in 
+    match symbolizeMLang symEnvDefault p with (_, p) in
     endPhaseStatsProg log "symbolization" p;
 
-    let checkOptions = {defaultCompositionCheckOptions with 
-      disableStrictSumExtension = options.disableStrictSumExtension} in 
-    match result.consume (checkCompositionWithOptions checkOptions p) with (_, res) in 
+    let checkOptions = {defaultCompositionCheckOptions with
+      disableStrictSumExtension = options.disableStrictSumExtension} in
+    match result.consume (checkCompositionWithOptions checkOptions p) with (_, res) in
     endPhaseStatsExpr log "composition-check" uunit_;
 
-    -- let p = typeCheckProgram p in 
+    -- let p = typeCheckProgram p in
     -- endPhaseStatsExpr log "mlang-type-checking" uunit_;
 
-    switch res 
-      case Left errs then 
+    switch res
+      case Left errs then
         iter raiseError errs ;
         never
       case Right env then
-        let ctx = _emptyCompilationContext env in 
-        let res = result.consume (compile ctx p) in 
-        match res with (_, rhs) in 
+        let ctx = _emptyCompilationContext env in
+        let res = result.consume (compile ctx p) in
+        match res with (_, rhs) in
         match rhs with Right expr in
         endPhaseStatsExpr log "mlang-mexpr-lower" expr;
 
-        let expr = postprocess env.semSymMap expr in 
+        let expr = postprocess env.semSymMap expr in
         endPhaseStatsExpr log "postprocess" expr;
 
         -- printLn (expr2str expr);


### PR DESCRIPTION
This is based on #738 until it is merged.

This PR adds a new flag `--debug-phase <phase>` that uses `mexpr/json-debug.mc` to dump the AST at a named phase, which is specified with `endPhaseStats` in the code. The option can be given multiple times to print multiple phases. No spell-checking is done, since we don't have a data structure that stores the existing phases, so you'd typically use this by running with `--debug-phases` first (note the plural) then with the appropriate `--debug-phase` (or looking in the code of course).

I also add a new function in `json.mc` for printing the json representation directly, because building the interim string was *very* prohibitive. I suppose this is something of a known thing performance-wise, but it might also be relevant for `pprint.mc` when it's used during compilation, maybe we could make compilation faster if we could change this.