### PR TITLE
Discretized gamma

### DIFF
--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -129,8 +129,7 @@ let discretizedGammaSample = lam shape:Float. lam scale:Float. lam n:Int.
   let ind = uniformDiscreteSample 0 (subi n 1) in
   get scaledMedians ind
 let discretizedGammaLogPmf = lam shape:Float. lam scale:Float. lam n:Int. lam x:Float.
-  let support = discretizedGammaSupport shape scale n in
-  if any (lam s. eqfApprox 1e-12 x s) support then log (divf 1. (int2float n))
+  if geqf x 0. then log (divf 1. (int2float n))
   else negf inf
 
 -- Poisson
@@ -291,8 +290,8 @@ utest uniformDiscretePdf 1 2 1 with 0.5 using _eqf in
 utest discretizedGammaSupport 0.5 2. 4 with [0.0290777547619,0.28071453714,0.924773065114,2.76543464298] using eqSeq _eqf in
 utest let s = (discretizedGammaSample 0.5 2. 4) in
   any (lam x. _eqf x s) [0.0290777547619,0.28071453714,0.924773065114,2.76543464298] with true in
-utest discretizedGammaLogPmf 0.5 2. 4 0.0290777547619 with negf 1.38629436112 using _eqf in
-utest discretizedGammaLogPmf 0.5 2. 4 5. with negf inf in
+utest discretizedGammaLogPmf 0.5 2. 4 0.02 with negf 1.38629436112 using _eqf in
+utest discretizedGammaLogPmf 0.5 2. 4 (negf 1.) with negf inf in
 
 -- Testing Poisson
 utest poissonPmf 2.0 2 with 0.270670566473 using _eqf in

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -1,5 +1,6 @@
 include "math.mc"
 include "bool.mc"
+include "seq.mc"
 
 -- Gamma
 external externalGammaLogPdf : Float -> Float -> Float -> Float
@@ -114,6 +115,23 @@ let uniformDiscretePdf : Int -> Int -> Int -> Float = lam a. lam b. lam x.
     if leqi x b then divf 1.0 (int2float (addi 1 (subi b a)))
     else 0.
   else 0.
+
+-- Discretized Gamma
+let discretizedGammaSupport = lam shape:Float. lam scale:Float. lam n:Int.
+  let bins = (linspace 0. 1. (addi n 1)) in
+  let quantilesX = map (lam b. gammaPpf shape scale b) bins in
+  let medians = mapi (lam ind. lam x. gammaPpf shape scale (divf (addf (gammaCdf shape scale x) (gammaCdf shape scale (get quantilesX (addi ind 1)))) 2.)) (init quantilesX) in
+  let factor = divf (int2float n) (foldl addf 0. medians) in
+  let scaledMedians = map (lam e. mulf e factor) medians in
+  scaledMedians
+let discretizedGammaSample = lam shape:Float. lam scale:Float. lam n:Int.
+  let scaledMedians = discretizedGammaSupport shape scale n in
+  let ind = uniformDiscreteSample 0 (subi n 1) in
+  get scaledMedians ind
+let discretizedGammaLogPmf = lam shape:Float. lam scale:Float. lam n:Int. lam x:Float.
+  let support = discretizedGammaSupport shape scale n in
+  if any (lam s. eqfApprox 1e-12 x s) support then log (divf 1. (int2float n))
+  else negf inf
 
 -- Poisson
 let poissonLogPmf = lam lambda:Float. lam x:Int.
@@ -268,6 +286,13 @@ utest uniformSample () with 0. using floatRange 0. 1. in
 utest uniformDiscreteSample 3 8 with 3 using intRange 3 8 in
 utest exp (uniformDiscreteLogPdf 1 2 1) with 0.5 using _eqf in
 utest uniformDiscretePdf 1 2 1 with 0.5 using _eqf in
+
+-- Testing Discretized Gamma
+utest discretizedGammaSupport 0.5 2. 4 with [0.0290777547619,0.28071453714,0.924773065114,2.76543464298] using eqSeq _eqf in
+utest let s = (discretizedGammaSample 0.5 2. 4) in
+  any (lam x. _eqf x s) [0.0290777547619,0.28071453714,0.924773065114,2.76543464298] with true in
+utest discretizedGammaLogPmf 0.5 2. 4 0.0290777547619 with negf 1.38629436112 using _eqf in
+utest discretizedGammaLogPmf 0.5 2. 4 5. with negf inf in
 
 -- Testing Poisson
 utest poissonPmf 2.0 2 with 0.270670566473 using _eqf in

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -116,7 +116,7 @@ let uniformDiscretePdf : Int -> Int -> Int -> Float = lam a. lam b. lam x.
     else 0.
   else 0.
 
--- Discretized Gamma, n categorized are used to approximate the continous distribution with equal probability for each category. The median is used to represent the average rate.
+-- Discretized Gamma, n categories are used to approximate the continous distribution with equal probability for each category. The median is used to represent the average rate.
 let discretizedGammaSupport = lam shape:Float. lam scale:Float. lam n:Int.
   let bins = (linspace 0. 1. (addi n 1)) in
   let quantilesX = map (lam b. gammaPpf shape scale b) bins in

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -116,7 +116,7 @@ let uniformDiscretePdf : Int -> Int -> Int -> Float = lam a. lam b. lam x.
     else 0.
   else 0.
 
--- Discretized Gamma
+-- Discretized Gamma, n categorized are used to approximate the continous distribution with equal probability for each category. The median is used to represent the average rate.
 let discretizedGammaSupport = lam shape:Float. lam scale:Float. lam n:Int.
   let bins = (linspace 0. 1. (addi n 1)) in
   let quantilesX = map (lam b. gammaPpf shape scale b) bins in

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -129,7 +129,8 @@ let discretizedGammaSample = lam shape:Float. lam scale:Float. lam n:Int.
   let ind = uniformDiscreteSample 0 (subi n 1) in
   get scaledMedians ind
 let discretizedGammaLogPmf = lam shape:Float. lam scale:Float. lam n:Int. lam x:Float.
-  if geqf x 0. then log (divf 1. (int2float n))
+  let support = discretizedGammaSupport shape scale n in
+  if any (lam s. eqfApprox 1e-12 x s) support then log (divf 1. (int2float n))
   else negf inf
 
 -- Poisson
@@ -290,8 +291,9 @@ utest uniformDiscretePdf 1 2 1 with 0.5 using _eqf in
 utest discretizedGammaSupport 0.5 2. 4 with [0.0290777547619,0.28071453714,0.924773065114,2.76543464298] using eqSeq _eqf in
 utest let s = (discretizedGammaSample 0.5 2. 4) in
   any (lam x. _eqf x s) [0.0290777547619,0.28071453714,0.924773065114,2.76543464298] with true in
-utest discretizedGammaLogPmf 0.5 2. 4 0.02 with negf 1.38629436112 using _eqf in
+utest discretizedGammaLogPmf 0.5 2. 4 0.0290777547619 with negf 1.38629436112 using _eqf in
 utest discretizedGammaLogPmf 0.5 2. 4 (negf 1.) with negf inf in
+utest discretizedGammaLogPmf 0.5 2. 4 5. with negf inf in
 
 -- Testing Poisson
 utest poissonPmf 2.0 2 with 0.270670566473 using _eqf in

--- a/src/stdlib/math.mc
+++ b/src/stdlib/math.mc
@@ -118,3 +118,11 @@ utest pascalrow 2 with [1, 2, 1]
 utest pascalrow 3 with [1, 3, 3, 1]
 utest pascalrow 4 with [1, 4, 6, 4, 1]
 utest pascalrow 5 with [1, 5, 10, 10, 5, 1]
+
+let linspace = lam start. lam stop. lam n.
+  let step = divf (subf stop start) (int2float (subi n 1)) in
+  create n (lam i. addf start (mulf (int2float i) step))
+
+utest linspace 0. 1. 0 with []
+utest linspace 0. 1. 5 with [0.,0.25,0.5,0.75,1.]
+utest linspace 0. 0. 4 with [0.,0.,0.,0.]

--- a/src/stdlib/seq.mc
+++ b/src/stdlib/seq.mc
@@ -897,11 +897,3 @@ utest subseqReplace eqi [3,4,5] [42,42] [1,2,3,4,5,6,7] with [1,2,42,42,6,7]
 utest subseqReplace eqi [1,1] [100,101,100] [0,1,0,1,2,1,1,3,4,0,0,1,1,0,1,0] with [0,1,0,1,2,100,101,100,3,4,0,0,100,101,100,0,1,0]
 utest subseqReplace eqi [1,1] [2] [3,4,3] with [3,4,3]
 utest subseqReplace eqi [0,1,2] [88] [0,0,1,2,100,0,1] with [0,88,100,0,1]
-
-let linspace = lam start. lam stop. lam n.
-  let step = divf (subf stop start) (int2float (subi n 1)) in
-  create n (lam i. addf start (mulf (int2float i) step))
-
-utest linspace 0. 1. 0 with []
-utest linspace 0. 1. 5 with [0.,0.25,0.5,0.75,1.]
-utest linspace 0. 0. 4 with [0.,0.,0.,0.]

--- a/src/stdlib/seq.mc
+++ b/src/stdlib/seq.mc
@@ -897,3 +897,11 @@ utest subseqReplace eqi [3,4,5] [42,42] [1,2,3,4,5,6,7] with [1,2,42,42,6,7]
 utest subseqReplace eqi [1,1] [100,101,100] [0,1,0,1,2,1,1,3,4,0,0,1,1,0,1,0] with [0,1,0,1,2,100,101,100,3,4,0,0,100,101,100,0,1,0]
 utest subseqReplace eqi [1,1] [2] [3,4,3] with [3,4,3]
 utest subseqReplace eqi [0,1,2] [88] [0,0,1,2,100,0,1] with [0,88,100,0,1]
+
+let linspace = lam start. lam stop. lam n.
+  let step = divf (subf stop start) (int2float (subi n 1)) in
+  create n (lam i. addf start (mulf (int2float i) step))
+
+utest linspace 0. 1. 0 with []
+utest linspace 0. 1. 5 with [0.,0.25,0.5,0.75,1.]
+utest linspace 0. 0. 4 with [0.,0.,0.,0.]


### PR DESCRIPTION
- Add support for discretized gamma in `dist-ext.mc`. The continuous gamma distribution is discretized into **n equal-probability bins**, and the representative **median** of each bin is calculated as the average rate per category.
- Add linspace function to `math.mc`
