### PR TITLE
Op overload loader

### DIFF
--- a/src/stdlib/mexpr/desugar.mc
+++ b/src/stdlib/mexpr/desugar.mc
@@ -1,7 +1,30 @@
 include "mexpr/ast.mc"
+include "mlang/loader.mc"
 
 lang Desugar = Ast
   sem desugarExpr: Expr -> Expr
   sem desugarExpr =
   | tm -> smap_Expr_Expr desugarExpr tm
+end
+
+lang DesugarLoader = Ast + MCoreLoader
+  syn Hook =
+  | DesugarHook ()
+
+  sem desugarDecl : Loader -> Decl -> (Loader, Decl)
+  sem desugarDecl loader = | decl ->
+    smapAccumL_Decl_Expr desugarExpr loader decl
+
+  sem desugarExpr : Loader -> Expr -> (Loader, Expr)
+  sem desugarExpr loader = | expr ->
+    smapAccumL_Expr_Expr desugarExpr loader expr
+
+  sem enableDesugar : Loader -> Loader
+  sem enableDesugar = | loader ->
+    if hasHook (lam x. match x with DesugarHook _ then true else false) loader then loader else
+
+    addHook loader (DesugarHook ())
+
+  sem _postTypecheck loader decl = | DesugarHook _ ->
+    desugarDecl loader decl
 end

--- a/src/stdlib/mexpr/op-overload.mc
+++ b/src/stdlib/mexpr/op-overload.mc
@@ -58,6 +58,23 @@ lang OverloadedOpDesugar = Desugar + OverloadedOpAst + FunTypeAst
     else errorSingle [x.info] "Wrong type shape in desugarExpr"
 end
 
+lang OverloadedOpDesugarLoader = DesugarLoader + OverloadedOpAst + FunTypeAst
+  sem desugarExpr loader =
+  | TmOverloadedOp x ->
+    match unwrapType x.ty with TyArrow t then
+      recursive let flattenArrow = lam acc. lam t.
+        match unwrapType t with TyArrow t then flattenArrow (snoc acc t.from) t.to
+        else snoc acc t
+      in
+      let types = map unwrapType (flattenArrow [t.from] t.to) in
+      resolveOpLoader loader x.info {params = init types, return = last types, op = x.op}
+    else errorSingle [x.info] "Wrong type shape in desugarExpr"
+
+  sem resolveOpLoader : Loader -> Info -> {params: [Type], return: Type, op: Op} -> (Loader, Expr)
+  sem resolveOpLoader loader info = | params ->
+    (loader, resolveOp info params)
+end
+
 lang OverloadedOpPrettyPrint = OverloadedOpAst + PrettyPrint
   sem getOpStringCode: Int -> PprintEnv -> Op -> (PprintEnv, String)
   sem opIsAtomic: Op -> Bool


### PR DESCRIPTION
This PR adds a `Loader`-compatible implementation of the poor man's operator overloading present in the miking stdlib. Includes #901 until it's been merged.