### PR TITLE
Minor utils for producing more reasonably typed asts with ast-builder

### DIFF
--- a/src/stdlib/mexpr/ast-builder.mc
+++ b/src/stdlib/mexpr/ast-builder.mc
@@ -594,6 +594,18 @@ let record_ = tmRecord (NoInfo ())
 
 let urecord_ = record_ tyunknown_
 
+let autoty_record_ = lam bindings.
+  use MExprAst in
+  let bindings = mapFromSeq cmpSID (map (lam x. (stringToSid x.0, x.1)) bindings) in
+  TmRecord {
+    bindings = bindings,
+    ty = TyRecord {
+      fields = mapMap tyTm bindings,
+      info = NoInfo ()
+    },
+    info = NoInfo ()
+  }
+
 let tmTuple = use MExprAst in
   lam info : Info. lam ty : Type. lam tms : [Expr].
   tmRecord info ty (mapi (lam i. lam t. (int2string i, t)) tms)
@@ -658,7 +670,7 @@ let nrecordproj_ = use MExprAst in
   -- It is fine to use any variable name here. It doesn't matter if it
   -- overwrites a previous binding, since that binding will never be used in
   -- the then clause in any case.
-  match_ r (prec_ [(key,npvar_ name)]) (nvar_ name) never_
+  match_ r (withTypePat (tyTm r) (prec_ [(key,npvar_ name)])) (nvar_ name) never_
 
 let recordproj_ = use MExprAst in
   lam key. lam r.

--- a/src/stdlib/mexpr/shallow-patterns.mc
+++ b/src/stdlib/mexpr/shallow-patterns.mc
@@ -520,7 +520,7 @@ lang ShallowRecord = ShallowBase + RecordPat + RecordTypeAst + PrettyPrint
       , ty = x.ty
       , info = x.info
       } in
-    match_ (nvar_ scrutinee) pat t never_
+    withInfo x.info (match_ (nvar_ scrutinee) pat t never_)
 
   sem shallowIsInfallible =
   | SPatRecord _ -> true
@@ -654,10 +654,6 @@ lang ShallowSeq = ShallowBase + SeqTotPat + SeqEdgePat
         let expr = switch pair
           case (0, 0) then nvar_ scrutinee
           case (n, 0) then
-            -- TODO(vipa, 2024-07-19): tupleproj_ (and ast-builder in
-            -- general) inserts nodes without ty and info fields,
-            -- which is particularly an issue when what's inserted is
-            -- related to records
             tupleproj_ 1
               (withType
                 (tytuple_ [x.ty, x.ty])


### PR DESCRIPTION
This PR makes the shallow pattern transformation slightly better at attaching enough type annotations for the OCaml backend to be satisfied. This change is enough to make TreePPL build without type-annot at all, but I think more is needed to achieve the same in the main compiler (`utest` generation most likely).

More generally relevant changes:
- New `ast-builder` function: `autoty_record_` works like `urecord_` except it constructs a type based on the fields given and the `ty` fields of the corresponding values.
- `nrecordproj_` and other functions built on it use the type of the value being projected from for the `ty` field of the constructed record pattern.

Speaking more broadly, I don't know if we want to make `ast-builder` functions as good as possible at putting reasonable values in fields. It's a bit more work that is sometimes unnecessary (e.g., if code is constructed and inserted before type-checking) and creates some coupling with the corresponding compiler passes. It's quite convenient though, and probably reduces the risk of inserting code with poor or no attached fields. The current change attaches a `ty` field in a case we know *will* be needed in the backend but not in other places.