### PR TITLE
Feat: Add -j flag to test script and have make & tup obey it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ else
 SET_OCAMLPATH=OCAMLPATH=$(current_dir)/build/lib
 endif
 
+j_flag := $(filter -j%, $(MAKEFLAGS))
+
 .PHONY: default
 default: bootstrap
 
@@ -98,13 +100,13 @@ uninstall:
 .PHONY: test test-all test-quick
 test test-all test-quick: lint
 test:
-	+ exec misc/test --bootstrapped smart
+	+ exec misc/test $(j_flag) --bootstrapped smart
 
 test-all:
-	+ exec misc/test --bootstrapped --non-interactive all
+	+ exec misc/test $(j_flag) --bootstrapped --non-interactive all
 
 test-quick:
-	+ exec misc/test --bootstrapped
+	+ exec misc/test $(j_flag) --bootstrapped
 
 test-info:
 	@echo "Tasks run:" `find build/src/ -name '*.out' | wc -l`

--- a/misc/scripts/test-utils
+++ b/misc/scripts/test-utils
@@ -48,7 +48,6 @@ util_set_vars() {
         echo "'tup' installed, but not set up."
         if util_user_consent "Would you like set up 'tup' now?"; then
           util_make_setup_tup
-          util_vars[use_tup]=1
         else
           echo "Run 'make setup-tup' if you want to use 'tup'."
         fi
@@ -190,7 +189,9 @@ util_make_install() {
 
 util_make_setup_tup() {
   echo "Setting up 'tup'..."
-  make -C "$DIR" setup-tup || {
+  if make -C "$DIR" setup-tup; then
+    util_vars[use_tup]=1
+  else
     echo "Setting up 'tup' failed. Continuing without 'tup'."
-  }
+  fi
 }

--- a/misc/scripts/test-utils
+++ b/misc/scripts/test-utils
@@ -8,6 +8,10 @@ declare -A util_vars=(
   [is_cheated]=0
   [is_installed]=0
   [non_interactive]=0
+  # NOTE(wmuth, 2025-04-03):
+  # Using "0" as a sentinel for don't use threads instead of 1 since a user could
+  # have set their own value using env vars or aliases so we don't always
+  # want to overwrite the value with e.g. a default of "1"
   [num_threads]="0"
   [use_tup]=0
 )

--- a/misc/scripts/test-utils
+++ b/misc/scripts/test-utils
@@ -8,6 +8,7 @@ declare -A util_vars=(
   [is_cheated]=0
   [is_installed]=0
   [non_interactive]=0
+  [use_threads]=1
   [use_tup]=0
 )
 
@@ -22,6 +23,7 @@ util_set_vars() {
       "--cheated") util_vars[cheated]=1; clean_args+=("$arg") ;;
       "--installed") util_vars[installed]=1; clean_args+=("$arg") ;;
       "--non-interactive") util_vars[non_interactive]=1 ;;
+      "--sequential") util_vars[use_threads]=0 ;;
       "--use-make") use_make=1 ;;
       *) clean_args+=("$arg") ;;
     esac
@@ -78,6 +80,10 @@ util_compile_test_spec() {
   fi
 }
 
+util_use_threads() {
+  (( util_vars[use_threads] == 1 ))
+}
+
 util_use_tup() {
   (( util_vars[use_tup] == 1 ))
 }
@@ -105,6 +111,13 @@ util_user_consent() {
   esac
 }
 
+util_get_threads() {
+  case $(uname -s) in
+    "Darwin") echo $(sysctl -n hw.logicalcpu) ;;
+    "Linux") echo $(nproc) ;;
+    *) echo "1" ;;
+  esac
+}
 
 util_install_desired_mi() {
   if (( util_vars[bootstrapped] == 1 )); then

--- a/misc/scripts/test-utils
+++ b/misc/scripts/test-utils
@@ -8,8 +8,7 @@ declare -A util_vars=(
   [is_cheated]=0
   [is_installed]=0
   [non_interactive]=0
-  [num_threads]=0
-  [use_threads]=0
+  [num_threads]="0"
   [use_tup]=0
 )
 
@@ -23,12 +22,11 @@ util_set_vars() {
       "--bootstrapped") util_vars[bootstrapped]=1; clean_args+=("$arg") ;;
       "--cheated") util_vars[cheated]=1; clean_args+=("$arg") ;;
       "--installed") util_vars[installed]=1; clean_args+=("$arg") ;;
-      "-j") util_vars[use_threads]=1 ;;
+      "-j") util_set_threads ;;
       "--non-interactive") util_vars[non_interactive]=1 ;;
       "--use-make") use_make=1 ;;
       *)
         if [[ "$arg" =~ ^-j[0-9]+$ ]]; then
-          util_vars[use_threads]=1;
           util_vars[num_threads]=${arg#-j}
         else
           clean_args+=("$arg")
@@ -88,7 +86,21 @@ util_compile_test_spec() {
 }
 
 util_use_threads() {
-  (( util_vars[use_threads] == 1 ))
+  (( util_vars[num_threads] != "0" ))
+}
+
+util_get_threads() {
+  echo "${util_vars[num_threads]}"
+}
+
+util_set_threads() {
+  case $(uname -s) in
+    "Darwin") util_vars[num_threads]=$(sysctl -n hw.logicalcpu) ;;
+    "Linux") util_vars[num_threads]=$(nproc) ;;
+    *)
+      echo "Unsure how to get logical CPUs. Defaulting to 1."
+      util_vars[num_threads]="1" ;;
+  esac
 }
 
 util_use_tup() {
@@ -116,18 +128,6 @@ util_user_consent() {
     [yY][eE][sS]|[yY]) return 0 ;;
     *) return 1 ;;
   esac
-}
-
-util_get_threads() {
-  if (( util_vars[num_threads] != 0 )); then
-    echo "${util_vars[num_threads]}"
-  else
-    case $(uname -s) in
-      "Darwin") echo $(sysctl -n hw.logicalcpu) ;;
-      "Linux") echo $(nproc) ;;
-      *) echo "1" ;;
-    esac
-  fi
 }
 
 util_install_desired_mi() {

--- a/misc/scripts/test-utils
+++ b/misc/scripts/test-utils
@@ -8,7 +8,8 @@ declare -A util_vars=(
   [is_cheated]=0
   [is_installed]=0
   [non_interactive]=0
-  [use_threads]=1
+  [num_threads]=0
+  [use_threads]=0
   [use_tup]=0
 )
 
@@ -22,8 +23,9 @@ util_set_vars() {
       "--bootstrapped") util_vars[bootstrapped]=1; clean_args+=("$arg") ;;
       "--cheated") util_vars[cheated]=1; clean_args+=("$arg") ;;
       "--installed") util_vars[installed]=1; clean_args+=("$arg") ;;
+      "-j"[0-9]*) util_vars[use_threads]=1; util_vars[num_threads]=${arg#-j} ;;
+      "-j") util_vars[use_threads]=1 ;;
       "--non-interactive") util_vars[non_interactive]=1 ;;
-      "--sequential") util_vars[use_threads]=0 ;;
       "--use-make") use_make=1 ;;
       *) clean_args+=("$arg") ;;
     esac
@@ -112,11 +114,15 @@ util_user_consent() {
 }
 
 util_get_threads() {
-  case $(uname -s) in
-    "Darwin") echo $(sysctl -n hw.logicalcpu) ;;
-    "Linux") echo $(nproc) ;;
-    *) echo "1" ;;
-  esac
+  if (( util_vars[num_threads] != 0 )); then
+    echo "${util_vars[num_threads]}"
+  else
+    case $(uname -s) in
+      "Darwin") echo $(sysctl -n hw.logicalcpu) ;;
+      "Linux") echo $(nproc) ;;
+      *) echo "1" ;;
+    esac
+  fi
 }
 
 util_install_desired_mi() {

--- a/misc/scripts/test-utils
+++ b/misc/scripts/test-utils
@@ -23,11 +23,16 @@ util_set_vars() {
       "--bootstrapped") util_vars[bootstrapped]=1; clean_args+=("$arg") ;;
       "--cheated") util_vars[cheated]=1; clean_args+=("$arg") ;;
       "--installed") util_vars[installed]=1; clean_args+=("$arg") ;;
-      "-j"[0-9]*) util_vars[use_threads]=1; util_vars[num_threads]=${arg#-j} ;;
       "-j") util_vars[use_threads]=1 ;;
       "--non-interactive") util_vars[non_interactive]=1 ;;
       "--use-make") use_make=1 ;;
-      *) clean_args+=("$arg") ;;
+      *)
+        if [[ "$arg" =~ ^-j[0-9]+$ ]]; then
+          util_vars[use_threads]=1;
+          util_vars[num_threads]=${arg#-j}
+        else
+          clean_args+=("$arg")
+        fi ;;
     esac
   done
 

--- a/misc/test
+++ b/misc/test
@@ -52,5 +52,10 @@ else
   if [[ ! (":$OCAMLPATH:" == *":$DIR/build/lib:"*) ]]; then
       export OCAMLPATH=$DIR/build/lib:$OCAMLPATH
   fi
-  exec make -f <("$DIR/misc/test-spec" --make "${TEST_SPEC_ARGS[@]}")
+
+  if util_use_threads; then
+    exec make -j$(util_get_threads) -f <("$DIR/misc/test-spec" --make "${TEST_SPEC_ARGS[@]}")
+  else
+    exec make -f <("$DIR/misc/test-spec" --make "${TEST_SPEC_ARGS[@]}")
+  fi
 fi

--- a/misc/test
+++ b/misc/test
@@ -32,8 +32,13 @@ if util_use_tup; then
   util_compile_test_spec
 
   if TUPTARGETS=`"$DIR/misc/test-spec" --tup-filter "${TEST_SPEC_ARGS}"`; then
-      IFS=$'\n'
+    IFS=$'\n'
+
+    if util_use_threads; then
+      exec tup -j$(util_get_threads) $TUPTARGETS
+    else
       exec tup $TUPTARGETS
+    fi
   fi
 else
   echo "Using 'make' as a test runner"
@@ -53,7 +58,7 @@ else
       export OCAMLPATH=$DIR/build/lib:$OCAMLPATH
   fi
 
-  if util_use_threads; then
+  if util_use_threads && ! [[ $MAKEFLAGS =~ .*-j.* ]]; then
     exec make -j$(util_get_threads) -f <("$DIR/misc/test-spec" --make "${TEST_SPEC_ARGS[@]}")
   else
     exec make -f <("$DIR/misc/test-spec" --make "${TEST_SPEC_ARGS[@]}")


### PR DESCRIPTION
This PR adds parallelization to the test script `misc/test` using a `-j` flag the same way `make` and `tup` has.

Parallelization is disabled by default and is enabled using the `-j%d` flag. If you provide `-j` without a number then the script automatically detects your number of logical cpu cores and automatically runs that many jobs in parallel.

Before this PR, running `make test -j%d`, would run the tests in parallel since recursive `make` invocations inherit flags trough the `MAKEFLAGS` environment variable. This still works but now `tup` also follows the specified `-j` flag, even if provided to `make` trough e.g. `make test -j5`.