### PR TITLE
Add autoty_tuple_, mirroring autoty_record_

### DIFF
--- a/src/stdlib/mexpr/ast-builder.mc
+++ b/src/stdlib/mexpr/ast-builder.mc
@@ -623,6 +623,8 @@ let tuple_ = tmTuple (NoInfo ())
 
 let utuple_ = tuple_ tyunknown_
 
+let autoty_tuple_ = lam tms. autoty_record_ (mapi (lam i. lam t. (int2string i, t)) tms)
+
 let urecord_empty = uunit_
 let record_empty = unit_
 


### PR DESCRIPTION
Shallow wrapper around `autoty_record_` from #888.