### PR TITLE
.editorconfig should follow EditorConfig spec regarding inline comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,14 @@ root = true
 
 # Default rules
 [*]
-end_of_line = lf                # Use Unix line endings
+# Use Unix line endings
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 80            # A line should not have more than this amount
-                                # of chars (not supported by all plugins)
+# A line should not have more than this amount
+# of chars (not supported by all plugins)
+max_line_length = 80
 
 [*.mc]
 indent_style = space


### PR DESCRIPTION
Hi,

The EditorConfig spec does not include inline comments since version 0.15.0.

See the relevant part of the spec [here](https://spec.editorconfig.org/#no-inline-comments).

This means that whenever I open my editor the built-in EditorConfig parser fails as it parses the value of "end_of_line" to be

```
lf                # Use Unix line endings
```

instead of

```
lf
```

and therefore resulting in the error

```
end_of_line must be one of "lf", "crlf", or "cr"
```