### PR TITLE
External reflection library

### DIFF
--- a/misc/test-spec.mc
+++ b/misc/test-spec.mc
@@ -817,6 +817,7 @@ testMain
         , "stdlib/ext/cblas-ext.mc"
         , "stdlib/ext/vec-ext.mc"
         , "stdlib/ext/mat-ext.mc"
+        , "stdlib/ext/reflection-ext.mc"
         , "test/examples/external/ext-list-map.mc"
         , "test/examples/external/ext-list-concat-map.mc"
         , "stdlib/multicore/atomic.mc"

--- a/src/stdlib/ext/reflection-ext.ext-ocaml.mc
+++ b/src/stdlib/ext/reflection-ext.ext-ocaml.mc
@@ -1,0 +1,16 @@
+include "map.mc"
+include "ocaml/ast.mc"
+
+let impl = lam arg : { expr : String, ty : use Ast in Type }.
+  { expr = arg.expr, ty = arg.ty, libraries = [], cLibraries = [] }
+
+let reflectionMap =
+  use OCamlTypeAst in
+  mapFromSeq cmpString [
+    ("isfloat", [
+      impl {
+        expr = "(fun x -> Obj.tag (Obj.repr x) = Obj.double_tag)",
+        ty = tyarrows_ [tyfloat_, tybool_]
+      }
+    ])
+  ]

--- a/src/stdlib/ext/reflection-ext.mc
+++ b/src/stdlib/ext/reflection-ext.mc
@@ -1,0 +1,9 @@
+/-
+  This library implements runtime reflection functions, use with caution.
+ -/
+
+-- is the value a float?
+external isfloat : Float -> Bool
+
+utest isfloat 0. with true
+utest isfloat (unsafeCoerce 1) with false

--- a/src/stdlib/ocaml/external-includes.mc
+++ b/src/stdlib/ocaml/external-includes.mc
@@ -21,6 +21,7 @@ include "multicore/thread.ext-ocaml.mc"
 include "multicore/mutex.ext-ocaml.mc"
 include "multicore/cond.ext-ocaml.mc"
 include "ipopt/ipopt.ext-ocaml.mc"
+include "ext/reflection-ext.ext-ocaml.mc"
 
 
 type ExternalImpl = {
@@ -55,7 +56,8 @@ let globalExternalImplsMap : Map String [ExternalImpl] =
       ipoptExtMap,
       tomlExtMap,
       asyncExtMap,
-      rtpplExtMap
+      rtpplExtMap,
+      reflectionMap
     ]
 
 -- List OCaml packages available on the system. These are returned on the format


### PR DESCRIPTION
This PR adds an external (written by @br4sco) for the OCaml backend that checks if a runtime value is a `Float`. This is normally useless since a value with the static type `Float` will also be a `Float` at runtime, but in the AD implementation of miking-dppl some floats will have a different runtime representation, at which point this check becomes relevant. 