### PR TITLE
Update names in selfhost.syn to not conflict with mlang/mexpr

### DIFF
--- a/src/stdlib/parser/selfhost-gen.mc
+++ b/src/stdlib/parser/selfhost-gen.mc
@@ -2,1688 +2,1300 @@ include "seq.mc"
 include "parser/ll1.mc"
 include "parser/breakable.mc"
 lang SelfhostBaseAst
-  syn Expr =
-  syn Regex =
-  syn Decl =
-  syn File =
-  sem smapAccumL_File_File : all a. (a -> File -> (a, File)) -> a -> File -> (a, File)
-sem smapAccumL_File_File f acc =
+  syn SHExpr =
+  syn SHRegex =
+  syn SHDecl =
+  syn SHFile =
+  sem smapAccumL_SHFile_SHFile : all a. (a -> SHFile -> (a, SHFile)) -> a -> SHFile -> (a, SHFile)
+sem smapAccumL_SHFile_SHFile f acc =
   | x ->
     (acc, x)
-  sem smap_File_File : (File -> File) -> File -> File
-sem smap_File_File f =
+  sem smap_SHFile_SHFile : (SHFile -> SHFile) -> SHFile -> SHFile
+sem smap_SHFile_SHFile f =
   | x ->
-    (smapAccumL_File_File
-       (lam #var"".
+    (smapAccumL_SHFile_SHFile (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_File_File : all a. (a -> File -> a) -> a -> File -> a
-sem sfold_File_File f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHFile_SHFile : all a. (a -> SHFile -> a) -> a -> SHFile -> a
+sem sfold_SHFile_SHFile f acc =
   | x ->
-    (smapAccumL_File_File
-       (lam acc.
+    (smapAccumL_SHFile_SHFile (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_File_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> File -> (a, File)
-sem smapAccumL_File_Decl f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHFile_SHDecl : all a. (a -> SHDecl -> (a, SHDecl)) -> a -> SHFile -> (a, SHFile)
+sem smapAccumL_SHFile_SHDecl f acc =
   | x ->
     (acc, x)
-  sem smap_File_Decl : (Decl -> Decl) -> File -> File
-sem smap_File_Decl f =
+  sem smap_SHFile_SHDecl : (SHDecl -> SHDecl) -> SHFile -> SHFile
+sem smap_SHFile_SHDecl f =
   | x ->
-    (smapAccumL_File_Decl
-       (lam #var"".
+    (smapAccumL_SHFile_SHDecl (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_File_Decl : all a. (a -> Decl -> a) -> a -> File -> a
-sem sfold_File_Decl f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHFile_SHDecl : all a. (a -> SHDecl -> a) -> a -> SHFile -> a
+sem sfold_SHFile_SHDecl f acc =
   | x ->
-    (smapAccumL_File_Decl
-       (lam acc.
+    (smapAccumL_SHFile_SHDecl (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_File_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> File -> (a, File)
-sem smapAccumL_File_Regex f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHFile_SHRegex : all a. (a -> SHRegex -> (a, SHRegex)) -> a -> SHFile -> (a, SHFile)
+sem smapAccumL_SHFile_SHRegex f acc =
   | x ->
     (acc, x)
-  sem smap_File_Regex : (Regex -> Regex) -> File -> File
-sem smap_File_Regex f =
+  sem smap_SHFile_SHRegex : (SHRegex -> SHRegex) -> SHFile -> SHFile
+sem smap_SHFile_SHRegex f =
   | x ->
-    (smapAccumL_File_Regex
-       (lam #var"".
+    (smapAccumL_SHFile_SHRegex (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_File_Regex : all a. (a -> Regex -> a) -> a -> File -> a
-sem sfold_File_Regex f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHFile_SHRegex : all a. (a -> SHRegex -> a) -> a -> SHFile -> a
+sem sfold_SHFile_SHRegex f acc =
   | x ->
-    (smapAccumL_File_Regex
-       (lam acc.
+    (smapAccumL_SHFile_SHRegex (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_File_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> File -> (a, File)
-sem smapAccumL_File_Expr f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHFile_SHExpr : all a. (a -> SHExpr -> (a, SHExpr)) -> a -> SHFile -> (a, SHFile)
+sem smapAccumL_SHFile_SHExpr f acc =
   | x ->
     (acc, x)
-  sem smap_File_Expr : (Expr -> Expr) -> File -> File
-sem smap_File_Expr f =
+  sem smap_SHFile_SHExpr : (SHExpr -> SHExpr) -> SHFile -> SHFile
+sem smap_SHFile_SHExpr f =
   | x ->
-    (smapAccumL_File_Expr
-       (lam #var"".
+    (smapAccumL_SHFile_SHExpr (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_File_Expr : all a. (a -> Expr -> a) -> a -> File -> a
-sem sfold_File_Expr f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHFile_SHExpr : all a. (a -> SHExpr -> a) -> a -> SHFile -> a
+sem sfold_SHFile_SHExpr f acc =
   | x ->
-    (smapAccumL_File_Expr
-       (lam acc.
+    (smapAccumL_SHFile_SHExpr (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Decl_File : all a. (a -> File -> (a, File)) -> a -> Decl -> (a, Decl)
-sem smapAccumL_Decl_File f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHDecl_SHFile : all a. (a -> SHFile -> (a, SHFile)) -> a -> SHDecl -> (a, SHDecl)
+sem smapAccumL_SHDecl_SHFile f acc =
   | x ->
     (acc, x)
-  sem smap_Decl_File : (File -> File) -> Decl -> Decl
-sem smap_Decl_File f =
+  sem smap_SHDecl_SHFile : (SHFile -> SHFile) -> SHDecl -> SHDecl
+sem smap_SHDecl_SHFile f =
   | x ->
-    (smapAccumL_Decl_File
-       (lam #var"".
+    (smapAccumL_SHDecl_SHFile (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Decl_File : all a. (a -> File -> a) -> a -> Decl -> a
-sem sfold_Decl_File f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHDecl_SHFile : all a. (a -> SHFile -> a) -> a -> SHDecl -> a
+sem sfold_SHDecl_SHFile f acc =
   | x ->
-    (smapAccumL_Decl_File
-       (lam acc.
+    (smapAccumL_SHDecl_SHFile (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Decl_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> Decl -> (a, Decl)
-sem smapAccumL_Decl_Decl f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHDecl_SHDecl : all a. (a -> SHDecl -> (a, SHDecl)) -> a -> SHDecl -> (a, SHDecl)
+sem smapAccumL_SHDecl_SHDecl f acc =
   | x ->
     (acc, x)
-  sem smap_Decl_Decl : (Decl -> Decl) -> Decl -> Decl
-sem smap_Decl_Decl f =
+  sem smap_SHDecl_SHDecl : (SHDecl -> SHDecl) -> SHDecl -> SHDecl
+sem smap_SHDecl_SHDecl f =
   | x ->
-    (smapAccumL_Decl_Decl
-       (lam #var"".
+    (smapAccumL_SHDecl_SHDecl (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Decl_Decl : all a. (a -> Decl -> a) -> a -> Decl -> a
-sem sfold_Decl_Decl f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHDecl_SHDecl : all a. (a -> SHDecl -> a) -> a -> SHDecl -> a
+sem sfold_SHDecl_SHDecl f acc =
   | x ->
-    (smapAccumL_Decl_Decl
-       (lam acc.
+    (smapAccumL_SHDecl_SHDecl (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Decl_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> Decl -> (a, Decl)
-sem smapAccumL_Decl_Regex f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHDecl_SHRegex : all a. (a -> SHRegex -> (a, SHRegex)) -> a -> SHDecl -> (a, SHDecl)
+sem smapAccumL_SHDecl_SHRegex f acc =
   | x ->
     (acc, x)
-  sem smap_Decl_Regex : (Regex -> Regex) -> Decl -> Decl
-sem smap_Decl_Regex f =
+  sem smap_SHDecl_SHRegex : (SHRegex -> SHRegex) -> SHDecl -> SHDecl
+sem smap_SHDecl_SHRegex f =
   | x ->
-    (smapAccumL_Decl_Regex
-       (lam #var"".
+    (smapAccumL_SHDecl_SHRegex (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Decl_Regex : all a. (a -> Regex -> a) -> a -> Decl -> a
-sem sfold_Decl_Regex f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHDecl_SHRegex : all a. (a -> SHRegex -> a) -> a -> SHDecl -> a
+sem sfold_SHDecl_SHRegex f acc =
   | x ->
-    (smapAccumL_Decl_Regex
-       (lam acc.
+    (smapAccumL_SHDecl_SHRegex (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Decl_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> Decl -> (a, Decl)
-sem smapAccumL_Decl_Expr f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHDecl_SHExpr : all a. (a -> SHExpr -> (a, SHExpr)) -> a -> SHDecl -> (a, SHDecl)
+sem smapAccumL_SHDecl_SHExpr f acc =
   | x ->
     (acc, x)
-  sem smap_Decl_Expr : (Expr -> Expr) -> Decl -> Decl
-sem smap_Decl_Expr f =
+  sem smap_SHDecl_SHExpr : (SHExpr -> SHExpr) -> SHDecl -> SHDecl
+sem smap_SHDecl_SHExpr f =
   | x ->
-    (smapAccumL_Decl_Expr
-       (lam #var"".
+    (smapAccumL_SHDecl_SHExpr (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Decl_Expr : all a. (a -> Expr -> a) -> a -> Decl -> a
-sem sfold_Decl_Expr f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHDecl_SHExpr : all a. (a -> SHExpr -> a) -> a -> SHDecl -> a
+sem sfold_SHDecl_SHExpr f acc =
   | x ->
-    (smapAccumL_Decl_Expr
-       (lam acc.
+    (smapAccumL_SHDecl_SHExpr (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Regex_File : all a. (a -> File -> (a, File)) -> a -> Regex -> (a, Regex)
-sem smapAccumL_Regex_File f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHRegex_SHFile : all a. (a -> SHFile -> (a, SHFile)) -> a -> SHRegex -> (a, SHRegex)
+sem smapAccumL_SHRegex_SHFile f acc =
   | x ->
     (acc, x)
-  sem smap_Regex_File : (File -> File) -> Regex -> Regex
-sem smap_Regex_File f =
+  sem smap_SHRegex_SHFile : (SHFile -> SHFile) -> SHRegex -> SHRegex
+sem smap_SHRegex_SHFile f =
   | x ->
-    (smapAccumL_Regex_File
-       (lam #var"".
+    (smapAccumL_SHRegex_SHFile (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Regex_File : all a. (a -> File -> a) -> a -> Regex -> a
-sem sfold_Regex_File f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHRegex_SHFile : all a. (a -> SHFile -> a) -> a -> SHRegex -> a
+sem sfold_SHRegex_SHFile f acc =
   | x ->
-    (smapAccumL_Regex_File
-       (lam acc.
+    (smapAccumL_SHRegex_SHFile (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Regex_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> Regex -> (a, Regex)
-sem smapAccumL_Regex_Decl f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHRegex_SHDecl : all a. (a -> SHDecl -> (a, SHDecl)) -> a -> SHRegex -> (a, SHRegex)
+sem smapAccumL_SHRegex_SHDecl f acc =
   | x ->
     (acc, x)
-  sem smap_Regex_Decl : (Decl -> Decl) -> Regex -> Regex
-sem smap_Regex_Decl f =
+  sem smap_SHRegex_SHDecl : (SHDecl -> SHDecl) -> SHRegex -> SHRegex
+sem smap_SHRegex_SHDecl f =
   | x ->
-    (smapAccumL_Regex_Decl
-       (lam #var"".
+    (smapAccumL_SHRegex_SHDecl (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Regex_Decl : all a. (a -> Decl -> a) -> a -> Regex -> a
-sem sfold_Regex_Decl f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHRegex_SHDecl : all a. (a -> SHDecl -> a) -> a -> SHRegex -> a
+sem sfold_SHRegex_SHDecl f acc =
   | x ->
-    (smapAccumL_Regex_Decl
-       (lam acc.
+    (smapAccumL_SHRegex_SHDecl (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Regex_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> Regex -> (a, Regex)
-sem smapAccumL_Regex_Regex f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHRegex_SHRegex : all a. (a -> SHRegex -> (a, SHRegex)) -> a -> SHRegex -> (a, SHRegex)
+sem smapAccumL_SHRegex_SHRegex f acc =
   | x ->
     (acc, x)
-  sem smap_Regex_Regex : (Regex -> Regex) -> Regex -> Regex
-sem smap_Regex_Regex f =
+  sem smap_SHRegex_SHRegex : (SHRegex -> SHRegex) -> SHRegex -> SHRegex
+sem smap_SHRegex_SHRegex f =
   | x ->
-    (smapAccumL_Regex_Regex
-       (lam #var"".
+    (smapAccumL_SHRegex_SHRegex (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Regex_Regex : all a. (a -> Regex -> a) -> a -> Regex -> a
-sem sfold_Regex_Regex f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHRegex_SHRegex : all a. (a -> SHRegex -> a) -> a -> SHRegex -> a
+sem sfold_SHRegex_SHRegex f acc =
   | x ->
-    (smapAccumL_Regex_Regex
-       (lam acc.
+    (smapAccumL_SHRegex_SHRegex (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Regex_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> Regex -> (a, Regex)
-sem smapAccumL_Regex_Expr f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHRegex_SHExpr : all a. (a -> SHExpr -> (a, SHExpr)) -> a -> SHRegex -> (a, SHRegex)
+sem smapAccumL_SHRegex_SHExpr f acc =
   | x ->
     (acc, x)
-  sem smap_Regex_Expr : (Expr -> Expr) -> Regex -> Regex
-sem smap_Regex_Expr f =
+  sem smap_SHRegex_SHExpr : (SHExpr -> SHExpr) -> SHRegex -> SHRegex
+sem smap_SHRegex_SHExpr f =
   | x ->
-    (smapAccumL_Regex_Expr
-       (lam #var"".
+    (smapAccumL_SHRegex_SHExpr (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Regex_Expr : all a. (a -> Expr -> a) -> a -> Regex -> a
-sem sfold_Regex_Expr f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHRegex_SHExpr : all a. (a -> SHExpr -> a) -> a -> SHRegex -> a
+sem sfold_SHRegex_SHExpr f acc =
   | x ->
-    (smapAccumL_Regex_Expr
-       (lam acc.
+    (smapAccumL_SHRegex_SHExpr (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Expr_File : all a. (a -> File -> (a, File)) -> a -> Expr -> (a, Expr)
-sem smapAccumL_Expr_File f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHExpr_SHFile : all a. (a -> SHFile -> (a, SHFile)) -> a -> SHExpr -> (a, SHExpr)
+sem smapAccumL_SHExpr_SHFile f acc =
   | x ->
     (acc, x)
-  sem smap_Expr_File : (File -> File) -> Expr -> Expr
-sem smap_Expr_File f =
+  sem smap_SHExpr_SHFile : (SHFile -> SHFile) -> SHExpr -> SHExpr
+sem smap_SHExpr_SHFile f =
   | x ->
-    (smapAccumL_Expr_File
-       (lam #var"".
+    (smapAccumL_SHExpr_SHFile (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Expr_File : all a. (a -> File -> a) -> a -> Expr -> a
-sem sfold_Expr_File f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHExpr_SHFile : all a. (a -> SHFile -> a) -> a -> SHExpr -> a
+sem sfold_SHExpr_SHFile f acc =
   | x ->
-    (smapAccumL_Expr_File
-       (lam acc.
+    (smapAccumL_SHExpr_SHFile (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Expr_Decl : all a. (a -> Decl -> (a, Decl)) -> a -> Expr -> (a, Expr)
-sem smapAccumL_Expr_Decl f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHExpr_SHDecl : all a. (a -> SHDecl -> (a, SHDecl)) -> a -> SHExpr -> (a, SHExpr)
+sem smapAccumL_SHExpr_SHDecl f acc =
   | x ->
     (acc, x)
-  sem smap_Expr_Decl : (Decl -> Decl) -> Expr -> Expr
-sem smap_Expr_Decl f =
+  sem smap_SHExpr_SHDecl : (SHDecl -> SHDecl) -> SHExpr -> SHExpr
+sem smap_SHExpr_SHDecl f =
   | x ->
-    (smapAccumL_Expr_Decl
-       (lam #var"".
+    (smapAccumL_SHExpr_SHDecl (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Expr_Decl : all a. (a -> Decl -> a) -> a -> Expr -> a
-sem sfold_Expr_Decl f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHExpr_SHDecl : all a. (a -> SHDecl -> a) -> a -> SHExpr -> a
+sem sfold_SHExpr_SHDecl f acc =
   | x ->
-    (smapAccumL_Expr_Decl
-       (lam acc.
+    (smapAccumL_SHExpr_SHDecl (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Expr_Regex : all a. (a -> Regex -> (a, Regex)) -> a -> Expr -> (a, Expr)
-sem smapAccumL_Expr_Regex f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHExpr_SHRegex : all a. (a -> SHRegex -> (a, SHRegex)) -> a -> SHExpr -> (a, SHExpr)
+sem smapAccumL_SHExpr_SHRegex f acc =
   | x ->
     (acc, x)
-  sem smap_Expr_Regex : (Regex -> Regex) -> Expr -> Expr
-sem smap_Expr_Regex f =
+  sem smap_SHExpr_SHRegex : (SHRegex -> SHRegex) -> SHExpr -> SHExpr
+sem smap_SHExpr_SHRegex f =
   | x ->
-    (smapAccumL_Expr_Regex
-       (lam #var"".
+    (smapAccumL_SHExpr_SHRegex (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Expr_Regex : all a. (a -> Regex -> a) -> a -> Expr -> a
-sem sfold_Expr_Regex f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHExpr_SHRegex : all a. (a -> SHRegex -> a) -> a -> SHExpr -> a
+sem sfold_SHExpr_SHRegex f acc =
   | x ->
-    (smapAccumL_Expr_Regex
-       (lam acc.
+    (smapAccumL_SHExpr_SHRegex (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem smapAccumL_Expr_Expr : all a. (a -> Expr -> (a, Expr)) -> a -> Expr -> (a, Expr)
-sem smapAccumL_Expr_Expr f acc =
+            (f acc x, x)) acc x).0
+  sem smapAccumL_SHExpr_SHExpr : all a. (a -> SHExpr -> (a, SHExpr)) -> a -> SHExpr -> (a, SHExpr)
+sem smapAccumL_SHExpr_SHExpr f acc =
   | x ->
     (acc, x)
-  sem smap_Expr_Expr : (Expr -> Expr) -> Expr -> Expr
-sem smap_Expr_Expr f =
+  sem smap_SHExpr_SHExpr : (SHExpr -> SHExpr) -> SHExpr -> SHExpr
+sem smap_SHExpr_SHExpr f =
   | x ->
-    (smapAccumL_Expr_Expr
-       (lam #var"".
+    (smapAccumL_SHExpr_SHExpr (lam #var"".
           lam x.
-            ({}, f
-              x))
-       {}
-       x).1
-  sem sfold_Expr_Expr : all a. (a -> Expr -> a) -> a -> Expr -> a
-sem sfold_Expr_Expr f acc =
+            ({}, f x)) {} x).1
+  sem sfold_SHExpr_SHExpr : all a. (a -> SHExpr -> a) -> a -> SHExpr -> a
+sem sfold_SHExpr_SHExpr f acc =
   | x ->
-    (smapAccumL_Expr_Expr
-       (lam acc.
+    (smapAccumL_SHExpr_SHExpr (lam acc.
           lam x.
-            (f
-              acc
-              x, x))
-       acc
-       x).0
-  sem get_File_info : File -> Info
-  sem set_File_info : Info -> File -> File
-sem set_File_info val =
-  sem mapAccum_File_info : all a. (a -> Info -> (a, Info)) -> a -> File -> (a, File)
-sem mapAccum_File_info f acc =
+            (f acc x, x)) acc x).0
+  sem get_SHFile_info : SHFile -> Info
+sem get_SHFile_info =
+  sem set_SHFile_info : Info -> SHFile -> SHFile
+sem set_SHFile_info val =
+  sem mapAccum_SHFile_info : all a. (a -> Info -> (a, Info)) -> a -> SHFile -> (a, SHFile)
+sem mapAccum_SHFile_info f acc =
   | target ->
     match
-      f
-        acc
-        (get_File_info
-           target)
+      f acc (get_SHFile_info target)
     with
       (acc, val)
     in
-    (acc, set_File_info
-        val
-        target)
-  sem map_File_info : (Info -> Info) -> File -> File
-sem map_File_info f =
+    (acc, set_SHFile_info val target)
+  sem map_SHFile_info : (Info -> Info) -> SHFile -> SHFile
+sem map_SHFile_info f =
   | target ->
-    set_File_info
-      (f
-         (get_File_info
-            target))
-      target
-  sem get_Decl_info : Decl -> Info
-  sem set_Decl_info : Info -> Decl -> Decl
-sem set_Decl_info val =
-  sem mapAccum_Decl_info : all a. (a -> Info -> (a, Info)) -> a -> Decl -> (a, Decl)
-sem mapAccum_Decl_info f acc =
+    set_SHFile_info (f (get_SHFile_info target)) target
+  sem get_SHDecl_info : SHDecl -> Info
+sem get_SHDecl_info =
+  sem set_SHDecl_info : Info -> SHDecl -> SHDecl
+sem set_SHDecl_info val =
+  sem mapAccum_SHDecl_info : all a. (a -> Info -> (a, Info)) -> a -> SHDecl -> (a, SHDecl)
+sem mapAccum_SHDecl_info f acc =
   | target ->
     match
-      f
-        acc
-        (get_Decl_info
-           target)
+      f acc (get_SHDecl_info target)
     with
       (acc, val)
     in
-    (acc, set_Decl_info
-        val
-        target)
-  sem map_Decl_info : (Info -> Info) -> Decl -> Decl
-sem map_Decl_info f =
+    (acc, set_SHDecl_info val target)
+  sem map_SHDecl_info : (Info -> Info) -> SHDecl -> SHDecl
+sem map_SHDecl_info f =
   | target ->
-    set_Decl_info
-      (f
-         (get_Decl_info
-            target))
-      target
-  sem get_Regex_info : Regex -> Info
-  sem set_Regex_info : Info -> Regex -> Regex
-sem set_Regex_info val =
-  sem mapAccum_Regex_info : all a. (a -> Info -> (a, Info)) -> a -> Regex -> (a, Regex)
-sem mapAccum_Regex_info f acc =
+    set_SHDecl_info (f (get_SHDecl_info target)) target
+  sem get_SHRegex_info : SHRegex -> Info
+sem get_SHRegex_info =
+  sem set_SHRegex_info : Info -> SHRegex -> SHRegex
+sem set_SHRegex_info val =
+  sem mapAccum_SHRegex_info : all a. (a -> Info -> (a, Info)) -> a -> SHRegex -> (a, SHRegex)
+sem mapAccum_SHRegex_info f acc =
   | target ->
     match
-      f
-        acc
-        (get_Regex_info
-           target)
+      f acc (get_SHRegex_info target)
     with
       (acc, val)
     in
-    (acc, set_Regex_info
-        val
-        target)
-  sem map_Regex_info : (Info -> Info) -> Regex -> Regex
-sem map_Regex_info f =
+    (acc, set_SHRegex_info val target)
+  sem map_SHRegex_info : (Info -> Info) -> SHRegex -> SHRegex
+sem map_SHRegex_info f =
   | target ->
-    set_Regex_info
-      (f
-         (get_Regex_info
-            target))
-      target
-  sem get_Expr_info : Expr -> Info
-  sem set_Expr_info : Info -> Expr -> Expr
-sem set_Expr_info val =
-  sem mapAccum_Expr_info : all a. (a -> Info -> (a, Info)) -> a -> Expr -> (a, Expr)
-sem mapAccum_Expr_info f acc =
+    set_SHRegex_info (f (get_SHRegex_info target)) target
+  sem get_SHExpr_info : SHExpr -> Info
+sem get_SHExpr_info =
+  sem set_SHExpr_info : Info -> SHExpr -> SHExpr
+sem set_SHExpr_info val =
+  sem mapAccum_SHExpr_info : all a. (a -> Info -> (a, Info)) -> a -> SHExpr -> (a, SHExpr)
+sem mapAccum_SHExpr_info f acc =
   | target ->
     match
-      f
-        acc
-        (get_Expr_info
-           target)
+      f acc (get_SHExpr_info target)
     with
       (acc, val)
     in
-    (acc, set_Expr_info
-        val
-        target)
-  sem map_Expr_info : (Info -> Info) -> Expr -> Expr
-sem map_Expr_info f =
+    (acc, set_SHExpr_info val target)
+  sem map_SHExpr_info : (Info -> Info) -> SHExpr -> SHExpr
+sem map_SHExpr_info f =
   | target ->
-    set_Expr_info
-      (f
-         (get_Expr_info
-            target))
-      target
+    set_SHExpr_info (f (get_SHExpr_info target)) target
 end
-lang LangFileAst =
+lang LangSHFileAst =
   SelfhostBaseAst
-  type LangFileRecord =
-    {info: Info, name: {i: Info, v: String}, decls: [Decl]}
-  syn File =
-  | LangFile LangFileRecord
-  sem smapAccumL_File_Decl f acc =
-  | LangFile x ->
+  type LangSHFileRecord =
+    {info: Info, name: {i: Info, v: String}, decls: [SHDecl]}
+  syn SHFile =
+  | LangSHFile LangSHFileRecord
+  sem smapAccumL_SHFile_SHDecl f acc =
+  | LangSHFile x ->
     match
       match
-        let decls =
-          x.decls
-        in
+        let decls = x.decls in
         mapAccumL
           (lam acc1.
-             lam x1: Decl.
-               f
-                 acc1
-                 x1)
+             lam x1: SHDecl.
+               f acc1 x1)
           acc
           decls
       with
         (acc, decls)
       in
-      (acc, { x
-          with
-          decls =
-            decls })
+      (acc, { x with decls = decls })
     with
       (acc, x)
     in
-    (acc, LangFile
+    (acc, LangSHFile
         x)
-  sem get_File_info =
-  | LangFile target ->
+  sem get_SHFile_info =
+  | LangSHFile target ->
     target.info
-  sem set_File_info val =
-  | LangFile target ->
-    LangFile
-      { target
-        with
-        info =
-          val }
+  sem set_SHFile_info val =
+  | LangSHFile target ->
+    LangSHFile
+      { target with info = val }
 end
-lang StartDeclAst =
+lang StartSHDeclAst =
   SelfhostBaseAst
-  type StartDeclRecord =
+  type StartSHDeclRecord =
     {info: Info, name: {i: Info, v: Name}}
-  syn Decl =
-  | StartDecl StartDeclRecord
-  sem get_Decl_info =
-  | StartDecl target ->
+  syn SHDecl =
+  | StartSHDecl StartSHDeclRecord
+  sem get_SHDecl_info =
+  | StartSHDecl target ->
     target.info
-  sem set_Decl_info val =
-  | StartDecl target ->
-    StartDecl
-      { target
-        with
-        info =
-          val }
+  sem set_SHDecl_info val =
+  | StartSHDecl target ->
+    StartSHDecl
+      { target with info = val }
 end
-lang IncludeDeclAst =
+lang IncludeSHDeclAst =
   SelfhostBaseAst
-  type IncludeDeclRecord =
+  type IncludeSHDeclRecord =
     {info: Info, path: {i: Info, v: String}}
-  syn Decl =
-  | IncludeDecl IncludeDeclRecord
-  sem get_Decl_info =
-  | IncludeDecl target ->
+  syn SHDecl =
+  | IncludeSHDecl IncludeSHDeclRecord
+  sem get_SHDecl_info =
+  | IncludeSHDecl target ->
     target.info
-  sem set_Decl_info val =
-  | IncludeDecl target ->
-    IncludeDecl
-      { target
-        with
-        info =
-          val }
+  sem set_SHDecl_info val =
+  | IncludeSHDecl target ->
+    IncludeSHDecl
+      { target with info = val }
 end
-lang TypeDeclAst =
+lang TypeSHDeclAst =
   SelfhostBaseAst
-  type TypeDeclRecord =
-    {info: Info, name: {i: Info, v: Name}, properties: [{val: Expr, name: {i: Info, v: String}}]}
-  syn Decl =
-  | TypeDecl TypeDeclRecord
-  sem smapAccumL_Decl_Expr f acc =
-  | TypeDecl x ->
+  type TypeSHDeclRecord =
+    {info: Info, name: {i: Info, v: Name}, properties: [{val: SHExpr, name: {i: Info, v: String}}]}
+  syn SHDecl =
+  | TypeSHDecl TypeSHDeclRecord
+  sem smapAccumL_SHDecl_SHExpr f acc =
+  | TypeSHDecl x ->
     match
       match
-        let properties =
-          x.properties
-        in
+        let properties = x.properties in
         mapAccumL
           (lam acc1.
-             lam x1: {val: Expr, name: {i: Info, v: String}}.
+             lam x1: {val: SHExpr, name: {i: Info, v: String}}.
                match
-                 let val1 =
-                   x1.val
-                 in
-                 f
-                   acc1
-                   val1
+                 let val1 = x1.val in
+                 f acc1 val1
                with
                  (acc1, val1)
                in
-               (acc1, { x1
-                   with
-                   val =
-                     val1 }))
+               (acc1, { x1 with val = val1 }))
           acc
           properties
       with
         (acc, properties)
       in
-      (acc, { x
-          with
-          properties =
-            properties })
+      (acc, { x with properties = properties })
     with
       (acc, x)
     in
-    (acc, TypeDecl
+    (acc, TypeSHDecl
         x)
-  sem get_Decl_info =
-  | TypeDecl target ->
+  sem get_SHDecl_info =
+  | TypeSHDecl target ->
     target.info
-  sem set_Decl_info val =
-  | TypeDecl target ->
-    TypeDecl
-      { target
-        with
-        info =
-          val }
+  sem set_SHDecl_info val =
+  | TypeSHDecl target ->
+    TypeSHDecl
+      { target with info = val }
 end
-lang TokenDeclAst =
+lang TokenSHDeclAst =
   SelfhostBaseAst
-  type TokenDeclRecord =
-    {info: Info, name: Option {i: Info, v: Name}, properties: [{val: Expr, name: {i: Info, v: String}}]}
-  syn Decl =
-  | TokenDecl TokenDeclRecord
-  sem smapAccumL_Decl_Expr f acc =
-  | TokenDecl x ->
+  type TokenSHDeclRecord =
+    {info: Info, name: Option {i: Info, v: Name}, properties: [{val: SHExpr, name: {i: Info, v: String}}]}
+  syn SHDecl =
+  | TokenSHDecl TokenSHDeclRecord
+  sem smapAccumL_SHDecl_SHExpr f acc =
+  | TokenSHDecl x ->
     match
       match
-        let properties =
-          x.properties
-        in
+        let properties = x.properties in
         mapAccumL
           (lam acc1.
-             lam x1: {val: Expr, name: {i: Info, v: String}}.
+             lam x1: {val: SHExpr, name: {i: Info, v: String}}.
                match
-                 let val1 =
-                   x1.val
-                 in
-                 f
-                   acc1
-                   val1
+                 let val1 = x1.val in
+                 f acc1 val1
                with
                  (acc1, val1)
                in
-               (acc1, { x1
-                   with
-                   val =
-                     val1 }))
+               (acc1, { x1 with val = val1 }))
           acc
           properties
       with
         (acc, properties)
       in
-      (acc, { x
-          with
-          properties =
-            properties })
+      (acc, { x with properties = properties })
     with
       (acc, x)
     in
-    (acc, TokenDecl
+    (acc, TokenSHDecl
         x)
-  sem get_Decl_info =
-  | TokenDecl target ->
+  sem get_SHDecl_info =
+  | TokenSHDecl target ->
     target.info
-  sem set_Decl_info val =
-  | TokenDecl target ->
-    TokenDecl
-      { target
-        with
-        info =
-          val }
+  sem set_SHDecl_info val =
+  | TokenSHDecl target ->
+    TokenSHDecl
+      { target with info = val }
 end
-lang PrecedenceTableDeclAst =
+lang PrecedenceTableSHDeclAst =
   SelfhostBaseAst
-  type PrecedenceTableDeclRecord =
+  type PrecedenceTableSHDeclRecord =
     {info: Info, levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]}
-  syn Decl =
-  | PrecedenceTableDecl PrecedenceTableDeclRecord
-  sem get_Decl_info =
-  | PrecedenceTableDecl target ->
+  syn SHDecl =
+  | PrecedenceTableSHDecl PrecedenceTableSHDeclRecord
+  sem get_SHDecl_info =
+  | PrecedenceTableSHDecl target ->
     target.info
-  sem set_Decl_info val =
-  | PrecedenceTableDecl target ->
-    PrecedenceTableDecl
-      { target
-        with
-        info =
-          val }
+  sem set_SHDecl_info val =
+  | PrecedenceTableSHDecl target ->
+    PrecedenceTableSHDecl
+      { target with info = val }
 end
-lang ProductionDeclAst =
+lang ProductionSHDeclAst =
   SelfhostBaseAst
-  type ProductionDeclRecord =
-    {nt: {i: Info, v: Name}, info: Info, kinf: Option Info, name: {i: Info, v: Name}, assoc: Option {i: Info, v: String}, kpref: Option Info, kprod: Option Info, regex: Regex, kpostf: Option Info}
-  syn Decl =
-  | ProductionDecl ProductionDeclRecord
-  sem smapAccumL_Decl_Regex f acc =
-  | ProductionDecl x ->
+  type ProductionSHDeclRecord =
+    {nt: {i: Info, v: Name}, info: Info, kinf: Option Info, name: {i: Info, v: Name}, assoc: Option {i: Info, v: String}, kpref: Option Info, kprod: Option Info, regex: SHRegex, kpostf: Option Info}
+  syn SHDecl =
+  | ProductionSHDecl ProductionSHDeclRecord
+  sem smapAccumL_SHDecl_SHRegex f acc =
+  | ProductionSHDecl x ->
     match
       match
-        let regex =
-          x.regex
-        in
-        f
-          acc
-          regex
+        let regex = x.regex in
+        f acc regex
       with
         (acc, regex)
       in
-      (acc, { x
-          with
-          regex =
-            regex })
+      (acc, { x with regex = regex })
     with
       (acc, x)
     in
-    (acc, ProductionDecl
+    (acc, ProductionSHDecl
         x)
-  sem get_Decl_info =
-  | ProductionDecl target ->
+  sem get_SHDecl_info =
+  | ProductionSHDecl target ->
     target.info
-  sem set_Decl_info val =
-  | ProductionDecl target ->
-    ProductionDecl
-      { target
-        with
-        info =
-          val }
+  sem set_SHDecl_info val =
+  | ProductionSHDecl target ->
+    ProductionSHDecl
+      { target with info = val }
 end
-lang RecordRegexAst =
+lang RecordSHRegexAst =
   SelfhostBaseAst
-  type RecordRegexRecord =
-    {info: Info, regex: Regex}
-  syn Regex =
-  | RecordRegex RecordRegexRecord
-  sem smapAccumL_Regex_Regex f acc =
-  | RecordRegex x ->
+  type RecordSHRegexRecord =
+    {info: Info, regex: SHRegex}
+  syn SHRegex =
+  | RecordSHRegex RecordSHRegexRecord
+  sem smapAccumL_SHRegex_SHRegex f acc =
+  | RecordSHRegex x ->
     match
       match
-        let regex =
-          x.regex
-        in
-        f
-          acc
-          regex
+        let regex = x.regex in
+        f acc regex
       with
         (acc, regex)
       in
-      (acc, { x
-          with
-          regex =
-            regex })
+      (acc, { x with regex = regex })
     with
       (acc, x)
     in
-    (acc, RecordRegex
+    (acc, RecordSHRegex
         x)
-  sem get_Regex_info =
-  | RecordRegex target ->
+  sem get_SHRegex_info =
+  | RecordSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | RecordRegex target ->
-    RecordRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | RecordSHRegex target ->
+    RecordSHRegex
+      { target with info = val }
 end
-lang EmptyRegexAst =
+lang EmptySHRegexAst =
   SelfhostBaseAst
-  type EmptyRegexRecord =
+  type EmptySHRegexRecord =
     {info: Info}
-  syn Regex =
-  | EmptyRegex EmptyRegexRecord
-  sem get_Regex_info =
-  | EmptyRegex target ->
+  syn SHRegex =
+  | EmptySHRegex EmptySHRegexRecord
+  sem get_SHRegex_info =
+  | EmptySHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | EmptyRegex target ->
-    EmptyRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | EmptySHRegex target ->
+    EmptySHRegex
+      { target with info = val }
 end
-lang LiteralRegexAst =
+lang LiteralSHRegexAst =
   SelfhostBaseAst
-  type LiteralRegexRecord =
+  type LiteralSHRegexRecord =
     {val: {i: Info, v: String}, info: Info}
-  syn Regex =
-  | LiteralRegex LiteralRegexRecord
-  sem get_Regex_info =
-  | LiteralRegex target ->
+  syn SHRegex =
+  | LiteralSHRegex LiteralSHRegexRecord
+  sem get_SHRegex_info =
+  | LiteralSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | LiteralRegex target ->
-    LiteralRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | LiteralSHRegex target ->
+    LiteralSHRegex
+      { target with info = val }
 end
-lang TokenRegexAst =
+lang TokenSHRegexAst =
   SelfhostBaseAst
-  type TokenRegexRecord =
-    {arg: Option Expr, info: Info, name: {i: Info, v: Name}}
-  syn Regex =
-  | TokenRegex TokenRegexRecord
-  sem smapAccumL_Regex_Expr f acc =
-  | TokenRegex x ->
+  type TokenSHRegexRecord =
+    {arg: Option SHExpr, info: Info, name: {i: Info, v: Name}}
+  syn SHRegex =
+  | TokenSHRegex TokenSHRegexRecord
+  sem smapAccumL_SHRegex_SHExpr f acc =
+  | TokenSHRegex x ->
     match
       match
-        let arg =
-          x.arg
-        in
+        let arg = x.arg in
         optionMapAccum
           (lam acc1.
              lam x1.
-               f
-                 acc1
-                 x1)
+               f acc1 x1)
           acc
           arg
       with
         (acc, arg)
       in
-      (acc, { x
-          with
-          arg =
-            arg })
+      (acc, { x with arg = arg })
     with
       (acc, x)
     in
-    (acc, TokenRegex
+    (acc, TokenSHRegex
         x)
-  sem get_Regex_info =
-  | TokenRegex target ->
+  sem get_SHRegex_info =
+  | TokenSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | TokenRegex target ->
-    TokenRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | TokenSHRegex target ->
+    TokenSHRegex
+      { target with info = val }
 end
-lang RepeatPlusRegexAst =
+lang RepeatPlusSHRegexAst =
   SelfhostBaseAst
-  type RepeatPlusRegexRecord =
-    {info: Info, left: Regex}
-  syn Regex =
-  | RepeatPlusRegex RepeatPlusRegexRecord
-  sem smapAccumL_Regex_Regex f acc =
-  | RepeatPlusRegex x ->
+  type RepeatPlusSHRegexRecord =
+    {info: Info, left: SHRegex}
+  syn SHRegex =
+  | RepeatPlusSHRegex RepeatPlusSHRegexRecord
+  sem smapAccumL_SHRegex_SHRegex f acc =
+  | RepeatPlusSHRegex x ->
     match
       match
-        let left =
-          x.left
-        in
-        f
-          acc
-          left
+        let left = x.left in
+        f acc left
       with
         (acc, left)
       in
-      (acc, { x
-          with
-          left =
-            left })
+      (acc, { x with left = left })
     with
       (acc, x)
     in
-    (acc, RepeatPlusRegex
+    (acc, RepeatPlusSHRegex
         x)
-  sem get_Regex_info =
-  | RepeatPlusRegex target ->
+  sem get_SHRegex_info =
+  | RepeatPlusSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | RepeatPlusRegex target ->
-    RepeatPlusRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | RepeatPlusSHRegex target ->
+    RepeatPlusSHRegex
+      { target with info = val }
 end
-lang RepeatStarRegexAst =
+lang RepeatStarSHRegexAst =
   SelfhostBaseAst
-  type RepeatStarRegexRecord =
-    {info: Info, left: Regex}
-  syn Regex =
-  | RepeatStarRegex RepeatStarRegexRecord
-  sem smapAccumL_Regex_Regex f acc =
-  | RepeatStarRegex x ->
+  type RepeatStarSHRegexRecord =
+    {info: Info, left: SHRegex}
+  syn SHRegex =
+  | RepeatStarSHRegex RepeatStarSHRegexRecord
+  sem smapAccumL_SHRegex_SHRegex f acc =
+  | RepeatStarSHRegex x ->
     match
       match
-        let left =
-          x.left
-        in
-        f
-          acc
-          left
+        let left = x.left in
+        f acc left
       with
         (acc, left)
       in
-      (acc, { x
-          with
-          left =
-            left })
+      (acc, { x with left = left })
     with
       (acc, x)
     in
-    (acc, RepeatStarRegex
+    (acc, RepeatStarSHRegex
         x)
-  sem get_Regex_info =
-  | RepeatStarRegex target ->
+  sem get_SHRegex_info =
+  | RepeatStarSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | RepeatStarRegex target ->
-    RepeatStarRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | RepeatStarSHRegex target ->
+    RepeatStarSHRegex
+      { target with info = val }
 end
-lang RepeatQuestionRegexAst =
+lang RepeatQuestionSHRegexAst =
   SelfhostBaseAst
-  type RepeatQuestionRegexRecord =
-    {info: Info, left: Regex}
-  syn Regex =
-  | RepeatQuestionRegex RepeatQuestionRegexRecord
-  sem smapAccumL_Regex_Regex f acc =
-  | RepeatQuestionRegex x ->
+  type RepeatQuestionSHRegexRecord =
+    {info: Info, left: SHRegex}
+  syn SHRegex =
+  | RepeatQuestionSHRegex RepeatQuestionSHRegexRecord
+  sem smapAccumL_SHRegex_SHRegex f acc =
+  | RepeatQuestionSHRegex x ->
     match
       match
-        let left =
-          x.left
-        in
-        f
-          acc
-          left
+        let left = x.left in
+        f acc left
       with
         (acc, left)
       in
-      (acc, { x
-          with
-          left =
-            left })
+      (acc, { x with left = left })
     with
       (acc, x)
     in
-    (acc, RepeatQuestionRegex
+    (acc, RepeatQuestionSHRegex
         x)
-  sem get_Regex_info =
-  | RepeatQuestionRegex target ->
+  sem get_SHRegex_info =
+  | RepeatQuestionSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | RepeatQuestionRegex target ->
-    RepeatQuestionRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | RepeatQuestionSHRegex target ->
+    RepeatQuestionSHRegex
+      { target with info = val }
 end
-lang NamedRegexAst =
+lang NamedSHRegexAst =
   SelfhostBaseAst
-  type NamedRegexRecord =
-    {info: Info, name: {i: Info, v: String}, right: Regex}
-  syn Regex =
-  | NamedRegex NamedRegexRecord
-  sem smapAccumL_Regex_Regex f acc =
-  | NamedRegex x ->
+  type NamedSHRegexRecord =
+    {info: Info, name: {i: Info, v: String}, right: SHRegex}
+  syn SHRegex =
+  | NamedSHRegex NamedSHRegexRecord
+  sem smapAccumL_SHRegex_SHRegex f acc =
+  | NamedSHRegex x ->
     match
       match
-        let right =
-          x.right
-        in
-        f
-          acc
-          right
+        let right = x.right in
+        f acc right
       with
         (acc, right)
       in
-      (acc, { x
-          with
-          right =
-            right })
+      (acc, { x with right = right })
     with
       (acc, x)
     in
-    (acc, NamedRegex
+    (acc, NamedSHRegex
         x)
-  sem get_Regex_info =
-  | NamedRegex target ->
+  sem get_SHRegex_info =
+  | NamedSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | NamedRegex target ->
-    NamedRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | NamedSHRegex target ->
+    NamedSHRegex
+      { target with info = val }
 end
-lang AlternativeRegexAst =
+lang AlternativeSHRegexAst =
   SelfhostBaseAst
-  type AlternativeRegexRecord =
-    {info: Info, left: Regex, right: Regex}
-  syn Regex =
-  | AlternativeRegex AlternativeRegexRecord
-  sem smapAccumL_Regex_Regex f acc =
-  | AlternativeRegex x ->
+  type AlternativeSHRegexRecord =
+    {info: Info, left: SHRegex, right: SHRegex}
+  syn SHRegex =
+  | AlternativeSHRegex AlternativeSHRegexRecord
+  sem smapAccumL_SHRegex_SHRegex f acc =
+  | AlternativeSHRegex x ->
     match
       match
-        let left =
-          x.left
-        in
-        f
-          acc
-          left
+        let left = x.left in
+        f acc left
       with
         (acc, left)
       in
       match
-          let right =
-            x.right
-          in
-          f
-            acc
-            right
+          let right = x.right in
+          f acc right
         with
           (acc, right)
         in
-        (acc, { { x
-              with
-              left =
-                left }
-            with
-            right =
-              right })
+        (acc, { x with left = left, right = right })
     with
       (acc, x)
     in
-    (acc, AlternativeRegex
+    (acc, AlternativeSHRegex
         x)
-  sem get_Regex_info =
-  | AlternativeRegex target ->
+  sem get_SHRegex_info =
+  | AlternativeSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | AlternativeRegex target ->
-    AlternativeRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | AlternativeSHRegex target ->
+    AlternativeSHRegex
+      { target with info = val }
 end
-lang ConcatRegexAst =
+lang ConcatSHRegexAst =
   SelfhostBaseAst
-  type ConcatRegexRecord =
-    {info: Info, left: Regex, right: Regex}
-  syn Regex =
-  | ConcatRegex ConcatRegexRecord
-  sem smapAccumL_Regex_Regex f acc =
-  | ConcatRegex x ->
+  type ConcatSHRegexRecord =
+    {info: Info, left: SHRegex, right: SHRegex}
+  syn SHRegex =
+  | ConcatSHRegex ConcatSHRegexRecord
+  sem smapAccumL_SHRegex_SHRegex f acc =
+  | ConcatSHRegex x ->
     match
       match
-        let left =
-          x.left
-        in
-        f
-          acc
-          left
+        let left = x.left in
+        f acc left
       with
         (acc, left)
       in
       match
-          let right =
-            x.right
-          in
-          f
-            acc
-            right
+          let right = x.right in
+          f acc right
         with
           (acc, right)
         in
-        (acc, { { x
-              with
-              left =
-                left }
-            with
-            right =
-              right })
+        (acc, { x with left = left, right = right })
     with
       (acc, x)
     in
-    (acc, ConcatRegex
+    (acc, ConcatSHRegex
         x)
-  sem get_Regex_info =
-  | ConcatRegex target ->
+  sem get_SHRegex_info =
+  | ConcatSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | ConcatRegex target ->
-    ConcatRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | ConcatSHRegex target ->
+    ConcatSHRegex
+      { target with info = val }
 end
-lang AppExprAst =
+lang AppSHExprAst =
   SelfhostBaseAst
-  type AppExprRecord =
-    {info: Info, left: Expr, right: Expr}
-  syn Expr =
-  | AppExpr AppExprRecord
-  sem smapAccumL_Expr_Expr f acc =
-  | AppExpr x ->
+  type AppSHExprRecord =
+    {info: Info, left: SHExpr, right: SHExpr}
+  syn SHExpr =
+  | AppSHExpr AppSHExprRecord
+  sem smapAccumL_SHExpr_SHExpr f acc =
+  | AppSHExpr x ->
     match
       match
-        let left =
-          x.left
-        in
-        f
-          acc
-          left
+        let left = x.left in
+        f acc left
       with
         (acc, left)
       in
       match
-          let right =
-            x.right
-          in
-          f
-            acc
-            right
+          let right = x.right in
+          f acc right
         with
           (acc, right)
         in
-        (acc, { { x
-              with
-              left =
-                left }
-            with
-            right =
-              right })
+        (acc, { x with left = left, right = right })
     with
       (acc, x)
     in
-    (acc, AppExpr
+    (acc, AppSHExpr
         x)
-  sem get_Expr_info =
-  | AppExpr target ->
+  sem get_SHExpr_info =
+  | AppSHExpr target ->
     target.info
-  sem set_Expr_info val =
-  | AppExpr target ->
-    AppExpr
-      { target
-        with
-        info =
-          val }
+  sem set_SHExpr_info val =
+  | AppSHExpr target ->
+    AppSHExpr
+      { target with info = val }
 end
-lang ConExprAst =
+lang ConSHExprAst =
   SelfhostBaseAst
-  type ConExprRecord =
+  type ConSHExprRecord =
     {info: Info, name: {i: Info, v: Name}}
-  syn Expr =
-  | ConExpr ConExprRecord
-  sem get_Expr_info =
-  | ConExpr target ->
+  syn SHExpr =
+  | ConSHExpr ConSHExprRecord
+  sem get_SHExpr_info =
+  | ConSHExpr target ->
     target.info
-  sem set_Expr_info val =
-  | ConExpr target ->
-    ConExpr
-      { target
-        with
-        info =
-          val }
+  sem set_SHExpr_info val =
+  | ConSHExpr target ->
+    ConSHExpr
+      { target with info = val }
 end
-lang StringExprAst =
+lang StringSHExprAst =
   SelfhostBaseAst
-  type StringExprRecord =
+  type StringSHExprRecord =
     {val: {i: Info, v: String}, info: Info}
-  syn Expr =
-  | StringExpr StringExprRecord
-  sem get_Expr_info =
-  | StringExpr target ->
+  syn SHExpr =
+  | StringSHExpr StringSHExprRecord
+  sem get_SHExpr_info =
+  | StringSHExpr target ->
     target.info
-  sem set_Expr_info val =
-  | StringExpr target ->
-    StringExpr
-      { target
-        with
-        info =
-          val }
+  sem set_SHExpr_info val =
+  | StringSHExpr target ->
+    StringSHExpr
+      { target with info = val }
 end
-lang VariableExprAst =
+lang VariableSHExprAst =
   SelfhostBaseAst
-  type VariableExprRecord =
+  type VariableSHExprRecord =
     {info: Info, name: {i: Info, v: Name}}
-  syn Expr =
-  | VariableExpr VariableExprRecord
-  sem get_Expr_info =
-  | VariableExpr target ->
+  syn SHExpr =
+  | VariableSHExpr VariableSHExprRecord
+  sem get_SHExpr_info =
+  | VariableSHExpr target ->
     target.info
-  sem set_Expr_info val =
-  | VariableExpr target ->
-    VariableExpr
-      { target
-        with
-        info =
-          val }
+  sem set_SHExpr_info val =
+  | VariableSHExpr target ->
+    VariableSHExpr
+      { target with info = val }
 end
-lang RecordExprAst =
+lang RecordSHExprAst =
   SelfhostBaseAst
-  type RecordExprRecord =
-    {info: Info, fields: [{val: Expr, name: {i: Info, v: String}}]}
-  syn Expr =
-  | RecordExpr RecordExprRecord
-  sem smapAccumL_Expr_Expr f acc =
-  | RecordExpr x ->
+  type RecordSHExprRecord =
+    {info: Info, fields: [{val: SHExpr, name: {i: Info, v: String}}]}
+  syn SHExpr =
+  | RecordSHExpr RecordSHExprRecord
+  sem smapAccumL_SHExpr_SHExpr f acc =
+  | RecordSHExpr x ->
     match
       match
-        let fields =
-          x.fields
-        in
+        let fields = x.fields in
         mapAccumL
           (lam acc1.
-             lam x1: {val: Expr, name: {i: Info, v: String}}.
+             lam x1: {val: SHExpr, name: {i: Info, v: String}}.
                match
-                 let val1 =
-                   x1.val
-                 in
-                 f
-                   acc1
-                   val1
+                 let val1 = x1.val in
+                 f acc1 val1
                with
                  (acc1, val1)
                in
-               (acc1, { x1
-                   with
-                   val =
-                     val1 }))
+               (acc1, { x1 with val = val1 }))
           acc
           fields
       with
         (acc, fields)
       in
-      (acc, { x
-          with
-          fields =
-            fields })
+      (acc, { x with fields = fields })
     with
       (acc, x)
     in
-    (acc, RecordExpr
+    (acc, RecordSHExpr
         x)
-  sem get_Expr_info =
-  | RecordExpr target ->
+  sem get_SHExpr_info =
+  | RecordSHExpr target ->
     target.info
-  sem set_Expr_info val =
-  | RecordExpr target ->
-    RecordExpr
-      { target
-        with
-        info =
-          val }
+  sem set_SHExpr_info val =
+  | RecordSHExpr target ->
+    RecordSHExpr
+      { target with info = val }
 end
-lang BadFileAst =
+lang BadSHFileAst =
   SelfhostBaseAst
-  type BadFileRecord =
+  type BadSHFileRecord =
     {info: Info}
-  syn File =
-  | BadFile BadFileRecord
-  sem get_File_info =
-  | BadFile target ->
+  syn SHFile =
+  | BadSHFile BadSHFileRecord
+  sem get_SHFile_info =
+  | BadSHFile target ->
     target.info
-  sem set_File_info val =
-  | BadFile target ->
-    BadFile
-      { target
-        with
-        info =
-          val }
+  sem set_SHFile_info val =
+  | BadSHFile target ->
+    BadSHFile
+      { target with info = val }
 end
-lang BadDeclAst =
+lang BadSHDeclAst =
   SelfhostBaseAst
-  type BadDeclRecord =
+  type BadSHDeclRecord =
     {info: Info}
-  syn Decl =
-  | BadDecl BadDeclRecord
-  sem get_Decl_info =
-  | BadDecl target ->
+  syn SHDecl =
+  | BadSHDecl BadSHDeclRecord
+  sem get_SHDecl_info =
+  | BadSHDecl target ->
     target.info
-  sem set_Decl_info val =
-  | BadDecl target ->
-    BadDecl
-      { target
-        with
-        info =
-          val }
+  sem set_SHDecl_info val =
+  | BadSHDecl target ->
+    BadSHDecl
+      { target with info = val }
 end
-lang BadRegexAst =
+lang BadSHRegexAst =
   SelfhostBaseAst
-  type BadRegexRecord =
+  type BadSHRegexRecord =
     {info: Info}
-  syn Regex =
-  | BadRegex BadRegexRecord
-  sem get_Regex_info =
-  | BadRegex target ->
+  syn SHRegex =
+  | BadSHRegex BadSHRegexRecord
+  sem get_SHRegex_info =
+  | BadSHRegex target ->
     target.info
-  sem set_Regex_info val =
-  | BadRegex target ->
-    BadRegex
-      { target
-        with
-        info =
-          val }
+  sem set_SHRegex_info val =
+  | BadSHRegex target ->
+    BadSHRegex
+      { target with info = val }
 end
-lang BadExprAst =
+lang BadSHExprAst =
   SelfhostBaseAst
-  type BadExprRecord =
+  type BadSHExprRecord =
     {info: Info}
-  syn Expr =
-  | BadExpr BadExprRecord
-  sem get_Expr_info =
-  | BadExpr target ->
+  syn SHExpr =
+  | BadSHExpr BadSHExprRecord
+  sem get_SHExpr_info =
+  | BadSHExpr target ->
     target.info
-  sem set_Expr_info val =
-  | BadExpr target ->
-    BadExpr
-      { target
-        with
-        info =
-          val }
+  sem set_SHExpr_info val =
+  | BadSHExpr target ->
+    BadSHExpr
+      { target with info = val }
 end
 lang SelfhostAst =
-  LangFileAst
-  + StartDeclAst
-  + IncludeDeclAst
-  + TypeDeclAst
-  + TokenDeclAst
-  + PrecedenceTableDeclAst
-  + ProductionDeclAst
-  + RecordRegexAst
-  + EmptyRegexAst
-  + LiteralRegexAst
-  + TokenRegexAst
-  + RepeatPlusRegexAst
-  + RepeatStarRegexAst
-  + RepeatQuestionRegexAst
-  + NamedRegexAst
-  + AlternativeRegexAst
-  + ConcatRegexAst
-  + AppExprAst
-  + ConExprAst
-  + StringExprAst
-  + VariableExprAst
-  + RecordExprAst
-  + BadFileAst
-  + BadDeclAst
-  + BadRegexAst
-  + BadExprAst
+  LangSHFileAst
+  + StartSHDeclAst
+  + IncludeSHDeclAst
+  + TypeSHDeclAst
+  + TokenSHDeclAst
+  + PrecedenceTableSHDeclAst
+  + ProductionSHDeclAst
+  + RecordSHRegexAst
+  + EmptySHRegexAst
+  + LiteralSHRegexAst
+  + TokenSHRegexAst
+  + RepeatPlusSHRegexAst
+  + RepeatStarSHRegexAst
+  + RepeatQuestionSHRegexAst
+  + NamedSHRegexAst
+  + AlternativeSHRegexAst
+  + ConcatSHRegexAst
+  + AppSHExprAst
+  + ConSHExprAst
+  + StringSHExprAst
+  + VariableSHExprAst
+  + RecordSHExprAst
+  + BadSHFileAst
+  + BadSHDeclAst
+  + BadSHRegexAst
+  + BadSHExprAst
 end
-lang FileOpBase =
+lang SHFileOpBase =
   SelfhostAst
-  syn FileOp lstyle rstyle =
-  sem topAllowed_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> Bool
-sem topAllowed_FileOp =
+  syn SHFileOp lstyle rstyle =
+  sem topAllowed_SHFileOp : all lstyle. all rstyle. SHFileOp lstyle rstyle -> Bool
+sem topAllowed_SHFileOp =
   | _ ->
     true
-  sem leftAllowed_FileOp : all lstyle. all style. all rstyle. {child: FileOp lstyle rstyle, parent: FileOp LOpen style} -> Bool
-sem leftAllowed_FileOp =
+  sem leftAllowed_SHFileOp : all lstyle. all style. all rstyle. {child: SHFileOp lstyle rstyle, parent: SHFileOp LOpen style} -> Bool
+sem leftAllowed_SHFileOp =
   | _ ->
     true
-  sem rightAllowed_FileOp : all style. all lstyle. all rstyle. {child: FileOp lstyle rstyle, parent: FileOp style ROpen} -> Bool
-sem rightAllowed_FileOp =
+  sem rightAllowed_SHFileOp : all style. all lstyle. all rstyle. {child: SHFileOp lstyle rstyle, parent: SHFileOp style ROpen} -> Bool
+sem rightAllowed_SHFileOp =
   | _ ->
     true
-  sem groupingsAllowed_FileOp : all lstyle. all rstyle. (FileOp lstyle ROpen, FileOp LOpen rstyle) -> AllowedDirection
-sem groupingsAllowed_FileOp =
+  sem groupingsAllowed_SHFileOp : all lstyle. all rstyle. (SHFileOp lstyle ROpen, SHFileOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_SHFileOp =
   | _ ->
     GEither
       {}
-  sem parenAllowed_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> AllowedDirection
-sem parenAllowed_FileOp =
+  sem parenAllowed_SHFileOp : all lstyle. all rstyle. SHFileOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_SHFileOp =
   | _ ->
     GEither
       {}
-  sem getInfo_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> Info
-  sem getTerms_FileOp : all lstyle. all rstyle. FileOp lstyle rstyle -> [Info]
-  sem unsplit_FileOp : PermanentNode FileOp -> (Info, File)
+  sem getInfo_SHFileOp : all lstyle. all rstyle. SHFileOp lstyle rstyle -> Info
+sem getInfo_SHFileOp =
+  sem getTerms_SHFileOp : all lstyle. all rstyle. SHFileOp lstyle rstyle -> [Info]
+sem getTerms_SHFileOp =
+  sem unsplit_SHFileOp : PermanentNode SHFileOp -> (Info, SHFile)
+sem unsplit_SHFileOp =
 end
-lang DeclOpBase =
+lang SHDeclOpBase =
   SelfhostAst
-  syn DeclOp lstyle rstyle =
-  sem topAllowed_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> Bool
-sem topAllowed_DeclOp =
+  syn SHDeclOp lstyle rstyle =
+  sem topAllowed_SHDeclOp : all lstyle. all rstyle. SHDeclOp lstyle rstyle -> Bool
+sem topAllowed_SHDeclOp =
   | _ ->
     true
-  sem leftAllowed_DeclOp : all lstyle. all style. all rstyle. {child: DeclOp lstyle rstyle, parent: DeclOp LOpen style} -> Bool
-sem leftAllowed_DeclOp =
+  sem leftAllowed_SHDeclOp : all lstyle. all style. all rstyle. {child: SHDeclOp lstyle rstyle, parent: SHDeclOp LOpen style} -> Bool
+sem leftAllowed_SHDeclOp =
   | _ ->
     true
-  sem rightAllowed_DeclOp : all style. all lstyle. all rstyle. {child: DeclOp lstyle rstyle, parent: DeclOp style ROpen} -> Bool
-sem rightAllowed_DeclOp =
+  sem rightAllowed_SHDeclOp : all style. all lstyle. all rstyle. {child: SHDeclOp lstyle rstyle, parent: SHDeclOp style ROpen} -> Bool
+sem rightAllowed_SHDeclOp =
   | _ ->
     true
-  sem groupingsAllowed_DeclOp : all lstyle. all rstyle. (DeclOp lstyle ROpen, DeclOp LOpen rstyle) -> AllowedDirection
-sem groupingsAllowed_DeclOp =
+  sem groupingsAllowed_SHDeclOp : all lstyle. all rstyle. (SHDeclOp lstyle ROpen, SHDeclOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_SHDeclOp =
   | _ ->
     GEither
       {}
-  sem parenAllowed_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> AllowedDirection
-sem parenAllowed_DeclOp =
+  sem parenAllowed_SHDeclOp : all lstyle. all rstyle. SHDeclOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_SHDeclOp =
   | _ ->
     GEither
       {}
-  sem getInfo_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> Info
-  sem getTerms_DeclOp : all lstyle. all rstyle. DeclOp lstyle rstyle -> [Info]
-  sem unsplit_DeclOp : PermanentNode DeclOp -> (Info, Decl)
+  sem getInfo_SHDeclOp : all lstyle. all rstyle. SHDeclOp lstyle rstyle -> Info
+sem getInfo_SHDeclOp =
+  sem getTerms_SHDeclOp : all lstyle. all rstyle. SHDeclOp lstyle rstyle -> [Info]
+sem getTerms_SHDeclOp =
+  sem unsplit_SHDeclOp : PermanentNode SHDeclOp -> (Info, SHDecl)
+sem unsplit_SHDeclOp =
 end
-lang RegexOpBase =
+lang SHRegexOpBase =
   SelfhostAst
-  syn RegexOp lstyle rstyle =
-  sem topAllowed_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> Bool
-sem topAllowed_RegexOp =
+  syn SHRegexOp lstyle rstyle =
+  sem topAllowed_SHRegexOp : all lstyle. all rstyle. SHRegexOp lstyle rstyle -> Bool
+sem topAllowed_SHRegexOp =
   | _ ->
     true
-  sem leftAllowed_RegexOp : all lstyle. all style. all rstyle. {child: RegexOp lstyle rstyle, parent: RegexOp LOpen style} -> Bool
-sem leftAllowed_RegexOp =
+  sem leftAllowed_SHRegexOp : all lstyle. all style. all rstyle. {child: SHRegexOp lstyle rstyle, parent: SHRegexOp LOpen style} -> Bool
+sem leftAllowed_SHRegexOp =
   | _ ->
     true
-  sem rightAllowed_RegexOp : all style. all lstyle. all rstyle. {child: RegexOp lstyle rstyle, parent: RegexOp style ROpen} -> Bool
-sem rightAllowed_RegexOp =
+  sem rightAllowed_SHRegexOp : all style. all lstyle. all rstyle. {child: SHRegexOp lstyle rstyle, parent: SHRegexOp style ROpen} -> Bool
+sem rightAllowed_SHRegexOp =
   | _ ->
     true
-  sem groupingsAllowed_RegexOp : all lstyle. all rstyle. (RegexOp lstyle ROpen, RegexOp LOpen rstyle) -> AllowedDirection
-sem groupingsAllowed_RegexOp =
+  sem groupingsAllowed_SHRegexOp : all lstyle. all rstyle. (SHRegexOp lstyle ROpen, SHRegexOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_SHRegexOp =
   | _ ->
     GEither
       {}
-  sem parenAllowed_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> AllowedDirection
-sem parenAllowed_RegexOp =
+  sem parenAllowed_SHRegexOp : all lstyle. all rstyle. SHRegexOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_SHRegexOp =
   | _ ->
     GEither
       {}
-  sem getInfo_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> Info
-  sem getTerms_RegexOp : all lstyle. all rstyle. RegexOp lstyle rstyle -> [Info]
-  sem unsplit_RegexOp : PermanentNode RegexOp -> (Info, Regex)
+  sem getInfo_SHRegexOp : all lstyle. all rstyle. SHRegexOp lstyle rstyle -> Info
+sem getInfo_SHRegexOp =
+  sem getTerms_SHRegexOp : all lstyle. all rstyle. SHRegexOp lstyle rstyle -> [Info]
+sem getTerms_SHRegexOp =
+  sem unsplit_SHRegexOp : PermanentNode SHRegexOp -> (Info, SHRegex)
+sem unsplit_SHRegexOp =
 end
-lang ExprOpBase =
+lang SHExprOpBase =
   SelfhostAst
-  syn ExprOp lstyle rstyle =
-  sem topAllowed_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> Bool
-sem topAllowed_ExprOp =
+  syn SHExprOp lstyle rstyle =
+  sem topAllowed_SHExprOp : all lstyle. all rstyle. SHExprOp lstyle rstyle -> Bool
+sem topAllowed_SHExprOp =
   | _ ->
     true
-  sem leftAllowed_ExprOp : all lstyle. all style. all rstyle. {child: ExprOp lstyle rstyle, parent: ExprOp LOpen style} -> Bool
-sem leftAllowed_ExprOp =
+  sem leftAllowed_SHExprOp : all lstyle. all style. all rstyle. {child: SHExprOp lstyle rstyle, parent: SHExprOp LOpen style} -> Bool
+sem leftAllowed_SHExprOp =
   | _ ->
     true
-  sem rightAllowed_ExprOp : all style. all lstyle. all rstyle. {child: ExprOp lstyle rstyle, parent: ExprOp style ROpen} -> Bool
-sem rightAllowed_ExprOp =
+  sem rightAllowed_SHExprOp : all style. all lstyle. all rstyle. {child: SHExprOp lstyle rstyle, parent: SHExprOp style ROpen} -> Bool
+sem rightAllowed_SHExprOp =
   | _ ->
     true
-  sem groupingsAllowed_ExprOp : all lstyle. all rstyle. (ExprOp lstyle ROpen, ExprOp LOpen rstyle) -> AllowedDirection
-sem groupingsAllowed_ExprOp =
+  sem groupingsAllowed_SHExprOp : all lstyle. all rstyle. (SHExprOp lstyle ROpen, SHExprOp LOpen rstyle) -> AllowedDirection
+sem groupingsAllowed_SHExprOp =
   | _ ->
     GEither
       {}
-  sem parenAllowed_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> AllowedDirection
-sem parenAllowed_ExprOp =
+  sem parenAllowed_SHExprOp : all lstyle. all rstyle. SHExprOp lstyle rstyle -> AllowedDirection
+sem parenAllowed_SHExprOp =
   | _ ->
     GEither
       {}
-  sem getInfo_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> Info
-  sem getTerms_ExprOp : all lstyle. all rstyle. ExprOp lstyle rstyle -> [Info]
-  sem unsplit_ExprOp : PermanentNode ExprOp -> (Info, Expr)
+  sem getInfo_SHExprOp : all lstyle. all rstyle. SHExprOp lstyle rstyle -> Info
+sem getInfo_SHExprOp =
+  sem getTerms_SHExprOp : all lstyle. all rstyle. SHExprOp lstyle rstyle -> [Info]
+sem getTerms_SHExprOp =
+  sem unsplit_SHExprOp : PermanentNode SHExprOp -> (Info, SHExpr)
+sem unsplit_SHExprOp =
 end
-lang LangFileOp =
-  FileOpBase
-  + LangFileAst
-  syn FileOp lstyle rstyle =
-  | LangFileOp {name: [{i: Info, v: String}], decls: [Decl], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_FileOp =
-  | LangFileOp x ->
+lang LangSHFileOp =
+  SHFileOpBase
+  + LangSHFileAst
+  syn SHFileOp lstyle rstyle =
+  | LangSHFileOp {name: [{i: Info, v: String}], decls: [SHDecl], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHFileOp =
+  | LangSHFileOp x ->
     x.__br_info
-  sem getTerms_FileOp =
-  | LangFileOp x ->
+  sem getTerms_SHFileOp =
+  | LangSHFileOp x ->
     x.__br_terms
-  sem unsplit_FileOp =
-  | AtomP {self = LangFileOp x} ->
-    (x.__br_info, LangFile
-      { info =
-          x.__br_info,
-        decls =
-          x.decls,
+  sem unsplit_SHFileOp =
+  | AtomP {self = LangSHFileOp x} ->
+    (x.__br_info, LangSHFile
+      { info = x.__br_info,
+        decls = x.decls,
         name =
           match
             x.name
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang StartDeclOp =
-  DeclOpBase
-  + StartDeclAst
-  syn DeclOp lstyle rstyle =
-  | StartDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_DeclOp =
-  | StartDeclOp x ->
+lang StartSHDeclOp =
+  SHDeclOpBase
+  + StartSHDeclAst
+  syn SHDeclOp lstyle rstyle =
+  | StartSHDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHDeclOp =
+  | StartSHDeclOp x ->
     x.__br_info
-  sem getTerms_DeclOp =
-  | StartDeclOp x ->
+  sem getTerms_SHDeclOp =
+  | StartSHDeclOp x ->
     x.__br_terms
-  sem unsplit_DeclOp =
-  | AtomP {self = StartDeclOp x} ->
-    (x.__br_info, StartDecl
-      { info =
-          x.__br_info,
+  sem unsplit_SHDeclOp =
+  | AtomP {self = StartSHDeclOp x} ->
+    (x.__br_info, StartSHDecl
+      { info = x.__br_info,
         name =
           match
             x.name
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang IncludeDeclOp =
-  DeclOpBase
-  + IncludeDeclAst
-  syn DeclOp lstyle rstyle =
-  | IncludeDeclOp {path: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_DeclOp =
-  | IncludeDeclOp x ->
+lang IncludeSHDeclOp =
+  SHDeclOpBase
+  + IncludeSHDeclAst
+  syn SHDeclOp lstyle rstyle =
+  | IncludeSHDeclOp {path: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHDeclOp =
+  | IncludeSHDeclOp x ->
     x.__br_info
-  sem getTerms_DeclOp =
-  | IncludeDeclOp x ->
+  sem getTerms_SHDeclOp =
+  | IncludeSHDeclOp x ->
     x.__br_terms
-  sem unsplit_DeclOp =
-  | AtomP {self = IncludeDeclOp x} ->
-    (x.__br_info, IncludeDecl
-      { info =
-          x.__br_info,
+  sem unsplit_SHDeclOp =
+  | AtomP {self = IncludeSHDeclOp x} ->
+    (x.__br_info, IncludeSHDecl
+      { info = x.__br_info,
         path =
           match
             x.path
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang TypeDeclOp =
-  DeclOpBase
-  + TypeDeclAst
-  syn DeclOp lstyle rstyle =
-  | TypeDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]}
-  sem getInfo_DeclOp =
-  | TypeDeclOp x ->
+lang TypeSHDeclOp =
+  SHDeclOpBase
+  + TypeSHDeclAst
+  syn SHDeclOp lstyle rstyle =
+  | TypeSHDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]}
+  sem getInfo_SHDeclOp =
+  | TypeSHDeclOp x ->
     x.__br_info
-  sem getTerms_DeclOp =
-  | TypeDeclOp x ->
+  sem getTerms_SHDeclOp =
+  | TypeSHDeclOp x ->
     x.__br_terms
-  sem unsplit_DeclOp =
-  | AtomP {self = TypeDeclOp x} ->
-    (x.__br_info, TypeDecl
-      { info =
-          x.__br_info,
+  sem unsplit_SHDeclOp =
+  | AtomP {self = TypeSHDeclOp x} ->
+    (x.__br_info, TypeSHDecl
+      { info = x.__br_info,
         name =
           match
             x.name
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1,
-        properties =
-          x.properties })
+        properties = x.properties })
 end
-lang TokenDeclOp =
-  DeclOpBase
-  + TokenDeclAst
-  syn DeclOp lstyle rstyle =
-  | TokenDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]}
-  sem getInfo_DeclOp =
-  | TokenDeclOp x ->
+lang TokenSHDeclOp =
+  SHDeclOpBase
+  + TokenSHDeclAst
+  syn SHDeclOp lstyle rstyle =
+  | TokenSHDeclOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]}
+  sem getInfo_SHDeclOp =
+  | TokenSHDeclOp x ->
     x.__br_info
-  sem getTerms_DeclOp =
-  | TokenDeclOp x ->
+  sem getTerms_SHDeclOp =
+  | TokenSHDeclOp x ->
     x.__br_terms
-  sem unsplit_DeclOp =
-  | AtomP {self = TokenDeclOp x} ->
-    (x.__br_info, TokenDecl
-      { info =
-          x.__br_info,
+  sem unsplit_SHDeclOp =
+  | AtomP {self = TokenSHDeclOp x} ->
+    (x.__br_info, TokenSHDecl
+      { info = x.__br_info,
         name =
           match
             x.name
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           then
             Some
               x1
           else
             None
               {},
-        properties =
-          x.properties })
+        properties = x.properties })
 end
-lang PrecedenceTableDeclOp =
-  DeclOpBase
-  + PrecedenceTableDeclAst
-  syn DeclOp lstyle rstyle =
-  | PrecedenceTableDeclOp {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]}
-  sem getInfo_DeclOp =
-  | PrecedenceTableDeclOp x ->
+lang PrecedenceTableSHDeclOp =
+  SHDeclOpBase
+  + PrecedenceTableSHDeclAst
+  syn SHDeclOp lstyle rstyle =
+  | PrecedenceTableSHDeclOp {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]}
+  sem getInfo_SHDeclOp =
+  | PrecedenceTableSHDeclOp x ->
     x.__br_info
-  sem getTerms_DeclOp =
-  | PrecedenceTableDeclOp x ->
+  sem getTerms_SHDeclOp =
+  | PrecedenceTableSHDeclOp x ->
     x.__br_terms
-  sem unsplit_DeclOp =
-  | AtomP {self = PrecedenceTableDeclOp x} ->
-    (x.__br_info, PrecedenceTableDecl
-      { info =
-          x.__br_info,
-        levels =
-          x.levels,
-        exceptions =
-          x.exceptions })
+  sem unsplit_SHDeclOp =
+  | AtomP {self = PrecedenceTableSHDeclOp x} ->
+    (x.__br_info, PrecedenceTableSHDecl
+      { info = x.__br_info,
+        levels = x.levels,
+        exceptions = x.exceptions })
 end
-lang ProductionDeclOp =
-  DeclOpBase
-  + ProductionDeclAst
-  syn DeclOp lstyle rstyle =
-  | ProductionDeclOp {nt: [{i: Info, v: Name}], kinf: [Info], name: [{i: Info, v: Name}], assoc: [{i: Info, v: String}], kpref: [Info], kprod: [Info], regex: [Regex], kpostf: [Info], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_DeclOp =
-  | ProductionDeclOp x ->
+lang ProductionSHDeclOp =
+  SHDeclOpBase
+  + ProductionSHDeclAst
+  syn SHDeclOp lstyle rstyle =
+  | ProductionSHDeclOp {nt: [{i: Info, v: Name}], kinf: [Info], name: [{i: Info, v: Name}], assoc: [{i: Info, v: String}], kpref: [Info], kprod: [Info], regex: [SHRegex], kpostf: [Info], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHDeclOp =
+  | ProductionSHDeclOp x ->
     x.__br_info
-  sem getTerms_DeclOp =
-  | ProductionDeclOp x ->
+  sem getTerms_SHDeclOp =
+  | ProductionSHDeclOp x ->
     x.__br_terms
-  sem unsplit_DeclOp =
-  | AtomP {self = ProductionDeclOp x} ->
-    (x.__br_info, ProductionDecl
-      { info =
-          x.__br_info,
+  sem unsplit_SHDeclOp =
+  | AtomP {self = ProductionSHDeclOp x} ->
+    (x.__br_info, ProductionSHDecl
+      { info = x.__br_info,
         nt =
           match
             x.nt
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1,
         name =
           match
             x.name
           with
-            [ x2 ] ++ _ ++ ""
+            [ x2 ] ++ _
           in
           x2,
         kinf =
           match
             x.kinf
           with
-            [ x3 ] ++ _ ++ ""
+            [ x3 ] ++ _
           then
             Some
               x3
@@ -1694,7 +1306,7 @@ lang ProductionDeclOp =
           match
             x.kpref
           with
-            [ x4 ] ++ _ ++ ""
+            [ x4 ] ++ _
           then
             Some
               x4
@@ -1705,7 +1317,7 @@ lang ProductionDeclOp =
           match
             x.kprod
           with
-            [ x5 ] ++ _ ++ ""
+            [ x5 ] ++ _
           then
             Some
               x5
@@ -1716,7 +1328,7 @@ lang ProductionDeclOp =
           match
             x.kpostf
           with
-            [ x6 ] ++ _ ++ ""
+            [ x6 ] ++ _
           then
             Some
               x6
@@ -1727,7 +1339,7 @@ lang ProductionDeclOp =
           match
             x.assoc
           with
-            [ x7 ] ++ _ ++ ""
+            [ x7 ] ++ _
           then
             Some
               x7
@@ -1738,103 +1350,99 @@ lang ProductionDeclOp =
           match
             x.regex
           with
-            [ x8 ] ++ _ ++ ""
+            [ x8 ] ++ _
           in
           x8 })
 end
-lang RecordRegexOp =
-  RegexOpBase
-  + RecordRegexAst
-  syn RegexOp lstyle rstyle =
-  | RecordRegexOp {regex: [Regex], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | RecordRegexOp x ->
+lang RecordSHRegexOp =
+  SHRegexOpBase
+  + RecordSHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | RecordSHRegexOp {regex: [SHRegex], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | RecordSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | RecordRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | RecordSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | AtomP {self = RecordRegexOp x} ->
-    (x.__br_info, RecordRegex
-      { info =
-          x.__br_info,
+  sem unsplit_SHRegexOp =
+  | AtomP {self = RecordSHRegexOp x} ->
+    (x.__br_info, RecordSHRegex
+      { info = x.__br_info,
         regex =
           match
             x.regex
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang EmptyRegexOp =
-  RegexOpBase
-  + EmptyRegexAst
-  syn RegexOp lstyle rstyle =
-  | EmptyRegexOp {__br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | EmptyRegexOp x ->
+lang EmptySHRegexOp =
+  SHRegexOpBase
+  + EmptySHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | EmptySHRegexOp {__br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | EmptySHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | EmptyRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | EmptySHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | AtomP {self = EmptyRegexOp x} ->
-    (x.__br_info, EmptyRegex
-      { info =
-          x.__br_info })
+  sem unsplit_SHRegexOp =
+  | AtomP {self = EmptySHRegexOp x} ->
+    (x.__br_info, EmptySHRegex
+      { info = x.__br_info })
 end
-lang LiteralRegexOp =
-  RegexOpBase
-  + LiteralRegexAst
-  syn RegexOp lstyle rstyle =
-  | LiteralRegexOp {val: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | LiteralRegexOp x ->
+lang LiteralSHRegexOp =
+  SHRegexOpBase
+  + LiteralSHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | LiteralSHRegexOp {val: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | LiteralSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | LiteralRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | LiteralSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | AtomP {self = LiteralRegexOp x} ->
-    (x.__br_info, LiteralRegex
-      { info =
-          x.__br_info,
+  sem unsplit_SHRegexOp =
+  | AtomP {self = LiteralSHRegexOp x} ->
+    (x.__br_info, LiteralSHRegex
+      { info = x.__br_info,
         val =
           match
             x.val
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang TokenRegexOp =
-  RegexOpBase
-  + TokenRegexAst
-  syn RegexOp lstyle rstyle =
-  | TokenRegexOp {arg: [Expr], name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | TokenRegexOp x ->
+lang TokenSHRegexOp =
+  SHRegexOpBase
+  + TokenSHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | TokenSHRegexOp {arg: [SHExpr], name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | TokenSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | TokenRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | TokenSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | AtomP {self = TokenRegexOp x} ->
-    (x.__br_info, TokenRegex
-      { info =
-          x.__br_info,
+  sem unsplit_SHRegexOp =
+  | AtomP {self = TokenSHRegexOp x} ->
+    (x.__br_info, TokenSHRegex
+      { info = x.__br_info,
         name =
           match
             x.name
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1,
         arg =
           match
             x.arg
           with
-            [ x2 ] ++ _ ++ ""
+            [ x2 ] ++ _
           then
             Some
               x2
@@ -1842,448 +1450,397 @@ lang TokenRegexOp =
             None
               {} })
 end
-lang RepeatPlusRegexOp =
-  RegexOpBase
-  + RepeatPlusRegexAst
-  syn RegexOp lstyle rstyle =
-  | RepeatPlusRegexOp {__br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | RepeatPlusRegexOp x ->
+lang RepeatPlusSHRegexOp =
+  SHRegexOpBase
+  + RepeatPlusSHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | RepeatPlusSHRegexOp {__br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | RepeatPlusSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | RepeatPlusRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | RepeatPlusSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | PostfixP {self = RepeatPlusRegexOp x, leftChildAlts = [ l ] ++ _ ++ ""} ->
+  sem unsplit_SHRegexOp =
+  | PostfixP {self = RepeatPlusSHRegexOp x, leftChildAlts = [ l ] ++ _} ->
     match
-      unsplit_RegexOp
-        l
+      unsplit_SHRegexOp l
     with
       (linfo, l)
     in
-    let info =
-        mergeInfo
-          linfo
-          (x.__br_info)
-      in
-      (info, RepeatPlusRegex
-        { info =
-            info,
+    let info = mergeInfo linfo x.__br_info in
+      (info, RepeatPlusSHRegex
+        { info = info,
           left =
             match
               [ l ]
             with
-              [ x1 ] ++ _ ++ ""
+              [ x1 ] ++ _
             in
             x1 })
 end
-lang RepeatStarRegexOp =
-  RegexOpBase
-  + RepeatStarRegexAst
-  syn RegexOp lstyle rstyle =
-  | RepeatStarRegexOp {__br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | RepeatStarRegexOp x ->
+lang RepeatStarSHRegexOp =
+  SHRegexOpBase
+  + RepeatStarSHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | RepeatStarSHRegexOp {__br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | RepeatStarSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | RepeatStarRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | RepeatStarSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | PostfixP {self = RepeatStarRegexOp x, leftChildAlts = [ l ] ++ _ ++ ""} ->
+  sem unsplit_SHRegexOp =
+  | PostfixP {self = RepeatStarSHRegexOp x, leftChildAlts = [ l ] ++ _} ->
     match
-      unsplit_RegexOp
-        l
+      unsplit_SHRegexOp l
     with
       (linfo, l)
     in
-    let info =
-        mergeInfo
-          linfo
-          (x.__br_info)
-      in
-      (info, RepeatStarRegex
-        { info =
-            info,
+    let info = mergeInfo linfo x.__br_info in
+      (info, RepeatStarSHRegex
+        { info = info,
           left =
             match
               [ l ]
             with
-              [ x1 ] ++ _ ++ ""
+              [ x1 ] ++ _
             in
             x1 })
 end
-lang RepeatQuestionRegexOp =
-  RegexOpBase
-  + RepeatQuestionRegexAst
-  syn RegexOp lstyle rstyle =
-  | RepeatQuestionRegexOp {__br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | RepeatQuestionRegexOp x ->
+lang RepeatQuestionSHRegexOp =
+  SHRegexOpBase
+  + RepeatQuestionSHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | RepeatQuestionSHRegexOp {__br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | RepeatQuestionSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | RepeatQuestionRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | RepeatQuestionSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | PostfixP {self = RepeatQuestionRegexOp x, leftChildAlts = [ l ] ++ _ ++ ""} ->
+  sem unsplit_SHRegexOp =
+  | PostfixP {self = RepeatQuestionSHRegexOp x, leftChildAlts = [ l ] ++ _} ->
     match
-      unsplit_RegexOp
-        l
+      unsplit_SHRegexOp l
     with
       (linfo, l)
     in
-    let info =
-        mergeInfo
-          linfo
-          (x.__br_info)
-      in
-      (info, RepeatQuestionRegex
-        { info =
-            info,
+    let info = mergeInfo linfo x.__br_info in
+      (info, RepeatQuestionSHRegex
+        { info = info,
           left =
             match
               [ l ]
             with
-              [ x1 ] ++ _ ++ ""
+              [ x1 ] ++ _
             in
             x1 })
 end
-lang NamedRegexOp =
-  RegexOpBase
-  + NamedRegexAst
-  syn RegexOp lstyle rstyle =
-  | NamedRegexOp {name: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | NamedRegexOp x ->
+lang NamedSHRegexOp =
+  SHRegexOpBase
+  + NamedSHRegexAst
+  syn SHRegexOp lstyle rstyle =
+  | NamedSHRegexOp {name: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | NamedSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | NamedRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | NamedSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | PrefixP {self = NamedRegexOp x, rightChildAlts = [ r ] ++ _ ++ ""} ->
+  sem unsplit_SHRegexOp =
+  | PrefixP {self = NamedSHRegexOp x, rightChildAlts = [ r ] ++ _} ->
     match
-      unsplit_RegexOp
-        r
+      unsplit_SHRegexOp r
     with
       (rinfo, r)
     in
-    let info =
-        mergeInfo
-          (x.__br_info)
-          rinfo
-      in
-      (info, NamedRegex
-        { info =
-            info,
+    let info = mergeInfo x.__br_info rinfo in
+      (info, NamedSHRegex
+        { info = info,
           name =
             match
               x.name
             with
-              [ x1 ] ++ _ ++ ""
+              [ x1 ] ++ _
             in
             x1,
           right =
             match
               [ r ]
             with
-              [ x2 ] ++ _ ++ ""
+              [ x2 ] ++ _
             in
             x2 })
 end
-lang AlternativeRegexOp =
-  RegexOpBase
-  + AlternativeRegexAst
-  sem groupingsAllowed_RegexOp =
-  | (AlternativeRegexOp _, AlternativeRegexOp _) ->
+lang AlternativeSHRegexOp =
+  SHRegexOpBase
+  + AlternativeSHRegexAst
+  sem groupingsAllowed_SHRegexOp =
+  | (AlternativeSHRegexOp _, AlternativeSHRegexOp _) ->
     GLeft
       {}
-  syn RegexOp lstyle rstyle =
-  | AlternativeRegexOp {__br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | AlternativeRegexOp x ->
+  syn SHRegexOp lstyle rstyle =
+  | AlternativeSHRegexOp {__br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | AlternativeSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | AlternativeRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | AlternativeSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | InfixP {self = AlternativeRegexOp x, leftChildAlts = [ l ] ++ _ ++ "", rightChildAlts = [ r ] ++ _ ++ ""} ->
+  sem unsplit_SHRegexOp =
+  | InfixP {self = AlternativeSHRegexOp x, leftChildAlts = [ l ] ++ _, rightChildAlts = [ r ] ++ _} ->
     match
-      (unsplit_RegexOp
-        l, unsplit_RegexOp
-        r)
+      (unsplit_SHRegexOp l, unsplit_SHRegexOp r)
     with
       ((linfo, l), (rinfo, r))
     in
-    let info =
-        foldl
-          mergeInfo
-          linfo
-          [ x.__br_info,
+    let info = foldl mergeInfo linfo [ x.__br_info,
             rinfo ]
       in
-      (info, AlternativeRegex
-        { info =
-            info,
+      (info, AlternativeSHRegex
+        { info = info,
           left =
             match
               [ l ]
             with
-              [ x1 ] ++ _ ++ ""
+              [ x1 ] ++ _
             in
             x1,
           right =
             match
               [ r ]
             with
-              [ x2 ] ++ _ ++ ""
+              [ x2 ] ++ _
             in
             x2 })
 end
-lang ConcatRegexOp =
-  RegexOpBase
-  + ConcatRegexAst
-  sem groupingsAllowed_RegexOp =
-  | (ConcatRegexOp _, ConcatRegexOp _) ->
+lang ConcatSHRegexOp =
+  SHRegexOpBase
+  + ConcatSHRegexAst
+  sem groupingsAllowed_SHRegexOp =
+  | (ConcatSHRegexOp _, ConcatSHRegexOp _) ->
     GLeft
       {}
-  syn RegexOp lstyle rstyle =
-  | ConcatRegexOp {__br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | ConcatRegexOp x ->
+  syn SHRegexOp lstyle rstyle =
+  | ConcatSHRegexOp {__br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | ConcatSHRegexOp x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | ConcatRegexOp x ->
+  sem getTerms_SHRegexOp =
+  | ConcatSHRegexOp x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | InfixP {self = ConcatRegexOp x, leftChildAlts = [ l ] ++ _ ++ "", rightChildAlts = [ r ] ++ _ ++ ""} ->
+  sem unsplit_SHRegexOp =
+  | InfixP {self = ConcatSHRegexOp x, leftChildAlts = [ l ] ++ _, rightChildAlts = [ r ] ++ _} ->
     match
-      (unsplit_RegexOp
-        l, unsplit_RegexOp
-        r)
+      (unsplit_SHRegexOp l, unsplit_SHRegexOp r)
     with
       ((linfo, l), (rinfo, r))
     in
-    let info =
-        foldl
-          mergeInfo
-          linfo
-          [ x.__br_info,
+    let info = foldl mergeInfo linfo [ x.__br_info,
             rinfo ]
       in
-      (info, ConcatRegex
-        { info =
-            info,
+      (info, ConcatSHRegex
+        { info = info,
           left =
             match
               [ l ]
             with
-              [ x1 ] ++ _ ++ ""
+              [ x1 ] ++ _
             in
             x1,
           right =
             match
               [ r ]
             with
-              [ x2 ] ++ _ ++ ""
+              [ x2 ] ++ _
             in
             x2 })
 end
-lang AppExprOp =
-  ExprOpBase
-  + AppExprAst
-  sem groupingsAllowed_ExprOp =
-  | (AppExprOp _, AppExprOp _) ->
+lang AppSHExprOp =
+  SHExprOpBase
+  + AppSHExprAst
+  sem groupingsAllowed_SHExprOp =
+  | (AppSHExprOp _, AppSHExprOp _) ->
     GLeft
       {}
-  syn ExprOp lstyle rstyle =
-  | AppExprOp {__br_info: Info, __br_terms: [Info]}
-  sem getInfo_ExprOp =
-  | AppExprOp x ->
+  syn SHExprOp lstyle rstyle =
+  | AppSHExprOp {__br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHExprOp =
+  | AppSHExprOp x ->
     x.__br_info
-  sem getTerms_ExprOp =
-  | AppExprOp x ->
+  sem getTerms_SHExprOp =
+  | AppSHExprOp x ->
     x.__br_terms
-  sem unsplit_ExprOp =
-  | InfixP {self = AppExprOp x, leftChildAlts = [ l ] ++ _ ++ "", rightChildAlts = [ r ] ++ _ ++ ""} ->
+  sem unsplit_SHExprOp =
+  | InfixP {self = AppSHExprOp x, leftChildAlts = [ l ] ++ _, rightChildAlts = [ r ] ++ _} ->
     match
-      (unsplit_ExprOp
-        l, unsplit_ExprOp
-        r)
+      (unsplit_SHExprOp l, unsplit_SHExprOp r)
     with
       ((linfo, l), (rinfo, r))
     in
-    let info =
-        foldl
-          mergeInfo
-          linfo
-          [ x.__br_info,
+    let info = foldl mergeInfo linfo [ x.__br_info,
             rinfo ]
       in
-      (info, AppExpr
-        { info =
-            info,
+      (info, AppSHExpr
+        { info = info,
           left =
             match
               [ l ]
             with
-              [ x1 ] ++ _ ++ ""
+              [ x1 ] ++ _
             in
             x1,
           right =
             match
               [ r ]
             with
-              [ x2 ] ++ _ ++ ""
+              [ x2 ] ++ _
             in
             x2 })
 end
-lang ConExprOp =
-  ExprOpBase
-  + ConExprAst
-  syn ExprOp lstyle rstyle =
-  | ConExprOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_ExprOp =
-  | ConExprOp x ->
+lang ConSHExprOp =
+  SHExprOpBase
+  + ConSHExprAst
+  syn SHExprOp lstyle rstyle =
+  | ConSHExprOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHExprOp =
+  | ConSHExprOp x ->
     x.__br_info
-  sem getTerms_ExprOp =
-  | ConExprOp x ->
+  sem getTerms_SHExprOp =
+  | ConSHExprOp x ->
     x.__br_terms
-  sem unsplit_ExprOp =
-  | AtomP {self = ConExprOp x} ->
-    (x.__br_info, ConExpr
-      { info =
-          x.__br_info,
+  sem unsplit_SHExprOp =
+  | AtomP {self = ConSHExprOp x} ->
+    (x.__br_info, ConSHExpr
+      { info = x.__br_info,
         name =
           match
             x.name
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang StringExprOp =
-  ExprOpBase
-  + StringExprAst
-  syn ExprOp lstyle rstyle =
-  | StringExprOp {val: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_ExprOp =
-  | StringExprOp x ->
+lang StringSHExprOp =
+  SHExprOpBase
+  + StringSHExprAst
+  syn SHExprOp lstyle rstyle =
+  | StringSHExprOp {val: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHExprOp =
+  | StringSHExprOp x ->
     x.__br_info
-  sem getTerms_ExprOp =
-  | StringExprOp x ->
+  sem getTerms_SHExprOp =
+  | StringSHExprOp x ->
     x.__br_terms
-  sem unsplit_ExprOp =
-  | AtomP {self = StringExprOp x} ->
-    (x.__br_info, StringExpr
-      { info =
-          x.__br_info,
+  sem unsplit_SHExprOp =
+  | AtomP {self = StringSHExprOp x} ->
+    (x.__br_info, StringSHExpr
+      { info = x.__br_info,
         val =
           match
             x.val
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang VariableExprOp =
-  ExprOpBase
-  + VariableExprAst
-  syn ExprOp lstyle rstyle =
-  | VariableExprOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_ExprOp =
-  | VariableExprOp x ->
+lang VariableSHExprOp =
+  SHExprOpBase
+  + VariableSHExprAst
+  syn SHExprOp lstyle rstyle =
+  | VariableSHExprOp {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHExprOp =
+  | VariableSHExprOp x ->
     x.__br_info
-  sem getTerms_ExprOp =
-  | VariableExprOp x ->
+  sem getTerms_SHExprOp =
+  | VariableSHExprOp x ->
     x.__br_terms
-  sem unsplit_ExprOp =
-  | AtomP {self = VariableExprOp x} ->
-    (x.__br_info, VariableExpr
-      { info =
-          x.__br_info,
+  sem unsplit_SHExprOp =
+  | AtomP {self = VariableSHExprOp x} ->
+    (x.__br_info, VariableSHExpr
+      { info = x.__br_info,
         name =
           match
             x.name
           with
-            [ x1 ] ++ _ ++ ""
+            [ x1 ] ++ _
           in
           x1 })
 end
-lang RecordExprOp =
-  ExprOpBase
-  + RecordExprAst
-  syn ExprOp lstyle rstyle =
-  | RecordExprOp {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]}
-  sem getInfo_ExprOp =
-  | RecordExprOp x ->
+lang RecordSHExprOp =
+  SHExprOpBase
+  + RecordSHExprAst
+  syn SHExprOp lstyle rstyle =
+  | RecordSHExprOp {fields: [{val: SHExpr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHExprOp =
+  | RecordSHExprOp x ->
     x.__br_info
-  sem getTerms_ExprOp =
-  | RecordExprOp x ->
+  sem getTerms_SHExprOp =
+  | RecordSHExprOp x ->
     x.__br_terms
-  sem unsplit_ExprOp =
-  | AtomP {self = RecordExprOp x} ->
-    (x.__br_info, RecordExpr
-      { info =
-          x.__br_info,
-        fields =
-          x.fields })
+  sem unsplit_SHExprOp =
+  | AtomP {self = RecordSHExprOp x} ->
+    (x.__br_info, RecordSHExpr
+      { info = x.__br_info, fields = x.fields })
 end
-lang RegexGrouping =
-  RegexOpBase
-  syn RegexOp lstyle rstyle =
-  | RegexGrouping {inner: Regex, __br_info: Info, __br_terms: [Info]}
-  sem getInfo_RegexOp =
-  | RegexGrouping x ->
+lang SHRegexGrouping =
+  SHRegexOpBase
+  syn SHRegexOp lstyle rstyle =
+  | SHRegexGrouping {inner: SHRegex, __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHRegexOp =
+  | SHRegexGrouping x ->
     x.__br_info
-  sem getTerms_RegexOp =
-  | RegexGrouping x ->
+  sem getTerms_SHRegexOp =
+  | SHRegexGrouping x ->
     x.__br_terms
-  sem unsplit_RegexOp =
-  | AtomP {self = RegexGrouping x} ->
+  sem unsplit_SHRegexOp =
+  | AtomP {self = SHRegexGrouping x} ->
     (x.__br_info, x.inner)
 end
-lang ExprGrouping =
-  ExprOpBase
-  syn ExprOp lstyle rstyle =
-  | ExprGrouping {inner: Expr, __br_info: Info, __br_terms: [Info]}
-  sem getInfo_ExprOp =
-  | ExprGrouping x ->
+lang SHExprGrouping =
+  SHExprOpBase
+  syn SHExprOp lstyle rstyle =
+  | SHExprGrouping {inner: SHExpr, __br_info: Info, __br_terms: [Info]}
+  sem getInfo_SHExprOp =
+  | SHExprGrouping x ->
     x.__br_info
-  sem getTerms_ExprOp =
-  | ExprGrouping x ->
+  sem getTerms_SHExprOp =
+  | SHExprGrouping x ->
     x.__br_terms
-  sem unsplit_ExprOp =
-  | AtomP {self = ExprGrouping x} ->
+  sem unsplit_SHExprOp =
+  | AtomP {self = SHExprGrouping x} ->
     (x.__br_info, x.inner)
 end
 lang ParseSelfhost =
-  LangFileOp
-  + StartDeclOp
-  + IncludeDeclOp
-  + TypeDeclOp
-  + TokenDeclOp
-  + PrecedenceTableDeclOp
-  + ProductionDeclOp
-  + RecordRegexOp
-  + EmptyRegexOp
-  + LiteralRegexOp
-  + TokenRegexOp
-  + RepeatPlusRegexOp
-  + RepeatStarRegexOp
-  + RepeatQuestionRegexOp
-  + NamedRegexOp
-  + AlternativeRegexOp
-  + ConcatRegexOp
-  + AppExprOp
-  + ConExprOp
-  + StringExprOp
-  + VariableExprOp
-  + RecordExprOp
-  + RegexGrouping
-  + ExprGrouping
-  + BadFileAst
-  + BadDeclAst
-  + BadRegexAst
-  + BadExprAst
+  LangSHFileOp
+  + StartSHDeclOp
+  + IncludeSHDeclOp
+  + TypeSHDeclOp
+  + TokenSHDeclOp
+  + PrecedenceTableSHDeclOp
+  + ProductionSHDeclOp
+  + RecordSHRegexOp
+  + EmptySHRegexOp
+  + LiteralSHRegexOp
+  + TokenSHRegexOp
+  + RepeatPlusSHRegexOp
+  + RepeatStarSHRegexOp
+  + RepeatQuestionSHRegexOp
+  + NamedSHRegexOp
+  + AlternativeSHRegexOp
+  + ConcatSHRegexOp
+  + AppSHExprOp
+  + ConSHExprOp
+  + StringSHExprOp
+  + VariableSHExprOp
+  + RecordSHExprOp
+  + SHRegexGrouping
+  + SHExprGrouping
+  + BadSHFileAst
+  + BadSHDeclAst
+  + BadSHRegexAst
+  + BadSHExprAst
   + LL1Parser
   + SemiTokenParser
   + CommaTokenParser
@@ -2295,279 +1852,125 @@ lang ParseSelfhost =
   + BracketTokenParser
   + OperatorTokenParser
   + MultilineCommentParser
-  
-  
-  sem groupingsAllowed_RegexOp =
-  | (NamedRegexOp _, RepeatPlusRegexOp _) ->
+  sem groupingsAllowed_SHFileOp =
+  sem groupingsAllowed_SHDeclOp =
+  sem groupingsAllowed_SHRegexOp =
+  | (NamedSHRegexOp _, RepeatPlusSHRegexOp _) ->
     GLeft
       {}
-  | (AlternativeRegexOp _, RepeatPlusRegexOp _) ->
+  | (AlternativeSHRegexOp _, RepeatPlusSHRegexOp _) ->
     GRight
       {}
-  | (ConcatRegexOp _, RepeatPlusRegexOp _) ->
+  | (ConcatSHRegexOp _, RepeatPlusSHRegexOp _) ->
     GRight
       {}
-  | (NamedRegexOp _, RepeatStarRegexOp _) ->
+  | (NamedSHRegexOp _, RepeatStarSHRegexOp _) ->
     GLeft
       {}
-  | (AlternativeRegexOp _, RepeatStarRegexOp _) ->
+  | (AlternativeSHRegexOp _, RepeatStarSHRegexOp _) ->
     GRight
       {}
-  | (ConcatRegexOp _, RepeatStarRegexOp _) ->
+  | (ConcatSHRegexOp _, RepeatStarSHRegexOp _) ->
     GRight
       {}
-  | (NamedRegexOp _, RepeatQuestionRegexOp _) ->
+  | (NamedSHRegexOp _, RepeatQuestionSHRegexOp _) ->
     GLeft
       {}
-  | (AlternativeRegexOp _, RepeatQuestionRegexOp _) ->
+  | (AlternativeSHRegexOp _, RepeatQuestionSHRegexOp _) ->
     GRight
       {}
-  | (ConcatRegexOp _, RepeatQuestionRegexOp _) ->
+  | (ConcatSHRegexOp _, RepeatQuestionSHRegexOp _) ->
     GRight
       {}
-  | (NamedRegexOp _, AlternativeRegexOp _) ->
+  | (NamedSHRegexOp _, AlternativeSHRegexOp _) ->
     GLeft
       {}
-  | (NamedRegexOp _, ConcatRegexOp _) ->
+  | (NamedSHRegexOp _, ConcatSHRegexOp _) ->
     GLeft
       {}
-  | (AlternativeRegexOp _, ConcatRegexOp _) ->
+  | (AlternativeSHRegexOp _, ConcatSHRegexOp _) ->
     GRight
       {}
-  | (ConcatRegexOp _, AlternativeRegexOp _) ->
+  | (ConcatSHRegexOp _, AlternativeSHRegexOp _) ->
     GLeft
       {}
-  
+  sem groupingsAllowed_SHExprOp =
 end
 let _table =
   use ParseSelfhost
   in
   let target =
     genParsingTable
-      (let #var"File" =
-         nameSym
-           "File"
-       in
-       let #var"Decl" =
-         nameSym
-           "Decl"
-       in
-       let #var"Regex" =
-         nameSym
-           "Regex"
-       in
-       let #var"Expr" =
-         nameSym
-           "Expr"
-       in
-       let #var"FilePostfix" =
-         nameSym
-           "FilePostfix"
-       in
-       let #var"FileAtom" =
-         nameSym
-           "FileAtom"
-       in
-       let #var"FileInfix" =
-         nameSym
-           "FileInfix"
-       in
-       let #var"FilePrefix" =
-         nameSym
-           "FilePrefix"
-       in
-       let #var"DeclPostfix" =
-         nameSym
-           "DeclPostfix"
-       in
-       let #var"DeclAtom" =
-         nameSym
-           "DeclAtom"
-       in
-       let #var"DeclInfix" =
-         nameSym
-           "DeclInfix"
-       in
-       let #var"DeclPrefix" =
-         nameSym
-           "DeclPrefix"
-       in
-       let #var"RegexPostfix" =
-         nameSym
-           "RegexPostfix"
-       in
-       let #var"RegexAtom" =
-         nameSym
-           "RegexAtom"
-       in
-       let #var"RegexInfix" =
-         nameSym
-           "RegexInfix"
-       in
-       let #var"RegexPrefix" =
-         nameSym
-           "RegexPrefix"
-       in
-       let #var"ExprPostfix" =
-         nameSym
-           "ExprPostfix"
-       in
-       let #var"ExprAtom" =
-         nameSym
-           "ExprAtom"
-       in
-       let #var"ExprInfix" =
-         nameSym
-           "ExprInfix"
-       in
-       let #var"ExprPrefix" =
-         nameSym
-           "ExprPrefix"
-       in
-       let kleene =
-         nameSym
-           "kleene"
-       in
-       let kleene1 =
-         nameSym
-           "kleene"
-       in
-       let alt =
-         nameSym
-           "alt"
-       in
-       let alt1 =
-         nameSym
-           "alt"
-       in
-       let kleene2 =
-         nameSym
-           "kleene"
-       in
-       let alt2 =
-         nameSym
-           "alt"
-       in
-       let alt3 =
-         nameSym
-           "alt"
-       in
-       let kleene3 =
-         nameSym
-           "kleene"
-       in
-       let kleene4 =
-         nameSym
-           "kleene"
-       in
-       let kleene5 =
-         nameSym
-           "kleene"
-       in
-       let kleene6 =
-         nameSym
-           "kleene"
-       in
-       let kleene7 =
-         nameSym
-           "kleene"
-       in
-       let alt4 =
-         nameSym
-           "alt"
-       in
-       let alt5 =
-         nameSym
-           "alt"
-       in
-       let alt6 =
-         nameSym
-           "alt"
-       in
-       let alt7 =
-         nameSym
-           "alt"
-       in
-       let kleene8 =
-         nameSym
-           "kleene"
-       in
-       let alt8 =
-         nameSym
-           "alt"
-       in
-       let #var"File_lclosed" =
-         nameSym
-           "File_lclosed"
-       in
-       let #var"File_lopen" =
-         nameSym
-           "File_lopen"
-       in
-       let #var"Decl_lclosed" =
-         nameSym
-           "Decl_lclosed"
-       in
-       let #var"Decl_lopen" =
-         nameSym
-           "Decl_lopen"
-       in
-       let #var"Regex_lclosed" =
-         nameSym
-           "Regex_lclosed"
-       in
-       let #var"Regex_lopen" =
-         nameSym
-           "Regex_lopen"
-       in
-       let #var"Expr_lclosed" =
-         nameSym
-           "Expr_lclosed"
-       in
-       let #var"Expr_lopen" =
-         nameSym
-           "Expr_lopen"
-       in
-       { start =
-           #var"File",
+      (let #var"SHFile" = nameSym "SHFile" in
+       let #var"SHDecl" = nameSym "SHDecl" in
+       let #var"SHRegex" = nameSym "SHRegex" in
+       let #var"SHExpr" = nameSym "SHExpr" in
+       let #var"SHFilePostfix" = nameSym "SHFilePostfix" in
+       let #var"SHFilePrefix" = nameSym "SHFilePrefix" in
+       let #var"SHFileInfix" = nameSym "SHFileInfix" in
+       let #var"SHFileAtom" = nameSym "SHFileAtom" in
+       let #var"SHDeclPostfix" = nameSym "SHDeclPostfix" in
+       let #var"SHDeclPrefix" = nameSym "SHDeclPrefix" in
+       let #var"SHDeclInfix" = nameSym "SHDeclInfix" in
+       let #var"SHDeclAtom" = nameSym "SHDeclAtom" in
+       let #var"SHRegexPostfix" = nameSym "SHRegexPostfix" in
+       let #var"SHRegexPrefix" = nameSym "SHRegexPrefix" in
+       let #var"SHRegexInfix" = nameSym "SHRegexInfix" in
+       let #var"SHRegexAtom" = nameSym "SHRegexAtom" in
+       let #var"SHExprPostfix" = nameSym "SHExprPostfix" in
+       let #var"SHExprPrefix" = nameSym "SHExprPrefix" in
+       let #var"SHExprInfix" = nameSym "SHExprInfix" in
+       let #var"SHExprAtom" = nameSym "SHExprAtom" in
+       let kleene = nameSym "kleene" in
+       let kleene1 = nameSym "kleene" in
+       let alt = nameSym "alt" in
+       let alt1 = nameSym "alt" in
+       let kleene2 = nameSym "kleene" in
+       let alt2 = nameSym "alt" in
+       let alt3 = nameSym "alt" in
+       let kleene3 = nameSym "kleene" in
+       let kleene4 = nameSym "kleene" in
+       let kleene5 = nameSym "kleene" in
+       let kleene6 = nameSym "kleene" in
+       let kleene7 = nameSym "kleene" in
+       let alt4 = nameSym "alt" in
+       let alt5 = nameSym "alt" in
+       let alt6 = nameSym "alt" in
+       let alt7 = nameSym "alt" in
+       let kleene8 = nameSym "kleene" in
+       let alt8 = nameSym "alt" in
+       let #var"SHFile_lclosed" = nameSym "SHFile_lclosed" in
+       let #var"SHFile_lopen" = nameSym "SHFile_lopen" in
+       let #var"SHDecl_lclosed" = nameSym "SHDecl_lclosed" in
+       let #var"SHDecl_lopen" = nameSym "SHDecl_lopen" in
+       let #var"SHRegex_lclosed" = nameSym "SHRegex_lclosed" in
+       let #var"SHRegex_lopen" = nameSym "SHRegex_lopen" in
+       let #var"SHExpr_lclosed" = nameSym "SHExpr_lclosed" in
+       let #var"SHExpr_lopen" = nameSym "SHExpr_lopen" in
+       { start = #var"SHFile",
          productions =
            let config =
-             { topAllowed =
-                 #frozen"topAllowed_FileOp",
-               leftAllowed =
-                 #frozen"leftAllowed_FileOp",
-               rightAllowed =
-                 #frozen"rightAllowed_FileOp",
-               parenAllowed =
-                 #frozen"parenAllowed_FileOp",
-               groupingsAllowed =
-                 #frozen"groupingsAllowed_FileOp" }
+             { parenAllowed = #frozen"parenAllowed_SHFileOp",
+               topAllowed = #frozen"topAllowed_SHFileOp",
+               leftAllowed = #frozen"leftAllowed_SHFileOp",
+               rightAllowed = #frozen"rightAllowed_SHFileOp",
+               groupingsAllowed = #frozen"groupingsAllowed_SHFileOp" }
            in
            let reportConfig =
-             { topAllowed =
-                 #frozen"topAllowed_FileOp",
-               parenAllowed =
-                 #frozen"parenAllowed_FileOp",
-               terminalInfos =
-                 #frozen"getTerms_FileOp",
-               getInfo =
-                 #frozen"getInfo_FileOp",
-               lpar =
-                 "(",
-               rpar =
-                 ")" }
+             { parenAllowed = #frozen"parenAllowed_SHFileOp",
+               topAllowed = #frozen"topAllowed_SHFileOp",
+               terminalInfos = #frozen"getTerms_SHFileOp",
+               getInfo = #frozen"getInfo_SHFileOp",
+               lpar = "(",
+               rpar = ")" }
            in
-           let addFileOpAtom =
+           let addSHFileOpAtom =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddAtom
-                        config
-                        x33)
-                     st
+                   optionMap (breakableAddAtom config x33) st
            in
-           let addFileOpInfix =
+           let addSHFileOpInfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -2576,24 +1979,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddInfix
-                         config
-                         x33
-                         st
-                     in
+                     let st = breakableAddInfix config x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_FileOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHFileOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -2601,17 +1995,13 @@ let _table =
                      None
                        {}
            in
-           let addFileOpPrefix =
+           let addSHFileOpPrefix =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddPrefix
-                        config
-                        x33)
-                     st
+                   optionMap (breakableAddPrefix config x33) st
            in
-           let addFileOpPostfix =
+           let addSHFileOpPostfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -2620,24 +2010,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddPostfix
-                         config
-                         x33
-                         st
-                     in
+                     let st = breakableAddPostfix config x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_FileOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHFileOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -2645,7 +2026,7 @@ let _table =
                      None
                        {}
            in
-           let finalizeFileOp =
+           let finalizeSHFileOp =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam st.
                  let res60 =
@@ -2653,97 +2034,64 @@ let _table =
                      st
                      (lam st.
                         match
-                          breakableFinalizeParse
-                            config
-                            st
+                          breakableFinalizeParse config st
                         with
-                          Some (tops & ([ top ] ++ _ ++ ""))
+                          Some (tops & ([ top ] ++ _))
                         then
-                          let errs =
-                            breakableDefaultHighlight
-                              reportConfig
-                              (p.content)
-                              tops
+                          let errs = breakableDefaultHighlight reportConfig p.content tops
                           in
-                          let res60 =
-                            unsplit_FileOp
-                              top
-                          in
+                          let res60 = unsplit_SHFileOp top in
                           match
-                            null
-                              errs
+                            null errs
                           with
                             true
                           then
                             Some
                               res60
                           else
-                            (modref
-                                 (p.errors)
-                                 (concat
-                                    (deref
-                                       (p.errors))
-                                    errs))
+                            (modref p.errors (concat (deref p.errors) errs))
                             ; Some
-                              (res60.0, BadFile
-                                { info =
-                                    res60.0 })
+                              (res60.0, BadSHFile
+                                { info = res60.0 })
                         else
                           (modref
-                               (p.errors)
+                               p.errors
                                (snoc
-                                  (deref
-                                     (p.errors))
+                                  (deref p.errors)
                                   (NoInfo
-                                    {}, "Unfinished File")))
+                                    {}, "Unfinished SHFile")))
                           ; None
                             {})
                  in
                  optionGetOr
                    (NoInfo
-                     {}, BadFile
-                     { info =
-                         NoInfo
+                     {}, BadSHFile
+                     { info = NoInfo
                            {} })
                    res60
            in
            let config1 =
-             { topAllowed =
-                 #frozen"topAllowed_DeclOp",
-               leftAllowed =
-                 #frozen"leftAllowed_DeclOp",
-               rightAllowed =
-                 #frozen"rightAllowed_DeclOp",
-               parenAllowed =
-                 #frozen"parenAllowed_DeclOp",
-               groupingsAllowed =
-                 #frozen"groupingsAllowed_DeclOp" }
+             { parenAllowed = #frozen"parenAllowed_SHDeclOp",
+               topAllowed = #frozen"topAllowed_SHDeclOp",
+               leftAllowed = #frozen"leftAllowed_SHDeclOp",
+               rightAllowed = #frozen"rightAllowed_SHDeclOp",
+               groupingsAllowed = #frozen"groupingsAllowed_SHDeclOp" }
            in
            let reportConfig1 =
-             { topAllowed =
-                 #frozen"topAllowed_DeclOp",
-               parenAllowed =
-                 #frozen"parenAllowed_DeclOp",
-               terminalInfos =
-                 #frozen"getTerms_DeclOp",
-               getInfo =
-                 #frozen"getInfo_DeclOp",
-               lpar =
-                 "(",
-               rpar =
-                 ")" }
+             { parenAllowed = #frozen"parenAllowed_SHDeclOp",
+               topAllowed = #frozen"topAllowed_SHDeclOp",
+               terminalInfos = #frozen"getTerms_SHDeclOp",
+               getInfo = #frozen"getInfo_SHDeclOp",
+               lpar = "(",
+               rpar = ")" }
            in
-           let addDeclOpAtom =
+           let addSHDeclOpAtom =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddAtom
-                        config1
-                        x33)
-                     st
+                   optionMap (breakableAddAtom config1 x33) st
            in
-           let addDeclOpInfix =
+           let addSHDeclOpInfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -2752,24 +2100,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddInfix
-                         config1
-                         x33
-                         st
-                     in
+                     let st = breakableAddInfix config1 x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_DeclOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHDeclOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -2777,17 +2116,13 @@ let _table =
                      None
                        {}
            in
-           let addDeclOpPrefix =
+           let addSHDeclOpPrefix =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddPrefix
-                        config1
-                        x33)
-                     st
+                   optionMap (breakableAddPrefix config1 x33) st
            in
-           let addDeclOpPostfix =
+           let addSHDeclOpPostfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -2796,24 +2131,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddPostfix
-                         config1
-                         x33
-                         st
-                     in
+                     let st = breakableAddPostfix config1 x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_DeclOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHDeclOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -2821,7 +2147,7 @@ let _table =
                      None
                        {}
            in
-           let finalizeDeclOp =
+           let finalizeSHDeclOp =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam st.
                  let res60 =
@@ -2829,97 +2155,64 @@ let _table =
                      st
                      (lam st.
                         match
-                          breakableFinalizeParse
-                            config1
-                            st
+                          breakableFinalizeParse config1 st
                         with
-                          Some (tops & ([ top ] ++ _ ++ ""))
+                          Some (tops & ([ top ] ++ _))
                         then
-                          let errs =
-                            breakableDefaultHighlight
-                              reportConfig1
-                              (p.content)
-                              tops
+                          let errs = breakableDefaultHighlight reportConfig1 p.content tops
                           in
-                          let res60 =
-                            unsplit_DeclOp
-                              top
-                          in
+                          let res60 = unsplit_SHDeclOp top in
                           match
-                            null
-                              errs
+                            null errs
                           with
                             true
                           then
                             Some
                               res60
                           else
-                            (modref
-                                 (p.errors)
-                                 (concat
-                                    (deref
-                                       (p.errors))
-                                    errs))
+                            (modref p.errors (concat (deref p.errors) errs))
                             ; Some
-                              (res60.0, BadDecl
-                                { info =
-                                    res60.0 })
+                              (res60.0, BadSHDecl
+                                { info = res60.0 })
                         else
                           (modref
-                               (p.errors)
+                               p.errors
                                (snoc
-                                  (deref
-                                     (p.errors))
+                                  (deref p.errors)
                                   (NoInfo
-                                    {}, "Unfinished Decl")))
+                                    {}, "Unfinished SHDecl")))
                           ; None
                             {})
                  in
                  optionGetOr
                    (NoInfo
-                     {}, BadDecl
-                     { info =
-                         NoInfo
+                     {}, BadSHDecl
+                     { info = NoInfo
                            {} })
                    res60
            in
            let config2 =
-             { topAllowed =
-                 #frozen"topAllowed_RegexOp",
-               leftAllowed =
-                 #frozen"leftAllowed_RegexOp",
-               rightAllowed =
-                 #frozen"rightAllowed_RegexOp",
-               parenAllowed =
-                 #frozen"parenAllowed_RegexOp",
-               groupingsAllowed =
-                 #frozen"groupingsAllowed_RegexOp" }
+             { parenAllowed = #frozen"parenAllowed_SHRegexOp",
+               topAllowed = #frozen"topAllowed_SHRegexOp",
+               leftAllowed = #frozen"leftAllowed_SHRegexOp",
+               rightAllowed = #frozen"rightAllowed_SHRegexOp",
+               groupingsAllowed = #frozen"groupingsAllowed_SHRegexOp" }
            in
            let reportConfig2 =
-             { topAllowed =
-                 #frozen"topAllowed_RegexOp",
-               parenAllowed =
-                 #frozen"parenAllowed_RegexOp",
-               terminalInfos =
-                 #frozen"getTerms_RegexOp",
-               getInfo =
-                 #frozen"getInfo_RegexOp",
-               lpar =
-                 "(",
-               rpar =
-                 ")" }
+             { parenAllowed = #frozen"parenAllowed_SHRegexOp",
+               topAllowed = #frozen"topAllowed_SHRegexOp",
+               terminalInfos = #frozen"getTerms_SHRegexOp",
+               getInfo = #frozen"getInfo_SHRegexOp",
+               lpar = "(",
+               rpar = ")" }
            in
-           let addRegexOpAtom =
+           let addSHRegexOpAtom =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddAtom
-                        config2
-                        x33)
-                     st
+                   optionMap (breakableAddAtom config2 x33) st
            in
-           let addRegexOpInfix =
+           let addSHRegexOpInfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -2928,24 +2221,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddInfix
-                         config2
-                         x33
-                         st
-                     in
+                     let st = breakableAddInfix config2 x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_RegexOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHRegexOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -2953,17 +2237,13 @@ let _table =
                      None
                        {}
            in
-           let addRegexOpPrefix =
+           let addSHRegexOpPrefix =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddPrefix
-                        config2
-                        x33)
-                     st
+                   optionMap (breakableAddPrefix config2 x33) st
            in
-           let addRegexOpPostfix =
+           let addSHRegexOpPostfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -2972,24 +2252,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddPostfix
-                         config2
-                         x33
-                         st
-                     in
+                     let st = breakableAddPostfix config2 x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_RegexOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHRegexOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -2997,7 +2268,7 @@ let _table =
                      None
                        {}
            in
-           let finalizeRegexOp =
+           let finalizeSHRegexOp =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam st.
                  let res60 =
@@ -3005,97 +2276,64 @@ let _table =
                      st
                      (lam st.
                         match
-                          breakableFinalizeParse
-                            config2
-                            st
+                          breakableFinalizeParse config2 st
                         with
-                          Some (tops & ([ top ] ++ _ ++ ""))
+                          Some (tops & ([ top ] ++ _))
                         then
-                          let errs =
-                            breakableDefaultHighlight
-                              reportConfig2
-                              (p.content)
-                              tops
+                          let errs = breakableDefaultHighlight reportConfig2 p.content tops
                           in
-                          let res60 =
-                            unsplit_RegexOp
-                              top
-                          in
+                          let res60 = unsplit_SHRegexOp top in
                           match
-                            null
-                              errs
+                            null errs
                           with
                             true
                           then
                             Some
                               res60
                           else
-                            (modref
-                                 (p.errors)
-                                 (concat
-                                    (deref
-                                       (p.errors))
-                                    errs))
+                            (modref p.errors (concat (deref p.errors) errs))
                             ; Some
-                              (res60.0, BadRegex
-                                { info =
-                                    res60.0 })
+                              (res60.0, BadSHRegex
+                                { info = res60.0 })
                         else
                           (modref
-                               (p.errors)
+                               p.errors
                                (snoc
-                                  (deref
-                                     (p.errors))
+                                  (deref p.errors)
                                   (NoInfo
-                                    {}, "Unfinished Regex")))
+                                    {}, "Unfinished SHRegex")))
                           ; None
                             {})
                  in
                  optionGetOr
                    (NoInfo
-                     {}, BadRegex
-                     { info =
-                         NoInfo
+                     {}, BadSHRegex
+                     { info = NoInfo
                            {} })
                    res60
            in
            let config3 =
-             { topAllowed =
-                 #frozen"topAllowed_ExprOp",
-               leftAllowed =
-                 #frozen"leftAllowed_ExprOp",
-               rightAllowed =
-                 #frozen"rightAllowed_ExprOp",
-               parenAllowed =
-                 #frozen"parenAllowed_ExprOp",
-               groupingsAllowed =
-                 #frozen"groupingsAllowed_ExprOp" }
+             { parenAllowed = #frozen"parenAllowed_SHExprOp",
+               topAllowed = #frozen"topAllowed_SHExprOp",
+               leftAllowed = #frozen"leftAllowed_SHExprOp",
+               rightAllowed = #frozen"rightAllowed_SHExprOp",
+               groupingsAllowed = #frozen"groupingsAllowed_SHExprOp" }
            in
            let reportConfig3 =
-             { topAllowed =
-                 #frozen"topAllowed_ExprOp",
-               parenAllowed =
-                 #frozen"parenAllowed_ExprOp",
-               terminalInfos =
-                 #frozen"getTerms_ExprOp",
-               getInfo =
-                 #frozen"getInfo_ExprOp",
-               lpar =
-                 "(",
-               rpar =
-                 ")" }
+             { parenAllowed = #frozen"parenAllowed_SHExprOp",
+               topAllowed = #frozen"topAllowed_SHExprOp",
+               terminalInfos = #frozen"getTerms_SHExprOp",
+               getInfo = #frozen"getInfo_SHExprOp",
+               lpar = "(",
+               rpar = ")" }
            in
-           let addExprOpAtom =
+           let addSHExprOpAtom =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddAtom
-                        config3
-                        x33)
-                     st
+                   optionMap (breakableAddAtom config3 x33) st
            in
-           let addExprOpInfix =
+           let addSHExprOpInfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -3104,24 +2342,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddInfix
-                         config3
-                         x33
-                         st
-                     in
+                     let st = breakableAddInfix config3 x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_ExprOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHExprOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -3129,17 +2358,13 @@ let _table =
                      None
                        {}
            in
-           let addExprOpPrefix =
+           let addSHExprOpPrefix =
              lam #var"".
                lam x33.
                  lam st.
-                   optionMap
-                     (breakableAddPrefix
-                        config3
-                        x33)
-                     st
+                   optionMap (breakableAddPrefix config3 x33) st
            in
-           let addExprOpPostfix =
+           let addSHExprOpPostfix =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam x33.
                  lam st.
@@ -3148,24 +2373,15 @@ let _table =
                    with
                      Some st
                    then
-                     let st =
-                       breakableAddPostfix
-                         config3
-                         x33
-                         st
-                     in
+                     let st = breakableAddPostfix config3 x33 st in
                      (match
                           st
                         with
                           None _
                         then
                           modref
-                            (p.errors)
-                            (snoc
-                               (deref
-                                  (p.errors))
-                               (getInfo_ExprOp
-                                 x33, "Invalid input"))
+                            p.errors
+                            (snoc (deref p.errors) (getInfo_SHExprOp x33, "Invalid input"))
                         else
                           {})
                      ; st
@@ -3173,7 +2389,7 @@ let _table =
                      None
                        {}
            in
-           let finalizeExprOp =
+           let finalizeSHExprOp =
              lam p: {errors: Ref [(Info, [Char])], content: String}.
                lam st.
                  let res60 =
@@ -3181,69 +2397,46 @@ let _table =
                      st
                      (lam st.
                         match
-                          breakableFinalizeParse
-                            config3
-                            st
+                          breakableFinalizeParse config3 st
                         with
-                          Some (tops & ([ top ] ++ _ ++ ""))
+                          Some (tops & ([ top ] ++ _))
                         then
-                          let errs =
-                            breakableDefaultHighlight
-                              reportConfig3
-                              (p.content)
-                              tops
+                          let errs = breakableDefaultHighlight reportConfig3 p.content tops
                           in
-                          let res60 =
-                            unsplit_ExprOp
-                              top
-                          in
+                          let res60 = unsplit_SHExprOp top in
                           match
-                            null
-                              errs
+                            null errs
                           with
                             true
                           then
                             Some
                               res60
                           else
-                            (modref
-                                 (p.errors)
-                                 (concat
-                                    (deref
-                                       (p.errors))
-                                    errs))
+                            (modref p.errors (concat (deref p.errors) errs))
                             ; Some
-                              (res60.0, BadExpr
-                                { info =
-                                    res60.0 })
+                              (res60.0, BadSHExpr
+                                { info = res60.0 })
                         else
                           (modref
-                               (p.errors)
+                               p.errors
                                (snoc
-                                  (deref
-                                     (p.errors))
+                                  (deref p.errors)
                                   (NoInfo
-                                    {}, "Unfinished Expr")))
+                                    {}, "Unfinished SHExpr")))
                           ; None
                             {})
                  in
                  optionGetOr
                    (NoInfo
-                     {}, BadExpr
-                     { info =
-                         NoInfo
+                     {}, BadSHExpr
+                     { info = NoInfo
                            {} })
                    res60
            in
-           [ { nt =
-                 kleene,
-               label =
-                 {},
-               rhs =
-                 [ ntSym
-                     #var"Decl",
-                   ntSym
-                     kleene ],
+           [ { nt = kleene,
+               label = {},
+               rhs = [ ntSym #var"SHDecl",
+                   ntSym kleene ],
                action =
                  lam state: {errors: Ref [(Info, [Char])], content: String}.
                    lam res.
@@ -3253,31 +2446,16 @@ let _table =
                        [ UserSym ntVal,
                          UserSym val1 ]
                      in
-                     let ntVal: (Info, Decl) =
-                         fromDyn
-                           ntVal
-                       in
-                       let val1: {decls: [Decl], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val1
+                     let ntVal: (Info, SHDecl) = fromDyn ntVal in
+                       let val1: {decls: [SHDecl], __br_info: Info, __br_terms: [Info]} = fromDyn val1
                        in
                        asDyn
-                         { __br_terms =
-                             val1.__br_terms,
-                           __br_info =
-                             mergeInfo
-                               (ntVal.0)
-                               (val1.__br_info),
-                           decls =
-                             concat
-                               [ ntVal.1 ]
-                               (val1.decls) } },
-             { nt =
-                 kleene,
-               label =
-                 {},
-               rhs =
-                 "",
+                         { __br_info = mergeInfo ntVal.0 val1.__br_info,
+                           __br_terms = val1.__br_terms,
+                           decls = concat [ ntVal.1 ] val1.decls } },
+             { nt = kleene,
+               label = {},
+               rhs = "",
                action =
                  lam state1: {errors: Ref [(Info, [Char])], content: String}.
                    lam res1.
@@ -3287,27 +2465,18 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           decls =
-                             "" } },
-             { nt =
-                 #var"FileAtom",
-               label =
-                 {},
+                           __br_terms = "",
+                           decls = "" } },
+             { nt = #var"SHFileAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "language",
-                   tokSym
-                     (UIdentRepr
+                 [ litSym "language",
+                   tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     #var"Decl",
-                   ntSym
-                     kleene ],
+                   ntSym #var"SHDecl",
+                   ntSym kleene ],
                action =
                  lam state2: {errors: Ref [(Info, [Char])], content: String}.
                    lam res2.
@@ -3319,46 +2488,30 @@ let _table =
                          UserSym ntVal1,
                          UserSym val1 ]
                      in
-                     let ntVal1: (Info, Decl) =
-                         fromDyn
-                           ntVal1
-                       in
-                       let val1: {decls: [Decl], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val1
+                     let ntVal1: (Info, SHDecl) = fromDyn ntVal1 in
+                       let val1: {decls: [SHDecl], __br_info: Info, __br_terms: [Info]} = fromDyn val1
                        in
                        asDyn
-                         (LangFileOp
-                            { __br_terms =
+                         (LangSHFileOp
+                            { __br_info =
+                                foldl
+                                  mergeInfo
+                                  l.info
+                                  [ x.info,
+                                    ntVal1.0,
+                                    val1.__br_info ],
+                              __br_terms =
                                 join
                                   [ [ l.info ],
                                     [ x.info ],
                                     val1.__br_terms ],
-                              __br_info =
-                                foldl
-                                  mergeInfo
-                                  (l.info)
-                                  [ x.info,
-                                    ntVal1.0,
-                                    val1.__br_info ],
-                              decls =
-                                concat
-                                  [ ntVal1.1 ]
-                                  (val1.decls),
-                              name =
-                                [ { v =
-                                      x.val,
-                                    i =
-                                      x.info } ] }) },
-             { nt =
-                 #var"DeclAtom",
-               label =
-                 {},
+                              decls = concat [ ntVal1.1 ] val1.decls,
+                              name = [ { v = x.val, i = x.info } ] }) },
+             { nt = #var"SHDeclAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "start",
-                   tokSym
-                     (UIdentRepr
+                 [ litSym "start",
+                   tokSym (UIdentRepr
                         {}) ],
                action =
                  lam state3: {errors: Ref [(Info, [Char])], content: String}.
@@ -3370,30 +2523,15 @@ let _table =
                          TokParsed (UIdentTok x1) ]
                      in
                      asDyn
-                         (StartDeclOp
-                            { __br_terms =
-                                concat
-                                  [ l1.info ]
-                                  [ x1.info ],
-                              __br_info =
-                                mergeInfo
-                                  (l1.info)
-                                  (x1.info),
-                              name =
-                                [ { v =
-                                      nameNoSym
-                                        (x1.val),
-                                    i =
-                                      x1.info } ] }) },
-             { nt =
-                 #var"DeclAtom",
-               label =
-                 {},
+                         (StartSHDeclOp
+                            { __br_info = mergeInfo l1.info x1.info,
+                              __br_terms = concat [ l1.info ] [ x1.info ],
+                              name = [ { v = nameNoSym x1.val, i = x1.info } ] }) },
+             { nt = #var"SHDeclAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "include",
-                   tokSym
-                     (StringRepr
+                 [ litSym "include",
+                   tokSym (StringRepr
                         {}) ],
                action =
                  lam state4: {errors: Ref [(Info, [Char])], content: String}.
@@ -3405,36 +2543,19 @@ let _table =
                          TokParsed (StringTok x2) ]
                      in
                      asDyn
-                         (IncludeDeclOp
-                            { __br_terms =
-                                concat
-                                  [ l2.info ]
-                                  [ x2.info ],
-                              __br_info =
-                                mergeInfo
-                                  (l2.info)
-                                  (x2.info),
-                              path =
-                                [ { v =
-                                      x2.val,
-                                    i =
-                                      x2.info } ] }) },
-             { nt =
-                 kleene1,
-               label =
-                 {},
+                         (IncludeSHDeclOp
+                            { __br_info = mergeInfo l2.info x2.info,
+                              __br_terms = concat [ l2.info ] [ x2.info ],
+                              path = [ { v = x2.val, i = x2.info } ] }) },
+             { nt = kleene1,
+               label = {},
                rhs =
-                 [ tokSym
-                     (LIdentRepr
+                 [ tokSym (LIdentRepr
                         {}),
-                   litSym
-                     "=",
-                   ntSym
-                     #var"Expr",
-                   litSym
-                     ",",
-                   ntSym
-                     kleene1 ],
+                   litSym "=",
+                   ntSym #var"SHExpr",
+                   litSym ",",
+                   ntSym kleene1 ],
                action =
                  lam state5: {errors: Ref [(Info, [Char])], content: String}.
                    lam res5.
@@ -3447,55 +2568,44 @@ let _table =
                          LitParsed l4,
                          UserSym val2 ]
                      in
-                     let ntVal2: (Info, Expr) =
-                         fromDyn
-                           ntVal2
-                       in
-                       let val2: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                         fromDyn
-                           val2
+                     let ntVal2: (Info, SHExpr) = fromDyn ntVal2 in
+                       let val2: {__br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]} = fromDyn val2
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               x3.info
+                               [ l3.info,
+                                 ntVal2.0,
+                                 l4.info,
+                                 val2.__br_info ],
+                           __br_terms =
                              join
                                [ [ x3.info ],
                                  [ l3.info ],
                                  [ l4.info ],
                                  val2.__br_terms ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (x3.info)
-                               [ l3.info,
-                                 ntVal2.0,
-                                 l4.info,
-                                 val2.__br_info ],
                            properties =
                              concat
                                [ { val =
                                      match
                                        [ ntVal2.1 ]
                                      with
-                                       [ x4 ] ++ _ ++ ""
+                                       [ x4 ] ++ _
                                      in
                                      x4,
                                    name =
                                      match
-                                       [ { v =
-                                             x3.val,
-                                           i =
-                                             x3.info } ]
+                                       [ { v = x3.val, i = x3.info } ]
                                      with
-                                       [ x5 ] ++ _ ++ ""
+                                       [ x5 ] ++ _
                                      in
                                      x5 } ]
-                               (val2.properties) } },
-             { nt =
-                 kleene1,
-               label =
-                 {},
-               rhs =
-                 "",
+                               val2.properties } },
+             { nt = kleene1,
+               label = {},
+               rhs = "",
                action =
                  lam state6: {errors: Ref [(Info, [Char])], content: String}.
                    lam res6.
@@ -3505,19 +2615,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           properties =
-                             "" } },
-             { nt =
-                 alt,
-               label =
-                 {},
-               rhs =
-                 "",
+                           __br_terms = "",
+                           properties = "" } },
+             { nt = alt,
+               label = {},
+               rhs = "",
                action =
                  lam state7: {errors: Ref [(Info, [Char])], content: String}.
                    lam res7.
@@ -3527,24 +2631,16 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           properties =
-                             "" } },
-             { nt =
-                 alt,
-               label =
-                 {},
+                           __br_terms = "",
+                           properties = "" } },
+             { nt = alt,
+               label = {},
                rhs =
-                 [ litSym
-                     "{",
-                   ntSym
-                     kleene1,
-                   litSym
-                     "}" ],
+                 [ litSym "{",
+                   ntSym kleene1,
+                   litSym "}" ],
                action =
                  lam state8: {errors: Ref [(Info, [Char])], content: String}.
                    lam res8.
@@ -3555,36 +2651,28 @@ let _table =
                          UserSym val2,
                          LitParsed l6 ]
                      in
-                     let val2: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                         fromDyn
-                           val2
+                     let val2: {__br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]} = fromDyn val2
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               l5.info
+                               [ val2.__br_info,
+                                 l6.info ],
+                           __br_terms =
                              join
                                [ [ l5.info ],
                                  val2.__br_terms,
                                  [ l6.info ] ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (l5.info)
-                               [ val2.__br_info,
-                                 l6.info ],
-                           properties =
-                             val2.properties } },
-             { nt =
-                 #var"DeclAtom",
-               label =
-                 {},
+                           properties = val2.properties } },
+             { nt = #var"SHDeclAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "type",
-                   tokSym
-                     (UIdentRepr
+                 [ litSym "type",
+                   tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     alt ],
+                   ntSym alt ],
                action =
                  lam state9: {errors: Ref [(Info, [Char])], content: String}.
                    lam res9.
@@ -3595,37 +2683,26 @@ let _table =
                          TokParsed (UIdentTok x6),
                          UserSym val3 ]
                      in
-                     let val3: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                         fromDyn
-                           val3
+                     let val3: {__br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]} = fromDyn val3
                        in
                        asDyn
-                         (TypeDeclOp
-                            { __br_terms =
+                         (TypeSHDeclOp
+                            { __br_info =
+                                foldl
+                                  mergeInfo
+                                  l7.info
+                                  [ x6.info,
+                                    val3.__br_info ],
+                              __br_terms =
                                 join
                                   [ [ l7.info ],
                                     [ x6.info ],
                                     val3.__br_terms ],
-                              __br_info =
-                                foldl
-                                  mergeInfo
-                                  (l7.info)
-                                  [ x6.info,
-                                    val3.__br_info ],
-                              name =
-                                [ { v =
-                                      nameNoSym
-                                        (x6.val),
-                                    i =
-                                      x6.info } ],
-                              properties =
-                                val3.properties }) },
-             { nt =
-                 alt1,
-               label =
-                 {},
-               rhs =
-                 "",
+                              name = [ { v = nameNoSym x6.val, i = x6.info } ],
+                              properties = val3.properties }) },
+             { nt = alt1,
+               label = {},
+               rhs = "",
                action =
                  lam state10: {errors: Ref [(Info, [Char])], content: String}.
                    lam res10.
@@ -3635,20 +2712,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           name =
-                             "" } },
-             { nt =
-                 alt1,
-               label =
-                 {},
-               rhs =
-                 [ tokSym
-                     (UIdentRepr
+                           __br_terms = "",
+                           name = "" } },
+             { nt = alt1,
+               label = {},
+               rhs = [ tokSym (UIdentRepr
                         {}) ],
                action =
                  lam state11: {errors: Ref [(Info, [Char])], content: String}.
@@ -3659,32 +2729,18 @@ let _table =
                        [ TokParsed (UIdentTok x7) ]
                      in
                      asDyn
-                         { __br_terms =
-                             [ x7.info ],
-                           __br_info =
-                             x7.info,
-                           name =
-                             [ { v =
-                                   nameNoSym
-                                     (x7.val),
-                                 i =
-                                   x7.info } ] } },
-             { nt =
-                 kleene2,
-               label =
-                 {},
+                         { __br_info = x7.info,
+                           __br_terms = [ x7.info ],
+                           name = [ { v = nameNoSym x7.val, i = x7.info } ] } },
+             { nt = kleene2,
+               label = {},
                rhs =
-                 [ tokSym
-                     (LIdentRepr
+                 [ tokSym (LIdentRepr
                         {}),
-                   litSym
-                     "=",
-                   ntSym
-                     #var"Expr",
-                   litSym
-                     ",",
-                   ntSym
-                     kleene2 ],
+                   litSym "=",
+                   ntSym #var"SHExpr",
+                   litSym ",",
+                   ntSym kleene2 ],
                action =
                  lam state12: {errors: Ref [(Info, [Char])], content: String}.
                    lam res12.
@@ -3697,55 +2753,44 @@ let _table =
                          LitParsed l9,
                          UserSym val4 ]
                      in
-                     let ntVal3: (Info, Expr) =
-                         fromDyn
-                           ntVal3
-                       in
-                       let val4: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                         fromDyn
-                           val4
+                     let ntVal3: (Info, SHExpr) = fromDyn ntVal3 in
+                       let val4: {__br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]} = fromDyn val4
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               x8.info
+                               [ l8.info,
+                                 ntVal3.0,
+                                 l9.info,
+                                 val4.__br_info ],
+                           __br_terms =
                              join
                                [ [ x8.info ],
                                  [ l8.info ],
                                  [ l9.info ],
                                  val4.__br_terms ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (x8.info)
-                               [ l8.info,
-                                 ntVal3.0,
-                                 l9.info,
-                                 val4.__br_info ],
                            properties =
                              concat
                                [ { val =
                                      match
                                        [ ntVal3.1 ]
                                      with
-                                       [ x9 ] ++ _ ++ ""
+                                       [ x9 ] ++ _
                                      in
                                      x9,
                                    name =
                                      match
-                                       [ { v =
-                                             x8.val,
-                                           i =
-                                             x8.info } ]
+                                       [ { v = x8.val, i = x8.info } ]
                                      with
-                                       [ x10 ] ++ _ ++ ""
+                                       [ x10 ] ++ _
                                      in
                                      x10 } ]
-                               (val4.properties) } },
-             { nt =
-                 kleene2,
-               label =
-                 {},
-               rhs =
-                 "",
+                               val4.properties } },
+             { nt = kleene2,
+               label = {},
+               rhs = "",
                action =
                  lam state13: {errors: Ref [(Info, [Char])], content: String}.
                    lam res13.
@@ -3755,19 +2800,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           properties =
-                             "" } },
-             { nt =
-                 alt2,
-               label =
-                 {},
-               rhs =
-                 "",
+                           __br_terms = "",
+                           properties = "" } },
+             { nt = alt2,
+               label = {},
+               rhs = "",
                action =
                  lam state14: {errors: Ref [(Info, [Char])], content: String}.
                    lam res14.
@@ -3777,24 +2816,16 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           properties =
-                             "" } },
-             { nt =
-                 alt2,
-               label =
-                 {},
+                           __br_terms = "",
+                           properties = "" } },
+             { nt = alt2,
+               label = {},
                rhs =
-                 [ litSym
-                     "{",
-                   ntSym
-                     kleene2,
-                   litSym
-                     "}" ],
+                 [ litSym "{",
+                   ntSym kleene2,
+                   litSym "}" ],
                action =
                  lam state15: {errors: Ref [(Info, [Char])], content: String}.
                    lam res15.
@@ -3805,35 +2836,27 @@ let _table =
                          UserSym val4,
                          LitParsed l11 ]
                      in
-                     let val4: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                         fromDyn
-                           val4
+                     let val4: {__br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]} = fromDyn val4
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               l10.info
+                               [ val4.__br_info,
+                                 l11.info ],
+                           __br_terms =
                              join
                                [ [ l10.info ],
                                  val4.__br_terms,
                                  [ l11.info ] ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (l10.info)
-                               [ val4.__br_info,
-                                 l11.info ],
-                           properties =
-                             val4.properties } },
-             { nt =
-                 #var"DeclAtom",
-               label =
-                 {},
+                           properties = val4.properties } },
+             { nt = #var"SHDeclAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "token",
-                   ntSym
-                     alt1,
-                   ntSym
-                     alt2 ],
+                 [ litSym "token",
+                   ntSym alt1,
+                   ntSym alt2 ],
                action =
                  lam state16: {errors: Ref [(Info, [Char])], content: String}.
                    lam res16.
@@ -3844,37 +2867,28 @@ let _table =
                          UserSym val5,
                          UserSym val6 ]
                      in
-                     let val5: {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val5
+                     let val5: {name: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} = fromDyn val5
                        in
-                       let val6: {__br_info: Info, __br_terms: [Info], properties: [{val: Expr, name: {i: Info, v: String}}]} =
-                         fromDyn
-                           val6
+                       let val6: {__br_info: Info, __br_terms: [Info], properties: [{val: SHExpr, name: {i: Info, v: String}}]} = fromDyn val6
                        in
                        asDyn
-                         (TokenDeclOp
-                            { __br_terms =
+                         (TokenSHDeclOp
+                            { __br_info =
+                                foldl
+                                  mergeInfo
+                                  l12.info
+                                  [ val5.__br_info,
+                                    val6.__br_info ],
+                              __br_terms =
                                 join
                                   [ [ l12.info ],
                                     val5.__br_terms,
                                     val6.__br_terms ],
-                              __br_info =
-                                foldl
-                                  mergeInfo
-                                  (l12.info)
-                                  [ val5.__br_info,
-                                    val6.__br_info ],
-                              name =
-                                val5.name,
-                              properties =
-                                val6.properties }) },
-             { nt =
-                 alt3,
-               label =
-                 {},
-               rhs =
-                 "",
+                              name = val5.name,
+                              properties = val6.properties }) },
+             { nt = alt3,
+               label = {},
+               rhs = "",
                action =
                  lam state17: {errors: Ref [(Info, [Char])], content: String}.
                    lam res17.
@@ -3884,20 +2898,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           noeq =
-                             "" } },
-             { nt =
-                 alt3,
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "~" ],
+                           __br_terms = "",
+                           noeq = "" } },
+             { nt = alt3,
+               label = {},
+               rhs = [ litSym "~" ],
                action =
                  lam state18: {errors: Ref [(Info, [Char])], content: String}.
                    lam res18.
@@ -3907,22 +2914,15 @@ let _table =
                        [ LitParsed l13 ]
                      in
                      asDyn
-                         { __br_terms =
-                             [ l13.info ],
-                           __br_info =
-                             l13.info,
-                           noeq =
-                             [ l13.info ] } },
-             { nt =
-                 kleene3,
-               label =
-                 {},
+                         { __br_info = l13.info,
+                           __br_terms = [ l13.info ],
+                           noeq = [ l13.info ] } },
+             { nt = kleene3,
+               label = {},
                rhs =
-                 [ tokSym
-                     (UIdentRepr
+                 [ tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     kleene3 ],
+                   ntSym kleene3 ],
                action =
                  lam state19: {errors: Ref [(Info, [Char])], content: String}.
                    lam res19.
@@ -3932,33 +2932,16 @@ let _table =
                        [ TokParsed (UIdentTok x11),
                          UserSym val7 ]
                      in
-                     let val7: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} =
-                         fromDyn
-                           val7
+                     let val7: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} = fromDyn val7
                        in
                        asDyn
-                         { __br_terms =
-                             concat
-                               [ x11.info ]
-                               (val7.__br_terms),
-                           __br_info =
-                             mergeInfo
-                               (x11.info)
-                               (val7.__br_info),
+                         { __br_info = mergeInfo x11.info val7.__br_info,
+                           __br_terms = concat [ x11.info ] val7.__br_terms,
                            operators =
-                             concat
-                               [ { v =
-                                     nameNoSym
-                                       (x11.val),
-                                   i =
-                                     x11.info } ]
-                               (val7.operators) } },
-             { nt =
-                 kleene3,
-               label =
-                 {},
-               rhs =
-                 "",
+                             concat [ { v = nameNoSym x11.val, i = x11.info } ] val7.operators } },
+             { nt = kleene3,
+               label = {},
+               rhs = "",
                action =
                  lam state20: {errors: Ref [(Info, [Char])], content: String}.
                    lam res20.
@@ -3968,29 +2951,19 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           operators =
-                             "" } },
-             { nt =
-                 kleene4,
-               label =
-                 {},
+                           __br_terms = "",
+                           operators = "" } },
+             { nt = kleene4,
+               label = {},
                rhs =
-                 [ ntSym
-                     alt3,
-                   tokSym
-                     (UIdentRepr
+                 [ ntSym alt3,
+                   tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     kleene3,
-                   litSym
-                     ";",
-                   ntSym
-                     kleene4 ],
+                   ntSym kleene3,
+                   litSym ";",
+                   ntSym kleene4 ],
                action =
                  lam state21: {errors: Ref [(Info, [Char])], content: String}.
                    lam res21.
@@ -4003,41 +2976,35 @@ let _table =
                          LitParsed l14,
                          UserSym val9 ]
                      in
-                     let val8: {noeq: [Info], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val8
+                     let val8: {noeq: [Info], __br_info: Info, __br_terms: [Info]} = fromDyn val8
                        in
-                       let val7: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} =
-                         fromDyn
-                           val7
+                       let val7: {__br_info: Info, operators: [{i: Info, v: Name}], __br_terms: [Info]} = fromDyn val7
                        in
-                       let val9: {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val9
+                       let val9: {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} = fromDyn val9
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               val8.__br_info
+                               [ x12.info,
+                                 val7.__br_info,
+                                 l14.info,
+                                 val9.__br_info ],
+                           __br_terms =
                              join
                                [ val8.__br_terms,
                                  [ x12.info ],
                                  val7.__br_terms,
                                  [ l14.info ],
                                  val9.__br_terms ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (val8.__br_info)
-                               [ x12.info,
-                                 val7.__br_info,
-                                 l14.info,
-                                 val9.__br_info ],
                            levels =
                              concat
                                [ { noeq =
                                      match
                                        val8.noeq
                                      with
-                                       [ x13 ] ++ _ ++ ""
+                                       [ x13 ] ++ _
                                      then
                                        Some
                                          x13
@@ -4045,20 +3012,11 @@ let _table =
                                        None
                                          {},
                                    operators =
-                                     concat
-                                       [ { v =
-                                             nameNoSym
-                                               (x12.val),
-                                           i =
-                                             x12.info } ]
-                                       (val7.operators) } ]
-                               (val9.levels) } },
-             { nt =
-                 kleene4,
-               label =
-                 {},
-               rhs =
-                 "",
+                                     concat [ { v = nameNoSym x12.val, i = x12.info } ] val7.operators } ]
+                               val9.levels } },
+             { nt = kleene4,
+               label = {},
+               rhs = "",
                action =
                  lam state22: {errors: Ref [(Info, [Char])], content: String}.
                    lam res22.
@@ -4068,23 +3026,16 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           levels =
-                             "" } },
-             { nt =
-                 kleene5,
-               label =
-                 {},
+                           __br_terms = "",
+                           levels = "" } },
+             { nt = kleene5,
+               label = {},
                rhs =
-                 [ tokSym
-                     (UIdentRepr
+                 [ tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     kleene5 ],
+                   ntSym kleene5 ],
                action =
                  lam state23: {errors: Ref [(Info, [Char])], content: String}.
                    lam res23.
@@ -4094,33 +3045,16 @@ let _table =
                        [ TokParsed (UIdentTok x14),
                          UserSym val10 ]
                      in
-                     let val10: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val10
+                     let val10: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} = fromDyn val10
                        in
                        asDyn
-                         { __br_terms =
-                             concat
-                               [ x14.info ]
-                               (val10.__br_terms),
-                           __br_info =
-                             mergeInfo
-                               (x14.info)
-                               (val10.__br_info),
+                         { __br_info = mergeInfo x14.info val10.__br_info,
+                           __br_terms = concat [ x14.info ] val10.__br_terms,
                            lefts =
-                             concat
-                               [ { v =
-                                     nameNoSym
-                                       (x14.val),
-                                   i =
-                                     x14.info } ]
-                               (val10.lefts) } },
-             { nt =
-                 kleene5,
-               label =
-                 {},
-               rhs =
-                 "",
+                             concat [ { v = nameNoSym x14.val, i = x14.info } ] val10.lefts } },
+             { nt = kleene5,
+               label = {},
+               rhs = "",
                action =
                  lam state24: {errors: Ref [(Info, [Char])], content: String}.
                    lam res24.
@@ -4130,23 +3064,16 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           lefts =
-                             "" } },
-             { nt =
-                 kleene6,
-               label =
-                 {},
+                           __br_terms = "",
+                           lefts = "" } },
+             { nt = kleene6,
+               label = {},
                rhs =
-                 [ tokSym
-                     (UIdentRepr
+                 [ tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     kleene6 ],
+                   ntSym kleene6 ],
                action =
                  lam state25: {errors: Ref [(Info, [Char])], content: String}.
                    lam res25.
@@ -4156,33 +3083,16 @@ let _table =
                        [ TokParsed (UIdentTok x15),
                          UserSym val11 ]
                      in
-                     let val11: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val11
+                     let val11: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} = fromDyn val11
                        in
                        asDyn
-                         { __br_terms =
-                             concat
-                               [ x15.info ]
-                               (val11.__br_terms),
-                           __br_info =
-                             mergeInfo
-                               (x15.info)
-                               (val11.__br_info),
+                         { __br_info = mergeInfo x15.info val11.__br_info,
+                           __br_terms = concat [ x15.info ] val11.__br_terms,
                            rights =
-                             concat
-                               [ { v =
-                                     nameNoSym
-                                       (x15.val),
-                                   i =
-                                     x15.info } ]
-                               (val11.rights) } },
-             { nt =
-                 kleene6,
-               label =
-                 {},
-               rhs =
-                 "",
+                             concat [ { v = nameNoSym x15.val, i = x15.info } ] val11.rights } },
+             { nt = kleene6,
+               label = {},
+               rhs = "",
                action =
                  lam state26: {errors: Ref [(Info, [Char])], content: String}.
                    lam res26.
@@ -4192,34 +3102,22 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           rights =
-                             "" } },
-             { nt =
-                 kleene7,
-               label =
-                 {},
+                           __br_terms = "",
+                           rights = "" } },
+             { nt = kleene7,
+               label = {},
                rhs =
-                 [ tokSym
-                     (UIdentRepr
+                 [ tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     kleene5,
-                   litSym
-                     "?",
-                   tokSym
-                     (UIdentRepr
+                   ntSym kleene5,
+                   litSym "?",
+                   tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     kleene6,
-                   litSym
-                     ";",
-                   ntSym
-                     kleene7 ],
+                   ntSym kleene6,
+                   litSym ";",
+                   ntSym kleene7 ],
                action =
                  lam state27: {errors: Ref [(Info, [Char])], content: String}.
                    lam res27.
@@ -4234,20 +3132,24 @@ let _table =
                          LitParsed l16,
                          UserSym val12 ]
                      in
-                     let val10: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val10
+                     let val10: {lefts: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} = fromDyn val10
                        in
-                       let val11: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val11
+                       let val11: {rights: [{i: Info, v: Name}], __br_info: Info, __br_terms: [Info]} = fromDyn val11
                        in
-                       let val12: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
-                         fromDyn
-                           val12
+                       let val12: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} = fromDyn val12
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               x16.info
+                               [ val10.__br_info,
+                                 l15.info,
+                                 x17.info,
+                                 val11.__br_info,
+                                 l16.info,
+                                 val12.__br_info ],
+                           __br_terms =
                              join
                                [ [ x16.info ],
                                  val10.__br_terms,
@@ -4256,41 +3158,16 @@ let _table =
                                  val11.__br_terms,
                                  [ l16.info ],
                                  val12.__br_terms ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (x16.info)
-                               [ val10.__br_info,
-                                 l15.info,
-                                 x17.info,
-                                 val11.__br_info,
-                                 l16.info,
-                                 val12.__br_info ],
                            exceptions =
                              concat
                                [ { lefts =
-                                     concat
-                                       [ { v =
-                                             nameNoSym
-                                               (x16.val),
-                                           i =
-                                             x16.info } ]
-                                       (val10.lefts),
+                                     concat [ { v = nameNoSym x16.val, i = x16.info } ] val10.lefts,
                                    rights =
-                                     concat
-                                       [ { v =
-                                             nameNoSym
-                                               (x17.val),
-                                           i =
-                                             x17.info } ]
-                                       (val11.rights) } ]
-                               (val12.exceptions) } },
-             { nt =
-                 kleene7,
-               label =
-                 {},
-               rhs =
-                 "",
+                                     concat [ { v = nameNoSym x17.val, i = x17.info } ] val11.rights } ]
+                               val12.exceptions } },
+             { nt = kleene7,
+               label = {},
+               rhs = "",
                action =
                  lam state28: {errors: Ref [(Info, [Char])], content: String}.
                    lam res28.
@@ -4300,19 +3177,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           exceptions =
-                             "" } },
-             { nt =
-                 alt4,
-               label =
-                 {},
-               rhs =
-                 "",
+                           __br_terms = "",
+                           exceptions = "" } },
+             { nt = alt4,
+               label = {},
+               rhs = "",
                action =
                  lam state29: {errors: Ref [(Info, [Char])], content: String}.
                    lam res29.
@@ -4322,26 +3193,17 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           exceptions =
-                             "" } },
-             { nt =
-                 alt4,
-               label =
-                 {},
+                           __br_terms = "",
+                           exceptions = "" } },
+             { nt = alt4,
+               label = {},
                rhs =
-                 [ litSym
-                     "except",
-                   litSym
-                     "{",
-                   ntSym
-                     kleene7,
-                   litSym
-                     "}" ],
+                 [ litSym "except",
+                   litSym "{",
+                   ntSym kleene7,
+                   litSym "}" ],
                action =
                  lam state30: {errors: Ref [(Info, [Char])], content: String}.
                    lam res30.
@@ -4353,41 +3215,31 @@ let _table =
                          UserSym val12,
                          LitParsed l19 ]
                      in
-                     let val12: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
-                         fromDyn
-                           val12
+                     let val12: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} = fromDyn val12
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               l17.info
+                               [ l18.info,
+                                 val12.__br_info,
+                                 l19.info ],
+                           __br_terms =
                              join
                                [ [ l17.info ],
                                  [ l18.info ],
                                  val12.__br_terms,
                                  [ l19.info ] ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (l17.info)
-                               [ l18.info,
-                                 val12.__br_info,
-                                 l19.info ],
-                           exceptions =
-                             val12.exceptions } },
-             { nt =
-                 #var"DeclAtom",
-               label =
-                 {},
+                           exceptions = val12.exceptions } },
+             { nt = #var"SHDeclAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "precedence",
-                   litSym
-                     "{",
-                   ntSym
-                     kleene4,
-                   litSym
-                     "}",
-                   ntSym
-                     alt4 ],
+                 [ litSym "precedence",
+                   litSym "{",
+                   ntSym kleene4,
+                   litSym "}",
+                   ntSym alt4 ],
                action =
                  lam state31: {errors: Ref [(Info, [Char])], content: String}.
                    lam res31.
@@ -4400,42 +3252,32 @@ let _table =
                          LitParsed l22,
                          UserSym val13 ]
                      in
-                     let val9: {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val9
+                     let val9: {levels: [{noeq: Option Info, operators: [{i: Info, v: Name}]}], __br_info: Info, __br_terms: [Info]} = fromDyn val9
                        in
-                       let val13: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} =
-                         fromDyn
-                           val13
+                       let val13: {__br_info: Info, __br_terms: [Info], exceptions: [{lefts: [{i: Info, v: Name}], rights: [{i: Info, v: Name}]}]} = fromDyn val13
                        in
                        asDyn
-                         (PrecedenceTableDeclOp
-                            { __br_terms =
+                         (PrecedenceTableSHDeclOp
+                            { __br_info =
+                                foldl
+                                  mergeInfo
+                                  l20.info
+                                  [ l21.info,
+                                    val9.__br_info,
+                                    l22.info,
+                                    val13.__br_info ],
+                              __br_terms =
                                 join
                                   [ [ l20.info ],
                                     [ l21.info ],
                                     val9.__br_terms,
                                     [ l22.info ],
                                     val13.__br_terms ],
-                              __br_info =
-                                foldl
-                                  mergeInfo
-                                  (l20.info)
-                                  [ l21.info,
-                                    val9.__br_info,
-                                    l22.info,
-                                    val13.__br_info ],
-                              levels =
-                                val9.levels,
-                              exceptions =
-                                val13.exceptions }) },
-             { nt =
-                 alt5,
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "prod" ],
+                              levels = val9.levels,
+                              exceptions = val13.exceptions }) },
+             { nt = alt5,
+               label = {},
+               rhs = [ litSym "prod" ],
                action =
                  lam state32: {errors: Ref [(Info, [Char])], content: String}.
                    lam res32.
@@ -4445,25 +3287,15 @@ let _table =
                        [ LitParsed l23 ]
                      in
                      asDyn
-                         { __br_terms =
-                             [ l23.info ],
-                           __br_info =
-                             l23.info,
-                           kinf =
-                             "",
-                           kpref =
-                             "",
-                           kprod =
-                             [ l23.info ],
-                           kpostf =
-                             "" } },
-             { nt =
-                 alt5,
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "infix" ],
+                         { __br_info = l23.info,
+                           __br_terms = [ l23.info ],
+                           kinf = "",
+                           kpref = "",
+                           kprod = [ l23.info ],
+                           kpostf = "" } },
+             { nt = alt5,
+               label = {},
+               rhs = [ litSym "infix" ],
                action =
                  lam state33: {errors: Ref [(Info, [Char])], content: String}.
                    lam res33.
@@ -4473,25 +3305,15 @@ let _table =
                        [ LitParsed l24 ]
                      in
                      asDyn
-                         { __br_terms =
-                             [ l24.info ],
-                           __br_info =
-                             l24.info,
-                           kinf =
-                             [ l24.info ],
-                           kpref =
-                             "",
-                           kprod =
-                             "",
-                           kpostf =
-                             "" } },
-             { nt =
-                 alt5,
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "prefix" ],
+                         { __br_info = l24.info,
+                           __br_terms = [ l24.info ],
+                           kinf = [ l24.info ],
+                           kpref = "",
+                           kprod = "",
+                           kpostf = "" } },
+             { nt = alt5,
+               label = {},
+               rhs = [ litSym "prefix" ],
                action =
                  lam state34: {errors: Ref [(Info, [Char])], content: String}.
                    lam res34.
@@ -4501,25 +3323,15 @@ let _table =
                        [ LitParsed l25 ]
                      in
                      asDyn
-                         { __br_terms =
-                             [ l25.info ],
-                           __br_info =
-                             l25.info,
-                           kinf =
-                             "",
-                           kpref =
-                             [ l25.info ],
-                           kprod =
-                             "",
-                           kpostf =
-                             "" } },
-             { nt =
-                 alt5,
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "postfix" ],
+                         { __br_info = l25.info,
+                           __br_terms = [ l25.info ],
+                           kinf = "",
+                           kpref = [ l25.info ],
+                           kprod = "",
+                           kpostf = "" } },
+             { nt = alt5,
+               label = {},
+               rhs = [ litSym "postfix" ],
                action =
                  lam state35: {errors: Ref [(Info, [Char])], content: String}.
                    lam res35.
@@ -4529,24 +3341,15 @@ let _table =
                        [ LitParsed l26 ]
                      in
                      asDyn
-                         { __br_terms =
-                             [ l26.info ],
-                           __br_info =
-                             l26.info,
-                           kinf =
-                             "",
-                           kpref =
-                             "",
-                           kprod =
-                             "",
-                           kpostf =
-                             [ l26.info ] } },
-             { nt =
-                 alt6,
-               label =
-                 {},
-               rhs =
-                 "",
+                         { __br_info = l26.info,
+                           __br_terms = [ l26.info ],
+                           kinf = "",
+                           kpref = "",
+                           kprod = "",
+                           kpostf = [ l26.info ] } },
+             { nt = alt6,
+               label = {},
+               rhs = "",
                action =
                  lam state36: {errors: Ref [(Info, [Char])], content: String}.
                    lam res36.
@@ -4556,20 +3359,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           assoc =
-                             "" } },
-             { nt =
-                 alt6,
-               label =
-                 {},
-               rhs =
-                 [ tokSym
-                     (LIdentRepr
+                           __br_terms = "",
+                           assoc = "" } },
+             { nt = alt6,
+               label = {},
+               rhs = [ tokSym (LIdentRepr
                         {}) ],
                action =
                  lam state37: {errors: Ref [(Info, [Char])], content: String}.
@@ -4580,36 +3376,21 @@ let _table =
                        [ TokParsed (LIdentTok x18) ]
                      in
                      asDyn
-                         { __br_terms =
-                             [ x18.info ],
-                           __br_info =
-                             x18.info,
-                           assoc =
-                             [ { v =
-                                   x18.val,
-                                 i =
-                                   x18.info } ] } },
-             { nt =
-                 #var"DeclAtom",
-               label =
-                 {},
+                         { __br_info = x18.info,
+                           __br_terms = [ x18.info ],
+                           assoc = [ { v = x18.val, i = x18.info } ] } },
+             { nt = #var"SHDeclAtom",
+               label = {},
                rhs =
-                 [ ntSym
-                     alt5,
-                   ntSym
-                     alt6,
-                   tokSym
-                     (UIdentRepr
+                 [ ntSym alt5,
+                   ntSym alt6,
+                   tokSym (UIdentRepr
                         {}),
-                   litSym
-                     ":",
-                   tokSym
-                     (UIdentRepr
+                   litSym ":",
+                   tokSym (UIdentRepr
                         {}),
-                   litSym
-                     "=",
-                   ntSym
-                     #var"Regex" ],
+                   litSym "=",
+                   ntSym #var"SHRegex" ],
                action =
                  lam state38: {errors: Ref [(Info, [Char])], content: String}.
                    lam res38.
@@ -4624,21 +3405,24 @@ let _table =
                          LitParsed l28,
                          UserSym ntVal4 ]
                      in
-                     let val14: {kinf: [Info], kpref: [Info], kprod: [Info], kpostf: [Info], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val14
+                     let val14: {kinf: [Info], kpref: [Info], kprod: [Info], kpostf: [Info], __br_info: Info, __br_terms: [Info]} = fromDyn val14
                        in
-                       let val15: {assoc: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val15
+                       let val15: {assoc: [{i: Info, v: String}], __br_info: Info, __br_terms: [Info]} = fromDyn val15
                        in
-                       let ntVal4: (Info, Regex) =
-                         fromDyn
-                           ntVal4
-                       in
+                       let ntVal4: (Info, SHRegex) = fromDyn ntVal4 in
                        asDyn
-                         (ProductionDeclOp
-                            { __br_terms =
+                         (ProductionSHDeclOp
+                            { __br_info =
+                                foldl
+                                  mergeInfo
+                                  val14.__br_info
+                                  [ val15.__br_info,
+                                    x19.info,
+                                    l27.info,
+                                    x20.info,
+                                    l28.info,
+                                    ntVal4.0 ],
+                              __br_terms =
                                 join
                                   [ val14.__br_terms,
                                     val15.__br_terms,
@@ -4646,51 +3430,20 @@ let _table =
                                     [ l27.info ],
                                     [ x20.info ],
                                     [ l28.info ] ],
-                              __br_info =
-                                foldl
-                                  mergeInfo
-                                  (val14.__br_info)
-                                  [ val15.__br_info,
-                                    x19.info,
-                                    l27.info,
-                                    x20.info,
-                                    l28.info,
-                                    ntVal4.0 ],
-                              nt =
-                                [ { v =
-                                      nameNoSym
-                                        (x20.val),
-                                    i =
-                                      x20.info } ],
-                              name =
-                                [ { v =
-                                      nameNoSym
-                                        (x19.val),
-                                    i =
-                                      x19.info } ],
-                              kinf =
-                                val14.kinf,
-                              kpref =
-                                val14.kpref,
-                              kprod =
-                                val14.kprod,
-                              kpostf =
-                                val14.kpostf,
-                              assoc =
-                                val15.assoc,
-                              regex =
-                                [ ntVal4.1 ] }) },
-             { nt =
-                 #var"RegexAtom",
-               label =
-                 {},
+                              nt = [ { v = nameNoSym x20.val, i = x20.info } ],
+                              name = [ { v = nameNoSym x19.val, i = x19.info } ],
+                              kinf = val14.kinf,
+                              kpref = val14.kpref,
+                              kprod = val14.kprod,
+                              kpostf = val14.kpostf,
+                              assoc = val15.assoc,
+                              regex = [ ntVal4.1 ] }) },
+             { nt = #var"SHRegexAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "{",
-                   ntSym
-                     #var"Regex",
-                   litSym
-                     "}" ],
+                 [ litSym "{",
+                   ntSym #var"SHRegex",
+                   litSym "}" ],
                action =
                  lam state39: {errors: Ref [(Info, [Char])], content: String}.
                    lam res39.
@@ -4701,31 +3454,20 @@ let _table =
                          UserSym ntVal5,
                          LitParsed l30 ]
                      in
-                     let ntVal5: (Info, Regex) =
-                         fromDyn
-                           ntVal5
-                       in
+                     let ntVal5: (Info, SHRegex) = fromDyn ntVal5 in
                        asDyn
-                         (RecordRegexOp
-                            { __br_terms =
-                                concat
-                                  [ l29.info ]
-                                  [ l30.info ],
-                              __br_info =
+                         (RecordSHRegexOp
+                            { __br_info =
                                 foldl
                                   mergeInfo
-                                  (l29.info)
+                                  l29.info
                                   [ ntVal5.0,
                                     l30.info ],
-                              regex =
-                                [ ntVal5.1 ] }) },
-             { nt =
-                 #var"RegexAtom",
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "empty" ],
+                              __br_terms = concat [ l29.info ] [ l30.info ],
+                              regex = [ ntVal5.1 ] }) },
+             { nt = #var"SHRegexAtom",
+               label = {},
+               rhs = [ litSym "empty" ],
                action =
                  lam state40: {errors: Ref [(Info, [Char])], content: String}.
                    lam res40.
@@ -4735,18 +3477,11 @@ let _table =
                        [ LitParsed l31 ]
                      in
                      asDyn
-                         (EmptyRegexOp
-                            { __br_terms =
-                                [ l31.info ],
-                              __br_info =
-                                l31.info }) },
-             { nt =
-                 #var"RegexAtom",
-               label =
-                 {},
-               rhs =
-                 [ tokSym
-                     (StringRepr
+                         (EmptySHRegexOp
+                            { __br_info = l31.info, __br_terms = [ l31.info ] }) },
+             { nt = #var"SHRegexAtom",
+               label = {},
+               rhs = [ tokSym (StringRepr
                         {}) ],
                action =
                  lam state41: {errors: Ref [(Info, [Char])], content: String}.
@@ -4757,22 +3492,13 @@ let _table =
                        [ TokParsed (StringTok x21) ]
                      in
                      asDyn
-                         (LiteralRegexOp
-                            { val =
-                                [ { v =
-                                      x21.val,
-                                    i =
-                                      x21.info } ],
-                              __br_terms =
-                                [ x21.info ],
-                              __br_info =
-                                x21.info }) },
-             { nt =
-                 alt7,
-               label =
-                 {},
-               rhs =
-                 "",
+                         (LiteralSHRegexOp
+                            { val = [ { v = x21.val, i = x21.info } ],
+                              __br_info = x21.info,
+                              __br_terms = [ x21.info ] }) },
+             { nt = alt7,
+               label = {},
+               rhs = "",
                action =
                  lam state42: {errors: Ref [(Info, [Char])], content: String}.
                    lam res42.
@@ -4782,24 +3508,16 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           arg =
-                             "" } },
-             { nt =
-                 alt7,
-               label =
-                 {},
+                           __br_terms = "",
+                           arg = "" } },
+             { nt = alt7,
+               label = {},
                rhs =
-                 [ litSym
-                     "[",
-                   ntSym
-                     #var"Expr",
-                   litSym
-                     "]" ],
+                 [ litSym "[",
+                   ntSym #var"SHExpr",
+                   litSym "]" ],
                action =
                  lam state43: {errors: Ref [(Info, [Char])], content: String}.
                    lam res43.
@@ -4810,33 +3528,22 @@ let _table =
                          UserSym ntVal6,
                          LitParsed l33 ]
                      in
-                     let ntVal6: (Info, Expr) =
-                         fromDyn
-                           ntVal6
-                       in
+                     let ntVal6: (Info, SHExpr) = fromDyn ntVal6 in
                        asDyn
-                         { __br_terms =
-                             concat
-                               [ l32.info ]
-                               [ l33.info ],
-                           __br_info =
+                         { __br_info =
                              foldl
                                mergeInfo
-                               (l32.info)
+                               l32.info
                                [ ntVal6.0,
                                  l33.info ],
-                           arg =
-                             [ ntVal6.1 ] } },
-             { nt =
-                 #var"RegexAtom",
-               label =
-                 {},
+                           __br_terms = concat [ l32.info ] [ l33.info ],
+                           arg = [ ntVal6.1 ] } },
+             { nt = #var"SHRegexAtom",
+               label = {},
                rhs =
-                 [ tokSym
-                     (UIdentRepr
+                 [ tokSym (UIdentRepr
                         {}),
-                   ntSym
-                     alt7 ],
+                   ntSym alt7 ],
                action =
                  lam state44: {errors: Ref [(Info, [Char])], content: String}.
                    lam res44.
@@ -4846,35 +3553,17 @@ let _table =
                        [ TokParsed (UIdentTok x22),
                          UserSym val16 ]
                      in
-                     let val16: {arg: [Expr], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val16
+                     let val16: {arg: [SHExpr], __br_info: Info, __br_terms: [Info]} = fromDyn val16
                        in
                        asDyn
-                         (TokenRegexOp
-                            { __br_terms =
-                                concat
-                                  [ x22.info ]
-                                  (val16.__br_terms),
-                              __br_info =
-                                mergeInfo
-                                  (x22.info)
-                                  (val16.__br_info),
-                              name =
-                                [ { v =
-                                      nameNoSym
-                                        (x22.val),
-                                    i =
-                                      x22.info } ],
-                              arg =
-                                val16.arg }) },
-             { nt =
-                 #var"RegexPostfix",
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "+" ],
+                         (TokenSHRegexOp
+                            { __br_info = mergeInfo x22.info val16.__br_info,
+                              __br_terms = concat [ x22.info ] val16.__br_terms,
+                              name = [ { v = nameNoSym x22.val, i = x22.info } ],
+                              arg = val16.arg }) },
+             { nt = #var"SHRegexPostfix",
+               label = {},
+               rhs = [ litSym "+" ],
                action =
                  lam state45: {errors: Ref [(Info, [Char])], content: String}.
                    lam res45.
@@ -4884,18 +3573,11 @@ let _table =
                        [ LitParsed l34 ]
                      in
                      asDyn
-                         (RepeatPlusRegexOp
-                            { __br_terms =
-                                [ l34.info ],
-                              __br_info =
-                                l34.info }) },
-             { nt =
-                 #var"RegexPostfix",
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "*" ],
+                         (RepeatPlusSHRegexOp
+                            { __br_info = l34.info, __br_terms = [ l34.info ] }) },
+             { nt = #var"SHRegexPostfix",
+               label = {},
+               rhs = [ litSym "*" ],
                action =
                  lam state46: {errors: Ref [(Info, [Char])], content: String}.
                    lam res46.
@@ -4905,18 +3587,11 @@ let _table =
                        [ LitParsed l35 ]
                      in
                      asDyn
-                         (RepeatStarRegexOp
-                            { __br_terms =
-                                [ l35.info ],
-                              __br_info =
-                                l35.info }) },
-             { nt =
-                 #var"RegexPostfix",
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "?" ],
+                         (RepeatStarSHRegexOp
+                            { __br_info = l35.info, __br_terms = [ l35.info ] }) },
+             { nt = #var"SHRegexPostfix",
+               label = {},
+               rhs = [ litSym "?" ],
                action =
                  lam state47: {errors: Ref [(Info, [Char])], content: String}.
                    lam res47.
@@ -4926,21 +3601,14 @@ let _table =
                        [ LitParsed l36 ]
                      in
                      asDyn
-                         (RepeatQuestionRegexOp
-                            { __br_terms =
-                                [ l36.info ],
-                              __br_info =
-                                l36.info }) },
-             { nt =
-                 #var"RegexPrefix",
-               label =
-                 {},
+                         (RepeatQuestionSHRegexOp
+                            { __br_info = l36.info, __br_terms = [ l36.info ] }) },
+             { nt = #var"SHRegexPrefix",
+               label = {},
                rhs =
-                 [ tokSym
-                     (LIdentRepr
+                 [ tokSym (LIdentRepr
                         {}),
-                   litSym
-                     ":" ],
+                   litSym ":" ],
                action =
                  lam state48: {errors: Ref [(Info, [Char])], content: String}.
                    lam res48.
@@ -4951,27 +3619,13 @@ let _table =
                          LitParsed l37 ]
                      in
                      asDyn
-                         (NamedRegexOp
-                            { __br_terms =
-                                concat
-                                  [ x23.info ]
-                                  [ l37.info ],
-                              __br_info =
-                                mergeInfo
-                                  (x23.info)
-                                  (l37.info),
-                              name =
-                                [ { v =
-                                      x23.val,
-                                    i =
-                                      x23.info } ] }) },
-             { nt =
-                 #var"RegexInfix",
-               label =
-                 {},
-               rhs =
-                 [ litSym
-                     "|" ],
+                         (NamedSHRegexOp
+                            { __br_info = mergeInfo x23.info l37.info,
+                              __br_terms = concat [ x23.info ] [ l37.info ],
+                              name = [ { v = x23.val, i = x23.info } ] }) },
+             { nt = #var"SHRegexInfix",
+               label = {},
+               rhs = [ litSym "|" ],
                action =
                  lam state49: {errors: Ref [(Info, [Char])], content: String}.
                    lam res49.
@@ -4981,17 +3635,11 @@ let _table =
                        [ LitParsed l38 ]
                      in
                      asDyn
-                         (AlternativeRegexOp
-                            { __br_terms =
-                                [ l38.info ],
-                              __br_info =
-                                l38.info }) },
-             { nt =
-                 #var"RegexInfix",
-               label =
-                 {},
-               rhs =
-                 "",
+                         (AlternativeSHRegexOp
+                            { __br_info = l38.info, __br_terms = [ l38.info ] }) },
+             { nt = #var"SHRegexInfix",
+               label = {},
+               rhs = "",
                action =
                  lam state50: {errors: Ref [(Info, [Char])], content: String}.
                    lam res50.
@@ -5001,18 +3649,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         (ConcatRegexOp
-                            { __br_terms =
-                                "",
-                              __br_info =
-                                NoInfo
-                                  {} }) },
-             { nt =
-                 #var"ExprInfix",
-               label =
-                 {},
-               rhs =
-                 "",
+                         (ConcatSHRegexOp
+                            { __br_info = NoInfo
+                                  {},
+                              __br_terms = "" }) },
+             { nt = #var"SHExprInfix",
+               label = {},
+               rhs = "",
                action =
                  lam state51: {errors: Ref [(Info, [Char])], content: String}.
                    lam res51.
@@ -5022,19 +3665,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         (AppExprOp
-                            { __br_terms =
-                                "",
-                              __br_info =
-                                NoInfo
-                                  {} }) },
-             { nt =
-                 #var"ExprAtom",
-               label =
-                 {},
-               rhs =
-                 [ tokSym
-                     (UIdentRepr
+                         (AppSHExprOp
+                            { __br_info = NoInfo
+                                  {},
+                              __br_terms = "" }) },
+             { nt = #var"SHExprAtom",
+               label = {},
+               rhs = [ tokSym (UIdentRepr
                         {}) ],
                action =
                  lam state52: {errors: Ref [(Info, [Char])], content: String}.
@@ -5045,24 +3682,13 @@ let _table =
                        [ TokParsed (UIdentTok x24) ]
                      in
                      asDyn
-                         (ConExprOp
-                            { __br_terms =
-                                [ x24.info ],
-                              __br_info =
-                                x24.info,
-                              name =
-                                [ { v =
-                                      nameNoSym
-                                        (x24.val),
-                                    i =
-                                      x24.info } ] }) },
-             { nt =
-                 #var"ExprAtom",
-               label =
-                 {},
-               rhs =
-                 [ tokSym
-                     (StringRepr
+                         (ConSHExprOp
+                            { __br_info = x24.info,
+                              __br_terms = [ x24.info ],
+                              name = [ { v = nameNoSym x24.val, i = x24.info } ] }) },
+             { nt = #var"SHExprAtom",
+               label = {},
+               rhs = [ tokSym (StringRepr
                         {}) ],
                action =
                  lam state53: {errors: Ref [(Info, [Char])], content: String}.
@@ -5073,23 +3699,13 @@ let _table =
                        [ TokParsed (StringTok x25) ]
                      in
                      asDyn
-                         (StringExprOp
-                            { val =
-                                [ { v =
-                                      x25.val,
-                                    i =
-                                      x25.info } ],
-                              __br_terms =
-                                [ x25.info ],
-                              __br_info =
-                                x25.info }) },
-             { nt =
-                 #var"ExprAtom",
-               label =
-                 {},
-               rhs =
-                 [ tokSym
-                     (LIdentRepr
+                         (StringSHExprOp
+                            { val = [ { v = x25.val, i = x25.info } ],
+                              __br_info = x25.info,
+                              __br_terms = [ x25.info ] }) },
+             { nt = #var"SHExprAtom",
+               label = {},
+               rhs = [ tokSym (LIdentRepr
                         {}) ],
                action =
                  lam state54: {errors: Ref [(Info, [Char])], content: String}.
@@ -5100,33 +3716,19 @@ let _table =
                        [ TokParsed (LIdentTok x26) ]
                      in
                      asDyn
-                         (VariableExprOp
-                            { __br_terms =
-                                [ x26.info ],
-                              __br_info =
-                                x26.info,
-                              name =
-                                [ { v =
-                                      nameNoSym
-                                        (x26.val),
-                                    i =
-                                      x26.info } ] }) },
-             { nt =
-                 kleene8,
-               label =
-                 {},
+                         (VariableSHExprOp
+                            { __br_info = x26.info,
+                              __br_terms = [ x26.info ],
+                              name = [ { v = nameNoSym x26.val, i = x26.info } ] }) },
+             { nt = kleene8,
+               label = {},
                rhs =
-                 [ litSym
-                     ",",
-                   tokSym
-                     (LIdentRepr
+                 [ litSym ",",
+                   tokSym (LIdentRepr
                         {}),
-                   litSym
-                     "=",
-                   ntSym
-                     #var"Expr",
-                   ntSym
-                     kleene8 ],
+                   litSym "=",
+                   ntSym #var"SHExpr",
+                   ntSym kleene8 ],
                action =
                  lam state55: {errors: Ref [(Info, [Char])], content: String}.
                    lam res55.
@@ -5139,55 +3741,44 @@ let _table =
                          UserSym ntVal7,
                          UserSym val17 ]
                      in
-                     let ntVal7: (Info, Expr) =
-                         fromDyn
-                           ntVal7
-                       in
-                       let val17: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val17
+                     let ntVal7: (Info, SHExpr) = fromDyn ntVal7 in
+                       let val17: {fields: [{val: SHExpr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} = fromDyn val17
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               l39.info
+                               [ x27.info,
+                                 l40.info,
+                                 ntVal7.0,
+                                 val17.__br_info ],
+                           __br_terms =
                              join
                                [ [ l39.info ],
                                  [ x27.info ],
                                  [ l40.info ],
                                  val17.__br_terms ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (l39.info)
-                               [ x27.info,
-                                 l40.info,
-                                 ntVal7.0,
-                                 val17.__br_info ],
                            fields =
                              concat
                                [ { val =
                                      match
                                        [ ntVal7.1 ]
                                      with
-                                       [ x28 ] ++ _ ++ ""
+                                       [ x28 ] ++ _
                                      in
                                      x28,
                                    name =
                                      match
-                                       [ { v =
-                                             x27.val,
-                                           i =
-                                             x27.info } ]
+                                       [ { v = x27.val, i = x27.info } ]
                                      with
-                                       [ x29 ] ++ _ ++ ""
+                                       [ x29 ] ++ _
                                      in
                                      x29 } ]
-                               (val17.fields) } },
-             { nt =
-                 kleene8,
-               label =
-                 {},
-               rhs =
-                 "",
+                               val17.fields } },
+             { nt = kleene8,
+               label = {},
+               rhs = "",
                action =
                  lam state56: {errors: Ref [(Info, [Char])], content: String}.
                    lam res56.
@@ -5197,19 +3788,13 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           fields =
-                             "" } },
-             { nt =
-                 alt8,
-               label =
-                 {},
-               rhs =
-                 "",
+                           __br_terms = "",
+                           fields = "" } },
+             { nt = alt8,
+               label = {},
+               rhs = "",
                action =
                  lam state57: {errors: Ref [(Info, [Char])], content: String}.
                    lam res57.
@@ -5219,27 +3804,18 @@ let _table =
                        ""
                      in
                      asDyn
-                         { __br_terms =
-                             "",
-                           __br_info =
-                             NoInfo
+                         { __br_info = NoInfo
                                {},
-                           fields =
-                             "" } },
-             { nt =
-                 alt8,
-               label =
-                 {},
+                           __br_terms = "",
+                           fields = "" } },
+             { nt = alt8,
+               label = {},
                rhs =
-                 [ tokSym
-                     (LIdentRepr
+                 [ tokSym (LIdentRepr
                         {}),
-                   litSym
-                     "=",
-                   ntSym
-                     #var"Expr",
-                   ntSym
-                     kleene8 ],
+                   litSym "=",
+                   ntSym #var"SHExpr",
+                   ntSym kleene8 ],
                action =
                  lam state58: {errors: Ref [(Info, [Char])], content: String}.
                    lam res58.
@@ -5251,58 +3827,45 @@ let _table =
                          UserSym ntVal8,
                          UserSym val17 ]
                      in
-                     let ntVal8: (Info, Expr) =
-                         fromDyn
-                           ntVal8
-                       in
-                       let val17: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val17
+                     let ntVal8: (Info, SHExpr) = fromDyn ntVal8 in
+                       let val17: {fields: [{val: SHExpr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} = fromDyn val17
                        in
                        asDyn
-                         { __br_terms =
+                         { __br_info =
+                             foldl
+                               mergeInfo
+                               x30.info
+                               [ l41.info,
+                                 ntVal8.0,
+                                 val17.__br_info ],
+                           __br_terms =
                              join
                                [ [ x30.info ],
                                  [ l41.info ],
                                  val17.__br_terms ],
-                           __br_info =
-                             foldl
-                               mergeInfo
-                               (x30.info)
-                               [ l41.info,
-                                 ntVal8.0,
-                                 val17.__br_info ],
                            fields =
                              concat
                                [ { val =
                                      match
                                        [ ntVal8.1 ]
                                      with
-                                       [ x31 ] ++ _ ++ ""
+                                       [ x31 ] ++ _
                                      in
                                      x31,
                                    name =
                                      match
-                                       [ { v =
-                                             x30.val,
-                                           i =
-                                             x30.info } ]
+                                       [ { v = x30.val, i = x30.info } ]
                                      with
-                                       [ x32 ] ++ _ ++ ""
+                                       [ x32 ] ++ _
                                      in
                                      x32 } ]
-                               (val17.fields) } },
-             { nt =
-                 #var"ExprAtom",
-               label =
-                 {},
+                               val17.fields } },
+             { nt = #var"SHExprAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "{",
-                   ntSym
-                     alt8,
-                   litSym
-                     "}" ],
+                 [ litSym "{",
+                   ntSym alt8,
+                   litSym "}" ],
                action =
                  lam state59: {errors: Ref [(Info, [Char])], content: String}.
                    lam res59.
@@ -5313,36 +3876,28 @@ let _table =
                          UserSym val18,
                          LitParsed l43 ]
                      in
-                     let val18: {fields: [{val: Expr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} =
-                         fromDyn
-                           val18
+                     let val18: {fields: [{val: SHExpr, name: {i: Info, v: String}}], __br_info: Info, __br_terms: [Info]} = fromDyn val18
                        in
                        asDyn
-                         (RecordExprOp
-                            { __br_terms =
+                         (RecordSHExprOp
+                            { __br_info =
+                                foldl
+                                  mergeInfo
+                                  l42.info
+                                  [ val18.__br_info,
+                                    l43.info ],
+                              __br_terms =
                                 join
                                   [ [ l42.info ],
                                     val18.__br_terms,
                                     [ l43.info ] ],
-                              __br_info =
-                                foldl
-                                  mergeInfo
-                                  (l42.info)
-                                  [ val18.__br_info,
-                                    l43.info ],
-                              fields =
-                                val18.fields }) },
-             { nt =
-                 #var"RegexAtom",
-               label =
-                 {},
+                              fields = val18.fields }) },
+             { nt = #var"SHRegexAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "(",
-                   ntSym
-                     #var"Regex",
-                   litSym
-                     ")" ],
+                 [ litSym "(",
+                   ntSym #var"SHRegex",
+                   litSym ")" ],
                action =
                  lam #var"".
                    lam seq.
@@ -5353,21 +3908,18 @@ let _table =
                          UserSym ntVal9,
                          LitParsed l45 ]
                      in
-                     let ntVal9: (Info, Regex) =
-                         fromDyn
-                           ntVal9
-                       in
+                     let ntVal9: (Info, SHRegex) = fromDyn ntVal9 in
                        asDyn
-                         (RegexGrouping
-                            { __br_terms =
-                                [ l44.info,
-                                  l45.info ],
-                              __br_info =
+                         (SHRegexGrouping
+                            { __br_info =
                                 foldl
                                   mergeInfo
-                                  (l44.info)
+                                  l44.info
                                   [ ntVal9.0,
                                     l45.info ],
+                              __br_terms =
+                                [ l44.info,
+                                  l45.info ],
                               inner =
                                 match
                                   [ ntVal9.1 ]
@@ -5375,17 +3927,12 @@ let _table =
                                   [ x33 ]
                                 in
                                 x33 }) },
-             { nt =
-                 #var"ExprAtom",
-               label =
-                 {},
+             { nt = #var"SHExprAtom",
+               label = {},
                rhs =
-                 [ litSym
-                     "(",
-                   ntSym
-                     #var"Expr",
-                   litSym
-                     ")" ],
+                 [ litSym "(",
+                   ntSym #var"SHExpr",
+                   litSym ")" ],
                action =
                  lam #var"".
                    lam seq1.
@@ -5396,21 +3943,18 @@ let _table =
                          UserSym ntVal10,
                          LitParsed l47 ]
                      in
-                     let ntVal10: (Info, Expr) =
-                         fromDyn
-                           ntVal10
-                       in
+                     let ntVal10: (Info, SHExpr) = fromDyn ntVal10 in
                        asDyn
-                         (ExprGrouping
-                            { __br_terms =
-                                [ l46.info,
-                                  l47.info ],
-                              __br_info =
+                         (SHExprGrouping
+                            { __br_info =
                                 foldl
                                   mergeInfo
-                                  (l46.info)
+                                  l46.info
                                   [ ntVal10.0,
                                     l47.info ],
+                              __br_terms =
+                                [ l46.info,
+                                  l47.info ],
                               inner =
                                 match
                                   [ ntVal10.1 ]
@@ -5418,13 +3962,9 @@ let _table =
                                   [ x33 ]
                                 in
                                 x33 }) },
-             { nt =
-                 #var"File",
-               label =
-                 {},
-               rhs =
-                 [ ntSym
-                     #var"File_lclosed" ],
+             { nt = #var"SHFile",
+               label = {},
+               rhs = [ ntSym #var"SHFile_lclosed" ],
                action =
                  lam #var"".
                    lam seq2.
@@ -5436,17 +3976,12 @@ let _table =
                      fromDyn
                          cont
                          (Some
-                            (breakableInitState
-                               {})) },
-             { nt =
-                 #var"File_lclosed",
-               label =
-                 {},
+                            (breakableInitState {})) },
+             { nt = #var"SHFile_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"FileAtom",
-                   ntSym
-                     #var"File_lopen" ],
+                 [ ntSym #var"SHFileAtom",
+                   ntSym #var"SHFile_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5458,22 +3993,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addFileOpAtom
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"File_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHFileOpAtom p (fromDyn x33) st)) },
+             { nt = #var"SHFile_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"FileInfix",
-                   ntSym
-                     #var"File_lclosed" ],
+                 [ ntSym #var"SHFileInfix",
+                   ntSym #var"SHFile_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5485,22 +4010,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addFileOpInfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"File_lclosed",
-               label =
-                 {},
+                            fromDyn cont (addSHFileOpInfix p (fromDyn x33) st)) },
+             { nt = #var"SHFile_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"FilePrefix",
-                   ntSym
-                     #var"File_lclosed" ],
+                 [ ntSym #var"SHFilePrefix",
+                   ntSym #var"SHFile_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5512,22 +4027,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addFileOpPrefix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"File_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHFileOpPrefix p (fromDyn x33) st)) },
+             { nt = #var"SHFile_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"FilePostfix",
-                   ntSym
-                     #var"File_lopen" ],
+                 [ ntSym #var"SHFilePostfix",
+                   ntSym #var"SHFile_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5539,34 +4044,18 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addFileOpPostfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"File_lopen",
-               label =
-                 {},
-               rhs =
-                 "",
+                            fromDyn cont (addSHFileOpPostfix p (fromDyn x33) st)) },
+             { nt = #var"SHFile_lopen",
+               label = {},
+               rhs = "",
                action =
                  lam p.
                    lam #var"".
-                     asDyn
-                       (lam st.
-                          finalizeFileOp
-                            p
-                            st) },
-             { nt =
-                 #var"Decl",
-               label =
-                 {},
-               rhs =
-                 [ ntSym
-                     #var"Decl_lclosed" ],
+                     asDyn (lam st.
+                          finalizeSHFileOp p st) },
+             { nt = #var"SHDecl",
+               label = {},
+               rhs = [ ntSym #var"SHDecl_lclosed" ],
                action =
                  lam #var"".
                    lam seq2.
@@ -5578,17 +4067,12 @@ let _table =
                      fromDyn
                          cont
                          (Some
-                            (breakableInitState
-                               {})) },
-             { nt =
-                 #var"Decl_lclosed",
-               label =
-                 {},
+                            (breakableInitState {})) },
+             { nt = #var"SHDecl_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"DeclAtom",
-                   ntSym
-                     #var"Decl_lopen" ],
+                 [ ntSym #var"SHDeclAtom",
+                   ntSym #var"SHDecl_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5600,22 +4084,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addDeclOpAtom
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Decl_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHDeclOpAtom p (fromDyn x33) st)) },
+             { nt = #var"SHDecl_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"DeclInfix",
-                   ntSym
-                     #var"Decl_lclosed" ],
+                 [ ntSym #var"SHDeclInfix",
+                   ntSym #var"SHDecl_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5627,22 +4101,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addDeclOpInfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Decl_lclosed",
-               label =
-                 {},
+                            fromDyn cont (addSHDeclOpInfix p (fromDyn x33) st)) },
+             { nt = #var"SHDecl_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"DeclPrefix",
-                   ntSym
-                     #var"Decl_lclosed" ],
+                 [ ntSym #var"SHDeclPrefix",
+                   ntSym #var"SHDecl_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5654,22 +4118,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addDeclOpPrefix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Decl_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHDeclOpPrefix p (fromDyn x33) st)) },
+             { nt = #var"SHDecl_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"DeclPostfix",
-                   ntSym
-                     #var"Decl_lopen" ],
+                 [ ntSym #var"SHDeclPostfix",
+                   ntSym #var"SHDecl_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5681,34 +4135,18 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addDeclOpPostfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Decl_lopen",
-               label =
-                 {},
-               rhs =
-                 "",
+                            fromDyn cont (addSHDeclOpPostfix p (fromDyn x33) st)) },
+             { nt = #var"SHDecl_lopen",
+               label = {},
+               rhs = "",
                action =
                  lam p.
                    lam #var"".
-                     asDyn
-                       (lam st.
-                          finalizeDeclOp
-                            p
-                            st) },
-             { nt =
-                 #var"Regex",
-               label =
-                 {},
-               rhs =
-                 [ ntSym
-                     #var"Regex_lclosed" ],
+                     asDyn (lam st.
+                          finalizeSHDeclOp p st) },
+             { nt = #var"SHRegex",
+               label = {},
+               rhs = [ ntSym #var"SHRegex_lclosed" ],
                action =
                  lam #var"".
                    lam seq2.
@@ -5720,17 +4158,12 @@ let _table =
                      fromDyn
                          cont
                          (Some
-                            (breakableInitState
-                               {})) },
-             { nt =
-                 #var"Regex_lclosed",
-               label =
-                 {},
+                            (breakableInitState {})) },
+             { nt = #var"SHRegex_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"RegexAtom",
-                   ntSym
-                     #var"Regex_lopen" ],
+                 [ ntSym #var"SHRegexAtom",
+                   ntSym #var"SHRegex_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5742,22 +4175,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addRegexOpAtom
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Regex_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHRegexOpAtom p (fromDyn x33) st)) },
+             { nt = #var"SHRegex_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"RegexInfix",
-                   ntSym
-                     #var"Regex_lclosed" ],
+                 [ ntSym #var"SHRegexInfix",
+                   ntSym #var"SHRegex_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5769,22 +4192,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addRegexOpInfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Regex_lclosed",
-               label =
-                 {},
+                            fromDyn cont (addSHRegexOpInfix p (fromDyn x33) st)) },
+             { nt = #var"SHRegex_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"RegexPrefix",
-                   ntSym
-                     #var"Regex_lclosed" ],
+                 [ ntSym #var"SHRegexPrefix",
+                   ntSym #var"SHRegex_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5796,22 +4209,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addRegexOpPrefix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Regex_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHRegexOpPrefix p (fromDyn x33) st)) },
+             { nt = #var"SHRegex_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"RegexPostfix",
-                   ntSym
-                     #var"Regex_lopen" ],
+                 [ ntSym #var"SHRegexPostfix",
+                   ntSym #var"SHRegex_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5823,34 +4226,18 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addRegexOpPostfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Regex_lopen",
-               label =
-                 {},
-               rhs =
-                 "",
+                            fromDyn cont (addSHRegexOpPostfix p (fromDyn x33) st)) },
+             { nt = #var"SHRegex_lopen",
+               label = {},
+               rhs = "",
                action =
                  lam p.
                    lam #var"".
-                     asDyn
-                       (lam st.
-                          finalizeRegexOp
-                            p
-                            st) },
-             { nt =
-                 #var"Expr",
-               label =
-                 {},
-               rhs =
-                 [ ntSym
-                     #var"Expr_lclosed" ],
+                     asDyn (lam st.
+                          finalizeSHRegexOp p st) },
+             { nt = #var"SHExpr",
+               label = {},
+               rhs = [ ntSym #var"SHExpr_lclosed" ],
                action =
                  lam #var"".
                    lam seq2.
@@ -5862,17 +4249,12 @@ let _table =
                      fromDyn
                          cont
                          (Some
-                            (breakableInitState
-                               {})) },
-             { nt =
-                 #var"Expr_lclosed",
-               label =
-                 {},
+                            (breakableInitState {})) },
+             { nt = #var"SHExpr_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"ExprAtom",
-                   ntSym
-                     #var"Expr_lopen" ],
+                 [ ntSym #var"SHExprAtom",
+                   ntSym #var"SHExpr_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5884,22 +4266,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addExprOpAtom
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Expr_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHExprOpAtom p (fromDyn x33) st)) },
+             { nt = #var"SHExpr_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"ExprInfix",
-                   ntSym
-                     #var"Expr_lclosed" ],
+                 [ ntSym #var"SHExprInfix",
+                   ntSym #var"SHExpr_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5911,22 +4283,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addExprOpInfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Expr_lclosed",
-               label =
-                 {},
+                            fromDyn cont (addSHExprOpInfix p (fromDyn x33) st)) },
+             { nt = #var"SHExpr_lclosed",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"ExprPrefix",
-                   ntSym
-                     #var"Expr_lclosed" ],
+                 [ ntSym #var"SHExprPrefix",
+                   ntSym #var"SHExpr_lclosed" ],
                action =
                  lam p.
                    lam seq2.
@@ -5938,22 +4300,12 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addExprOpPrefix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Expr_lopen",
-               label =
-                 {},
+                            fromDyn cont (addSHExprOpPrefix p (fromDyn x33) st)) },
+             { nt = #var"SHExpr_lopen",
+               label = {},
                rhs =
-                 [ ntSym
-                     #var"ExprPostfix",
-                   ntSym
-                     #var"Expr_lopen" ],
+                 [ ntSym #var"SHExprPostfix",
+                   ntSym #var"SHExpr_lopen" ],
                action =
                  lam p.
                    lam seq2.
@@ -5965,27 +4317,15 @@ let _table =
                      in
                      asDyn
                          (lam st.
-                            fromDyn
-                              cont
-                              (addExprOpPostfix
-                                 p
-                                 (fromDyn
-                                    x33)
-                                 st)) },
-             { nt =
-                 #var"Expr_lopen",
-               label =
-                 {},
-               rhs =
-                 "",
+                            fromDyn cont (addSHExprOpPostfix p (fromDyn x33) st)) },
+             { nt = #var"SHExpr_lopen",
+               label = {},
+               rhs = "",
                action =
                  lam p.
                    lam #var"".
-                     asDyn
-                       (lam st.
-                          finalizeExprOp
-                            p
-                            st) } ] })
+                     asDyn (lam st.
+                          finalizeSHExprOp p st) } ] })
   in
   match
     target
@@ -5998,69 +4338,41 @@ let parseSelfhost =
     lam content.
       use ParseSelfhost
       in
-      let config4 =
-        { errors =
-            ref
-              "",
-          content =
-            content }
-      in
-      let res60 =
-        parseWithTable
-          _table
-          filename
-          config4
-          content
-      in
-      let #var"X" =
-        (res60, deref
-          (config4.errors))
-      in
+      let config4 = { errors = ref "", content = content } in
+      let res60 = parseWithTable _table filename config4 content in
+      let #var"X" = (res60, deref config4.errors) in
       match
         #var"X"
       with
         (Right dyn, "")
       then
         match
-          fromDyn
-            dyn
+          fromDyn dyn
         with
           (_, res60)
         in
         Right
             res60
-      else
-        match
-          #var"X"
-        with
-          (Left err, errors)
-        then
-          let err =
-            ll1DefaultHighlight
-              content
-              (ll1ToErrorHighlightSpec
-                 err)
-          in
-          Left
-            (snoc
-               errors
-               err)
-        else
-          match
-            #var"X"
-          with
-            (_, errors)
-          in
-          Left
-              errors
+      else match
+        #var"X"
+      with
+        (Left err, errors)
+      then
+        let err = ll1DefaultHighlight content (ll1ToErrorHighlightSpec err)
+        in
+        Left
+          (snoc errors err)
+      else match
+        #var"X"
+      with
+        (_, errors)
+      in
+      Left
+          errors
 let parseSelfhostExn =
   lam filename.
     lam content.
-      let #var"X" =
-        parseSelfhost
-          filename
-          content
-      in
+      let #var"X" = parseSelfhost filename content in
       match
         #var"X"
       with
@@ -6074,18 +4386,13 @@ let parseSelfhostExn =
                 with
                   (info, msg)
                 in
-                printLn
-                    (infoErrorString
-                       info
-                       msg)))
-        ; exit
-          1
-      else
-        match
-          #var"X"
-        with
-          Right file
-        in
-        file
+                printLn (infoErrorString info msg)))
+        ; exit 1
+      else match
+        #var"X"
+      with
+        Right file
+      in
+      file
 mexpr
 {}

--- a/src/stdlib/parser/selfhost.syn
+++ b/src/stdlib/parser/selfhost.syn
@@ -1,13 +1,13 @@
 language Selfhost
 
-start File
+start SHFile
 
-type File
-type Decl
-type Regex {
+type SHFile
+type SHDecl
+type SHRegex {
   grouping = "(" ")",
 }
-type Expr {
+type SHExpr {
   grouping = "(" ")",
 }
 
@@ -54,25 +54,25 @@ token {fragment = LineCommentParser,}
 token {fragment = MultilineCommentParser,}
 token {fragment = WhitespaceParser,}
 
-prod Lang: File =
+prod Lang: SHFile =
   "language" name:UIdent
-  decls:Decl+
+  decls:SHDecl+
 
-prod Start: Decl = "start" name:UName
-prod Include: Decl = "include" path:String
-prod Type: Decl =
+prod Start: SHDecl = "start" name:UName
+prod Include: SHDecl = "include" path:String
+prod Type: SHDecl =
   "type" name:UName
   ( "{"
-    properties:{name:LIdent "=" val:Expr ","}*
+    properties:{name:LIdent "=" val:SHExpr ","}*
   "}"
   )?
-prod TokenDecl: Decl =
+prod TokenSHDecl: SHDecl =
   "token" name:UName?
   ( "{"
-    properties:{name:LIdent "=" val:Expr ","}*
+    properties:{name:LIdent "=" val:SHExpr ","}*
   "}"
   )?
-prod PrecedenceTable: Decl =
+prod PrecedenceTable: SHDecl =
   "precedence" "{"
     levels:{noeq:"~"? operators:UName+ ";"}*
   "}"
@@ -80,20 +80,20 @@ prod PrecedenceTable: Decl =
     exceptions:{lefts:UName+ "?" rights:UName+ ";"}*
   "}"
   )?
-prod Production: Decl =
+prod Production: SHDecl =
   (kprod:"prod" | kinf:"infix" | kpref:"prefix" | kpostf:"postfix")
-  assoc:LIdent? name:UName ":" nt:UName "=" regex:Regex
+  assoc:LIdent? name:UName ":" nt:UName "=" regex:SHRegex
 
-prod Record: Regex = "{" regex:Regex "}"
-prod Empty: Regex = "empty"
-prod Literal: Regex = val:String
-prod Token: Regex = name:UName ("[" arg:Expr "]")?
-postfix RepeatPlus: Regex = "+"
-postfix RepeatStar: Regex = "*"
-postfix RepeatQuestion: Regex = "?"
-prefix Named: Regex = name:LIdent ":"
-infix left Alternative: Regex = "|"
-infix left Concat: Regex = empty
+prod Record: SHRegex = "{" regex:SHRegex "}"
+prod Empty: SHRegex = "empty"
+prod Literal: SHRegex = val:String
+prod Token: SHRegex = name:UName ("[" arg:SHExpr "]")?
+postfix RepeatPlus: SHRegex = "+"
+postfix RepeatStar: SHRegex = "*"
+postfix RepeatQuestion: SHRegex = "?"
+prefix Named: SHRegex = name:LIdent ":"
+infix left Alternative: SHRegex = "|"
+infix left Concat: SHRegex = empty
 
 precedence {
   Named;
@@ -102,12 +102,12 @@ precedence {
   Alternative;
 }
 
-infix left App: Expr = empty
-prod Con: Expr = name:UName
-prod String: Expr = val:String
-prod Variable: Expr = name:LName
-prod RecordExpr: Expr =
+infix left App: SHExpr = empty
+prod Con: SHExpr = name:UName
+prod String: SHExpr = val:String
+prod Variable: SHExpr = name:LName
+prod RecordSHExpr: SHExpr =
   "{"
-    (fields:{name:LIdent "=" val:Expr}
-     fields:{"," name:LIdent "=" val:Expr}*)?
+    (fields:{name:LIdent "=" val:SHExpr}
+     fields:{"," name:LIdent "=" val:SHExpr}*)?
   "}"

--- a/src/stdlib/parser/tool.mc
+++ b/src/stdlib/parser/tool.mc
@@ -112,7 +112,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   let filename = args.synFile in
   let destinationFile = args.outFile in
   let content = readFile filename in
-  match parseSelfhostExn filename content with LangFile {decls = decls, name = {v = langName}} in
+  match parseSelfhostExn filename content with LangSHFile {decls = decls, name = {v = langName}} in
 
   let simpleHighlight
     : Info -> String
@@ -147,9 +147,9 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   -- needs a bit of conversion to create proper MExpr code (though most
   -- of it is just switching from XExpr to TmX).
   recursive let exprToMExpr
-    : Expr -> Res MExpr
+    : SHExpr -> Res MExpr
     = lam e. switch e
-      case AppExpr (x & {left = ConExpr c}) then
+      case AppSHExpr (x & {left = ConSHExpr c}) then
         result.map
           (lam r. TmConApp
             { ident = c.name.v
@@ -158,7 +158,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
             , info = x.info
             })
           (exprToMExpr x.right)
-      case AppExpr x then
+      case AppSHExpr x then
         result.map2
           (lam l. lam r. TmApp
             { lhs = l
@@ -168,19 +168,19 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
             })
           (exprToMExpr x.left)
           (exprToMExpr x.right)
-      case ConExpr x then
+      case ConSHExpr x then
         result.err (simpleMsg x.info "A constructor must be applied to an argument.")
-      case StringExpr x then
+      case StringSHExpr x then
         result.ok (withInfo x.info (str_ x.val.v))
-      case VariableExpr x then
+      case VariableSHExpr x then
         result.ok (TmVar
           { ident = x.name.v
           , ty = tyunknown_
           , info = x.info
           , frozen = false
           })
-      case RecordExpr x then
-        let f : {name : {v: String, i: Info}, val: Expr} -> Res (String, MExpr) = lam field.
+      case RecordSHExpr x then
+        let f : {name : {v: String, i: Info}, val: SHExpr} -> Res (String, MExpr) = lam field.
           result.map (lam e. (field.name.v, e)) (exprToMExpr field.val) in
         result.map (lam pairs. withInfo x.info (urecord_ pairs)) (result.mapM f x.fields)
       end
@@ -190,9 +190,9 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   -- syntactically as much as possible with `Type` in MExpr, so a
   -- similar approach to exprToMExpr is needed for conversion.
   recursive let exprToMExprTy
-    : Expr -> Res MType
+    : SHExpr -> Res MType
     = lam e. switch e
-      case AppExpr x then
+      case AppSHExpr x then
         result.map2
           (lam l. lam r. TyApp
             { lhs = l
@@ -201,62 +201,62 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
             })
           (exprToMExprTy x.left)
           (exprToMExprTy x.right)
-      case ConExpr x then
+      case ConSHExpr x then
         result.ok (TyCon
           { ident = x.name.v
           , info = x.info
           , data = tyunknown_
           })
-      case VariableExpr x then
+      case VariableSHExpr x then
         result.ok (TyVar
           { ident = x.name.v
           , info = x.info
           })
-      case RecordExpr (x & {fields = []}) then
+      case RecordSHExpr (x & {fields = []}) then
         result.ok (tyWithInfo x.info tyunit_)
-      case RecordExpr x then
+      case RecordSHExpr x then
         result.err (simpleMsg x.info "Non-unit record types are not yet supported.")
       end
   in
 
-  let decls : [Decl] =
-    let makeNamedRegex : Info -> {v: Name, i: Info} -> String -> Regex = lam info. lam synName. lam field.
-      NamedRegex
+  let decls : [SHDecl] =
+    let makeNamedRegex : Info -> {v: Name, i: Info} -> String -> SHRegex = lam info. lam synName. lam field.
+      NamedSHRegex
         { name = {v = field, i = info}
-        , right = TokenRegex {name = synName, info = info, arg = None ()}
+        , right = TokenSHRegex {name = synName, info = info, arg = None ()}
         , info = info
         } in
     let desugarProds = lam d.
-      match d with ProductionDecl x then
-        let regexInfo = get_Regex_info x.regex in
+      match d with ProductionSHDecl x then
+        let regexInfo = get_SHRegex_info x.regex in
         let regex = x.regex in
         let regex = match (x.kinf, x.kpostf) with (Some info, _) | (_, Some info)
-          then ConcatRegex {info = regexInfo, left = makeNamedRegex info x.nt "left", right = regex}
+          then ConcatSHRegex {info = regexInfo, left = makeNamedRegex info x.nt "left", right = regex}
           else regex in
         let regex = match (x.kinf, x.kpref) with (Some info, _) | (_, Some info)
-          then ConcatRegex {info = regexInfo, left = regex, right = makeNamedRegex info x.nt "right"}
+          then ConcatSHRegex {info = regexInfo, left = regex, right = makeNamedRegex info x.nt "right"}
           else regex in
-        ProductionDecl {x with regex = regex}
+        ProductionSHDecl {x with regex = regex}
       else d in
     map desugarProds decls
   in
 
-  let includes : [IncludeDeclRecord] = mapOption
-    (lam x. match x with IncludeDecl x then Some x else None ())
+  let includes : [IncludeSHDeclRecord] = mapOption
+    (lam x. match x with IncludeSHDecl x then Some x else None ())
     decls
   in
 
   -- NOTE(vipa, 2022-03-18): Find all definitions in the file
   type PreNameEnv = {types : Map String [(Info, Name)], productions : Map String [(Info, Name)]} in
   let pullDefinition
-    : PreNameEnv -> Decl -> PreNameEnv
+    : PreNameEnv -> SHDecl -> PreNameEnv
     = lam env. lam decl.
       switch decl
-      case TypeDecl x then
+      case TypeSHDecl x then
         {env with types = mapInsertWith concat (nameGetStr x.name.v) [(x.name.i, nameSetNewSym x.name.v)] env.types}
-      case ProductionDecl x then
+      case ProductionSHDecl x then
         {env with productions = mapInsertWith concat (nameGetStr x.name.v) [(x.name.i, nameSetNewSym x.name.v)] env.productions}
-      case TokenDecl {name = Some n} then
+      case TokenSHDecl {name = Some n} then
         let n : {v : Name, i : Info} = n in
         {env with types = mapInsertWith concat (nameGetStr n.v) [(n.i, nameSetNewSym n.v)] env.types}
       case _ then
@@ -304,20 +304,20 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   -- expressions in regexes. Presumably I should call out to
   -- symbolize.mc, but I'll postpone that until later
   recursive let resolveRegex
-    : Regex -> Res Regex
+    : SHRegex -> Res SHRegex
     = lam reg.
-      let smapM : (Regex -> Res Regex) -> Regex -> Res Regex = lam f. lam reg.
+      let smapM : (SHRegex -> Res SHRegex) -> SHRegex -> Res SHRegex = lam f. lam reg.
         let inner = lam annot. lam here.
           let res = f here in
           let here = match result.consume res with (_, Right x) then x else here in
           (result.withAnnotations res annot, here) in
-        match smapAccumL_Regex_Regex inner (result.ok ()) reg with (annot, res) in
+        match smapAccumL_SHRegex_SHRegex inner (result.ok ()) reg with (annot, res) in
         result.withAnnotations annot (result.ok res)
       in
       switch reg
-      case TokenRegex x then
+      case TokenSHRegex x then
         result.map
-          (lam name. TokenRegex {x with name = name})
+          (lam name. TokenSHRegex {x with name = name})
           (lookupName x.name nameEnv.types)
       case other then
         smapM resolveRegex other
@@ -336,7 +336,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
     let defs = result.map (lam x. match x with [x] ++ _ then Some x else None ()) defs in
     result.withAnnotations multi defs
   in
-  type TokenDeclDesugaredRecord =
+  type TokenSHDeclDesugaredRecord =
     { repr : Option (Info, MExpr)
     , constructor : Option (Info, {v: Name, i: Info})
     , fragment : Option (Info, {v: String, i: Info})
@@ -344,7 +344,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
     , base : Option (Info, {v: Name, i: Info})
     , wrap : Option (Info, MExpr)
     } in
-  type TokenDeclPropertyMass =
+  type TokenSHDeclPropertyMass =
     { repr : [(Info, Res MExpr)]
     , constructor : [(Info, Res {v: Name, i: Info})]
     , fragment : [(Info, Res {v: String, i: Info})]
@@ -353,7 +353,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
     , wrap : [(Info, Res MExpr)]
     , unknown : [Info]
     } in
-  let emptyTokenDeclPropertyMass : TokenDeclPropertyMass =
+  let emptyTokenDeclPropertyMass : TokenSHDeclPropertyMass =
     { repr = []
     , constructor = []
     , fragment = []
@@ -363,7 +363,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
     , unknown = []
     } in
   let mergeTokenDeclPropertyMass
-    : TokenDeclPropertyMass -> TokenDeclPropertyMass -> TokenDeclPropertyMass
+    : TokenSHDeclPropertyMass -> TokenSHDeclPropertyMass -> TokenSHDeclPropertyMass
     = lam a. lam b.
       { repr = concat a.repr b.repr
       , constructor = concat a.constructor b.constructor
@@ -374,27 +374,27 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
       , unknown = concat a.unknown b.unknown
       } in
   let resolveTokenProperty
-    : {name: {v: String, i: Info}, val: Expr} -> TokenDeclPropertyMass
+    : {name: {v: String, i: Info}, val: SHExpr} -> TokenSHDeclPropertyMass
     = lam prop.
       let field = prop.name in
       let value = prop.val in
       switch field.v
       case "repr" then {emptyTokenDeclPropertyMass with repr = [(field.i, exprToMExpr value)]}
       case "constructor" then
-        let res = match value with ConExpr x
+        let res = match value with ConSHExpr x
           then result.ok x.name
-          else result.err (simpleMsg (get_Expr_info value) "The constructor must be a single constructor name.")
+          else result.err (simpleMsg (get_SHExpr_info value) "The constructor must be a single constructor name.")
         in {emptyTokenDeclPropertyMass with constructor = [(field.i, res)]}
       case "fragment" then
-        let res = match value with ConExpr x
+        let res = match value with ConSHExpr x
           then result.ok {v = nameGetStr x.name.v, i = x.name.i}
-          else result.err (simpleMsg (get_Expr_info value) "The language fragment must be a single fragment name.")
+          else result.err (simpleMsg (get_SHExpr_info value) "The language fragment must be a single fragment name.")
         in {emptyTokenDeclPropertyMass with fragment = [(field.i, res)]}
       case "ty" then {emptyTokenDeclPropertyMass with ty = [(field.i, exprToMExprTy value)]}
       case "base" then
-        let res = match value with ConExpr x
+        let res = match value with ConSHExpr x
           then result.ok x.name
-          else result.err (simpleMsg (get_Expr_info value) "The base token must be a single token name.")
+          else result.err (simpleMsg (get_SHExpr_info value) "The base token must be a single token name.")
         in {emptyTokenDeclPropertyMass with base = [(field.i, res)]}
       case "wrap" then {emptyTokenDeclPropertyMass with wrap = [(field.i, exprToMExpr value)]}
       case _ then
@@ -402,9 +402,9 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
       end
   in
   let desugarAndResolveTokenDecl
-    : TokenDeclRecord -> Res TokenDeclDesugaredRecord
+    : TokenSHDeclRecord -> Res TokenSHDeclDesugaredRecord
     = lam x.
-      let mass: TokenDeclPropertyMass = foldl mergeTokenDeclPropertyMass emptyTokenDeclPropertyMass
+      let mass: TokenSHDeclPropertyMass = foldl mergeTokenDeclPropertyMass emptyTokenDeclPropertyMass
         (map resolveTokenProperty x.properties) in
       let unknownError = match mass.unknown with [] then result.ok () else
         let msg = match mass.unknown with [_] then "Unknown property:\n" else "Unknown properties:\n" in
@@ -431,7 +431,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
             wrap)
   in
   let desugaredTokenToTokenInfo
-    : Info -> Option {v: Name, i: Info} -> TokenDeclDesugaredRecord -> (Option (Res String), Option (Res TokenInfo))
+    : Info -> Option {v: Name, i: Info} -> TokenSHDeclDesugaredRecord -> (Option (Res String), Option (Res TokenInfo))
     = lam surround. lam name. lam record.
       -- TODO(vipa, 2022-04-21): It would be nice to warn about unused
       -- properties, but it's annoying to implement atm
@@ -481,50 +481,50 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
         let fragErr = (result.err (simpleMsg surround "A token declaration without a name must have a 'fragment' property.\n")) in
         (Some fragErr, None ())
   in
-  type TypeDeclDesugaredRecord =
+  type TypeSHDeclDesugaredRecord =
     { grouping : Option (Info, ({v: Either Name String, i: Info}, {v: Either Name String, i: Info}))
     } in
-  type TypeDeclPropertyMass =
+  type TypeSHDeclPropertyMass =
     { grouping : [(Info, Res ({v: Either Name String, i: Info}, {v: Either Name String, i: Info}))]
     , unknown : [Info]
     } in
   let emptyTypeDeclPropertyMass =
     { grouping = [], unknown = [] } in
   let mergeTypeDeclPropertyMass
-    : TypeDeclPropertyMass -> TypeDeclPropertyMass -> TypeDeclPropertyMass
+    : TypeSHDeclPropertyMass -> TypeSHDeclPropertyMass -> TypeSHDeclPropertyMass
     = lam l. lam r.
       { grouping = concat l.grouping r.grouping
       , unknown = concat l.unknown r.unknown
       } in
   let resolveTypeProperty
-    : {name: {v: String, i: Info}, val: Expr} -> TypeDeclPropertyMass
+    : {name: {v: String, i: Info}, val: SHExpr} -> TypeSHDeclPropertyMass
     = lam prop.
       let field = prop.name in
       let value = prop.val in
       switch field.v
       case "grouping" then
-        let mkParen : Expr -> Res {v: Either Name String, i: Info} = lam e. switch e
-          case ConExpr c then
+        let mkParen : SHExpr -> Res {v: Either Name String, i: Info} = lam e. switch e
+          case ConSHExpr c then
             result.map
               (lam name. {v = Left name.v, i = c.name.i})
               (lookupName c.name nameEnv.types)
-          case StringExpr s then
+          case StringSHExpr s then
             result.ok {v = Right s.val.v, i = s.val.i}
           case e then
-            result.err (simpleMsg (get_Expr_info e) "Expected a string literal or token name.")
+            result.err (simpleMsg (get_SHExpr_info e) "Expected a string literal or token name.")
           end in
-        let res = match value with AppExpr x
+        let res = match value with AppSHExpr x
           then result.map2 (lam a. lam b. (a, b)) (mkParen x.left) (mkParen x.right)
-          else result.err (simpleMsg (get_Expr_info value) "Grouping must be two tokens (string literals or token names).")
+          else result.err (simpleMsg (get_SHExpr_info value) "Grouping must be two tokens (string literals or token names).")
         in {emptyTypeDeclPropertyMass with grouping = [(field.i, res)]}
       case _ then
         {emptyTypeDeclPropertyMass with unknown = [field.i]}
       end
   in
   let desugarAndResolveTypeDecl
-    : TypeDeclRecord -> Res TypeDeclDesugaredRecord
+    : TypeSHDeclRecord -> Res TypeSHDeclDesugaredRecord
     = lam x.
-      let mass: TypeDeclPropertyMass = foldl mergeTypeDeclPropertyMass emptyTypeDeclPropertyMass
+      let mass: TypeSHDeclPropertyMass = foldl mergeTypeDeclPropertyMass emptyTypeDeclPropertyMass
         (map resolveTypeProperty x.properties) in
       let unknownError = match mass.unknown with [] then result.ok () else
         let msg = match mass.unknown with [_] then "Unknown property:\n" else "Unknown properties:\n" in
@@ -539,13 +539,13 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
           grouping)
   in
   let resolveDecl
-    : Decl -> Res Decl
+    : SHDecl -> Res SHDecl
     = lam decl.
       switch decl
-      case TypeDecl x then
+      case TypeSHDecl x then
         let name = lookupName x.name nameEnv.types in
         let record = desugarAndResolveTypeDecl x in
-        let f = lam name: {v: Name, i: Info}. lam x: TypeDeclDesugaredRecord.
+        let f = lam name: {v: Name, i: Info}. lam x: TypeSHDeclDesugaredRecord.
           { ty = ntycon_ name.v
           , ensureSuffix = true
           , commonFields = mapEmpty cmpString
@@ -559,8 +559,8 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
         );
         result.withAnnotations
           record
-          (result.map (lam name. TypeDecl {x with name = name}) name)
-      case TokenDecl x then
+          (result.map (lam name. TypeSHDecl {x with name = name}) name)
+      case TokenSHDecl x then
         let name = match x.name with Some name
           then result.map (lam x. Some x) (lookupName name nameEnv.types)
           else result.ok (None ()) in
@@ -577,13 +577,13 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
              else ())
           tinfo;
         result.map
-          (lam name. TokenDecl {x with name = name})
+          (lam name. TokenSHDecl {x with name = name})
           name
-      case StartDecl x then
+      case StartSHDecl x then
         result.map
-          (lam name. StartDecl {x with name = name})
+          (lam name. StartSHDecl {x with name = name})
           (lookupName x.name nameEnv.types)
-      case PrecedenceTableDecl x then
+      case PrecedenceTableSHDecl x then
         let resolveLevel = lam level: {noeq : Option Info, operators : [{v: Name, i: Info}]}.
           result.map
             (lam operators. {level with operators = operators})
@@ -594,12 +594,12 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
             (result.mapM (lam n. lookupName n nameEnv.productions) exception.lefts)
             (result.mapM (lam n. lookupName n nameEnv.productions) exception.rights) in
         result.map2
-          (lam levels. lam exceptions. PrecedenceTableDecl {{x with levels = levels} with exceptions = exceptions})
+          (lam levels. lam exceptions. PrecedenceTableSHDecl {{x with levels = levels} with exceptions = exceptions})
           (result.mapM resolveLevel x.levels)
           (result.mapM resolveException x.exceptions)
-      case ProductionDecl x then
+      case ProductionSHDecl x then
         result.map3
-          (lam name. lam nt. lam regex. ProductionDecl {{{x with name = name} with nt = nt} with regex = regex})
+          (lam name. lam nt. lam regex. ProductionSHDecl {{{x with name = name} with nt = nt} with regex = regex})
           (lookupName x.name nameEnv.productions)
           (lookupName x.nt nameEnv.types)
           (resolveRegex x.regex)
@@ -611,14 +611,14 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   -- type `Res ()` that is ok iff all declarations name resolve
   -- properly, and one list of only the declarations without binding
   -- errors
-  let decls: [Res Decl] = map resolveDecl decls in
+  let decls: [Res SHDecl] = map resolveDecl decls in
   let allResolved: Res () = result.map (lam. ()) (result.mapM identity decls) in
-  let decls: [Decl] = mapOption result.toOption decls in
+  let decls: [SHDecl] = mapOption result.toOption decls in
   let typeMap: Map Name (Either (Res TypeInfo) (Res TokenInfo)) = deref typeMap in
 
   -- NOTE(vipa, 2022-03-21): Compute the required sfunctions
   let ntsWithInfo: [{v: Name, i: Info}] =
-    let inner = lam x. match x with TypeDecl x then Some x.name else None () in
+    let inner = lam x. match x with TypeSHDecl x then Some x.name else None () in
     mapOption inner decls in
   let nts: [Name] =
     map (lam name: {v: Name, i: Info}. name.v) ntsWithInfo in
@@ -637,7 +637,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
 
   -- NOTE(vipa, 2022-03-22): Find the starting non-terminal
   let start: Res Name =
-    let inner = lam x. match x with StartDecl x then Some (x.info, x.name.v) else None () in
+    let inner = lam x. match x with StartSHDecl x then Some (x.info, x.name.v) else None () in
     let starts: [(Info, Name)] = mapOption inner decls in
     switch starts
     case [(_, start)] then result.ok start
@@ -681,14 +681,14 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   -- NOTE(vipa, 2022-03-28): Compute a canonicalized form of a regex, with embedded type information
   recursive
     let inner
-    : Option (Info, String) -> Regex -> Res [SRegex]
+    : Option (Info, String) -> SHRegex -> Res [SRegex]
     = lam field. lam reg.
       let suggestLabel: String -> Res () = lam msg.
         match field with Some _ then result.ok () else
-        let info = get_Regex_info reg in
+        let info = get_SHRegex_info reg in
         result.withAnnotations (result.warn (simpleMsg info msg)) (result.ok ()) in
       let res = switch reg
-        case RecordRegex x then
+        case RecordSHRegex x then
           let suggest = suggestLabel "You probably want to save this record to a field (otherwise you should use parentheses for grouping).\n" in
           let mkReg = lam. lam content. [RecordReg
             { content = content
@@ -696,9 +696,9 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
             , info = x.info
             }] in
           result.map2 mkReg suggest (regexToSRegex x.regex)
-        case LiteralRegex x then
+        case LiteralSHRegex x then
           result.ok [TerminalReg {term = LitTerm x.val.v, info = x.info, field = field}]
-        case TokenRegex x then
+        case TokenSHRegex x then
           switch mapFindExn x.name.v typeMap
           case Left config then
             let suggest = suggestLabel "You probably want to save this type to a field.\n" in
@@ -707,42 +707,42 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
           case Right config then
             result.ok [TerminalReg {term = TokenTerm config, field = field, info = x.info}]
           end
-        case ConcatRegex x then
+        case ConcatSHRegex x then
           result.map2 concat (regexToSRegex x.left) (regexToSRegex x.right)
-        case AlternativeRegex x then
+        case AlternativeSHRegex x then
           let sregAlts = lam info. lam regs. match regs with [AltReg x]
             then x.alts
             else [{v = regs, i = info}] in
           let combine = lam ls. lam rs.
             [ AltReg
               { alts = concat
-                (sregAlts (get_Regex_info x.left) ls)
-                (sregAlts (get_Regex_info x.right) rs)
+                (sregAlts (get_SHRegex_info x.left) ls)
+                (sregAlts (get_SHRegex_info x.right) rs)
               }
             ] in
           result.map2 combine (regexToSRegex x.left) (regexToSRegex x.right)
-        case EmptyRegex _ then
+        case EmptySHRegex _ then
           result.ok []
-        case NamedRegex x then
+        case NamedSHRegex x then
           inner (Some (x.name.i, x.name.v)) x.right
-        case RepeatPlusRegex x then
-          let mkReg = lam regs. snoc regs (KleeneReg {content = {v = regs, i = get_Regex_info x.left}, info = x.info}) in
+        case RepeatPlusSHRegex x then
+          let mkReg = lam regs. snoc regs (KleeneReg {content = {v = regs, i = get_SHRegex_info x.left}, info = x.info}) in
           result.map mkReg (regexToSRegex x.left)
-        case RepeatStarRegex x then
-          let mkReg = lam regs. [KleeneReg {content = {v = regs, i = get_Regex_info x.left}, info = x.info}] in
+        case RepeatStarSHRegex x then
+          let mkReg = lam regs. [KleeneReg {content = {v = regs, i = get_SHRegex_info x.left}, info = x.info}] in
           result.map mkReg (regexToSRegex x.left)
-        case RepeatQuestionRegex x then
+        case RepeatQuestionSHRegex x then
           let mkReg = lam regs.
-            [AltReg {alts = [{v = [], i = x.info}, {v = regs, i = get_Regex_info x.left}]}] in
+            [AltReg {alts = [{v = [], i = x.info}, {v = regs, i = get_SHRegex_info x.left}]}] in
           result.map mkReg (regexToSRegex x.left)
         end
       in
-      match (field, reg) with (Some (info, _), !(RecordRegex _ | TokenRegex _ | LiteralRegex _)) then
+      match (field, reg) with (Some (info, _), !(RecordSHRegex _ | TokenSHRegex _ | LiteralSHRegex _)) then
         let err = result.err (simpleMsg info "Only tokens, types, literals, and records can be saved in a field.\n") in
         result.withAnnotations err res
       else res
     let regexToSRegex
-    : Regex -> Res [SRegex]
+    : SHRegex -> Res [SRegex]
     = lam reg. inner (None ()) reg
   in
 
@@ -1238,7 +1238,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
 
   -- NOTE(vipa, 2022-04-01): Figure out the operatorness of a production
   let findOperator
-    : ProductionDeclRecord -> Name -> [SRegex] -> Res Operator
+    : ProductionSHDeclRecord -> Name -> [SRegex] -> Res Operator
     = lam x. lam name. lam reg.
       let temp =
         match reg with [TerminalReg {field = Some (_, field), term = NtTerm {name = lname}}] ++ rest then
@@ -1364,9 +1364,9 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
     } in
   let constructors : Res [ConstructorInfo] =
     let check = lam decl.
-      match decl with ProductionDecl x then
+      match decl with ProductionSHDecl x then
         let name = computeConstructorName {constructor = x.name, nt = x.nt} in
-        let regInfo = get_Regex_info x.regex in
+        let regInfo = get_SHRegex_info x.regex in
         let reg = regexToSRegex x.regex in
         let content = result.map concatted reg in
         let content = result.map (addInfoField x.info) content in
@@ -1416,8 +1416,8 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
         then mapInsertWith concat pair [def]
         else mapInsertWith concat (pair.1, pair.0) [{def with ordering = flipOrdering def.ordering}]
     in
-    let computeOrders : Acc -> Decl -> Acc = lam acc. lam decl.
-      match decl with PrecedenceTableDecl x then
+    let computeOrders : Acc -> SHDecl -> Acc = lam acc. lam decl.
+      match decl with PrecedenceTableSHDecl x then
         let ensureNonAtomic : Info -> Operator -> Res Operator = lam info. lam op.
           match (op.lfield, op.rfield) with !(None _, None _) then result.ok op else
           result.err (simpleMsg info "This is not an operator") in


### PR DESCRIPTION
This PR updates the syntax tool's syntax definition to not share type names with the MExpr AST. Previously we worked around this by getting the `include` order correct, but that's turned out to be a tad fragile (no great surprise there).