### PR TITLE
Proper include logic

### DIFF
--- a/src/stdlib/fileutils.mc
+++ b/src/stdlib/fileutils.mc
@@ -4,46 +4,7 @@ include "string.mc"
 include "sys.mc"
 include "common.mc"
 
-let parseMCoreLibs : String -> Map String String = lam str.
-  match str with "" then mapEmpty cmpString else 
-  let libs = strSplit ":" str in 
-  let pairs = map (lam lib. strSplit "=" lib) libs in 
-
-  let isValid = lam pair. 
-    if neqi (length pair) 2 then 
-      error (join [
-        "Invalid $MCORE_LIBS environment: '",
-        str,
-        "'!"
-      ])
-    else  ()
-  in 
-  iter isValid pairs ;
-
-  let pairs = map (lam p. (head p, get p 1)) pairs in 
-
-  mapFromSeq cmpString pairs
-
-utest parseMCoreLibs "" with mapEmpty cmpString using mapEq eqString
-utest parseMCoreLibs "stdlib=a/b/c" 
-  with mapFromSeq cmpString [("stdlib", "a/b/c")] 
-  using mapEq eqString
-utest parseMCoreLibs "stdlib=a/b/c:foo=bar" 
-  with mapFromSeq cmpString [("stdlib", "a/b/c"), ("foo", "bar")] 
-  using mapEq eqString
-
--- TODO(voorberg, 27-05-2024): Add a sensible default for $MCORE_LIBS to 
---                             fall back on. 
-let parseMCoreLibsEnv : () -> Map String String = lam.
-  match sysGetEnv "MCORE_LIBS" with Some s then
-    parseMCoreLibs s
-  else
-    error "Environment variable $MCORE_LIBS is not set!"
-
-let addCWDtoLibs : Map String String -> Map String String = lam libs. 
-  mapInsert "cwd" (sysGetCwd ()) libs
-
-let filepathConcat : String -> String -> String = lam dir. lam path. 
+let filepathConcat : String -> String -> String = lam dir. lam path.
   if eqc '/' (last dir) then
     concat dir path
   else
@@ -51,15 +12,29 @@ let filepathConcat : String -> String -> String = lam dir. lam path.
 utest filepathConcat "a/b/c" "foo.mc" with "a/b/c/foo.mc"
 utest filepathConcat "a/b/c/" "foo.mc" with "a/b/c/foo.mc"
 
-let eraseFile : String -> String = lam filepath. 
+let dirname : String -> String = lam filepath.
   match findiLast (eqc '/') filepath with Some i then
     subsequence filepath 0 i
-  else 
+  else
     ""
 
-utest eraseFile "foo.mc" with "" 
-utest eraseFile "a/b/c/foo.mc" with "a/b/c"
-utest eraseFile "a/b/c/../foo.mc" with "a/b/c/.."
+utest dirname "foo.mc" with ""
+utest dirname "a/b/c/foo.mc" with "a/b/c"
+utest dirname "a/b/c/../foo.mc" with "a/b/c/.."
+
+let fileutilsNormalize : String -> String = lam path.
+  recursive let recur = lam zipper : ([String], [String]).
+    switch zipper
+    case (segments, []) then strJoin "/" segments
+    case ([], [""] ++ after) then recur ([""], after)
+    case (before, ["." | ""] ++ after) then recur (before, after)
+    case (before ++ [_], [".."] ++ after) then recur (before, after)
+    case (before, [here] ++ after) then recur (snoc before here, after)
+    end in
+  let path = match path with "/" ++ _
+    then path
+    else concat (sysGetCwd ()) (cons '/' path) in
+  recur ([], strSplit "/" path)
 
 -- type Filepath = [String]
 
@@ -70,7 +45,7 @@ utest eraseFile "a/b/c/../foo.mc" with "a/b/c/.."
 -- utest filepath2string ["a", "b", "foo.mc"] with "/a/b/foo.mc"
 
 -- mexpr
--- let m = parseMCoreLibsEnv () in 
--- let m = addCWDtoLibs m in 
--- let m = mapToSeq m in 
+-- let m = parseMCoreLibsEnv () in
+-- let m = addCWDtoLibs m in
+-- let m = mapToSeq m in
 -- iter (lam p. match p with (_, y) in printLn y) m

--- a/src/stdlib/mlang/include-handler.mc
+++ b/src/stdlib/mlang/include-handler.mc
@@ -3,18 +3,18 @@
 -- The semantic function `parseAndHandleIncludes` parses a MLang file
 -- at a specific filepath using the boot-parser. It then traverses it looks
 -- for any `DeclInclude`s in that program. When a `DeclInclude`, we first
--- normalize the filepath. Then based on the normalized file path, one of 
+-- normalize the filepath. Then based on the normalized file path, one of
 -- two things happen:
 -- (1) If this filepath has not yet been included, then we parse the program
 --     at this path and replace the DeclInclude with the top-level declarations
 --     in the included program. In this case, we also transitively include
 --     any files included by the included file in the same way.
 -- (2) If this filepath has already been included, then we get rid of it without
---     adding any declarations. 
--- 
+--     adding any declarations.
+--
 -- Note that this is a rather crude way of handling includes that can lead
 -- undesirable behavior in which the order of includes can cause significant
--- changes to the behaviour of the program. 
+-- changes to the behaviour of the program.
 include "ast.mc"
 include "boot-parser.mc"
 include "pprint.mc"
@@ -23,29 +23,30 @@ include "error.mc"
 include "stdlib.mc"
 include "set.mc"
 include "fileutils.mc"
+include "stdlib.mc"
 include "sys.mc"
 
 lang MLangIncludeHandler = MLangAst + BootParserMLang
   sem parseAndHandleIncludes : String -> MLangProgram
-  sem parseAndHandleIncludes =| path -> 
-    let dir = filepathConcat (sysGetCwd ()) (eraseFile path) in 
-    let libs = addCWDtoLibs (parseMCoreLibsEnv ()) in
-    let included = ref (setEmpty cmpString) in 
+  sem parseAndHandleIncludes =| path ->
+    let dir = filepathConcat (sysGetCwd ()) (dirname path) in
+    let libs = addCWDtoLibs stdlibMCoreLibs in
+    let included = ref (setEmpty cmpString) in
     handleIncludesFile included dir libs path
 
-  sem handleIncludesProgram : Ref (Set String) -> String -> Map String String -> MLangProgram -> MLangProgram 
+  sem handleIncludesProgram : Ref (Set String) -> String -> Map String String -> MLangProgram -> MLangProgram
   sem handleIncludesProgram included dir libs =| prog ->
-    let f = lam decls. lam decl. 
-      concat decls (flattenIncludes included dir libs decl) in 
+    let f = lam decls. lam decl.
+      concat decls (flattenIncludes included dir libs decl) in
     {prog with decls = foldl f [] prog.decls}
 
   sem handleIncludesFile : Ref (Set String) -> String -> Map String String -> String -> MLangProgram
   sem handleIncludesFile included dir libs =| path ->
-    let s = deref included in 
+    let s = deref included in
 
-    if setMem path s then 
+    if setMem path s then
       {decls = [], expr = uunit_}
-    else 
+    else
       match result.consume (parseMLangFile path) with (_, errOrProg) in
       switch errOrProg
         case Left err then error (join [
@@ -53,7 +54,7 @@ lang MLangIncludeHandler = MLangAst + BootParserMLang
           path,
           "' could not be parsed!"
         ])
-        case Right prog then 
+        case Right prog then
           modref included (setInsert path s);
           handleIncludesProgram included dir libs prog
       end
@@ -61,28 +62,28 @@ lang MLangIncludeHandler = MLangAst + BootParserMLang
   sem flattenIncludes : Ref (Set String) -> String -> Map String String -> Decl -> [Decl]
   sem flattenIncludes included dir libs =
   | DeclInclude {path = path, info = info} ->
-    let path = findPath dir libs info path in 
-    let prog = handleIncludesFile included (eraseFile path) libs path in 
+    let path = findPath dir libs info path in
+    let prog = handleIncludesFile included (dirname path) libs path in
     prog.decls
   | other -> [other]
 
   sem findPath : String -> Map String String -> Info -> String -> String
   sem findPath dir libs info =| path ->
-    let libs = mapInsert "current" dir libs in 
-    let prefixes = mapValues libs in 
-    let paths = map (lam prefix. filepathConcat prefix path) prefixes in 
+    let libs = mapInsert "current" dir libs in
+    let prefixes = mapValues libs in
+    let paths = map (lam prefix. filepathConcat prefix path) prefixes in
 
-    let existingFiles = filter sysFileExists paths in 
-    let existingFilesAsSet = setOfSeq cmpString existingFiles in 
+    let existingFiles = filter sysFileExists paths in
+    let existingFilesAsSet = setOfSeq cmpString existingFiles in
 
     switch (setSize existingFilesAsSet)
-      case 0 then 
+      case 0 then
         errorSingle [info] "File not found!"
-      case 1 then 
+      case 1 then
         head (setToSeq existingFilesAsSet)
-      case _ then 
+      case _ then
         -- TODO(voorberg, 09/05/2024): This happens because we dont properly
-        -- deal with libraries yet. The code does not yet realise that 
+        -- deal with libraries yet. The code does not yet realise that
         -- some absolute path is equal to some relative path.
         warnSingle [info] "Multiple files found" ;
         head (setToSeq existingFilesAsSet)

--- a/src/stdlib/stdlib.mc
+++ b/src/stdlib/stdlib.mc
@@ -3,6 +3,38 @@
 
 include "sys.mc"
 include "option.mc"
+include "map.mc"
+include "error.mc"
+include "fileutils.mc"
+
+-- Helpers
+
+let parseMCoreLibs : String -> Map String String = lam str.
+  match str with "" then mapEmpty cmpString else
+  let processBinding = lam acc. lam str.
+    match strSplit "=" str with [lib, path] ++ paths
+    then mapInsert lib (strJoin "=" (cons path paths)) acc
+    else
+      warnSingle [] (join
+        [ "Invalid element of MCORE_LIBS: \""
+        , str
+        , "\"\nShould be a lib=path/to/lib pair"]);
+      acc in
+  foldl processBinding (mapEmpty cmpString) (strSplit ":" str)
+
+utest parseMCoreLibs "" with mapEmpty cmpString using mapEq eqString
+utest parseMCoreLibs "stdlib=a/b/c"
+  with mapFromSeq cmpString [("stdlib", "a/b/c")]
+  using mapEq eqString
+utest parseMCoreLibs "stdlib=a/b/c:foo=bar"
+  with mapFromSeq cmpString [("stdlib", "a/b/c"), ("foo", "bar")]
+  using mapEq eqString
+
+let addCWDtoLibs : Map String String -> Map String String = lam libs.
+  mapInsert "cwd" (sysGetCwd ()) libs
+
+-- Side-effecting computation of the stdlib location as well as the
+-- location of other libraries
 
 let stdlibCwd = join [sysGetCwd (), "/src/stdlib"]
 
@@ -11,18 +43,47 @@ let stdlibLocUnix =
     join [path, "/.local/lib/mcore/stdlib"]
   else stdlibCwd
 
-let stdlibLoc =
-  optionGetOrElse
-    (lam.
-      -- NOTE(dlunde,2022-05-04) The boot parser also checks if the OS type is
-      -- "Unix" here
-      if sysFileExists stdlibLocUnix then stdlibLocUnix else stdlibCwd)
-    (optionBind
-       (sysGetEnv "MCORE_LIBS")
-       (lam path.
-         let libs = strSplit ":" path in
-         findMap
-           (lam str.
-             match splitAt str 7 with ("stdlib=", loc)
-             then Some loc else None ())
-           libs))
+let stdlibMCoreLibs =
+  let map = optionMapOr
+    (mapEmpty cmpString)
+    parseMCoreLibs
+    (sysGetEnv "MCORE_LIBS") in
+  mapInsertWith (lam prev. lam. prev)
+    "stdlib"
+    (if sysFileExists stdlibLocUnix then stdlibLocUnix else stdlibCwd)
+    map
+
+let stdlibLoc = mapFindExn "stdlib" stdlibMCoreLibs
+
+
+-- Resolves a path specified in a file in directory
+-- `relativeTo`. Applies path normalization. The `doError` function
+-- will be called with an error message if an error occurs. Follows
+-- these rules:
+-- - If path has the form "lib::path/to/file" and MCORE_LIBS contains
+--   "lib=path/to/lib", return "path/to/lib/path/to/file".
+-- - If path has the form "./path/to/file" or "../path/to/file",
+--   return path relative to the `relativeTo` path.
+-- - If path has the form "path/to/file", return a path relative to
+--   the given directory or in the stdlib. Checks for ambiguity,
+--   errors if both exist. Priority: existing file, then local file.
+let stdlibResolveFileOr : (String -> String) -> String -> String -> String = lam doError. lam relativeTo. lam path.
+  match strSplit "::" path with [lib, path] ++ paths then
+    -- Explicit library use
+    match mapLookup lib stdlibMCoreLibs with Some libPath
+    then fileutilsNormalize (filepathConcat libPath (strJoin "::" (cons path paths)))
+    else doError (join ["Library ", lib, " not found in MCORE_LIBS"])
+  else
+    -- Non-explicit
+    let localPath = fileutilsNormalize (filepathConcat relativeTo path) in
+    -- Check if explicitly local
+    match path with "./" ++ _ | "../" ++ _ then localPath else
+    -- Implicit, check if in stdlib
+    let stdlibPath = fileutilsNormalize (filepathConcat stdlibLoc path) in
+    -- Check if both resolve to the same path, return it if so
+    if eqString localPath stdlibPath then stdlibPath else
+    switch (sysFileExists stdlibPath, sysFileExists localPath)
+    case (true, false) then stdlibPath
+    case (true, true) then doError (join ["Path ", path, " is ambiguous, exists both locally and in stdlib"])
+    case _ then localPath
+    end


### PR DESCRIPTION
This PR adds logic to resolve includes in the same way as done in `boot`, as well as some changes to some utilities for working with filepaths. Note that the `include` handling for the new mlang-pipeline (which does not quite follow what `boot` does) is unchanged, I have merely ensured that the functions it calls that were changed are up-to-date.