### PR TITLE
Makefile improvements, +setup-tup, +test-info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,26 +4,14 @@ MI_MID_NAME=mi-mid
 MI_NAME=mi
 MI_CHEAT_NAME=mi-cheat
 
-ifndef prefix
-prefix=$(HOME)/.local
-endif
-ifndef bindir
-bindir=$(prefix)/bin
-endif
-ifndef libdir
-libdir=$(prefix)/lib
-endif
+prefix ?= $(HOME)/.local
+bindir ?= $(prefix)/bin
+libdir ?= $(prefix)/lib
+mcoredir = $(libdir)/mcore
 ifdef OPAM_SWITCH_PREFIX
-opamlibdir=$(OPAM_SWITCH_PREFIX)/lib
+opamlibdir = $(OPAM_SWITCH_PREFIX)/lib
 endif
-ifndef ocamllibdir
-ifdef opamlibdir
-ocamllibdir=$(opamlibdir)
-else
-ocamllibdir=$(libdir)/ocaml/site-lib
-endif
-endif
-mcoredir=$(libdir)/mcore
+ocamllibdir ?= $(or $(opamlibdir), $(libdir)/ocaml/site-lib)
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(dir $(mkfile_path))
@@ -108,12 +96,23 @@ uninstall:
 # or `misc/watch` to autorun tests when files change)
 
 .PHONY: test test-all test-quick
-test test-all test-quick: $(if $(wildcard .tup/.),,build/$(MI_NAME))
+test test-all test-quick:
 test:
-	exec misc/test --bootstrapped smart
+	+ exec misc/test --bootstrapped smart
 
 test-all:
-	exec misc/test --bootstrapped all
+	+ exec misc/test --bootstrapped all
 
 test-quick:
-	exec misc/test --bootstrapped
+	+ exec misc/test --bootstrapped
+
+test-info:
+	@echo "Tasks run:" `find build/src/ -name '*.out' | wc -l`
+	@misc/test-spec --bootstrapped smart 2>&1 >/dev/null
+
+
+# Building and testing via tup
+
+.PHONY: setup-tup
+setup-tup:
+	misc/scripts/setup-tup

--- a/misc/scripts/setup-tup
+++ b/misc/scripts/setup-tup
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$(dirname $(dirname "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"))
+cd "$DIR"
+
+if ! command -v tup >/dev/null 2>&1; then
+  echo "Cannot find 'tup' in environment, refusing to run."
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "Cannot find 'rsync' in environment, refusing to run."
+fi
+
+if [ -e .tup ]; then
+  read -p "'.tup' already exists. Remove it and re-run setup? [yN] " -n 1 -r
+  echo
+  case "$REPLY" in
+    y|Y ) rm -rf .tup;;
+    * ) echo "Exiting"; exit 1;;
+  esac
+fi
+
+if [ ! -f misc/test-spec ]; then
+  if command -v mi >/dev/null 2>&1; then
+    # NOTE(vipa, 2024-11-22): Use built-in mi, with built-in stdlib
+    mi compile misc/test-spec.mc --output misc/test-spec
+  elif [ -f build/mi ]; then
+    # NOTE(vipa, 2024-11-22): Use bootstrapped mi, with repo-local stdlib and boot
+    MCORE_LIBS=stdlib=$DIR/src/stdlib OCAMLPATH=$DIR/build/lib:$OCAMLPATH build/mi compile misc/test-spec.mc --output misc/test-spec
+  else
+    echo "You need 'mi' to setup tup, e.g., by bootstrapping via 'make'"
+    exit 1
+  fi
+fi
+
+if [ -e build/src ]; then
+  echo "This will clear 'build/src', which contains logs and intermediate"
+  echo "executables from previous tests. This is typically not an issue as"
+  echo "they will be rebuilt by tup when re-running the tests, but it"
+  echo "seems polite to ask."
+  read -p "Proceed? [yN] " -n 1 -r
+  echo
+  case "$REPLY" in
+      y|Y ) rm -rf build/src;;
+      * ) echo "Exiting"; exit 1;;
+  esac
+fi
+
+# NOTE(vipa, 2025-02-18): This dance is here because 'tup' wants to be
+# the sole owner of everything in the 'build' directory, but we have
+# constructed things in such a way that tup will only ever build to
+# the 'build/src' directory, while the 'Makefile' builds to other
+# places in 'build'. Fortunately 'tup' only checks if there are files
+# it does not own when it initially adds a variant, not later on. Thus
+# we move 'build' out of the way, present a clean directory to 'tup',
+# then move everything else back.
+mv build build-bak
+mkdir build
+mv build-bak/tup.config build
+tup init
+tup build/src/marker # NOTE(vipa, 2025-02-18): This is when 'tup' wants the directory to be empty
+rsync -a build-bak/* build --remove-source-files
+rm -rf build-bak
+
+echo "Done, test builds will now use tup"

--- a/misc/test
+++ b/misc/test
@@ -20,25 +20,25 @@ if [ misc/test-spec -ot misc/test-spec.mc ]; then
   if command -v mi >/dev/null 2>&1; then
     # NOTE(vipa, 2024-11-22): Use built-in mi, with built-in stdlib
     mi compile misc/test-spec.mc --output misc/test-spec
-  else
+  elif [ -f build/mi ]; then
     # NOTE(vipa, 2024-11-22): Use bootstrapped mi, with repo-local stdlib and boot
     MCORE_LIBS=stdlib=$DIR/src/stdlib OCAMLPATH=$DIR/build/lib:$OCAMLPATH build/mi compile misc/test-spec.mc --output misc/test-spec
+  else
+    echo "You need 'mi' to setup tup, e.g., by bootstrapping via 'make'"
+    exit 1
   fi
 fi
 
 # NOTE(vipa, 2024-11-22): Unconditionally overwrite MCORE_LIBS, since
 # tests should run with this value.
 export MCORE_LIBS=stdlib=$DIR/src/stdlib
-if [[ ! (":$OCAMLPATH:" == *":$DIR/build/lib:"*) ]]; then
-  export OCAMLPATH=$DIR/build/lib:$OCAMLPATH
-fi
 
 if command -v tup >/dev/null 2>&1; then
   if [ -d ".tup" ]; then
     useTup=1
   else
     useTup=0
-    echo "'tup' installed, but not initialized. Run 'tup init' if you want to use 'tup'."
+    echo "'tup' installed, but not initialized. Run 'make setup-tup' if you want to use 'tup'."
   fi
 else
   useTup=0
@@ -46,8 +46,14 @@ fi
 
 if [ $useTup -eq 1 ]; then
   echo "Using 'tup' as a test runner"
-  misc/test-spec --tup-filter "$@" | tr "\n" "\0" | xargs -0r tup -k
+  if TUPTARGETS=`misc/test-spec --tup-filter "$@"`; then
+      IFS=$'\n'
+      exec tup $TUPTARGETS
+  fi
 else
   echo "Using 'make' as a test runner"
+  if [[ ! (":$OCAMLPATH:" == *":$DIR/build/lib:"*) ]]; then
+      export OCAMLPATH=$DIR/build/lib:$OCAMLPATH
+  fi
   exec make -f <(misc/test-spec --make "$@")
 fi

--- a/src/Tupfile
+++ b/src/Tupfile
@@ -1,6 +1,6 @@
 include_rules
 
-STDLIB := MCORE_LIBS=stdlib=$(ROOT)/src/stdlib OCAMLPATH=$(VARIANT_SRC)/lib${OCAMLPATH:+:}$OCAMLPATH
+STDLIB := MCORE_LIBS=stdlib=$(ROOT)/src/stdlib OCAMLPATH=`realpath $(VARIANT_SRC)/lib`${OCAMLPATH:+:}$OCAMLPATH
 
 # NOTE(vipa, 2023-05-16): This is ugly, but appears stable and does
 # seem to work
@@ -13,10 +13,130 @@ BOOT_LIB_FILES += lib/boot/parser.mli
 BOOT_LIB_FILES += lib/boot/rope.mli
 BOOT_LIB_FILES += lib/boot/tensor.mli
 BOOT_LIB_FILES += lib/boot/ustring.mli
+BOOT_LIB_FILES += lib/boot/ast.ml
+BOOT_LIB_FILES += lib/boot/boot.cmi
+BOOT_LIB_FILES += lib/boot/boot.cmt
+BOOT_LIB_FILES += lib/boot/boot.cmx
+BOOT_LIB_FILES += lib/boot/boot.ml
+BOOT_LIB_FILES += lib/boot/boot__Ast.cmi
+BOOT_LIB_FILES += lib/boot/boot__Ast.cmt
+BOOT_LIB_FILES += lib/boot/boot__Ast.cmx
+BOOT_LIB_FILES += lib/boot/boot__Bootparser.cmi
+BOOT_LIB_FILES += lib/boot/boot__Bootparser.cmt
+BOOT_LIB_FILES += lib/boot/boot__Bootparser.cmx
+BOOT_LIB_FILES += lib/boot/boot__Builtin.cmi
+BOOT_LIB_FILES += lib/boot/boot__Builtin.cmt
+BOOT_LIB_FILES += lib/boot/boot__Builtin.cmx
+BOOT_LIB_FILES += lib/boot/boot__Deadcode.cmi
+BOOT_LIB_FILES += lib/boot/boot__Deadcode.cmt
+BOOT_LIB_FILES += lib/boot/boot__Deadcode.cmx
+BOOT_LIB_FILES += lib/boot/boot__Eval.cmi
+BOOT_LIB_FILES += lib/boot/boot__Eval.cmt
+BOOT_LIB_FILES += lib/boot/boot__Eval.cmx
+BOOT_LIB_FILES += lib/boot/boot__Ext.cmi
+BOOT_LIB_FILES += lib/boot/boot__Ext.cmt
+BOOT_LIB_FILES += lib/boot/boot__Ext.cmx
+BOOT_LIB_FILES += lib/boot/boot__Exttest.cmi
+BOOT_LIB_FILES += lib/boot/boot__Exttest.cmt
+BOOT_LIB_FILES += lib/boot/boot__Exttest.cmx
+BOOT_LIB_FILES += lib/boot/boot__Intrinsics.cmi
+BOOT_LIB_FILES += lib/boot/boot__Intrinsics.cmt
+BOOT_LIB_FILES += lib/boot/boot__Intrinsics.cmti
+BOOT_LIB_FILES += lib/boot/boot__Intrinsics.cmx
+BOOT_LIB_FILES += lib/boot/boot__Lexer.cmi
+BOOT_LIB_FILES += lib/boot/boot__Lexer.cmt
+BOOT_LIB_FILES += lib/boot/boot__Lexer.cmx
+BOOT_LIB_FILES += lib/boot/boot__Mexpr.cmi
+BOOT_LIB_FILES += lib/boot/boot__Mexpr.cmt
+BOOT_LIB_FILES += lib/boot/boot__Mexpr.cmx
+BOOT_LIB_FILES += lib/boot/boot__Mlang.cmi
+BOOT_LIB_FILES += lib/boot/boot__Mlang.cmt
+BOOT_LIB_FILES += lib/boot/boot__Mlang.cmx
+BOOT_LIB_FILES += lib/boot/boot__Msg.cmi
+BOOT_LIB_FILES += lib/boot/boot__Msg.cmt
+BOOT_LIB_FILES += lib/boot/boot__Msg.cmx
+BOOT_LIB_FILES += lib/boot/boot__Parser.cmi
+BOOT_LIB_FILES += lib/boot/boot__Parser.cmt
+BOOT_LIB_FILES += lib/boot/boot__Parser.cmti
+BOOT_LIB_FILES += lib/boot/boot__Parser.cmx
+BOOT_LIB_FILES += lib/boot/boot__Parserutils.cmi
+BOOT_LIB_FILES += lib/boot/boot__Parserutils.cmt
+BOOT_LIB_FILES += lib/boot/boot__Parserutils.cmx
+BOOT_LIB_FILES += lib/boot/boot__Patterns.cmi
+BOOT_LIB_FILES += lib/boot/boot__Patterns.cmt
+BOOT_LIB_FILES += lib/boot/boot__Patterns.cmx
+BOOT_LIB_FILES += lib/boot/boot__Pprint.cmi
+BOOT_LIB_FILES += lib/boot/boot__Pprint.cmt
+BOOT_LIB_FILES += lib/boot/boot__Pprint.cmx
+BOOT_LIB_FILES += lib/boot/boot__Pyast.cmi
+BOOT_LIB_FILES += lib/boot/boot__Pyast.cmt
+BOOT_LIB_FILES += lib/boot/boot__Pyast.cmx
+BOOT_LIB_FILES += lib/boot/boot__Pyffi.cmi
+BOOT_LIB_FILES += lib/boot/boot__Pyffi.cmt
+BOOT_LIB_FILES += lib/boot/boot__Pyffi.cmx
+BOOT_LIB_FILES += lib/boot/boot__Pypprint.cmi
+BOOT_LIB_FILES += lib/boot/boot__Pypprint.cmt
+BOOT_LIB_FILES += lib/boot/boot__Pypprint.cmx
+BOOT_LIB_FILES += lib/boot/boot__Repl.cmi
+BOOT_LIB_FILES += lib/boot/boot__Repl.cmt
+BOOT_LIB_FILES += lib/boot/boot__Repl.cmx
+BOOT_LIB_FILES += lib/boot/boot__Rope.cmi
+BOOT_LIB_FILES += lib/boot/boot__Rope.cmt
+BOOT_LIB_FILES += lib/boot/boot__Rope.cmti
+BOOT_LIB_FILES += lib/boot/boot__Rope.cmx
+BOOT_LIB_FILES += lib/boot/boot__Symbolize.cmi
+BOOT_LIB_FILES += lib/boot/boot__Symbolize.cmt
+BOOT_LIB_FILES += lib/boot/boot__Symbolize.cmx
+BOOT_LIB_FILES += lib/boot/boot__Symbutils.cmi
+BOOT_LIB_FILES += lib/boot/boot__Symbutils.cmt
+BOOT_LIB_FILES += lib/boot/boot__Symbutils.cmx
+BOOT_LIB_FILES += lib/boot/boot__Tensor.cmi
+BOOT_LIB_FILES += lib/boot/boot__Tensor.cmt
+BOOT_LIB_FILES += lib/boot/boot__Tensor.cmti
+BOOT_LIB_FILES += lib/boot/boot__Tensor.cmx
+BOOT_LIB_FILES += lib/boot/boot__Ustring.cmi
+BOOT_LIB_FILES += lib/boot/boot__Ustring.cmt
+BOOT_LIB_FILES += lib/boot/boot__Ustring.cmti
+BOOT_LIB_FILES += lib/boot/boot__Ustring.cmx
+BOOT_LIB_FILES += lib/boot/boot__Utils.cmi
+BOOT_LIB_FILES += lib/boot/boot__Utils.cmt
+BOOT_LIB_FILES += lib/boot/boot__Utils.cmx
+BOOT_LIB_FILES += lib/boot/bootparser.ml
+BOOT_LIB_FILES += lib/boot/builtin.ml
+BOOT_LIB_FILES += lib/boot/deadcode.ml
+BOOT_LIB_FILES += lib/boot/dune-package
+BOOT_LIB_FILES += lib/boot/eval.ml
+BOOT_LIB_FILES += lib/boot/ext.ml
+BOOT_LIB_FILES += lib/boot/exttest.ml
+BOOT_LIB_FILES += lib/boot/intrinsics.ml
+BOOT_LIB_FILES += lib/boot/lexer.ml
+BOOT_LIB_FILES += lib/boot/mexpr.ml
+BOOT_LIB_FILES += lib/boot/mlang.ml
+BOOT_LIB_FILES += lib/boot/msg.ml
+BOOT_LIB_FILES += lib/boot/opam
+BOOT_LIB_FILES += lib/boot/parser.ml
+BOOT_LIB_FILES += lib/boot/parserutils.ml
+BOOT_LIB_FILES += lib/boot/patterns.ml
+BOOT_LIB_FILES += lib/boot/pprint.ml
+BOOT_LIB_FILES += lib/boot/pyast.ml
+BOOT_LIB_FILES += lib/boot/pyffi.ml
+BOOT_LIB_FILES += lib/boot/pypprint.ml
+BOOT_LIB_FILES += lib/boot/repl.ml
+BOOT_LIB_FILES += lib/boot/rope.ml
+BOOT_LIB_FILES += lib/boot/symbolize.ml
+BOOT_LIB_FILES += lib/boot/symbutils.ml
+BOOT_LIB_FILES += lib/boot/tensor.ml
+BOOT_LIB_FILES += lib/boot/ustring.ml
+BOOT_LIB_FILES += lib/boot/utils.ml
+BOOT_LIB_FILES += lib/boot/boot.cmxs
 
 preload boot
 
-: |> ^b dune build^ OCAMLRUNPARAM=b ../misc/scripts/with-tmp-dir dune build --root=boot/ --build-dir="{}" "&&" mv "{}/default/"{META.boot,lib/META} "&&" shopt -s nullglob "&&" ocamlfind install -destdir $(VARIANT_SRC)/lib boot "{}/default/lib/"{META,*.mli,*.cmi,*.cmo,*.cmx,*.cma,*.cmxa,*.a} "&&" mv "{}"/default/boot.exe %1o |> mi-boot | $(BOOT_LIB_FILES) <boot-lib>
+# NOTE(vipa, 2025-02-24): This is really hacky:
+# - If we don't 'cd .' then 'dune' (Stdune__Fpath.initial_cwd) says "No such file or directory"
+# - If we don't create a temporary '.git', then 'dune' will cd to the actual .git, which tup doesn't allow
+# - Tup does not allow us to create non-temporary directories, so we have to clean everything up afterwards
+: |> ^b dune build^ ../misc/scripts/with-tmp-dir dune build --root=boot/ --build-dir="{}" "&&" cd . "&&" mkdir boot/.git "&&" dune install --root=boot/ --build-dir="{}" --prefix=`realpath $(VARIANT_SRC)` "&&" mv $(VARIANT_SRC)/bin/boot %1o "&&" rm -r boot/.git $(VARIANT_SRC)/bin |> mi-boot | $(BOOT_LIB_FILES) <boot-lib>
 
 : main/mi-lite.mc | mi-boot $(BOOT_LIB_FILES) |> ^ ./boot eval %f -- 0 %f %o^ $(STDLIB) ./%1i eval %f -- 0 %f %o |> mi-lite
 : main/mi.mc | mi-lite $(BOOT_LIB_FILES) |> ^ ./mi-lite 1 %f %o^ $(STDLIB) ./%1i 1 %f %o |> mi1
@@ -24,7 +144,6 @@ preload boot
 
 : main/mi.mc | mi-boot $(BOOT_LIB_FILES) |> ^ mi compile %f --output %o^ $(STDLIB) mi compile %f --output %o |> mi-cheat <mi-cheat>
 
-: |> ld -lev  | tee %o |> ld-test-thing
-: |> env > %o |> env
-: |> file `which ld` | tee %o |> ld
-: |> echo $NIX_LDFLAGS | tee %o |> ld-flags
+# NOTE(vipa, 2025-02-18): This is here to make it possible to tell tup
+# to look at the 'build'-variant without building the entire world
+: |> touch %o |> marker


### PR DESCRIPTION
This PR includes a number of improvements primarily to the Makefile:
- It turns out you need `+` to propagate `-jN` flags from `make test` to `misc/test`.
- A new make target for initializing `tup`.
- A new make target for printing information about what tests have been run, partly as support for the new test script.
- Change back to using `dune` to "install" the `boot` package when building via `tup`, and all the hacks that entails.

The last point probably bears more explanation, since what's in the setup right now is very hacky. `dune` wraps libraries by default, i.e., when we write a module `Intrinsics` it's available as `Boot.Intrinsics`. This is a good idea, and we depend on it in our generated code. For some reason this wrapping seems to happen during `dune install`, not `dune build`, which means we need to use `dune install` rather than `ocamlfind install` (or at least I haven't figured out how to make the same wrapping happen with the latter). Unfortunately `dune` does not play nice at all with `tup`, so we have to do a bunch of things to accommodate it, which is the hacky stuff.