### PR TITLE
Add short-circuit logic and convenience tempfile functions

### DIFF
--- a/misc/test-spec.mc
+++ b/misc/test-spec.mc
@@ -754,43 +754,7 @@ mexpr
 testMain
   [ { testColl "accelerate"
     with checkCondition = lam.
-      if scallb [
-        lam. sysCommandExists "nvcc",
-        lam. sysCommandExists "futhark",
-        lam. sysWithTempDir (lam td.
-          let checkProgPath = sysJoinPath td "check.cu" in
-          let contents = "
-          int main()
-          {
-              int c = 0;
-              cudaError_t r = cudaGetDeviceCount(&c);
-              if (r != cudaSuccess) {
-                 std::cout << cudaGetErrorString(r) << std::endl;
-                 return 0;
-              }
-              return c;
-          }
-          " in
-          writeFile checkProgPath contents;
-          let run = lam cmd. sysRunCommandWithTimingTimeout (Some 60.0) cmd "" td in
-
-          match run ["nvcc", "check.cu", "--output-file", "check.out"]
-          with (execTime, _) in
-          if gtf execTime 59.0 then
-            -- Assume it timed out or something else went wrong, should not
-            -- take more than a second...
-            false
-          else -- continue
-
-          match run ["./check.out"]
-          with (execTime, execResult) in
-          if gtf execTime 59.0 then
-            false
-          else
-            -- The return code should be positive if we have a CUDA device to run on
-            gti execResult.returncode 0
-        )
-      ]
+      if and (sysCommandExists "nvcc") (sysCommandExists "futhark")
       then ConditionsMet ()
       else ConditionsImpossible () -- TODO(vipa, 2023-04-25): figure out how to check if we have nvidia hardware
     , exclusions = lam api.

--- a/misc/test-spec.mc
+++ b/misc/test-spec.mc
@@ -754,7 +754,43 @@ mexpr
 testMain
   [ { testColl "accelerate"
     with checkCondition = lam.
-      if and (sysCommandExists "nvcc") (sysCommandExists "futhark")
+      if scallb [
+        lam. sysCommandExists "nvcc",
+        lam. sysCommandExists "futhark",
+        lam. sysWithTempDir (lam td.
+          let checkProgPath = sysJoinPath td "check.cu" in
+          let contents = "
+          int main()
+          {
+              int c = 0;
+              cudaError_t r = cudaGetDeviceCount(&c);
+              if (r != cudaSuccess) {
+                 std::cout << cudaGetErrorString(r) << std::endl;
+                 return 0;
+              }
+              return c;
+          }
+          " in
+          writeFile checkProgPath contents;
+          let run = lam cmd. sysRunCommandWithTimingTimeout (Some 60.0) cmd "" td in
+
+          match run ["nvcc", "check.cu", "--output-file", "check.out"]
+          with (execTime, _) in
+          if gtf execTime 59.0 then
+            -- Assume it timed out or something else went wrong, should not
+            -- take more than a second...
+            false
+          else -- continue
+
+          match run ["./check.out"]
+          with (execTime, execResult) in
+          if gtf execTime 59.0 then
+            false
+          else
+            -- The return code should be positive if we have a CUDA device to run on
+            gti execResult.returncode 0
+        )
+      ]
       then ConditionsMet ()
       else ConditionsImpossible () -- TODO(vipa, 2023-04-25): figure out how to check if we have nvidia hardware
     , exclusions = lam api.

--- a/src/stdlib/bool.mc
+++ b/src/stdlib/bool.mc
@@ -5,13 +5,17 @@
 -- its truth table.
 
 
+
+-- ┌────────────────────┐
+-- │ Pure Boolean Logic │
+-- └────────────────────┘
+
 -- Logical NOT
 let not: Bool -> Bool =
   lam a. if a then false else true
 
 utest not true with false
 utest not false with true
-
 
 -- Logical AND
 let and: Bool -> Bool -> Bool =
@@ -49,7 +53,6 @@ utest someb [true] with true
 utest someb [false] with false
 utest someb [] with false
 
-
 -- Logical XOR
 let xor: Bool -> Bool -> Bool =
   lam a. lam b. if a then not b else b
@@ -70,10 +73,79 @@ utest xnor false true with false
 utest xnor false false with true
 
 
+-- ┌─────────────────────────────┐
+-- │ Short-circuit Boolean Logic │
+-- └─────────────────────────────┘
+
+-- Short-circuited Logical AND
+let scand: (() -> Bool) -> (() -> Bool) -> Bool =
+  lam a. lam b. if a () then b () else false
+
+utest scand (lam. true) (lam. true) with true
+utest scand (lam. true) (lam. false) with false
+utest scand (lam. false) (lam. true) with false
+utest scand (lam. false) (lam. false) with false
+
+utest
+  let r = ref 0 in
+  scand (lam. true) (lam. modref r 1; true);
+  deref r
+with 1
+
+utest
+  let r = ref 0 in
+  scand (lam. false) (lam. modref r 1; true);
+  deref r
+with 0
+
+-- Short-circuited Logical AND of sequence
+let scallb : [() -> Bool] -> Bool =
+  foldl (lam acc. lam p. scand (lam. acc) p) true
+
+utest scallb [lam. true, lam. true, lam. true] with true
+utest scallb [lam. false, lam. true, lam. true] with false
+utest scallb [lam. true] with true
+utest scallb [lam. false] with false
+utest scallb [] with true
+
+-- Short-circuited Logical OR
+let scor: (() -> Bool) -> (() -> Bool) -> Bool =
+  lam a. lam b. if a () then true else b ()
+
+utest scor (lam. true) (lam. true) with true
+utest scor (lam. true) (lam. false) with true
+utest scor (lam. false) (lam. true) with true
+utest scor (lam. false) (lam. false) with false
+
+utest
+  let r = ref 0 in
+  scor (lam. true) (lam. modref r 1; true);
+  deref r
+with 0
+
+utest
+  let r = ref 0 in
+  scor (lam. false) (lam. modref r 1; true);
+  deref r
+with 1
+
+-- Short-circuited Logical OR of sequence
+let scsomeb : [(() -> Bool)] -> Bool =
+  foldl (lam acc. lam p. scor (lam. acc) p) false
+
+utest scsomeb [lam. false, lam. false, lam. false] with false
+utest scsomeb [lam. false, lam. true, lam. true] with true
+utest scsomeb [lam. true] with true
+utest scsomeb [lam. false] with false
+utest scsomeb [] with false
+
+
+-- ┌───────────────────────────┐
+-- │ Boolean Utility Functions │
+-- └───────────────────────────┘
+
 -- Boolean equality
-let eqBool: Bool -> Bool -> Bool =
-  lam b1: Bool. lam b2: Bool.
-  if b1 then b2 else (if b2 then false else true)
+let eqBool: Bool -> Bool -> Bool = xnor
 
 utest eqBool false false with true
 utest eqBool false true  with false

--- a/src/stdlib/sys.mc
+++ b/src/stdlib/sys.mc
@@ -90,6 +90,36 @@ utest
   [exists, sysFileExists (sysTempDirName d)]
 with [true, false]
 
+let sysWithTempDir: all a. (String -> a) -> a = lam f.
+  let path = sysTempDirMake () in
+  let output = f path in
+  -- NOTE(johnwikman,2025-03-20): This assumes `rm -rf` semantics, as opposed
+  -- to the rmdir semantics which won't remove the directory unless it's empty.
+  sysDeleteDir path;
+  output
+
+utest
+  match sysWithTempDir (lam path.
+    (sysFileExists path, path)
+  ) with (inExists, path) in
+  let outExists = sysFileExists path in
+  [inExists, outExists]
+with [true, false]
+
+let sysWithTempFile: all a. (String -> a) -> a = lam f.
+  let path = sysTempFileMake () in
+  let output = f path in
+  sysDeleteFile path;
+  output
+
+utest
+  match sysWithTempFile (lam path.
+    (sysFileExists path, path)
+  ) with (inExists, path) in
+  let outExists = sysFileExists path in
+  [inExists, outExists]
+with [true, false]
+
 let sysRunCommandWithTimingTimeoutFileIO
     : Option Float -> [String] -> String -> String -> String -> String
       -> (Float, ReturnCode) =


### PR DESCRIPTION
This PR adds the following convenience functions:

- Short-circuit logic in `bool.mc`. This is useful to perform a sequential evaluation only if the previous one failed. The use case is to check that a command exists prior to running that command in the test spec, but that is now moved to its own PR.
- Adds the `sysWithTempDir` and `sysWithTempFile` in `sys.mc` that emulates the python `with tempfile.TemporaryFile` scope that automatically cleans up the file or directory once we are done with it.