### PR TITLE
fix: Lexer type error

### DIFF
--- a/stdlib/parser/lexer.mc
+++ b/stdlib/parser/lexer.mc
@@ -99,7 +99,7 @@ lang ErrorTokenParser = TokenParser
   | ErrorTok x -> x.info
 
   sem tokToStr =
-  | ErrorTok x -> join ["<Lexing error: '", x.char, "'"]
+  | ErrorTok x -> join ["<Lexing error: '", [x.char], "'"]
 
   sem tokToRepr =
   | ErrorTok _ -> ErrorRepr ()


### PR DESCRIPTION
This fixes a type error:

```
Compile error: 
* Expected an expression of type: [Char]
*    Found an expression of type: Char
* (errors: types [Char] != Char)
* When type checking the expression
[0m  | ErrorTok x -> join ["<Lexing error: '", [31mx.char[0m[0m, "'"]
```