### PR TITLE
Fix post rebase

### DIFF
--- a/src/stdlib/mexpr/reptypes.mc
+++ b/src/stdlib/mexpr/reptypes.mc
@@ -398,7 +398,7 @@ end
 lang RepTypesAnalysis = LamRepTypesAnalysis + LetRepTypesAnalysis + RecLetsRepTypesAnalysis + VarRepTypesAnalysis + OpImplRepTypesAnalysis + OpDeclTypeCheck + RepTypesUnify + OpVarTypeCheck + ReprDeclTypeCheck
 end
 
-lang MExprRepTypesAnalysis = MExprTypeCheckMost + RepTypesAnalysis + MExprPrettyPrint + RepTypesPrettyPrint
+lang MExprRepTypesAnalysis = MExprTypeCheckMost + RecordUpdateTypeCheck + RepTypesAnalysis + MExprPrettyPrint + RepTypesPrettyPrint
 end
 
 lang RepTypesFragments = ReprTypeAst + ReprSubstAst + ReprTypeUnify + OpDeclAst + OpDeclSym + OpDeclTypeCheck + TyWildAst + TyWildUnify + RepTypesPrettyPrint

--- a/src/stdlib/mexpr/type-check.mc
+++ b/src/stdlib/mexpr/type-check.mc
@@ -1790,11 +1790,10 @@ lang MExprTypeCheckMost =
   MetaVarTypeCmp + MetaVarTypeEq + MetaVarTypePrettyPrint
 end
 
-lang MExprTypeCheck = MExprTypeCheckMost + MExprTypeCheckLamLetVar +
-                      RecordUpdateTypeCheck
+lang MExprTypeCheck = MExprTypeCheckMost + MExprTypeCheckLamLetVar + RecordUpdateTypeCheck
 end
 
-lang RepTypesTypeCheck = OpDeclTypeCheck + ReprDeclTypeCheck + OpVarTypeCheck + OpImplTypeCheck + RepTypesUnify
+lang RepTypesTypeCheck = OpDeclTypeCheck + ReprDeclTypeCheck + OpVarTypeCheck + OpImplTypeCheck + RepTypesUnify + RecordUpdateTypeCheck
 end
 
 -- NOTE(vipa, 2022-10-07): This can't use AnnotateMExprBase because it

--- a/src/stdlib/mlang/symbolize.mc
+++ b/src/stdlib/mlang/symbolize.mc
@@ -77,25 +77,21 @@ lang DeclLetSym = DeclSym + LetDeclAst + LetSym
   | DeclLet t ->
     match symbolizeTyAnnot env t.tyAnnot with (tyVarEnv, tyAnnot) in
     match setSymbol env.currentEnv.varEnv t.ident with (varEnv, ident) in
-    let env = symbolizeUpdateVarEnv env varEnv in
-    let env = symbolizeUpdateTyVarEnv env tyVarEnv in
     let decl = DeclLet {t with ident = ident,
                         tyAnnot = tyAnnot,
-                        body = symbolizeExpr env t.body} in
-    (env, decl)
+                        body = symbolizeExpr (symbolizeUpdateTyVarEnv env tyVarEnv) t.body} in
+    (symbolizeUpdateVarEnv env varEnv, decl)
 end
 
 lang DeclTypeSym = DeclSym + TypeDeclAst
   sem symbolizeDecl env =
   | DeclType t ->
     match setSymbol env.currentEnv.tyConEnv t.ident with (tyConEnv, ident) in
-    let env = symbolizeUpdateTyConEnv env tyConEnv in
     match mapAccumL setSymbol env.currentEnv.tyVarEnv t.params with (tyVarEnv, params) in
     let decl = DeclType {t with ident = ident,
                                 params = params,
                                 tyIdent = symbolizeType (symbolizeUpdateTyVarEnv env tyVarEnv) t.tyIdent} in
-    let env = symbolizeUpdateTyVarEnv env tyVarEnv in
-    (env, decl)
+    (symbolizeUpdateTyConEnv env tyConEnv, decl)
 end
 
 
@@ -127,8 +123,7 @@ lang DeclConDefSym = DeclSym + DataDeclAst
 
     let decl = DeclConDef {t with ident = ident,
                                   tyIdent = symbolizeType env t.tyIdent} in
-    let env = symbolizeUpdateConEnv env conEnv in
-    (env, decl)
+    (symbolizeUpdateConEnv env conEnv, decl)
 end
 
 lang DeclUtestSym = DeclSym + UtestDeclAst

--- a/src/stdlib/mlang/type-check.mc
+++ b/src/stdlib/mlang/type-check.mc
@@ -99,7 +99,7 @@ lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst +
   | DeclRecLets t ->
     -- NOTE(aathn, 2024-05-24): This code assumes that each recursive let-binding
     -- is a syntactic lambda, so that generalization is always safe.
-    let newLvl = 0 in 
+    let newLvl = addi 1 env.currentLvl in
     -- First: Generate a new environment containing the recursive bindings
     let recLetEnvIteratee = lam acc. lam b: RecLetBinding.
       let tyAnnot = resolveType t.info env false b.tyAnnot in


### PR DESCRIPTION
This PR fixes some minor things in #882; some missing fragments in some language compositions, errors in environment propagation in `mlang/symbolize.mc` and a level issue in `mlang/type-check.mc`. Includes #901 until it's been merged.