### PR TITLE
Better types in generate pprint eq

### DIFF
--- a/src/stdlib/mexpr/generate-eq.mc
+++ b/src/stdlib/mexpr/generate-eq.mc
@@ -70,7 +70,7 @@ lang GenerateEqRecord = GenerateEq + RecordTypeAst
     match mapAccumL (lam env. lam f. f env) env elems with (env, [first] ++ elems) in
 
     let f = lam acc. lam elem. if_ elem acc false_ in
-    (env, nulam_ lName (nulam_ rName (foldl f first elems)))
+    (env, nlam_ lName ty (nlam_ rName ty (foldl f first elems)))
 end
 
 lang GenerateEqApp = GenerateEq + AppTypeAst

--- a/src/stdlib/mexpr/generate-pprint.mc
+++ b/src/stdlib/mexpr/generate-pprint.mc
@@ -54,16 +54,16 @@ end
 
 lang GeneratePprintString = GeneratePprint + SeqTypeAst + CharTypeAst
   sem _getPprintFunction env =
-  | TySeq {ty = TyChar _} ->
+  | ty & TySeq {ty = TyChar _} ->
     let n = nameSym "x" in
-    (env, nulam_ n (cons_ (char_ '"') (snoc_ (app_ (nvar_ env.escapeString) (nvar_ n)) (char_ '"'))))
+    (env, nlam_ n ty (cons_ (char_ '"') (snoc_ (app_ (nvar_ env.escapeString) (nvar_ n)) (char_ '"'))))
 end
 
 lang GeneratePprintChar = GeneratePprint + CharTypeAst
   sem _getPprintFunction env =
-  | TyChar _ ->
+  | ty & TyChar _ ->
     let n = nameSym "c" in
-    (env, nulam_ n (seq_ [char_ '\'', app_ (nvar_ env.escapeChar) (nvar_ n), char_ '\'']))
+    (env, nlam_ n ty (seq_ [char_ '\'', app_ (nvar_ env.escapeChar) (nvar_ n), char_ '\'']))
 end
 
 lang GeneratePprintRecord = GeneratePprint + RecordTypeAst + MExprIdentifierPrettyPrint
@@ -96,7 +96,7 @@ lang GeneratePprintRecord = GeneratePprint + RecordTypeAst + MExprIdentifierPret
         (char_ (if isTuple then '(' else '{'))
         (foldr withComma last rest))
       (char_ (if isTuple then ')' else '}')) in
-    (env, nulam_ recName body)
+    (env, nlam_ recName ty body)
 end
 
 lang GeneratePprintApp = GeneratePprint + AppTypeAst


### PR DESCRIPTION
This PR makes `generate-eq.mc` and `generate-pprint.mc` a bit more diligent in adding explicit type-annotations to generated code. This is relevant for `generate-utest` because it inserts the generated code after type checking has already been done.  Includes #901 until it's been merged.