### PR TITLE
Check for existence of CUDA devices prior to running accelerate tests

### DIFF
--- a/misc/test-spec.mc
+++ b/misc/test-spec.mc
@@ -763,7 +763,7 @@ testMain
         lam. optionMapOr false (lti 0) (cudaGetDeviceCount ())
       ]
       then ConditionsMet ()
-      else ConditionsImpossible () -- TODO(vipa, 2023-04-25): figure out how to check if we have nvidia hardware
+      else ConditionsImpossible ()
     , exclusions = lam api.
       -- NOTE(vipa, 2023-04-25): Accelerate isn't supported in
       -- interpreted mode, and compiled mode is already tested via the

--- a/misc/test-spec.mc
+++ b/misc/test-spec.mc
@@ -17,6 +17,7 @@ include "map.mc"
 include "set.mc"
 include "common.mc"
 include "tuple.mc"
+include "cuda/sys.mc"
 
 -- A path representing some file in the repository, either source or
 -- generated through some command.
@@ -754,7 +755,13 @@ mexpr
 testMain
   [ { testColl "accelerate"
     with checkCondition = lam.
-      if and (sysCommandExists "nvcc") (sysCommandExists "futhark")
+      if scallb [
+        lam. sysCommandExists "nvcc",
+        lam. sysCommandExists "futhark",
+        -- NOTE(johnwikman, 2025-03-28): Checking 0 < n_devices and that we can
+        -- run CUDA programs
+        lam. optionMapOr false (lti 0) (cudaGetDeviceCount ())
+      ]
       then ConditionsMet ()
       else ConditionsImpossible () -- TODO(vipa, 2023-04-25): figure out how to check if we have nvidia hardware
     , exclusions = lam api.

--- a/src/stdlib/cuda/sys.mc
+++ b/src/stdlib/cuda/sys.mc
@@ -5,7 +5,7 @@ include "../sys.mc"
 -- Returns the number of CUDA devices available on the system. Uses nvcc to
 -- retrieve the device count, so will also fail if nvcc is not present on the
 -- system.
-let cudaSysGetDeviceCount : () -> Option Int = lam.
+let cudaGetDeviceCount : () -> Option Int = lam.
     if not (sysCommandExists "nvcc") then
         None ()
     else -- continue

--- a/src/stdlib/cuda/sys.mc
+++ b/src/stdlib/cuda/sys.mc
@@ -27,21 +27,19 @@ int main()
 }
       " in
       writeFile checkProgPath contents;
-      let run = lam cmd. sysRunCommandWithTimingTimeout (Some 60.0) cmd "" td in
+      let run = lam cmd. sysRunCommand cmd "" td in
 
       match run ["nvcc", "check.cu", "--output-file", "check.out"]
-      with (execTime, _) in
-      if gtf execTime 59.0 then
+      with execResult in
+      if neqi execResult.returncode 0 then
         -- Assume it timed out or something else went wrong, should not
         -- take more than a second...
         None ()
       else -- continue
 
       match run ["./check.out"]
-      with (execTime, execResult) in
-      if gtf execTime 59.0 then
-        None ()
-      else if eqi execResult.returncode 0 then
+      with execResult in
+      if eqi execResult.returncode 0 then
         -- The return code should be 0 if we could retrieve the CUDA device
         Some (string2int (strTrim execResult.stdout))
       else

--- a/src/stdlib/cuda/sys.mc
+++ b/src/stdlib/cuda/sys.mc
@@ -32,8 +32,7 @@ int main()
       match run ["nvcc", "check.cu", "--output-file", "check.out"]
       with execResult in
       if neqi execResult.returncode 0 then
-        -- Assume it timed out or something else went wrong, should not
-        -- take more than a second...
+        -- Assuming return code 0 indicated successful compilation here...
         None ()
       else -- continue
 

--- a/src/stdlib/cuda/sys.mc
+++ b/src/stdlib/cuda/sys.mc
@@ -1,0 +1,49 @@
+
+include "../string.mc"
+include "../sys.mc"
+
+-- Returns the number of CUDA devices available on the system. Uses nvcc to
+-- retrieve the device count, so will also fail if nvcc is not present on the
+-- system.
+let cudaSysGetDeviceCount : () -> Option Int = lam.
+    if not (sysCommandExists "nvcc") then
+        None ()
+    else -- continue
+    sysWithTempDir (lam td.
+      let checkProgPath = sysJoinPath td "check.cu" in
+      let contents = "
+      int main()
+      {
+          int c = 0;
+          cudaError_t r = cudaGetDeviceCount(&c);
+          if (r != cudaSuccess) {
+             std::cout << cudaGetErrorString(r) << std::endl;
+             return -1;
+          } else {
+             std::cout << c << std::endl;
+             return 0;
+          }
+      }
+      " in
+      writeFile checkProgPath contents;
+      let run = lam cmd. sysRunCommandWithTimingTimeout (Some 60.0) cmd "" td in
+
+      match run ["nvcc", "check.cu", "--output-file", "check.out"]
+      with (execTime, _) in
+      if gtf execTime 59.0 then
+        -- Assume it timed out or something else went wrong, should not
+        -- take more than a second...
+        None ()
+      else -- continue
+
+      match run ["./check.out"]
+      with (execTime, execResult) in
+      if gtf execTime 59.0 then
+        None ()
+      else if eqi execResult.returncode 0 then
+        -- The return code should be 0 if we could retrieve the CUDA device
+        Some (string2int (strTrim execResult.stdout))
+      else
+        -- Something went wrong
+        None ()
+    )

--- a/src/stdlib/cuda/sys.mc
+++ b/src/stdlib/cuda/sys.mc
@@ -12,18 +12,19 @@ let cudaGetDeviceCount : () -> Option Int = lam.
     sysWithTempDir (lam td.
       let checkProgPath = sysJoinPath td "check.cu" in
       let contents = "
-      int main()
-      {
-          int c = 0;
-          cudaError_t r = cudaGetDeviceCount(&c);
-          if (r != cudaSuccess) {
-             std::cout << cudaGetErrorString(r) << std::endl;
-             return -1;
-          } else {
-             std::cout << c << std::endl;
-             return 0;
-          }
-      }
+#include <iostream>
+int main()
+{
+    int c = 0;
+    cudaError_t r = cudaGetDeviceCount(&c);
+    if (r != cudaSuccess) {
+       std::cout << cudaGetErrorString(r) << std::endl;
+       return -1;
+    } else {
+       std::cout << c << std::endl;
+       return 0;
+    }
+}
       " in
       writeFile checkProgPath contents;
       let run = lam cmd. sysRunCommandWithTimingTimeout (Some 60.0) cmd "" td in

--- a/src/test/examples/cuda/device_count.mc
+++ b/src/test/examples/cuda/device_count.mc
@@ -1,0 +1,16 @@
+-- Prints the number of CUDA devices on the system.
+
+include "common.mc"
+include "string.mc"
+include "cuda/sys.mc"
+
+mexpr
+
+let dc: Option Int = cudaGetDeviceCount () in
+
+match cudaGetDeviceCount () with Some c then
+    printLn (join [
+        "Found ", int2string c, " CUDA devices on your system."
+    ])
+else
+    printLn "Could not compile and run CUDA programs in your environment."


### PR DESCRIPTION
This PR adds a check in `misc/test-spec.mc` to check that there is at least one CUDA device that we can compile and run programs on before trying to run the accelerate tests. This is necessary for containerized build environments which will have `nvcc` installed, but no access to any GPUs.

This check is done by a function `cudaGetDeviceCount` that I added to a file `cuda/sys.mc`. This function will return `None ()` if it cannot run CUDA programs on the system. Otherwise it will return the number of available devices wrapped in a `Some`. There is also a file `test/examples/cuda/device_count.mc` which can be used to quickly test the behavior of this function.

I tested this under various runtime conditions on a server that has access to 4 GPUs. The runtime conditions were constrained through containerization. The containers were launched as:

 1. `podman run --rm -it localhost/mikinglang/baseline:v8-debian12.6-linux-amd64 bash`
 2. `podman run --rm -it localhost/mikinglang/baseline:v8-cuda11.4-linux-amd64 bash`
 3. `podman run --rm -it --device "nvidia.com/gpu=all" localhost/mikinglang/baseline:v8-cuda11.4-linux-amd64 bash`

The first container neither has GPU or `nvcc`. The second one has `nvcc` but no GPUs. The third one has `nvcc` and access to 4 GPUs.

We test this by running this install script:
```sh
git clone https://github.com/johnwikman/miking.git \
&& cd miking \
&& git checkout cudacheck2 \
&& make install
```

Followed by this to compile and run the check program:
```sh
mi compile src/test/examples/cuda/device_count.mc
./device_count
```

We get the expected output for each respective container:

 1. `Could not compile and run CUDA programs in your environment.`
 2. `Could not compile and run CUDA programs in your environment.`
 3. `Found 4 CUDA devices on your system.`

Also, if running with `CUDA_VISIBLE_DEVICES="1,2" ./device_count` on the 3rd container, then we instead get the output `Found 2 CUDA devices on your system.` which is to be expected.