### PR TITLE
Make builtin types symbolized from the start

### DIFF
--- a/src/stdlib/mexpr/builtin.mc
+++ b/src/stdlib/mexpr/builtin.mc
@@ -1,5 +1,4 @@
 include "ast.mc"
-include "const-types.mc"
 include "map.mc"
 include "set.mc"
 include "stringid.mc"
@@ -148,3 +147,8 @@ let builtinTypes : [(String, [String])] =
   , ("Ref", ["a"])
   , ("BootParseTree", [])
   ]
+let builtinTypes : [(String, Name, [String])] =
+  map (lam pair. (pair.0, nameSym pair.0, pair.1)) builtinTypes
+
+let builtinTypeNames : Map String Name =
+  foldl (lam env. lam t. mapInsert t.0 t.1 env) (mapEmpty cmpString) builtinTypes

--- a/src/stdlib/mexpr/const-types.mc
+++ b/src/stdlib/mexpr/const-types.mc
@@ -3,12 +3,13 @@
 
 include "ast.mc"
 include "ast-builder.mc"
+include "builtin.mc"
 
 let mktyall_ = lam s. lam f. tyall_ s (f (tyvar_ s))
 let mkstyall_ = lam s. lam k. lam f. styall_ s k (f (tyvar_ s))
 
 let mktybuiltin_ = lam s. lam d. lam disable. lam f.
-  let ident = nameNoSym s in
+  let ident = mapFindExn s builtinTypeNames in
   if disable then f (nsitycon_ ident tyunknown_ (NoInfo ()))
   else
     mkstyall_ d

--- a/src/stdlib/mexpr/symbolize.mc
+++ b/src/stdlib/mexpr/symbolize.mc
@@ -88,14 +88,12 @@ let _symEnvEmpty : SymEnv = {
   namespaceEnv = mapEmpty cmpString
 }
 
-let symEnvAddBuiltinTypes : all a. SymEnv -> [(String, a)] -> SymEnv
-  = lam env. lam tys. symbolizeUpdateTyConEnv env (foldl
-    (lam env. lam t. mapInsert t.0 (nameNoSym t.0) env)
-    env.currentEnv.tyConEnv
-    tys)
+let symEnvAddBuiltinTypes : all a. SymEnv -> SymEnv
+  = lam env. symbolizeUpdateTyConEnv env
+    (mapUnion env.currentEnv.tyConEnv builtinTypeNames)
 
 let symEnvDefault =
-  symEnvAddBuiltinTypes _symEnvEmpty builtinTypes
+  symEnvAddBuiltinTypes _symEnvEmpty
 
 -- TODO(oerikss, 2023-11-14): Change all DSLs that use this name for the
 -- symbolize environment to instead point to `symEnvDefault` and then

--- a/src/stdlib/mexpr/type-annot.mc
+++ b/src/stdlib/mexpr/type-annot.mc
@@ -28,7 +28,7 @@ let _typeEnvEmpty = {
   varEnv = mapEmpty nameCmp,
   conEnv = mapEmpty nameCmp,
   tyEnv  = mapFromSeq nameCmp (
-    map (lam t : (String, [String]). (nameNoSym t.0, tyvariant_ [])) builtinTypes
+    map (lam t : (String, Name, [String]). (t.1, tyvariant_ [])) builtinTypes
   )
 }
 

--- a/src/stdlib/mexpr/type-check.mc
+++ b/src/stdlib/mexpr/type-check.mc
@@ -108,13 +108,13 @@ let typcheckEnvEmpty : TCEnv = {
   }
 }
 
-let typecheckEnvAddBuiltinTypes : TCEnv -> [(String, [String])] -> TCEnv
+let typecheckEnvAddBuiltinTypes : TCEnv -> [(String, Name, [String])] -> TCEnv
   = lam env. lam tys.
     { env with
       tyConEnv =
         foldl
           (lam env. lam t.
-            mapInsert (nameNoSym t.0) (0, map nameSym t.1, tyvariant_ []) env)
+            mapInsert t.1 (0, map nameSym t.2, tyvariant_ []) env)
           env.tyConEnv tys }
 
 let typcheckEnvDefault =

--- a/src/stdlib/mexpr/utest-generate.mc
+++ b/src/stdlib/mexpr/utest-generate.mc
@@ -59,7 +59,7 @@ let _ppTensorTyVarName = nameSym "a"
 let _eqTensorName = nameSym "eqTensor"
 let _eqTensorTyVarName = nameSym "a"
 
-let _builtinTypes = map (lam s. nameNoSym s.0) builtinTypes
+let _builtinTypes = map (lam x. x.1) builtinTypes
 
 let _utestInfo =
   let pos = initPos "utest-generated" in
@@ -589,11 +589,11 @@ lang VariantPrettyPrint = GeneratePrettyPrintBase + UtestRuntime
   sem generatePrettyPrintBodyH info env =
   | (TyApp _ | TyCon _) & ty ->
     match collectTypeArguments [] ty with (id, tyArgs) in
-    if nameEq id (nameNoSym "Symbol") then
+    if nameEq id (mapFindExn "Symbol" builtinTypeNames) then
       generateSymbolPrettyPrint env ty
-    else if nameEq id (nameNoSym "Ref") then
+    else if nameEq id (mapFindExn "Ref" builtinTypeNames) then
       generateReferencePrettyPrint env ty
-    else if nameEq id (nameNoSym "BootParseTree") then
+    else if nameEq id (mapFindExn "BootParseTree" builtinTypeNames) then
       generateBootParseTreePrettyPrint env ty
     else defaultVariantPrettyPrint info env id tyArgs ty
 
@@ -773,11 +773,11 @@ lang VariantEquality = GenerateEqualityBase + UtestRuntime
   sem generateEqualityBodyH info env =
   | (TyCon _ | TyApp _) & ty ->
     match collectTypeArguments [] ty with (id, tyArgs) in
-    if nameEq id (nameNoSym "Symbol") then
+    if nameEq id (mapFindExn "Symbol" builtinTypeNames) then
       generateSymbolEquality info env ty
-    else if nameEq id (nameNoSym "Ref") then
+    else if nameEq id (mapFindExn "Ref" builtinTypeNames) then
       generateReferenceEquality info env ty
-    else if nameEq id (nameNoSym "BootParseTree") then
+    else if nameEq id (mapFindExn "BootParseTree" builtinTypeNames) then
       generateBootParseTreeEquality info env ty
     else defaultVariantEq info env id tyArgs ty
 
@@ -1213,13 +1213,13 @@ utest evalEquality env ty c4 c5 with false_ using eqExpr in
 utest evalEquality env ty c4 c4 with true_ using eqExpr in
 utest evalEquality env ty c5 c5 with true_ using eqExpr in
 
-let symTy = tycon_ "Symbol" in
+let symTy = ntycon_ (mapFindExn "Symbol" builtinTypeNames) in
 let s = gensym_ unit_ in
 utest evalEquality env symTy s s with false_ using eqExpr in
 utest match expr2str (evalPrettyPrint env symTy s) with "\"sym (" ++ _ ++ ")\"" then true else false
 with true in
 
-let refTy = tyapp_ (tycon_ "Ref") tyint_ in
+let refTy = tyapp_ (ntycon_ (mapFindExn "Ref" builtinTypeNames)) tyint_ in
 let r = ref_ (int_ 0) in
 utest evalPrettyPrint env refTy r with str_ "<ref>" using eqExpr in
 


### PR DESCRIPTION
This PR gives all built-in types that aren't distinct AST nodes (e.g., `Symbol` and `Ref`, not `Int` and `Bool`) actually symbolized `Name`s which are used throughout the compiler pipeline.  