### PR TITLE
Filter utests

### DIFF
--- a/src/stdlib/mexpr/generate-utest.mc
+++ b/src/stdlib/mexpr/generate-utest.mc
@@ -31,12 +31,13 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
     { defaultOnFail : Name
     , runner : Name
     , exitOnFailure : Name
+    , includeUtestIf : {static : Bool, info : Info} -> Bool
     }
 
   -- Enable code generation replacing `utest` with equivalent
   -- code. Will remove `StripUtestHook` if present.
-  sem enableUtestGeneration : Loader -> Loader
-  sem enableUtestGeneration = | loader ->
+  sem enableUtestGeneration : ({static : Bool, info : Info} -> Bool) -> Loader -> Loader
+  sem enableUtestGeneration includeUtestIf = | loader ->
     if hasHook (lam x. match x with UtestHook _ then true else false) loader then loader else
 
     -- NOTE(vipa, 2025-01-27): We strip utests found in files before
@@ -52,6 +53,7 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
       { defaultOnFail = _getVarExn "utestDefaultOnFail" utestEnv
       , runner = _getVarExn "utestRunner" utestEnv
       , exitOnFailure = _getVarExn "utestExitOnFailure" utestEnv
+      , includeUtestIf = includeUtestIf
       } in
     let loader = remHook (lam x. match x with StripUtestHook _ then true else false) loader in
     addHook loader (UtestHook hook)
@@ -76,52 +78,66 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
 
   sem _postTypecheck loader decl = | UtestHook hook ->
     match decl with DeclUtest d then
-      match replaceUtests hook loader (declAsExpr unit_ decl) with (loader, expr) in
-      let decl = DeclLet
-        { ident = nameNoSym ""
-        , tyAnnot = tyunit_
-        , tyBody = tyunit_
-        , body = expr
-        , info = d.info
-        } in
-      (loader, decl)
+      if hook.includeUtestIf {static = true, info = d.info} then
+        match replaceUtests hook true loader (declAsExpr unit_ decl) with (loader, expr) in
+        let decl = DeclLet
+          { ident = nameNoSym ""
+          , tyAnnot = tyunit_
+          , tyBody = tyunit_
+          , body = expr
+          , info = d.info
+          } in
+        (loader, decl)
+      else
+        let noop = DeclLet
+          { ident = nameNoSym ""
+          , tyAnnot = tyunknown_
+          , tyBody = tyunit_
+          , body = unit_
+          , info = d.info
+          } in
+        (loader, noop)
     else
-      smapAccumL_Decl_Expr (replaceUtests hook) loader decl
+      smapAccumL_Decl_Expr (replaceUtests hook true) loader decl
 
-  sem replaceUtests hook loader =
-  | tm -> smapAccumL_Expr_Expr (replaceUtests hook) loader tm
+  sem replaceUtests hook static loader =
+  | tm & TmLam _ -> smapAccumL_Expr_Expr (replaceUtests hook false) loader tm
+  | tm -> smapAccumL_Expr_Expr (replaceUtests hook static) loader tm
   | TmUtest x ->
-    let infoStr = str_ (info2str x.info) in
+    if hook.includeUtestIf {static = static, info = x.info} then
+      let infoStr = str_ (info2str x.info) in
 
-    match
-      match x.tusing with Some eqfn
-      then (loader, str_ (concat "    Using: " (expr2str eqfn)), eqfn)
-      else match eqFunctionsFor [tyTm x.expected] loader with (loader, [eqfn]) in (loader, str_ "", eqfn)
-    with (loader, usingStr, eqFn) in
+      match
+        match x.tusing with Some eqfn
+        then (loader, str_ (concat "    Using: " (expr2str eqfn)), eqfn)
+        else match eqFunctionsFor [tyTm x.expected] loader with (loader, [eqfn]) in (loader, str_ "", eqfn)
+      with (loader, usingStr, eqFn) in
 
-    match
-      match x.tonfail with Some ppfn then (loader, ppfn) else
-      match pprintFunctionsFor [tyTm x.test, tyTm x.expected] loader with (loader, [testF, expectedF]) in
-      (loader, appf2_ (nvar_ hook.defaultOnFail) testF expectedF)
-    with (loader, onFailFn) in
+      match
+        match x.tonfail with Some ppfn then (loader, ppfn) else
+        match pprintFunctionsFor [tyTm x.test, tyTm x.expected] loader with (loader, [testF, expectedF]) in
+        (loader, appf2_ (nvar_ hook.defaultOnFail) testF expectedF)
+      with (loader, onFailFn) in
 
-    -- NOTE(vipa, 2025-01-27): This doesn't replace utests occurring
-    -- in `using` or `else`, which is consistent with the old
-    -- implementation, but maybe not ideal? It should be *very* rare
-    -- that it matters though.
-    match replaceUtests hook loader x.test with (loader, test) in
-    match replaceUtests hook loader x.expected with (loader, expected) in
-    match replaceUtests hook loader x.next with (loader, next) in
+      -- NOTE(vipa, 2025-01-27): This doesn't replace utests occurring
+      -- in `using` or `else`, which is consistent with the old
+      -- implementation, but maybe not ideal? It should be *very* rare
+      -- that it matters though.
+      match replaceUtests hook static loader x.test with (loader, test) in
+      match replaceUtests hook static loader x.expected with (loader, expected) in
+      match replaceUtests hook static loader x.next with (loader, next) in
 
-    let test = appSeq_ (nvar_ hook.runner) [infoStr, usingStr, onFailFn, eqFn, test, expected] in
-    let tm = TmLet
-      { ident = nameNoSym ""
-      , tyAnnot = tyunknown_
-      , tyBody = tyunit_
-      , body = test
-      , inexpr = next
-      , ty = tyTm next
-      , info = x.info
-      } in
-    (loader, tm)
+      let test = appSeq_ (nvar_ hook.runner) [infoStr, usingStr, onFailFn, eqFn, test, expected] in
+      let tm = TmLet
+        { ident = nameNoSym ""
+        , tyAnnot = tyunknown_
+        , tyBody = tyunit_
+        , body = test
+        , inexpr = next
+        , ty = tyTm next
+        , info = x.info
+        } in
+      (loader, tm)
+    else
+      replaceUtests hook static loader x.next
 end


### PR DESCRIPTION
This PR enables compile-time filtering of which `utest`s to include to the `Loader`-based code, mirroring what's already present in the normal pipeline. Includes #901 until it's been merged.