### PR TITLE
feat: Add running single utest

### DIFF
--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -228,7 +228,7 @@ let compileAccelerated =
   let ast = demoteParallel ast in
 
   -- Generate utests or strip them from the program.
-  let ast = generateUtest options.runTests ast in
+  let ast = generateUtest options.runTests options.runSpecificTest ast in
 
   let ast = lowerAll ast in
   let ast = typeAnnot ast in

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -98,7 +98,7 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
 
     -- If option --test, then generate utest runner calls. Otherwise strip away
     -- all utest nodes from the AST.
-    let ast = generateUtest options.runTests ast in
+    let ast = generateUtest options.runTests options.runSpecificTest ast in
     endPhaseStats log "generate-utest" ast;
 
     let ast =

--- a/src/main/eval.mc
+++ b/src/main/eval.mc
@@ -77,7 +77,7 @@ let eval = lam files. lam options : Options. lam args.
 
     -- If option --test, then generate utest runner calls. Otherwise strip away
     -- all utest nodes from the AST.
-    let ast = generateUtest options.runTests ast in
+    let ast = generateUtest options.runTests options.runSpecificTest ast in
     if options.exitBefore then exit 0
     else
       eval (evalCtxEmpty ()) (updateArgv args ast); ()

--- a/src/main/options-config.mc
+++ b/src/main/options-config.mc
@@ -56,6 +56,10 @@ let optionsConfig : ParseConfig Options = [
     "Generate utest code",
     lam p: ArgPart Options.
       let o: Options = p.options in {o with runTests = true}),
+  ([("--specific-test", " ", "<location>")],
+    "Specifically test this utest",
+    lam p: ArgPart Options.
+      let o: Options = p.options in {o with runTests = true, runSpecificTest = Some (argToString p)}),
   ([("--runtime-checks", "", "")],
     "Enables runtime checks",
     lam p: ArgPart Options.

--- a/src/main/options-type.mc
+++ b/src/main/options-type.mc
@@ -15,6 +15,7 @@ type Options = {
   disablePruneExternalUtests : Bool,
   disablePruneExternalUtestsWarning : Bool,
   runTests : Bool,
+  runSpecificTest : Option String,
   runtimeChecks : Bool,
   disableOptimizations : Bool,
   enableConstantFold : Bool,

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -18,6 +18,7 @@ let optionsDefault : Options = {
   disablePruneExternalUtests = false,
   disablePruneExternalUtestsWarning = false,
   runTests = false,
+  runSpecificTest = None (),
   runtimeChecks = false,
   disableOptimizations = false,
   enableConstantFold = false,

--- a/stdlib/mexpr/utest-generate.mc
+++ b/stdlib/mexpr/utest-generate.mc
@@ -242,7 +242,10 @@ lang UtestBase =
 
     -- Maps the identifier of a variant type to an inner map, which in turn
     -- maps constructor names to their types.
-    variants : Map Name (Map Name Type)
+    variants : Map Name (Map Name Type),
+
+    -- Only include utests on these locations
+    specificTest : Option String
   }
 
   sem utestEnvEmpty : () -> UtestEnv
@@ -251,7 +254,8 @@ lang UtestBase =
     let baseTypes = [_boolTy, _intTy, _charTy, _floatTy] in
     { eq = mapEmpty cmpType, eqDef = setOfSeq cmpType baseTypes
     , pprint = mapEmpty cmpType, pprintDef = setOfSeq cmpType baseTypes
-    , variants = mapEmpty nameCmp }
+    , variants = mapEmpty nameCmp
+    , specificTest = None () }
 
   sem lookupVariant : Name -> UtestEnv -> Info -> Map Name Type
   sem lookupVariant id env =
@@ -932,6 +936,20 @@ lang MExprUtestGenerate =
   sem replaceUtests : UtestEnv -> Expr -> (UtestEnv, Expr)
   sem replaceUtests env =
   | TmUtest t ->
+    let earlyExit = match env.specificTest with Some specificTest then
+      let location = info2str t.info in
+      if eqString location specificTest then
+        None ()
+      else
+        Some ((env, t.next))
+    else
+      None ()
+    in
+
+    match earlyExit with Some ((env, next))
+      then replaceUtests env next
+    else
+
     let info = _stringLit (info2str t.info) in
     let usingStr =
       _stringLit
@@ -1063,11 +1081,14 @@ lang MExprUtestGenerate =
   | TmUtest t -> stripUtests t.next
   | t -> smap_Expr_Expr stripUtests t
 
-  sem generateUtest : Bool -> Expr -> Expr
-  sem generateUtest testsEnabled =
+  sem generateUtest : Bool -> Option String -> Expr -> Expr
+  sem generateUtest testsEnabled specificTest =
   | ast ->
     if testsEnabled then
-      match replaceUtests (utestEnvEmpty ()) ast with (env, ast) in
+      let utestEnv = {utestEnvEmpty () with
+        specificTest = specificTest
+      } in
+      match replaceUtests utestEnv ast with (env, ast) in
       let ast = insertUtestTail ast in
       let ast = mergeWithHeader ast (loadUtestRuntime ()) in
       eliminateDuplicateCode ast


### PR DESCRIPTION
By using the option `--specific-test <location>` where `location` is a pretty printed `Info`, you specify to the compiler that you only want that specific utest to be included. This is used in the LSP "code lens" feature, allowing the user to press a "Run test" on a single utest.