### PR TITLE
Auto-promote JsonInt to Float when deserializing

### DIFF
--- a/src/stdlib/json.mc
+++ b/src/stdlib/json.mc
@@ -454,7 +454,9 @@ let jsonDeserializeInt: JsonValue -> Option Int = lam ji.
 
 let jsonSerializeFloat: Float -> JsonValue = lam f. JsonFloat f
 let jsonDeserializeFloat: JsonValue -> Option Float = lam jf.
-  match jf with JsonFloat f then Some f else None ()
+  match jf with JsonFloat f then Some f else
+  match jf with JsonInt i then Some (int2float i) else
+  None ()
 
 let jsonSerializeChar: Char -> JsonValue = lam c. JsonString [c]
 let jsonDeserializeChar: JsonValue -> Option Char = lam jc.


### PR DESCRIPTION
Json doesn't distinguish between `Int` and `Float`, it only has numbers, but our `json` library does (to be more convenient with the rest of the system). This means that something that looks like an `Int` (no fractional part) will be parsed to `JsonInt` even if our program expected a `Float` in that position. The easiest way to deal with this is to let the deserialization function used after parsing (`jsonDeserializeFloat`) automatically promote to `Float` if it encounters a `JsonInt`.