### PR TITLE
Effect is a keyword in ocaml 5.3

### DIFF
--- a/src/boot/lib/deadcode.ml
+++ b/src/boot/lib/deadcode.ml
@@ -17,8 +17,8 @@ let tm_has_side_effect nmap tm =
         if acc_se then (true, acc_prerun)
         else
           match SymbMap.find_opt s nmap with
-          | Some (_, _, effect, _) ->
-              (effect, acc_prerun)
+          | Some (_, _, side_effect, _) ->
+              (side_effect, acc_prerun)
           | None ->
               (false, acc_prerun) (* In case of lambda or pattern variables *)
         )

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -664,14 +664,14 @@ let getData = function
         , [] )
     | _, _ ->
         failwith "bootparser getData undefined" )
-  | PTreeTop (TopExt (Ext (fi, str, effect, ty))) ->
+  | PTreeTop (TopExt (Ext (fi, str, side_effect, ty))) ->
       ( idDeclExt
       , [fi]
       , []
       , [ty]
       , []
       , [str]
-      , [(if effect then 1 else 0)]
+      , [(if side_effect then 1 else 0)]
       , []
       , []
       , []


### PR DESCRIPTION
## TLDR
I was compiling the project using Ocaml 5.3.0 and got some syntax errors. Currently the easiest fix is to rename the variables causing the issues from `effect` to `side_effect` since they represent a boolean which in turn represents whether something has side effects.

## Explaination

In Ocaml 5.3.0 the `effect` keyword was added, see the release [here](https://ocaml.org/changelog/2025-01-08-ocaml-5.3.0).

A couple places in the `/src/boot` project uses `effect` as a variable name and hence the project does not compile using Ocaml 5.3.0.

With 5.3.0 a `-keywords` flag was added and appending `-keywords 5.2` to the compilation flags would avoid this issue. See [this PR](https://github.com/ocaml/ocaml/pull/13471). However, since `boot` is compiled using dune this is not currently possible. This is because when I ran `dune b --verbose` I discovered that dune runs ocamldep first which throws the syntax error and dune does not currently have the ability to pass flags to ocamldep. See [this issue](https://github.com/ocaml/dune/issues/11419). Ocamldep does support the `-keywords` flag on the newest development branches, however, this was added [in this PR](https://github.com/ocaml/ocaml/pull/13779). That PR was after the release of 5.3.0 and so ocamldep 5.3.0 does not support the `-keywords` flag. And even if it did, like mentioned earlier, dune does not currently support sending flags to ocamldep.