### PR TITLE
New flag: '--debug-dprint'

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -26,6 +26,7 @@ include "tuning/tune-file.mc"
 include "jvm/compile.mc"
 include "mlang/main.mc"
 include "peval/compile.mc"
+include "mexpr/generate-pprint.mc"
 
 include "extrec/main.mc"
 
@@ -41,6 +42,7 @@ lang MCoreCompile =
   MExprConstantFold +
   OCamlTryWithWrap + MCoreCompileLang + PhaseStats +
   SpecializeCompile +
+  OldDPrintViaPprint + MExprGeneratePprint + GeneratePprintMissingCase +
   PprintTyAnnot + HtmlAnnotator +
   MExprToJson
 end
@@ -115,6 +117,11 @@ let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
     endPhaseStatsExpr log "pattern-lowering" ast;
     (if options.debugShallow then
       printLn (expr2str ast) else ());
+
+    let ast = if options.debugDprint
+      then dprintToPprint ast
+      else ast in
+    endPhaseStatsExpr log "dprintToPprint" ast;
 
     let res =
       if options.toJVM then compileMCoreToJVM ast else

--- a/src/main/options-config.mc
+++ b/src/main/options-config.mc
@@ -35,6 +35,10 @@ let optionsConfig : ParseConfig Options = [
     "Print the AST after constant folding and constant propagation",
      lam p: ArgPart Options.
       let o: Options = p.options in {o with debugConstantFold = true}),
+  ([("--debug-dprint", "", "")],
+    "Replace dprint with a generated pprint. Warning: might introduce 'unbound' errors if some functions aren't imported.",
+     lam p: ArgPart Options.
+      let o: Options = p.options in {o with debugDprint = true}),
   ([("--debug-phases", "", "")],
     "Show debug and profiling information about each pass",
     lam p: ArgPart Options.

--- a/src/main/options-type.mc
+++ b/src/main/options-type.mc
@@ -11,6 +11,7 @@ type Options = {
   debugProfile : Bool,
   debugShallow : Bool,
   debugConstantFold : Bool,
+  debugDprint : Bool,
   debugPhases : Bool,
   debugDumpPhases : Set String,
   exitBefore : Bool,

--- a/src/main/options.mc
+++ b/src/main/options.mc
@@ -13,6 +13,7 @@ let optionsDefault : Options = {
   debugProfile = false,
   debugShallow = false,
   debugConstantFold = false,
+  debugDprint = false,
   debugPhases = false,
   debugDumpPhases = setEmpty cmpString,
   exitBefore = false,

--- a/src/stdlib/mexpr/generate-eq.mc
+++ b/src/stdlib/mexpr/generate-eq.mc
@@ -81,9 +81,9 @@ lang GenerateEqApp = GenerateEq + AppTypeAst
     (env, app_ lhs rhs)
 end
 
-lang GenerateEqCon = GenerateEq + ConTypeAst
+lang GenerateEqCon = GenerateEq + ConTypeAst + Generalize + UnifyPure
   sem _getEqFunction env =
-  | TyCon x ->
+  | ty & TyCon x ->
     -- TODO(vipa, 2025-01-27): Invalidate old eq functions if
     -- we've introduced constructors to pre-existing types
     match mapLookup x.ident env.conFunctions with Some n then (env, nvar_ n) else
@@ -97,6 +97,7 @@ lang GenerateEqCon = GenerateEq + ConTypeAst
       then params
       else errorSingle [x.info] (concat "Typecheck environment does not contain information about type " (nameGetStr x.ident)) in
     let paramFNames = foldl (lam acc. lam n. mapInsert n (nameSetNewSym n) acc) (mapEmpty nameCmp) params in
+    let fullType = tyapps_ ty (map ntyvar_ (mapKeys paramFNames)) in
     let prevVarFunctions = env.varFunctions in
     let env = {env with varFunctions = mapUnion env.varFunctions paramFNames} in
 
@@ -109,15 +110,19 @@ lang GenerateEqCon = GenerateEq + ConTypeAst
     let rName = nameSym "r" in
     let addMatch = lam acc. lam c. lam t.
       match acc with (env, tm) in
-      match getEqFunction env t with (env, subf) in
-      let subl = nameSym "subl" in
-      let subr = nameSym "subr" in
-      let tm = match_ (nvar_ lName) (npcon_ c (npvar_ subl))
-        (match_ (nvar_ rName) (npcon_ c (npvar_ subr))
-          (appf2_ subf (nvar_ subl) (nvar_ subr))
-          false_)
-        tm in
-      (env, tm) in
+      match inst (infoTy t) 0 t with TyArrow {from = from, to = to} in
+      let uni = emptyUnification () in
+      match unifyPure uni to fullType with Some uni then
+        match getEqFunction env t with (env, subf) in
+        let subl = nameSym "subl" in
+        let subr = nameSym "subr" in
+        let tm = match_ (nvar_ lName) (npcon_ c (npvar_ subl))
+          (match_ (nvar_ rName) (npcon_ c (npvar_ subr))
+            (appf2_ subf (nvar_ subl) (nvar_ subr))
+            false_)
+          tm in
+        (env, tm)
+      else error "Unification should always be possible here" in
     match mapFoldWithKey addMatch (env, never_) constructors with (env, matchChain) in
     let matchChain = nulam_ lName (nulam_ rName matchChain) in
     let body = foldr (lam pname. lam body. nulam_ (mapFindExn pname paramFNames) body) matchChain params in

--- a/src/stdlib/mexpr/generate-pprint.mc
+++ b/src/stdlib/mexpr/generate-pprint.mc
@@ -107,9 +107,9 @@ lang GeneratePprintApp = GeneratePprint + AppTypeAst
     (env, app_ lhs rhs)
 end
 
-lang GeneratePprintCon = GeneratePprint + ConTypeAst
+lang GeneratePprintCon = GeneratePprint + ConTypeAst + Generalize + UnifyPure
   sem _getPprintFunction env =
-  | TyCon x ->
+  | ty & TyCon x ->
     -- TODO(vipa, 2025-01-27): Invalidate old pprint functions if
     -- we've introduced constructors to pre-existing types
     match mapLookup x.ident env.conFunctions with Some n then (env, nvar_ n) else
@@ -123,24 +123,31 @@ lang GeneratePprintCon = GeneratePprint + ConTypeAst
       then params
       else errorSingle [x.info] (concat "Typecheck environment does not contain information about type " (nameGetStr x.ident)) in
     let paramFNames = foldl (lam acc. lam n. mapInsert n (nameSetNewSym n) acc) (mapEmpty nameCmp) params in
-    let prevVarFunctions = env.varFunctions in
-    let env = {env with varFunctions = mapUnion env.varFunctions paramFNames} in
 
     let constructors = mapIntersectWith
       (lam. lam pair. pair.1)
       (mapLookupOr (setEmpty nameCmp) x.ident env.tcEnv.conDeps)
       env.tcEnv.conEnv in
 
+    let fullType = tyapps_ ty (map ntyvar_ (mapKeys paramFNames)) in
+    let prevVarFunctions = env.varFunctions in
+    let env = {env with varFunctions = mapUnion env.varFunctions paramFNames} in
+
     let targetName = nameSym "_target" in
     let addMatch = lam acc. lam c. lam t.
       match acc with (env, tm) in
-      match getPprintFunction env t with (env, subf) in
-      let sub = nameSym "x" in
-      let tm = match_ (nvar_ targetName) (npcon_ c (npvar_ sub))
-        (cons_ (char_ '(') (snoc_ (concat_ (str_ (pprintConString (nameGetStr c))) (cons_ (char_ ' ') (app_ subf (nvar_ sub)))) (char_ ')')))
-        tm in
-      (env, tm) in
-    match mapFoldWithKey addMatch (env, never_) constructors with (env, matchChain) in
+      match inst (infoTy t) 0 t with TyArrow {from = from, to = to} in
+      let uni = emptyUnification () in
+      match unifyPure uni to fullType with Some uni then
+        let from = pureApplyUniToType uni from in
+        match getPprintFunction env from with (env, subf) in
+        let sub = nameSym "x" in
+        let tm = match_ (nvar_ targetName) (npcon_ c (npvar_ sub))
+          (cons_ (char_ '(') (snoc_ (concat_ (str_ (pprintConString (nameGetStr c))) (cons_ (char_ ' ') (app_ subf (nvar_ sub)))) (char_ ')')))
+          tm in
+        (env, tm)
+      else error "Unification should always be possible here" in
+    match mapFoldWithKey addMatch (env, str_ (join ["<missing case for ", nameGetStr x.ident, ">"])) constructors with (env, matchChain) in
     let matchChain = nulam_ targetName matchChain in
     let body = foldr (lam pname. lam body. nulam_ (mapFindExn pname paramFNames) body) matchChain params in
 
@@ -165,6 +172,12 @@ lang GeneratePprintTensor = GeneratePprint + TensorTypeAst
   sem _getPprintFunction env =
   | TyTensor x ->
     (env, ulam_ "" (str_ "<tensor>"))
+end
+
+lang GeneratePprintMissingCase = GeneratePprint
+  sem _getPprintFunction env =
+  | !TyUnknown _ -> (env, ulam_ "" (str_ "<missing case>"))
+  | TyUnknown _ -> (env, ulam_ "" (str_ "<tyunknown>"))
 end
 
 lang MExprGeneratePprint
@@ -230,4 +243,66 @@ lang GeneratePprintLoader = MCoreLoader + GeneratePprint
   sem pprintFunctionsFor : [Type] -> Loader -> (Loader, [Expr])
   sem pprintFunctionsFor tys = | loader ->
     withHookState (_pprintFunctionsFor tys) loader
+end
+
+lang OldDPrintViaPprint = GeneratePprint + MExprAsDecl + AppTypeUtils
+  sem findPprintDefinitions : GPprintEnv -> Expr -> GPprintEnv
+  sem findPprintDefinitions env = | tm ->
+    match exprAsDecl tm with Some (decl, expr) then
+      let env = switch decl
+        case DeclLet (x & {info = Info {filename = filename}}) then
+          _findPprintDefinitions env x.ident (nameGetStr x.ident, filename)
+        case DeclType x then
+          let tcEnv = env.tcEnv in
+          let tyConEnv =
+            mapInsert x.ident (env.tcEnv.currentLvl, x.params, x.tyIdent) env.tcEnv.tyConEnv in
+          {env with tcEnv = {env.tcEnv with tyConEnv = tyConEnv}}
+        case DeclConDef x then
+          match inspectType x.tyIdent with TyArrow {to = to} in
+          match getTypeArgs to with (TyCon target, _) in
+          -- NOTE(vipa, 2025-04-08): The level isn't used here, so we
+          -- just insert a dummy value
+          let conEnv = mapInsert x.ident (env.tcEnv.currentLvl, x.tyIdent) env.tcEnv.conEnv in
+          let conDeps = mapInsertWith setUnion target.ident (setSingleton nameCmp x.ident) env.tcEnv.conDeps in
+          {env with tcEnv = {env.tcEnv with conEnv = conEnv, conDeps = conDeps}}
+        case _ then env
+        end in
+      findPprintDefinitions env expr
+    else env
+  sem _findPprintDefinitions : GPprintEnv -> Name -> (String, String) -> GPprintEnv
+  sem _findPprintDefinitions env ident =
+  | ("int2string", _ ++ "/string.mc") -> {env with int2string = ident}
+  | ("bool2string", _ ++ "/bool.mc") -> {env with bool2string = ident}
+  | ("seq2string", _ ++ "/string.mc") -> {env with seq2string = ident}
+  | ("escapeString", _ ++ "/string.mc") -> {env with escapeString = ident}
+  | ("escapeChar", _ ++ "/char.mc") -> {env with escapeChar = ident}
+  | (n, path) -> env
+
+  sem dprintToPprint : Expr -> Expr
+  sem dprintToPprint = | tm ->
+    let env =
+      { conFunctions = mapEmpty nameCmp
+      , varFunctions = mapEmpty nameCmp
+      , newFunctions = []
+      , tcEnv = typcheckEnvDefault
+      , int2string = nameNoSym "int2string"
+      , bool2string = nameNoSym "bool2string"
+      , seq2string = nameNoSym "seq2string"
+      , escapeString = nameNoSym "escapeString"
+      , escapeChar = nameNoSym "escapeChar"
+      } in
+    let env = findPprintDefinitions env tm in
+    _dprintToPprint env tm
+
+  sem _dprintToPprint : GPprintEnv -> Expr -> Expr
+  sem _dprintToPprint env =
+  | TmConst {val = CDPrint _, ty = ty} ->
+    match unwrapType ty with TyArrow {from = from} in
+    match getPprintFunction env from with (env, fn) in
+    -- NOTE(vipa, 2025-04-08): We intentionally insert all generated
+    -- functions right here, which might duplicate code and such,
+    -- becasue it is significantly easier than finding a good location
+    -- to insert it
+    bind_ (nureclets_ env.newFunctions) (ulam_ "x" (semi_ (print_ (app_ fn (var_ "x"))) (flushStdout_ unit_)))
+  | tm -> smap_Expr_Expr (_dprintToPprint env) tm
 end


### PR DESCRIPTION
This PR (finally!) enables `mi` to replace `dprint` with essentially `(lam x. print (pprintTy x); flushStdout ())`, where `pprintTy` is an auto-generated function based on the inferred type of the `dprint`. This is based on `generate-pprint.mc`. I also fix a bug with generating code for user-defined types. There are some important caveats however:

- When using the old pipeline there's no terribly convenient way of making sure we have the functions we need in scope. If a required function (e.g., `int2string` or `seq2string`) isn't in scope, the compiler will insert an unsymbolized variable, which makes the OCaml backend error out later, saying something like "unbound variable `nv_int2string`. This is the primary reason this feature is behind a flag.
  - This can interact poorly with dead code elimination. For example, when using this in `miking-dppl` I have to ensure there's a reference somewhere to `seq2string`, because that function is otherwise not used, even if the file it's defined in (`string.mc`) is included.
- The compiler should insert something that can run in all cases, even for things that can't reasonably be inspected. For example, polymorphic values will be printed as `<poly varName>`, and types that don't have support in `generate-pprint.mc` will print as `<missing case>`.

As an example, in code I'm working on right now some DPPL terms aren't removed and instead survive to reach the ocaml backend. Adding a `dprint` in the wildcard case, then compiling the `cppl` compiler with `mi compile --debug-dprint` I can run and get this error message:

```
(Assume_TmAssume {ty = (FloatTypeAst_TyFloat {info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"})}), info = (Info {col1 = 6, col2 = 12, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"}), dist = (VarAst_TmVar {ty = (UnknownTypeAst_TyUnknown {info = (NoInfo ())}), info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"}), ident = ("dist", <missing case for Symbol>), frozen = false}), driftKernel = (Some (LamAst_TmLam {ty = (UnknownTypeAst_TyUnknown {info = (NoInfo ())}), info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"}), ident = ("", <missing case for Symbol>), body = (VarAst_TmVar {ty = (UnknownTypeAst_TyUnknown {info = (NoInfo ())}), info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"}), ident = ("dist", <missing case for Symbol>), frozen = false}), tyAnnot = (UnknownTypeAst_TyUnknown {info = (NoInfo ())}), tyParam = (UnknownTypeAst_TyUnknown {info = (NoInfo ())})}))})ERROR: infoTm not implemented for OCaml terms!
```
...or with some extra newlines for readability:
```
(Assume_TmAssume
  { ty = (FloatTypeAst_TyFloat {info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"})})
  , info = (Info {col1 = 6, col2 = 12, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"})
  , dist = (VarAst_TmVar
    { ty = (UnknownTypeAst_TyUnknown {info = (NoInfo ())})
    , info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"})
    , ident = ("dist", <missing case for Symbol>)
    , frozen = false})
  , driftKernel = (Some (LamAst_TmLam
    { ty = (UnknownTypeAst_TyUnknown {info = (NoInfo ())})
    , info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"})
    , ident = ("", <missing case for Symbol>)
    , body = (VarAst_TmVar {ty = (UnknownTypeAst_TyUnknown {info = (NoInfo ())}), info = (Info {col1 = 14, col2 = 56, row1 = 57, row2 = 57, filename = "/home/vipa/repositories/miking-dppl/coreppl/models/ssm.mc"}), ident = ("dist", <missing case for Symbol>), frozen = false})
    , tyAnnot = (UnknownTypeAst_TyUnknown {info = (NoInfo ())})
    , tyParam = (UnknownTypeAst_TyUnknown {info = (NoInfo ())})
    }))
  })
ERROR: infoTm not implemented for OCaml terms!
```

Note `<missing case for Symbol>`, that's because `Symbol` is a `TyCon` even though it's a builtin, and I haven't made the extra effort of adding something that looks for that.