### PR TITLE
Update .git-blame-ignore-revs after merge

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,4 +4,4 @@
 a347d30c5f4b0c76e6a517debb3890f411dba3ab
 
 # Running ocamlformat
-ffaf97e175955b7dc7589b8308bb7d712d9af71a
+d14a7408f4e0e78565b2ce1124e8e3b9a63a95ca


### PR DESCRIPTION
As I was asked to do I have updated the git blame ignore ref after my run of ocamlformat was squashed and merged.