### PR TITLE
Make `arityFunType` handle polymorphic functions + CPS handle nullary externals

### DIFF
--- a/src/stdlib/mexpr/anf.mc
+++ b/src/stdlib/mexpr/anf.mc
@@ -263,7 +263,7 @@ lang NeverANF = ANF + NeverAst
 
 end
 
-lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst
+lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst + FunArity
 
   sem normalize (k : Expr -> Expr) =
   | TmExt ({inexpr = inexpr} & t) ->

--- a/src/stdlib/mexpr/cps.mc
+++ b/src/stdlib/mexpr/cps.mc
@@ -316,12 +316,12 @@ lang NeverCPS = CPS + NeverAst
     TmLet { t with inexpr = exprCps env k t.inexpr }
 end
 
-lang ExtCPS = CPS + ExtAst
+lang ExtCPS = CPS + ExtAst + FunArity
   sem exprCps env k =
   | TmExt t ->
     errorSingle [t.info]
       "Error in CPS: Should not happen due to ANF transformation"
-  | TmExt ({ inexpr = TmLet ({ ident = ident, body = TmLam _, inexpr = inexpr } & tl) } & t) ->
+  | TmExt ({ inexpr = TmLet ({ ident = ident, body = TmLam _ | TmVar _, inexpr = inexpr } & tl) } & t) ->
     if not (transform env ident) then
       TmExt { t with inexpr = TmLet { tl with inexpr = exprCps env k inexpr } }
     else

--- a/src/stdlib/mexpr/type.mc
+++ b/src/stdlib/mexpr/type.mc
@@ -192,9 +192,13 @@ lang AppTypeUtils = AppTypeAst + FunTypeAst
     else error "Invalid type in getConDefType"
 end
 
--- Returns the arity of a function type
-recursive let arityFunType = use MExprAst in lam ty.
-  match ty with TyArrow t then addi 1 (arityFunType t.to) else 0
+
+lang FunArity = FunTypeAst + AllTypeAst
+  sem arityFunType : Type -> Int
+  sem arityFunType =
+  | TyArrow t -> addi 1 (arityFunType t.to)
+  | TyAll t -> arityFunType t.ty
+  | ty -> (rappAccumL_Type_Type (lam. lam ty. (arityFunType ty, ty)) 0 ty).0
 end
 
 let isHigherOrderFunType = use MExprAst in lam ty.


### PR DESCRIPTION
This makes `arityFunType` a semantic function that also strips `TyAll`, which makes it handle polymorphic functions. There is also a minor fix to the CPS transform to make it properly handle non-function externals.

Includes more PRs until they're merged.