### PR TITLE
FIX: Send array to tup

### DIFF
--- a/misc/test
+++ b/misc/test
@@ -31,7 +31,7 @@ if util_use_tup; then
 
   util_compile_test_spec
 
-  if TUPTARGETS=`"$DIR/misc/test-spec" --tup-filter "${TEST_SPEC_ARGS}"`; then
+  if TUPTARGETS=`"$DIR/misc/test-spec" --tup-filter "${TEST_SPEC_ARGS[@]}"`; then
       IFS=$'\n'
       exec tup $TUPTARGETS
   fi


### PR DESCRIPTION
@david-broman Please merge asap

Currently there is a bug such that only the first arg is sent to tup, not the whole array. Make works fine. 