### PR TITLE
Move typeAnnot out of compileMCore

### DIFF
--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -56,6 +56,7 @@ lang PMExprCompile =
   BootParser +
   MExprSym + MExprTypeCheck + MExprRemoveTypeAscription +
   MExprLowerNestedPatterns + MExprUtestGenerate + PMExprAst + MExprANF +
+  MExprTypeAnnot +
   PMExprDemote + PMExprRewrite + PMExprTailRecursion + PMExprParallelPattern +
   MExprLambdaLift + MExprCSE + MExprDemoteRecursive +
   PMExprExtractAccelerate + PMExprClassify + PMExprCExternals +

--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -35,7 +35,7 @@ lang MCoreCompile =
   MExprHoles +
   MExprCmp +
   MExprSym + MExprRemoveTypeAscription + MExprTypeCheck +
-  MExprUtestGenerate + MExprRuntimeCheck + MExprProfileInstrument +
+  MExprUtestGenerate + MExprRuntimeCheck + MExprProfileInstrument + MExprTypeAnnot +
   MExprPrettyPrint +
   MExprLowerNestedPatterns +
   MExprConstantFold +
@@ -124,9 +124,13 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
         , generalOptimizations = not options.disableJsGeneralOptimizations
         , tailCallOptimizations = not options.disableJsTCO
         } ast sourcePath
-      else compileMCore ast
-        { debugTypeAnnot = lam ast. if options.debugTypeAnnot then printLn (expr2str ast) else ()
-        , debugGenerate = lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ()
+      else
+        let ast = typeAnnot ast in
+        endPhaseStatsExpr log "type-annot" ast;
+        -- If option --debug-type-annot, then pretty-print the AST
+        (if options.debugTypeAnnot then printLn (expr2str ast) else ());
+        compileMCore ast
+        { debugGenerate = lam ocamlProg. if options.debugGenerate then printLn ocamlProg else ()
         , exitBefore = lam. if options.exitBefore then exit 0 else ()
         , postprocessOcamlTops = lam tops. if options.runtimeChecks then wrapInTryWith tops else tops
         , compileOcaml = ocamlCompile options sourcePath

--- a/src/stdlib/ocaml/mcore.mc
+++ b/src/stdlib/ocaml/mcore.mc
@@ -8,8 +8,7 @@ include "ocaml/pprint.mc"
 include "sys.mc"
 
 type Hooks a =
-  { debugTypeAnnot : use Ast in Expr -> ()
-  , debugGenerate : String -> ()
+  { debugGenerate : String -> ()
   , exitBefore : () -> ()
   , postprocessOcamlTops : [use OCamlTopAst in Top] -> [use OCamlTopAst in Top]
   , compileOcaml : [String] -> [String] -> String -> a
@@ -17,15 +16,14 @@ type Hooks a =
 
 let mkEmptyHooks : all a. ([String] -> [String] -> String -> a) -> Hooks a =
   lam compileOcaml.
-  { debugTypeAnnot = lam. ()
-  , debugGenerate = lam. ()
+  { debugGenerate = lam. ()
   , exitBefore = lam. ()
   , postprocessOcamlTops = lam tops. tops
   , compileOcaml = compileOcaml
   }
 
 lang MCoreCompileLang =
-  MExprTypeAnnot + MExprRemoveTypeAscription + MExprTypeLift +
+  MExprRemoveTypeAscription + MExprTypeLift +
   OCamlTypeDeclGenerate + OCamlGenerate + OCamlGenerateExternalNaive
 
   sem collectLibraries : Map Name [ExternalImpl] -> Set String -> ([String], [String])
@@ -46,11 +44,7 @@ lang MCoreCompileLang =
   sem compileMCore : all a. Expr -> Hooks a -> a
   sem compileMCore ast =
   | hooks ->
-    let ast = typeAnnot ast in
     let ast = removeTypeAscription ast in
-
-    -- If option --debug-type-annot, then pretty-print the AST
-    hooks.debugTypeAnnot ast;
 
     match typeLift ast with (env, ast) in
     match generateTypeDecls env with (env, typeTops) in

--- a/src/stdlib/tuning/tune.mc
+++ b/src/stdlib/tuning/tune.mc
@@ -16,6 +16,7 @@ include "tune-stats.mc"
 include "mexpr/shallow-patterns.mc"
 include "ocaml/mcore.mc"
 include "ocaml/pprint.mc"
+include "mexpr/type-annot.mc"
 
 -- Performs tuning of a context expanded program with holes.
 
@@ -537,7 +538,8 @@ lang TestLang =
   MExprTune + GraphColoring + MExprHoleCFA + DependencyAnalysis +
   NestedMeasuringPoints + ContextExpand + Instrumentation +
   BootParser + MExprSym + MExprPrettyPrint + MExprEval + MExprTypeCheck +
-  MExprLowerNestedPatterns + MCoreCompileLang
+  MExprLowerNestedPatterns + MCoreCompileLang +
+  MExprTypeAnnot
 end
 
 mexpr
@@ -597,6 +599,7 @@ let test : Bool -> Bool -> TuneOptions -> Expr -> (LookupTable, Option SearchSta
       let opt = {optimize = true, libraries = libs, cLibraries = clibs} in
       ocamlCompileWithConfig opt ocamlProg
     in
+    let ast = typeAnnot ast in
     let cunit: CompileResult = compileMCore ast (mkEmptyHooks compileOCaml) in
 
     -- Run the program


### PR DESCRIPTION
This PR makes it possible to use `compileMCore` without running `typeAnnot` by expecting the caller to already have a sufficiently well-type-tagged AST. I've added a corresponding call to `typeAnnot` in places I either know it's necessary or where I wasn't sure if it was.