### PR TITLE
Insert more info fields in mlang transformation in boot

### DIFF
--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -149,7 +149,7 @@ type alias_data =
 
 type ty_in_lang = (alias_data, syn_data) Either.t
 
-type lang_data = {values: sem_data Record.t; types: ty_in_lang Record.t}
+type lang_data = {values: sem_data Record.t; types: ty_in_lang Record.t; fi: info}
 
 (* let spprint_inter_data {info; cases; _} : ustring = *)
 (*   List.map *)
@@ -341,7 +341,10 @@ let merge_langs : info -> lang_data -> lang_data -> lang_data =
   ; types=
       Record.union
         (fun name a b -> Some (merge_types_in_lang fi name a b))
-        a.types b.types }
+        a.types b.types
+  ; fi=
+      a.fi
+  }
 
 (* === Functions that facilitate renaming types and values, and thus merging them after the fact === *)
 
@@ -1016,7 +1019,7 @@ let wrap_sems : mlang_env -> ustring -> lang_data -> tm -> tm =
   if Record.is_empty lang.values then tm
   else
     TmRecLets
-      ( NoInfo
+      ( lang.fi
       , Record.to_seq lang.values |> Seq.map sem_to_binding |> List.of_seq
       , tm )
 
@@ -1063,7 +1066,7 @@ let translate_lang (env : mlang_env) (Lang (fi, name, includes, renames, decls))
     List.to_seq includes |> Seq.map fetch_include |> Record.of_seq
   in
   let includes = List.fold_left apply_rename includes renames in
-  let lang = {values= Record.empty; types= Record.empty} in
+  let lang = {values= Record.empty; types= Record.empty; fi= fi} in
   let lang =
     Record.to_seq includes |> Seq.map snd
     |> Seq.fold_left (merge_langs fi) lang


### PR DESCRIPTION
Minor change that inserts more info fields in the mlang transformation in `boot`.