### PR TITLE
fix: Add missing lang for type in PEvalApply

### DIFF
--- a/stdlib/peval/peval.mc
+++ b/stdlib/peval/peval.mc
@@ -119,7 +119,7 @@ lang PEval = PEvalCtx + Eval + PrettyPrint
   sem pevalReadbackH ctx =| t -> smapAccumL_Expr_Expr pevalReadbackH ctx t
 end
 
-lang PEvalApply = Ast
+lang PEvalApply = Ast + PEvalCtx
   sem pevalApply : Info -> PEvalCtx -> (Expr -> Expr) -> (Expr, Expr) -> Expr
 end
 


### PR DESCRIPTION
```
* Encountered an unknown type constructor: PEvalCtx
* When checking the annotation
  sem pevalApply : Info -> PEvalCtx -> (Expr -> Expr) -> (Expr, Expr) -> Expr
```

![CleanShot 2024-12-05 at 15 46 16@2x](https://github.com/user-attachments/assets/786d3449-ac72-4a1b-8d23-f5551a79364d)

