### PR TITLE
Rewrite to include `Decl` in the standard AST

### DIFF
--- a/misc/mcore-comby.json
+++ b/misc/mcore-comby.json
@@ -1,14 +1,8 @@
 {
     "user_defined_delimiters": [
-        [ "lang", "end" ],
         [ "(", ")" ],
         [ "[", "]" ],
-        [ "{", "}" ],
-        [ "let", "in" ],
-        [ "recursive", "in" ],
-        [ "recursive", "end" ],
-        [ "type", "in" ],
-        [ "use", "in" ]
+        [ "{", "}" ]
     ],
     "escapable_string_literals": {
         "delimiters": [ "\"" ],

--- a/misc/test-spec.mc
+++ b/misc/test-spec.mc
@@ -866,7 +866,11 @@ testMain
     }
 
   , { testColl "microbenchmark"
-    with exclusions = lam api.
+    with checkCondition = lam.
+      if eqi 0 (command "ocamlfind query owl >/dev/null 2>&1")
+      then ConditionsMet ()
+      else ConditionsUnmet ()
+    , exclusions = lam api.
       -- NOTE(vipa, 2023-05-16): These are tested via new tests instead
       api.mark noTasks (api.glob ["test", "microbenchmark"] (IncludeSubs ()) (SuffixFile ".mc"));
       -- TODO(vipa, 2024-11-08): Actually run this one, not just

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -23,7 +23,7 @@ lang MCoreLiteCompile =
   -- code size.
   sem stripUtests : Expr -> Expr
   sem stripUtests =
-  | TmUtest t -> stripUtests t.next
+  | TmDecl {decl = DeclUtest t} -> stripUtests t.next
   | t -> smap_Expr_Expr stripUtests t
 end
 

--- a/src/main/mi-lite.mc
+++ b/src/main/mi-lite.mc
@@ -23,7 +23,7 @@ lang MCoreLiteCompile =
   -- code size.
   sem stripUtests : Expr -> Expr
   sem stripUtests =
-  | TmDecl {decl = DeclUtest t} -> stripUtests t.next
+  | TmDecl (x & {decl = DeclUtest _}) -> stripUtests x.inexpr
   | t -> smap_Expr_Expr stripUtests t
 end
 

--- a/src/stdlib/c/compile.mc
+++ b/src/stdlib/c/compile.mc
@@ -485,12 +485,12 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
   -----------------------
 
   sem collectExternals (acc: Map Name ExtInfo) =
-  | TmDecl {decl = DeclExt t} ->
+  | TmDecl (x & {decl = DeclExt t}) ->
     let str = nameGetStr t.ident in
     match mapLookup str externalsMap with Some e then
       let e: ExtInfo = e in -- TODO(dlunde,2021-10-25): Remove with more complete type system?
       let acc = mapInsert t.ident e acc in
-      sfold_Expr_Expr collectExternals acc t.inexpr
+      sfold_Expr_Expr collectExternals acc x.inexpr
     else errorSingle [t.info] "Unsupported external"
   | expr -> sfold_Expr_Expr collectExternals acc expr
 
@@ -853,7 +853,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
 
   sem compileTops (env: CompileCEnv) (accTop: [CTop]) (accInit: [CStmt]) =
 
-  | TmDecl {decl = DeclLet { ident = ident, tyBody = tyBody, body = body, inexpr = inexpr }} ->
+    | TmDecl {decl = DeclLet { ident = ident, tyBody = tyBody, body = body }, inexpr = inexpr } ->
 
     -- Functions
     match body with TmLam _ then
@@ -885,7 +885,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
         compileTops env accTop accInit inexpr
       else never
 
-  | TmDecl {decl = DeclRecLets { bindings = bindings, inexpr = inexpr }} ->
+  | TmDecl {decl = DeclRecLets { bindings = bindings}, inexpr = inexpr } ->
     let f = lam env. lam binding: DeclLetRecord.
       match binding with { ident = ident, tyBody = tyBody, body = body } then
         compileFun env ident tyBody body
@@ -905,7 +905,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
     else never
 
   -- Ignore externals (handled elsewhere)
-  | TmDecl {decl = DeclExt { inexpr = inexpr }} -> compileTops env accTop accInit inexpr
+  | TmDecl {decl = DeclExt _, inexpr = inexpr} -> compileTops env accTop accInit inexpr
 
   -- Set up initialization code (for use, e.g., in a main function)
   | rest ->
@@ -1111,7 +1111,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
 
   sem compileStmts (env: CompileCEnv) (res: Result) (acc: [CStmt]) =
 
-  | TmDecl {decl = DeclLet { ident = ident, tyBody = tyBody, body = body, inexpr = inexpr }} ->
+  | TmDecl {decl = DeclLet { ident = ident, tyBody = tyBody, body = body}, inexpr = inexpr } ->
 
     -- Optimize direct allocations
     match body with TmConApp _ | TmRecord _ | TmSeq _ then
@@ -1145,7 +1145,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
   | TmNever _ -> (env, snoc acc (CSNop {}))
 
   -- Ignore externals (handled elsewhere)
-  | TmDecl {decl = DeclExt { inexpr = inexpr }} -> compileStmts env res acc inexpr
+  | TmDecl {decl = DeclExt _, inexpr = inexpr} -> compileStmts env res acc inexpr
 
 
   -----------------
@@ -1430,9 +1430,8 @@ let testCompile32Bit : Expr -> String = lam expr.
   printCompiledCProg (compile opts expr) in
 
 let simpleLet = bindall_ [
-  ulet_ "x" (int_ 1),
-  int_ 0
-] in
+  ulet_ "x" (int_ 1)]
+  (int_ 0) in
 utest testCompile simpleLet with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1447,9 +1446,8 @@ utest testCompile simpleLet with strJoin "\n" [
 let simpleFun = bindall_ [
   let_ "foo" (tyarrows_ [tyint_, tyint_, tyint_])
     (ulam_ "a" (ulam_ "b" (addi_ (var_ "a") (var_ "b")))),
-  ulet_ "x" (appf2_ (var_ "foo") (int_ 1) (int_ 2)),
-  int_ 0
-] in
+  ulet_ "x" (appf2_ (var_ "foo") (int_ 1) (int_ 2))]
+  (int_ 0) in
 utest testCompile simpleFun with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1476,11 +1474,10 @@ let constants = bindall_ [
       ulet_ "t" (eqf_ (float_ 1.) (float_ 2.)),
       ulet_ "t" (lti_ (int_ 1) (int_ 2)),
       ulet_ "t" (ltf_ (float_ 1.) (float_ 2.)),
-      ulet_ "t" (negf_ (float_ 1.)),
+      ulet_ "t" (negf_ (float_ 1.))]
       (print_ (str_ "Hello, world!"))
-    ])),
-  int_ 0
-] in
+    ))]
+  (int_ 0) in
 utest testCompile constants with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1554,9 +1551,8 @@ let factorial = bindall_ [
         (int_ 1)
         (muli_ (var_ "n")
           (app_ (var_ "factorial")
-            (subi_ (var_ "n") (int_ 1)))))),
-   int_ 0
-] in
+            (subi_ (var_ "n") (int_ 1))))))]
+  (int_ 0) in
 utest testCompile factorial with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1599,9 +1595,8 @@ let oddEven = bindall_ [
             false_
             (app_ (var_ "odd")
               (subi_ (var_ "x") (int_ 1))))))
-  ],
-  int_ 0
-] in
+  ]]
+  (int_ 0) in
 utest testCompile oddEven with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1659,10 +1654,9 @@ let typedefs = bindall_ [
     (tyarrow_ (tyrecord_ [("v", (tycon_ "Integer2"))]) (tycon_ "Tree")),
   condef_ "Node" (tyarrow_
     (tyrecord_ [("v", tyint_), ("l", (tycon_ "Tree")), ("r", (tycon_ "Tree"))])
-    (tycon_ "Tree")),
+    (tycon_ "Tree"))]
 
-  int_ 0
-] in
+  (int_ 0) in
 utest testCompile typedefs with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1686,9 +1680,8 @@ utest testCompile typedefs with strJoin "\n" [
 -- Potentially tricky case with type aliases
 let alias = bindall_ [
   type_ "MyRec" [] (tyrecord_ [("k", tyint_)]),
-  let_ "myRec" (tycon_ "MyRec") (urecord_ [("k", int_ 0)]),
-  int_ 0
-] in
+  let_ "myRec" (tycon_ "MyRec") (urecord_ [("k", int_ 0)])]
+  (int_ 0) in
 utest testCompile alias with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1705,9 +1698,8 @@ utest testCompile alias with strJoin "\n" [
 -- Externals test
 let ext = bindall_ [
   ext_ "externalLog" false (tyarrow_ tyfloat_ tyfloat_),
-  let_ "x" (tyfloat_) (app_ (var_ "externalLog") (float_ 2.)),
-  int_ 0
-] in
+  let_ "x" (tyfloat_) (app_ (var_ "externalLog") (float_ 2.))]
+  (int_ 0) in
 utest testCompile ext with strJoin "\n" [
   "#include <stdint.h>",
   "#include <stdio.h>",
@@ -1756,10 +1748,9 @@ let trees = bindall_ [
             (var_ "v") never_))
       ),
 
-  ulet_ "sum" (app_ (var_ "treeRec") (var_ "tree")),
+  ulet_ "sum" (app_ (var_ "treeRec") (var_ "tree"))]
 
-  int_ 0
-] in
+  (int_ 0) in
 
 utest testCompile trees with strJoin "\n" [
   "#include <stdint.h>",
@@ -1842,11 +1833,9 @@ utest testCompile trees with strJoin "\n" [
 -- let leaf = match tree with node then leftnode else
 let manyAllocs = bindall_ [
 
-  ulet_ "rec" (match_ (bool_ true) (pbool_ true) (urecord_ [("a",int_ 1)]) (urecord_ [("a",int_ 2)])),
+  ulet_ "rec" (match_ (bool_ true) (pbool_ true) (urecord_ [("a",int_ 1)]) (urecord_ [("a",int_ 2)]))]
 
-  int_ 0
-
-] in
+  (int_ 0) in
 
 utest testCompile manyAllocs with strJoin "\n" [
   "#include <stdint.h>",
@@ -1871,13 +1860,13 @@ utest testCompile manyAllocs with strJoin "\n" [
 -- NOTE(larshum, 2022-03-02): We use type-ascriptions so that the intrinsic
 -- functions are treated as monomorphic, even though they are not.
 let seq = bindall_ [
-  let_ "s" (tyseq_ tyint_) (seq_ [int_ 1, int_ 2, int_ 3]),
-  app_
+  let_ "s" (tyseq_ tyint_) (seq_ [int_ 1, int_ 2, int_ 3])]
+  (app_
     (bind_
       (let_ "len" (tyarrow_ (tyseq_ tyint_) tyint_) (uconst_ (CLength ())))
       (var_ "len"))
     (var_ "s")
-] in
+) in
 
 utest testCompile seq with strJoin "\n" [
   "#include <stdint.h>",
@@ -1924,9 +1913,8 @@ let tensor = bindall_ [
         (bind_
           (let_ "s" (tytensorshape_ tyint_) (uconst_ (CTensorShape ())))
           (var_ "s"))
-        (var_ "t"))),
-  int_ 0
-] in
+        (var_ "t")))]
+  (int_ 0) in
 
 utest testCompile tensor with strJoin "\n" [
   "#include <stdint.h>",
@@ -2011,12 +1999,10 @@ utest testCompile tensor with strJoin "\n" [
 let seqs = bindall_ [
 
   -- Define nested sequence, and see how it is handled
-  ulet_ "seq" (seq_ [seq_ [int_ 1], seq_ [int_ 2]]),
-
+  ulet_ "seq" (seq_ [seq_ [int_ 1], seq_ [int_ 2]])]
   -- Use "length" and "get" functions
 
-  int_ 0
-
-] in
+  (int_ 0)
+in
 
 ()

--- a/src/stdlib/c/compile.mc
+++ b/src/stdlib/c/compile.mc
@@ -485,7 +485,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
   -----------------------
 
   sem collectExternals (acc: Map Name ExtInfo) =
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     let str = nameGetStr t.ident in
     match mapLookup str externalsMap with Some e then
       let e: ExtInfo = e in -- TODO(dlunde,2021-10-25): Remove with more complete type system?
@@ -853,7 +853,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
 
   sem compileTops (env: CompileCEnv) (accTop: [CTop]) (accInit: [CStmt]) =
 
-  | TmLet { ident = ident, tyBody = tyBody, body = body, inexpr = inexpr } ->
+  | TmDecl {decl = DeclLet { ident = ident, tyBody = tyBody, body = body, inexpr = inexpr }} ->
 
     -- Functions
     match body with TmLam _ then
@@ -885,7 +885,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
         compileTops env accTop accInit inexpr
       else never
 
-  | TmRecLets { bindings = bindings, inexpr = inexpr } ->
+  | TmDecl {decl = DeclRecLets { bindings = bindings, inexpr = inexpr }} ->
     let f = lam env. lam binding: DeclLetRecord.
       match binding with { ident = ident, tyBody = tyBody, body = body } then
         compileFun env ident tyBody body
@@ -905,7 +905,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
     else never
 
   -- Ignore externals (handled elsewhere)
-  | TmExt { inexpr = inexpr } -> compileTops env accTop accInit inexpr
+  | TmDecl {decl = DeclExt { inexpr = inexpr }} -> compileTops env accTop accInit inexpr
 
   -- Set up initialization code (for use, e.g., in a main function)
   | rest ->
@@ -1111,7 +1111,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
 
   sem compileStmts (env: CompileCEnv) (res: Result) (acc: [CStmt]) =
 
-  | TmLet { ident = ident, tyBody = tyBody, body = body, inexpr = inexpr } ->
+  | TmDecl {decl = DeclLet { ident = ident, tyBody = tyBody, body = body, inexpr = inexpr }} ->
 
     -- Optimize direct allocations
     match body with TmConApp _ | TmRecord _ | TmSeq _ then
@@ -1145,7 +1145,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
   | TmNever _ -> (env, snoc acc (CSNop {}))
 
   -- Ignore externals (handled elsewhere)
-  | TmExt { inexpr = inexpr } -> compileStmts env res acc inexpr
+  | TmDecl {decl = DeclExt { inexpr = inexpr }} -> compileStmts env res acc inexpr
 
 
   -----------------
@@ -1275,10 +1275,10 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
     else errorSingle [infoTm t] "ERROR: Records cannot be handled in compileExpr."
 
   -- Should not occur after ANF and type lifting.
-  | (TmRecordUpdate _ | TmLet _
-    | TmRecLets _ | TmType _ | TmConDef _
-    | TmConApp _ | TmMatch _ | TmUtest _
-    | TmSeq _ | TmExt _) & t ->
+  | (TmRecordUpdate _ | TmDecl {decl = DeclLet _}
+    | TmDecl {decl = DeclRecLets _} | TmDecl {decl = DeclType _} | TmDecl {decl = DeclConDef _}
+    | TmConApp _ | TmMatch _ | TmDecl {decl = DeclUtest _}
+    | TmSeq _ | TmDecl {decl = DeclExt _}) & t ->
     errorSingle [infoTm t] "ERROR: Term cannot be handled in compileExpr."
 
   -- Literals

--- a/src/stdlib/c/compile.mc
+++ b/src/stdlib/c/compile.mc
@@ -886,7 +886,7 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile + RecordTypeUtils
       else never
 
   | TmRecLets { bindings = bindings, inexpr = inexpr } ->
-    let f = lam env. lam binding: RecLetBinding.
+    let f = lam env. lam binding: DeclLetRecord.
       match binding with { ident = ident, tyBody = tyBody, body = body } then
         compileFun env ident tyBody body
       else never

--- a/src/stdlib/cuda/inline-higher.mc
+++ b/src/stdlib/cuda/inline-higher.mc
@@ -12,11 +12,11 @@ lang CudaInlineHigherOrder = MExprAst
   sem inlinePartialFunctionsH inlineBodies =
   | TmVar t ->
     match mapLookup t.ident inlineBodies with Some body then body else TmVar t
-  | TmLet (t & {body = !TmLam _}) ->
+  | TmDecl {decl = DeclLet (t & {body = !TmLam _})} ->
     match t.tyBody with TyArrow _ then
       let inlineBodies = mapInsert t.ident t.body inlineBodies in
       inlinePartialFunctionsH inlineBodies t.inexpr
-    else TmLet {t with body = inlinePartialFunctionsH inlineBodies t.body,
-                       inexpr = inlinePartialFunctionsH inlineBodies t.inexpr}
+    else TmDecl {decl = DeclLet {t with body = inlinePartialFunctionsH inlineBodies t.body,
+                       inexpr = inlinePartialFunctionsH inlineBodies t.inexpr}}
   | t -> smap_Expr_Expr (inlinePartialFunctionsH inlineBodies) t
 end

--- a/src/stdlib/cuda/inline-higher.mc
+++ b/src/stdlib/cuda/inline-higher.mc
@@ -12,11 +12,11 @@ lang CudaInlineHigherOrder = MExprAst
   sem inlinePartialFunctionsH inlineBodies =
   | TmVar t ->
     match mapLookup t.ident inlineBodies with Some body then body else TmVar t
-  | TmDecl {decl = DeclLet (t & {body = !TmLam _})} ->
+  | TmDecl (x & {decl = DeclLet (t & {body = !TmLam _})}) ->
     match t.tyBody with TyArrow _ then
       let inlineBodies = mapInsert t.ident t.body inlineBodies in
-      inlinePartialFunctionsH inlineBodies t.inexpr
-    else TmDecl {decl = DeclLet {t with body = inlinePartialFunctionsH inlineBodies t.body,
-                       inexpr = inlinePartialFunctionsH inlineBodies t.inexpr}}
+      inlinePartialFunctionsH inlineBodies x.inexpr
+    else TmDecl {x with decl = DeclLet {t with body = inlinePartialFunctionsH inlineBodies t.body},
+                       inexpr = inlinePartialFunctionsH inlineBodies x.inexpr}
   | t -> smap_Expr_Expr (inlinePartialFunctionsH inlineBodies) t
 end

--- a/src/stdlib/cuda/lang-fix.mc
+++ b/src/stdlib/cuda/lang-fix.mc
@@ -27,10 +27,10 @@ lang CudaLanguageFragmentFix = PMExprAst
     TmNever {ty = TyUnknown {info = info}, info = info}
   | t -> t
 
-  sem _eliminateFailureCodeInSemanticFunction : RecLetBinding -> RecLetBinding
+  sem _eliminateFailureCodeInSemanticFunction : DeclLetRecord -> DeclLetRecord
   sem _eliminateFailureCodeInSemanticFunction =
   | recLetBinding ->
-    let recLetBinding : RecLetBinding = recLetBinding in
+    let DeclLetRecord : DeclLetRecord = DeclLetRecord in
     let body = _eliminateFailureCodeInSemanticFunctionBody recLetBinding.body in
     {recLetBinding with body = body}
 

--- a/src/stdlib/cuda/lang-fix.mc
+++ b/src/stdlib/cuda/lang-fix.mc
@@ -17,10 +17,10 @@ lang CudaLanguageFragmentFix = PMExprAst
   | TmMatch t ->
     TmMatch {t with els = _eliminateFailureCodeInSemanticFunctionBody t.els}
   | TmDecl {decl = DeclLet {
-      body = TmApp {lhs = TmConst {val = CDPrint _}},
+      body = TmApp {lhs = TmConst {val = CDPrint _}}},
       inexpr = TmApp {lhs = TmConst {val = CError _},
                       rhs = TmSeq _},
-      info = info}} ->
+      info = info} ->
     -- NOTE(larshum, 2022-03-29): If we find an expression that corresponds to
     -- what is (currently) generated when compiling a semantic function, we
     -- replace it with a never term (which is compiled correctly).
@@ -30,25 +30,18 @@ lang CudaLanguageFragmentFix = PMExprAst
   sem _eliminateFailureCodeInSemanticFunction : DeclLetRecord -> DeclLetRecord
   sem _eliminateFailureCodeInSemanticFunction =
   | recLetBinding ->
-    let DeclLetRecord : DeclLetRecord = DeclLetRecord in
+    let recLetBinding : DeclLetRecord = recLetBinding in
     let body = _eliminateFailureCodeInSemanticFunctionBody recLetBinding.body in
     {recLetBinding with body = body}
 
   sem fixLanguageFragmentSemanticFunction : Expr -> Expr
   sem fixLanguageFragmentSemanticFunction =
-  | TmDecl {decl = DeclLet t} ->
-    TmDecl {decl = DeclLet {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl x -> TmDecl {x with inexpr = fixLanguageFragmentSemanticFunction x.inexpr}
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let bindings = map _eliminateFailureCodeInSemanticFunction t.bindings in
-    TmDecl {decl = DeclRecLets {{t with bindings = bindings}
-                  with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
-  | TmDecl {decl = DeclType t} ->
-    TmDecl {decl = DeclType {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
-  | TmDecl {decl = DeclConDef t} ->
-    TmDecl {decl = DeclConDef {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
-  | TmDecl {decl = DeclUtest t} ->
-    TmDecl {decl = DeclUtest {t with next = fixLanguageFragmentSemanticFunction t.next}}
-  | TmDecl {decl = DeclExt t} ->
-    TmDecl {decl = DeclExt {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
+    TmDecl
+    { x with decl = DeclRecLets {t with bindings = bindings}
+    , inexpr = fixLanguageFragmentSemanticFunction x.inexpr
+    }
   | t -> t
 end

--- a/src/stdlib/cuda/lang-fix.mc
+++ b/src/stdlib/cuda/lang-fix.mc
@@ -16,11 +16,11 @@ lang CudaLanguageFragmentFix = PMExprAst
     TmLam {t with body = _eliminateFailureCodeInSemanticFunctionBody t.body}
   | TmMatch t ->
     TmMatch {t with els = _eliminateFailureCodeInSemanticFunctionBody t.els}
-  | TmLet {
+  | TmDecl {decl = DeclLet {
       body = TmApp {lhs = TmConst {val = CDPrint _}},
       inexpr = TmApp {lhs = TmConst {val = CError _},
                       rhs = TmSeq _},
-      info = info} ->
+      info = info}} ->
     -- NOTE(larshum, 2022-03-29): If we find an expression that corresponds to
     -- what is (currently) generated when compiling a semantic function, we
     -- replace it with a never term (which is compiled correctly).
@@ -36,19 +36,19 @@ lang CudaLanguageFragmentFix = PMExprAst
 
   sem fixLanguageFragmentSemanticFunction : Expr -> Expr
   sem fixLanguageFragmentSemanticFunction =
-  | TmLet t ->
-    TmLet {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}
-  | TmRecLets t ->
+  | TmDecl {decl = DeclLet t} ->
+    TmDecl {decl = DeclLet {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
+  | TmDecl {decl = DeclRecLets t} ->
     let bindings = map _eliminateFailureCodeInSemanticFunction t.bindings in
-    TmRecLets {{t with bindings = bindings}
-                  with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}
-  | TmType t ->
-    TmType {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}
-  | TmConDef t ->
-    TmConDef {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}
-  | TmUtest t ->
-    TmUtest {t with next = fixLanguageFragmentSemanticFunction t.next}
-  | TmExt t ->
-    TmExt {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}
+    TmDecl {decl = DeclRecLets {{t with bindings = bindings}
+                  with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
+  | TmDecl {decl = DeclType t} ->
+    TmDecl {decl = DeclType {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
+  | TmDecl {decl = DeclConDef t} ->
+    TmDecl {decl = DeclConDef {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
+  | TmDecl {decl = DeclUtest t} ->
+    TmDecl {decl = DeclUtest {t with next = fixLanguageFragmentSemanticFunction t.next}}
+  | TmDecl {decl = DeclExt t} ->
+    TmDecl {decl = DeclExt {t with inexpr = fixLanguageFragmentSemanticFunction t.inexpr}}
   | t -> t
 end

--- a/src/stdlib/cuda/pmexpr-compile.mc
+++ b/src/stdlib/cuda/pmexpr-compile.mc
@@ -33,7 +33,7 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
     let bindMap : Map Name Expr =
       mapFromSeq nameCmp
         (map
-          (lam bind : RecLetBinding. (bind.ident, bind.body))
+          (lam bind : DeclLetRecord. (bind.ident, bind.body))
           t.bindings) in
     let markFunctionsInComponent = lam marked. lam comp.
       if any (lam e. setMem e marked) comp then
@@ -76,7 +76,7 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
       let body = promoteKernelsBody t.body in
       TmLet {{t with body = body} with inexpr = inexpr}
   | TmRecLets t ->
-    let promoteKernelBinding = lam binding : RecLetBinding.
+    let promoteKernelBinding = lam binding : DeclLetRecord.
       if setMem binding.ident marked then binding
       else {binding with body = promoteKernelsBody binding.body}
     in

--- a/src/stdlib/cuda/pmexpr-compile.mc
+++ b/src/stdlib/cuda/pmexpr-compile.mc
@@ -24,12 +24,12 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
   | t -> markNonKernelFunctionsH (setEmpty nameCmp) t
 
   sem markNonKernelFunctionsH (marked : Set Name) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let marked = markNonKernelFunctionsH marked t.inexpr in
     if setMem t.ident marked then
       markInBody marked t.body
     else markInUnmarkedBody marked t.body
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let bindMap : Map Name Expr =
       mapFromSeq nameCmp
         (map
@@ -49,13 +49,13 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
       else marked
     in
     let marked = markNonKernelFunctionsH marked t.inexpr in
-    let g : Digraph Name Int = constructCallGraph (TmRecLets t) in
+    let g : Digraph Name Int = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
     let sccs = digraphTarjan g in
     foldl markFunctionsInComponent marked (reverse sccs)
-  | TmType t -> markNonKernelFunctionsH marked t.inexpr
-  | TmConDef t -> markNonKernelFunctionsH marked t.inexpr
-  | TmUtest t -> markNonKernelFunctionsH marked t.next
-  | TmExt t -> markNonKernelFunctionsH marked t.inexpr
+  | TmDecl {decl = DeclType t} -> markNonKernelFunctionsH marked t.inexpr
+  | TmDecl {decl = DeclConDef t} -> markNonKernelFunctionsH marked t.inexpr
+  | TmDecl {decl = DeclUtest t} -> markNonKernelFunctionsH marked t.next
+  | TmDecl {decl = DeclExt t} -> markNonKernelFunctionsH marked t.inexpr
   | t -> marked
 
   sem markInUnmarkedBody (marked : Set Name) =
@@ -69,24 +69,24 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
   -- Promotes parallel operations used in functions that have not been marked
   -- to kernel operations.
   sem promoteKernels (marked : Set Name) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let inexpr = promoteKernels marked t.inexpr in
-    if setMem t.ident marked then TmLet {t with inexpr = inexpr}
+    if setMem t.ident marked then TmDecl {decl = DeclLet {t with inexpr = inexpr}}
     else
       let body = promoteKernelsBody t.body in
-      TmLet {{t with body = body} with inexpr = inexpr}
-  | TmRecLets t ->
+      TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}}
+  | TmDecl {decl = DeclRecLets t} ->
     let promoteKernelBinding = lam binding : DeclLetRecord.
       if setMem binding.ident marked then binding
       else {binding with body = promoteKernelsBody binding.body}
     in
     let inexpr = promoteKernels marked t.inexpr in
     let bindings = map promoteKernelBinding t.bindings in
-    TmRecLets {{t with inexpr = inexpr} with bindings = bindings}
-  | TmType t -> TmType {t with inexpr = promoteKernels marked t.inexpr}
-  | TmConDef t -> TmConDef {t with inexpr = promoteKernels marked t.inexpr}
-  | TmUtest t -> TmUtest {t with next = promoteKernels marked t.next}
-  | TmExt t -> TmExt {t with inexpr = promoteKernels marked t.inexpr}
+    TmDecl {decl = DeclRecLets {{t with inexpr = inexpr} with bindings = bindings}}
+  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = promoteKernels marked t.inexpr}}
+  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = promoteKernels marked t.inexpr}}
+  | TmDecl {decl = DeclUtest t} -> TmDecl {decl = DeclUtest {t with next = promoteKernels marked t.next}}
+  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = promoteKernels marked t.inexpr}}
   | t -> t
 
   -- TODO(larshum, 2022-03-22): Add support for sequence map and reduce

--- a/src/stdlib/cuda/pmexpr-compile.mc
+++ b/src/stdlib/cuda/pmexpr-compile.mc
@@ -24,12 +24,12 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
   | t -> markNonKernelFunctionsH (setEmpty nameCmp) t
 
   sem markNonKernelFunctionsH (marked : Set Name) =
-  | TmDecl {decl = DeclLet t} ->
-    let marked = markNonKernelFunctionsH marked t.inexpr in
+  | TmDecl (x & {decl = DeclLet t}) ->
+    let marked = markNonKernelFunctionsH marked x.inexpr in
     if setMem t.ident marked then
       markInBody marked t.body
     else markInUnmarkedBody marked t.body
-  | TmDecl {decl = DeclRecLets t} ->
+  | tm & TmDecl (x & {decl = DeclRecLets t}) ->
     let bindMap : Map Name Expr =
       mapFromSeq nameCmp
         (map
@@ -48,14 +48,11 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
           marked comp
       else marked
     in
-    let marked = markNonKernelFunctionsH marked t.inexpr in
-    let g : Digraph Name Int = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
+    let marked = markNonKernelFunctionsH marked x.inexpr in
+    let g : Digraph Name Int = constructCallGraph tm in
     let sccs = digraphTarjan g in
     foldl markFunctionsInComponent marked (reverse sccs)
-  | TmDecl {decl = DeclType t} -> markNonKernelFunctionsH marked t.inexpr
-  | TmDecl {decl = DeclConDef t} -> markNonKernelFunctionsH marked t.inexpr
-  | TmDecl {decl = DeclUtest t} -> markNonKernelFunctionsH marked t.next
-  | TmDecl {decl = DeclExt t} -> markNonKernelFunctionsH marked t.inexpr
+  | TmDecl x -> markNonKernelFunctionsH marked x.inexpr
   | t -> marked
 
   sem markInUnmarkedBody (marked : Set Name) =
@@ -69,24 +66,21 @@ lang CudaPMExprKernelCalls = CudaPMExprAst + MExprCallGraph
   -- Promotes parallel operations used in functions that have not been marked
   -- to kernel operations.
   sem promoteKernels (marked : Set Name) =
-  | TmDecl {decl = DeclLet t} ->
-    let inexpr = promoteKernels marked t.inexpr in
-    if setMem t.ident marked then TmDecl {decl = DeclLet {t with inexpr = inexpr}}
+  | TmDecl (x & {decl = DeclLet t}) ->
+    let inexpr = promoteKernels marked x.inexpr in
+    if setMem t.ident marked then TmDecl {x with inexpr = inexpr}
     else
       let body = promoteKernelsBody t.body in
-      TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}}
-  | TmDecl {decl = DeclRecLets t} ->
+      TmDecl {x with decl = DeclLet {t with body = body}, inexpr = inexpr}
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let promoteKernelBinding = lam binding : DeclLetRecord.
       if setMem binding.ident marked then binding
       else {binding with body = promoteKernelsBody binding.body}
     in
-    let inexpr = promoteKernels marked t.inexpr in
+    let inexpr = promoteKernels marked x.inexpr in
     let bindings = map promoteKernelBinding t.bindings in
-    TmDecl {decl = DeclRecLets {{t with inexpr = inexpr} with bindings = bindings}}
-  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = promoteKernels marked t.inexpr}}
-  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = promoteKernels marked t.inexpr}}
-  | TmDecl {decl = DeclUtest t} -> TmDecl {decl = DeclUtest {t with next = promoteKernels marked t.next}}
-  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = promoteKernels marked t.inexpr}}
+    TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr}
+  | TmDecl x -> TmDecl {x with inexpr = promoteKernels marked x.inexpr}
   | t -> t
 
   -- TODO(larshum, 2022-03-22): Add support for sequence map and reduce

--- a/src/stdlib/cuda/well-formed.mc
+++ b/src/stdlib/cuda/well-formed.mc
@@ -11,6 +11,7 @@ include "pmexpr/well-formed.mc"
 lang CudaWellFormed = WellFormed + CudaPMExprAst
   syn WFError =
   | CudaExprError Expr
+  | CudaDeclError Decl
   | CudaTypeError Type
   | CudaPatternError Pat
   | CudaConstantError Info
@@ -76,6 +77,25 @@ lang CudaWellFormed = WellFormed + CudaPMExprAst
       else foldl cudaWellFormedExpr acc args in
     cudaWellFormedExpr acc fun
 
+  sem cudaWellFormedDecl : [WFError] -> Decl -> [WFError]
+  sem cudaWellFormedDecl acc =
+  | DeclLet t ->
+    let acc =
+      if cudaWellFormedLambdas (t.body, t.tyBody) then acc
+      else cons (CudaFunctionDefError t.body) acc in
+    cudaWellFormedExpr acc t.body
+  | DeclRecLets t ->
+    let checkBinding = lam acc. lam bind.
+      let acc =
+        if cudaWellFormedLambdas (bind.body, bind.tyBody) then acc
+        else cons (CudaFunctionDefError bind.body) acc in
+      cudaWellFormedExpr acc bind.body
+    in
+    foldl checkBinding acc t.bindings
+  | DeclExt _ -> acc
+  | DeclType t -> cudaWellFormedType acc t.tyIdent
+  | decl -> cons (CudaDeclError decl) acc
+
   sem cudaWellFormedExprH : [WFError] -> Expr -> [WFError]
   sem cudaWellFormedExprH acc =
   | TmVar t -> acc
@@ -84,21 +104,9 @@ lang CudaWellFormed = WellFormed + CudaPMExprAst
       cons (CudaAppResultTypeError app) acc
     else _cudaCheckApp acc app
   | TmLam t -> cudaWellFormedExpr acc t.body
-  | TmDecl {decl = DeclLet t} ->
-    let acc =
-      if cudaWellFormedLambdas (t.body, t.tyBody) then acc
-      else cons (CudaFunctionDefError t.body) acc in
-    let acc = cudaWellFormedExpr acc t.body in
-    cudaWellFormedExpr acc t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
-    let checkBinding = lam acc. lam bind.
-      let acc =
-        if cudaWellFormedLambdas (bind.body, bind.tyBody) then acc
-        else cons (CudaFunctionDefError bind.body) acc in
-      cudaWellFormedExpr acc bind.body
-    in
-    let acc = foldl checkBinding acc t.bindings in
-    cudaWellFormedExpr acc t.inexpr
+  | TmDecl x ->
+    let acc = cudaWellFormedDecl acc x.decl in
+    cudaWellFormedExpr acc x.inexpr
   | TmConst t ->
     if isCudaSupportedConstant t.val then acc
     else cons (CudaConstantError t.info) acc
@@ -115,13 +123,6 @@ lang CudaWellFormed = WellFormed + CudaPMExprAst
       (lam acc. lam. lam expr. cudaWellFormedExpr acc expr) acc bindings
   | TmSeq {tms = tms} ->
     foldl (lam acc. lam expr. cudaWellFormedExpr acc expr) acc tms
-  | TmDecl {decl = DeclExt t} -> cudaWellFormedExpr acc t.inexpr
-  | TmDecl {decl = DeclType t} ->
-    let acc = cudaWellFormedType acc t.tyIdent in
-    cudaWellFormedExpr acc t.inexpr
-  | TmDecl {decl = DeclConDef t} ->
-    let acc = cons (CudaExprError (TmDecl {decl = DeclConDef t})) acc in
-    cudaWellFormedExpr acc t.inexpr
   | TmLoop t | TmParallelLoop t ->
     let acc = cudaWellFormedExpr acc t.n in
     cudaWellFormedHigherOrder acc t.f
@@ -215,6 +216,8 @@ let eqCudaError = lam lerr : WFError. lam rerr : WFError.
   let t = (lerr, rerr) in
   match t with (CudaExprError le, CudaExprError re) then
     eqExpr le re
+  else match t with (CudaDeclError le, CudaDeclError re) then
+    eqDecl le re
   else match t with (CudaTypeError lty, CudaTypeError rty) then
     eqType lty rty
   else match t with (CudaConstantError li, CudaConstantError ri) then
@@ -299,20 +302,20 @@ let recursiveConstructorExpr =
 in
 let conDef = bindall_ [
   ntype_ t [] (tyvariant_ []),
-  recursiveConstructorExpr,
-  int_ 0] in
-let expectedExpr = bind_ recursiveConstructorExpr (int_ 0) in
+  recursiveConstructorExpr]
+  (int_ 0) in
+let expectedExpr = recursiveConstructorExpr in
 -- NOTE(larshum, 2022-07-12): Skip the first expression (a type) since we
 -- cannot compare those.
-utest tail (checkWellFormedExpr conDef) with [CudaExprError expectedExpr]
+utest tail (checkWellFormedExpr conDef) with [CudaDeclError expectedExpr]
 using eqSeq eqCudaError in
 
-let ext = ext_ "sin" false (tyarrow_ tyfloat_ tyfloat_) in
+let ext = bind_ (ext_ "sin" false (tyarrow_ tyfloat_ tyfloat_)) unit_ in
 utest checkWellFormedExpr ext with []
 using eqSeq eqCudaError in
 
-let utestTerm = utest_ (int_ 1) (int_ 2) (int_ 0) in
-utest checkWellFormedExpr utestTerm with [CudaExprError utestTerm]
+let utestTerm = utest_ (int_ 1) (int_ 2)in
+utest checkWellFormedExpr (bind_ utestTerm (int_ 0)) with [CudaDeclError utestTerm]
 using eqSeq eqCudaError in
 
 let i = Info {filename = "", row1 = 0, row2 = 0, col1 = 0, col2 = 0} in

--- a/src/stdlib/cuda/well-formed.mc
+++ b/src/stdlib/cuda/well-formed.mc
@@ -84,13 +84,13 @@ lang CudaWellFormed = WellFormed + CudaPMExprAst
       cons (CudaAppResultTypeError app) acc
     else _cudaCheckApp acc app
   | TmLam t -> cudaWellFormedExpr acc t.body
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let acc =
       if cudaWellFormedLambdas (t.body, t.tyBody) then acc
       else cons (CudaFunctionDefError t.body) acc in
     let acc = cudaWellFormedExpr acc t.body in
     cudaWellFormedExpr acc t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let checkBinding = lam acc. lam bind.
       let acc =
         if cudaWellFormedLambdas (bind.body, bind.tyBody) then acc
@@ -115,12 +115,12 @@ lang CudaWellFormed = WellFormed + CudaPMExprAst
       (lam acc. lam. lam expr. cudaWellFormedExpr acc expr) acc bindings
   | TmSeq {tms = tms} ->
     foldl (lam acc. lam expr. cudaWellFormedExpr acc expr) acc tms
-  | TmExt t -> cudaWellFormedExpr acc t.inexpr
-  | TmType t ->
+  | TmDecl {decl = DeclExt t} -> cudaWellFormedExpr acc t.inexpr
+  | TmDecl {decl = DeclType t} ->
     let acc = cudaWellFormedType acc t.tyIdent in
     cudaWellFormedExpr acc t.inexpr
-  | TmConDef t ->
-    let acc = cons (CudaExprError (TmConDef t)) acc in
+  | TmDecl {decl = DeclConDef t} ->
+    let acc = cons (CudaExprError (TmDecl {decl = DeclConDef t})) acc in
     cudaWellFormedExpr acc t.inexpr
   | TmLoop t | TmParallelLoop t ->
     let acc = cudaWellFormedExpr acc t.n in

--- a/src/stdlib/extrec/ast-builder.mc
+++ b/src/stdlib/extrec/ast-builder.mc
@@ -9,16 +9,6 @@ let ext_record_ = lam s. lam b.
                ty = tyunknown_,
                info = NoInfo ()}
 
-recursive let extrec_bindF_ = use MLangAst in
-  lam f : Expr -> Expr -> Expr. lam letexpr. lam expr.
-  bindF_ (lam letexpr. lam expr.
-    match letexpr with TmUse t then
-      TmUse {t with inexpr = extrec_bindF_ f t.inexpr expr}
-    else
-      f letexpr expr -- Insert at the end of the chain
-  ) letexpr expr
-end
-
 let placeholder_ = use PlaceholderAst in
   TmPlaceholder {info = NoInfo (),
                  ty = tyunknown_}

--- a/src/stdlib/extrec/ast.mc
+++ b/src/stdlib/extrec/ast.mc
@@ -81,16 +81,6 @@ end
 
 lang ExtRecordAst = Ast
   syn Expr =
-  | TmRecType {ident : Name,
-               params : [Name],
-               ty : Type,
-               inexpr : Expr,
-               info : Info}
-  | TmRecField {label : String,
-                tyIdent : Type,
-                inexpr : Expr,
-                ty : Type,
-                info : Info}
   | TmExtRecord  {bindings : Map String Expr,
                   ident : Name,
                   ty : Type,
@@ -100,37 +90,40 @@ lang ExtRecordAst = Ast
                  ty : Type,
                  info : Info}
 
+  syn Decl =
+  | DeclRecType {ident : Name,
+                 params : [Name],
+                 info : Info}
+  | DeclRecField {label : String,
+                  tyIdent : Type,
+                  info : Info}
+
+
   sem infoTm =
-  | TmRecField t -> t.info
-  | TmRecType t -> t.info
   | TmExtRecord t -> t.info
   | TmExtExtend t -> t.info
 
+  sem infoDecl =
+  | DeclRecField t -> t.info
+  | DeclRecType t -> t.info
+
   sem tyTm =
-  | TmRecField t -> t.ty
-  | TmRecType t -> t.ty
   | TmExtRecord t -> t.ty
   | TmExtExtend t -> t.ty
 
   sem withInfo info =
-  | TmRecField t -> TmRecField {t with info = info}
-  | TmRecType t -> TmRecType {t with info = info}
   | TmExtRecord t -> TmExtRecord {t with info = info}
   | TmExtExtend t -> TmExtExtend {t with info = info}
 
+  sem declWithInfo info =
+  | DeclRecField t -> DeclRecField {t with info = info}
+  | DeclRecType t -> DeclRecType {t with info = info}
+
   sem withType  ty =
-  | TmRecField t -> TmRecField {t with ty = ty}
-  | TmRecType t -> TmRecType {t with ty = ty}
   | TmExtRecord t -> TmExtRecord {t with ty = ty}
   | TmExtExtend t -> TmExtExtend {t with ty = ty}
 
   sem smapAccumL_Expr_Expr f acc =
-  | TmRecType t ->
-    match f acc t.inexpr with (acc, inexpr) in
-    (acc, TmRecType {t with inexpr = inexpr})
-  | TmRecField t ->
-    match f acc t.inexpr with (acc, inexpr) in
-    (acc, TmRecField {t with inexpr = inexpr})
   | TmExtRecord t ->
     match mapMapAccum (lam acc. lam. lam e. f acc e) acc t.bindings with (acc, bindings) in
     (acc, TmExtRecord {t with bindings = bindings})
@@ -140,21 +133,10 @@ lang ExtRecordAst = Ast
     with (acc, bindings) in
     (acc, TmExtExtend {t with e = e, bindings = bindings})
 
-  sem smapAccumL_Expr_Type f acc =
-  | TmRecType t ->
-    match f acc t.ty with (acc, ty) in
-    (acc, TmRecType {t with ty = ty})
-  | TmRecField t ->
+  sem smapAccumL_Decl_Type f acc =
+  | DeclRecField t ->
     match f acc t.tyIdent with (acc, tyIdent) in
-    match f acc t.ty with (acc, ty) in
-    (acc, TmRecField {t with tyIdent = tyIdent,
-                             ty = ty})
-  | TmExtRecord t ->
-    match f acc t.ty with (acc, ty) in
-    (acc, TmExtRecord {t with ty = ty})
-  | TmExtExtend t ->
-    match f acc t.ty with (acc, ty) in
-    (acc, TmExtExtend {t with ty = ty})
+    (acc, DeclRecField {t with tyIdent = tyIdent})
 end
 
 lang TypeAbsAst = Ast

--- a/src/stdlib/extrec/boot-parser.mc
+++ b/src/stdlib/extrec/boot-parser.mc
@@ -18,18 +18,26 @@ lang ExtRecordBootParser = BootParserMLang + ExtRecordAst
   | 117 ->
     let n = glistlen t 0 in
     let params = map (lam i. gname t (addi i 1)) (range 0 n 1) in
-
-    TmRecType {ident = gname t 0,
-               params = params,
-               ty = tyunknown_,
-               inexpr = gterm t 0,
-               info = ginfo t 0}
-  | 118 ->
-    TmRecField {label = gstr t 0,
-                tyIdent = gtype t 0,
-                inexpr = gterm t 0,
-                ty = tyunknown_,
-                info = ginfo t 0}
+    TmDecl
+    { decl = DeclRecType
+      { ident = gname t 0
+      , params = params
+      , info = ginfo t 0
+      }
+    , ty = tyunknown_
+    , inexpr = gterm t 0
+    , info = ginfo t 0
+    }
+  | 118 -> TmDecl
+    { decl = DeclRecField
+      { label = gstr t 0
+      , tyIdent = gtype t 0
+      , info = ginfo t 0
+      }
+    , inexpr = gterm t 0
+    , ty = tyunknown_
+    , info = ginfo t 0
+    }
   | 119 ->
     let n = glistlen t 0 in
     let ident = gname t 0 in

--- a/src/stdlib/extrec/collect-env.mc
+++ b/src/stdlib/extrec/collect-env.mc
@@ -24,15 +24,15 @@ lang ExtRecCollectEnv = MExprAst + ExtRecordAst + MExprPrettyPrint +
                         TypeAbsAst
   sem collectEnv : AccEnv -> Expr -> AccEnv
   sem collectEnv env =
-  | TmRecType t ->
+  | TmDecl (x & {decl = DeclRecType t}) ->
     match mapLookup t.ident env.defs with Some _ then
       errorMulti
         [(t.info, nameGetStr t.ident)]
         "An extensible record type with this Name already exists!"
     else
       let defs = mapInsert t.ident (mapEmpty cmpString) env.defs in
-      collectEnv {env with defs = defs} t.inexpr
-  | TmRecField t ->
+      collectEnv {env with defs = defs} x.inexpr
+  | TmDecl (x & {decl = DeclRecField t}) ->
     match t.tyIdent with TyAll tyAll then
 
       -- Collect other parameters to re-insert later.
@@ -72,7 +72,7 @@ lang ExtRecCollectEnv = MExprAst + ExtRecordAst + MExprPrettyPrint +
             let labelTypeMap = mapInsert t.label (nameNoSym "", ty) labelTypeMap in
 
             let env = {env with defs = mapInsert ident labelTypeMap env.defs} in
-            collectEnv env t.inexpr
+            collectEnv env x.inexpr
           else
             errorMulti
               [(t.info, "")]

--- a/src/stdlib/extrec/compile.mc
+++ b/src/stdlib/extrec/compile.mc
@@ -34,10 +34,8 @@ lang SynPayloadTypesDeclCompiler = SynDeclAst + ExtRecordAst
   | DeclSyn s ->
     -- Generate a record type for each definition in the syntax type.
     let work = lam ctx. lam def.
-      withExpr ctx (TmRecType {ident = def.tyName,
+      withDecl ctx (DeclRecType {ident = def.tyName,
                                params = s.params,
-                               ty = tyunknown_,
-                               inexpr = uunit_,
                                info = infoTy def.tyIdent}) in
     foldl work ctx s.defs
 end
@@ -57,10 +55,8 @@ lang SynProdDeclCompiler = SynProdExtDeclAst + ExtRecordAst + RecordTypeAst
       let work = lam acc. lam sid. lam ty.
           let label = sidToString sid in
           let tyIdent = tyarrow_ (ntycon_ recIdent) ty in
-          withExpr acc (TmRecField {label = label,
+          withDecl acc (DeclRecField {label = label,
                                     tyIdent = nstyall_ (head s.params) (data_ recIdent) tyIdent,
-                                    inexpr = uunit_,
-                                    ty = tyunknown_,
                                     info = infoTy ty})
       in
       mapFoldWithKey work ctx rec.fields
@@ -84,7 +80,7 @@ lang SynProdDeclCompiler = SynProdExtDeclAst + ExtRecordAst + RecordTypeAst
       --   let work = lam acc. lam sid. lam ty.
       --     let label = sidToString sid in
       --     let tyIdent = tyarrow_ (ntycon_ recIdent) ty in
-      --       withExpr acc (TmRecField {label = label,
+      --       withDecl acc (TmRecField {label = label,
       --                                 tyIdent = nstyall_ mapParamIdent (data_ s.ident) tyIdent,
       --                                 inexpr = uunit_,
       --                                 ty = tyunknown_,
@@ -136,26 +132,20 @@ lang ExtrecSynDefCompiler = SynDeclAst + ExtRecordAst + MExprAst
         let work = lam ctx. lam sid. lam ty.
           let label = sidToString sid in
           let tyIdent = tyarrow_ (conappWrapper (ntycon_ recIdent)) ty in
-          withExpr ctx (TmRecField {label = label,
+          withDecl ctx (DeclRecField {label = label,
                                     tyIdent = forallWrapper tyIdent,
-                                    inexpr = uunit_,
-                                    ty = tyunknown_,
                                     info = infoTy ty}) in
         let ctx = mapFoldWithKey work ctx rec.fields in
         let lhs = TyCon {info = infoTy def.tyIdent,
                          ident = recIdent,
                          data = intyvar_ s.info (head s.params)} in
-        withExpr ctx (TmDecl {decl = DeclConDef {ident = def.ident,
+        withDecl ctx (DeclConDef {ident = def.ident,
                                 tyIdent = forallWrapper (tyarrow_ (conappWrapper lhs) (conappWrapper tyconApp)),
-                                inexpr = uunit_,
-                                ty = tyunknown_,
-                                info = s.info}})
+                                info = s.info})
       else
-        withExpr ctx (TmDecl {decl = DeclConDef {ident = def.ident,
+        withDecl ctx (DeclConDef {ident = def.ident,
                                 tyIdent = forallWrapper (tyarrow_ def.tyIdent tyconApp),
-                                inexpr = uunit_,
-                                ty = tyunknown_,
-                                info = s.info}})
+                                info = s.info})
     in
     let ctx = foldl compileDef ctx s.defs in
 
@@ -235,21 +225,17 @@ lang CosynDeclCompiler = CosynDeclAst + RecordTypeAst + ExtRecAst
     with Some baseIdent in
 
     let ctx = if s.isBase
-              then withExpr ctx (TmRecType {ident = s.ident,
+              then withDecl ctx (DeclRecType {ident = s.ident,
                                             params = s.params,
-                                            info = s.info,
-                                            ty = tyunknown_,
-                                            inexpr = uunit_})
+                                            info = s.info})
               else ctx in
 
     let wrap = lam ty. lam n. nstyall_ n (data_ baseIdent) ty in
 
     let compileField = lam ctx. lam sid. lam ty.
       let tyIdent = tyarrow_ (ntycon_ baseIdent) ty in
-      withExpr ctx (TmRecField {label = sidToString sid,
+      withDecl ctx (DeclRecField {label = sidToString sid,
                                 tyIdent = foldl wrap tyIdent s.params,
-                                inexpr = uunit_,
-                                ty = tyunknown_,
                                 info = s.info}) in
 
     match s.ty with TyRecord rec then
@@ -295,10 +281,8 @@ lang ExtRecLangDeclCompiler = DeclCompiler + LangDeclAst + MExprAst + SemDeclAst
       = lam ctx. lam sems. lam cosems.
         let semBindings = map (compileSem langStr ctx semNames) sems in
         let cosemBindings = map (compileCosem langStr ctx semNames) cosems in
-        withExpr ctx (TmDecl {decl = DeclRecLets {bindings = concat semBindings cosemBindings,
-                                 inexpr = uunit_,
-                                 ty = tyunknown_,
-                                 info = l.info}})
+        withDecl ctx (DeclRecLets {bindings = concat semBindings cosemBindings,
+                                 info = l.info})
     in
     result.map (lam ctx. compileSemToResult ctx semDecls cosemDecls) res
   | DeclSyn s ->
@@ -317,13 +301,13 @@ lang MLangTopLevelCompiler = MLangTopLevel + DeclCompiler + LangDeclAst + SynDec
   | _ -> acc
 
 
-  sem compileProg : CompilationContext -> MLangProgram -> CompilationResult
+  sem compileProg : CompilationContext -> MLangProgram -> Result CompilationWarning CompilationError (CompilationContext, Expr)
   sem compileProg ctx =
   | prog ->
     let ctx = {ctx with allBaseSyns = foldl _gatherBaseSemNames (setEmpty nameCmp) prog.decls} in
 
     let res = result.foldlM compileDecl ctx prog.decls in
-    result.map (lam ctx. withExpr ctx prog.expr) res
+    result.map (lam ctx. (ctx, prog.expr)) res
 end
 
 lang MLangCompiler = MLangAst + MExprAst +
@@ -336,8 +320,8 @@ lang MLangCompiler = MLangAst + MExprAst +
     switch res
       case Left err then
         result.err (head err)
-      case Right ctx then
-        result.ok (bindall_ (concat ctx.toplevelExprs ctx.exprs))
+      case Right (ctx, expr) then
+        result.ok (bindall_ (concat ctx.toplevelDecls ctx.decls) expr)
     end
 end
 

--- a/src/stdlib/extrec/compile.mc
+++ b/src/stdlib/extrec/compile.mc
@@ -145,17 +145,17 @@ lang ExtrecSynDefCompiler = SynDeclAst + ExtRecordAst + MExprAst
         let lhs = TyCon {info = infoTy def.tyIdent,
                          ident = recIdent,
                          data = intyvar_ s.info (head s.params)} in
-        withExpr ctx (TmConDef {ident = def.ident,
+        withExpr ctx (TmDecl {decl = DeclConDef {ident = def.ident,
                                 tyIdent = forallWrapper (tyarrow_ (conappWrapper lhs) (conappWrapper tyconApp)),
                                 inexpr = uunit_,
                                 ty = tyunknown_,
-                                info = s.info})
+                                info = s.info}})
       else
-        withExpr ctx (TmConDef {ident = def.ident,
+        withExpr ctx (TmDecl {decl = DeclConDef {ident = def.ident,
                                 tyIdent = forallWrapper (tyarrow_ def.tyIdent tyconApp),
                                 inexpr = uunit_,
                                 ty = tyunknown_,
-                                info = s.info})
+                                info = s.info}})
     in
     let ctx = foldl compileDef ctx s.defs in
 
@@ -295,10 +295,10 @@ lang ExtRecLangDeclCompiler = DeclCompiler + LangDeclAst + MExprAst + SemDeclAst
       = lam ctx. lam sems. lam cosems.
         let semBindings = map (compileSem langStr ctx semNames) sems in
         let cosemBindings = map (compileCosem langStr ctx semNames) cosems in
-        withExpr ctx (TmRecLets {bindings = concat semBindings cosemBindings,
+        withExpr ctx (TmDecl {decl = DeclRecLets {bindings = concat semBindings cosemBindings,
                                  inexpr = uunit_,
                                  ty = tyunknown_,
-                                 info = l.info})
+                                 info = l.info}})
     in
     result.map (lam ctx. compileSemToResult ctx semDecls cosemDecls) res
   | DeclSyn s ->

--- a/src/stdlib/extrec/main.mc
+++ b/src/stdlib/extrec/main.mc
@@ -105,11 +105,11 @@ lang BigPipeline = BigIncludeHandler +
   -- I can not figure out why.
   sem dumpTypes : [String] -> Expr -> [String]
   sem dumpTypes acc =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let acc = snoc acc (join [nameGetStr t.ident, " : ", type2str t.tyBody]) in
     let acc = sfold_Expr_Expr dumpTypes acc t.body in
     sfold_Expr_Expr dumpTypes acc t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let acc = foldl
 
       (lam acc. lam b. snoc acc (join [nameGetStr b.ident, " : ", type2str b.tyBody]))

--- a/src/stdlib/extrec/monomorphise.mc
+++ b/src/stdlib/extrec/monomorphise.mc
@@ -38,13 +38,13 @@ lang ExtRecMonomorphise = MLangAst + MExprAst + ExtRecAst
       labelToType
     in
 
-    TmType {ident = t.ident,
+    TmDecl {decl = DeclType {ident = t.ident,
              -- params = cons mapParamIdent t.params,
             params = t.params,
             tyIdent = TyRecord {info = NoInfo (), fields = fields},
             inexpr = monomorphiseExpr env t.inexpr,
             ty = t.ty,
-            info = t.info}
+            info = t.info}}
   | TmRecField t -> monomorphiseExpr env t.inexpr
   | TmExtRecord t ->
     match mapLookup t.ident env.defs with Some labelToType in
@@ -88,18 +88,18 @@ lang ExtRecMonomorphise = MLangAst + MExprAst + ExtRecAst
 
 
   sem removeExtRecTypes_Expr env =
-  | TmType t ->
+  | TmDecl {decl = DeclType t} ->
     -- We need to remove the first parameter from TmTypes representing
     -- open sum types or payloads. Type aliases should remain unaffected.
     if or (setMem t.ident env.sumTypeNames) (setMem t.ident env.payloadNames) then
-      TmType {t with params = tail t.params,
+      TmDecl {decl = DeclType {t with params = tail t.params,
                     tyIdent = removeExtRecTypes_Type env t.tyIdent,
                     ty = removeExtRecTypes_Type env t.ty,
-                    inexpr = removeExtRecTypes_Expr env t.inexpr}
+                    inexpr = removeExtRecTypes_Expr env t.inexpr}}
     else
-      TmType {t with tyIdent = removeExtRecTypes_Type env t.tyIdent,
+      TmDecl {decl = DeclType {t with tyIdent = removeExtRecTypes_Type env t.tyIdent,
                      ty = removeExtRecTypes_Type env t.ty,
-                     inexpr = removeExtRecTypes_Expr env t.inexpr}
+                     inexpr = removeExtRecTypes_Expr env t.inexpr}}
   | expr ->
     let expr = smap_Expr_Type (removeExtRecTypes_Type env) expr in
     let expr = smap_Expr_TypeLabel (removeExtRecTypes_Type env) expr in

--- a/src/stdlib/extrec/monomorphise.mc
+++ b/src/stdlib/extrec/monomorphise.mc
@@ -23,7 +23,7 @@ lang ExtRecMonomorphise = MLangAst + MExprAst + ExtRecAst
 
   sem monomorphiseExpr : ExtRecEnvType -> Expr -> Expr
   sem monomorphiseExpr env =
-  | TmRecType t ->
+  | TmDecl (x & {decl = DeclRecType t}) ->
     match mapLookup t.ident env.defs with Some labelToType in
 
     let fields = mapFoldWithKey
@@ -37,15 +37,16 @@ lang ExtRecMonomorphise = MLangAst + MExprAst + ExtRecAst
       (mapEmpty cmpSID)
       labelToType
     in
-
-    TmDecl {decl = DeclType {ident = t.ident,
-             -- params = cons mapParamIdent t.params,
-            params = t.params,
-            tyIdent = TyRecord {info = NoInfo (), fields = fields},
-            inexpr = monomorphiseExpr env t.inexpr,
-            ty = t.ty,
-            info = t.info}}
-  | TmRecField t -> monomorphiseExpr env t.inexpr
+    TmDecl
+    { x with decl = DeclType
+      { tyIdent = TyRecord {info = NoInfo (), fields = fields}
+      , ident = t.ident
+      , params = t.params
+      , info = t.info
+      }
+    , inexpr = monomorphiseExpr env x.inexpr
+    }
+  | TmDecl (x & {decl = DeclRecField _}) -> monomorphiseExpr env x.inexpr
   | TmExtRecord t ->
     match mapLookup t.ident env.defs with Some labelToType in
 
@@ -88,18 +89,18 @@ lang ExtRecMonomorphise = MLangAst + MExprAst + ExtRecAst
 
 
   sem removeExtRecTypes_Expr env =
-  | TmDecl {decl = DeclType t} ->
+  | TmDecl (x & {decl = DeclType t}) ->
     -- We need to remove the first parameter from TmTypes representing
     -- open sum types or payloads. Type aliases should remain unaffected.
     if or (setMem t.ident env.sumTypeNames) (setMem t.ident env.payloadNames) then
-      TmDecl {decl = DeclType {t with params = tail t.params,
-                    tyIdent = removeExtRecTypes_Type env t.tyIdent,
-                    ty = removeExtRecTypes_Type env t.ty,
-                    inexpr = removeExtRecTypes_Expr env t.inexpr}}
+      TmDecl {x with decl = DeclType {t with params = tail t.params,
+                    tyIdent = removeExtRecTypes_Type env t.tyIdent},
+                    ty = removeExtRecTypes_Type env x.ty,
+                    inexpr = removeExtRecTypes_Expr env x.inexpr}
     else
-      TmDecl {decl = DeclType {t with tyIdent = removeExtRecTypes_Type env t.tyIdent,
-                     ty = removeExtRecTypes_Type env t.ty,
-                     inexpr = removeExtRecTypes_Expr env t.inexpr}}
+      TmDecl {x with decl = DeclType {t with tyIdent = removeExtRecTypes_Type env t.tyIdent},
+                     ty = removeExtRecTypes_Type env x.ty,
+                     inexpr = removeExtRecTypes_Expr env x.inexpr}
   | expr ->
     let expr = smap_Expr_Type (removeExtRecTypes_Type env) expr in
     let expr = smap_Expr_TypeLabel (removeExtRecTypes_Type env) expr in

--- a/src/stdlib/extrec/pprint.mc
+++ b/src/stdlib/extrec/pprint.mc
@@ -8,35 +8,19 @@ include "ast-builder.mc"
 
 lang ExtRecTermPrettyPrint = TypePrettyPrint + PrettyPrint + ExtRecordAst
   sem isAtomic =
-  | TmRecField _ | TmRecType _ -> false
   | TmExtRecord  _ -> true
   | TmExtExtend _ | TmExtExtend _ -> false
 
+  sem pprintDeclCode indent env =
+  | DeclRecType t ->
+    match pprintTypeName env t.ident with (env, name) in
+    match mapAccumL pprintEnvGetStr env t.params with (env, paramsStr) in
+    (env, join ["rectype ", name, " ", strJoin " " paramsStr])
+  | DeclRecField t ->
+    let ty =  typeToString env t.tyIdent in
+    (env, join ["recfield ", t.label, " : ", ty])
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmRecType t ->
-    match pprintTypeName env t.ident with (env, name) in
-    match pprintCode indent env t.inexpr with (env, inexpr) in
-    match mapAccumL pprintEnvGetStr env t.params with (env, paramsStr) in
-    (env, join [
-      "rectype ",
-      name,
-      " ",
-      strJoin " " paramsStr,
-      " in", pprintNewline indent,
-      inexpr])
-  | TmRecField t ->
-    let ty =  typeToString env t.tyIdent in
-    match pprintCode indent env t.inexpr with (env, inexpr) in
-    (env, join [
-      "recfield ",
-      t.label,
-      " : ",
-      ty,
-      " in ",
-      pprintNewline indent,
-      inexpr
-    ])
   | TmExtRecord {bindings = bindings, ident = ident} ->
     let innerIndent = pprintIncr (pprintIncr indent) in
       match

--- a/src/stdlib/extrec/symbolize.mc
+++ b/src/stdlib/extrec/symbolize.mc
@@ -9,20 +9,19 @@ include "name.mc"
 include "option.mc"
 
 lang ExtRecordSym = Sym + ExtRecordAst
-  sem symbolizeExpr env =
-  | TmRecType t ->
+  sem symbolizeDecl env =
+  | DeclRecType t ->
     match setSymbol env.currentEnv.tyConEnv t.ident with (tyConEnv, ident) in
-    let env = symbolizeUpdateTyConEnv env tyConEnv in
+    let params = (mapAccumL setSymbol env.currentEnv.tyVarEnv t.params).1 in
+    ( symbolizeUpdateTyConEnv env tyConEnv
+    , DeclRecType {t with ident = ident, params = params}
+    )
+  | DeclRecField t ->
+    ( env
+    , DeclRecField {t with tyIdent = symbolizeType env t.tyIdent}
+    )
 
-    let params = map (setSymbol env.currentEnv.tyVarEnv) t.params in
-    let params = map snd params in
-
-    TmRecType {t with ident = ident,
-                      params = params,
-                      inexpr = symbolizeExpr env t.inexpr}
-  | TmRecField t ->
-    TmRecField {t with inexpr = symbolizeExpr env t.inexpr,
-                       tyIdent = symbolizeType env t.tyIdent}
+  sem symbolizeExpr env =
   | TmExtRecord t ->
     let ident = getSymbol {kind = "type constructor",
                            info = [t.info],
@@ -278,15 +277,15 @@ lang ExtRecSym = ExtRecordSym + QualifiedNameSym + RecordCopatSym +
 end
 
 lang ExtRecTestLang = TestLangWithoutLang + ExtRecSym
+  sem isFullySymbolizedDecl =
+  | DeclRecType t ->
+    _and
+      (lam. nameHasSym t.ident)
+      (lam. forAll nameHasSym t.params)
+  | DeclRecField t ->
+    isFullySymbolizedType t.tyIdent
+
   sem isFullySymbolizedExpr =
-  | TmRecType t ->
-    foldl _and (lam. true) [
-      lam. nameHasSym t.ident,
-      lam. forAll nameHasSym t.params,
-      isFullySymbolizedExpr t.inexpr
-    ]
-  | TmRecField t ->
-    _and (isFullySymbolizedExpr t.inexpr) (isFullySymbolizedType t.tyIdent)
   | TmExtRecord t ->
     foldl _and (lam. true) [
       lam. nameHasSym t.ident,

--- a/src/stdlib/extrec/type-check.mc
+++ b/src/stdlib/extrec/type-check.mc
@@ -130,27 +130,20 @@ lang ExtRecordTypeCheck = TypeCheck + ExtRecordAst +
     match mapLookup label innerMap with Some deps in
     deps
 
-  sem typeCheckExpr env =
-  | TmRecField t ->
+  sem typeCheckDecl env =
+  | DeclRecField t ->
     let newLvl = addi 1 env.currentLvl in
     let tyIdent = tyunknown_ in
     let conEnv = mapInsert (nameNoSym t.label) (newLvl, tyIdent) env.conEnv in
-    let env = {env with conEnv = conEnv,
-                        currentLvl = newLvl} in
-
-    let inexpr = typeCheckExpr env t.inexpr in
-    TmRecField {t with inexpr = inexpr, ty = tyTm inexpr}
-  | TmRecType t ->
+    let env = {env with conEnv = conEnv, currentLvl = newLvl} in
+    (env, DeclRecField t)
+  | DeclRecType t ->
     let newLvl = addi 1 env.currentLvl in
     let newTyConEnv = mapInsert t.ident (newLvl, t.params, tyvariant_ []) env.tyConEnv in
-    let env = {env with tyConEnv = newTyConEnv} in
-    let inexpr =
-      typeCheckExpr {env with currentLvl = newLvl,
-                              tyConEnv = newTyConEnv,
-                              reptypes = env.reptypes} t.inexpr in
-    unify env [t.info, infoTm inexpr] (newpolyvar env.currentLvl t.info) (tyTm inexpr);
-    TmRecType {t with inexpr = inexpr,
-                      ty =  tyTm inexpr}
+    let env = {env with tyConEnv = newTyConEnv, currentLvl = newLvl} in
+    (env, DeclRecType t)
+
+  sem typeCheckExpr env =
   | TmExtRecord t ->
     let labelToType = match mapLookup t.ident env.extRecordType.defs
                       with Some l then l

--- a/src/stdlib/futhark/generate.mc
+++ b/src/stdlib/futhark/generate.mc
@@ -392,13 +392,13 @@ lang FutharkExprGenerate = FutharkConstGenerate + FutharkTypeGenerate +
   | TmLam t ->
     FELam {ident = t.ident, body = generateExpr env t.body,
            ty = generateType env t.ty, info = t.info}
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let boundNames = mapInsert t.ident t.body env.boundNames in
     let inexprEnv = {env with boundNames = boundNames} in
     FELet {ident = t.ident, tyBody = generateType env t.tyBody,
            body = generateExpr env t.body,
-           inexpr = generateExpr inexprEnv t.inexpr,
-           ty = generateType env t.ty, info = t.info}
+           inexpr = generateExpr inexprEnv x.inexpr,
+           ty = generateType env x.ty, info = t.info}
   | TmFlatten t ->
     withTypeFutTm
       (generateType env t.ty)
@@ -474,9 +474,9 @@ lang FutharkToplevelGenerate = FutharkExprGenerate + FutharkConstGenerate +
 
   sem generateToplevel : FutharkGenerateEnv -> Expr -> [FutDecl]
   sem generateToplevel env =
-  | TmDecl {decl = DeclType t} ->
-    generateToplevel env t.inexpr
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl {decl = DeclType _, inexpr = inexpr} ->
+    generateToplevel env inexpr
+  | TmDecl (x & {decl = DeclLet t}) ->
     recursive let findReturnType = lam params. lam ty.
       if null params then ty
       else
@@ -505,12 +505,12 @@ lang FutharkToplevelGenerate = FutharkExprGenerate + FutharkConstGenerate +
                   params = params, ret = retTy,
                   body = stripLambdas body, info = t.info}
     in
-    cons decl (generateToplevel env t.inexpr)
+    cons decl (generateToplevel env x.inexpr)
   | TmDecl {decl = DeclRecLets t} ->
     errorSingle [t.info] "Recursive functions are not supported by the Futhark backend"
-  | TmDecl {decl = DeclExt t} ->
+  | TmDecl (x & {decl = DeclExt t}) ->
     match mapLookup (nameGetStr t.ident) extMap with Some str then
-      generateToplevel env t.inexpr
+      generateToplevel env x.inexpr
     else
       errorSingle [t.info] "External functions are not supported by the Futhark backend"
   | TmDecl {decl = DeclUtest t} ->
@@ -539,7 +539,7 @@ end
 mexpr
 
 use TestLang in
-use FutharkPrettyPrint in 
+use FutharkPrettyPrint in
 
 let f = nameSym "f" in
 let c = nameSym "c" in
@@ -547,8 +547,8 @@ let chars = typeCheck (bindall_ [
   nlet_ f (tyarrows_ [tychar_, tybool_]) (nlam_ c tychar_ (
     match_ (nvar_ c) (pchar_ 'a')
       true_
-      false_)),
-  app_ (nvar_ f) (char_ 'x')]) in
+      false_))]
+  (app_ (nvar_ f) (char_ 'x'))) in
 
 let charsExpected = FProg {decls = [
   FDeclFun {
@@ -603,8 +603,8 @@ let t = typeCheck (bindall_ [
                if_ (geqi_ (nvar_ a3) (nvar_ b3)) (nvar_ b3) (nvar_ a3)))),
   nlet_ map (tyarrows_ [tyarrow_ tyint_ tyint_, ntycon_ intseq, ntycon_ intseq])
              (nlam_ f3 (tyarrow_ tyint_ tyint_) (nlam_ s (ntycon_ intseq)
-               (map_ (nvar_ f3) (nvar_ s)))),
-  unit_]) in
+               (map_ (nvar_ f3) (nvar_ s))))]
+  unit_) in
 
 let intSeqType = lam n. FTyArray {
   elem = FTyInt {info = NoInfo (), sz = I64 ()}, dim = Some (NamedDim n), info = NoInfo ()
@@ -659,12 +659,12 @@ let x = nameSym "x" in
 let y = nameSym "y" in
 let n = nameSym "n" in
 let foldlToFor = typeCheck
-  (nlet_ f (tyarrows_ [tyseq_ tyint_, tyint_]) (
+  (bind_ (nlet_ f (tyarrows_ [tyseq_ tyint_, tyint_]) (
     nlam_ s (tyseq_ tyint_) (
       foldl_
         (nlam_ acc tyint_ (nlam_ y tyint_ (
           addi_ (nvar_ acc) (nvar_ y))))
-        (int_ 0) (nvar_ s)))) in
+        (int_ 0) (nvar_ s)))) unit_) in
 let expected = FProg {decls = [
   FDeclFun {
     ident = f, entry = true, typeParams = [FPSize {val = n}],
@@ -679,9 +679,9 @@ utest printFutProg (generateProgram entryPoints foldlToFor)
 with printFutProg expected using eqSeq eqc in
 
 let negation = typeCheck
-  (nlet_ f (tyarrows_ [tyint_, tyfloat_, tyrecord_ [("a", tyint_), ("b", tyfloat_)]])
+  (bind_ (nlet_ f (tyarrows_ [tyint_, tyfloat_, tyrecord_ [("a", tyint_), ("b", tyfloat_)]])
     (nlam_ a tyint_ (nlam_ b tyfloat_ (
-      urecord_ [("a", negi_ (nvar_ a)), ("b", negf_ (nvar_ b))])))) in
+      urecord_ [("a", negi_ (nvar_ a)), ("b", negf_ (nvar_ b))])))) unit_) in
 let expected = FProg {decls = [
   FDeclFun {
     ident = f, entry = false, typeParams = [],
@@ -698,11 +698,11 @@ with printFutProg expected using eqSeq eqc in
 let recordTy = tyrecord_ [("a", tyint_), ("b", tyfloat_)] in
 let recordPat = prec_ [("a", npvar_ a), ("b", npvar_ b)] in
 let recordMatchNotProj = typeCheck
-  (nlet_ f (tyarrows_ [recordTy, tyint_])
+  (bind_ (nlet_ f (tyarrows_ [recordTy, tyint_])
     (nlam_ x recordTy
       (match_ (nvar_ x) recordPat
         (nvar_ a)
-        never_))) in
+        never_))) unit_) in
 let expected = FProg {decls = [
   FDeclFun {
     ident = f, entry = false, typeParams = [],
@@ -721,7 +721,7 @@ let sinId = nameSym "sin" in
 let x = nameSym "x" in
 let extDefn = typeCheck (bindall_ [
   next_ extSinId false (tyarrow_ tyfloat_ tyfloat_),
-  nulet_ sinId (nlam_ x tyfloat_ (app_ (nvar_ extSinId) (nvar_ x)))]) in
+  nulet_ sinId (nlam_ x tyfloat_ (app_ (nvar_ extSinId) (nvar_ x)))] unit_) in
 let expected = FProg {decls = [
   FDeclFun {
     ident = sinId, entry = false, typeParams = [],

--- a/src/stdlib/futhark/generate.mc
+++ b/src/stdlib/futhark/generate.mc
@@ -392,7 +392,7 @@ lang FutharkExprGenerate = FutharkConstGenerate + FutharkTypeGenerate +
   | TmLam t ->
     FELam {ident = t.ident, body = generateExpr env t.body,
            ty = generateType env t.ty, info = t.info}
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let boundNames = mapInsert t.ident t.body env.boundNames in
     let inexprEnv = {env with boundNames = boundNames} in
     FELet {ident = t.ident, tyBody = generateType env t.tyBody,
@@ -426,7 +426,7 @@ lang FutharkExprGenerate = FutharkConstGenerate + FutharkTypeGenerate +
   | TmParallelSizeEquality t ->
     FESizeEquality {x1 = t.x1, d1 = t.d1, x2 = t.x2, d2 = t.d2,
                     ty = generateType env t.ty, info = t.info}
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     errorSingle [t.info] "Recursive functions are not supported by the Futhark backend"
   | t ->
     errorSingle [infoTm t] "Term is not supported by the Futhark backend"
@@ -474,9 +474,9 @@ lang FutharkToplevelGenerate = FutharkExprGenerate + FutharkConstGenerate +
 
   sem generateToplevel : FutharkGenerateEnv -> Expr -> [FutDecl]
   sem generateToplevel env =
-  | TmType t ->
+  | TmDecl {decl = DeclType t} ->
     generateToplevel env t.inexpr
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     recursive let findReturnType = lam params. lam ty.
       if null params then ty
       else
@@ -506,18 +506,18 @@ lang FutharkToplevelGenerate = FutharkExprGenerate + FutharkConstGenerate +
                   body = stripLambdas body, info = t.info}
     in
     cons decl (generateToplevel env t.inexpr)
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     errorSingle [t.info] "Recursive functions are not supported by the Futhark backend"
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     match mapLookup (nameGetStr t.ident) extMap with Some str then
       generateToplevel env t.inexpr
     else
       errorSingle [t.info] "External functions are not supported by the Futhark backend"
-  | TmUtest t ->
+  | TmDecl {decl = DeclUtest t} ->
     -- NOTE(larshum, 2021-11-25): This case should never be reached, as utests
     -- are removed/replaced in earlier stages of the compilation.
     errorSingle [t.info] "Utests are not supported by the Futhark backend"
-  | TmConDef t ->
+  | TmDecl {decl = DeclConDef t} ->
     errorSingle [t.info] "Constructor definitions are not supported by the Futhark backend"
   | _ -> []
 end

--- a/src/stdlib/futhark/well-formed.mc
+++ b/src/stdlib/futhark/well-formed.mc
@@ -63,11 +63,11 @@ lang FutharkWellFormed = WellFormed + PMExprAst
       else wellFormedApp fun args
     else wellFormedApp fun args
   | TmLam t -> futharkWellFormedExpr acc t.body
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let acc = futharkWellFormedExpr acc t.body in
     futharkWellFormedExpr acc t.inexpr
-  | TmRecLets t ->
-    let acc = cons (FutharkRecLet (TmRecLets t)) acc in
+  | TmDecl {decl = DeclRecLets t} ->
+    let acc = cons (FutharkRecLet (TmDecl {decl = DeclRecLets t})) acc in
     futharkWellFormedExpr acc t.inexpr
   | TmConst t ->
     if isFutharkSupportedConstant t.val then acc
@@ -88,8 +88,8 @@ lang FutharkWellFormed = WellFormed + PMExprAst
     let acc = futharkWellFormedExpr acc t.rec in
     futharkWellFormedExpr acc t.value
   | TmSeq {tms = tms} -> foldl futharkWellFormedExpr acc tms
-  | TmExt t -> futharkWellFormedExpr acc t.inexpr
-  | TmType t ->
+  | TmDecl {decl = DeclExt t} -> futharkWellFormedExpr acc t.inexpr
+  | TmDecl {decl = DeclType t} ->
     let acc = futharkWellFormedType acc t.tyIdent in
     futharkWellFormedExpr acc t.inexpr
   | TmFlatten t -> futharkWellFormedExpr acc t.e

--- a/src/stdlib/futhark/well-formed.mc
+++ b/src/stdlib/futhark/well-formed.mc
@@ -63,12 +63,12 @@ lang FutharkWellFormed = WellFormed + PMExprAst
       else wellFormedApp fun args
     else wellFormedApp fun args
   | TmLam t -> futharkWellFormedExpr acc t.body
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let acc = futharkWellFormedExpr acc t.body in
-    futharkWellFormedExpr acc t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
-    let acc = cons (FutharkRecLet (TmDecl {decl = DeclRecLets t})) acc in
-    futharkWellFormedExpr acc t.inexpr
+    futharkWellFormedExpr acc x.inexpr
+  | TmDecl (x & {decl = DeclRecLets t}) ->
+    let acc = cons (FutharkRecLet (TmDecl x)) acc in
+    futharkWellFormedExpr acc x.inexpr
   | TmConst t ->
     if isFutharkSupportedConstant t.val then acc
     else cons (FutharkConstantError t.info) acc
@@ -88,10 +88,10 @@ lang FutharkWellFormed = WellFormed + PMExprAst
     let acc = futharkWellFormedExpr acc t.rec in
     futharkWellFormedExpr acc t.value
   | TmSeq {tms = tms} -> foldl futharkWellFormedExpr acc tms
-  | TmDecl {decl = DeclExt t} -> futharkWellFormedExpr acc t.inexpr
-  | TmDecl {decl = DeclType t} ->
+  | TmDecl (x & {decl = DeclExt t}) -> futharkWellFormedExpr acc x.inexpr
+  | TmDecl (x & {decl = DeclType t}) ->
     let acc = futharkWellFormedType acc t.tyIdent in
-    futharkWellFormedExpr acc t.inexpr
+    futharkWellFormedExpr acc x.inexpr
   | TmFlatten t -> futharkWellFormedExpr acc t.e
   | TmMap2 t ->
     let acc = futharkWellFormedExpr acc t.f in
@@ -214,8 +214,8 @@ using eqSeq eqFutError in
 let funType = tyarrow_ tyint_ tyint_ in
 let foldExpr = foldl_ (var_ "f") (lam_ "x" tyint_ (var_ "x")) (seq_ []) in
 let expr = bindall_ [
-  ulet_ "f" (lam_ "x" funType (lam_ "y" funType (var_ "y"))),
-  foldExpr] in
+  ulet_ "f" (lam_ "x" funType (lam_ "y" funType (var_ "y")))]
+  foldExpr in
 utest checkWellFormedExpr expr with [FutharkFunctionFromFold foldExpr]
 using eqSeq eqFutError in
 

--- a/src/stdlib/javascript/compile.mc
+++ b/src/stdlib/javascript/compile.mc
@@ -321,7 +321,7 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
 
   | TmRecLets { bindings = bindings, inexpr = e, ty = ty } ->
     match compileMExpr ctx e with (ctx, e) in
-    match foldl (lam acc: (CompileJSContext, [JSExpr]). lam bind : RecLetBinding.
+    match foldl (lam acc: (CompileJSContext, [JSExpr]). lam bind : DeclLetRecord.
       match acc with (ctx, es) in
       match bind with { ident = ident, body = body, info = info } in
       match body with TmLam _ then

--- a/src/stdlib/javascript/compile.mc
+++ b/src/stdlib/javascript/compile.mc
@@ -297,7 +297,7 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
   -- STATEMENTS --
   ----------------
 
-  | TmDecl {decl = DeclLet { ident = ident, body = body, inexpr = e, info = info }} ->
+  | TmDecl {decl = DeclLet { ident = ident, body = body, info = info }, inexpr = e} ->
     match nameGetStr ident with [] then
       match compileMExpr ctx body with (ctx1, body) in
       match compileMExpr ctx e with (ctx2, e) in
@@ -319,7 +319,7 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
           ret = e})} in
       (ctx, bindingExpr)
 
-  | TmDecl {decl = DeclRecLets { bindings = bindings, inexpr = e, ty = ty }} ->
+  | TmDecl {decl = DeclRecLets { bindings = bindings }, inexpr = e, ty = ty} ->
     match compileMExpr ctx e with (ctx, e) in
     match foldl (lam acc: (CompileJSContext, [JSExpr]). lam bind : DeclLetRecord.
       match acc with (ctx, es) in
@@ -339,8 +339,8 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
       ret = e
     }))
 
-  | TmDecl {decl = DeclType { inexpr = e }} -> compileMExpr ctx e -- Ignore
-  | TmDecl {decl = DeclConDef { ident = ident, inexpr = e }} ->
+  | TmDecl {decl = DeclType _, inexpr = e} -> compileMExpr ctx e -- Ignore
+  | TmDecl {decl = DeclConDef { ident = ident }, inexpr = e} ->
     let valueParam = nameSym "v" in
     match compileMExpr ctx e with (ctx, e) in
     match compileDeclarations ctx with (ctx, decs) in

--- a/src/stdlib/javascript/compile.mc
+++ b/src/stdlib/javascript/compile.mc
@@ -297,7 +297,7 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
   -- STATEMENTS --
   ----------------
 
-  | TmLet { ident = ident, body = body, inexpr = e, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = body, inexpr = e, info = info }} ->
     match nameGetStr ident with [] then
       match compileMExpr ctx body with (ctx1, body) in
       match compileMExpr ctx e with (ctx2, e) in
@@ -319,7 +319,7 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
           ret = e})} in
       (ctx, bindingExpr)
 
-  | TmRecLets { bindings = bindings, inexpr = e, ty = ty } ->
+  | TmDecl {decl = DeclRecLets { bindings = bindings, inexpr = e, ty = ty }} ->
     match compileMExpr ctx e with (ctx, e) in
     match foldl (lam acc: (CompileJSContext, [JSExpr]). lam bind : DeclLetRecord.
       match acc with (ctx, es) in
@@ -339,8 +339,8 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
       ret = e
     }))
 
-  | TmType { inexpr = e } -> compileMExpr ctx e -- Ignore
-  | TmConDef { ident = ident, inexpr = e } ->
+  | TmDecl {decl = DeclType { inexpr = e }} -> compileMExpr ctx e -- Ignore
+  | TmDecl {decl = DeclConDef { ident = ident, inexpr = e }} ->
     let valueParam = nameSym "v" in
     match compileMExpr ctx e with (ctx, e) in
     match compileDeclarations ctx with (ctx, decs) in
@@ -374,8 +374,8 @@ lang MExprJSCompile = JSProgAst + PatJSCompile + MExprAst + MExprPrettyPrint +
       thn = immediatelyInvokeBlock thn,
       els = immediatelyInvokeBlock els} in
     (ctx, if ctx.options.generalOptimizations then optimizeExpr3 expr else expr)
-  | TmUtest _ & t -> errorSingle [infoTm t] "Unit test expressions cannot be handled in compileMExpr"
-  | TmExt _ & t -> errorSingle [infoTm t] "External expressions cannot be handled in compileMExpr"
+  | TmDecl {decl = DeclUtest _} & t -> errorSingle [infoTm t] "Unit test expressions cannot be handled in compileMExpr"
+  | TmDecl {decl = DeclExt _} & t -> errorSingle [infoTm t] "External expressions cannot be handled in compileMExpr"
   | TmNever _ -> (ctx, intrinsicStrGen "never" [JSENop {}])
 
 

--- a/src/stdlib/javascript/util.mc
+++ b/src/stdlib/javascript/util.mc
@@ -70,7 +70,7 @@ recursive let extractRFR : use Ast in RecursiveFunctionRegistry -> Expr -> Recur
   use MExprAst in
   lam rfr : RecursiveFunctionRegistry. lam e.
   match e with TmRecLets t then
-    let rfr = foldl (lam rfr: RecursiveFunctionRegistry. lam b: RecLetBinding.
+    let rfr = foldl (lam rfr: RecursiveFunctionRegistry. lam b: DeclLetRecord.
       match b with { ident = ident, body = body } in
       match body with TmLam _ then (setRFR ident rfr) else rfr
     ) rfr t.bindings in

--- a/src/stdlib/javascript/util.mc
+++ b/src/stdlib/javascript/util.mc
@@ -69,7 +69,7 @@ let getRFR : Name -> RecursiveFunctionRegistry -> Option Name =
 recursive let extractRFR : use Ast in RecursiveFunctionRegistry -> Expr -> RecursiveFunctionRegistry =
   use MExprAst in
   lam rfr : RecursiveFunctionRegistry. lam e.
-  match e with TmRecLets t then
+  match e with TmDecl {decl = DeclRecLets t} then
     let rfr = foldl (lam rfr: RecursiveFunctionRegistry. lam b: DeclLetRecord.
       match b with { ident = ident, body = body } in
       match body with TmLam _ then (setRFR ident rfr) else rfr

--- a/src/stdlib/javascript/util.mc
+++ b/src/stdlib/javascript/util.mc
@@ -69,12 +69,12 @@ let getRFR : Name -> RecursiveFunctionRegistry -> Option Name =
 recursive let extractRFR : use Ast in RecursiveFunctionRegistry -> Expr -> RecursiveFunctionRegistry =
   use MExprAst in
   lam rfr : RecursiveFunctionRegistry. lam e.
-  match e with TmDecl {decl = DeclRecLets t} then
+  match e with TmDecl (x & {decl = DeclRecLets t}) then
     let rfr = foldl (lam rfr: RecursiveFunctionRegistry. lam b: DeclLetRecord.
       match b with { ident = ident, body = body } in
       match body with TmLam _ then (setRFR ident rfr) else rfr
     ) rfr t.bindings in
-    extractRFR rfr t.inexpr
+    extractRFR rfr x.inexpr
   else sfold_Expr_Expr extractRFR rfr e
 end
 

--- a/src/stdlib/jvm/compile.mc
+++ b/src/stdlib/jvm/compile.mc
@@ -12,7 +12,7 @@ lang MExprJVMCompile = MExprAst + JVMAst
 
     type JVMEnv = {
         bytecode : [Bytecode],
-        vars : Map Name Int, 
+        vars : Map Name Int,
         fieldVars : Map Name Field,
         localVars : Int, -- number of local vars on the JVM
         classes : [Class],
@@ -27,120 +27,120 @@ lang MExprJVMCompile = MExprAst + JVMAst
     sem toJSONExpr : JVMEnv -> Expr -> JVMEnv
     sem toJSONExpr env =
     | TmSeq { tms = tms } -> { env with bytecode = concat env.bytecode [ldcString_ (_charSeq2String tms)]} -- only for strings now
-    | TmConst { val = val } -> 
-        let bc = (match val with CInt { val = val } then 
+    | TmConst { val = val } ->
+        let bc = (match val with CInt { val = val } then
             concat [ldcLong_ val] wrapInteger_
         else match val with CFloat { val = val } then
-            concat [ldcFloat_ val] wrapFloat_ 
-        else match val with CBool { val = val } then 
+            concat [ldcFloat_ val] wrapFloat_
+        else match val with CBool { val = val } then
             match val with true then
                 concat [ldcInt_ 1] wrapBoolean_
-            else 
+            else
                 concat [ldcInt_ 0] wrapBoolean_
         else never)
         in { env with bytecode = concat env.bytecode bc }
     | TmApp { lhs = lhs, rhs = rhs, ty = ty } ->
-        let to = ty in 
+        let to = ty in
         let arg = toJSONExpr { env with bytecode = [], classes = [] } rhs in
-        match lhs with TmConst _ then 
+        match lhs with TmConst _ then
             match lhs with TmConst { val = CPrint _ } then
-                { env with 
-                    bytecode = foldl concat env.bytecode 
-                        [[getstatic_ "java/lang/System" "out" "Ljava/io/PrintStream;"], 
-                        arg.bytecode, 
+                { env with
+                    bytecode = foldl concat env.bytecode
+                        [[getstatic_ "java/lang/System" "out" "Ljava/io/PrintStream;"],
+                        arg.bytecode,
                         [invokevirtual_ "java/io/PrintStream" "print" "(Ljava/lang/String;)V"],
                         [ldcInt_ 1],
-                        wrapInteger_], -- change this to () later 
+                        wrapInteger_], -- change this to () later
                     classes = concat env.classes arg.classes }
-            else match lhs with TmConst { val = CAddi _ } then 
-                applyArithI_ "Addi" env arg.bytecode 
-            else match lhs with TmConst { val = CSubi _ } then 
+            else match lhs with TmConst { val = CAddi _ } then
+                applyArithI_ "Addi" env arg.bytecode
+            else match lhs with TmConst { val = CSubi _ } then
                 applyArithI_ "Subi" env arg.bytecode
-            else match lhs with TmConst { val = CMuli _ } then 
+            else match lhs with TmConst { val = CMuli _ } then
                 applyArithI_ "Muli" env arg.bytecode
-            else match lhs with TmConst { val = CDivi _ } then 
+            else match lhs with TmConst { val = CDivi _ } then
                 applyArithI_ "Divi" env arg.bytecode
-            else match lhs with TmConst { val = CModi _ } then 
+            else match lhs with TmConst { val = CModi _ } then
                 applyArithI_ "Modi" env arg.bytecode
-            else match lhs with TmConst { val = CAddf _ } then 
-                applyArithF_ "Addf" env arg.bytecode 
-            else match lhs with TmConst { val = CSubf _ } then 
+            else match lhs with TmConst { val = CAddf _ } then
+                applyArithF_ "Addf" env arg.bytecode
+            else match lhs with TmConst { val = CSubf _ } then
                 applyArithF_ "Subf" env arg.bytecode
-            else match lhs with TmConst { val = CMulf _ } then 
+            else match lhs with TmConst { val = CMulf _ } then
                 applyArithF_ "Mulf" env arg.bytecode
-            else match lhs with TmConst { val = CDivf _ } then 
+            else match lhs with TmConst { val = CDivf _ } then
                 applyArithF_ "Divf" env arg.bytecode
             else match lhs with TmConst { val = CEqi _ } then
                 applyArithI_ "Eqi" env arg.bytecode
             else match lhs with TmConst { val = CLti _ } then
                 applyArithI_ "Lti" env arg.bytecode
             else match lhs with TmConst { val = CNegf _ } then
-                { env with 
-                    bytecode = foldl concat env.bytecode 
+                { env with
+                    bytecode = foldl concat env.bytecode
                         [arg.bytecode,
                         unwrapFloat_,
                         [dneg_],
-                        wrapFloat_], 
+                        wrapFloat_],
                     classes = concat env.classes arg.classes }
             else match lhs with TmConst { val = CNegi _ } then
-                { env with 
-                    bytecode = foldl concat env.bytecode 
+                { env with
+                    bytecode = foldl concat env.bytecode
                         [arg.bytecode,
                         unwrapInteger_,
                         [lneg_],
-                        wrapInteger_], 
+                        wrapInteger_],
                     classes = concat env.classes arg.classes }
-            else 
+            else
                 (print "Unknown Const!\n");
                 env
         else
-            let fun = toJSONExpr env lhs in 
-            { fun with 
-                bytecode = foldl concat fun.bytecode 
-                    [arg.bytecode, 
+            let fun = toJSONExpr env lhs in
+            { fun with
+                bytecode = foldl concat fun.bytecode
+                    [arg.bytecode,
                     [checkcast_ object_T],
-                    [invokeinterface_ (concat pkg_ "Function") "apply" "(Ljava/lang/Object;)Ljava/lang/Object;"]], 
+                    [invokeinterface_ (concat pkg_ "Function") "apply" "(Ljava/lang/Object;)Ljava/lang/Object;"]],
                     classes = concat fun.classes arg.classes }
-    | TmDecl {decl = DeclLet { ident = ident, body = body, inexpr = inexpr, tyBody = tyBody }} -> 
+    | TmDecl {decl = DeclLet { ident = ident, body = body, tyBody = tyBody }, inexpr = inexpr} ->
         let b = toJSONExpr { env with fieldVars = mapEmpty nameCmp } body in
-        toJSONExpr { b with 
-                        bytecode = snoc b.bytecode (astore_ env.localVars), 
-                        fieldVars = mapEmpty nameCmp, 
-                        localVars = addi 1 env.localVars, 
+        toJSONExpr { b with
+                        bytecode = snoc b.bytecode (astore_ env.localVars),
+                        fieldVars = mapEmpty nameCmp,
+                        localVars = addi 1 env.localVars,
                         vars = mapInsert ident env.localVars env.vars } inexpr
     | TmLam { ident = ident, body = body } ->
         let className = env.nextClass in
         let newField = (createField (nameGetStr ident) object_LT) in
         let nextClass = createName_ "Func" in
-        let bodyEnv = toJSONExpr { env with bytecode = [], name = className, nextClass = nextClass, localVars = 2, vars = mapInsert ident 1 (mapEmpty nameCmp), fieldVars = mapInsert ident newField env.fieldVars } body in 
+        let bodyEnv = toJSONExpr { env with bytecode = [], name = className, nextClass = nextClass, localVars = 2, vars = mapInsert ident 1 (mapEmpty nameCmp), fieldVars = mapInsert ident newField env.fieldVars } body in
         let fields = map (lam x. x.1) (mapToSeq env.fieldVars) in
         match body with TmLam _ then
             let putfields = join (mapi (lam i. lam x. [aload_ 0, getfield_ (concat pkg_ className) (getNameField x) object_LT, putfield_ (concat pkg_ nextClass) (getNameField x) object_LT]) fields) in
             let dups = map (lam x. dup_) fields in
             let apply = apply_ (foldl concat bodyEnv.bytecode [dups, [dup_, aload_ 1, putfield_ (concat pkg_ nextClass) (nameGetStr ident) object_LT], putfields]) in
             let funcClass = createClass className (concat pkg_ "Function") (snoc fields newField) defaultConstructor [apply] in
-            { env with 
+            { env with
                 classes = snoc bodyEnv.classes funcClass,
                 bytecode = foldl concat env.bytecode [initClass_ className],
                 nextClass = bodyEnv.nextClass }
-        else 
+        else
             let apply = apply_ bodyEnv.bytecode in
             let funcClass = createClass className (concat pkg_ "Function") fields defaultConstructor [apply] in
-            { env with 
+            { env with
                 classes = snoc bodyEnv.classes funcClass,
                 bytecode = foldl concat env.bytecode [initClass_ className],
                 nextClass = bodyEnv.nextClass }
-    | TmVar { ident = ident } -> 
+    | TmVar { ident = ident } ->
         let store = (match mapLookup ident env.vars with Some i then
             [aload_ i]
-        else match mapLookup ident env.fieldVars with Some field then 
+        else match mapLookup ident env.fieldVars with Some field then
             -- do fieldlookup
             [aload_ 0, getfield_ (concat pkg_ env.name) (getNameField field) "Ljava/lang/Object;"]
         else
             (print (join ["No identifier! ", nameGetStr ident, "\n"]));
             []) in
         { env with bytecode = concat env.bytecode store }
-    | a -> 
+    | a ->
         (print "unknown expr\n");
         env
 
@@ -152,7 +152,7 @@ lang MExprJVMCompile = MExprAst + JVMAst
 
     sem toJSONConst : JVMEnv -> Const -> JVMEnv
     sem toJSONConst env =
-    | a -> 
+    | a ->
         (print "unknown const\n");
         env
 
@@ -160,17 +160,17 @@ end
 
 let compileJVMEnv = lam ast.
     use MExprJVMCompile in
-    let objToObj = createInterface "Function" [] [createFunction "apply" "(Ljava/lang/Object;)Ljava/lang/Object;" []] in 
+    let objToObj = createInterface "Function" [] [createFunction "apply" "(Ljava/lang/Object;)Ljava/lang/Object;" []] in
     let env = { bytecode = [], vars = mapEmpty nameCmp, localVars = 1, classes = [], fieldVars = mapEmpty nameCmp, name = "Main", nextClass = createName_ "Func" } in
     let compiledEnv = (toJSONExpr env ast) in
     let bytecode = concat compiledEnv.bytecode [pop_, return_] in
-    let mainFunc = createFunction "main" "([Ljava/lang/String;)V" bytecode in 
+    let mainFunc = createFunction "main" "([Ljava/lang/String;)V" bytecode in
     let constClasses = constClassList_ in
     let prog = createProg pkg_ (snoc (concat compiledEnv.classes constClasses) (createClass "Main" "" [] defaultConstructor [mainFunc])) [objToObj] in
     prog
 
 
-let compileMCoreToJVM = lam ast. 
+let compileMCoreToJVM = lam ast.
     use MExprJVMCompile in
     let jvmProgram = compileJVMEnv ast in
     (print (toStringProg jvmProgram));
@@ -201,10 +201,10 @@ let modifyMainClassForTest = lam prog.
     let modifiedMainFunc = createFunction f.name f.descriptor (concat bytecodes [astore_ 0, getstatic_ "java/lang/System" "out" "Ljava/io/PrintStream;", aload_ 0, invokevirtual_ "java/io/PrintStream" "print" "(Ljava/lang/Object;)V", return_]) in
     let modifiedMainClass = createClass m.name m.implements m.fields m.constructor [modifiedMainFunc] in
     createProg p.package (snoc (subsequence p.classes 0 (subi (length p.classes) 1)) modifiedMainClass) p.interfaces
-    
+
 
 let prepareForTests = lam path.
-    match sysCommandExists "java" with false then 
+    match sysCommandExists "java" with false then
         error "java needs to be installed\n"
         ()
     else
@@ -214,7 +214,7 @@ let prepareForTests = lam path.
             (sysRunCommand ["mkdir", (concat path "jar/")] "" ".");
             (sysRunCommand ["mkdir", (concat path "out/")] "" ".");
             ()
-        else 
+        else
             (sysRunCommand ["mkdir", path] "" ".");
             (sysRunCommand ["mkdir", (concat path "jar/")] "" ".");
             (sysRunCommand ["mkdir", (concat path "out/")] "" ".");
@@ -259,4 +259,3 @@ utest testJVM (mulf_ (float_ 2.2) (float_ (negf 1.0))) with "-2.2" in
 utest testJVM (negf_ (float_ 1.5)) with "-1.5" in
 
 sysDeleteDir jvmTmpPath
-

--- a/src/stdlib/jvm/compile.mc
+++ b/src/stdlib/jvm/compile.mc
@@ -101,7 +101,7 @@ lang MExprJVMCompile = MExprAst + JVMAst
                     [checkcast_ object_T],
                     [invokeinterface_ (concat pkg_ "Function") "apply" "(Ljava/lang/Object;)Ljava/lang/Object;"]], 
                     classes = concat fun.classes arg.classes }
-    | TmLet { ident = ident, body = body, inexpr = inexpr, tyBody = tyBody } -> 
+    | TmDecl {decl = DeclLet { ident = ident, body = body, inexpr = inexpr, tyBody = tyBody }} -> 
         let b = toJSONExpr { env with fieldVars = mapEmpty nameCmp } body in
         toJSONExpr { b with 
                         bytecode = snoc b.bytecode (astore_ env.localVars), 

--- a/src/stdlib/mexpr/anf.mc
+++ b/src/stdlib/mexpr/anf.mc
@@ -15,7 +15,7 @@ include "info.mc"
 include "error.mc"
 include "map.mc"
 
-lang ANF = LetAst + VarAst + UnknownTypeAst
+lang ANF = LetDeclAst + VarAst + UnknownTypeAst
 
   -- By default, everything is lifted (except variables)
   sem liftANF =
@@ -38,13 +38,18 @@ lang ANF = LetAst + VarAst + UnknownTypeAst
       frozen = false
     } in
     let inexpr = k var in
-    TmLet {ident = ident,
-           tyAnnot = TyUnknown {info = infoTm n},
-           tyBody = tyTm n,
-           body = n,
-           inexpr = inexpr,
-           ty = tyTm inexpr,
-           info = infoTm n }
+    TmDecl
+    { decl = DeclLet
+      { ident = ident
+      , tyAnnot = TyUnknown {info = infoTm n}
+      , tyBody = tyTm n
+      , body = n
+      , info = infoTm n
+      }
+    , inexpr = inexpr
+    , ty = tyTm inexpr
+    , info = infoTm n
+    }
 
   sem normalizeName (k : Expr -> Expr) =
   | m -> normalize (lam n. if (liftANF n) then bind k n else k n) m
@@ -139,40 +144,37 @@ lang RecordANF = ANF + RecordAst
 
 end
 
-lang LetANF = ANF + LetAst
+lang DeclANF = ANF + DeclAst
+  sem normalize k =
+  | TmDecl x ->
+    TmDecl {x with inexpr = normalizeName k x.inexpr}
+end
+
+lang LetANF = ANF + LetDeclAst
 
   sem normalize (k : Expr -> Expr) =
-  | TmLet t ->
+  | TmDecl (x & { decl = DeclLet t, inexpr = inexpr }) ->
     normalize
-      (lam n1. (TmLet {{t with body = n1}
-                          with inexpr = normalizeName k t.inexpr}))
+      (lam n1. TmDecl {x with decl = DeclLet {t with body = n1}, inexpr = normalizeName k inexpr})
       t.body
 
 end
 
-lang TypeANF = ANF + TypeAst
-
-  sem normalize (k : Expr -> Expr) =
-  | TmType t ->
-    TmType {t with inexpr = normalizeName k t.inexpr}
-end
-
-lang RecLetsANFBase = ANF + NormalizeLams + RecLetsAst + LamAst
+lang RecLetsANFBase = ANF + NormalizeLams + RecLetsDeclAst + LamAst
 
   sem normalize (k : Expr -> Expr) =
   -- We do not allow lifting things outside of reclets, since they might
   -- inductively depend on what is being defined.
-  | TmRecLets t ->
+  | TmDecl (x & { decl = DeclRecLets t, inexpr = inexpr }) ->
     let bindings = map (
-      lam b: RecLetBinding. { b with body =
+      lam b: DeclLetRecord. { b with body =
         match b.body with TmLam _ & t then normalizeLams t
         else errorSingle [infoTm b.body]
           "Error: Not a TmLam in TmRecLet binding in ANF transformation"
       }
     )
     t.bindings in
-    TmRecLets {{t with bindings = bindings}
-                  with inexpr = normalize k t.inexpr}
+    TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = normalize k inexpr}
 
 end
 
@@ -190,9 +192,6 @@ end
 lang DataANF = ANF + DataAst
 
   sem normalize (k : Expr -> Expr) =
-  | TmConDef t ->
-    TmConDef {t with inexpr = normalize k t.inexpr}
-
   | TmConApp t ->
     normalizeName
       (lam b. k (TmConApp {t with body = b})) t.body
@@ -211,22 +210,25 @@ lang MatchANF = ANF + MatchAst
 
 end
 
-lang UtestANF = ANF + UtestAst
+lang UtestANF = ANF + UtestDeclAst
 
   sem normalize (k : Expr -> Expr) =
-  | TmUtest t -> let tusing = optionMap normalizeTerm t.tusing in
+  | TmDecl (x & { decl = DeclUtest t, inexpr = inexpr }) ->
+    let tusing = optionMap normalizeTerm t.tusing in
     normalizeName
       (lam test.
          normalizeName
            (lam expected.
-             let inner = lam x.
-               match x with (tusing, tonfail) in
-               TmUtest {
-                 t with test = test,
-                 expected = expected,
-                 next = normalize k t.next,
-                 tusing = tusing,
-                 tonfail = tonfail
+             let inner = lam pair.
+               match pair with (tusing, tonfail) in
+               TmDecl
+               { x with inexpr = normalize k inexpr
+               , decl = DeclUtest
+                 { t with test = test
+                 , expected = expected
+                 , tusing = tusing
+                 , tonfail = tonfail
+                 }
                }
               in
              switch (t.tusing, t.tonfail)
@@ -263,10 +265,10 @@ lang NeverANF = ANF + NeverAst
 
 end
 
-lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst + FunArity
+lang ExtANF = ANF + ExtDeclAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst + FunArity
 
   sem normalize (k : Expr -> Expr) =
-  | TmExt ({inexpr = inexpr} & t) ->
+  | TmDecl (x & {decl = d & DeclExt t, inexpr = inexpr}) ->
     -- NOTE(dlunde,2022-06-14): Externals must always be fully applied
     -- (otherwise the parser throws an error). To make this compatible with
     -- ANF, we eta expand definitions of externals. In this way, the only
@@ -326,19 +328,30 @@ lang ExtANF = ANF + ExtAst + FunTypeAst + UnknownTypeAst + LamAst + AppAst + Fun
             body = acc, ty = TyArrow {from = ty, to = tyTm acc, info = t.info},
             info = t.info})
         inner varNameTypes in
-    TmExt { t with
-      inexpr = TmLet {
-        ident = t.ident, tyAnnot = TyUnknown {info = t.info},
-        tyBody = t.tyIdent, body = etaExpansion, inexpr = normalize k t.inexpr,
-        ty = tyTm t.inexpr, info = t.info} }
+    TmDecl
+    { x with decl = d
+    , inexpr = TmDecl
+      { decl = DeclLet
+        { ident = t.ident
+        , tyAnnot = TyUnknown {info = t.info}
+        , tyBody = t.tyIdent
+        , body = etaExpansion
+        , info = t.info
+        }
+      , inexpr = normalize k inexpr
+      , ty = tyTm inexpr
+      , info = x.info
+      }
+    }
 
 end
 
 -- The default ANF transformation for MExpr. Only lifts non-values, and does
 -- not lift individual terms in sequences of lambdas or applications.
 lang MExprANF =
-  VarANF + AppANF + LamANF + RecordANF + LetANF + TypeANF + RecLetsANF +
-  ConstANF + DataANF + MatchANF + UtestANF + SeqANF + NeverANF + ExtANF
+  VarANF + AppANF + LamANF + RecordANF + LetANF + RecLetsANF +
+  ConstANF + DataANF + MatchANF + UtestANF + SeqANF + NeverANF + ExtANF +
+  DeclANF
 
   sem liftANF =
   | TmLam _ -> false
@@ -352,8 +365,9 @@ end
 
 -- Full ANF transformation. Lifts everything.
 lang MExprANFAll =
-  VarANF + AppANFAll + LamANFAll + RecordANF + LetANF + TypeANF + RecLetsANFAll +
-  ConstANF + DataANF + MatchANF + UtestANF + SeqANF + NeverANF + ExtANF
+  VarANF + AppANFAll + LamANFAll + RecordANF + LetANF + RecLetsANFAll +
+  ConstANF + DataANF + MatchANF + UtestANF + SeqANF + NeverANF + ExtANF +
+  DeclANF
 end
 
 -----------

--- a/src/stdlib/mexpr/ast-builder.mc
+++ b/src/stdlib/mexpr/ast-builder.mc
@@ -355,30 +355,13 @@ let pnot_ = use MExprAst in
 -- Terms --
 -- Methods of binding an expression into a chain of lets/reclets/condefs --
 
-recursive let bindF_ = 
-  use MExprAst in
-  lam f : Expr -> Expr -> Expr. lam letexpr. lam expr.
-  match letexpr with TmLet t then
-    TmLet {t with inexpr = bindF_ f t.inexpr expr}
-  else match letexpr with TmRecLets t then
-    TmRecLets {t with inexpr = bindF_ f t.inexpr expr}
-  else match letexpr with TmConDef t then
-    TmConDef {t with inexpr = bindF_ f t.inexpr expr}
-  else match letexpr with TmType t then
-    TmType {t with inexpr = bindF_ f t.inexpr expr}
-  else match letexpr with TmExt t then
-    TmExt {t with inexpr = bindF_ f t.inexpr expr}
-  else match letexpr with TmUtest t then
-    TmUtest {t with next = bindF_ f t.next expr}
-  else
-    f letexpr expr -- Insert at the end of the chain
-end
+let bind_ : use Ast in Decl -> Expr -> Expr
+  = lam decl. lam expr. use DeclAst in
+    TmDecl { decl = decl, inexpr = expr, info = NoInfo (), ty = tyunknown_ }
 
-let bind_ = bindF_ (lam. lam expr. expr)
-
-let bindall_ = use MExprAst in
-  lam exprs.
-  foldr1 bind_ exprs
+let bindall_ : use Ast in [Decl] -> Expr -> Expr = use MExprAst in
+  lam decls. lam expr.
+  foldr bind_ expr decls
 
 let uunit_ = use MExprAst in
   TmRecord {bindings = mapEmpty cmpSID, ty = tyunknown_, info = NoInfo ()}
@@ -388,8 +371,7 @@ let unit_ = use MExprAst in
 
 let nlet_ = use MExprAst in
   lam n. lam ty. lam body.
-  TmLet {ident = n, tyAnnot = ty, tyBody = ty, body = body,
-  inexpr = uunit_, ty = tyunknown_, info = NoInfo ()}
+  DeclLet {ident = n, tyAnnot = ty, tyBody = ty, body = body, info = NoInfo ()}
 
 let let_ = use MExprAst in
   lam s. lam ty. lam body.
@@ -405,8 +387,7 @@ let ulet_ = use MExprAst in
 
 let next_ = use MExprAst in
   lam n. lam e. lam ty.
-  TmExt {ident = n, tyIdent = ty, effect = e, ty = tyunknown_,
-         inexpr = uunit_, info = NoInfo ()}
+  DeclExt {ident = n, tyIdent = ty, effect = e, info = NoInfo ()}
 
 let ext_ = use MExprAst in
   lam s. lam e. lam ty.
@@ -414,7 +395,7 @@ let ext_ = use MExprAst in
 
 let ntype_ = use MExprAst in
   lam n. lam params. lam ty.
-  TmType {ident = n, tyIdent = ty, params = params, ty = tyunknown_, inexpr = uunit_, info = NoInfo ()}
+  DeclType {ident = n, tyIdent = ty, params = params, info = NoInfo ()}
 
 let type_ = use MExprAst in
   lam s. lam params. lam ty.
@@ -430,8 +411,7 @@ let nreclets_ = use MExprAst in
     , info = NoInfo ()
     }
   in
-  TmRecLets {bindings = map bindingMapFunc bs,
-             inexpr = uunit_, ty = tyunknown_, info = NoInfo ()}
+  DeclRecLets {bindings = map bindingMapFunc bs, info = NoInfo ()}
 
 let reclets_ = use MExprAst in
   lam bs.
@@ -467,11 +447,11 @@ let reclets_empty = use MExprAst in
 
 let nreclets_add = use MExprAst in
   lam n. lam ty. lam body. lam reclets.
-  match reclets with TmRecLets t then
+  match reclets with DeclRecLets t then
     let newbind = {ident = n, tyAnnot = ty, tyBody = ty, body = body, info = NoInfo ()} in
-    TmRecLets {t with bindings = cons newbind t.bindings}
+    DeclRecLets {t with bindings = cons newbind t.bindings}
   else
-    errorSingle [infoTm reclets] "reclets is not a TmRecLets construct"
+    errorSingle [infoDecl reclets] "reclets is not a TmRecLets construct"
 
 let reclets_add = use MExprAst in
   lam s. lam ty. lam body. lam reclets.
@@ -487,8 +467,7 @@ let ureclets_add = use MExprAst in
 
 let ncondef_ = use MExprAst in
   lam n. lam ty.
-  TmConDef {ident = n, tyIdent = ty, ty = tyunknown_,
-            inexpr = uunit_, info = NoInfo ()}
+  DeclConDef {ident = n, tyIdent = ty, info = NoInfo ()}
 
 let condef_ = use MExprAst in
   lam s. lam ty.
@@ -663,7 +642,7 @@ let record2tuple
 let never_ = use MExprAst in
   TmNever {ty = tyunknown_, info = NoInfo ()}
 
-let inever_ = use MExprAst in 
+let inever_ = use MExprAst in
   lam i : Info. TmNever {ty = tyunknown_, info = i}
 
 -- Exhaustive match
@@ -751,50 +730,42 @@ let appf8_ = use MExprAst in
   app_ (appf7_ f a1 a2 a3 a4 a5 a6 a7) a8
 
 let utestu_ = use MExprAst in
-  lam t. lam e. lam n. lam u.
-    TmUtest {
+  lam t. lam e. lam u.
+    DeclUtest {
       test = t,
       expected = e,
-      next = n,
       tusing = Some u,
       tonfail = None (),
-      ty = tyunknown_,
       info = NoInfo ()
     }
 
 let utesto_ = use MExprAst in
-  lam t. lam e. lam n. lam o.
-    TmUtest {
+  lam t. lam e. lam o.
+    DeclUtest {
       test = t,
       expected = e,
-      next = n,
       tusing = None (),
       tonfail = Some o,
-      ty = tyunknown_,
       info = NoInfo ()
     }
 
 let utestuo_ = use MExprAst in
-  lam t. lam e. lam n. lam u. lam o.
-    TmUtest {
+  lam t. lam e. lam u. lam o.
+    DeclUtest {
       test = t,
       expected = e,
-      next = n,
       tusing = Some u,
       tonfail = Some o,
-      ty = tyunknown_,
       info = NoInfo ()
     }
 
 let utest_ = use MExprAst in
-  lam t. lam e. lam n.
-    TmUtest {
+  lam t. lam e.
+    DeclUtest {
       test = t,
       expected = e,
-      next = n,
       tusing = None (),
       tonfail = None (),
-      ty = tyunknown_,
       info = NoInfo ()
     }
 
@@ -1323,5 +1294,3 @@ let bootParserGetInfo_ = use MExprAst in
 
 -- Sequencing (;)
 let semi_ = lam expr1. lam expr2. bind_ (ulet_ "" expr1) expr2
-
-let bindSemi_ = bindF_ semi_

--- a/src/stdlib/mexpr/ast-builder.mc
+++ b/src/stdlib/mexpr/ast-builder.mc
@@ -1294,3 +1294,26 @@ let bootParserGetInfo_ = use MExprAst in
 
 -- Sequencing (;)
 let semi_ = lam expr1. lam expr2. bind_ (ulet_ "" expr1) expr2
+
+-- NOTE(vipa, 2025-05-27): This is here mostly to have a simple
+-- replacement for places that used `bind_` in a way that is
+-- incompatible with the new version (where the first argument must be
+-- a Decl). Note that this function is mildly unsafe in that it'll
+-- silently drop the innermost inexpr in the first argument,
+-- regardless of whether it has side-effects or not.
+recursive let oldBind_ : use Ast in Expr -> Expr -> Expr = use MExprAst in
+  lam l. lam r.
+  match l with TmDecl x
+  then TmDecl {x with inexpr = oldBind_ x.inexpr r}
+  else r
+end
+
+-- NOTE(vipa, 2025-05-28): This is also kept for a simple replacement,
+-- but is not unsafe; the left expression is kept and executed before
+-- the right.
+recursive let oldBindSemi_ : use Ast in Expr -> Expr -> Expr = use MExprAst in
+  lam l. lam r.
+  match l with TmDecl x
+  then TmDecl {x with inexpr = oldBindSemi_ x.inexpr r}
+  else semi_ l r
+end

--- a/src/stdlib/mexpr/ast-smap-sfold-tests.mc
+++ b/src/stdlib/mexpr/ast-smap-sfold-tests.mc
@@ -141,9 +141,9 @@ with match_ tmVarX punit_ tmVarX tmVarX using eqExpr in
 utest sfold_Expr_Expr fold2seq [] tmMatch with [tmVarZ, tmVarY, tmApp]
 using eqSeq eqExpr in
 
-let tmUtest = utest_ tmApp tmVarY tmVarZ in
+let tmUtest = bind_ (utest_ tmApp tmVarY) tmVarZ in
 
-utest smap_Expr_Expr map2varX tmUtest with utest_ tmVarX tmVarX tmVarX
+utest smap_Expr_Expr map2varX tmUtest with bind_ (utest_ tmVarX tmVarX) tmVarX
 using eqExpr in
 utest sfold_Expr_Expr fold2seq [] tmUtest with [tmVarZ, tmVarY, tmApp]
 using eqSeq eqExpr in
@@ -153,7 +153,7 @@ let tmnever = never_ in
 utest smap_Expr_Expr map2varX never_ with never_ using eqExpr in
 utest sfold_Expr_Expr fold2seq [] never_ with [] using eqSeq eqExpr in
 
-utest smap_Expr_Expr map2varX tmUtest with utest_ tmVarX tmVarX tmVarX
+utest smap_Expr_Expr map2varX tmUtest with bind_ (utest_ tmVarX tmVarX) tmVarX
 using eqExpr in
 utest sfold_Expr_Expr fold2seq [] tmUtest with [tmVarZ, tmVarY, tmApp]
 using eqSeq eqExpr in

--- a/src/stdlib/mexpr/ast.mc
+++ b/src/stdlib/mexpr/ast.mc
@@ -17,6 +17,9 @@ lang Ast
   syn Expr =
   -- Intentionally left blank
 
+  syn Decl =
+  -- Intentionally left blank
+
   syn Type =
   -- Intentionally left blank
 
@@ -36,10 +39,12 @@ lang Ast
   sem withInfoPat: Info -> Pat -> Pat
   sem withTypePat: Type -> Pat -> Pat
 
+  sem infoDecl: Decl -> Info
+  sem declWithInfo: Info -> Decl -> Decl
+
   sem infoTy: Type -> Info
   sem tyWithInfo: Info -> Type -> Type
 
-  -- TODO(vipa, 2021-05-27): Replace smap and sfold with smapAccumL for Expr and Type as well
   sem smapAccumL_Expr_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Expr -> (acc, Expr)
   sem smapAccumL_Expr_Expr f acc =
   | p -> (acc, p)
@@ -143,6 +148,56 @@ lang Ast
   | p ->
     match smapAccumL_Expr_Pat (lam acc. lam a. (f acc a, a)) acc p
     with (acc, _) in acc
+
+  sem smapAccumL_Decl_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Decl -> (acc, Decl)
+  sem smapAccumL_Decl_Expr f acc = | d -> (acc, d)
+
+  sem smap_Decl_Expr : (Expr -> Expr) -> Decl -> Decl
+  sem smap_Decl_Expr f = | d -> (smapAccumL_Decl_Expr (lam. lam a. ((), f a)) () d).1
+
+  sem sfold_Decl_Expr : all acc. (acc -> Expr -> acc) -> acc -> Decl -> acc
+  sem sfold_Decl_Expr f acc = | d -> (smapAccumL_Decl_Expr (lam acc. lam a. (f acc a, a)) acc d).0
+
+  sem smapAccumL_Decl_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Decl -> (acc, Decl)
+  sem smapAccumL_Decl_Type f acc = | d -> (acc, d)
+
+  sem smap_Decl_Type : (Type -> Type) -> Decl -> Decl
+  sem smap_Decl_Type f = | d -> (smapAccumL_Decl_Type (lam. lam a. ((), f a)) () d).1
+
+  sem sfold_Decl_Type : all acc. (acc -> Type -> acc) -> acc -> Decl -> acc
+  sem sfold_Decl_Type f acc = | d -> (smapAccumL_Decl_Type (lam acc. lam a. (f acc a, a)) acc d).0
+
+  sem smapAccumL_Decl_TypeLabel : all acc. (acc -> Type -> (acc, Type)) -> acc -> Decl -> (acc, Decl)
+  sem smapAccumL_Decl_TypeLabel f acc = | d -> (acc, d)
+
+  sem smap_Decl_TypeLabel : (Type -> Type) -> Decl -> Decl
+  sem smap_Decl_TypeLabel f =
+  | p ->
+    let res = smapAccumL_Decl_TypeLabel (lam. lam a. ((), f a)) () p in
+    res.1
+
+  sem sfold_Decl_TypeLabel : all acc. (acc -> Type -> acc) -> acc -> Decl -> acc
+  sem sfold_Decl_TypeLabel f acc =
+  | p ->
+    let res = smapAccumL_Decl_TypeLabel (lam acc. lam a. (f acc a, a)) acc p in
+    res.0
+
+  sem smapAccumL_Decl_Decl : all acc. (acc -> Decl -> (acc, Decl)) -> acc -> Decl -> (acc, Decl)
+  sem smapAccumL_Decl_Decl f acc = | d -> (acc, d)
+  sem smapAccumL_Decl_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Decl -> (acc, Decl)
+  sem smapAccumL_Decl_Pat f acc = | d -> (acc, d)
+
+  sem smap_Decl_Decl : (Decl -> Decl) -> Decl -> Decl
+  sem smap_Decl_Decl f = | d -> (smapAccumL_Decl_Decl (lam. lam a. ((), f a)) () d).1
+
+  sem sfold_Decl_Decl : all acc. (acc -> Decl -> acc) -> acc -> Decl -> acc
+  sem sfold_Decl_Decl f acc = | d -> (smapAccumL_Decl_Decl (lam acc. lam a. (f acc a, a)) acc d).0
+
+  sem smap_Decl_Pat : (Pat -> Pat) -> Decl -> Decl
+  sem smap_Decl_Pat f = | d -> (smapAccumL_Decl_Pat (lam. lam a. ((), f a)) () d).1
+
+  sem sfold_Decl_Pat : all acc. (acc -> Pat -> acc) -> acc -> Decl -> acc
+  sem sfold_Decl_Pat f acc = | d -> (smapAccumL_Decl_Pat (lam acc. lam a. (f acc a, a)) acc d).0
 
   sem smapAccumL_Type_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Type -> (acc, Type)
   sem smapAccumL_Type_Type f acc =
@@ -349,104 +404,113 @@ lang LamAst = Ast
     (acc, TmLam {t with body = body})
 end
 
-
--- TmLet --
-lang LetAst = Ast + VarAst
+-- TmDecl --
+lang DeclAst = Ast
   syn Expr =
-  | TmLet {ident : Name,
-           tyAnnot : Type,
-           tyBody : Type,
-           body : Expr,
-           inexpr : Expr,
-           ty : Type,
-           info : Info}
+  | TmDecl {decl : Decl, inexpr : Expr, info : Info, ty : Type}
 
-  sem infoTm =
-  | TmLet r -> r.info
-
-  sem tyTm =
-  | TmLet t -> t.ty
-
-  sem withInfo info =
-  | TmLet t -> TmLet {t with info = info}
-
-  sem withType (ty : Type) =
-  | TmLet t -> TmLet {t with ty = ty}
-
-  sem smapAccumL_Expr_Type f acc =
-  | TmLet t ->
-    match f acc t.tyAnnot with (acc, tyAnnot) in
-    (acc, TmLet {t with tyAnnot = tyAnnot})
-
-  sem smapAccumL_Expr_TypeLabel f acc =
-  | TmLet t ->
-    match f acc t.tyBody with (acc, tyBody) in
-    match f acc t.ty with (acc, ty) in
-    (acc, TmLet {t with tyBody = tyBody, ty = ty})
+  sem infoTm = | TmDecl x -> x.info
+  sem tyTm = | TmDecl x -> x.ty
+  sem withInfo info = | TmDecl x -> TmDecl {x with info = info}
+  sem withType ty = | TmDecl x -> TmDecl {x with ty = ty}
 
   sem smapAccumL_Expr_Expr f acc =
-  | TmLet t ->
-    match f acc t.body with (acc, body) in
-    match f acc t.inexpr with (acc, inexpr) in
-    (acc, TmLet {{t with body = body} with inexpr = inexpr})
-end
-
--- TmRecLets --
-lang RecLetsAst = Ast + VarAst
-  type RecLetBinding = {
-    ident : Name,
-    tyAnnot : Type,
-    tyBody : Type,
-    body : Expr,
-    info : Info }
-
-  syn Expr =
-  | TmRecLets {bindings : [RecLetBinding],
-               inexpr : Expr,
-               ty : Type,
-               info : Info}
-
-  sem infoTm =
-  | TmRecLets r -> r.info
-
-  sem tyTm =
-  | TmRecLets t -> t.ty
-
-  sem withInfo info =
-  | TmRecLets t -> TmRecLets {t with info = info}
-
-  sem withType (ty : Type) =
-  | TmRecLets t -> TmRecLets {t with ty = ty}
+  | TmDecl x ->
+    -- NOTE(vipa, 2025-05-07): We currently see a TmDecl as a
+    -- composite value that includes the Decl in itself, thus
+    -- smapAccumL looks "through" the decl as well
+    match smapAccumL_Decl_Expr f acc x.decl with (acc, decl) in
+    match f acc x.inexpr with (acc, inexpr) in
+    (acc, TmDecl {x with decl = decl, inexpr = inexpr})
 
   sem smapAccumL_Expr_Type f acc =
-  | TmRecLets t ->
-    let bindingFunc = lam acc. lam b: RecLetBinding.
+  | TmDecl x ->
+    -- NOTE(vipa, 2025-05-07): We currently see a TmDecl as a
+    -- composite value that includes the Decl in itself, thus
+    -- smapAccumL looks "through" the decl as well
+    match smapAccumL_Decl_Type f acc x.decl with (acc, decl) in
+    (acc, TmDecl {x with decl = decl})
+
+  sem smapAccumL_Expr_TypeLabel f acc =
+  | TmDecl x ->
+    match smapAccumL_Decl_TypeLabel f acc x.decl with (acc, decl) in
+    match f acc x.ty with (acc, ty) in
+    (acc, TmDecl {x with decl = decl, ty = ty})
+end
+
+-- DeclLetRecord --
+lang LetDeclAst = DeclAst
+  type DeclLetRecord =
+    { ident : Name
+    , tyAnnot : Type
+    , tyBody : Type
+    , body : Expr
+    , info: Info
+    }
+
+  syn Decl =
+  | DeclLet DeclLetRecord
+
+  sem infoDecl =
+  | DeclLet d -> d.info
+
+  sem declWithInfo info =
+  | DeclLet d -> DeclLet {d with info = info}
+
+  sem smapAccumL_Decl_Expr f acc =
+  | DeclLet x ->
+    match f acc x.body with (acc, body) in
+    (acc, DeclLet {x with body = body})
+
+  sem smapAccumL_Decl_Type f acc =
+  | DeclLet x ->
+    match f acc x.tyAnnot with (acc, tyAnnot) in
+    (acc, DeclLet {x with tyAnnot = tyAnnot})
+
+  sem smapAccumL_Decl_TypeLabel f acc =
+  | DeclLet x ->
+    match f acc x.tyBody with (acc, tyBody) in
+    (acc, DeclLet {x with tyBody = tyBody})
+end
+
+-- DeclRecLets --
+lang RecLetsDeclAst = DeclAst + LetDeclAst
+  syn Decl =
+  | DeclRecLets
+    { bindings : [DeclLetRecord]
+    , info : Info
+    }
+
+  sem infoDecl =
+  | DeclRecLets d -> d.info
+
+  sem declWithInfo info =
+  | DeclRecLets d -> DeclRecLets {d with info = info}
+
+  sem smapAccumL_Decl_Type f acc =
+  | DeclRecLets x ->
+    let fbinding = lam acc. lam b.
       match f acc b.tyAnnot with (acc, tyAnnot) in
       (acc, {b with tyAnnot = tyAnnot}) in
-    match mapAccumL bindingFunc acc t.bindings with (acc, bindings) in
-    (acc, TmRecLets {t with bindings = bindings})
+    match mapAccumL fbinding acc x.bindings with (acc, bindings) in
+    (acc, DeclRecLets {x with bindings = bindings})
 
-  sem smapAccumL_Expr_TypeLabel f acc =
-  | TmRecLets t ->
-    let bindingFunc = lam acc. lam b: RecLetBinding.
-      match f acc b.tyBody with (acc, tyBody) in
-      (acc, {b with tyBody = tyBody})
-    in
-    match mapAccumL bindingFunc acc t.bindings with (acc, bindings) in
-    match f acc t.ty with (acc, ty) in
-    (acc, TmRecLets {t with bindings = bindings, ty = ty})
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmRecLets t ->
-    let bindingFunc = lam acc. lam b: RecLetBinding.
+  sem smapAccumL_Decl_Expr f acc =
+  | DeclRecLets x ->
+    let fbinding = lam acc. lam b.
       match f acc b.body with (acc, body) in
-      (acc, {b with body = body})
-    in
-    match mapAccumL bindingFunc acc t.bindings with (acc, bindings) in
-    match f acc t.inexpr with (acc, inexpr) in
-    (acc, TmRecLets {{t with bindings = bindings} with inexpr = inexpr})
-end
+      (acc, {b with body = body}) in
+    match mapAccumL fbinding acc x.bindings with (acc, bindings) in
+    (acc, DeclRecLets {x with bindings = bindings})
 
+  sem smapAccumL_Decl_TypeLabel f acc =
+  | DeclRecLets x ->
+    let fbinding = lam acc. lam b.
+      match f acc b.tyBody with (acc, tyBody) in
+      (acc, {b with tyBody = tyBody}) in
+    match mapAccumL fbinding acc x.bindings with (acc, bindings) in
+    (acc, DeclRecLets {x with bindings = bindings})
+end
 
 -- TmConst --
 lang ConstAst = Ast
@@ -538,81 +602,66 @@ lang RecordAst = Ast
     else never
 end
 
--- TmType --
-lang TypeAst = Ast
-  syn Expr =
-  | TmType {ident : Name,
-            params : [Name],
-            tyIdent : Type,
-            inexpr : Expr,
-            ty : Type,
-            info : Info}
+-- DeclType --
+lang TypeDeclAst = DeclAst
+  syn Decl =
+  | DeclType {ident : Name,
+              params : [Name],
+              tyIdent : Type,
+              info : Info}
 
-  sem infoTm =
-  | TmType r -> r.info
+  sem infoDecl =
+  | DeclType d -> d.info
 
-  sem tyTm =
-  | TmType t -> t.ty
+  sem declWithInfo info =
+  | DeclType d -> DeclType {d with info = info}
 
-  sem withInfo info =
-  | TmType t -> TmType {t with info = info}
-
-  sem withType (ty : Type) =
-  | TmType t -> TmType {t with ty = ty}
-
-  sem smapAccumL_Expr_Type f acc =
-  | TmType t ->
-    match f acc t.tyIdent with (acc, tyIdent) then
-      (acc, TmType {t with tyIdent = tyIdent})
-    else never
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmType t ->
-    match f acc t.inexpr with (acc, inexpr) then
-      (acc, TmType {t with inexpr = inexpr})
-    else never
+  sem smapAccumL_Decl_Type f acc =
+  | DeclType x ->
+    match f acc x.tyIdent with (acc, tyIdent) in
+    (acc, DeclType {x with tyIdent = tyIdent})
 end
 
--- TmConDef and TmConApp --
+-- DeclConDef --
+lang DataDeclAst = DeclAst
+  syn Decl =
+  | DeclConDef {ident : Name,
+                tyIdent : Type,
+                info : Info}
+
+  sem infoDecl =
+  | DeclConDef d -> d.info
+
+  sem declWithInfo info =
+  | DeclConDef d -> DeclConDef {d with info = info}
+
+  sem smapAccumL_Decl_Type f acc =
+  | DeclConDef x ->
+    match f acc x.tyIdent with (acc, tyIdent) in
+    (acc, DeclConDef {x with tyIdent = tyIdent})
+end
+
+-- TmConApp --
 lang DataAst = Ast
   syn Expr =
-  | TmConDef {ident : Name,
-              tyIdent : Type,
-              inexpr : Expr,
-              ty : Type,
-              info : Info}
   | TmConApp {ident : Name,
               body : Expr,
               ty : Type,
               info: Info}
 
   sem infoTm =
-  | TmConDef r -> r.info
   | TmConApp r -> r.info
 
   sem tyTm =
-  | TmConDef t -> t.ty
   | TmConApp t -> t.ty
 
   sem withInfo info =
-  | TmConDef t -> TmConDef {t with info = info}
   | TmConApp t -> TmConApp {t with info = info}
 
   sem withType (ty : Type) =
-  | TmConDef t -> TmConDef {t with ty = ty}
   | TmConApp t -> TmConApp {t with ty = ty}
 
-  sem smapAccumL_Expr_Type f acc =
-  | TmConDef t ->
-    match f acc t.tyIdent with (acc, tyIdent) then
-      (acc, TmConDef {t with tyIdent = tyIdent})
-    else never
-
   sem smapAccumL_Expr_Expr f acc =
-  | TmConDef t ->
-    match f acc t.inexpr with (acc, inexpr) then
-      (acc, TmConDef {t with inexpr = inexpr})
-    else never
   | TmConApp t ->
     match f acc t.body with (acc, body) then
       (acc, TmConApp {t with body = body})
@@ -660,48 +709,32 @@ lang MatchAst = Ast
     (acc, TmMatch {t with pat = pat})
 end
 
+-- DeclUtest --
+lang UtestDeclAst = DeclAst
+  syn Decl =
+  | DeclUtest {test : Expr,
+               expected : Expr,
+               tusing : Option Expr,
+               tonfail : Option Expr,
+               info : Info}
 
--- TmUtest --
-lang UtestAst = Ast
-  syn Expr =
-  | TmUtest {test : Expr,
-             expected : Expr,
-             next : Expr,
-             tusing : Option Expr,
-             tonfail : Option Expr,
-             ty : Type,
-             info : Info}
+  sem infoDecl =
+  | DeclUtest d -> d.info
 
-  sem infoTm =
-  | TmUtest r -> r.info
+  sem declWithInfo info =
+  | DeclUtest d -> DeclUtest {d with info = info}
 
-  sem tyTm =
-  | TmUtest t -> t.ty
-
-  sem withInfo info =
-  | TmUtest t -> TmUtest {t with info = info}
-
-  sem withType (ty : Type) =
-  | TmUtest t -> TmUtest {t with ty = ty}
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmUtest t ->
-    match f acc t.test with (acc, test) in
-    match f acc t.expected with (acc, expected) in
-    match f acc t.next with (acc, next) in
-    match optionMapAccum f acc t.tusing with (acc, tusing) in
-    match optionMapAccum f acc t.tonfail with (acc, tonfail) in
-    ( acc
-    , TmUtest {
-      t with
-      test = test,
-      expected = expected,
-      next = next,
-      tusing = tusing,
-      tonfail = tonfail
-    })
+  sem smapAccumL_Decl_Expr f acc =
+  | DeclUtest x ->
+    match f acc x.test with (acc, test) in
+    match f acc x.expected with (acc, expected) in
+    match optionMapAccum f acc x.tusing with (acc, tusing) in
+    match optionMapAccum f acc x.tonfail with (acc, tonfail) in
+    (acc, DeclUtest {x with test = test,
+                            expected = expected,
+                            tusing = tusing,
+                            tonfail = tonfail})
 end
-
 
 -- TmNever --
 lang NeverAst = Ast
@@ -724,56 +757,41 @@ end
 
 -- TmPlaceholder --
 lang PlaceholderAst = Ast
-  syn Expr = 
+  syn Expr =
   | TmPlaceholder {ty : Type,
                    info : Info}
 
-  sem infoTm = 
+  sem infoTm =
   | TmPlaceholder t -> t.info
 
-  sem withInfo info = 
+  sem withInfo info =
   | TmPlaceholder t -> TmPlaceholder {t with info = info}
 
   sem tyTm =
   | TmPlaceholder t -> t.ty
 
-  sem withType ty = 
+  sem withType ty =
   | TmPlaceholder t -> TmPlaceholder {t with ty = ty}
 end
 
--- TmExt --
-lang ExtAst = Ast + VarAst
-  syn Expr =
-  | TmExt {ident : Name,
-           tyIdent : Type,
-           inexpr : Expr,
-           effect : Bool,
-           ty : Type,
-           info : Info}
+-- DeclExt --
+lang ExtDeclAst = DeclAst
+  syn Decl =
+  | DeclExt {ident : Name,
+             tyIdent : Type,
+             effect : Bool,
+             info : Info}
 
-  sem infoTm =
-  | TmExt r -> r.info
+  sem infoDecl =
+  | DeclExt d -> d.info
 
-  sem tyTm =
-  | TmExt t -> t.ty
+  sem declWithInfo info =
+  | DeclExt d -> DeclExt {d with info = info}
 
-  sem withInfo info =
-  | TmExt t -> TmExt {t with info = info}
-
-  sem withType (ty : Type) =
-  | TmExt t -> TmExt {t with ty = ty}
-
-  sem smapAccumL_Expr_Type f acc =
-  | TmExt t ->
-    match f acc t.tyIdent with (acc, tyIdent) then
-      (acc, TmExt {t with tyIdent = tyIdent})
-    else never
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmExt t ->
-    match f acc t.inexpr with (acc, inexpr) then
-      (acc, TmExt {t with inexpr = inexpr})
-    else never
+  sem smapAccumL_Decl_Type f acc =
+  | DeclExt x ->
+    match f acc x.tyIdent with (acc, tyIdent) in
+    (acc, DeclExt {x with tyIdent = tyIdent})
 end
 
 ---------------
@@ -967,7 +985,7 @@ lang RefOpAst = ConstAst
   | CDeRef {}
 end
 
-lang TypeOpAst = ConstAst 
+lang TypeOpAst = ConstAst
   syn Const =
   | CTypeOf {}
 end
@@ -1613,9 +1631,12 @@ end
 lang MExprAst =
 
   -- Terms
-  VarAst + AppAst + LamAst + RecordAst + LetAst + TypeAst + RecLetsAst +
-  ConstAst + DataAst + MatchAst + UtestAst + SeqAst + NeverAst + ExtAst +
-  PlaceholderAst +
+  VarAst + AppAst + LamAst + RecordAst + ConstAst + DataAst + MatchAst +
+  SeqAst + NeverAst + PlaceholderAst +
+
+  -- Decls
+  LetDeclAst + TypeDeclAst + RecLetsDeclAst + DataDeclAst + UtestDeclAst +
+  ExtDeclAst +
 
   -- Constants
   IntAst + ArithIntAst + ShiftIntAst + FloatAst + ArithFloatAst + BoolAst +
@@ -1623,7 +1644,7 @@ lang MExprAst =
   SymbAst + CmpSymbAst + SeqOpAst + FileOpAst + IOAst +
   RandomNumberGeneratorAst + SysAst + FloatIntConversionAst +
   FloatStringConversionAst + TimeAst + ConTagAst + RefOpAst + TensorOpAst +
-  BootParserAst + UnsafeCoerceAst + TypeOpAst + 
+  BootParserAst + UnsafeCoerceAst + TypeOpAst +
 
   -- Patterns
   NamedPat + SeqTotPat + SeqEdgePat + RecordPat + DataPat + IntPat + CharPat +
@@ -1632,8 +1653,8 @@ lang MExprAst =
   -- Types
   UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
   FunTypeAst + SeqTypeAst + RecordTypeAst + VariantTypeAst + ConTypeAst +
-  DataTypeAst + VarTypeAst + AppTypeAst + TensorTypeAst + AllTypeAst + 
-  AliasTypeAst +  
+  DataTypeAst + VarTypeAst + AppTypeAst + TensorTypeAst + AllTypeAst +
+  AliasTypeAst +
 
   -- Kinds
   PolyKindAst + MonoKindAst + RecordKindAst + DataKindAst

--- a/src/stdlib/mexpr/boot-parser.mc
+++ b/src/stdlib/mexpr/boot-parser.mc
@@ -179,25 +179,34 @@ lang BootParser = MExprAst + ConstTransformer
            ty = TyUnknown { info = ginfo t 0 },
            info = ginfo t 0,
            body = gterm t 0}
-  | 103 /-TmLet-/ ->
-    TmLet {ident = gname t 0,
-           tyAnnot = gtype t 0,
-           tyBody = TyUnknown { info = ginfo t 0 },
-           body = gterm t 0,
-           inexpr = gterm t 1,
-           ty = TyUnknown { info = ginfo t 0 },
-           info = ginfo t 0}
-  | 104 /-TmRecLets-/ ->
-    TmRecLets {bindings =
-               create (glistlen t 0)
-                      (lam n. {ident = gname t n,
-                               tyAnnot = gtype t n,
-                               tyBody = TyUnknown { info = ginfo t (addi n 1)},
-                               body = gterm t n,
-                               info = ginfo t (addi n 1)}),
-               inexpr = gterm t (glistlen t 0),
-               ty = TyUnknown { info = ginfo t 0 },
-               info = ginfo t 0}
+  | 103 /-TmLet-/ -> TmDecl
+    { decl = DeclLet
+      { ident = gname t 0
+      , tyAnnot = gtype t 0
+      , tyBody = TyUnknown { info = ginfo t 0 }
+      , body = gterm t 0
+      , info = ginfo t 0
+      }
+    , inexpr = gterm t 1
+    , ty = TyUnknown { info = ginfo t 0 }
+    , info = ginfo t 0
+    }
+  | 104 /-TmRecLets-/ -> TmDecl
+    { decl = DeclRecLets
+      { bindings = create (glistlen t 0)
+        (lam n.
+          { ident = gname t n
+          , tyAnnot = gtype t n
+          , tyBody = TyUnknown { info = ginfo t (addi n 1)}
+          , body = gterm t n
+          , info = ginfo t (addi n 1)
+          })
+      , info = ginfo t 0
+      }
+    , inexpr = gterm t (glistlen t 0)
+    , ty = TyUnknown { info = ginfo t 0 }
+    , info = ginfo t 0
+    }
   | 105 /-TmConst-/ ->
     let c = gconst t 0 in
     TmConst {val = gconst t 0,
@@ -220,19 +229,27 @@ lang BootParser = MExprAst + ConstTransformer
                    value = gterm t 1,
                    ty = TyUnknown { info = ginfo t 0 },
                    info = ginfo t 0}
-  | 109 /-TmType-/ ->
-    TmType {ident = gname t 0,
-            params = map (gname t) (range 1 (glistlen t 0) 1),
-            tyIdent = gtype t 0,
-            ty = TyUnknown { info = ginfo t 0 },
-            inexpr = gterm t 0,
-            info = ginfo t 0}
-  | 110 /-TmConDef-/ ->
-    TmConDef {ident = gname t 0,
-              tyIdent = gtype t 0,
-              ty = TyUnknown { info = ginfo t 0 },
-              inexpr = gterm t 0,
-              info = ginfo t 0}
+  | 109 /-TmType-/ -> TmDecl
+    { decl = DeclType
+      { ident = gname t 0
+      , params = map (gname t) (range 1 (glistlen t 0) 1)
+      , tyIdent = gtype t 0
+      , info = ginfo t 0
+      }
+    , ty = TyUnknown { info = ginfo t 0 }
+    , inexpr = gterm t 0
+    , info = ginfo t 0
+    }
+  | 110 /-TmConDef-/ -> TmDecl
+    { decl = DeclConDef
+      { ident = gname t 0
+      , tyIdent = gtype t 0
+      , info = ginfo t 0
+      }
+    , ty = TyUnknown { info = ginfo t 0 }
+    , inexpr = gterm t 0
+    , info = ginfo t 0
+    }
   | 111 /-TmConApp-/ ->
     TmConApp {ident = gname t 0,
               body = gterm t 0,
@@ -254,24 +271,32 @@ lang BootParser = MExprAst + ConstTransformer
       case _ then error "BootParser.matchTerm: Invalid list length for tmUtest"
       end
       with (tusing, tonfail)
-    in
-    TmUtest {test = gterm t 0,
-             expected = gterm t 1,
-             next = gterm t 2,
-             tusing = tusing,
-             tonfail = tonfail,
-             ty = TyUnknown { info = ginfo t 0 },
-             info = ginfo t 0}
+    in TmDecl
+    { decl = DeclUtest
+      { test = gterm t 0
+      , expected = gterm t 1
+      , tusing = tusing
+      , tonfail = tonfail
+      , info = ginfo t 0
+      }
+    , inexpr = gterm t 2
+    , ty = TyUnknown { info = ginfo t 0 }
+    , info = ginfo t 0
+    }
   | 114 /-TmNever-/ ->
     TmNever {ty = TyUnknown { info = ginfo t 0 },
              info = ginfo t 0}
-  | 115 /-TmExt-/ ->
-    TmExt {ident = gname t 0,
-           tyIdent = gtype t 0,
-           effect = neqi (gint t 0) 0,
-           ty = TyUnknown { info = ginfo t 0 },
-           inexpr = gterm t 0,
-           info = ginfo t 0}
+  | 115 /-TmExt-/ -> TmDecl
+    { decl = DeclExt
+      { ident = gname t 0
+      , tyIdent = gtype t 0
+      , effect = neqi (gint t 0) 0
+      , info = ginfo t 0
+      }
+    , inexpr = gterm t 0
+    , ty = TyUnknown { info = ginfo t 0 }
+    , info = ginfo t 0
+    }
   | _ -> error "Unknown expression"
 
   -- Get type help function
@@ -532,7 +557,7 @@ let s = "let y = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest l_infoClosed "  \n lam x.x" with r_info 2 1 2 8 in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet r
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet r}
   then infoTm r.body else NoInfo ()
 with r_info 1 8 1 15 in
 utest l_info ["y"] "  let x = 4 in y  " with r_info 1 2 1 14 in
@@ -547,8 +572,8 @@ utest lsideClosed s with rside s in
 let s = "   recursive let x = 5 \n let foo = 7 in x " in
 utest l_infoClosed s with r_info 1 3 2 15 in
 utest
-  match parseMExprStringKeywordsExn [] s with TmRecLets r then
-    let fst : RecLetBinding = head r.bindings in
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclRecLets r} then
+    let fst : DeclLetRecord = head r.bindings in
     fst.info
   else never
 with r_info 1 13 1 22 in
@@ -754,7 +779,7 @@ utest l_infoClosed "   \n  external y! : Int in 1" with r_info 2 2 2 24 in
 let s = "let y:Unknown = lam x.x in y" in
 utest lsideClosed s with rside "let y = lam x.x in y" in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 13 in
 let s = "lam x:Int. lam y:Char. x" in
@@ -769,7 +794,7 @@ with r_info 2 7 2 10 in
 let s = "let y:Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 9 in
 
@@ -777,7 +802,7 @@ with r_info 1 6 1 9 in
 let s = "let y:Float = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 11 in
 
@@ -785,7 +810,7 @@ with r_info 1 6 1 11 in
 let s = "let y:Char = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 10 in
 
@@ -793,7 +818,7 @@ with r_info 1 6 1 10 in
 let s = "let y:Int->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 14 in
 
@@ -801,7 +826,7 @@ with r_info 1 6 1 14 in
 let s = "let y:[Float]->Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 18 in
 
@@ -809,7 +834,7 @@ with r_info 1 6 1 18 in
 let s = "let y:[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 11 in
 
@@ -829,7 +854,7 @@ let typedLet = lam letTy.
         (var_ "y") in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 56 in
 
@@ -837,7 +862,7 @@ with r_info 1 6 1 56 in
 let s = "let y:Tensor[Int] = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 17 in
 
@@ -853,7 +878,7 @@ let typedLet = lam letTy.
         (var_ "y") in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 30 in
 
@@ -862,7 +887,7 @@ let s = "let y:{a:Int,b:[Char]} = lam x.x in y" in
 let recTy = tyrecord_ [("a", tyint_), ("b", tystr_)] in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 22 in
 
@@ -879,7 +904,7 @@ let recTy = tyrecord_ [
     ("b_2", tyfloat_)])] in
 utest parseMExprStringKeywordsExn [] s with typedLet recTy using eqExpr in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 54 in
 
@@ -887,14 +912,14 @@ with r_info 1 6 1 54 in
 -- NOTE(caylak,2021-03-17): Parsing of TyVariant is not supported yet
 -- let s = "let y:<> = lam x.x in y" in
 -- --utest lsideClosed s with rside s in
--- utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+-- utest match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l} then infoTy l.tyAnnot else NoInfo ()
 -- with r_info 1 6 1 8 in
 
 -- TyVar
 let s = "let y:_asd = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 10 in
 
@@ -902,7 +927,7 @@ with r_info 1 6 1 10 in
 let s = "let y:all x.x = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 13 in
 
@@ -910,7 +935,7 @@ with r_info 1 6 1 13 in
 let s = "let y:all x.(all y.all z.z)->all w.w = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 36 in
 
@@ -918,27 +943,27 @@ with r_info 1 6 1 36 in
 let s = "let y:Foo = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 9 in
 
 -- TyCon with literal constructor list
 let s = "let y:Foo[F1 F2] = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l} then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 16 in
 
 -- TyCon with variable constructor list
 let s = "let y:all d::{Foo[> F1 F2]}. Foo{d} = lam x.x in y" in
 utest lsideClosed s with rside s in
-utest match parseMExprStringKeywordsExn [] s with TmLet l then infoTy l.tyAnnot else NoInfo ()
+utest match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l} then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 6 1 35 in
 
 -- TyApp
 let s = "let y:(Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 7 1 19 in
 
@@ -946,7 +971,7 @@ with r_info 1 7 1 19 in
 let s = "let y:((Int->Int)Int->Int)Int = lam x.x in y" in
 utest lsideClosed s with rside s in
 utest
-  match parseMExprStringKeywordsExn [] s with TmLet l
+  match parseMExprStringKeywordsExn [] s with TmDecl {decl = DeclLet l}
   then infoTy l.tyAnnot else NoInfo ()
 with r_info 1 8 1 29 in
 

--- a/src/stdlib/mexpr/call-graph.mc
+++ b/src/stdlib/mexpr/call-graph.mc
@@ -10,40 +10,40 @@ include "mexpr/type-check.mc"
 
 lang MExprCallGraph = MExprAst
   sem constructCallGraph =
-  | TmRecLets t ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let g : Digraph Name Int = digraphEmpty nameCmp eqi in
-    let g = _addGraphVertices g (TmRecLets {t with inexpr = unit_}) in
+    let g = _addGraphVertices g (TmDecl {x with inexpr = unit_}) in
     _addGraphCallEdges g t.bindings
   | t ->
     errorSingle [infoTm t] (join ["A call graph can only be constructed ",
                                     "from a recursive let-expression"])
 
   sem _addGraphVertices (g : Digraph Name Int) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t, inexpr = inexpr} ->
     let g =
       match t.tyBody with TyArrow _ then digraphAddVertex t.ident g
       else g
     in
     let g = _addGraphVertices g t.body in
-    _addGraphVertices g t.inexpr
-  | TmRecLets t ->
+    _addGraphVertices g inexpr
+  | TmDecl {decl = DeclRecLets t, inexpr = inexpr} ->
     let g =
       foldl
-        (lam g. lam bind : RecLetBinding. digraphAddVertex bind.ident g)
+        (lam g. lam bind : DeclLetRecord. digraphAddVertex bind.ident g)
         g t.bindings in
     let g =
       foldl
-        (lam g. lam bind : RecLetBinding.
+        (lam g. lam bind : DeclLetRecord.
           _addGraphVertices g bind.body)
         g t.bindings in
-    _addGraphVertices g t.inexpr
+    _addGraphVertices g inexpr
   | t -> sfold_Expr_Expr _addGraphVertices g t
 
   sem _addGraphCallEdges (g : Digraph Name Int) =
-  | bindings /- : [RecLetBinding] -/ ->
+  | bindings /- : [DeclLetRecord] -/ ->
     let edges =
       foldl
-        (lam edges. lam bind : RecLetBinding.
+        (lam edges. lam bind : DeclLetRecord.
           _findCallEdges bind.ident g edges bind.body)
         (mapEmpty nameCmp) bindings in
     mapFoldWithKey
@@ -64,17 +64,17 @@ lang MExprCallGraph = MExprAst
         else setOfSeq nameCmp [t.ident] in
       mapInsert src outEdges edges
     else edges
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t, inexpr = inexpr} ->
     let letSrc = match t.tyBody with TyArrow _ then t.ident else src in
     let edges = _findCallEdges letSrc g edges t.body in
-    _findCallEdges src g edges t.inexpr
-  | TmRecLets t ->
+    _findCallEdges src g edges inexpr
+  | TmDecl {decl = DeclRecLets t, inexpr = inexpr} ->
     let edges =
       foldl
-        (lam edges : Map Name (Set Name). lam bind : RecLetBinding.
+        (lam edges : Map Name (Set Name). lam bind : DeclLetRecord.
           _findCallEdges bind.ident g edges bind.body)
         edges t.bindings in
-    _findCallEdges src g edges t.inexpr
+    _findCallEdges src g edges inexpr
   | t -> sfold_Expr_Expr (_findCallEdges src g) edges t
 end
 
@@ -93,14 +93,14 @@ let a = nameSym "a" in
 let b = nameSym "b" in
 let c = nameSym "c" in
 let d = nameSym "d" in
-let t = preprocess (nureclets_ [
+let t = preprocess (bind_ (nureclets_ [
   (a, ulam_ "x" (bindall_ [
     nulet_ b (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
     nulet_ c (ulam_ "x" (app_ (nvar_ b) (var_ "x"))),
-    nulet_ d (ulam_ "x" (app_ (nvar_ b) (var_ "x"))),
-    addi_ (addi_ (app_ (nvar_ b) (var_ "x"))
+    nulet_ d (ulam_ "x" (app_ (nvar_ b) (var_ "x")))]
+    (addi_ (addi_ (app_ (nvar_ b) (var_ "x"))
                  (app_ (nvar_ c) (var_ "x")))
-          (app_ (nvar_ d) (int_ 2))]))]) in
+          (app_ (nvar_ d) (int_ 2)))))]) unit_) in
 let g = constructCallGraph t in
 utest digraphSuccessors a g with [b, c, d] using eqSeq nameEq in
 utest digraphSuccessors b g with [] using eqSeq nameEq in

--- a/src/stdlib/mexpr/cfa.mc
+++ b/src/stdlib/mexpr/cfa.mc
@@ -529,7 +529,7 @@ lang RecLetsCFA = CFA + LamCFA + RecLetsAst
 
   sem generateConstraints graph =
   | TmRecLets { bindings = bindings } ->
-    let cstrs = map (lam b: RecLetBinding.
+    let cstrs = map (lam b: DeclLetRecord.
         match b.body with TmLam t then
           let av: AbsVal = AVLam {
             ident = name2intAcc graph.ia t.info t.ident,

--- a/src/stdlib/mexpr/cfa.mc
+++ b/src/stdlib/mexpr/cfa.mc
@@ -32,7 +32,7 @@ type IName = Int
 -- BASE FRAGMENT --
 -------------------
 
-lang CFABase = Ast + LetAst + MExprIndex + MExprFreeVars + MExprPrettyPrint
+lang CFABase = Ast + LetDeclAst + MExprIndex + MExprFreeVars + MExprPrettyPrint
 
   syn Constraint =
   -- Intentionally left blank
@@ -518,12 +518,12 @@ lang LamCFA = CFA + BaseConstraint + LamAst
 
 end
 
-lang LetCFA = CFA + LetAst
+lang LetCFA = CFA + LetDeclAst
   sem exprName =
   | TmLet t -> exprName t.inexpr
 end
 
-lang RecLetsCFA = CFA + LamCFA + RecLetsAst
+lang RecLetsCFA = CFA + LamCFA + RecLetsDeclAst
   sem exprName =
   | TmRecLets t -> exprName t.inexpr
 
@@ -868,7 +868,7 @@ lang SeqCFA = CFA + BaseConstraint + SetCFA + SeqAst
 
 end
 
-lang TypeCFA = CFA + TypeAst
+lang TypeCFA = CFA + TypeDeclAst
   sem exprName =
   | TmType t -> exprName t.inexpr
 end
@@ -963,7 +963,7 @@ lang MatchCFA = CFA + BaseConstraint + MatchAst + MExprCmp
 
 end
 
-lang UtestCFA = CFA + UtestAst
+lang UtestCFA = CFA + UtestDeclAst
   sem exprName =
   | TmUtest t -> exprName t.next
 end
@@ -972,7 +972,7 @@ lang NeverCFA = CFA + NeverAst
   -- Nothing to be done here
 end
 
-lang ExtCFA = CFA + ExtAst
+lang ExtCFA = CFA + ExtDeclAst
 
   syn AbsVal =
   -- Abstract representation of externals. Handled in a similar way as

--- a/src/stdlib/mexpr/cfa.mc
+++ b/src/stdlib/mexpr/cfa.mc
@@ -518,15 +518,12 @@ lang LamCFA = CFA + BaseConstraint + LamAst
 
 end
 
-lang LetCFA = CFA + LetDeclAst
+lang DeclCFA = CFA + DeclAst
   sem exprName =
-  | TmDecl {decl = DeclLet t} -> exprName t.inexpr
+  | TmDecl x -> exprName x.inexpr
 end
 
 lang RecLetsCFA = CFA + LamCFA + RecLetsDeclAst
-  sem exprName =
-  | TmDecl {decl = DeclRecLets t} -> exprName t.inexpr
-
   sem generateConstraints graph =
   | TmDecl {decl = DeclRecLets { bindings = bindings }} ->
     let cstrs = map (lam b: DeclLetRecord.
@@ -868,11 +865,6 @@ lang SeqCFA = CFA + BaseConstraint + SetCFA + SeqAst
 
 end
 
-lang TypeCFA = CFA + TypeDeclAst
-  sem exprName =
-  | TmDecl {decl = DeclType t} -> exprName t.inexpr
-end
-
 lang DataCFA = CFA + BaseConstraint + DataAst
   syn AbsVal =
   -- Abstract representation of constructed data.
@@ -898,10 +890,6 @@ lang DataCFA = CFA + BaseConstraint + DataAst
     match pprintConIName im env ident with (env,ident) in
     match pprintVarIName im env body with (env,body) in
     (env, join [ident, " ", body])
-
-  sem exprName =
-  | TmDecl {decl = DeclConDef t} -> exprName t.inexpr
-
 end
 
 lang MatchCFA = CFA + BaseConstraint + MatchAst + MExprCmp
@@ -961,11 +949,6 @@ lang MatchCFA = CFA + BaseConstraint + MatchAst + MExprCmp
   | pat ->
     [CstrMatch { id = id, pat = pat, target = target }]
 
-end
-
-lang UtestCFA = CFA + UtestDeclAst
-  sem exprName =
-  | TmDecl {decl = DeclUtest t} -> exprName t.next
 end
 
 lang NeverCFA = CFA + NeverAst
@@ -1046,12 +1029,12 @@ lang ExtCFA = CFA + ExtDeclAst
   -- the ANF transform and define eta expanded versions of the externals (so
   -- that they can be curried).
   sem collectConstraints cgfs graph =
-  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} & t ->
+  | TmDecl {decl = DeclExt _, inexpr = TmDecl {decl = DeclLet {ident = ident}, inexpr = inexpr}} & t ->
     let graph = foldl (lam acc. lam f. f graph t) graph cgfs in
     collectConstraints cgfs graph inexpr
 
   sem generateConstraints graph =
-  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} ->
+  | TmDecl {decl = DeclExt _, inexpr = TmDecl {decl = DeclLet {ident = ident}, inexpr = inexpr}} ->
     -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
     -- for externals. Similarly to constants, we probably want to delegate to
     -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
@@ -1061,7 +1044,7 @@ lang ExtCFA = CFA + ExtDeclAst
 
   sem exprName =
   -- Skip the eta expanded let added by ANF,
-  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { inexpr = inexpr }}}} -> exprName inexpr
+  | TmDecl {decl = DeclExt _, inexpr = TmDecl {decl = DeclLet _, inexpr = inexpr}} -> exprName inexpr
 
 end
 
@@ -1694,8 +1677,8 @@ lang MExprCFA = CFA +
 
   -- Terms
   VarCFA + LamCFA + AppCFA +
-  LetCFA + RecLetsCFA + ConstCFA + SeqCFA + RecordCFA + TypeCFA + DataCFA +
-  MatchCFA + UtestCFA + NeverCFA + ExtCFA +
+  DeclCFA + RecLetsCFA + ConstCFA + SeqCFA + RecordCFA + DataCFA +
+  MatchCFA + NeverCFA + ExtCFA +
 
   -- Constants
   IntCFA + ArithIntCFA + ShiftIntCFA + FloatCFA + ArithFloatCFA +

--- a/src/stdlib/mexpr/cfa.mc
+++ b/src/stdlib/mexpr/cfa.mc
@@ -477,7 +477,7 @@ end
 lang VarCFA = CFA + BaseConstraint + VarAst
 
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmVar t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmVar t, info = info }} ->
     let cstr = CstrDirect {
       lhs = name2intAcc graph.ia t.info t.ident,
       rhs = name2intAcc graph.ia info ident
@@ -502,7 +502,7 @@ lang LamCFA = CFA + BaseConstraint + LamAst
      if eqi diff 0 then subi lbody rbody else diff
 
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmLam t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmLam t, info = info }} ->
     let av: AbsVal = AVLam {
       ident = name2intAcc graph.ia t.info t.ident,
       body = name2intAcc graph.ia (infoTm t.body) (exprName t.body)
@@ -520,15 +520,15 @@ end
 
 lang LetCFA = CFA + LetDeclAst
   sem exprName =
-  | TmLet t -> exprName t.inexpr
+  | TmDecl {decl = DeclLet t} -> exprName t.inexpr
 end
 
 lang RecLetsCFA = CFA + LamCFA + RecLetsDeclAst
   sem exprName =
-  | TmRecLets t -> exprName t.inexpr
+  | TmDecl {decl = DeclRecLets t} -> exprName t.inexpr
 
   sem generateConstraints graph =
-  | TmRecLets { bindings = bindings } ->
+  | TmDecl {decl = DeclRecLets { bindings = bindings }} ->
     let cstrs = map (lam b: DeclLetRecord.
         match b.body with TmLam t then
           let av: AbsVal = AVLam {
@@ -583,7 +583,7 @@ lang ConstCFA = CFA + ConstAst + BaseConstraint + Cmp
     else cmp
 
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmConst t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmConst t, info = info }} ->
     generateConstraintsConst graph t.info (name2intAcc graph.ia info ident) t.val
 
   sem generateConstraintsConst:
@@ -690,7 +690,7 @@ lang AppCFA = CFA + ConstCFA + BaseConstraint + LamCFA + AppAst + MExprArity
     ]
 
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmApp app, info = info} ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmApp app, info = info}} ->
     match app.lhs with TmVar l then
       match app.rhs with TmVar r then
         let lhs = name2intAcc graph.ia l.info l.ident in
@@ -734,7 +734,7 @@ lang RecordCFA = CFA + BaseConstraint + RecordAst
   | CstrRecordUpdate r & cstr -> initConstraintName r.lhs graph cstr
 
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmRecord t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmRecord t, info = info }} ->
     let bindings = mapMap (lam v: Expr.
         match v with TmVar t then name2intAcc graph.ia t.info t.ident
         else errorSingle [infoTm v] "Not a TmVar in record"
@@ -744,7 +744,7 @@ lang RecordCFA = CFA + BaseConstraint + RecordAst
     let cstr = CstrInit { lhs = av, rhs = name2intAcc graph.ia info ident }  in
     { graph with cstrs = cons cstr graph.cstrs }
 
-  | TmLet { ident = ident, body = TmRecordUpdate t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmRecordUpdate t, info = info }} ->
     match t.rec with TmVar vrec then
       match t.value with TmVar vval then
         let lhs = name2intAcc graph.ia vrec.info vrec.ident in
@@ -856,7 +856,7 @@ end
 lang SeqCFA = CFA + BaseConstraint + SetCFA + SeqAst
 
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmSeq t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmSeq t, info = info }} ->
     let names = foldl (lam acc: [IName]. lam t: Expr.
       match t with TmVar t then
         cons (name2intAcc graph.ia t.info t.ident) acc
@@ -870,7 +870,7 @@ end
 
 lang TypeCFA = CFA + TypeDeclAst
   sem exprName =
-  | TmType t -> exprName t.inexpr
+  | TmDecl {decl = DeclType t} -> exprName t.inexpr
 end
 
 lang DataCFA = CFA + BaseConstraint + DataAst
@@ -885,7 +885,7 @@ lang DataCFA = CFA + BaseConstraint + DataAst
     if eqi idiff 0 then subi blhs brhs else idiff
 
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmConApp t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmConApp t, info = info }} ->
     let body =
       match t.body with TmVar v then name2intAcc graph.ia v.info v.ident
       else errorSingle [infoTm t.body] "Not a TmVar in con app" in
@@ -900,7 +900,7 @@ lang DataCFA = CFA + BaseConstraint + DataAst
     (env, join [ident, " ", body])
 
   sem exprName =
-  | TmConDef t -> exprName t.inexpr
+  | TmDecl {decl = DeclConDef t} -> exprName t.inexpr
 
 end
 
@@ -940,7 +940,7 @@ lang MatchCFA = CFA + BaseConstraint + MatchAst + MExprCmp
   sem generateConstraintsMatch: GenFun
   sem generateConstraintsMatch graph =
   | _ -> graph
-  | TmLet { ident = ident, body = TmMatch t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmMatch t, info = info }} ->
     let thn = name2intAcc graph.ia (infoTm t.thn) (exprName t.thn) in
     let els = name2intAcc graph.ia (infoTm t.els) (exprName t.els) in
     let ident = name2intAcc graph.ia info ident in
@@ -965,7 +965,7 @@ end
 
 lang UtestCFA = CFA + UtestDeclAst
   sem exprName =
-  | TmUtest t -> exprName t.next
+  | TmDecl {decl = DeclUtest t} -> exprName t.next
 end
 
 lang NeverCFA = CFA + NeverAst
@@ -1046,12 +1046,12 @@ lang ExtCFA = CFA + ExtDeclAst
   -- the ANF transform and define eta expanded versions of the externals (so
   -- that they can be curried).
   sem collectConstraints cgfs graph =
-  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } & t ->
+  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} & t ->
     let graph = foldl (lam acc. lam f. f graph t) graph cgfs in
     collectConstraints cgfs graph inexpr
 
   sem generateConstraints graph =
-  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
+  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} ->
     -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
     -- for externals. Similarly to constants, we probably want to delegate to
     -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
@@ -1061,7 +1061,7 @@ lang ExtCFA = CFA + ExtDeclAst
 
   sem exprName =
   -- Skip the eta expanded let added by ANF,
-  | TmExt { inexpr = TmLet { inexpr = inexpr }} -> exprName inexpr
+  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { inexpr = inexpr }}}} -> exprName inexpr
 
 end
 

--- a/src/stdlib/mexpr/cmp.mc
+++ b/src/stdlib/mexpr/cmp.mc
@@ -24,6 +24,17 @@ lang Cmp = ConstAst
         "Missing case in cmpExprH for expressions with equal indices."
     else res
 
+  sem cmpDecl (lhs : Decl) =
+  | rhs -> cmpDeclH (lhs, rhs)
+
+  sem cmpDeclH =
+  | (lhs, rhs) ->
+    let res = subi (constructorTag lhs) (constructorTag rhs) in
+    if eqi res 0 then
+      errorMulti [(infoDecl lhs, ""), (infoDecl rhs, "")]
+        "Missing case in cmpDeclH for declarations with equal indices."
+    else res
+
   sem cmpConst (lhs: Const) =
   | rhs /- : Const -/ -> cmpConstH (lhs, rhs)
 
@@ -93,34 +104,34 @@ lang LamCmp = Cmp + LamAst
     else identDiff
 end
 
-lang LetCmp = Cmp + LetAst
+lang DeclCmp = Cmp + DeclAst
   sem cmpExprH =
-  | (TmLet l, TmLet r) ->
-    let identDiff = nameCmp l.ident r.ident in
-    if eqi identDiff 0 then
-      let bodyDiff = cmpExpr l.body r.body in
-      if eqi bodyDiff 0 then cmpExpr l.inexpr r.inexpr
-      else bodyDiff
-    else identDiff
+  | (TmDecl l, TmDecl r) ->
+    let res = cmpDecl l.decl r.decl in
+    if neqi res 0 then res else
+    cmpExpr l.inexpr r.inexpr
 end
 
-lang RecLetBindingCmp = Cmp + RecLetsAst
-  sem cmpRecLetBinding (lhs : RecLetBinding) =
+lang LetBindingCmp = Cmp + LetDeclAst
+  sem cmpLetBindRec (lhs : DeclLetRecord) =
   | rhs ->
-    let rhs : RecLetBinding = rhs in
+    let rhs : DeclLetRecord = rhs in
     let identDiff = nameCmp lhs.ident rhs.ident in
     if eqi identDiff 0 then
       cmpExpr lhs.body rhs.body
     else identDiff
 end
 
-lang RecLetsCmp = Cmp + RecLetsAst + RecLetBindingCmp
-  sem cmpExprH =
-  | (TmRecLets l, TmRecLets r) ->
-    let bindingsDiff = seqCmp cmpRecLetBinding l.bindings r.bindings in
-    if eqi bindingsDiff 0 then
-      cmpExpr l.inexpr r.inexpr
-    else bindingsDiff
+lang LetCmp = Cmp + LetDeclAst + LetBindingCmp
+  sem cmpDeclH =
+  | (DeclLet l, DeclLet r) ->
+    cmpLetBindRec l r
+end
+
+lang RecLetsCmp = Cmp + RecLetsDeclAst + LetBindingCmp
+  sem cmpDeclH =
+  | (DeclRecLets l, DeclRecLets r) ->
+    seqCmp cmpLetBindRec l.bindings r.bindings
 end
 
 lang ConstCmp = Cmp + ConstAst
@@ -145,29 +156,27 @@ lang RecordCmp = Cmp + RecordAst
     else recDiff
 end
 
-lang TypeCmp = Cmp + TypeAst
-  sem cmpExprH =
-  | (TmType l, TmType r) ->
+lang TypeCmp = Cmp + TypeDeclAst
+  sem cmpDeclH =
+  | (DeclType l, DeclType r) ->
     let identDiff = nameCmp l.ident r.ident in
     if eqi identDiff 0 then
-      let tyIdentDiff = cmpType l.tyIdent r.tyIdent in
-      if eqi tyIdentDiff 0 then cmpExpr l.inexpr r.inexpr
-      else tyIdentDiff
+      cmpType l.tyIdent r.tyIdent
     else identDiff
 end
 
-lang DataCmp = Cmp + DataAst
+lang DataCmp = Cmp + DataAst + DataDeclAst
   sem cmpExprH =
-  | (TmConDef l, TmConDef r) ->
-    let identDiff = nameCmp l.ident r.ident in
-    if eqi identDiff 0 then
-      let tyIdentDiff = cmpType l.tyIdent r.tyIdent in
-      if eqi tyIdentDiff 0 then cmpExpr l.inexpr r.inexpr
-      else tyIdentDiff
-    else identDiff
   | (TmConApp l, TmConApp r) ->
     let identDiff = nameCmp l.ident r.ident in
     if eqi identDiff 0 then cmpExpr l.body r.body
+    else identDiff
+
+  sem cmpDeclH =
+  | (DeclConDef l, DeclConDef r) ->
+    let identDiff = nameCmp l.ident r.ident in
+    if eqi identDiff 0 then
+      cmpType l.tyIdent r.tyIdent
     else identDiff
 end
 
@@ -185,32 +194,29 @@ lang MatchCmp = Cmp + MatchAst
     else targetDiff
 end
 
-lang UtestCmp = Cmp + UtestAst
-  sem cmpExprH =
-  | (TmUtest l, TmUtest r) ->
+lang UtestCmp = Cmp + UtestDeclAst
+  sem cmpDeclH =
+  | (DeclUtest l, DeclUtest r) ->
     let testDiff = cmpExpr l.test r.test in
     if eqi testDiff 0 then
       let expectedDiff = cmpExpr l.expected r.expected in
       if eqi expectedDiff 0 then
-        let nextDiff = cmpExpr l.next r.next in
-        if eqi nextDiff 0 then
-          let usingDiff =
-            switch (l.tusing, r.tusing)
-            case (Some a, Some b) then cmpExpr a b
-            case (Some _, None _) then 1
-            case (None _, Some _) then negi 1
-            case _ then 0
-            end
-          in
-          if eqi usingDiff 0 then
-            switch (l.tonfail, r.tonfail)
-            case (Some a, Some b) then cmpExpr a b
-            case (Some _, None _) then 1
-            case (None _, Some _) then negi 1
-            case _ then 0
-            end
-          else usingDiff
-        else nextDiff
+        let usingDiff =
+          switch (l.tusing, r.tusing)
+          case (Some a, Some b) then cmpExpr a b
+          case (Some _, None _) then 1
+          case (None _, Some _) then negi 1
+          case _ then 0
+          end
+        in
+        if eqi usingDiff 0 then
+          switch (l.tonfail, r.tonfail)
+          case (Some a, Some b) then cmpExpr a b
+          case (Some _, None _) then 1
+          case (None _, Some _) then negi 1
+          case _ then 0
+          end
+        else usingDiff
       else expectedDiff
     else testDiff
 end
@@ -220,18 +226,16 @@ lang NeverCmp = Cmp + NeverAst
   | (TmNever _, TmNever _) -> 0
 end
 
-lang ExtCmp = Cmp + ExtAst
-  sem cmpExprH =
-  | (TmExt l, TmExt r) ->
+lang ExtCmp = Cmp + ExtDeclAst
+  sem cmpDeclH =
+  | (DeclExt l, DeclExt r) ->
     let identDiff = nameCmp l.ident r.ident in
     if eqi identDiff 0 then
       let tyIdentDiff = cmpType l.tyIdent r.tyIdent in
       if eqi tyIdentDiff 0 then
         let leffect = if l.effect then 1 else 0 in
         let reffect = if r.effect then 1 else 0 in
-        let effectDiff = subi leffect reffect in
-        if eqi effectDiff 0 then cmpExpr l.inexpr r.inexpr
-        else effectDiff
+        subi leffect reffect
       else tyIdentDiff
     else identDiff
 end
@@ -528,6 +532,7 @@ lang MExprCmp =
   -- Terms
   VarCmp + AppCmp + LamCmp + RecordCmp + LetCmp + TypeCmp + RecLetsCmp +
   ConstCmp + DataCmp + MatchCmp + UtestCmp + SeqCmp + NeverCmp + ExtCmp +
+  DeclCmp +
 
   -- Constants
   IntCmp + FloatCmp + BoolCmp + CharCmp + SymbCmp +
@@ -581,8 +586,8 @@ utest cmpExpr (bind_ (ulet_ "a" (var_ "b")) (var_ "b"))
 utest cmpExpr (bind_ (ulet_ "a" (var_ "a")) (var_ "b"))
               (bind_ (ulet_ "a" (var_ "a")) (var_ "a")) with 0 using neqi in
 
-utest cmpExpr (ureclets_ []) (ureclets_ []) with 0 in
-utest cmpExpr (ureclets_ [("a", ulam_ "b" (var_ "a"))])
+utest cmpDecl (ureclets_ []) (ureclets_ []) with 0 in
+utest cmpDecl (ureclets_ [("a", ulam_ "b" (var_ "a"))])
               (ureclets_ [("a", ulam_ "a" (var_ "a"))]) with 0 using neqi in
 
 utest cmpExpr (int_ 0) (int_ 0) with 0 in
@@ -609,13 +614,13 @@ utest cmpExpr (recordupdate_ r "a" (int_ 0))
 utest cmpExpr (recordupdate_ r "b" (int_ 0))
               (recordupdate_ r "a" (int_ 1)) with 0 using neqi in
 
-utest cmpExpr (type_ "a" [] tyint_) (type_ "a" [] tyint_) with 0 in
-utest cmpExpr (type_ "b" [] tyint_) (type_ "a" [] tyint_) with 0 using neqi in
-utest cmpExpr (type_ "a" [] tyfloat_) (type_ "a" [] tyint_) with 0 using neqi in
+utest cmpDecl (type_ "a" [] tyint_) (type_ "a" [] tyint_) with 0 in
+utest cmpDecl (type_ "b" [] tyint_) (type_ "a" [] tyint_) with 0 using neqi in
+utest cmpDecl (type_ "a" [] tyfloat_) (type_ "a" [] tyint_) with 0 using neqi in
 
-utest cmpExpr (condef_ "a" tyint_) (condef_ "a" tyint_) with 0 in
-utest cmpExpr (condef_ "b" tyint_) (condef_ "a" tyint_) with 0 using neqi in
-utest cmpExpr (condef_ "a" tyfloat_) (condef_ "a" tyint_) with 0 using neqi in
+utest cmpDecl (condef_ "a" tyint_) (condef_ "a" tyint_) with 0 in
+utest cmpDecl (condef_ "b" tyint_) (condef_ "a" tyint_) with 0 using neqi in
+utest cmpDecl (condef_ "a" tyfloat_) (condef_ "a" tyint_) with 0 using neqi in
 utest cmpExpr (conapp_ "a" (var_ "b")) (conapp_ "a" (var_ "b")) with 0 in
 utest cmpExpr (conapp_ "b" (var_ "b")) (conapp_ "a" (var_ "b")) with 0
 using neqi in
@@ -634,43 +639,43 @@ utest cmpExpr (if_ (var_ "a") (int_ 1) (int_ 1))
 utest cmpExpr (if_ (var_ "a") (int_ 0) (int_ 2))
               (if_ (var_ "a") (int_ 0) (int_ 1)) with 0 using neqi in
 
-utest cmpExpr (utest_ (var_ "a") (var_ "a") unit_)
-              (utest_ (var_ "a") (var_ "a") unit_) with 0 in
-utest cmpExpr (utest_ (var_ "b") (var_ "a") unit_)
-              (utest_ (var_ "a") (var_ "a") unit_) with 0 using neqi in
-utest cmpExpr (utest_ (var_ "a") (var_ "b") unit_)
-        (utest_ (var_ "a") (var_ "a") unit_) with 0 using neqi in
-utest cmpExpr
-        (utestu_ (var_ "a") (var_ "a") unit_ (var_ "cmp"))
-        (utestu_ (var_ "a") (var_ "a") unit_ (var_ "cmp")) with 0 in
-utest cmpExpr
-        (utesto_ (var_ "a") (var_ "a") unit_ (var_ "fail"))
-        (utesto_ (var_ "a") (var_ "a") unit_ (var_ "fail")) with 0 in
-utest cmpExpr
-        (utestuo_ (var_ "a") (var_ "a") unit_ (var_ "cmp") (var_ "fail"))
-        (utestuo_ (var_ "a") (var_ "a") unit_ (var_ "cmp") (var_ "fail"))
+utest cmpDecl (utest_ (var_ "a") (var_ "a"))
+              (utest_ (var_ "a") (var_ "a")) with 0 in
+utest cmpDecl (utest_ (var_ "b") (var_ "a"))
+              (utest_ (var_ "a") (var_ "a")) with 0 using neqi in
+utest cmpDecl (utest_ (var_ "a") (var_ "b"))
+        (utest_ (var_ "a") (var_ "a")) with 0 using neqi in
+utest cmpDecl
+        (utestu_ (var_ "a") (var_ "a") (var_ "cmp"))
+        (utestu_ (var_ "a") (var_ "a") (var_ "cmp")) with 0 in
+utest cmpDecl
+        (utesto_ (var_ "a") (var_ "a") (var_ "fail"))
+        (utesto_ (var_ "a") (var_ "a") (var_ "fail")) with 0 in
+utest cmpDecl
+        (utestuo_ (var_ "a") (var_ "a") (var_ "cmp") (var_ "fail"))
+        (utestuo_ (var_ "a") (var_ "a") (var_ "cmp") (var_ "fail"))
   with 0 in
-utest cmpExpr
-        (utestu_ (var_ "a") (var_ "a") unit_ (var_ "cmp"))
-        (utest_ (var_ "a") (var_ "a") unit_) with 0 using neqi in
-utest cmpExpr
-        (utesto_ (var_ "a") (var_ "a") unit_ (var_ "fail"))
-        (utest_ (var_ "a") (var_ "a") unit_) with 0 using neqi in
-utest cmpExpr
-        (utestuo_ (var_ "a") (var_ "a") unit_ (var_ "cmp") (var_ "fail"))
-        (utestu_ (var_ "a") (var_ "a") unit_ (var_ "cmp")) with 0 using neqi in
-utest cmpExpr
-        (utestuo_ (var_ "a") (var_ "a") unit_ (var_ "cmp") (var_ "fail"))
-        (utesto_ (var_ "a") (var_ "a") unit_ (var_ "fail")) with 0 using neqi in
+utest cmpDecl
+        (utestu_ (var_ "a") (var_ "a") (var_ "cmp"))
+        (utest_ (var_ "a") (var_ "a"))  with 0 using neqi in
+utest cmpDecl
+        (utesto_ (var_ "a") (var_ "a") (var_ "fail"))
+        (utest_ (var_ "a") (var_ "a"))  with 0 using neqi in
+utest cmpDecl
+        (utestuo_ (var_ "a") (var_ "a") (var_ "cmp") (var_ "fail"))
+        (utestu_ (var_ "a") (var_ "a") (var_ "cmp")) with 0 using neqi in
+utest cmpDecl
+        (utestuo_ (var_ "a") (var_ "a") (var_ "cmp") (var_ "fail"))
+        (utesto_ (var_ "a") (var_ "a") (var_ "fail")) with 0 using neqi in
 
 utest cmpExpr never_ never_ with 0 in
 
-utest cmpExpr (ext_ "a" false tyint_) (ext_ "a" false tyint_) with 0 in
-utest cmpExpr (ext_ "a" false tyint_) (ext_ "b" false tyint_) with 0
+utest cmpDecl (ext_ "a" false tyint_) (ext_ "a" false tyint_) with 0 in
+utest cmpDecl (ext_ "a" false tyint_) (ext_ "b" false tyint_) with 0
 using neqi in
-utest cmpExpr (ext_ "a" true tyint_) (ext_ "a" false tyint_) with 0
+utest cmpDecl (ext_ "a" true tyint_) (ext_ "a" false tyint_) with 0
 using neqi in
-utest cmpExpr (ext_ "a" true tyunknown_) (ext_ "a" false tyint_) with 0
+utest cmpDecl (ext_ "a" true tyunknown_) (ext_ "a" false tyint_) with 0
 using neqi in
 
 -- Constants

--- a/src/stdlib/mexpr/const-transformer.mc
+++ b/src/stdlib/mexpr/const-transformer.mc
@@ -21,7 +21,7 @@ let _constWithInfos: Info -> use Ast in Expr -> use Ast in Expr =
       TmConst {{t with info = i} with ty = TyUnknown {ty with info = i}}
     else tm
 
-lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + ExtAst + NamedPat + ConstAst
+lang ConstTransformer = VarAst + LamAst + LetDeclAst + RecLetsDeclAst + MatchAst + ExtDeclAst + NamedPat + ConstAst
 
   sem constTransform builtin =
   | t ->
@@ -32,12 +32,24 @@ lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + ExtAs
       --dprint t2;
       t2
 
+  sem ctWorkerDecl (env: Map String (Option Expr)) =
+  | DeclLet r ->
+    let body = ctWorker env r.body in
+    (mapInsert (nameGetStr r.ident) (None()) env, DeclLet {r with body = body})
+  | DeclRecLets r ->
+    let fEnv = lam acc. lam b:DeclLetRecord. mapInsert (nameGetStr b.ident) (None()) acc in
+    let env = foldl fEnv env r.bindings in
+    let bindings = map (lam b:DeclLetRecord. {b with body = ctWorker env b.body}) r.bindings in
+    (env, DeclRecLets {r with bindings = bindings})
+  | d & DeclExt r ->
+    (mapInsert (nameGetStr r.ident) (None()) env, d)
+  | d -> (env, smap_Decl_Expr (ctWorker env) d)
+
   sem ctWorker (env: Map String (Option Expr)) =
-  | TmLet r ->
-    let t1 = ctWorker env r.body in
-    let env = mapInsert (nameGetStr r.ident) (None()) env in
-    let t2 = ctWorker env r.inexpr in
-    TmLet {r with body = t1, inexpr = t2}
+  | TmDecl x ->
+    match ctWorkerDecl env x.decl with (env, decl) in
+    let inexpr = ctWorker env x.inexpr in
+    TmDecl {x with decl = decl, inexpr = inexpr}
   | TmLam r ->
     let t = ctWorker (mapInsert (nameGetStr r.ident) (None()) env) r.body in
     TmLam {r with body = t}
@@ -45,20 +57,12 @@ lang ConstTransformer = VarAst + LamAst + LetAst + RecLetsAst + MatchAst + ExtAs
     let ident = nameGetStr r.ident in
     match mapFindOrElse (lam. Some (TmVar r)) ident env with Some tm
     then _constWithInfos r.info tm else TmVar r
-  | TmRecLets r ->
-    let fEnv = lam acc. lam b:RecLetBinding. mapInsert (nameGetStr b.ident) (None()) acc in
-    let env = foldl fEnv env r.bindings in
-    let bindings = map (lam b:RecLetBinding. {b with body = ctWorker env b.body}) r.bindings in
-    TmRecLets {r with bindings = bindings, inexpr = ctWorker env r.inexpr}
   | TmMatch r ->
     let fEnv = lam acc. lam x. mapInsert x (None()) acc in
     let env2 = foldl fEnv env (ctGetPatVars [] r.pat) in
     TmMatch {r with target = ctWorker env r.target
                   , thn = ctWorker env2 r.thn
                   , els = ctWorker env r.els}
-  | TmExt r ->
-    let t = ctWorker (mapInsert (nameGetStr r.ident) (None()) env) r.inexpr in
-    TmExt {r with inexpr = t}
   | t -> smap_Expr_Expr (ctWorker env) t
 
 

--- a/src/stdlib/mexpr/constant-fold.mc
+++ b/src/stdlib/mexpr/constant-fold.mc
@@ -138,7 +138,7 @@ lang LamAppConstantFold = ConstantFold + AppAst + LamAst
       }
 end
 
-lang LetConstantFold = ConstantFold + LetAst
+lang LetConstantFold = ConstantFold + LetDeclAst
   sem constantFoldExpr ctx =
   | TmLet r ->
     let body = constantFoldExpr ctx r.body in

--- a/src/stdlib/mexpr/constant-fold.mc
+++ b/src/stdlib/mexpr/constant-fold.mc
@@ -140,17 +140,13 @@ end
 
 lang LetConstantFold = ConstantFold + LetDeclAst
   sem constantFoldExpr ctx =
-  | TmDecl {decl = DeclLet r} ->
+  | TmDecl (x & {decl = DeclLet r}) ->
     let body = constantFoldExpr ctx r.body in
     if doPropagate body then
       let ctx = { ctx with env = evalEnvInsert r.ident body ctx.env } in
-      constantFoldExpr ctx r.inexpr
+      constantFoldExpr ctx x.inexpr
     else
-      TmDecl {decl = DeclLet {
-        r with
-        body = body,
-        inexpr = constantFoldExpr ctx r.inexpr
-      }}
+      TmDecl {x with decl = DeclLet {r with body = body}, inexpr = constantFoldExpr ctx x.inexpr}
 end
 
 lang RecordConstantFold = ConstantFold + RecordAst

--- a/src/stdlib/mexpr/constant-fold.mc
+++ b/src/stdlib/mexpr/constant-fold.mc
@@ -140,17 +140,17 @@ end
 
 lang LetConstantFold = ConstantFold + LetDeclAst
   sem constantFoldExpr ctx =
-  | TmLet r ->
+  | TmDecl {decl = DeclLet r} ->
     let body = constantFoldExpr ctx r.body in
     if doPropagate body then
       let ctx = { ctx with env = evalEnvInsert r.ident body ctx.env } in
       constantFoldExpr ctx r.inexpr
     else
-      TmLet {
+      TmDecl {decl = DeclLet {
         r with
         body = body,
         inexpr = constantFoldExpr ctx r.inexpr
-      }
+      }}
 end
 
 lang RecordConstantFold = ConstantFold + RecordAst

--- a/src/stdlib/mexpr/cps.mc
+++ b/src/stdlib/mexpr/cps.mc
@@ -170,7 +170,7 @@ end
 lang RecLetsCPS = CPS + RecLetsAst + LamAst
   sem exprCps env k =
   | TmRecLets t ->
-    let bindings = map (lam b: RecLetBinding. { b with body =
+    let bindings = map (lam b: DeclLetRecord. { b with body =
         match b.body with TmLam t then
           if not (or (transform env b.ident) (transform env t.ident)) then
             TmLam { t with body = exprCps env (None ()) t.body }

--- a/src/stdlib/mexpr/cps.mc
+++ b/src/stdlib/mexpr/cps.mc
@@ -94,7 +94,7 @@ lang CPS = LamAst + VarAst + LetDeclAst
   | t -> smap_Type_Type (tyCps env) t
 
   sem tailCall =
-  | TmLet { ident = ident, inexpr = inexpr } ->
+  | TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} ->
     match inexpr with TmVar { ident = varIdent } then nameEq ident varIdent
     else false
 
@@ -112,15 +112,15 @@ lang VarCPS = CPS + VarAst + AppAst
   sem exprCps env k =
   | TmVar _ & t ->
     match k with Some k then withInfo (infoTm t) (app_ k t) else t
-  | TmLet ({ body = TmVar _ } & b) ->
-    TmLet { b with inexpr = exprCps env k b.inexpr }
+  | TmDecl {decl = DeclLet ({ body = TmVar _ } & b)} ->
+    TmDecl {decl = DeclLet { b with inexpr = exprCps env k b.inexpr }}
 end
 
 lang AppCPS = CPS + AppAst
   sem exprCps env k =
-  | TmLet ({ ident = ident, body = TmApp app, inexpr = inexpr } & b) & t ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmApp app, inexpr = inexpr } & b)} & t ->
     if not (transform env ident) then
-      TmLet { b with inexpr = exprCps env k inexpr }
+      TmDecl {decl = DeclLet { b with inexpr = exprCps env k inexpr }}
     else
       let i = withInfo (infoTm t) in
       let opt =
@@ -143,12 +143,12 @@ end
 
 lang LamCPS = CPS + LamAst
   sem exprCps env k =
-  | TmLet ({ ident = ident, body = TmLam t, inexpr = inexpr } & r) ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmLam t, inexpr = inexpr } & r)} ->
     if not (or (transform env ident) (transform env t.ident)) then
-      TmLet { r with
+      TmDecl {decl = DeclLet { r with
         body = TmLam { t with body = exprCps env (None ()) t.body },
         inexpr = exprCps env k inexpr
-      }
+      }}
     else
       let kName = nameSym "k" in
       let i = withInfo t.info in
@@ -156,7 +156,7 @@ lang LamCPS = CPS + LamAst
         i (nulam_ kName
              (TmLam {t with body = exprCps env (Some (i (nvar_ kName))) t.body}))
       in
-      TmLet { r with body = body, inexpr = exprCps env k inexpr }
+      TmDecl {decl = DeclLet { r with body = body, inexpr = exprCps env k inexpr }}
 
   sem exprTyCps env =
   | TmLam _ & e -> smap_Expr_Type (tyCps env) e
@@ -164,12 +164,12 @@ end
 
 lang LetCPS = CPS + LetDeclAst
   sem exprTyCps env =
-  | TmLet _ & e -> smap_Expr_Type (tyCps env) e
+  | TmDecl {decl = DeclLet _} & e -> smap_Expr_Type (tyCps env) e
 end
 
 lang RecLetsCPS = CPS + RecLetsDeclAst + LamAst
   sem exprCps env k =
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let bindings = map (lam b: DeclLetRecord. { b with body =
         match b.body with TmLam t then
           if not (or (transform env b.ident) (transform env t.ident)) then
@@ -182,10 +182,10 @@ lang RecLetsCPS = CPS + RecLetsDeclAst + LamAst
         else errorSingle [infoTm b.body]
           "Error: Not a TmLam in TmRecLet binding in CPS transformation"
       }) t.bindings
-    in TmRecLets { t with bindings = bindings, inexpr = exprCps env k t.inexpr }
+    in TmDecl {decl = DeclRecLets { t with bindings = bindings, inexpr = exprCps env k t.inexpr }}
 
   sem exprTyCps env =
-  | TmRecLets _ & e -> smap_Expr_Type (tyCps env) e
+  | TmDecl {decl = DeclRecLets _} & e -> smap_Expr_Type (tyCps env) e
 end
 
 -- Wraps a direct-style function with given arity as a CPS function
@@ -208,9 +208,9 @@ let wrapDirect = use MExprAst in
 
 lang ConstCPS = CPS + ConstAst + MExprArity + TyConst
   sem exprCps env k =
-  | TmLet ({ ident = ident, body = TmConst { val = c } & body} & t) ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmConst { val = c } & body} & t)} ->
     if not (transform env ident) then
-      TmLet { t with inexpr = exprCps env k t.inexpr }
+      TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
     else
       if isHigherOrderFunType (tyConst c) then
         -- TODO(dlunde,2022-09-19): Add support for higher-order constant
@@ -221,39 +221,39 @@ lang ConstCPS = CPS + ConstAst + MExprArity + TyConst
       else
         -- Constants are not in CPS, so we must wrap them in CPS lambdas
         let body = wrapDirect (constArity c) body in
-        TmLet { t with body = body, inexpr = exprCps env k t.inexpr }
+        TmDecl {decl = DeclLet { t with body = body, inexpr = exprCps env k t.inexpr }}
 end
 
 -- Thanks to ANF, we don't need to do anything at all when constructing data
 -- (TmRecord, TmSeq, TmConApp, etc.)
 lang SeqCPS = CPS + SeqAst
   sem exprCps env k =
-  | TmLet ({ body = TmSeq _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmDecl {decl = DeclLet ({ body = TmSeq _ } & t)} ->
+    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
 end
 
 lang RecordCPS = CPS + RecordAst
   sem exprCps env k =
-  | TmLet ({ body = TmRecord _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmLet ({ body = TmRecordUpdate _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmDecl {decl = DeclLet ({ body = TmRecord _ } & t)} ->
+    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
+  | TmDecl {decl = DeclLet ({ body = TmRecordUpdate _ } & t)} ->
+    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
 end
 
 lang TypeCPS = CPS + TypeDeclAst
   sem exprCps env k =
-  | TmType t -> TmType { t with inexpr = exprCps env k t.inexpr }
+  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType { t with inexpr = exprCps env k t.inexpr }}
 
   sem exprTyCps env =
-  | TmType _ & e -> smap_Expr_Type (tyCps env) e
+  | TmDecl {decl = DeclType _} & e -> smap_Expr_Type (tyCps env) e
 end
 
 lang DataCPS = CPS + DataAst + AllTypeAst + FunTypeAst
   sem exprCps env k =
-  | TmLet ({ body = TmConApp _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
-  | TmConDef t ->
-    TmConDef { t with inexpr = exprCps env k t.inexpr }
+  | TmDecl {decl = DeclLet ({ body = TmConApp _ } & t)} ->
+    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
+  | TmDecl {decl = DeclConDef t} ->
+    TmDecl {decl = DeclConDef { t with inexpr = exprCps env k t.inexpr }}
 
   -- We do not transform the top-level arrow type of the condef (due to
   -- the nested smap_Type_Type), as data values are constructed as usual even
@@ -264,7 +264,7 @@ lang DataCPS = CPS + DataAst + AllTypeAst + FunTypeAst
   -- of a condef is a type variable that was defined earlier with TmType. It is
   -- then CPS transformed.
   sem exprTyCps env =
-  | TmConDef t & e ->
+  | TmDecl {decl = DeclConDef t} & e ->
     recursive let rec = lam ty.
       match ty with TyAll b then TyAll { b with ty = rec b.ty }
       else match ty with TyArrow _ & t then smap_Type_Type (tyCps env) t
@@ -275,15 +275,15 @@ end
 
 lang MatchCPS = CPS + MatchAst
   sem exprCps env k =
-  | TmLet ({ ident = ident, body = TmMatch m, inexpr = inexpr } & b) & t ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m, inexpr = inexpr } & b)} & t ->
     if not (transform env ident) then
-      TmLet { b with
+      TmDecl {decl = DeclLet { b with
         body = TmMatch { m with
           thn = exprCps env (None ()) m.thn,
           els = exprCps env (None ()) m.els
         },
         inexpr = exprCps env k inexpr
-      }
+      }}
     else
       let opt = match k with Some k then tailCall t else false in
       if opt then
@@ -306,35 +306,35 @@ end
 -- Not much needs to be done here thanks to ANF
 lang UtestCPS = CPS + UtestDeclAst
   sem exprCps env k =
-  | TmUtest t -> TmUtest { t with next = exprCps env k t.next }
+  | TmDecl {decl = DeclUtest t} -> TmDecl {decl = DeclUtest { t with next = exprCps env k t.next }}
 
 end
 
 lang NeverCPS = CPS + NeverAst
   sem exprCps env k =
-  | TmLet ({ body = TmNever _ } & t) ->
-    TmLet { t with inexpr = exprCps env k t.inexpr }
+  | TmDecl {decl = DeclLet ({ body = TmNever _ } & t)} ->
+    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
 end
 
 lang ExtCPS = CPS + ExtDeclAst + FunArity
   sem exprCps env k =
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     errorSingle [t.info]
       "Error in CPS: Should not happen due to ANF transformation"
-  | TmExt ({ inexpr = TmLet ({ ident = ident, body = TmLam _ | TmVar _, inexpr = inexpr } & tl) } & t) ->
+  | TmDecl {decl = DeclExt ({ inexpr = TmDecl {decl = DeclLet ({ ident = ident, body = TmLam _ | TmVar _, inexpr = inexpr } & tl)} } & t)} ->
     if not (transform env ident) then
-      TmExt { t with inexpr = TmLet { tl with inexpr = exprCps env k inexpr } }
+      TmDecl {decl = DeclExt { t with inexpr = TmDecl {decl = DeclLet { tl with inexpr = exprCps env k inexpr }} }}
     else
       -- We know that ANF adds a let that eta expands the external just after its
       -- definition. Here, we simply replace this eta expansion with its CPS
       -- equivalent
       let arity = arityFunType t.tyIdent in
       let i = withInfo t.info in
-      TmExt { t with
+      TmDecl {decl = DeclExt { t with
         inexpr = bindall_
           [ i (nulet_ t.ident (wrapDirect arity (i (nvar_ t.ident)))),
             exprCps env k inexpr ]
-      }
+      }}
 end
 
 -----------

--- a/src/stdlib/mexpr/cps.mc
+++ b/src/stdlib/mexpr/cps.mc
@@ -55,7 +55,7 @@ let _cpsEnvDefault = {
   partial = false
 }
 
-lang CPS = LamAst + VarAst + LetAst
+lang CPS = LamAst + VarAst + LetDeclAst
 
   sem cpsFullIdentity : Expr -> Expr
   sem cpsFullIdentity =
@@ -162,12 +162,12 @@ lang LamCPS = CPS + LamAst
   | TmLam _ & e -> smap_Expr_Type (tyCps env) e
 end
 
-lang LetCPS = CPS + LetAst
+lang LetCPS = CPS + LetDeclAst
   sem exprTyCps env =
   | TmLet _ & e -> smap_Expr_Type (tyCps env) e
 end
 
-lang RecLetsCPS = CPS + RecLetsAst + LamAst
+lang RecLetsCPS = CPS + RecLetsDeclAst + LamAst
   sem exprCps env k =
   | TmRecLets t ->
     let bindings = map (lam b: DeclLetRecord. { b with body =
@@ -240,7 +240,7 @@ lang RecordCPS = CPS + RecordAst
     TmLet { t with inexpr = exprCps env k t.inexpr }
 end
 
-lang TypeCPS = CPS + TypeAst
+lang TypeCPS = CPS + TypeDeclAst
   sem exprCps env k =
   | TmType t -> TmType { t with inexpr = exprCps env k t.inexpr }
 
@@ -304,7 +304,7 @@ lang MatchCPS = CPS + MatchAst
 end
 
 -- Not much needs to be done here thanks to ANF
-lang UtestCPS = CPS + UtestAst
+lang UtestCPS = CPS + UtestDeclAst
   sem exprCps env k =
   | TmUtest t -> TmUtest { t with next = exprCps env k t.next }
 
@@ -316,7 +316,7 @@ lang NeverCPS = CPS + NeverAst
     TmLet { t with inexpr = exprCps env k t.inexpr }
 end
 
-lang ExtCPS = CPS + ExtAst + FunArity
+lang ExtCPS = CPS + ExtDeclAst + FunArity
   sem exprCps env k =
   | TmExt t ->
     errorSingle [t.info]

--- a/src/stdlib/mexpr/cps.mc
+++ b/src/stdlib/mexpr/cps.mc
@@ -94,7 +94,7 @@ lang CPS = LamAst + VarAst + LetDeclAst
   | t -> smap_Type_Type (tyCps env) t
 
   sem tailCall =
-  | TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} ->
+  | TmDecl {decl = DeclLet { ident = ident}, inexpr = inexpr } ->
     match inexpr with TmVar { ident = varIdent } then nameEq ident varIdent
     else false
 
@@ -112,15 +112,15 @@ lang VarCPS = CPS + VarAst + AppAst
   sem exprCps env k =
   | TmVar _ & t ->
     match k with Some k then withInfo (infoTm t) (app_ k t) else t
-  | TmDecl {decl = DeclLet ({ body = TmVar _ } & b)} ->
-    TmDecl {decl = DeclLet { b with inexpr = exprCps env k b.inexpr }}
+  | TmDecl (x & {decl = DeclLet ({ body = TmVar _ } & b)}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
 end
 
 lang AppCPS = CPS + AppAst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmApp app, inexpr = inexpr } & b)} & t ->
+  | TmDecl (x & {decl = DeclLet ({ ident = ident, body = TmApp app} & b), inexpr = inexpr }) & t ->
     if not (transform env ident) then
-      TmDecl {decl = DeclLet { b with inexpr = exprCps env k inexpr }}
+      TmDecl {x with inexpr = exprCps env k inexpr}
     else
       let i = withInfo (infoTm t) in
       let opt =
@@ -135,20 +135,19 @@ lang AppCPS = CPS + AppAst
         let inexpr = exprCps env k inexpr in
         let kName = nameSym "k" in
         let k = i (nulam_ ident inexpr) in
-        bindall_ [
-          i (nulet_ kName k),
-          i (appf2_ app.lhs (i (nvar_ kName)) app.rhs)
-        ]
+        bind_
+          (declWithInfo (infoTm t) (nulet_ kName k))
+          (i (appf2_ app.lhs (i (nvar_ kName)) app.rhs))
 end
 
 lang LamCPS = CPS + LamAst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmLam t, inexpr = inexpr } & r)} ->
+  | TmDecl (x & {decl = DeclLet ({ ident = ident, body = TmLam t } & r), inexpr = inexpr}) ->
     if not (or (transform env ident) (transform env t.ident)) then
-      TmDecl {decl = DeclLet { r with
-        body = TmLam { t with body = exprCps env (None ()) t.body },
-        inexpr = exprCps env k inexpr
-      }}
+      TmDecl
+      {x with decl = DeclLet {r with body = TmLam { t with body = exprCps env (None ()) t.body }}
+      , inexpr = exprCps env k inexpr
+      }
     else
       let kName = nameSym "k" in
       let i = withInfo t.info in
@@ -156,7 +155,7 @@ lang LamCPS = CPS + LamAst
         i (nulam_ kName
              (TmLam {t with body = exprCps env (Some (i (nvar_ kName))) t.body}))
       in
-      TmDecl {decl = DeclLet { r with body = body, inexpr = exprCps env k inexpr }}
+      TmDecl {x with decl = DeclLet {r with body = body}, inexpr = exprCps env k inexpr }
 
   sem exprTyCps env =
   | TmLam _ & e -> smap_Expr_Type (tyCps env) e
@@ -169,7 +168,7 @@ end
 
 lang RecLetsCPS = CPS + RecLetsDeclAst + LamAst
   sem exprCps env k =
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let bindings = map (lam b: DeclLetRecord. { b with body =
         match b.body with TmLam t then
           if not (or (transform env b.ident) (transform env t.ident)) then
@@ -182,7 +181,7 @@ lang RecLetsCPS = CPS + RecLetsDeclAst + LamAst
         else errorSingle [infoTm b.body]
           "Error: Not a TmLam in TmRecLet binding in CPS transformation"
       }) t.bindings
-    in TmDecl {decl = DeclRecLets { t with bindings = bindings, inexpr = exprCps env k t.inexpr }}
+    in TmDecl {x with decl = DeclRecLets { t with bindings = bindings}, inexpr = exprCps env k x.inexpr}
 
   sem exprTyCps env =
   | TmDecl {decl = DeclRecLets _} & e -> smap_Expr_Type (tyCps env) e
@@ -208,9 +207,9 @@ let wrapDirect = use MExprAst in
 
 lang ConstCPS = CPS + ConstAst + MExprArity + TyConst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmConst { val = c } & body} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ ident = ident, body = TmConst { val = c } & body} & t)}) ->
     if not (transform env ident) then
-      TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
+      TmDecl {x with inexpr = exprCps env k x.inexpr}
     else
       if isHigherOrderFunType (tyConst c) then
         -- TODO(dlunde,2022-09-19): Add support for higher-order constant
@@ -221,39 +220,40 @@ lang ConstCPS = CPS + ConstAst + MExprArity + TyConst
       else
         -- Constants are not in CPS, so we must wrap them in CPS lambdas
         let body = wrapDirect (constArity c) body in
-        TmDecl {decl = DeclLet { t with body = body, inexpr = exprCps env k t.inexpr }}
+        TmDecl {x with decl = DeclLet { t with body = body}, inexpr = exprCps env k x.inexpr}
 end
 
 -- Thanks to ANF, we don't need to do anything at all when constructing data
 -- (TmRecord, TmSeq, TmConApp, etc.)
 lang SeqCPS = CPS + SeqAst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ body = TmSeq _ } & t)} ->
-    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
+  | TmDecl (x & {decl = DeclLet { body = TmSeq _ }}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
 end
 
 lang RecordCPS = CPS + RecordAst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ body = TmRecord _ } & t)} ->
-    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
-  | TmDecl {decl = DeclLet ({ body = TmRecordUpdate _ } & t)} ->
-    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
+  | TmDecl (x & {decl = DeclLet { body = TmRecord _ }}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
+  | TmDecl (x & {decl = DeclLet { body = TmRecordUpdate _ }}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
 end
 
 lang TypeCPS = CPS + TypeDeclAst
   sem exprCps env k =
-  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType { t with inexpr = exprCps env k t.inexpr }}
+  | TmDecl (x & {decl = DeclType _}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
 
   sem exprTyCps env =
   | TmDecl {decl = DeclType _} & e -> smap_Expr_Type (tyCps env) e
 end
 
-lang DataCPS = CPS + DataAst + AllTypeAst + FunTypeAst
+lang DataCPS = CPS + DataAst + AllTypeAst + FunTypeAst + DataDeclAst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ body = TmConApp _ } & t)} ->
-    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
-  | TmDecl {decl = DeclConDef t} ->
-    TmDecl {decl = DeclConDef { t with inexpr = exprCps env k t.inexpr }}
+  | TmDecl (x & {decl = DeclLet { body = TmConApp _ }}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
+  | TmDecl (x & {decl = DeclConDef t}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
 
   -- We do not transform the top-level arrow type of the condef (due to
   -- the nested smap_Type_Type), as data values are constructed as usual even
@@ -275,15 +275,15 @@ end
 
 lang MatchCPS = CPS + MatchAst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m, inexpr = inexpr } & b)} & t ->
+  | TmDecl (x & {decl = DeclLet ({ ident = ident, body = TmMatch m } & b), inexpr = inexpr}) & t ->
     if not (transform env ident) then
-      TmDecl {decl = DeclLet { b with
+      TmDecl {x with decl = DeclLet { b with
         body = TmMatch { m with
           thn = exprCps env (None ()) m.thn,
           els = exprCps env (None ()) m.els
-        },
+        }},
         inexpr = exprCps env k inexpr
-      }}
+      }
     else
       let opt = match k with Some k then tailCall t else false in
       if opt then
@@ -294,26 +294,26 @@ lang MatchCPS = CPS + MatchAst
         let kName = nameSym "k" in
         let i = withInfo (infoTm t) in
         let k = i (nulam_ ident inexpr) in
-        bindall_ [
-          i (nulet_ kName k),
-          TmMatch { m with
+        bind_
+          (declWithInfo (infoTm t) (nulet_ kName k))
+          (TmMatch { m with
             thn = exprCps env (Some (i (nvar_ kName))) m.thn,
             els = exprCps env (Some (i (nvar_ kName))) m.els
-          }
-        ]
+          })
 end
 
 -- Not much needs to be done here thanks to ANF
 lang UtestCPS = CPS + UtestDeclAst
   sem exprCps env k =
-  | TmDecl {decl = DeclUtest t} -> TmDecl {decl = DeclUtest { t with next = exprCps env k t.next }}
+  | TmDecl (x & {decl = DeclUtest t}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
 
 end
 
 lang NeverCPS = CPS + NeverAst
   sem exprCps env k =
-  | TmDecl {decl = DeclLet ({ body = TmNever _ } & t)} ->
-    TmDecl {decl = DeclLet { t with inexpr = exprCps env k t.inexpr }}
+  | TmDecl (x & {decl = DeclLet { body = TmNever _ }}) ->
+    TmDecl {x with inexpr = exprCps env k x.inexpr}
 end
 
 lang ExtCPS = CPS + ExtDeclAst + FunArity
@@ -321,20 +321,30 @@ lang ExtCPS = CPS + ExtDeclAst + FunArity
   | TmDecl {decl = DeclExt t} ->
     errorSingle [t.info]
       "Error in CPS: Should not happen due to ANF transformation"
-  | TmDecl {decl = DeclExt ({ inexpr = TmDecl {decl = DeclLet ({ ident = ident, body = TmLam _ | TmVar _, inexpr = inexpr } & tl)} } & t)} ->
+  | TmDecl (x &
+    { decl = DeclExt t
+    , inexpr = TmDecl (x2 &
+      { decl = DeclLet (tl &
+        { ident = ident
+        , body = TmLam _ | TmVar _
+        })
+      , inexpr = inexpr
+      })
+    }) ->
     if not (transform env ident) then
-      TmDecl {decl = DeclExt { t with inexpr = TmDecl {decl = DeclLet { tl with inexpr = exprCps env k inexpr }} }}
+      TmDecl {x with inexpr = TmDecl {x2 with inexpr = exprCps env k inexpr}}
     else
       -- We know that ANF adds a let that eta expands the external just after its
       -- definition. Here, we simply replace this eta expansion with its CPS
       -- equivalent
       let arity = arityFunType t.tyIdent in
       let i = withInfo t.info in
-      TmDecl {decl = DeclExt { t with
-        inexpr = bindall_
-          [ i (nulet_ t.ident (wrapDirect arity (i (nvar_ t.ident)))),
-            exprCps env k inexpr ]
-      }}
+      TmDecl
+      { x with decl = DeclExt t
+      , inexpr = bind_
+        (declWithInfo t.info (nulet_ t.ident (wrapDirect arity (i (nvar_ t.ident)))))
+        (exprCps env k inexpr)
+      }
 end
 
 -----------
@@ -608,8 +618,7 @@ let typestest = _cps "
 " in
 -- print (mexprToString typestest);
 utest mexprToString typestest with
-"external e : Float -> Float
-in
+"external e : Float -> Float in
 let e = lam k11.
     lam a1.
       k11 (e a1) in
@@ -628,12 +637,11 @@ recursive
       lam y: a.
         k y
 in
-type T
-in
+type T in
 con C: (all x. (x -> Unknown) -> x -> Unknown) -> T in
 g (lam x.
      x) f"
-in
+using eqString else lam a. lam b. strJoin "\n\n" [a, b] in
 
 ----------------------------
 -- TESTS FOR PARTIAL CPS  --

--- a/src/stdlib/mexpr/cse.mc
+++ b/src/stdlib/mexpr/cse.mc
@@ -57,8 +57,18 @@ lang CSE = MExprCmp
           foldl
             (lam acc. lam namedExpr : (Name, Expr).
               match namedExpr with (id, e) then
-                TmLet {ident = id, tyAnnot = tyTm e, tyBody = tyTm e,
-                       body = e, inexpr = acc, ty = tyTm acc, info = infoTm e}
+                TmDecl
+                { decl = DeclLet
+                  { ident = id
+                  , tyAnnot = tyTm e
+                  , tyBody = tyTm e
+                  , body = e
+                  , info = infoTm e
+                  }
+                , ty = tyTm acc
+                , info = infoTm e
+                , inexpr = acc
+                }
               else never)
             t
             exprs)
@@ -158,53 +168,56 @@ lang LamCSE = CSE + LamAst
     else never
 end
 
-lang LetCSE = CSE + LetAst
+lang LetCSE = CSE + LetDeclAst
   sem cseSearchH (pos : ProgramPos) (env : CSESearchEnv) =
-  | TmLet t ->
+  | TmDecl { decl = DeclLet t, inexpr = inexpr } ->
     let env : CSESearchEnv = cseSearch pos env t.body in
     let inexprPos = snoc pos env.index in
-    cseSearch inexprPos env t.inexpr
+    cseSearch inexprPos env inexpr
 
   sem cseApplyH (env : CSEApplyEnv) =
-  | TmLet t ->
+  | TmDecl (d & { decl = DeclLet t, inexpr = inexpr }) ->
     match cseApply env t.body with (thnEnv, body) then
-      match cseApply thnEnv t.inexpr with (env, inexpr) then
+      match cseApply thnEnv inexpr with (env, inexpr) then
         let inexpr = insertSubexpressionDeclarations thnEnv inexpr in
-        (env, TmLet {{t with body = body}
-                        with inexpr = inexpr})
+        ( env
+        , TmDecl {d with decl = DeclLet {t with body = body}, inexpr = inexpr}
+        )
       else never
     else never
 end
 
-lang RecLetsCSE = CSE + RecLetsAst
+lang RecLetsCSE = CSE + RecLetsDeclAst
   sem cseSearchH (pos : ProgramPos) (env : CSESearchEnv) =
-  | TmRecLets t ->
+  | TmDecl { decl = DeclRecLets t, inexpr = inexpr } ->
     let recursiveIdents =
       foldl
-        (lam acc. lam binding : RecLetBinding. setInsert binding.ident acc)
+        (lam acc. lam binding : DeclLetRecord. setInsert binding.ident acc)
         env.recursiveIdents
         t.bindings in
     let bindEnv =
       foldl
-        (lam acc. lam binding : RecLetBinding.
+        (lam acc. lam binding : DeclLetRecord.
           cseSearch pos acc binding.body)
         {env with recursiveIdents = recursiveIdents}
         t.bindings in
-    cseSearch pos bindEnv t.inexpr
+    cseSearch pos bindEnv inexpr
 
   sem cseApplyH (env : CSEApplyEnv) =
-  | TmRecLets t ->
-    let applyBinding : CSEApplyEnv -> RecLetBinding
-                    -> (CSEApplyEnv, RecLetBinding) =
+  | TmDecl (d & {decl = DeclRecLets t, inexpr = inexpr}) ->
+    let applyBinding : CSEApplyEnv -> DeclLetRecord
+                    -> (CSEApplyEnv, DeclLetRecord) =
       lam env. lam binding.
       match cseApply env binding.body with (env, body) then
         (env, {binding with body = body})
       else never
     in
     match mapAccumL applyBinding env t.bindings with (inexprEnv, bindings) then
-      match cseApply inexprEnv t.inexpr with (env, inexpr) then
+      match cseApply inexprEnv inexpr with (env, inexpr) then
         let inexpr = insertSubexpressionDeclarations inexprEnv inexpr in
-        (env, TmRecLets {{t with bindings = bindings} with inexpr = inexpr})
+        ( env
+        , TmDecl {d with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr}
+        )
       else never
     else never
 end
@@ -259,23 +272,23 @@ lang MExprCSE =
     TmLam {t with body = cseFunction true t.body}
   | t -> if inLambda then cse t else t
 
-  -- Runs CSE globally within the body of each top-level function.
-  sem cseGlobal =
-  | TmLet t ->
-    TmLet {{t with body = cseFunction false t.body}
-              with inexpr = cseGlobal t.inexpr}
-  | TmRecLets t ->
+  sem cseDecl =
+  | DeclLet t -> DeclLet {t with body = cseFunction false t.body}
+  | DeclRecLets t ->
     let bindings =
       map
-        (lam bind : RecLetBinding.
+        (lam bind : DeclLetRecord.
           {bind with body = cseFunction false bind.body})
         t.bindings in
-    TmRecLets {{t with bindings = bindings}
-                  with inexpr = cseGlobal t.inexpr}
-  | TmType t -> TmType {t with inexpr = cseGlobal t.inexpr}
-  | TmConDef t -> TmConDef {t with inexpr = cseGlobal t.inexpr}
-  | TmUtest t -> TmUtest {t with next = cseGlobal t.next}
-  | TmExt t -> TmExt {t with inexpr = cseGlobal t.inexpr}
+    DeclRecLets {t with bindings = bindings}
+  | d -> d
+
+  -- Runs CSE globally within the body of each top-level function.
+  sem cseGlobal =
+  | TmDecl x ->
+    let decl = cseDecl x.decl in
+    let inexpr = cseGlobal x.inexpr in
+    TmDecl {x with decl = decl, inexpr = inexpr}
   | t -> t
 end
 
@@ -286,8 +299,8 @@ mexpr
 use TestLang in
 
 recursive let withoutTypes = lam e.
-  match e with TmType t then
-    withoutTypes t.inexpr
+  match e with TmDecl {decl = DeclType _, inexpr = inexpr} then
+    withoutTypes inexpr
   else e
 in
 
@@ -302,9 +315,9 @@ let t = preprocess (bindall_ [
     ("x", ulam_ "a" (muli_ commonExpr commonExpr)),
     ("x", ulam_ "a" commonExpr)],
   ulet_ "x" (muli_ commonExpr commonExpr),
-  ulet_ "x" (ulam_ "a" commonExpr),
+  ulet_ "x" (ulam_ "a" commonExpr)]
   unit_
-]) in
+) in
 let expected = preprocess (bindall_ [
   ulet_ "x" (ulam_ "a" (
     bind_ (ulet_ "t" commonExpr) (muli_ (var_ "t") (var_ "t")))),
@@ -312,40 +325,40 @@ let expected = preprocess (bindall_ [
     ("x", ulam_ "a" (bind_ (ulet_ "t" commonExpr) (muli_ (var_ "t") (var_ "t")))),
     ("x", ulam_ "a" commonExpr)],
   ulet_ "x" (muli_ commonExpr commonExpr),
-  ulet_ "x" (ulam_ "a" commonExpr),
+  ulet_ "x" (ulam_ "a" commonExpr)]
   unit_
-]) in
+) in
 utest cseGlobal t with expected using eqExpr in
 
 let t = preprocess (muli_ commonExpr commonExpr) in
-let expected = preprocess (bindall_ [
-  ulet_ "t" commonExpr,
-  muli_ (var_ "t") (var_ "t")]) in
+let expected = preprocess (bind_
+  (ulet_ "t" commonExpr)
+  (muli_ (var_ "t") (var_ "t"))) in
 utest cse t with expected using eqExpr in
 
-let t = preprocess (ulet_ "x" (muli_ commonExpr commonExpr)) in
+let t = preprocess (bind_ (ulet_ "x" (muli_ commonExpr commonExpr)) unit_) in
 let expected = preprocess (bindall_ [
   ulet_ "t" commonExpr,
-  ulet_ "x" (muli_ (var_ "t") (var_ "t"))]) in
+  ulet_ "x" (muli_ (var_ "t") (var_ "t"))] unit_) in
 utest cse t with expected using eqExpr in
 
 let t = preprocess (bindall_ [
   ulet_ "x" (muli_ commonExpr commonExpr),
-  ulet_ "y" (addi_ commonExpr commonExpr),
-  addi_ (var_ "x") (var_ "y")]) in
+  ulet_ "y" (addi_ commonExpr commonExpr)]
+  (addi_ (var_ "x") (var_ "y"))) in
 let expected = preprocess (bindall_ [
   ulet_ "t" commonExpr,
   ulet_ "x" (muli_ (var_ "t") (var_ "t")),
-  ulet_ "y" (addi_ (var_ "t") (var_ "t")),
-  addi_ (var_ "x") (var_ "y")]) in
+  ulet_ "y" (addi_ (var_ "t") (var_ "t"))]
+  (addi_ (var_ "x") (var_ "y"))) in
 utest cse t with expected using eqExpr in
 
-let t = preprocess (ureclets_ [
-  ("a", ulam_ "x" (addi_ (muli_ (var_ "x") commonExpr) commonExpr))]) in
-let expected = preprocess (ureclets_ [
-    ("a", ulam_ "x" (bindall_ [
-      ulet_ "t" commonExpr,
-      addi_ (muli_ (var_ "x") (var_ "t")) (var_ "t")]))]) in
+let t = preprocess (bind_ (ureclets_ [
+  ("a", ulam_ "x" (addi_ (muli_ (var_ "x") commonExpr) commonExpr))]) unit_) in
+let expected = preprocess (bind_ (ureclets_ [
+    ("a", ulam_ "x" (bind_
+      (ulet_ "t" commonExpr)
+      (addi_ (muli_ (var_ "x") (var_ "t")) (var_ "t"))))]) unit_) in
 utest cse t with expected using eqExpr in
 
 let t = preprocess (
@@ -361,29 +374,29 @@ let t = preprocess (
   if_ (eqi_ (int_ 0) (int_ 0))
     (muli_ commonExpr commonExpr)
     (addi_ commonExpr commonExpr)) in
-let expected = preprocess (bindall_ [
-  ulet_ "t" commonExpr,
-  if_ (eqi_ (int_ 0) (int_ 0))
+let expected = preprocess (bind_
+  (ulet_ "t" commonExpr)
+  (if_ (eqi_ (int_ 0) (int_ 0))
     (muli_ (var_ "t") (var_ "t"))
-    (addi_ (var_ "t") (var_ "t"))]) in
+    (addi_ (var_ "t") (var_ "t")))) in
 utest cse t with expected using eqExpr in
 
 let t = preprocess (
   if_ (eqi_ (subi_ commonExpr commonExpr) (int_ 0))
     (int_ 1)
     (int_ 2)) in
-let expected = preprocess (bindall_ [
-  ulet_ "t" commonExpr,
-  if_ (eqi_ (subi_ (var_ "t") (var_ "t")) (int_ 0))
+let expected = preprocess (bind_
+  (ulet_ "t" commonExpr)
+  (if_ (eqi_ (subi_ (var_ "t") (var_ "t")) (int_ 0))
     (int_ 1)
-    (int_ 2)]) in
+    (int_ 2))) in
 utest cse t with expected using eqExpr in
 
 -- Partial applications are not eliminated (in this case, 'muli 2 _')
 let t = preprocess (bindall_ [
   ulet_ "x" (muli_ (int_ 2) (int_ 3)),
-  ulet_ "y" (muli_ (int_ 2) (int_ 4)),
-  addi_ (var_ "x") (var_ "y")]) in
+  ulet_ "y" (muli_ (int_ 2) (int_ 4))]
+  (addi_ (var_ "x") (var_ "y"))) in
 utest cse t with t using eqExpr in
 
 let t = preprocess (bindall_ [
@@ -391,33 +404,31 @@ let t = preprocess (bindall_ [
   condef_ "CInt" (tyarrow_ tyint_ (tycon_ "Num")),
   ulet_ "x" (int_ 4),
   ulet_ "y" (conapp_ "CInt" (var_ "x")),
-  ulet_ "z" (conapp_ "CInt" (var_ "x")),
-  var_ "y",
-  uunit_
-]) in
+  ulet_ "z" (conapp_ "CInt" (var_ "x"))]
+  (utuple_ [var_ "y", uunit_])
+) in
 let expected = preprocess (bindall_ [
   type_ "Num" [] (tyvariant_ []),
   condef_ "CInt" (tyarrow_ tyint_ (tycon_ "Num")),
   ulet_ "x" (int_ 4),
   ulet_ "t" (conapp_ "CInt" (var_ "x")),
   ulet_ "y" (var_ "t"),
-  ulet_ "z" (var_ "t"),
-  var_ "y",
-  uunit_
-]) in
+  ulet_ "z" (var_ "t")]
+  (utuple_ [var_ "y", uunit_])
+) in
 utest cse t with expected using eqExpr in
 
 let t = preprocess (bindall_ [
   ulet_ "x" (urecord_ [("a", int_ 1), ("b", char_ 'x')]),
-  ulet_ "y" (urecord_ [("b", char_ 'x'), ("a", int_ 1)]),
+  ulet_ "y" (urecord_ [("b", char_ 'x'), ("a", int_ 1)])]
   unit_
-]) in
+) in
 let expected = preprocess (bindall_ [
   ulet_ "t" (urecord_ [("a", int_ 1), ("b", char_ 'x')]),
   ulet_ "x" (var_ "t"),
-  ulet_ "y" (var_ "t"),
+  ulet_ "y" (var_ "t")]
   unit_
-]) in
+) in
 utest cse t with expected using eqExpr in
 
 let t = preprocess (ulam_ "a" (ulam_ "b" (
@@ -428,37 +439,37 @@ let t = preprocess (ulam_ "a" (ulam_ "b" (
       (ptuple_ [pvarw_, pint_ 1])
       (int_ 1)
       (int_ 3))))) in
-let expected = preprocess (ulam_ "a" (ulam_ "b" (bindall_ [
-  ulet_ "t" (utuple_ [var_ "a", var_ "b"]),
-  match_ (var_ "t")
+let expected = preprocess (ulam_ "a" (ulam_ "b" (bind_
+  (ulet_ "t" (utuple_ [var_ "a", var_ "b"]))
+  (match_ (var_ "t")
     (ptuple_ [pint_ 1, pvarw_])
     (int_ 2)
     (match_ (var_ "t")
       (ptuple_ [pvarw_, pint_ 1])
       (int_ 1)
-      (int_ 3))]))) in
+      (int_ 3)))))) in
 utest cse t with expected using eqExpr in
 
-let t = preprocess (bindall_ [
-  ureclets_ [("f", ulam_ "x" commonExpr)],
-  commonExpr]) in
+let t = preprocess (bind_
+  (ureclets_ [("f", ulam_ "x" commonExpr)])
+  commonExpr) in
 let expected = preprocess (bindall_ [
   ulet_ "t" commonExpr,
-  ureclets_ [("f", ulam_ "x" (var_ "t"))],
-  var_ "t"]) in
+  ureclets_ [("f", ulam_ "x" (var_ "t"))]]
+  (var_ "t")) in
 utest cse t with expected using eqExpr in
 
 let t = preprocess (bindall_ [
   ulet_ "k" commonExpr,
-  ureclets_ [("f", ulam_ "x" commonExpr)],
+  ureclets_ [("f", ulam_ "x" commonExpr)]]
   unit_
-]) in
+) in
 let expected = preprocess (bindall_ [
   ulet_ "t" commonExpr,
   ulet_ "k" (var_ "t"),
-  ureclets_ [("f", ulam_ "x" (var_ "t"))],
+  ureclets_ [("f", ulam_ "x" (var_ "t"))]]
   unit_
-]) in
+) in
 utest cse t with expected using eqExpr in
 
 let t = preprocess (
@@ -478,14 +489,14 @@ let expected = preprocess (if_ true_
     ulet_ "x"
       (if_ true_
          (var_ "t")
-         (var_ "t")),
-    int_ 0
-  ])
-  (bindall_ [
-    ulet_ "t" commonExpr,
+         (var_ "t"))]
+    (int_ 0)
+  )
+  (bind_
+    (ulet_ "t" commonExpr)
     (if_ true_
       (var_ "t")
-      (var_ "t"))])) in
+      (var_ "t")))) in
 utest cse t with expected using eqExpr in
 
 -- Ignore subexpressions that are applications of recursive bindings
@@ -494,8 +505,8 @@ let t = preprocess (bindall_ [
     ("f", ulam_ "x" (var_ "x"))
   ],
   ulet_ "x" (app_ (var_ "f") (int_ 3)),
-  ulet_ "y" (app_ (var_ "f") (int_ 3)),
-  unit_]) in
+  ulet_ "y" (app_ (var_ "f") (int_ 3))]
+  unit_) in
 utest cse t with t using eqExpr in
 
 ()

--- a/src/stdlib/mexpr/demote-recursive.mc
+++ b/src/stdlib/mexpr/demote-recursive.mc
@@ -15,7 +15,7 @@ lang MExprDemoteRecursive = MExprAst + MExprFreeVars
   sem demoteRecursive : Expr -> Expr
   sem demoteRecursive =
   | tm -> smap_Expr_Expr demoteRecursive tm
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let f = lam acc. lam binding.
       ( mapInsert binding.ident (binding, freeVars binding.body) acc
       , {binding with body = demoteRecursive binding.body}
@@ -36,13 +36,26 @@ lang MExprDemoteRecursive = MExprAst + MExprFreeVars
       case [name] then
         match mapFindExn name usedMap with (binding, free) in
         if setMem name free
-        then TmDecl {decl = DeclRecLets {t with inexpr = inexpr, bindings = [binding]}}
-        else TmDecl {decl = DeclLet {ident = binding.ident, tyAnnot = binding.tyAnnot, tyBody = binding.tyBody, body = binding.body, inexpr = inexpr, ty = t.ty, info = binding.info}}
+        then TmDecl
+          {x with decl = DeclRecLets {t with bindings = [binding]}
+          , inexpr = inexpr
+          }
+        else TmDecl
+          {x with decl = DeclLet
+            {ident = binding.ident
+            , tyAnnot = binding.tyAnnot
+            , tyBody = binding.tyBody
+            , body = binding.body
+            , info = binding.info
+            }
+          , inexpr = inexpr
+          , ty = x.ty
+          }
       case names then
         let bindings = mapReverse (lam name. (mapFindExn name usedMap).0) names in
-        TmDecl {decl = DeclRecLets {t with inexpr = inexpr, bindings = bindings}}
+        TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr}
       end in
-    let inexpr = demoteRecursive t.inexpr in
+    let inexpr = demoteRecursive x.inexpr in
     foldr attachGroup inexpr (digraphTarjan g)
 end
 
@@ -52,17 +65,17 @@ mexpr
 
 use TestLang in
 
-let t = symbolize (ureclets_ [
+let t = symbolize (bind_ (ureclets_ [
   ("a", ulam_ "x" (app_ (var_ "b") (var_ "x"))),
   ("b", ulam_ "y" (app_ (var_ "b") (var_ "y")))
-]) in
+]) unit_) in
 let expected = symbolize (bindall_ [
   ureclets_ [ ("b", ulam_ "y" (app_ (var_ "b") (var_ "y"))) ],
   ulet_ "a" (ulam_ "x" (app_ (var_ "b") (var_ "x")))
-]) in
+] unit_) in
 utest demoteRecursive t with expected using eqExpr in
 
-let t = symbolize (ureclets_ [
+let t = symbolize (bind_ (ureclets_ [
   ("a", ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ("b", ulam_ "x" (app_ (var_ "c") (var_ "x"))),
   ("c", ulam_ "x" (app_ (var_ "b") (var_ "x"))),
@@ -70,7 +83,7 @@ let t = symbolize (ureclets_ [
     (ulet_ "e" (ulam_ "y" (app_ (var_ "c") (var_ "x"))))
     (app_ (var_ "e") (var_ "x")))),
   ("f", ulam_ "x" (app_ (var_ "a") (var_ "x")))
-]) in
+]) unit_) in
 let expected = symbolize (bindall_ [
   ulet_ "a" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ureclets_ [
@@ -80,20 +93,20 @@ let expected = symbolize (bindall_ [
     (ulet_ "e" (ulam_ "y" (app_ (var_ "c") (var_ "x"))))
     (app_ (var_ "e") (var_ "x")))),
   ulet_ "f" (ulam_ "x" (app_ (var_ "a") (var_ "x")))
-]) in
+] unit_) in
 utest demoteRecursive t with expected using eqExpr in
 
-let t = symbolize (ureclets_ [
+let t = symbolize (bind_ (ureclets_ [
   ("b", ulam_ "y" (muli_ (var_ "y") (app_ (var_ "a") (int_ 3)))),
   ("c", ulam_ "z" (subi_ (var_ "z") (app_ (var_ "b") (int_ 2)))),
   ("a", ulam_ "x" (addi_ (var_ "x") (int_ 2)))
-]) in
+]) unit_) in
 let expected = symbolize (bindall_ [
   ulet_ "a" (ulam_ "x" (addi_ (var_ "x") (int_ 2))),
   ulet_ "b" (ulam_ "y" (muli_ (var_ "y") (app_ (var_ "a") (int_ 3)))),
-  ulet_ "c" (ulam_ "z" (subi_ (var_ "z") (app_ (var_ "b") (int_ 2)))),
+  ulet_ "c" (ulam_ "z" (subi_ (var_ "z") (app_ (var_ "b") (int_ 2))))]
   unit_
-]) in
+) in
 utest demoteRecursive t with expected using eqExpr in
 
 ()

--- a/src/stdlib/mexpr/demote-recursive.mc
+++ b/src/stdlib/mexpr/demote-recursive.mc
@@ -15,7 +15,7 @@ lang MExprDemoteRecursive = MExprAst + MExprFreeVars
   sem demoteRecursive : Expr -> Expr
   sem demoteRecursive =
   | tm -> smap_Expr_Expr demoteRecursive tm
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let f = lam acc. lam binding.
       ( mapInsert binding.ident (binding, freeVars binding.body) acc
       , {binding with body = demoteRecursive binding.body}
@@ -36,11 +36,11 @@ lang MExprDemoteRecursive = MExprAst + MExprFreeVars
       case [name] then
         match mapFindExn name usedMap with (binding, free) in
         if setMem name free
-        then TmRecLets {t with inexpr = inexpr, bindings = [binding]}
-        else TmLet {ident = binding.ident, tyAnnot = binding.tyAnnot, tyBody = binding.tyBody, body = binding.body, inexpr = inexpr, ty = t.ty, info = binding.info}
+        then TmDecl {decl = DeclRecLets {t with inexpr = inexpr, bindings = [binding]}}
+        else TmDecl {decl = DeclLet {ident = binding.ident, tyAnnot = binding.tyAnnot, tyBody = binding.tyBody, body = binding.body, inexpr = inexpr, ty = t.ty, info = binding.info}}
       case names then
         let bindings = mapReverse (lam name. (mapFindExn name usedMap).0) names in
-        TmRecLets {t with inexpr = inexpr, bindings = bindings}
+        TmDecl {decl = DeclRecLets {t with inexpr = inexpr, bindings = bindings}}
       end in
     let inexpr = demoteRecursive t.inexpr in
     foldr attachGroup inexpr (digraphTarjan g)

--- a/src/stdlib/mexpr/duplicate-code-elimination.mc
+++ b/src/stdlib/mexpr/duplicate-code-elimination.mc
@@ -94,7 +94,7 @@ lang MExprEliminateDuplicateCode = MExprAst
     match eliminateDuplicateCodeExpr env replaced t.body with (replaced, body) in
     match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
     (replaced, TmConApp {t with ident = ident, body = body, ty = ty})
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     lookupDefinition
       env replaced t.ident t.info t.inexpr
       (lam env.
@@ -104,8 +104,8 @@ lang MExprEliminateDuplicateCode = MExprAst
         match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
         match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
         ( replaced
-        , TmLet {t with body = body, tyAnnot = tyAnnot, tyBody = tyBody, inexpr = inexpr, ty = ty} ))
-  | TmType t ->
+        , TmDecl {decl = DeclLet {t with body = body, tyAnnot = tyAnnot, tyBody = tyBody, inexpr = inexpr, ty = ty}} ))
+  | TmDecl {decl = DeclType t} ->
     lookupDefinition
       env replaced t.ident t.info t.inexpr
       (lam env.
@@ -113,8 +113,8 @@ lang MExprEliminateDuplicateCode = MExprAst
         match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
         match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
         ( replaced
-        , TmType {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty} ))
-  | TmConDef t ->
+        , TmDecl {decl = DeclType {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty}} ))
+  | TmDecl {decl = DeclConDef t} ->
     lookupDefinition
       env replaced t.ident t.info t.inexpr
       (lam env.
@@ -122,8 +122,8 @@ lang MExprEliminateDuplicateCode = MExprAst
         match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
         match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
         ( replaced
-        , TmConDef {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty} ))
-  | TmExt t ->
+        , TmDecl {decl = DeclConDef {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty}} ))
+  | TmDecl {decl = DeclExt t} ->
     lookupDefinition
       env replaced t.ident t.info t.inexpr
       (lam env.
@@ -131,8 +131,8 @@ lang MExprEliminateDuplicateCode = MExprAst
         match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
         match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
         ( replaced
-        , TmExt {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty} ))
-  | TmRecLets t ->
+        , TmDecl {decl = DeclExt {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty}} ))
+  | TmDecl {decl = DeclRecLets t} ->
     let eliminateDuplicateBinding = lam acc. lam binding.
       match acc with (replaced, env) in
       let defn = (binding.info, nameGetStr binding.ident) in
@@ -158,7 +158,7 @@ lang MExprEliminateDuplicateCode = MExprAst
     match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
     match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
     ( replaced
-    , TmRecLets {t with bindings = reverse bindings, inexpr = inexpr, ty = ty} )
+    , TmDecl {decl = DeclRecLets {t with bindings = reverse bindings, inexpr = inexpr, ty = ty}} )
   | t ->
     match smapAccumL_Expr_Expr (eliminateDuplicateCodeExpr env) replaced t with (replaced, t) in
     match smapAccumL_Expr_Type (eliminateDuplicateCodeType env) replaced t with (replaced, t) in
@@ -199,7 +199,7 @@ lang MExprEliminateDuplicateCode = MExprAst
   sem eliminateDuplicateExternalsExpr
     : Map String Name -> Map Name Name -> Expr -> (Map Name Name, Expr)
   sem eliminateDuplicateExternalsExpr externals replaced =
-  | TmExt r ->
+  | TmDecl {decl = DeclExt r} ->
     let identStr = nameGetStr r.ident in
     optionMapOrElse
       (lam.
@@ -207,7 +207,7 @@ lang MExprEliminateDuplicateCode = MExprAst
         match eliminateDuplicateExternalsExpr externals replaced r.inexpr
           with (replaced, inexpr)
         in
-        (replaced, TmExt { r with inexpr = inexpr }))
+        (replaced, TmDecl {decl = DeclExt { r with inexpr = inexpr }}))
       (lam ident.
         eliminateDuplicateExternalsExpr
           externals
@@ -294,8 +294,8 @@ utest expr2str (eliminateDuplicateCode t) with expr2str expected using eqString 
 let ireclets = lam bindings.
   let bindFn = lam idx. lam entry : (String, Expr).
     {ident = nameNoSym entry.0, tyAnnot = tyunknown_, tyBody = tyunknown_, body = entry.1, info = i idx} in
-  TmRecLets { bindings = mapi bindFn bindings, inexpr = uunit_,
-              ty = tyunknown_, info = NoInfo () } in
+  TmDecl {decl = DeclRecLets { bindings = mapi bindFn bindings, inexpr = uunit_,
+              ty = tyunknown_, info = NoInfo () }} in
 let baseBindings = [
   ("a", ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ("b", ulam_ "x" (muli_ (var_ "x") (int_ 2)))

--- a/src/stdlib/mexpr/duplicate-code-elimination.mc
+++ b/src/stdlib/mexpr/duplicate-code-elimination.mc
@@ -94,45 +94,45 @@ lang MExprEliminateDuplicateCode = MExprAst
     match eliminateDuplicateCodeExpr env replaced t.body with (replaced, body) in
     match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
     (replaced, TmConApp {t with ident = ident, body = body, ty = ty})
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     lookupDefinition
-      env replaced t.ident t.info t.inexpr
+      env replaced t.ident t.info x.inexpr
       (lam env.
         match eliminateDuplicateCodeType env replaced t.tyAnnot with (replaced, tyAnnot) in
         match eliminateDuplicateCodeType env replaced t.tyBody with (replaced, tyBody) in
         match eliminateDuplicateCodeExpr env replaced t.body with (replaced, body) in
-        match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
-        match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
+        match eliminateDuplicateCodeExpr env replaced x.inexpr with (replaced, inexpr) in
+        match eliminateDuplicateCodeType env replaced x.ty with (replaced, ty) in
         ( replaced
-        , TmDecl {decl = DeclLet {t with body = body, tyAnnot = tyAnnot, tyBody = tyBody, inexpr = inexpr, ty = ty}} ))
-  | TmDecl {decl = DeclType t} ->
+        , TmDecl {x with decl = DeclLet {t with body = body, tyAnnot = tyAnnot, tyBody = tyBody}, inexpr = inexpr, ty = ty} ))
+  | TmDecl (x & {decl = DeclType t}) ->
     lookupDefinition
-      env replaced t.ident t.info t.inexpr
+      env replaced t.ident t.info x.inexpr
       (lam env.
         match eliminateDuplicateCodeType env replaced t.tyIdent with (replaced, tyIdent) in
-        match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
-        match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
+        match eliminateDuplicateCodeExpr env replaced x.inexpr with (replaced, inexpr) in
+        match eliminateDuplicateCodeType env replaced x.ty with (replaced, ty) in
         ( replaced
-        , TmDecl {decl = DeclType {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty}} ))
-  | TmDecl {decl = DeclConDef t} ->
+        , TmDecl {x with decl = DeclType {t with tyIdent = tyIdent}, inexpr = inexpr, ty = ty} ))
+  | TmDecl (x & {decl = DeclConDef t}) ->
     lookupDefinition
-      env replaced t.ident t.info t.inexpr
+      env replaced t.ident t.info x.inexpr
       (lam env.
         match eliminateDuplicateCodeType env replaced t.tyIdent with (replaced, tyIdent) in
-        match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
-        match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
+        match eliminateDuplicateCodeExpr env replaced x.inexpr with (replaced, inexpr) in
+        match eliminateDuplicateCodeType env replaced x.ty with (replaced, ty) in
         ( replaced
-        , TmDecl {decl = DeclConDef {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty}} ))
-  | TmDecl {decl = DeclExt t} ->
+        , TmDecl {x with decl = DeclConDef {t with tyIdent = tyIdent}, inexpr = inexpr, ty = ty} ))
+  | TmDecl (x & {decl = DeclExt t}) ->
     lookupDefinition
-      env replaced t.ident t.info t.inexpr
+      env replaced t.ident t.info x.inexpr
       (lam env.
         match eliminateDuplicateCodeType env replaced t.tyIdent with (replaced, tyIdent) in
-        match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
-        match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
+        match eliminateDuplicateCodeExpr env replaced x.inexpr with (replaced, inexpr) in
+        match eliminateDuplicateCodeType env replaced x.ty with (replaced, ty) in
         ( replaced
-        , TmDecl {decl = DeclExt {t with tyIdent = tyIdent, inexpr = inexpr, ty = ty}} ))
-  | TmDecl {decl = DeclRecLets t} ->
+        , TmDecl {x with decl = DeclExt {t with tyIdent = tyIdent}, inexpr = inexpr, ty = ty} ))
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let eliminateDuplicateBinding = lam acc. lam binding.
       match acc with (replaced, env) in
       let defn = (binding.info, nameGetStr binding.ident) in
@@ -155,10 +155,10 @@ lang MExprEliminateDuplicateCode = MExprAst
     with ((replaced, env), optBindings) in
     let bindings = filterOption optBindings in
     match mapAccumL (eliminateDuplicateBody env) replaced bindings with (replaced, bindings) in
-    match eliminateDuplicateCodeExpr env replaced t.inexpr with (replaced, inexpr) in
-    match eliminateDuplicateCodeType env replaced t.ty with (replaced, ty) in
+    match eliminateDuplicateCodeExpr env replaced x.inexpr with (replaced, inexpr) in
+    match eliminateDuplicateCodeType env replaced x.ty with (replaced, ty) in
     ( replaced
-    , TmDecl {decl = DeclRecLets {t with bindings = reverse bindings, inexpr = inexpr, ty = ty}} )
+    , TmDecl {x with decl = DeclRecLets {t with bindings = reverse bindings}, inexpr = inexpr, ty = ty} )
   | t ->
     match smapAccumL_Expr_Expr (eliminateDuplicateCodeExpr env) replaced t with (replaced, t) in
     match smapAccumL_Expr_Type (eliminateDuplicateCodeType env) replaced t with (replaced, t) in
@@ -199,20 +199,20 @@ lang MExprEliminateDuplicateCode = MExprAst
   sem eliminateDuplicateExternalsExpr
     : Map String Name -> Map Name Name -> Expr -> (Map Name Name, Expr)
   sem eliminateDuplicateExternalsExpr externals replaced =
-  | TmDecl {decl = DeclExt r} ->
+  | TmDecl (x & {decl = DeclExt r}) ->
     let identStr = nameGetStr r.ident in
     optionMapOrElse
       (lam.
         let externals = mapInsert identStr r.ident externals in
-        match eliminateDuplicateExternalsExpr externals replaced r.inexpr
+        match eliminateDuplicateExternalsExpr externals replaced x.inexpr
           with (replaced, inexpr)
         in
-        (replaced, TmDecl {decl = DeclExt { r with inexpr = inexpr }}))
+        (replaced, TmDecl {x with inexpr = inexpr }))
       (lam ident.
         eliminateDuplicateExternalsExpr
           externals
           (mapInsert r.ident ident replaced)
-          r.inexpr)
+          x.inexpr)
       (mapLookup identStr externals)
   | TmVar r ->
     optionMapOr (replaced, TmVar r)
@@ -233,58 +233,64 @@ use MExprPrettyPrint in
 let i = lam idx.
   Info {filename = "dummy.txt", row1 = idx, col1 = 0, row2 = idx, col2 = 0} in
 
+recursive let exprBind = lam tm1. lam tm2.
+  match tm1 with TmDecl x
+  then TmDecl {x with inexpr = exprBind x.inexpr tm2}
+  else tm2
+in
+
 -- Tests that it works for expressions
 let fooDef =
-  withInfo (i 0) (ulet_ "foo" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))) in
+  declWithInfo (i 0) (ulet_ "foo" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))) in
 let t1 = bindall_ [
   fooDef,
-  ulet_ "foo" (addi_ (int_ 1) (int_ 1))] in
+  ulet_ "foo" (addi_ (int_ 1) (int_ 1))] unit_ in
 let t2 = bindall_ [
-  fooDef,
-  app_ (var_ "foo") (int_ 3)] in
-let t = bind_ (symbolize t1) (symbolize t2) in
+  fooDef]
+  (app_ (var_ "foo") (int_ 3)) in
+let t = exprBind (symbolize t1) (symbolize t2) in
 let foo1 = nameSym "foo" in
 let foo2 = nameSym "foo" in
 let fooDefSym = nulet_ foo1 (ulam_ "x" (addi_ (var_ "x") (int_ 1))) in
 let expected = bindall_ [
   fooDefSym,
-  nulet_ foo2 (addi_ (int_ 1) (int_ 1)),
-  app_ (nvar_ foo1) (int_ 3)
-] in
+  nulet_ foo2 (addi_ (int_ 1) (int_ 1))]
+  (app_ (nvar_ foo1) (int_ 3)
+) in
 utest eliminateDuplicateCode t with expected using eqExpr in
 
 -- Tests that it works for types
 let optionDef = bindall_ [
-  withInfo (i 1) (type_ "Option" ["a"] (tyvariant_ [])),
-  withInfo (i 2) (condef_ "Some" (tyall_ "a" (tyarrow_ (tyvar_ "a") (tyapp_ (tycon_ "Option") (tyvar_ "a"))))),
-  withInfo (i 3) (condef_ "None" (tyall_ "a" (tyarrow_ tyunit_ (tyapp_ (tycon_ "Option") (tyvar_ "a")))))] in
-let fDef =
-  withInfo (i 4)
+  declWithInfo (i 1) (type_ "Option" ["a"] (tyvariant_ [])),
+  declWithInfo (i 2) (condef_ "Some" (tyall_ "a" (tyarrow_ (tyvar_ "a") (tyapp_ (tycon_ "Option") (tyvar_ "a"))))),
+  declWithInfo (i 3) (condef_ "None" (tyall_ "a" (tyarrow_ tyunit_ (tyapp_ (tycon_ "Option") (tyvar_ "a")))))] unit_ in
+let fDef = bind_
+  (declWithInfo (i 4)
     (ulet_ "f" (ulam_ "o"
       (match_ (var_ "o") (pcon_ "Some" (pvar_ "x"))
         (var_ "x")
-        never_))) in
-let included = bind_ optionDef fDef in
-let t1 = withInfo (i 5) (ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))) in
+        never_)))) unit_ in
+let included = exprBind optionDef fDef in
+let t1 = withInfo (i 5) (bind_ (ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))) unit_) in
 let t2 = bind_
-  (withInfo (i 6) (ulet_ "x" ((conapp_ "Some" (int_ 3)))))
+  (declWithInfo (i 6) (ulet_ "x" ((conapp_ "Some" (int_ 3)))))
   (app_ (var_ "f") (var_ "x")) in
-let t = bind_
-  (symbolize (bind_ included t1))
-  (symbolize (bind_ included t2)) in
+let t = exprBind
+  (symbolize (exprBind included t1))
+  (symbolize (exprBind included t2)) in
 
 let fId = nameSym "f" in
 let f =
-  withInfo (i 7)
+  declWithInfo (i 7)
     (nulet_ fId (ulam_ "o"
       (match_ (var_ "o") (pcon_ "Some" (pvar_ "x"))
         (var_ "x")
         never_))) in
-let expected = symbolize (bindall_ [
+let expected = symbolize (foldr1 exprBind [
   optionDef,
-  f,
+  (bind_ f unit_),
   t1,
-  ulet_ "x" ((conapp_ "Some" (int_ 3))),
+  bind_ (ulet_ "x" ((conapp_ "Some" (int_ 3)))) unit_,
   app_ (nvar_ fId) (var_ "x")]) in
 -- NOTE(larshum, 2022-09-13): Compare pretty-printed strings as expression
 -- equality is not yet implemented for TmType.
@@ -294,8 +300,8 @@ utest expr2str (eliminateDuplicateCode t) with expr2str expected using eqString 
 let ireclets = lam bindings.
   let bindFn = lam idx. lam entry : (String, Expr).
     {ident = nameNoSym entry.0, tyAnnot = tyunknown_, tyBody = tyunknown_, body = entry.1, info = i idx} in
-  TmDecl {decl = DeclRecLets { bindings = mapi bindFn bindings, inexpr = uunit_,
-              ty = tyunknown_, info = NoInfo () }} in
+  TmDecl {decl = DeclRecLets { bindings = mapi bindFn bindings, info = NoInfo () }, inexpr = uunit_,
+              ty = tyunknown_, info = NoInfo ()} in
 let baseBindings = [
   ("a", ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ("b", ulam_ "x" (muli_ (var_ "x") (int_ 2)))
@@ -303,36 +309,36 @@ let baseBindings = [
 let extraBinding = [
   ("c", ulam_ "x" (addi_ (app_ (var_ "a") (var_ "x")) (app_ (var_ "b") (var_ "x"))))] in
 let extendedBindings = concat baseBindings extraBinding in
-let t1 = bind_
+let t1 = exprBind
   (ireclets baseBindings)
-  (withInfo (i 3) (ulet_ "x" (app_ (var_ "a") (int_ 2)))) in
-let t2 = bind_
+  (bind_ (declWithInfo (i 3) (ulet_ "x" (app_ (var_ "a") (int_ 2)))) unit_) in
+let t2 = exprBind
   (ireclets extendedBindings)
   (withInfo (i 4) (addi_ (app_ (var_ "b") (int_ 3)) (app_ (var_ "c") (int_ 1)))) in
-let t = bind_ (symbolize t1) (symbolize t2) in
-let expected = symbolize (bindall_ [
+let t = exprBind (symbolize t1) (symbolize t2) in
+let expected = symbolize (foldr1 exprBind [
   ireclets baseBindings,
-  ulet_ "x" (app_ (var_ "a") (int_ 2)),
+  bind_ (ulet_ "x" (app_ (var_ "a") (int_ 2))) unit_,
   ireclets extraBinding,
   addi_ (app_ (var_ "b") (int_ 3)) (app_ (var_ "c") (int_ 1))]) in
 
 utest eliminateDuplicateCode t with expected using eqExpr in
 
 -- Tests that it works for external identifiers
-let sinExt = withInfo (i 0) (ext_ "sin" false (tyarrow_ tyfloat_ tyfloat_)) in
-let t = bind_ sinExt sinExt in
-utest eliminateDuplicateCode t with sinExt using eqExpr in
+let sinExt = declWithInfo (i 0) (ext_ "sin" false (tyarrow_ tyfloat_ tyfloat_)) in
+let t = bind_ sinExt (bind_ sinExt unit_) in
+utest eliminateDuplicateCode t with bind_ sinExt unit_ using eqExpr in
 
 -- Tests that it works for patterns
-let t1 = withInfo (i 4) (ulet_ "x" (conapp_ "Some" (int_ 2))) in
-let t2 = bind_
-  (ulet_ "o" (conapp_ "Some" (int_ 4)))
+let t1 = bind_ (declWithInfo (i 4) (ulet_ "x" (conapp_ "Some" (int_ 2)))) unit_ in
+let t2 = exprBind
+  (bind_ (ulet_ "o" (conapp_ "Some" (int_ 4))) unit_)
   (match_ (var_ "o") (pcon_ "Some" (pvar_ "x"))
     (var_ "x") never_) in
-let t = bind_
-  (symbolize (bind_ optionDef t1))
-  (symbolize (bind_ optionDef t2)) in
-let expected = symbolize (bindall_ [optionDef, t1, t2]) in
+let t = exprBind
+  (symbolize (exprBind optionDef t1))
+  (symbolize (exprBind optionDef t2)) in
+let expected = symbolize (foldr1 exprBind [optionDef, t1, t2]) in
 
 match eliminateDuplicateCodeWithSummary t with (summary, t) in
 utest expr2str t with expr2str expected using eqString in
@@ -342,27 +348,26 @@ utest mapSize summary with 3 using eqi in
 -- they have no info-fields.
 let t = bindall_ [
   ulet_ "t" (addi_ (int_ 2) (int_ 3)),
-  ulet_ "t" (addi_ (int_ 4) (var_ "t")),
-  var_ "t"
-] in
+  ulet_ "t" (addi_ (int_ 4) (var_ "t"))]
+  (var_ "t") in
 utest eliminateDuplicateCode t with t using eqExpr in
 
 let t = symbolize (bindall_ [
-  withInfo (i 0) (type_ "T1" [] tyint_),
-  withInfo (i 0) (type_ "T1" [] tyint_),
+  declWithInfo (i 0) (type_ "T1" [] tyint_),
+  declWithInfo (i 0) (type_ "T1" [] tyint_),
   type_ "T2" [] (tyseq_ (tycon_ "T1"))
-]) in
+] unit_) in
 let expected = symbolize (bindall_ [
   type_ "T1" [] tyint_,
   type_ "T2" [] (tyseq_ (tycon_ "T1"))
-]) in
+] unit_) in
 utest expr2str (eliminateDuplicateCode t) with expr2str expected using eqString in
 
 -- Tests that eliminateDuplicateExternalsWithSummary works.
-let sinExt = withInfo (i 0) (ext_ "sin" false (tyarrow_ tyfloat_ tyfloat_)) in
-let t = bind_ sinExt sinExt in
+let sinExt = declWithInfo (i 0) (ext_ "sin" false (tyarrow_ tyfloat_ tyfloat_)) in
+let t = bind_ sinExt (bind_ sinExt unit_) in
 match eliminateDuplicateExternalsWithSummary t with (replaced, t) in
 utest mapSize replaced with 1 in
-utest eliminateDuplicateCode t with sinExt using eqExpr in
+utest eliminateDuplicateCode t with bind_ sinExt unit_ using eqExpr in
 
 ()

--- a/src/stdlib/mexpr/eq.mc
+++ b/src/stdlib/mexpr/eq.mc
@@ -137,6 +137,14 @@ lang Eq = ConstAst
   --   updated bijection between free variables.
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   -- Intentionally left blank
+
+  sem eqDecl (d1: Decl) =
+  | d2 ->
+    let empty = {varEnv = biEmpty, conEnv = biEmpty} in
+    match eqDeclH empty empty d1 d2 with Some _ then true else false
+
+  sem eqDeclH : EqEnv -> EqEnv -> Decl -> Decl -> Option (EqEnv, EqEnv)
+  sem eqDeclH env free lhs =
 end
 
 lang VarEq = Eq + VarAst
@@ -195,42 +203,49 @@ lang RecordEq = Eq + RecordAst
     else None ()
 end
 
-lang LetEq = Eq + LetAst
-  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmLet {ident = i2, body = b2, inexpr = ie2} ->
-    match lhs with TmLet {ident = i1, body = b1, inexpr = ie1} then
-      match eqExprH env free b1 b2 with Some free then
-        match env with {varEnv = varEnv} then
-          let varEnv = biInsert (i1,i2) varEnv in
-          eqExprH {env with varEnv = varEnv} free ie1 ie2
-        else never
+lang DeclEq = Eq + DeclAst
+  sem eqExprH env free lhs =
+  | TmDecl {decl = d2, inexpr = e2} ->
+    match lhs with TmDecl {decl = d1, inexpr = e1} then
+      match eqDeclH env free d1 d2 with Some (env, free) then
+        eqExprH env free e1 e2
       else None ()
     else None ()
 end
 
-lang RecLetsEq = Eq + RecLetsAst
-  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmRecLets {bindings = bs2, inexpr = ie2} ->
+lang LetEq = Eq + LetDeclAst
+  sem eqDeclH (env : EqEnv) (free : EqEnv) lhs =
+  | DeclLet {ident = i2, body = b2} ->
+    match lhs with DeclLet {ident = i1, body = b1} then
+      match eqExprH env free b1 b2 with Some free then
+        Some ({env with varEnv = biInsert (i1,i2) env.varEnv}, free)
+      else None ()
+    else None ()
+end
+
+lang RecLetsEq = Eq + RecLetsDeclAst
+  sem eqDeclH (env : EqEnv) (free : EqEnv) (lhs : Decl) =
+  | DeclRecLets {bindings = bs2} ->
     -- NOTE(dlunde,2020-09-25): This requires the bindings to occur in the same
     -- order. Do we want to allow equality of differently ordered (but equal)
     -- bindings as well?
     match env with {varEnv = varEnv} then
-      match lhs with TmRecLets {bindings = bs1, inexpr = ie1} then
+      match lhs with DeclRecLets {bindings = bs1} then
         if eqi (length bs1) (length bs2) then
           let bszip = zipWith (lam b1. lam b2. (b1, b2)) bs1 bs2 in
           let varEnv =
             foldl
-              (lam varEnv. lam t : (RecLetBinding, RecLetBinding).
+              (lam varEnv. lam t : (DeclLetRecord, DeclLetRecord).
                  biInsert ((t.0).ident,(t.1).ident) varEnv)
               varEnv bszip
           in
           let env = {env with varEnv = varEnv} in
           match optionFoldlM
-            (lam free. lam t : (RecLetBinding, RecLetBinding).
+            (lam free. lam t : (DeclLetRecord, DeclLetRecord).
               eqExprH env free (t.0).body (t.1).body)
             free bszip
           with Some free then
-            eqExprH env free ie1 ie2
+            Some (env, free)
           else None ()
         else None ()
       else None ()
@@ -245,21 +260,22 @@ lang ConstEq = Eq + ConstAst
     else None ()
 end
 
-lang TypeEq = Eq + TypeAst
-  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmType _ -> error "eqExpr not implemented for TmType!"
+lang TypeEq = Eq + TypeDeclAst
+  sem eqDeclH (env : EqEnv) (free : EqEnv) (lhs : Decl) =
+  | DeclType _ -> error "eqDecl not implemented for DeclType!"
 end
 
-lang DataEq = Eq + DataAst
-  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmConDef {ident = i2, inexpr = ie2, ty = ty2} ->
+lang DataEq = Eq + DataDeclAst + DataAst
+  sem eqDeclH env free lhs =
+  | DeclConDef {ident = i2, tyIdent = ty2} ->
     match env with {conEnv = conEnv} then
-      match lhs with TmConDef {ident = i1, inexpr = ie1, ty = ty1} then
+      match lhs with DeclConDef {ident = i1, tyIdent = ty1} then
         let conEnv = biInsert (i1,i2) conEnv in
-        eqExprH {env with conEnv = conEnv} free ie1 ie2
+        Some ({env with conEnv = conEnv}, free)
       else None ()
     else never
 
+  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmConApp {ident = i2, body = b2, ty = ty2} ->
     match lhs with TmConApp {ident = i1, body = b1, ty = ty1} then
       match (env,free) with ({conEnv = conEnv},{conEnv = freeConEnv}) then
@@ -294,11 +310,11 @@ lang MatchEq = Eq + MatchAst
 
 end
 
-lang UtestEq = Eq + UtestAst
-  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmUtest {test = t2, expected = e2, next = n2, tusing = u2, tonfail = o2} ->
+lang UtestEq = Eq + UtestDeclAst
+  sem eqDeclH (env : EqEnv) (free : EqEnv) (lhs : Decl) =
+  | DeclUtest {test = t2, expected = e2, tusing = u2, tonfail = o2} ->
     match lhs with
-      TmUtest {test = t1, expected = e1, next = n1, tusing = u1, tonfail = o1}
+      DeclUtest {test = t1, expected = e1, tusing = u1, tonfail = o1}
     then
       match eqExprH env free t1 t2 with Some free then
         match eqExprH env free e1 e2 with Some free then
@@ -306,22 +322,22 @@ lang UtestEq = Eq + UtestAst
             match eqExprH env free tu1 tu2 with Some free then
               match (o1, o2) with (Some to1, Some to2) then
                 match eqExprH env free to1 to2 with Some free then
-                  eqExprH env free n1 n2
+                  Some (env, free)
                 else None ()
               else
                 match (o1, o2) with (None (), None ()) then
-                  eqExprH env free n1 n2
+                  Some (env, free)
                 else None ()
             else None ()
           else
             match (u1, u2) with (None (), None ()) then
               match (o1, o2) with (Some to1, Some to2) then
                 match eqExprH env free to1 to2 with Some free then
-                  eqExprH env free n1 n2
+                  Some (env, free)
                 else None ()
               else
                 match (o1, o2) with (None (), None ()) then
-                  eqExprH env free n1 n2
+                  Some (env, free)
                 else None ()
             else None ()
         else None ()
@@ -345,14 +361,14 @@ lang NeverEq = Eq + NeverAst
   | TmNever _ -> match lhs with TmNever _ then Some free else None ()
 end
 
-lang ExtEq = Eq + ExtAst
-  sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
-  | TmExt {ident = i2, inexpr = ie2} ->
-    match lhs with TmExt {ident = i1, inexpr = ie1} then
+lang ExtEq = Eq + ExtDeclAst
+  sem eqDeclH (env : EqEnv) (free : EqEnv) (lhs : Decl) =
+  | DeclExt {ident = i2} ->
+    match lhs with DeclExt {ident = i1} then
       match env with {varEnv = varEnv} in
       if nameEqStr i1 i2 then -- Externals are a bit special, as the string component of their names are required to be identical
         let varEnv = biInsert (i1,i2) varEnv in
-        eqExprH {env with varEnv = varEnv} free ie1 ie2
+        Some ({env with varEnv = varEnv}, free)
       else None ()
     else None ()
 end
@@ -728,7 +744,7 @@ lang MExprEq =
 
   -- Terms
   + VarEq + AppEq + LamEq + RecordEq + LetEq + RecLetsEq + ConstEq + DataEq +
-  TypeEq + MatchEq + UtestEq + SeqEq + NeverEq + ExtEq
+  TypeEq + MatchEq + UtestEq + SeqEq + NeverEq + ExtEq + DeclAst + DeclEq
 
   -- Constants
   + IntEq + FloatEq + BoolEq + CharEq + SymbEq
@@ -825,9 +841,9 @@ let rlet1 = ureclets_ [("x", a1), ("y", lam1)] in
 let rlet2 = ureclets_ [("x", a2), ("y", lam2)] in
 let rlet3 = ureclets_ [("y", a2), ("x", lam2)] in
 let rlet4e = ureclets_ [("y", lam1), ("x", a1)] in -- Order matters
-utest rlet1 with rlet2 using eqExpr in
-utest rlet1 with rlet3 using eqExpr in
-utest eqExpr rlet1 rlet4e with false in
+utest rlet1 with rlet2 using eqDecl in
+utest rlet1 with rlet3 using eqDecl in
+utest eqDecl rlet1 rlet4e with false in
 
 -- Constants
 let c1 = (int_ 1) in
@@ -853,10 +869,10 @@ utest cda1 with cda2 using eqExpr in
 utest eqExpr cda1 cd3e with false in
 
 -- Match and patterns
-let m1 = match_ c1 (pint_ 1) cda1 rlet1 in
-let m2 = match_ c1 (pint_ 1) cda2 rlet2 in
-let m3e = match_ rlet1 (pint_ 1) cda2 rlet2 in
-let m4e = match_ c1 (pint_ 1) c1 rlet2 in
+let m1 = match_ c1 (pint_ 1) cda1 (bind_ rlet1 unit_) in
+let m2 = match_ c1 (pint_ 1) cda2 (bind_ rlet2 unit_) in
+let m3e = match_ (bind_ rlet1 unit_) (pint_ 1) cda2 (bind_ rlet2 unit_) in
+let m4e = match_ c1 (pint_ 1) c1 (bind_ rlet2 unit_) in
 let m5e = match_ c1 (pint_ 1) cda2 cda1 in
 utest m1 with m2 using eqExpr in
 utest eqExpr m1 m3e with false in
@@ -1170,20 +1186,20 @@ utest eqType tyAll2 tyAll4 with false in
 utest eqType tyAll4 tyAll6 with false in
 
 -- Utest
-let ut1 = utest_ lam1 lam2 v3 in
-let ut2 = utest_ lam2 lam1 v4 in
-let ut3e = utest_ v5e lam2 v3 in
-let ut4e = utest_ lam1 v5e v3 in
-let ut5e = utest_ lam1 lam2 v5e in
+let ut1 = bind_ (utest_ lam1 lam2) v3 in
+let ut2 = bind_ (utest_ lam2 lam1) v4 in
+let ut3e = bind_ (utest_ v5e lam2) v3 in
+let ut4e = bind_ (utest_ lam1 v5e) v3 in
+let ut5e = bind_ (utest_ lam1 lam2) v5e in
 utest ut1 with ut2 using eqExpr in
 utest eqExpr ut1 ut3e with false in
 utest eqExpr ut1 ut4e with false in
 utest eqExpr ut1 ut5e with false in
-let ut1 = utestu_ lam1 lam2 v3 v4 in
-let ut2 = utestu_ lam2 lam1 v4 v3 in
+let ut1 = bind_ (utestu_ lam1 lam2 v4) v3 in
+let ut2 = bind_ (utestu_ lam2 lam1 v3) v4 in
 utest ut1 with ut2 using eqExpr in
-let ut1 = utestuo_ lam1 lam2 v3 v4 v3 in
-let ut2 = utestuo_ lam2 lam1 v4 v3 v4 in
+let ut1 = bind_ (utestuo_ lam1 lam2 v4 v3) v3 in
+let ut2 = bind_ (utestuo_ lam2 lam1 v3 v4) v4 in
 utest ut1 with ut2 using eqExpr in
 
 -- Sequences

--- a/src/stdlib/mexpr/eval.mc
+++ b/src/stdlib/mexpr/eval.mc
@@ -70,6 +70,10 @@ lang Eval = Ast
   sem eval : EvalCtx -> Expr -> Expr
   sem eval ctx =| _ ->
     error "Unsupported Expr in eval!"
+
+  sem evalDecl : EvalCtx -> Decl -> EvalCtx
+  sem evalDecl ctx =| _ ->
+    error "Unsupported Decl in eval!"
 end
 
 -----------
@@ -135,11 +139,17 @@ lang LamEval = Eval + LamAst + ClosAst + AppEval
   | TmClos t -> TmClos t
 end
 
-lang LetEval = Eval + LetAst
+lang DeclEval = Eval + DeclAst
   sem eval ctx =
-  | TmLet t ->
-    eval {ctx with env = evalEnvInsert t.ident (eval ctx t.body) ctx.env}
-      t.inexpr
+  | TmDecl x ->
+    let ctx = evalDecl ctx x.decl in
+    eval ctx x.inexpr
+end
+
+lang LetEval = Eval + LetDeclAst
+  sem evalDecl ctx =
+  | DeclLet t ->
+    {ctx with env = evalEnvInsert t.ident (eval ctx t.body) ctx.env}
 end
 
 lang RecordEval = Eval + RecordAst
@@ -157,11 +167,11 @@ lang RecordEval = Eval + RecordAst
 end
 
 lang RecLetsEval =
-  Eval + RecLetsAst + VarEval + RecordEval + LetEval + LamEval +
+  Eval + RecLetsDeclAst + VarEval + RecordEval + LetEval + LamEval +
   UnknownTypeAst
 
-  sem eval ctx =
-  | TmRecLets t ->
+  sem evalDecl ctx =
+  | DeclRecLets t ->
     recursive let envPrime : Lazy EvalEnv = lam.
       let wraplambda = lam v.
         match v with TmLam t then
@@ -175,7 +185,7 @@ lang RecLetsEval =
           evalEnvInsert bind.ident (wraplambda bind.body) env)
         ctx.env t.bindings
     in
-    eval {ctx with env = envPrime ()} t.inexpr
+    {ctx with env = envPrime ()}
 end
 
 lang ConstAppAst = ConstAst + PrettyPrint + Eq
@@ -233,15 +243,17 @@ lang ConstEval = ConstEvalNoDefault
            ])
 end
 
-lang TypeEval = Eval + TypeAst
-  sem eval ctx =
-  | TmType t -> eval ctx t.inexpr
+lang TypeEval = Eval + TypeDeclAst
+  sem evalDecl ctx =
+  | DeclType _ -> ctx
 end
 
-lang DataEval = Eval + DataAst + AppEval
+lang DataEval = Eval + DataAst + DataDeclAst
   sem eval ctx =
-  | TmConDef t -> eval ctx t.inexpr
   | TmConApp t -> TmConApp {t with body = eval ctx t.body}
+
+  sem evalDecl ctx =
+  | DeclConDef t -> ctx
 end
 
 lang MatchEvalBase = Eval
@@ -259,12 +271,12 @@ lang MatchEval = Eval + MatchAst + MatchEvalBase
   | _ -> None ()
 end
 
-lang UtestEval = Eval + Eq + AppEval + UtestAst + BoolAst + SeqAst
+lang UtestEval = Eval + Eq + AppEval + UtestDeclAst + BoolAst + SeqAst
   sem eq (e1 : Expr) =
   | _ -> errorSingle [infoTm e1] "Equality not defined for expression"
 
-  sem eval ctx =
-  | TmUtest r ->
+  sem evalDecl ctx =
+  | DeclUtest r ->
     let v1 = eval ctx r.test in
     let v2 = eval ctx r.expected in
     let tusing = optionMap (eval ctx) r.tusing in
@@ -283,7 +295,7 @@ lang UtestEval = Eval + Eq + AppEval + UtestAst + BoolAst + SeqAst
           print (_evalSeqOfCharsToString seqr.info seqr.tms)
         else errorSingle [r.info] "Invalid utest failure function"
       else print "Test failed\n");
-    eval ctx r.next
+    ctx
 end
 
 lang SeqEval = Eval + SeqAst
@@ -378,9 +390,9 @@ lang TensorEval = Eval + Eq + PrettyPrint
     else None ()
 end
 
-lang ExtEval = Eval + ExtAst
-  sem eval ctx =
-  | TmExt r -> eval ctx r.inexpr -- nop
+lang ExtEval = Eval + ExtDeclAst
+  sem evalDecl ctx =
+  | DeclExt r -> ctx -- nop
 end
 
 ---------------
@@ -1292,8 +1304,8 @@ end
 
 lang PlaceholderEval = PlaceholderAst + Eval + IntAst + IntTypeAst
   sem eval env =
-  | TmPlaceholder {} -> 
-    TmConst {val = CInt {val = 0}, ty = TyInt {info = NoInfo ()}, info = NoInfo ()} 
+  | TmPlaceholder {} ->
+    TmConst {val = CInt {val = 0}, ty = TyInt {info = NoInfo ()}, info = NoInfo ()}
 end
 
 -------------------------
@@ -1305,7 +1317,7 @@ lang MExprEval =
   -- Terms
   VarEval + AppEval + LamEval + RecordEval + RecLetsEval +
   ConstEval + TypeEval + DataEval + MatchEval + UtestEval + SeqEval +
-  NeverEval + RefEval + ExtEval +
+  NeverEval + RefEval + ExtEval + DeclEval +
 
   -- Constants
   IntArity + FloatArity + BoolArity + CharArity + SymbArity + BootParserArity +
@@ -1313,7 +1325,7 @@ lang MExprEval =
   SymbEval + CmpSymbEval + SeqOpEval + FileOpEval + IOEval + SysEval +
   RandomNumberGeneratorEval + FloatIntConversionEval + CmpCharEval +
   IntCharConversionEval + FloatStringConversionEval + TimeEval + RefOpEval +
-  ConTagEval + TensorOpEval + BootParserEval + UnsafeCoerceEval + PlaceholderEval + 
+  ConTagEval + TensorOpEval + BootParserEval + UnsafeCoerceEval + PlaceholderEval +
 
   -- Patterns
   NamedPatEval + SeqTotPatEval + SeqEdgePatEval + RecordPatEval + DataPatEval +
@@ -1406,9 +1418,11 @@ let matchOuter =
   match_ (app_ (var_ "eval") (var_ "e1")) (pcon_ "Num" (pvar_ "n1"))
     matchInner uunit_ in
 
-let deconstruct = lam t.
-  bindall_
-    [(ulet_ "e1" (tupleproj_ 0 t)), (ulet_ "e2" (tupleproj_ 1 t)), matchOuter]
+let deconstruct = lam t. bindall_
+  [ ulet_ "e1" (tupleproj_ 0 t)
+  , ulet_ "e2" (tupleproj_ 1 t)
+  ]
+  matchOuter
 in
 
 let addCase = lam arg. lam els.
@@ -1421,7 +1435,7 @@ in
 
 -- con Num in con Add in let eval = ... in t
 let wrapInDecls = lam t.
-  bindall_ [ucondef_ "Num", ucondef_ "Add", evalFn, t] in
+  bindall_ [ucondef_ "Num", ucondef_ "Add", evalFn] t in
 
 let evalAdd1 = wrapInDecls (app_ (var_ "eval") addOneTwo) in
 let addOneTwoThree = add (add one two) three in
@@ -1650,8 +1664,8 @@ utest
   , ulet_ ""
     (iter_ (nulam_ x (modref_ (nvar_ r) (addi_ (nvar_ x) (deref_ (nvar_ r)))))
            (seq_ [int_ 1, int_ 2, int_ 3, int_ 4]))
-  , deref_ (nvar_ r)
-  ] in
+  ]
+  (deref_ (nvar_ r)) in
   eval iterAst
 with int_ 10 using eqExpr in
 
@@ -1677,8 +1691,8 @@ utest
     (iteri_ (nulam_ i (nulam_ x (modref_ (nvar_ r)
               (addi_ (nvar_ i) (addi_ (nvar_ x) (deref_ (nvar_ r)))))))
             (seq_ [int_ 1, int_ 2, int_ 3, int_ 4]))
-  , deref_ (nvar_ r)
-  ] in
+  ]
+  (deref_ (nvar_ r)) in
   eval iteriAst
 with int_ 16 using eqExpr in
 
@@ -1995,9 +2009,9 @@ let p = bindall_ [ulet_ "r1" (ref_ (int_ 1)),
                   ulet_ "r4"
                     (ref_ (ulam_ "x" (concat_ (str_ "Hello ") (var_ "x"))))]
 in
-utest eval (bind_ p (modref_ (var_ "r1") (int_ 2))) with uunit_ using eqExpr in
+utest eval (p (modref_ (var_ "r1") (int_ 2))) with uunit_ using eqExpr in
 utest
-  eval (bind_ p
+  eval (p
     (utuple_ [deref_ (var_ "r1"),
              deref_ (var_ "r2"),
              deref_ (var_ "r3"),
@@ -2006,11 +2020,11 @@ with utuple_ [int_ 1, float_ 2., int_ 1, str_ "Hello test"]
 using eqExpr in
 
 utest
-  eval (bind_ p (bindall_
+  eval (p (bindall_
     [ulet_ "_" (modref_ (var_ "r1") (int_ 3)),
      ulet_ "_" (modref_ (var_ "r2") (float_ 3.14)),
-     ulet_ "_" (modref_ (var_ "r3") (int_ 4)),
-     utuple_ [deref_ (var_ "r1"), deref_ (var_ "r2"), deref_ (var_ "r3")]]))
+     ulet_ "_" (modref_ (var_ "r3") (int_ 4))]
+     (utuple_ [deref_ (var_ "r1"), deref_ (var_ "r2"), deref_ (var_ "r3")])))
 with utuple_ [int_ 4, float_ 3.14, int_ 4]
 using eqExpr in
 

--- a/src/stdlib/mexpr/expansive.mc
+++ b/src/stdlib/mexpr/expansive.mc
@@ -20,6 +20,11 @@ lang NonExpansive = Ast
   | t ->
     sfold_Expr_Expr (lam v. lam tm.
       if v then nonExpansive false tm else false) true t
+
+  sem nonExpansiveDecl : Decl -> Bool
+  sem nonExpansiveDecl =
+  | d ->
+    sfold_Decl_Expr (lam v. lam tm. if v then nonExpansive false tm else false) true d
 end
 
 lang VarNonExpansive = NonExpansive + VarAst
@@ -37,29 +42,17 @@ lang LamNonExpansive = NonExpansive + LamAst
   | TmLam t -> true
 end
 
-lang LetNonExpansive = NonExpansive + LetAst
-  sem nonExpansive (guarded : Guarded) =
-  | TmLet t ->
-    if nonExpansive false t.body then nonExpansive guarded t.inexpr
+lang DeclNonExpansive = NonExpansive + DeclAst
+  sem nonExpansive guarded =
+  | TmDecl x ->
+    if nonExpansiveDecl x.decl
+    then nonExpansive guarded x.inexpr
     else false
 end
 
-lang RecLetsNonExpansive = NonExpansive + RecLetsAst
-  sem nonExpansive (guarded : Guarded) =
-  | TmRecLets t ->
-    if forAll (lam b. nonExpansive false b.body) t.bindings
-    then nonExpansive guarded t.inexpr
-    else false
-end
-
-lang TypeNonExpansive = NonExpansive + TypeAst
-  sem nonExpansive (guarded : Guarded) =
-  | TmType t -> nonExpansive guarded t.inexpr
-end
-
-lang DataNonExpansive = NonExpansive + DataAst
-  sem nonExpansive (guarded : Guarded) =
-  | TmConDef t -> nonExpansive guarded t.inexpr
+lang UtestNonExpansive = NonExpansive + UtestDeclAst
+  sem nonExpansiveDecl =
+  | DeclUtest _ -> true
 end
 
 lang MatchNonExpansive = NonExpansive + MatchAst
@@ -72,20 +65,9 @@ lang MatchNonExpansive = NonExpansive + MatchAst
     else false
 end
 
-lang UtestNonExpansive = NonExpansive + UtestAst
-  sem nonExpansive (guarded : Guarded) =
-  | TmUtest t -> nonExpansive guarded t.next
-end
-
-lang ExtNonExpansive = NonExpansive + ExtAst
-  sem nonExpansive (guarded : Guarded) =
-  | TmExt t -> nonExpansive guarded t.inexpr
-end
-
 lang MExprNonExpansive =
-  MExprAst + NonExpansive +
-  VarNonExpansive + AppNonExpansive + LamNonExpansive + LetNonExpansive + RecLetsNonExpansive +
-  TypeNonExpansive + DataNonExpansive + MatchNonExpansive + UtestNonExpansive + ExtNonExpansive
+  MExprAst + NonExpansive + DeclNonExpansive + VarNonExpansive +
+  AppNonExpansive + LamNonExpansive + MatchNonExpansive + UtestNonExpansive
 end
 
 mexpr
@@ -121,7 +103,7 @@ utest nonExpansive true (utuple_ [freeze_ (var_ "x"), int_ 0]) with true in
 utest nonExpansive false (utuple_ [app_ (var_ "y") (var_ "x"), int_ 0]) with false in
 
 -- Utest
-utest nonExpansive true (utest_ (app_ (var_ "y") (var_ "x"))
-                           (int_ 0) (int_ 0)) with true in
+utest nonExpansive true (bind_ (utest_ (app_ (var_ "y") (var_ "x"))
+                           (int_ 0)) unit_) with true in
 
 ()

--- a/src/stdlib/mexpr/externals.mc
+++ b/src/stdlib/mexpr/externals.mc
@@ -11,7 +11,7 @@ include "sys.mc"
 
 let _error = "Error in externals.mc: not an external in externalsMap"
 
-lang Externals = ExtAst + VarAst
+lang Externals = ExtDeclAst + VarAst
 
   -- Removes the given set of external definitions from the program.
   sem removeExternalDefs : Set String -> Expr -> Expr

--- a/src/stdlib/mexpr/externals.mc
+++ b/src/stdlib/mexpr/externals.mc
@@ -16,10 +16,10 @@ lang Externals = ExtDeclAst + VarAst
   -- Removes the given set of external definitions from the program.
   sem removeExternalDefs : Set String -> Expr -> Expr
   sem removeExternalDefs env =
-  | TmDecl {decl = DeclExt t} ->
-    let inexpr = removeExternalDefs env t.inexpr in
+  | TmDecl (x & {decl = DeclExt t}) ->
+    let inexpr = removeExternalDefs env x.inexpr in
     if setMem (nameGetStr t.ident) env then inexpr
-    else TmDecl {decl = DeclExt { t with inexpr = inexpr }}
+    else TmDecl {x with inexpr = inexpr}
   | expr -> smap_Expr_Expr (removeExternalDefs env) expr
 
   sem getExternalIds : Expr -> Set String
@@ -27,7 +27,7 @@ lang Externals = ExtDeclAst + VarAst
   | expr -> getExternalIdsH (setEmpty cmpString) expr
   sem getExternalIdsH : Set String -> Expr -> Set String
   sem getExternalIdsH acc =
-  | TmDecl {decl = DeclExt t} -> getExternalIdsH (setInsert (nameGetStr t.ident) acc) t.inexpr
+  | TmDecl {decl = DeclExt t, inexpr = inexpr} -> getExternalIdsH (setInsert (nameGetStr t.ident) acc) inexpr
   | expr -> sfold_Expr_Expr getExternalIdsH acc expr
 
 end

--- a/src/stdlib/mexpr/externals.mc
+++ b/src/stdlib/mexpr/externals.mc
@@ -16,10 +16,10 @@ lang Externals = ExtDeclAst + VarAst
   -- Removes the given set of external definitions from the program.
   sem removeExternalDefs : Set String -> Expr -> Expr
   sem removeExternalDefs env =
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     let inexpr = removeExternalDefs env t.inexpr in
     if setMem (nameGetStr t.ident) env then inexpr
-    else TmExt { t with inexpr = inexpr }
+    else TmDecl {decl = DeclExt { t with inexpr = inexpr }}
   | expr -> smap_Expr_Expr (removeExternalDefs env) expr
 
   sem getExternalIds : Expr -> Set String
@@ -27,7 +27,7 @@ lang Externals = ExtDeclAst + VarAst
   | expr -> getExternalIdsH (setEmpty cmpString) expr
   sem getExternalIdsH : Set String -> Expr -> Set String
   sem getExternalIdsH acc =
-  | TmExt t -> getExternalIdsH (setInsert (nameGetStr t.ident) acc) t.inexpr
+  | TmDecl {decl = DeclExt t} -> getExternalIdsH (setInsert (nameGetStr t.ident) acc) t.inexpr
   | expr -> sfold_Expr_Expr getExternalIdsH acc expr
 
 end

--- a/src/stdlib/mexpr/extract.mc
+++ b/src/stdlib/mexpr/extract.mc
@@ -12,7 +12,7 @@ include "mexpr/ast.mc"
 include "mexpr/type-check.mc"
 include "mexpr/free-vars.mc"
 
-lang MExprExtract = MExprAst + MExprAsDecl + MExprFreeNames
+lang MExprExtract = MExprAst + MExprFreeNames
   sem extractAst : Set Name -> Expr -> Expr
   sem extractAst identifiers = | ast ->
     -- NOTE(larshum, 2022-09-06): In the base case, we return the integer
@@ -27,10 +27,10 @@ lang MExprExtract = MExprAst + MExprAsDecl + MExprFreeNames
 
   sem extractAstExpr : Set Name -> Expr -> Expr -> (Set Name, Expr)
   sem extractAstExpr used base = | tm ->
-    match exprAsDecl tm with Some (decl, expr) then
+    match tm with TmDecl (x & {decl = decl, inexpr = expr}) then
       match extractAstExpr used base expr with (used, expr) in
       match extractAstDecl used decl with Some (used, decl)
-      then (used, declAsExpr expr decl)
+      then (used, TmDecl {x with decl = decl, inexpr = expr})
       else (used, expr)
     else (used, base)
 
@@ -95,42 +95,42 @@ let t = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   nulet_ g (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
   nulet_ h (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  nulet_ tmp (app_ (nvar_ h) (int_ 2)),
-  nvar_ tmp
-]) in
+  nulet_ tmp (app_ (nvar_ h) (int_ 2))]
+  (nvar_ tmp
+)) in
 let extractF = preprocess (bindall_ [
-  nulet_ f (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  int_ 0
-]) in
+  nulet_ f (ulam_ "x" (addi_ (var_ "x") (int_ 1)))]
+  (int_ 0
+)) in
 utest extractAst (setOfSeq [f]) t with extractF using eqExpr in
 
 let extractG = preprocess (bindall_ [
-  nulet_ g (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
-  int_ 0
-]) in
+  nulet_ g (ulam_ "x" (muli_ (var_ "x") (int_ 2)))]
+  (int_ 0
+)) in
 utest extractAst (setOfSeq [g]) t with extractG using eqExpr in
 
 let extractTmp = preprocess (bindall_ [
   nulet_ h (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  nulet_ tmp (app_ (nvar_ h) (int_ 2)),
-  int_ 0
-]) in
+  nulet_ tmp (app_ (nvar_ h) (int_ 2))]
+  (int_ 0
+)) in
 utest extractAst (setOfSeq [tmp]) t with extractTmp using eqExpr in
 
 let t = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   nulet_ g (ulam_ "x" (muli_ (app_ (nvar_ f) (var_ "x")) (int_ 2))),
   nulet_ h (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  nulet_ tmp (app_ (nvar_ g) (int_ 4)),
-  nvar_ tmp
-]) in
+  nulet_ tmp (app_ (nvar_ g) (int_ 4))]
+  (nvar_ tmp
+)) in
 
 let extracted = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   nulet_ g (ulam_ "x" (muli_ (app_ (nvar_ f) (var_ "x")) (int_ 2))),
-  nulet_ tmp (app_ (nvar_ g) (int_ 4)),
-  int_ 0
-]) in
+  nulet_ tmp (app_ (nvar_ g) (int_ 4))]
+  (int_ 0
+)) in
 utest extractAst (setOfSeq [tmp]) t with extracted using eqExpr in
 
 let t1 = nameSym "t" in
@@ -139,16 +139,16 @@ let distinctCalls = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   nulet_ g (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   nulet_ t1 (app_ (nvar_ f) (int_ 1)),
-  nulet_ t2 (app_ (nvar_ g) (int_ 0)),
-  addi_ (nvar_ t1) (nvar_ t2)
-]) in
+  nulet_ t2 (app_ (nvar_ g) (int_ 0))]
+  (addi_ (nvar_ t1) (nvar_ t2)
+)) in
 let extracted = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   nulet_ g (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   nulet_ t1 (app_ (nvar_ f) (int_ 1)),
-  nulet_ t2 (app_ (nvar_ g) (int_ 0)),
-  int_ 0
-]) in
+  nulet_ t2 (app_ (nvar_ g) (int_ 0))]
+  (int_ 0
+)) in
 utest extractAst (setOfSeq [t1, t2]) distinctCalls with extracted using eqExpr in
 
 let inRecursiveBinding = preprocess (bindall_ [
@@ -157,16 +157,16 @@ let inRecursiveBinding = preprocess (bindall_ [
     (g, ulam_ "x" (app_ (nvar_ f) (addi_ (var_ "x") (int_ 1)))),
     (h, ulam_ "x" (app_ (nvar_ t1) (var_ "x"))),
     (t1, ulam_ "x" (app_ (nvar_ g) (var_ "x")))
-  ],
-  app_ (nvar_ h) (int_ 3)
-]) in
+  ]]
+  (app_ (nvar_ h) (int_ 3)
+)) in
 let extracted = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
   nureclets_ [
     (g, ulam_ "x" (app_ (nvar_ f) (addi_ (var_ "x") (int_ 1)))),
-    (t1, ulam_ "x" (app_ (nvar_ g) (var_ "x")))],
-  int_ 0
-]) in
+    (t1, ulam_ "x" (app_ (nvar_ g) (var_ "x")))]]
+  (int_ 0
+)) in
 utest extractAst (setOfSeq [t1]) inRecursiveBinding with extracted using eqExpr in
 
 -- Tests that a binding that is used by multiple extracted bindings is only
@@ -176,17 +176,17 @@ let multipleDependOnSame = preprocess (bindall_ [
   nulet_ t1 (ulam_ "x" (ulam_ "y" (
     addi_ (var_ "x") (app_ (nvar_ f) (var_ "y"))))),
   nulet_ t2 (ulam_ "x" (ulam_ "y" (
-    muli_ (var_ "x") (app_ (nvar_ f) (var_ "y"))))),
-  addi_ (appf2_ (nvar_ t1) (int_ 0) (int_ 1)) (appf2_ (nvar_ t2) (int_ 3) (int_ 4))
-]) in
+    muli_ (var_ "x") (app_ (nvar_ f) (var_ "y")))))]
+  (addi_ (appf2_ (nvar_ t1) (int_ 0) (int_ 1)) (appf2_ (nvar_ t2) (int_ 3) (int_ 4))
+)) in
 let extracted = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   nulet_ t1 (ulam_ "x" (ulam_ "y" (
     addi_ (var_ "x") (app_ (nvar_ f) (var_ "y"))))),
   nulet_ t2 (ulam_ "x" (ulam_ "y" (
-    muli_ (var_ "x") (app_ (nvar_ f) (var_ "y"))))),
-  int_ 0
-]) in
+    muli_ (var_ "x") (app_ (nvar_ f) (var_ "y")))))]
+  (int_ 0
+)) in
 utest extractAst (setOfSeq [t1, t2]) multipleDependOnSame with extracted using eqExpr in
 
 -- NOTE(larshum, 2023-05-30): This test checks that the type referred to only
@@ -195,9 +195,9 @@ utest extractAst (setOfSeq [t1, t2]) multipleDependOnSame with extracted using e
 let extTypeDependency = preprocess (bindall_ [
   type_ "t" [] (tyvariant_ []),
   ext_ "fun" false (tyarrow_ tyint_ (tycon_ "t")),
-  nulet_ f (ulam_ "x" (app_ (var_ "fun") (var_ "x"))),
-  int_ 0
-]) in
+  nulet_ f (ulam_ "x" (app_ (var_ "fun") (var_ "x")))]
+  (int_ 0
+)) in
 utest expr2str (extractAst (setOfSeq [f]) extTypeDependency)
 with expr2str extTypeDependency using eqString in
 
@@ -207,18 +207,18 @@ let extConApp = symbolize (bindall_ [
   type_ "T" [] (tyvariant_ []),
   condef_ "Con" (tyarrow_ tyint_ (tycon_ "T")),
   nulet_ f (ulam_ "x" (var_ "x")),
-  nulet_ g (ulam_ "y" (conapp_ "Con" (app_ (nvar_ f) (var_ "y")))),
-  int_ 0
-]) in
+  nulet_ g (ulam_ "y" (conapp_ "Con" (app_ (nvar_ f) (var_ "y"))))]
+  (int_ 0
+)) in
 utest expr2str (extractAst (setOfSeq [g]) extConApp)
 with expr2str extConApp using eqString in
 
 let multiConExtract = preprocess (bindall_ [
   type_ "T" [] (tyvariant_ []),
   condef_ "A" (tyarrow_ tyint_ (tycon_ "T")),
-  nlet_ f (tyarrow_ tyint_ (tycon_ "T")) (ulam_ "x" (conapp_ "A" (var_ "x"))),
-  int_ 0
-]) in
+  nlet_ f (tyarrow_ tyint_ (tycon_ "T")) (ulam_ "x" (conapp_ "A" (var_ "x")))]
+  (int_ 0
+)) in
 utest expr2str (extractAst (setOfSeq [f]) multiConExtract)
 with expr2str multiConExtract using eqString in
 

--- a/src/stdlib/mexpr/free-vars.mc
+++ b/src/stdlib/mexpr/free-vars.mc
@@ -69,13 +69,13 @@ lang LamFreeNames = FreeNames + LamAst
     free
 end
 
-lang LetFreeVars = FreeVars + LetAst
+lang LetFreeVars = FreeVars + LetDeclAst
   sem freeVarsExpr acc =
   | TmLet r ->
     setRemove r.ident (freeVarsExpr (freeVarsExpr acc r.body) r.inexpr)
 end
 
-lang LetFreeNames = FreeNames + LetAst + AllTypeAst
+lang LetFreeNames = FreeNames + LetDeclAst + AllTypeAst
   sem freeNamesExpr free =
   | TmLet x ->
     let free = freeNamesExpr free x.inexpr in
@@ -89,7 +89,7 @@ lang LetFreeNames = FreeNames + LetAst + AllTypeAst
     free
 end
 
-lang RecLetsFreeVars = FreeVars + RecLetsAst
+lang RecLetsFreeVars = FreeVars + RecLetsDeclAst
   sem freeVarsExpr acc =
   | TmRecLets r ->
     let acc = foldl (lam acc. lam b.
@@ -97,7 +97,7 @@ lang RecLetsFreeVars = FreeVars + RecLetsAst
     foldl (lam acc. lam b. setRemove b.ident acc) acc r.bindings
 end
 
-lang RecLetsFreeNames = FreeNames + RecLetsAst + AllTypeAst
+lang RecLetsFreeNames = FreeNames + RecLetsDeclAst + AllTypeAst
   sem freeNamesExpr free =
   | TmRecLets x ->
     let free = freeNamesExpr free x.inexpr in
@@ -112,7 +112,7 @@ lang RecLetsFreeNames = FreeNames + RecLetsAst + AllTypeAst
     free
 end
 
-lang TypeFreeNames = FreeNames + TypeAst
+lang TypeFreeNames = FreeNames + TypeDeclAst
   sem freeNamesExpr free =
   | TmType x ->
     let free = freeNamesExpr free x.inexpr in
@@ -135,7 +135,7 @@ lang DataFreeNames = FreeNames + DataAst
     free
 end
 
-lang ExtFreeNames = FreeNames + ExtAst
+lang ExtFreeNames = FreeNames + ExtDeclAst
   sem freeNamesExpr free =
   | TmExt x ->
     let free = freeNamesExpr free x.inexpr in

--- a/src/stdlib/mexpr/free-vars.mc
+++ b/src/stdlib/mexpr/free-vars.mc
@@ -71,14 +71,14 @@ end
 
 lang LetFreeVars = FreeVars + LetDeclAst
   sem freeVarsExpr acc =
-  | TmDecl {decl = DeclLet r} ->
-    setRemove r.ident (freeVarsExpr (freeVarsExpr acc r.body) r.inexpr)
+  | TmDecl {decl = DeclLet r, inexpr = inexpr} ->
+    setRemove r.ident (freeVarsExpr (freeVarsExpr acc r.body) inexpr)
 end
 
 lang LetFreeNames = FreeNames + LetDeclAst + AllTypeAst
   sem freeNamesExpr free =
-  | TmDecl {decl = DeclLet x} ->
-    let free = freeNamesExpr free x.inexpr in
+  | TmDecl {decl = DeclLet x, inexpr = inexpr} ->
+    let free = freeNamesExpr free inexpr in
     let free = setRemove x.ident free in
     let free = freeNamesExpr free x.body in
     match stripTyAll x.tyAnnot with (tyalls, tyAnnot) in
@@ -91,16 +91,16 @@ end
 
 lang RecLetsFreeVars = FreeVars + RecLetsDeclAst
   sem freeVarsExpr acc =
-  | TmDecl {decl = DeclRecLets r} ->
+  | TmDecl {decl = DeclRecLets r, inexpr = inexpr} ->
     let acc = foldl (lam acc. lam b.
-      freeVarsExpr acc b.body) (freeVarsExpr acc r.inexpr) r.bindings in
+      freeVarsExpr acc b.body) (freeVarsExpr acc inexpr) r.bindings in
     foldl (lam acc. lam b. setRemove b.ident acc) acc r.bindings
 end
 
 lang RecLetsFreeNames = FreeNames + RecLetsDeclAst + AllTypeAst
   sem freeNamesExpr free =
-  | TmDecl {decl = DeclRecLets x} ->
-    let free = freeNamesExpr free x.inexpr in
+  | TmDecl {decl = DeclRecLets x, inexpr = inexpr} ->
+    let free = freeNamesExpr free inexpr in
     let f = lam free. lam binding.
       let free = freeNamesExpr free binding.body in
       match stripTyAll binding.tyAnnot with (tyalls, tyAnnot) in
@@ -114,18 +114,18 @@ end
 
 lang TypeFreeNames = FreeNames + TypeDeclAst
   sem freeNamesExpr free =
-  | TmDecl {decl = DeclType x} ->
-    let free = freeNamesExpr free x.inexpr in
+  | TmDecl {decl = DeclType x, inexpr = inexpr} ->
+    let free = freeNamesExpr free inexpr in
     let free = freeNamesType free x.tyIdent in
     let free = foldr setRemove free x.params in
     let free = setRemove x.ident free in
     free
 end
 
-lang DataFreeNames = FreeNames + DataAst
+lang DataFreeNames = FreeNames + DataAst + DataDeclAst
   sem freeNamesExpr free =
-  | TmDecl {decl = DeclConDef x} ->
-    let free = freeNamesExpr free x.inexpr in
+  | TmDecl {decl = DeclConDef x, inexpr = inexpr} ->
+    let free = freeNamesExpr free inexpr in
     let free = setRemove x.ident free in
     let free = freeNamesType free x.tyIdent in
     free
@@ -137,8 +137,8 @@ end
 
 lang ExtFreeNames = FreeNames + ExtDeclAst
   sem freeNamesExpr free =
-  | TmDecl {decl = DeclExt x} ->
-    let free = freeNamesExpr free x.inexpr in
+  | TmDecl {decl = DeclExt x, inexpr = inexpr} ->
+    let free = freeNamesExpr free inexpr in
     let free = setRemove x.ident free in
     let free = freeNamesType free x.tyIdent in
     free

--- a/src/stdlib/mexpr/free-vars.mc
+++ b/src/stdlib/mexpr/free-vars.mc
@@ -71,13 +71,13 @@ end
 
 lang LetFreeVars = FreeVars + LetDeclAst
   sem freeVarsExpr acc =
-  | TmLet r ->
+  | TmDecl {decl = DeclLet r} ->
     setRemove r.ident (freeVarsExpr (freeVarsExpr acc r.body) r.inexpr)
 end
 
 lang LetFreeNames = FreeNames + LetDeclAst + AllTypeAst
   sem freeNamesExpr free =
-  | TmLet x ->
+  | TmDecl {decl = DeclLet x} ->
     let free = freeNamesExpr free x.inexpr in
     let free = setRemove x.ident free in
     let free = freeNamesExpr free x.body in
@@ -91,7 +91,7 @@ end
 
 lang RecLetsFreeVars = FreeVars + RecLetsDeclAst
   sem freeVarsExpr acc =
-  | TmRecLets r ->
+  | TmDecl {decl = DeclRecLets r} ->
     let acc = foldl (lam acc. lam b.
       freeVarsExpr acc b.body) (freeVarsExpr acc r.inexpr) r.bindings in
     foldl (lam acc. lam b. setRemove b.ident acc) acc r.bindings
@@ -99,7 +99,7 @@ end
 
 lang RecLetsFreeNames = FreeNames + RecLetsDeclAst + AllTypeAst
   sem freeNamesExpr free =
-  | TmRecLets x ->
+  | TmDecl {decl = DeclRecLets x} ->
     let free = freeNamesExpr free x.inexpr in
     let f = lam free. lam binding.
       let free = freeNamesExpr free binding.body in
@@ -114,7 +114,7 @@ end
 
 lang TypeFreeNames = FreeNames + TypeDeclAst
   sem freeNamesExpr free =
-  | TmType x ->
+  | TmDecl {decl = DeclType x} ->
     let free = freeNamesExpr free x.inexpr in
     let free = freeNamesType free x.tyIdent in
     let free = foldr setRemove free x.params in
@@ -124,7 +124,7 @@ end
 
 lang DataFreeNames = FreeNames + DataAst
   sem freeNamesExpr free =
-  | TmConDef x ->
+  | TmDecl {decl = DeclConDef x} ->
     let free = freeNamesExpr free x.inexpr in
     let free = setRemove x.ident free in
     let free = freeNamesType free x.tyIdent in
@@ -137,7 +137,7 @@ end
 
 lang ExtFreeNames = FreeNames + ExtDeclAst
   sem freeNamesExpr free =
-  | TmExt x ->
+  | TmDecl {decl = DeclExt x} ->
     let free = freeNamesExpr free x.inexpr in
     let free = setRemove x.ident free in
     let free = freeNamesType free x.tyIdent in

--- a/src/stdlib/mexpr/generate-eq.mc
+++ b/src/stdlib/mexpr/generate-eq.mc
@@ -195,7 +195,7 @@ lang GenerateEqLoader = MCoreLoader + GenerateEq
     modref hook.functions env.conFunctions;
     let loader = if null env.newFunctions
       then loader
-      else _addDeclExn loader (decl_nureclets_ env.newFunctions) in
+      else _addDeclExn loader (nureclets_ env.newFunctions) in
     Some (loader, printFs)
 
   sem eqFunctionsFor : [Type] -> Loader -> (Loader, [Expr])

--- a/src/stdlib/mexpr/generate-json-serializers.mc
+++ b/src/stdlib/mexpr/generate-json-serializers.mc
@@ -142,9 +142,9 @@ lang GenerateJsonSerializers =
 
   sem _addType: GJSEnv -> Expr -> GJSEnv
   sem _addType env =
-  | TmType r & t ->
+  | TmDecl {decl = DeclType r} & t ->
     { env with namedTypes = mapInsert r.ident {params = r.params, tyIdent = r.tyIdent} env.namedTypes }
-  | TmConDef r & t ->
+  | TmDecl {decl = DeclConDef r} & t ->
     match getConDefType r.tyIdent with TyCon c then
       { env with constructors = mapInsertWith concat c.ident [{ident = r.ident, tyIdent = r.tyIdent}] env.constructors }
     else error "Not a TyCon at RHS of TmConDef type"

--- a/src/stdlib/mexpr/generate-json-serializers.mc
+++ b/src/stdlib/mexpr/generate-json-serializers.mc
@@ -451,13 +451,13 @@ lang JsonSerializationLoader = MCoreLoader + GenerateJsonSerializers
     match
       match pair.serializer with TmVar x then (loader, x.ident) else
       let serName = nameSym (concat "serialize" (nameGetStr tyConName)) in
-      let loader = _addDeclExn loader (decl_nulet_ serName pair.serializer) in
+      let loader = _addDeclExn loader (nulet_ serName pair.serializer) in
       (loader, serName)
     with (loader, serName) in
     match
       match pair.deserializer with TmVar x then (loader, x.ident) else
       let deserName = nameSym (concat "deserialize" (nameGetStr tyConName)) in
-      let loader = _addDeclExn loader (decl_nulet_ deserName pair.deserializer) in
+      let loader = _addDeclExn loader (nulet_ deserName pair.deserializer) in
       (loader, deserName)
     with (loader, deserName) in
     let named =
@@ -500,7 +500,7 @@ lang JsonSerializationLoader = MCoreLoader + GenerateJsonSerializers
     match mapMapAccum f [] gjsAcc with (bindings, gjsAcc) in
     modref hook.gjsAcc gjsAcc;
     if null bindings then Some (loader, tys) else
-    let decl = decl_nureclets_ bindings in
+    let decl = nureclets_ bindings in
     Some (_addSymbolizedDeclExn loader decl, tys)
 
   sem serializationPairsFor : [Type] -> Loader -> (Loader, [GJSSerializer])

--- a/src/stdlib/mexpr/generate-pprint.mc
+++ b/src/stdlib/mexpr/generate-pprint.mc
@@ -227,6 +227,18 @@ lang GeneratePprintLoader = MCoreLoader + GeneratePprint
       } in
     addHook loader hook
 
+  sem _registerCustomPprintFunction : Name -> Expr -> Loader -> Hook -> Option (Loader, ())
+  sem _registerCustomPprintFunction tyConName f loader =
+  | _ -> None ()
+  | PprintHook hook ->
+    let pprintName = nameSym (concat "pprint" (nameGetStr tyConName)) in
+    let loader = _addDeclExn loader (decl_nulet_ pprintName f) in
+    Some (loader, modref hook.functions (mapInsert tyConName pprintName (deref hook.functions)))
+
+  sem registerCustomPprintFunction : Name -> Expr -> Loader -> Loader
+  sem registerCustomPprintFunction tyConName f = | loader ->
+    (withHookState (_registerCustomPprintFunction tyConName f) loader).0
+
   sem _pprintFunctionsFor : [Type] -> Loader -> Hook -> Option (Loader, [Expr])
   sem _pprintFunctionsFor tys loader =
   | _ -> None ()

--- a/src/stdlib/mexpr/generate-pprint.mc
+++ b/src/stdlib/mexpr/generate-pprint.mc
@@ -232,7 +232,7 @@ lang GeneratePprintLoader = MCoreLoader + GeneratePprint
   | _ -> None ()
   | PprintHook hook ->
     let pprintName = nameSym (concat "pprint" (nameGetStr tyConName)) in
-    let loader = _addDeclExn loader (decl_nulet_ pprintName f) in
+    let loader = _addDeclExn loader (nulet_ pprintName f) in
     Some (loader, modref hook.functions (mapInsert tyConName pprintName (deref hook.functions)))
 
   sem registerCustomPprintFunction : Name -> Expr -> Loader -> Loader
@@ -249,7 +249,7 @@ lang GeneratePprintLoader = MCoreLoader + GeneratePprint
     modref hook.functions env.conFunctions;
     let loader = if null env.newFunctions
       then loader
-      else _addDeclExn loader (decl_nureclets_ env.newFunctions) in
+      else _addDeclExn loader (nureclets_ env.newFunctions) in
     Some (loader, printFs)
 
   sem pprintFunctionsFor : [Type] -> Loader -> (Loader, [Expr])
@@ -283,10 +283,10 @@ lang DPrintViaPprintLoader = GeneratePprintLoader + IOAst
     in smapAccumL_Decl_Expr work loader decl
 end
 
-lang OldDPrintViaPprint = GeneratePprint + MExprAsDecl + AppTypeUtils
+lang OldDPrintViaPprint = GeneratePprint + AppTypeUtils
   sem findPprintDefinitions : GPprintEnv -> Expr -> GPprintEnv
   sem findPprintDefinitions env = | tm ->
-    match exprAsDecl tm with Some (decl, expr) then
+    match tm with TmDecl {decl = decl, inexpr = expr} then
       let env = switch decl
         case DeclLet (x & {info = Info {filename = filename}}) then
           _findPprintDefinitions env x.ident (nameGetStr x.ident, filename)

--- a/src/stdlib/mexpr/generate-utest.mc
+++ b/src/stdlib/mexpr/generate-utest.mc
@@ -71,7 +71,7 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
   sem _postTypecheck loader decl = | UtestHook hook ->
     match decl with DeclUtest d then
       if hook.includeUtestIf {static = true, info = d.info} then
-        match replaceUtests hook true loader (declAsExpr unit_ decl) with (loader, expr) in
+        match replaceUtests hook true loader (bind_ decl unit_) with (loader, expr) in
         let decl = DeclLet
           { ident = nameNoSym ""
           , tyAnnot = tyunit_

--- a/src/stdlib/mexpr/generate-utest.mc
+++ b/src/stdlib/mexpr/generate-utest.mc
@@ -3,7 +3,7 @@ include "generate-eq.mc"
 
 include "mlang/loader.mc"
 
-lang StripUtestLoader = MCoreLoader + UtestAst
+lang StripUtestLoader = MCoreLoader + UtestDeclAst
   syn Hook =
   | StripUtestHook ()
 

--- a/src/stdlib/mexpr/generate-utest.mc
+++ b/src/stdlib/mexpr/generate-utest.mc
@@ -9,7 +9,7 @@ lang StripUtestLoader = MCoreLoader + UtestDeclAst
 
   sem stripUtests : Expr -> Expr
   sem stripUtests =
-  | TmDecl {decl = DeclUtest t} -> stripUtests t.next
+  | TmDecl (t & {decl = DeclUtest _}) -> stripUtests t.inexpr
   | t -> smap_Expr_Expr stripUtests t
 
   sem _postTypecheck loader decl = | StripUtestHook _ ->
@@ -95,19 +95,19 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
   sem replaceUtests hook static loader =
   | tm & TmLam _ -> smapAccumL_Expr_Expr (replaceUtests hook false) loader tm
   | tm -> smapAccumL_Expr_Expr (replaceUtests hook static) loader tm
-  | TmDecl {decl = DeclUtest x} ->
-    if hook.includeUtestIf {static = static, info = x.info} then
-      let infoStr = str_ (info2str x.info) in
+  | TmDecl (x & {decl = DeclUtest t}) ->
+    if hook.includeUtestIf {static = static, info = t.info} then
+      let infoStr = str_ (info2str t.info) in
 
       match
-        match x.tusing with Some eqfn
+        match t.tusing with Some eqfn
         then (loader, str_ (concat "    Using: " (expr2str eqfn)), eqfn)
-        else match eqFunctionsFor [tyTm x.expected] loader with (loader, [eqfn]) in (loader, str_ "", eqfn)
+        else match eqFunctionsFor [tyTm t.expected] loader with (loader, [eqfn]) in (loader, str_ "", eqfn)
       with (loader, usingStr, eqFn) in
 
       match
-        match x.tonfail with Some ppfn then (loader, ppfn) else
-        match pprintFunctionsFor [tyTm x.test, tyTm x.expected] loader with (loader, [testF, expectedF]) in
+        match t.tonfail with Some ppfn then (loader, ppfn) else
+        match pprintFunctionsFor [tyTm t.test, tyTm t.expected] loader with (loader, [testF, expectedF]) in
         (loader, appf2_ (nvar_ hook.defaultOnFail) testF expectedF)
       with (loader, onFailFn) in
 
@@ -115,20 +115,24 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
       -- in `using` or `else`, which is consistent with the old
       -- implementation, but maybe not ideal? It should be *very* rare
       -- that it matters though.
-      match replaceUtests hook static loader x.test with (loader, test) in
-      match replaceUtests hook static loader x.expected with (loader, expected) in
-      match replaceUtests hook static loader x.next with (loader, next) in
+      match replaceUtests hook static loader t.test with (loader, test) in
+      match replaceUtests hook static loader t.expected with (loader, expected) in
+      match replaceUtests hook static loader x.inexpr with (loader, inexpr) in
 
       let test = appSeq_ (nvar_ hook.runner) [infoStr, usingStr, onFailFn, eqFn, test, expected] in
-      let tm = TmDecl {decl = DeclLet { ident = nameNoSym ""
-        , tyAnnot = tyunknown_
-        , tyBody = tyunit_
-        , body = test
-        , inexpr = next
-        , ty = tyTm next
+      let tm = TmDecl
+        { decl = DeclLet
+          { ident = nameNoSym ""
+          , tyAnnot = tyunknown_
+          , tyBody = tyunit_
+          , body = test
+          , info = t.info
+          }
+        , inexpr = inexpr
+        , ty = tyTm inexpr
         , info = x.info
-        }} in
+        } in
       (loader, tm)
     else
-      replaceUtests hook static loader x.next
+      replaceUtests hook static loader x.inexpr
 end

--- a/src/stdlib/mexpr/generate-utest.mc
+++ b/src/stdlib/mexpr/generate-utest.mc
@@ -9,7 +9,7 @@ lang StripUtestLoader = MCoreLoader + UtestDeclAst
 
   sem stripUtests : Expr -> Expr
   sem stripUtests =
-  | TmUtest t -> stripUtests t.next
+  | TmDecl {decl = DeclUtest t} -> stripUtests t.next
   | t -> smap_Expr_Expr stripUtests t
 
   sem _postTypecheck loader decl = | StripUtestHook _ ->
@@ -95,7 +95,7 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
   sem replaceUtests hook static loader =
   | tm & TmLam _ -> smapAccumL_Expr_Expr (replaceUtests hook false) loader tm
   | tm -> smapAccumL_Expr_Expr (replaceUtests hook static) loader tm
-  | TmUtest x ->
+  | TmDecl {decl = DeclUtest x} ->
     if hook.includeUtestIf {static = static, info = x.info} then
       let infoStr = str_ (info2str x.info) in
 
@@ -120,15 +120,14 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
       match replaceUtests hook static loader x.next with (loader, next) in
 
       let test = appSeq_ (nvar_ hook.runner) [infoStr, usingStr, onFailFn, eqFn, test, expected] in
-      let tm = TmLet
-        { ident = nameNoSym ""
+      let tm = TmDecl {decl = DeclLet { ident = nameNoSym ""
         , tyAnnot = tyunknown_
         , tyBody = tyunit_
         , body = test
         , inexpr = next
         , ty = tyTm next
         , info = x.info
-        } in
+        }} in
       (loader, tm)
     else
       replaceUtests hook static loader x.next

--- a/src/stdlib/mexpr/index.mc
+++ b/src/stdlib/mexpr/index.mc
@@ -82,24 +82,24 @@ lang LamIndex = Index + LamAst
   | TmLam { ident = ident } -> addKey ident acc
 end
 
-lang LetIndex = Index + LetAst
+lang LetIndex = Index + LetDeclAst
   sem indexAdd (acc: IndexAcc) =
   | TmLet { ident = ident } -> addKey ident acc
 end
 
-lang RecLetsIndex = Index + RecLetsAst
+lang RecLetsIndex = Index + RecLetsDeclAst
   sem indexAdd (acc: IndexAcc) =
   | TmRecLets { bindings = bindings } ->
     foldl (lam acc: IndexAcc. lam b: DeclLetRecord. addKey b.ident acc)
       acc bindings
 end
 
-lang ExtIndex = Index + ExtAst
+lang ExtIndex = Index + ExtDeclAst
   sem indexAdd (acc: IndexAcc) =
   | TmExt { ident = ident } -> addKey ident acc
 end
 
-lang TypeIndex = Index + TypeAst
+lang TypeIndex = Index + TypeDeclAst
   sem indexAdd (acc: IndexAcc) =
   | TmType { ident = ident } -> addKey ident acc
 end

--- a/src/stdlib/mexpr/index.mc
+++ b/src/stdlib/mexpr/index.mc
@@ -104,7 +104,7 @@ lang TypeIndex = Index + TypeDeclAst
   | TmDecl {decl = DeclType { ident = ident }} -> addKey ident acc
 end
 
-lang DataIndex = Index + DataAst
+lang DataIndex = Index + DataAst + DataDeclAst
   sem indexAdd (acc: IndexAcc) =
   | TmDecl {decl = DeclConDef { ident = ident }} -> addKey ident acc
   | TmConApp { ident = ident } -> addKey ident acc

--- a/src/stdlib/mexpr/index.mc
+++ b/src/stdlib/mexpr/index.mc
@@ -90,7 +90,7 @@ end
 lang RecLetsIndex = Index + RecLetsAst
   sem indexAdd (acc: IndexAcc) =
   | TmRecLets { bindings = bindings } ->
-    foldl (lam acc: IndexAcc. lam b: RecLetBinding. addKey b.ident acc)
+    foldl (lam acc: IndexAcc. lam b: DeclLetRecord. addKey b.ident acc)
       acc bindings
 end
 

--- a/src/stdlib/mexpr/index.mc
+++ b/src/stdlib/mexpr/index.mc
@@ -84,29 +84,29 @@ end
 
 lang LetIndex = Index + LetDeclAst
   sem indexAdd (acc: IndexAcc) =
-  | TmLet { ident = ident } -> addKey ident acc
+  | TmDecl {decl = DeclLet { ident = ident }} -> addKey ident acc
 end
 
 lang RecLetsIndex = Index + RecLetsDeclAst
   sem indexAdd (acc: IndexAcc) =
-  | TmRecLets { bindings = bindings } ->
+  | TmDecl {decl = DeclRecLets { bindings = bindings }} ->
     foldl (lam acc: IndexAcc. lam b: DeclLetRecord. addKey b.ident acc)
       acc bindings
 end
 
 lang ExtIndex = Index + ExtDeclAst
   sem indexAdd (acc: IndexAcc) =
-  | TmExt { ident = ident } -> addKey ident acc
+  | TmDecl {decl = DeclExt { ident = ident }} -> addKey ident acc
 end
 
 lang TypeIndex = Index + TypeDeclAst
   sem indexAdd (acc: IndexAcc) =
-  | TmType { ident = ident } -> addKey ident acc
+  | TmDecl {decl = DeclType { ident = ident }} -> addKey ident acc
 end
 
 lang DataIndex = Index + DataAst
   sem indexAdd (acc: IndexAcc) =
-  | TmConDef { ident = ident } -> addKey ident acc
+  | TmDecl {decl = DeclConDef { ident = ident }} -> addKey ident acc
   | TmConApp { ident = ident } -> addKey ident acc
 end
 

--- a/src/stdlib/mexpr/json-debug.mc
+++ b/src/stdlib/mexpr/json-debug.mc
@@ -78,7 +78,7 @@ end
 
 lang DeclsToJson = AstToJson + MExprAsDecl
   sem exprToJson =
-  | tm & (TmLet _ | TmRecLets _ | TmType _ | TmConDef _ | TmUtest _ | TmExt _) ->
+  | tm & (TmDecl {decl = DeclLet _} | TmDecl {decl = DeclRecLets _} | TmDecl {decl = DeclType _} | TmDecl {decl = DeclConDef _} | TmDecl {decl = DeclUtest _} | TmDecl {decl = DeclExt _}) ->
     recursive let work = lam acc. lam expr.
       match exprAsDecl expr with Some (decl, inexpr) then
         work (snoc acc decl) inexpr

--- a/src/stdlib/mexpr/json-debug.mc
+++ b/src/stdlib/mexpr/json-debug.mc
@@ -76,20 +76,20 @@ lang LamToJson = AstToJson + LamAst
     ] )
 end
 
-lang DeclsToJson = AstToJson + MExprAsDecl
+lang DeclToJson = AstToJson + DeclAst
   sem exprToJson =
-  | tm & (TmDecl {decl = DeclLet _} | TmDecl {decl = DeclRecLets _} | TmDecl {decl = DeclType _} | TmDecl {decl = DeclConDef _} | TmDecl {decl = DeclUtest _} | TmDecl {decl = DeclExt _}) ->
-    recursive let work = lam acc. lam expr.
-      match exprAsDecl expr with Some (decl, inexpr) then
-        work (snoc acc decl) inexpr
-      else (acc, expr) in
+  | tm & TmDecl x ->
+    recursive let work = lam acc. lam tm.
+      match tm with TmDecl x
+      then work (snoc acc x.decl) x.inexpr
+      else (acc, tm) in
     match work [] tm with (decls, inexpr) in
     JsonObject (mapFromSeq cmpString
       [ ("con", JsonString "TmDecl (merged)")
       , ("decls", JsonArray (map declToJson decls))
       , ("inexpr", exprToJson inexpr)
-      , ("ty", typeToJson (tyTm tm))
-      , ("info", infoToJson (infoTm tm))
+      , ("ty", typeToJson x.ty)
+      , ("info", infoToJson x.info)
       ] )
 end
 
@@ -475,15 +475,14 @@ lang DataKindToJson = AstToJson + DataKindAst
     ] )
 end
 
-lang UseToJson = AstToJson + UseAst
+lang UseToJson = AstToJson + UseDeclAst
   -- TODO(vipa, 2024-05-17): This should probably actually be a Decl,
   -- it's just not a good idea to do a `use` on the top-level right
   -- now because of how includes work.
-  sem exprToJson =
-  | TmUse x -> JsonObject (mapFromSeq cmpString
-    [ ("con", JsonString "TmUse")
+  sem declToJson =
+  | DeclUse x -> JsonObject (mapFromSeq cmpString
+    [ ("con", JsonString "DeclUse")
     , ("ident", nameToJson x.ident)
-    , ("ty", typeToJson x.ty)
     , ("info", infoToJson x.info)
     ] )
 end
@@ -597,7 +596,7 @@ lang MExprToJson
   = VarToJson
   + AppToJson
   + LamToJson
-  + DeclsToJson
+  + DeclToJson
   + ConstToJson
   + SeqToJson
   + RecordToJson

--- a/src/stdlib/mexpr/json-debug.mc
+++ b/src/stdlib/mexpr/json-debug.mc
@@ -513,7 +513,7 @@ lang TypeToJson = TypeDeclAst + AstToJson
 end
 
 -- DeclRecLets --
-lang RecLetsToJson = RecLetsDeclAst + RecLetsAst + AstToJson
+lang RecLetsToJson = RecLetsDeclAst + RecLetsDeclAst + AstToJson
   sem declToJson =
   | DeclRecLets x -> JsonObject (mapFromSeq cmpString
     [ ("con", JsonString "DeclRecLets")

--- a/src/stdlib/mexpr/kcfa.mc
+++ b/src/stdlib/mexpr/kcfa.mc
@@ -558,21 +558,18 @@ lang LamKCFA = KCFA + KBaseConstraint + LamAst
   | TmLam t -> acc
 end
 
-lang LetKCFA = KCFA + LetDeclAst
+lang DeclKCFA = KCFA + DeclAst
   sem exprName =
-  | TmDecl {decl = DeclLet t} -> exprName t.inexpr
+  | TmDecl x -> exprName x.inexpr
 end
 
 lang RecLetsKCFA = KCFA + LamKCFA + RecLetsDeclAst
-  sem exprName =
-  | TmDecl {decl = DeclRecLets t} -> exprName t.inexpr
-
   sem generateConstraints im ctx env =
-  | TmDecl {decl = DeclRecLets ({ bindings = bindings } & t)} ->
+  | tm & TmDecl {decl = DeclRecLets ({ bindings = bindings } & t)} ->
     -- Make each binding available in the environment
     let idents = map (lam b. name2int im b.info b.ident) bindings in
     let envBody = foldl (lam env. lam i.
-        ctxEnvAdd i ctx env) (ctxEnvFilterFree im (TmDecl {decl = DeclRecLets t}) env) idents in
+        ctxEnvAdd i ctx env) (ctxEnvFilterFree im tm env) idents in
     let cstrs = map (lam identBind: (IName, DeclLetRecord).
       match identBind with (ident, b) in
       match b.body with TmLam t then
@@ -849,11 +846,6 @@ lang SeqKCFA = KCFA + KBaseConstraint + SeqAst
     (env, join ["[{", names, "}]"])
 end
 
-lang TypeKCFA = KCFA + TypeDeclAst
-  sem exprName =
-  | TmDecl {decl = DeclType t} -> exprName t.inexpr
-end
-
 lang DataKCFA = KCFA + KBaseConstraint + DataAst
   syn AbsVal =
   -- Abstract representation of constructed data.
@@ -884,10 +876,6 @@ lang DataKCFA = KCFA + KBaseConstraint + DataAst
     match pprintConINameCtx im env ident with (env,ident) in
     match pprintVarINameCtx im env body with (env,body) in
     (env, join [ident, " ", body])
-
-  sem exprName =
-  | TmDecl {decl = DeclConDef t} -> exprName t.inexpr
-
 end
 
 lang MatchKCFA = KCFA + KBaseConstraint + MatchAst + MExprCmp
@@ -961,11 +949,6 @@ lang MatchKCFA = KCFA + KBaseConstraint + MatchAst + MExprCmp
   | p ->
     sfold_Pat_Pat patNames acc p
 
-end
-
-lang UtestKCFA = KCFA + UtestDeclAst
-  sem exprName =
-  | TmDecl {decl = DeclUtest t} -> exprName t.next
 end
 
 lang NeverKCFA = KCFA + NeverAst
@@ -1043,7 +1026,7 @@ lang ExtKCFA = KCFA + ExtDeclAst
   -- the ANF transform and define eta expanded versions of the externals (so
   -- that they can be curried).
   sem collectConstraints ctx cgfs acc =
-  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} & t ->
+  | TmDecl {decl = DeclExt _, inexpr = TmDecl {decl = DeclLet {ident = ident}, inexpr = inexpr}} & t ->
     let acc = foldl (lam acc. lam f.
         match acc with (env, cstrs) in
         match f ctx env t with (env, fcstrs) in
@@ -1052,7 +1035,7 @@ lang ExtKCFA = KCFA + ExtDeclAst
     collectConstraints ctx cgfs acc inexpr
 
   sem generateConstraints im ctx env =
-  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} ->
+  | TmDecl {decl = DeclExt _, inexpr = TmDecl {decl = DeclLet {ident = ident}, inexpr = inexpr}} ->
     -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
     -- for externals. Similarly to constants, we probably want to delegate to
     -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
@@ -1062,7 +1045,7 @@ lang ExtKCFA = KCFA + ExtDeclAst
 
   sem exprName =
   -- Skip the eta expanded let added by ANF,
-  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { inexpr = inexpr }}}} -> exprName inexpr
+  | TmDecl {decl = DeclExt _, inexpr = TmDecl {decl = DeclLet _, inexpr = inexpr}} -> exprName inexpr
 
 end
 
@@ -1737,8 +1720,8 @@ lang MExprKCFA = KCFA +
 
   -- Terms
   VarKCFA + LamKCFA + AppKCFA +
-  LetKCFA + RecLetsKCFA + ConstKCFA + SeqKCFA + RecordKCFA + TypeKCFA + DataKCFA +
-  MatchKCFA + UtestKCFA + NeverKCFA + ExtKCFA +
+  DeclKCFA + RecLetsKCFA + ConstKCFA + SeqKCFA + RecordKCFA + DataKCFA +
+  MatchKCFA + NeverKCFA + ExtKCFA +
 
   -- Constants
   IntKCFA + ArithIntKCFA + ShiftIntKCFA + FloatKCFA + ArithFloatKCFA +

--- a/src/stdlib/mexpr/kcfa.mc
+++ b/src/stdlib/mexpr/kcfa.mc
@@ -558,12 +558,12 @@ lang LamKCFA = KCFA + KBaseConstraint + LamAst
   | TmLam t -> acc
 end
 
-lang LetKCFA = KCFA + LetAst
+lang LetKCFA = KCFA + LetDeclAst
   sem exprName =
   | TmLet t -> exprName t.inexpr
 end
 
-lang RecLetsKCFA = KCFA + LamKCFA + RecLetsAst
+lang RecLetsKCFA = KCFA + LamKCFA + RecLetsDeclAst
   sem exprName =
   | TmRecLets t -> exprName t.inexpr
 
@@ -849,7 +849,7 @@ lang SeqKCFA = KCFA + KBaseConstraint + SeqAst
     (env, join ["[{", names, "}]"])
 end
 
-lang TypeKCFA = KCFA + TypeAst
+lang TypeKCFA = KCFA + TypeDeclAst
   sem exprName =
   | TmType t -> exprName t.inexpr
 end
@@ -963,7 +963,7 @@ lang MatchKCFA = KCFA + KBaseConstraint + MatchAst + MExprCmp
 
 end
 
-lang UtestKCFA = KCFA + UtestAst
+lang UtestKCFA = KCFA + UtestDeclAst
   sem exprName =
   | TmUtest t -> exprName t.next
 end
@@ -972,7 +972,7 @@ lang NeverKCFA = KCFA + NeverAst
   -- Nothing to be done here
 end
 
-lang ExtKCFA = KCFA + ExtAst
+lang ExtKCFA = KCFA + ExtDeclAst
 
   syn AbsVal =
   -- Abstract representation of externals. Handled in a similar way as

--- a/src/stdlib/mexpr/kcfa.mc
+++ b/src/stdlib/mexpr/kcfa.mc
@@ -504,7 +504,7 @@ end
 lang VarKCFA = KCFA + KBaseConstraint + VarAst
 
   sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmVar t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmVar t, info = info }} ->
     let ident = name2int im info ident in
     let lhs = name2int im t.info t.ident in
     let cstrs =
@@ -535,7 +535,7 @@ lang LamKCFA = KCFA + KBaseConstraint + LamAst
      else diff
 
   sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmLam t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmLam t, info = info }} ->
     let ident = name2int im info ident in
     let av: AbsVal = AVLam {
       ident = name2int im t.info t.ident,
@@ -560,19 +560,19 @@ end
 
 lang LetKCFA = KCFA + LetDeclAst
   sem exprName =
-  | TmLet t -> exprName t.inexpr
+  | TmDecl {decl = DeclLet t} -> exprName t.inexpr
 end
 
 lang RecLetsKCFA = KCFA + LamKCFA + RecLetsDeclAst
   sem exprName =
-  | TmRecLets t -> exprName t.inexpr
+  | TmDecl {decl = DeclRecLets t} -> exprName t.inexpr
 
   sem generateConstraints im ctx env =
-  | TmRecLets ({ bindings = bindings } & t) ->
+  | TmDecl {decl = DeclRecLets ({ bindings = bindings } & t)} ->
     -- Make each binding available in the environment
     let idents = map (lam b. name2int im b.info b.ident) bindings in
     let envBody = foldl (lam env. lam i.
-        ctxEnvAdd i ctx env) (ctxEnvFilterFree im (TmRecLets t) env) idents in
+        ctxEnvAdd i ctx env) (ctxEnvFilterFree im (TmDecl {decl = DeclRecLets t}) env) idents in
     let cstrs = map (lam identBind: (IName, DeclLetRecord).
       match identBind with (ident, b) in
       match b.body with TmLam t then
@@ -616,7 +616,7 @@ lang ConstKCFA = KCFA + ConstAst + KBaseConstraint + Cmp
     else cmp
 
   sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmConst t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmConst t, info = info }} ->
     let ident = name2int im info ident in
     let cstrs = generateConstraintsConst t.info (ident,ctx) t.val in
     (ctxEnvAdd ident ctx env, cstrs)
@@ -702,7 +702,7 @@ lang AppKCFA = KCFA + ConstKCFA + KBaseConstraint + LamKCFA + AppAst + MExprArit
       ])
 
   sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmApp app, info = info} ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmApp app, info = info}} ->
     let ident = name2int im info ident in
     match app.lhs with TmVar l then
       match app.rhs with TmVar r then
@@ -761,7 +761,7 @@ lang RecordKCFA = KCFA + KBaseConstraint + RecordAst
   | CstrRecordUpdate r & cstr -> initConstraintName r.lhs graph cstr
 
   sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmRecord t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmRecord t, info = info }} ->
     let bindings = mapMap (lam v: Expr.
         match v with TmVar t then
           let vident = name2int im t.info t.ident in
@@ -774,7 +774,7 @@ lang RecordKCFA = KCFA + KBaseConstraint + RecordAst
     let ident = name2int im info ident in
     let cstrs = [ CstrInit { lhs = av, rhs = (ident, ctx) } ] in
     (ctxEnvAdd ident ctx env, cstrs)
-  | TmLet { ident = ident, body = TmRecordUpdate t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmRecordUpdate t, info = info }} ->
     match t.rec with TmVar vrec then
       match t.value with TmVar vval then
         let lhs = name2int im vrec.info vrec.ident in
@@ -829,7 +829,7 @@ lang SeqKCFA = KCFA + KBaseConstraint + SeqAst
   | (AVSeq { names = lhs }, AVSeq { names = rhs }) -> setCmp lhs rhs
 
   sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmSeq t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmSeq t, info = info }} ->
     let names = foldl (lam acc: [(IName,Ctx)]. lam t: Expr.
       match t with TmVar t then
         let tident = name2int im t.info t.ident in
@@ -851,7 +851,7 @@ end
 
 lang TypeKCFA = KCFA + TypeDeclAst
   sem exprName =
-  | TmType t -> exprName t.inexpr
+  | TmDecl {decl = DeclType t} -> exprName t.inexpr
 end
 
 lang DataKCFA = KCFA + KBaseConstraint + DataAst
@@ -866,7 +866,7 @@ lang DataKCFA = KCFA + KBaseConstraint + DataAst
     if eqi idiff 0 then cmpINameCtx blhs brhs else idiff
 
   sem generateConstraints im ctx env =
-  | TmLet { ident = ident, body = TmConApp t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmConApp t, info = info }} ->
     let body =
       match t.body with TmVar v then name2int im v.info v.ident
       else errorSingle [infoTm t.body] "Not a TmVar in con app" in
@@ -886,7 +886,7 @@ lang DataKCFA = KCFA + KBaseConstraint + DataAst
     (env, join [ident, " ", body])
 
   sem exprName =
-  | TmConDef t -> exprName t.inexpr
+  | TmDecl {decl = DeclConDef t} -> exprName t.inexpr
 
 end
 
@@ -928,7 +928,7 @@ lang MatchKCFA = KCFA + KBaseConstraint + MatchAst + MExprCmp
   : IndexMap -> [MatchGenFun] -> Ctx -> CtxEnv -> Expr -> GenFunAcc
   sem generateConstraintsMatch im mcgfs ctx env =
   | _ -> (env,[])
-  | TmLet { ident = ident, body = TmMatch t, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmMatch t, info = info }} ->
     let thn = name2int im (infoTm t.thn) (exprName t.thn) in
     let els = name2int im (infoTm t.els) (exprName t.els) in
     let ident = name2int im info ident in
@@ -965,7 +965,7 @@ end
 
 lang UtestKCFA = KCFA + UtestDeclAst
   sem exprName =
-  | TmUtest t -> exprName t.next
+  | TmDecl {decl = DeclUtest t} -> exprName t.next
 end
 
 lang NeverKCFA = KCFA + NeverAst
@@ -1043,7 +1043,7 @@ lang ExtKCFA = KCFA + ExtDeclAst
   -- the ANF transform and define eta expanded versions of the externals (so
   -- that they can be curried).
   sem collectConstraints ctx cgfs acc =
-  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } & t ->
+  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} & t ->
     let acc = foldl (lam acc. lam f.
         match acc with (env, cstrs) in
         match f ctx env t with (env, fcstrs) in
@@ -1052,7 +1052,7 @@ lang ExtKCFA = KCFA + ExtDeclAst
     collectConstraints ctx cgfs acc inexpr
 
   sem generateConstraints im ctx env =
-  | TmExt { inexpr = TmLet { ident = ident, inexpr = inexpr } } ->
+  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { ident = ident, inexpr = inexpr }} }} ->
     -- NOTE(dlunde,2022-06-15): Currently, we do not generate any constraints
     -- for externals. Similarly to constants, we probably want to delegate to
     -- `generateConstraintsExts` here. As with `propagateConstraintExt`, it is
@@ -1062,7 +1062,7 @@ lang ExtKCFA = KCFA + ExtDeclAst
 
   sem exprName =
   -- Skip the eta expanded let added by ANF,
-  | TmExt { inexpr = TmLet { inexpr = inexpr }} -> exprName inexpr
+  | TmDecl {decl = DeclExt { inexpr = TmDecl {decl = DeclLet { inexpr = inexpr }}}} -> exprName inexpr
 
 end
 

--- a/src/stdlib/mexpr/kcfa.mc
+++ b/src/stdlib/mexpr/kcfa.mc
@@ -573,7 +573,7 @@ lang RecLetsKCFA = KCFA + LamKCFA + RecLetsAst
     let idents = map (lam b. name2int im b.info b.ident) bindings in
     let envBody = foldl (lam env. lam i.
         ctxEnvAdd i ctx env) (ctxEnvFilterFree im (TmRecLets t) env) idents in
-    let cstrs = map (lam identBind: (IName, RecLetBinding).
+    let cstrs = map (lam identBind: (IName, DeclLetRecord).
       match identBind with (ident, b) in
       match b.body with TmLam t then
         let av: AbsVal = AVLam {

--- a/src/stdlib/mexpr/keyword-maker.mc
+++ b/src/stdlib/mexpr/keyword-maker.mc
@@ -82,7 +82,7 @@ lang KeywordMakerBase = VarAst + AppAst + ConTypeAst + AppTypeAst
 end
 
 -- Support for keywords starting with capital letter. Uses ConApp and ConDef
-lang KeywordMakerData = KeywordMakerBase + DataAst
+lang KeywordMakerData = KeywordMakerBase + DataAst + DataDeclAst
   sem makeExprKeywords (args: [Expr]) =
   | TmConApp r ->
      let ident = nameGetStr r.ident in
@@ -93,22 +93,22 @@ lang KeywordMakerData = KeywordMakerBase + DataAst
          else makeKeywordError r.info noArgs (length args) ident
        else never
      else TmConApp r
-  | TmDecl {decl = DeclConDef r} ->
+  | TmDecl (x & {decl = DeclConDef r}) ->
      let ident = nameGetStr r.ident in
      match matchKeywordString r.info ident with Some _ then
        errorSingle [r.info] (join ["Keyword '", ident,
        "' cannot be used in a constructor definition."])
-     else TmDecl {decl = DeclConDef {r with inexpr = makeExprKeywords [] r.inexpr}}
+     else TmDecl {x with inexpr = makeExprKeywords [] x.inexpr}
 end
 
 lang KeywordMakerType = KeywordMakerBase + TypeDeclAst
   sem makeExprKeywords (args: [Expr]) =
-  | TmDecl {decl = DeclType r} ->
+  | TmDecl (x & {decl = DeclType r}) ->
      let ident = nameGetStr r.ident in
      match matchTypeKeywordString r.info ident with Some _ then
        errorSingle [r.info] (join ["Type keyword '", ident,
        "' cannot be used in a type definition."])
-     else TmDecl {decl = DeclType {r with inexpr = makeExprKeywords [] r.inexpr}}
+     else TmDecl {x with inexpr = makeExprKeywords [] x.inexpr}
 end
 
 -- Includes a check that a keyword cannot be used as a binding variable in a lambda
@@ -125,12 +125,15 @@ end
 -- Includes a check that a keyword cannot be used as a binding variable in a let expression
 lang KeywordMakerLet = KeywordMakerBase + LetDeclAst
   sem makeExprKeywords (args: [Expr]) =
-  | TmDecl {decl = DeclLet r} ->
+  | TmDecl (x & {decl = DeclLet r}) ->
      let ident = nameGetStr r.ident in
      match matchKeywordString r.info ident with Some _ then
        errorSingle [r.info] (join ["Keyword '", ident, "' cannot be used in a let expressions."])
      else
-       TmDecl {decl = DeclLet {{r with body = makeExprKeywords [] r.body} with inexpr = makeExprKeywords [] r.inexpr}}
+       TmDecl
+       {x with decl = DeclLet {r with body = makeExprKeywords [] r.body}
+       , inexpr = makeExprKeywords [] x.inexpr
+       }
 end
 
 
@@ -298,7 +301,7 @@ utest makeKeywords expr with expr using eqExpr in
 let expr = match_ true_  (pvar_ "ok") true_ false_ in
 utest makeKeywords expr with expr using eqExpr in
 
-let expr = ucondef_ "Ok" in
+let expr = bind_ (ucondef_ "Ok") unit_ in
 utest makeKeywords expr with expr using eqExpr in
 
 let expr = ulam_ "x" (var_ "noargs") in

--- a/src/stdlib/mexpr/keyword-maker.mc
+++ b/src/stdlib/mexpr/keyword-maker.mc
@@ -101,7 +101,7 @@ lang KeywordMakerData = KeywordMakerBase + DataAst
      else TmConDef {r with inexpr = makeExprKeywords [] r.inexpr}
 end
 
-lang KeywordMakerType = KeywordMakerBase + TypeAst
+lang KeywordMakerType = KeywordMakerBase + TypeDeclAst
   sem makeExprKeywords (args: [Expr]) =
   | TmType r ->
      let ident = nameGetStr r.ident in
@@ -123,7 +123,7 @@ end
 
 
 -- Includes a check that a keyword cannot be used as a binding variable in a let expression
-lang KeywordMakerLet = KeywordMakerBase + LetAst
+lang KeywordMakerLet = KeywordMakerBase + LetDeclAst
   sem makeExprKeywords (args: [Expr]) =
   | TmLet r ->
      let ident = nameGetStr r.ident in

--- a/src/stdlib/mexpr/keyword-maker.mc
+++ b/src/stdlib/mexpr/keyword-maker.mc
@@ -93,22 +93,22 @@ lang KeywordMakerData = KeywordMakerBase + DataAst
          else makeKeywordError r.info noArgs (length args) ident
        else never
      else TmConApp r
-  | TmConDef r ->
+  | TmDecl {decl = DeclConDef r} ->
      let ident = nameGetStr r.ident in
      match matchKeywordString r.info ident with Some _ then
        errorSingle [r.info] (join ["Keyword '", ident,
        "' cannot be used in a constructor definition."])
-     else TmConDef {r with inexpr = makeExprKeywords [] r.inexpr}
+     else TmDecl {decl = DeclConDef {r with inexpr = makeExprKeywords [] r.inexpr}}
 end
 
 lang KeywordMakerType = KeywordMakerBase + TypeDeclAst
   sem makeExprKeywords (args: [Expr]) =
-  | TmType r ->
+  | TmDecl {decl = DeclType r} ->
      let ident = nameGetStr r.ident in
      match matchTypeKeywordString r.info ident with Some _ then
        errorSingle [r.info] (join ["Type keyword '", ident,
        "' cannot be used in a type definition."])
-     else TmType {r with inexpr = makeExprKeywords [] r.inexpr}
+     else TmDecl {decl = DeclType {r with inexpr = makeExprKeywords [] r.inexpr}}
 end
 
 -- Includes a check that a keyword cannot be used as a binding variable in a lambda
@@ -125,12 +125,12 @@ end
 -- Includes a check that a keyword cannot be used as a binding variable in a let expression
 lang KeywordMakerLet = KeywordMakerBase + LetDeclAst
   sem makeExprKeywords (args: [Expr]) =
-  | TmLet r ->
+  | TmDecl {decl = DeclLet r} ->
      let ident = nameGetStr r.ident in
      match matchKeywordString r.info ident with Some _ then
        errorSingle [r.info] (join ["Keyword '", ident, "' cannot be used in a let expressions."])
      else
-       TmLet {{r with body = makeExprKeywords [] r.body} with inexpr = makeExprKeywords [] r.inexpr}
+       TmDecl {decl = DeclLet {{r with body = makeExprKeywords [] r.body} with inexpr = makeExprKeywords [] r.inexpr}}
 end
 
 

--- a/src/stdlib/mexpr/lamlift.mc
+++ b/src/stdlib/mexpr/lamlift.mc
@@ -88,7 +88,7 @@ lang LambdaLiftNameAnonymous = MExprAst
   | TmRecLets t ->
     let bindings =
       map
-        (lam bind : RecLetBinding.
+        (lam bind : DeclLetRecord.
           {bind with body = nameAnonymousLambdasInBody bind.body})
         t.bindings in
     TmRecLets {{t with bindings = bindings}
@@ -270,7 +270,7 @@ lang LambdaLiftFindFreeVariables =
         else state
     in
     let findFreeVariablesBinding
-      : LambdaLiftState -> RecLetBinding -> LambdaLiftState
+      : LambdaLiftState -> DeclLetRecord -> LambdaLiftState
       = lam state. lam bind.
         let tyvars = concat (stripTyAll bind.tyAnnot).0 (stripTyAll bind.tyBody).0 in
         let state = foldl (lam acc. lam pair. {acc with tyVars = mapInsert pair.0 pair.1 acc.tyVars}) state tyvars in
@@ -368,11 +368,11 @@ lang LambdaLiftLiftGlobal = MExprAst
     case _ then rest
     end
 
-  sem liftRecursiveBindingH (bindings : [RecLetBinding]) =
+  sem liftRecursiveBindingH (bindings : [DeclLetRecord]) =
   | TmLet t ->
     match liftRecursiveBindingH bindings t.body with (bindings, body) in
     match t.body with TmLam _ then
-      let bind : RecLetBinding =
+      let bind : DeclLetRecord =
         { ident = t.ident, tyAnnot = t.tyAnnot, tyBody = t.tyBody
         , body = body, info = t.info } in
       let bindings = snoc bindings bind in
@@ -380,7 +380,7 @@ lang LambdaLiftLiftGlobal = MExprAst
     else match liftRecursiveBindingH bindings t.inexpr with (bindings, inexpr) in
       (bindings, TmLet {{t with body = body} with inexpr = inexpr})
   | TmRecLets t ->
-    let liftBinding : [RecLetBinding] -> RecLetBinding -> [RecLetBinding] =
+    let liftBinding : [DeclLetRecord] -> DeclLetRecord -> [DeclLetRecord] =
       lam bindings. lam bind.
       match liftRecursiveBindingH bindings bind.body with (bindings, body) in
       snoc bindings {bind with body = body}
@@ -391,7 +391,7 @@ lang LambdaLiftLiftGlobal = MExprAst
 
   sem liftRecursiveBinding =
   | TmRecLets t /- : Expr -> Expr -/ ->
-    let liftBinding : [RecLetBinding] -> RecLetBinding -> [RecLetBinding] =
+    let liftBinding : [DeclLetRecord] -> DeclLetRecord -> [DeclLetRecord] =
       lam bindings. lam bind.
       match liftRecursiveBindingH bindings bind.body with (bindings, body) in
       snoc bindings {bind with body = body}
@@ -588,7 +588,7 @@ lang MExprLambdaLiftAllowSpineCapture =
         else state
     in
     let findFreeVariablesBinding
-      : LambdaLiftState -> RecLetBinding -> LambdaLiftState
+      : LambdaLiftState -> DeclLetRecord -> LambdaLiftState
       = lam state. lam bind.
         let tyvars = concat (stripTyAll bind.tyAnnot).0 (stripTyAll bind.tyBody).0 in
         let state = foldl (lam acc. lam pair. {acc with tyVars = mapInsert pair.0 pair.1 acc.tyVars}) state tyvars in

--- a/src/stdlib/mexpr/lamlift.mc
+++ b/src/stdlib/mexpr/lamlift.mc
@@ -79,20 +79,20 @@ lang LambdaLiftNameAnonymous = MExprAst
     in
     let lambdaName = nameSym "t" in
     let letBody = TmLam {t with body = recurseInLambdaBody t.body} in
-    TmLet {ident = lambdaName, tyAnnot = t.ty, tyBody = t.ty, body = letBody,
+    TmDecl {decl = DeclLet {ident = lambdaName, tyAnnot = t.ty, tyBody = t.ty, body = letBody,
            inexpr = TmVar {ident = lambdaName, ty = t.ty, info = t.info, frozen = false},
-           ty = t.ty, info = t.info}
-  | TmLet t ->
-    TmLet {{t with body = nameAnonymousLambdasInBody t.body}
-              with inexpr = nameAnonymousLambdas t.inexpr}
-  | TmRecLets t ->
+           ty = t.ty, info = t.info}}
+  | TmDecl {decl = DeclLet t} ->
+    TmDecl {decl = DeclLet {{t with body = nameAnonymousLambdasInBody t.body}
+              with inexpr = nameAnonymousLambdas t.inexpr}}
+  | TmDecl {decl = DeclRecLets t} ->
     let bindings =
       map
         (lam bind : DeclLetRecord.
           {bind with body = nameAnonymousLambdasInBody bind.body})
         t.bindings in
-    TmRecLets {{t with bindings = bindings}
-                  with inexpr = nameAnonymousLambdas t.inexpr}
+    TmDecl {decl = DeclRecLets {{t with bindings = bindings}
+                  with inexpr = nameAnonymousLambdas t.inexpr}}
   | t -> smap_Expr_Expr nameAnonymousLambdas t
 end
 
@@ -185,15 +185,14 @@ lang UpdateDefinitionsAndUses = MExprAst
       -- value. We know from the transformation that it will be a
       -- value, and we could eta-expand if we want to get it fully
       -- correct, but I'm leaving it like this for the moment.
-      TmLet
-      { ident = n
+      TmDecl {decl = DeclLet { ident = n
       , tyAnnot = x.ty
       , tyBody = x.ty
       , body = tm
       , inexpr = TmVar {ident = n, frozen = true, info = x.info, ty = x.ty}
       , info = x.info
       , ty = x.ty
-      }
+      }}
     else tm
 end
 
@@ -230,7 +229,7 @@ lang LambdaLiftFindFreeVariables =
   | TmLam t ->
     let state = {state with vars = mapInsert t.ident t.tyParam state.vars} in
     findFreeVariables state t.body
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let state =
       match t.body with TmLam _ then
         -- NOTE(vipa, 2023-10-09): A let-bound lambda, find a solution
@@ -246,7 +245,7 @@ lang LambdaLiftFindFreeVariables =
       foldl (lam acc. lam pair. {acc with tyVars = mapInsert pair.0 pair.1 acc.tyVars}) state tyvars in
     let state = findFreeVariables state t.body in
     findFreeVariables state t.inexpr
-  | tm & TmRecLets t -> recursive
+  | tm & TmDecl {decl = DeclRecLets t} -> recursive
     let insertInitialSolution = lam state. lam binding.
       let sol = findFreeVariablesInBody state _solEmpty binding.body in
       {state with sols = mapInsert binding.ident sol state.sols} in
@@ -287,7 +286,7 @@ lang LambdaLiftFindFreeVariables =
     let state = findFreeVariablesPat state t.pat in
     let state = findFreeVariables state t.thn in
     findFreeVariables state t.els
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     let state = {state with sols = mapInsert t.ident _solEmpty state.sols} in
     findFreeVariables state t.inexpr
   | t -> sfold_Expr_Expr findFreeVariables state t
@@ -309,7 +308,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
   sem insertFreeVariablesH solutions subMap =
   | tm & TmVar t ->
     optionMapOr tm (lam f. f t) (mapLookup t.ident subMap)
-  | TmLet (t & {body = TmLam _}) ->
+  | TmDecl {decl = DeclLet (t & {body = TmLam _})} ->
     match mapLookup t.ident solutions with Some sol then
       let sol = _orderSolution sol in
       let tyBody = updateType sol t.tyBody t.tyBody in
@@ -319,11 +318,11 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
       let inexpr =
         let subMap = mapInsert t.ident (mkSolApplication sol tyBody) subMap in
         insertFreeVariablesH solutions subMap t.inexpr in
-      TmLet {t with tyBody = tyBody, tyAnnot = tyAnnot, body = body,
-                    inexpr = inexpr}
+      TmDecl {decl = DeclLet {t with tyBody = tyBody, tyAnnot = tyAnnot, body = body,
+                    inexpr = inexpr}}
     else errorSingle [t.info] (join ["Found no free variable solution for ",
                                      nameGetStr t.ident])
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let updateBindingShallow = lam solutions. lam subMap. lam binding.
       match mapLookup binding.ident solutions with Some sol then
         let sol = _orderSolution sol in
@@ -340,7 +339,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
     match mapAccumL (updateBindingShallow solutions) subMap t.bindings with (subMap, bindings) in
     let bindings = map (updateBindingNonShallow solutions subMap) bindings in
     let inexpr = insertFreeVariablesH solutions subMap t.inexpr in
-    TmRecLets {t with bindings = bindings, inexpr = inexpr}
+    TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr}}
   | t -> smap_Expr_Expr (insertFreeVariablesH solutions subMap) t
 
   sem insertFreeVariables (solutions : Map Name LambdaLiftSolution) =
@@ -360,16 +359,16 @@ lang LambdaLiftLiftGlobal = MExprAst
     if null rest then bind else
     let rest = _bindLiftedH rest in
     switch bind
-    case TmLet t then TmLet {t with inexpr = rest}
-    case TmRecLets t then TmRecLets {t with inexpr = rest}
-    case TmConDef t then TmConDef {t with inexpr = rest}
-    case TmType t then TmType {t with inexpr = rest}
-    case TmExt t then TmExt {t with inexpr = rest}
+    case TmDecl {decl = DeclLet t} then TmDecl {decl = DeclLet {t with inexpr = rest}}
+    case TmDecl {decl = DeclRecLets t} then TmDecl {decl = DeclRecLets {t with inexpr = rest}}
+    case TmDecl {decl = DeclConDef t} then TmDecl {decl = DeclConDef {t with inexpr = rest}}
+    case TmDecl {decl = DeclType t} then TmDecl {decl = DeclType {t with inexpr = rest}}
+    case TmDecl {decl = DeclExt t} then TmDecl {decl = DeclExt {t with inexpr = rest}}
     case _ then rest
     end
 
   sem liftRecursiveBindingH (bindings : [DeclLetRecord]) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     match liftRecursiveBindingH bindings t.body with (bindings, body) in
     match t.body with TmLam _ then
       let bind : DeclLetRecord =
@@ -378,8 +377,8 @@ lang LambdaLiftLiftGlobal = MExprAst
       let bindings = snoc bindings bind in
       liftRecursiveBindingH bindings t.inexpr
     else match liftRecursiveBindingH bindings t.inexpr with (bindings, inexpr) in
-      (bindings, TmLet {{t with body = body} with inexpr = inexpr})
-  | TmRecLets t ->
+      (bindings, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
+  | TmDecl {decl = DeclRecLets t} ->
     let liftBinding : [DeclLetRecord] -> DeclLetRecord -> [DeclLetRecord] =
       lam bindings. lam bind.
       match liftRecursiveBindingH bindings bind.body with (bindings, body) in
@@ -390,50 +389,50 @@ lang LambdaLiftLiftGlobal = MExprAst
   | t -> smapAccumL_Expr_Expr liftRecursiveBindingH bindings t
 
   sem liftRecursiveBinding =
-  | TmRecLets t /- : Expr -> Expr -/ ->
+  | TmDecl {decl = DeclRecLets t} /- : Expr -> Expr -/ ->
     let liftBinding : [DeclLetRecord] -> DeclLetRecord -> [DeclLetRecord] =
       lam bindings. lam bind.
       match liftRecursiveBindingH bindings bind.body with (bindings, body) in
       snoc bindings {bind with body = body}
     in
     let bindings = foldl liftBinding [] t.bindings in
-    TmRecLets {{t with bindings = bindings} with inexpr = unit_}
+    TmDecl {decl = DeclRecLets {{t with bindings = bindings} with inexpr = unit_}}
 
   sem liftGlobalH (lifted : [Expr]) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     match liftGlobalH lifted t.body with (lifted, body) in
     match t.body with TmLam _ then
-      let lifted = snoc lifted (TmLet {{t with body = body}
-                                          with inexpr = unit_}) in
+      let lifted = snoc lifted (TmDecl {decl = DeclLet {{t with body = body}
+                                          with inexpr = unit_}}) in
       liftGlobalH lifted t.inexpr
     else match liftGlobalH lifted t.inexpr with (lifted, inexpr) in
-      (lifted, TmLet {{t with body = body} with inexpr = inexpr})
-  | TmRecLets t ->
-    let lifted = snoc lifted (liftRecursiveBinding (TmRecLets t)) in
+      (lifted, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
+  | TmDecl {decl = DeclRecLets t} ->
+    let lifted = snoc lifted (liftRecursiveBinding (TmDecl {decl = DeclRecLets t})) in
     liftGlobalH lifted t.inexpr
-  | TmType t ->
-    let lifted = snoc lifted (TmType {t with inexpr = unit_}) in
+  | TmDecl {decl = DeclType t} ->
+    let lifted = snoc lifted (TmDecl {decl = DeclType {t with inexpr = unit_}}) in
     liftGlobalH lifted t.inexpr
-  | TmConDef t ->
-    let lifted = snoc lifted (TmConDef {t with inexpr = unit_}) in
+  | TmDecl {decl = DeclConDef t} ->
+    let lifted = snoc lifted (TmDecl {decl = DeclConDef {t with inexpr = unit_}}) in
     liftGlobalH lifted t.inexpr
-  | TmExt t ->
-    let lifted = snoc lifted (TmExt {t with inexpr = unit_}) in
+  | TmDecl {decl = DeclExt t} ->
+    let lifted = snoc lifted (TmDecl {decl = DeclExt {t with inexpr = unit_}}) in
     liftGlobalH lifted t.inexpr
   | t -> smapAccumL_Expr_Expr liftGlobalH lifted t
 
   sem liftGlobal =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     match liftGlobalH [] t.body with (lifted, body) in
     _bindLifted
       lifted
-      (TmLet {{t with body = body} with inexpr = liftGlobal t.inexpr})
-  | TmRecLets t ->
-    let lifted = [liftRecursiveBinding (TmRecLets t)] in
+      (TmDecl {decl = DeclLet {{t with body = body} with inexpr = liftGlobal t.inexpr}})
+  | TmDecl {decl = DeclRecLets t} ->
+    let lifted = [liftRecursiveBinding (TmDecl {decl = DeclRecLets t})] in
     _bindLifted lifted (liftGlobal t.inexpr)
-  | TmType t -> TmType {t with inexpr = liftGlobal t.inexpr}
-  | TmConDef t -> TmConDef {t with inexpr = liftGlobal t.inexpr}
-  | TmUtest t ->
+  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = liftGlobal t.inexpr}}
+  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = liftGlobal t.inexpr}}
+  | TmDecl {decl = DeclUtest t} ->
     let optionLiftGlobalH = lam lifted. lam t.
       match t with Some t then
         match liftGlobalH lifted t with (lifted, t) in (lifted, Some t)
@@ -445,13 +444,13 @@ lang LambdaLiftLiftGlobal = MExprAst
     match optionLiftGlobalH lifted t.tonfail with (lifted, tonfail) in
     _bindLifted
       lifted
-      (TmUtest {t with
+      (TmDecl {decl = DeclUtest {t with
                 test = test,
                 expected = expected,
                 tusing = tusing,
                 tonfail = tonfail,
-                next = liftGlobal t.next})
-  | TmExt t -> TmExt {t with inexpr = liftGlobal t.inexpr}
+                next = liftGlobal t.next}})
+  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = liftGlobal t.inexpr}}
   | t ->
     match liftGlobalH [] t with (lifted, t) in
     _bindLifted lifted t
@@ -484,7 +483,7 @@ lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
 
   sem replaceCapturedParametersH : Map Name (Map Name Name) -> Expr -> Expr
   sem replaceCapturedParametersH subMap =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let t =
       match mapLookup t.ident subMap with Some subs then
         let body = substituteIdentifiers subs t.body in
@@ -495,8 +494,8 @@ lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
         , tyBody = substituteIdentifiersType subs t.tyBody
         }
       else t in
-    TmLet {t with inexpr = replaceCapturedParametersH subMap t.inexpr}
-  | TmRecLets t ->
+    TmDecl {decl = DeclLet {t with inexpr = replaceCapturedParametersH subMap t.inexpr}}
+  | TmDecl {decl = DeclRecLets t} ->
     let replaceCapturedParametersBinding = lam bind.
       match mapLookup bind.ident subMap with Some subs then
         { bind with body = substituteIdentifiers subs bind.body
@@ -506,8 +505,8 @@ lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
       else bind
     in
     let bindings = map replaceCapturedParametersBinding t.bindings in
-    TmRecLets {t with bindings = bindings,
-                      inexpr = replaceCapturedParametersH subMap t.inexpr}
+    TmDecl {decl = DeclRecLets {t with bindings = bindings,
+                      inexpr = replaceCapturedParametersH subMap t.inexpr}}
   | t -> smap_Expr_Expr (replaceCapturedParametersH subMap) t
 end
 
@@ -539,7 +538,7 @@ lang MExprLambdaLiftAllowSpineCapture =
 
   sem findFreeVariablesSpine : ({ty : Type, body : Expr} -> AllowCapture) -> LambdaLiftState -> Expr -> LambdaLiftState
   sem findFreeVariablesSpine shouldAllowCapture state =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let state =
       match t.body with TmLam _ then
         -- NOTE(vipa, 2023-10-09): A let-bound lambda, find a solution
@@ -564,7 +563,7 @@ lang MExprLambdaLiftAllowSpineCapture =
       foldl (lam acc. lam pair. {acc with tyVars = mapInsert pair.0 pair.1 acc.tyVars}) state tyvars in
     let state = findFreeVariables state t.body in
     findFreeVariablesSpine shouldAllowCapture state t.inexpr
-  | tm & TmRecLets t -> recursive
+  | tm & TmDecl {decl = DeclRecLets t} -> recursive
     let insertInitialSolution = lam state. lam binding.
       let sol = findFreeVariablesInBody state _solEmpty binding.body in
       {state with sols = mapInsert binding.ident sol state.sols} in
@@ -600,7 +599,7 @@ lang MExprLambdaLiftAllowSpineCapture =
     let state = propagateFunNames state (reverse sccs) in
     let state = foldl findFreeVariablesBinding state t.bindings in
     findFreeVariablesSpine shouldAllowCapture state t.inexpr
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     let state = {state with sols = mapInsert t.ident _solEmpty state.sols} in
     findFreeVariablesSpine shouldAllowCapture state t.inexpr
   | tm ->

--- a/src/stdlib/mexpr/lamlift.mc
+++ b/src/stdlib/mexpr/lamlift.mc
@@ -66,34 +66,33 @@ let emptyLambdaLiftState = {
 -- These are all lambda expressions that are not part of the right-hand side of
 -- a let-expression or a recursive binding.
 lang LambdaLiftNameAnonymous = MExprAst
-  sem nameAnonymousLambdasInBody =
-  | TmLam t -> TmLam {t with body = nameAnonymousLambdasInBody t.body}
-  | t -> nameAnonymousLambdas t
+  sem nameAnonymousLambdas : Expr -> Expr
+  sem nameAnonymousLambdas = | tm -> nameAnonymousLambdasWork false tm
 
-  sem nameAnonymousLambdas =
-  | TmLam t ->
-    recursive let recurseInLambdaBody = lam t : Expr.
-      match t with TmLam tt then
-        TmLam {tt with body = recurseInLambdaBody tt.body}
-      else nameAnonymousLambdas t
-    in
-    let lambdaName = nameSym "t" in
-    let letBody = TmLam {t with body = recurseInLambdaBody t.body} in
-    TmDecl {decl = DeclLet {ident = lambdaName, tyAnnot = t.ty, tyBody = t.ty, body = letBody,
-           inexpr = TmVar {ident = lambdaName, ty = t.ty, info = t.info, frozen = false},
-           ty = t.ty, info = t.info}}
-  | TmDecl {decl = DeclLet t} ->
-    TmDecl {decl = DeclLet {{t with body = nameAnonymousLambdasInBody t.body}
-              with inexpr = nameAnonymousLambdas t.inexpr}}
-  | TmDecl {decl = DeclRecLets t} ->
-    let bindings =
-      map
-        (lam bind : DeclLetRecord.
-          {bind with body = nameAnonymousLambdasInBody bind.body})
-        t.bindings in
-    TmDecl {decl = DeclRecLets {{t with bindings = bindings}
-                  with inexpr = nameAnonymousLambdas t.inexpr}}
-  | t -> smap_Expr_Expr nameAnonymousLambdas t
+  sem nameAnonymousLambdasDecl : Decl -> Decl
+  sem nameAnonymousLambdasDecl =
+  | d -> smap_Decl_Expr (nameAnonymousLambdasWork false) d
+  | DeclLet x ->
+    let body = nameAnonymousLambdasWork true x.body in
+    DeclLet {x with body = body}
+  | DeclRecLets x ->
+    let f = lam binding. {binding with body = nameAnonymousLambdasWork true binding.body} in
+    let bindings = map f x.bindings in
+    DeclRecLets {x with bindings = bindings}
+
+  sem nameAnonymousLambdasWork : Bool -> Expr -> Expr
+  sem nameAnonymousLambdasWork named =
+  | tm -> smap_Expr_Expr (nameAnonymousLambdasWork false) tm
+  | tm & TmLam t ->
+    let tm = smap_Expr_Expr (nameAnonymousLambdasWork true) tm in
+    if named then tm else
+    let lamName = nameSym "anon" in
+    let ty = tyTm tm in
+    bind_ (nlet_ lamName ty tm) (withType ty (nvar_ lamName))
+  | TmDecl x ->
+    let decl = nameAnonymousLambdasDecl x.decl in
+    let inexpr = nameAnonymousLambdasWork false x.inexpr in
+    TmDecl {x with decl = decl, inexpr = inexpr}
 end
 
 lang LambdaLiftFindFreeVariablesPat = MExprAst
@@ -185,14 +184,18 @@ lang UpdateDefinitionsAndUses = MExprAst
       -- value. We know from the transformation that it will be a
       -- value, and we could eta-expand if we want to get it fully
       -- correct, but I'm leaving it like this for the moment.
-      TmDecl {decl = DeclLet { ident = n
-      , tyAnnot = x.ty
-      , tyBody = x.ty
-      , body = tm
+      TmDecl
+      { decl = DeclLet
+        { ident = n
+        , tyAnnot = x.ty
+        , tyBody = x.ty
+        , body = tm
+        , info = x.info
+        }
       , inexpr = TmVar {ident = n, frozen = true, info = x.info, ty = x.ty}
       , info = x.info
       , ty = x.ty
-      }}
+      }
     else tm
 end
 
@@ -229,7 +232,7 @@ lang LambdaLiftFindFreeVariables =
   | TmLam t ->
     let state = {state with vars = mapInsert t.ident t.tyParam state.vars} in
     findFreeVariables state t.body
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let state =
       match t.body with TmLam _ then
         -- NOTE(vipa, 2023-10-09): A let-bound lambda, find a solution
@@ -244,8 +247,8 @@ lang LambdaLiftFindFreeVariables =
       let tyvars = concat (stripTyAll t.tyAnnot).0 (stripTyAll t.tyBody).0 in
       foldl (lam acc. lam pair. {acc with tyVars = mapInsert pair.0 pair.1 acc.tyVars}) state tyvars in
     let state = findFreeVariables state t.body in
-    findFreeVariables state t.inexpr
-  | tm & TmDecl {decl = DeclRecLets t} -> recursive
+    findFreeVariables state x.inexpr
+  | tm & TmDecl (x & {decl = DeclRecLets t}) -> recursive
     let insertInitialSolution = lam state. lam binding.
       let sol = findFreeVariablesInBody state _solEmpty binding.body in
       {state with sols = mapInsert binding.ident sol state.sols} in
@@ -280,15 +283,15 @@ lang LambdaLiftFindFreeVariables =
     let sccs = digraphTarjan g in
     let state = propagateFunNames state (reverse sccs) in
     let state = foldl findFreeVariablesBinding state t.bindings in
-    findFreeVariables state t.inexpr
+    findFreeVariables state x.inexpr
   | TmMatch t ->
     let state = findFreeVariables state t.target in
     let state = findFreeVariablesPat state t.pat in
     let state = findFreeVariables state t.thn in
     findFreeVariables state t.els
-  | TmDecl {decl = DeclExt t} ->
+  | TmDecl (x & {decl = DeclExt t}) ->
     let state = {state with sols = mapInsert t.ident _solEmpty state.sols} in
-    findFreeVariables state t.inexpr
+    findFreeVariables state x.inexpr
   | t -> sfold_Expr_Expr findFreeVariables state t
 end
 
@@ -308,7 +311,7 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
   sem insertFreeVariablesH solutions subMap =
   | tm & TmVar t ->
     optionMapOr tm (lam f. f t) (mapLookup t.ident subMap)
-  | TmDecl {decl = DeclLet (t & {body = TmLam _})} ->
+  | TmDecl (x & {decl = DeclLet (t & {body = TmLam _})}) ->
     match mapLookup t.ident solutions with Some sol then
       let sol = _orderSolution sol in
       let tyBody = updateType sol t.tyBody t.tyBody in
@@ -317,12 +320,11 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
       let body = updateLambdaBody sol body in
       let inexpr =
         let subMap = mapInsert t.ident (mkSolApplication sol tyBody) subMap in
-        insertFreeVariablesH solutions subMap t.inexpr in
-      TmDecl {decl = DeclLet {t with tyBody = tyBody, tyAnnot = tyAnnot, body = body,
-                    inexpr = inexpr}}
+        insertFreeVariablesH solutions subMap x.inexpr in
+      TmDecl {x with decl = DeclLet {t with tyBody = tyBody, tyAnnot = tyAnnot, body = body}, inexpr = inexpr}
     else errorSingle [t.info] (join ["Found no free variable solution for ",
                                      nameGetStr t.ident])
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let updateBindingShallow = lam solutions. lam subMap. lam binding.
       match mapLookup binding.ident solutions with Some sol then
         let sol = _orderSolution sol in
@@ -338,8 +340,8 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
       {binding with body = insertFreeVariablesH solutions subMap binding.body} in
     match mapAccumL (updateBindingShallow solutions) subMap t.bindings with (subMap, bindings) in
     let bindings = map (updateBindingNonShallow solutions subMap) bindings in
-    let inexpr = insertFreeVariablesH solutions subMap t.inexpr in
-    TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr}}
+    let inexpr = insertFreeVariablesH solutions subMap x.inexpr in
+    TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr}
   | t -> smap_Expr_Expr (insertFreeVariablesH solutions subMap) t
 
   sem insertFreeVariables (solutions : Map Name LambdaLiftSolution) =
@@ -347,113 +349,56 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
 end
 
 lang LambdaLiftLiftGlobal = MExprAst
-  sem _bindLifted : [Expr] -> Expr -> Expr
-  sem _bindLifted lifted =
-  | t ->
-    let binds = snoc lifted t in
-    _bindLiftedH binds
+  -- Lift all bound lambdas to the top-level. Also lift Decls they may
+  -- depend on (type, con, external). Note that this is run after
+  -- lambda lifting, i.e., no bound lambdas can depend on bound
+  -- non-lambda values.
 
-  sem _bindLiftedH : [Expr] -> Expr
-  sem _bindLiftedH =
-  | [bind] ++ rest ->
-    if null rest then bind else
-    let rest = _bindLiftedH rest in
-    switch bind
-    case TmDecl {decl = DeclLet t} then TmDecl {decl = DeclLet {t with inexpr = rest}}
-    case TmDecl {decl = DeclRecLets t} then TmDecl {decl = DeclRecLets {t with inexpr = rest}}
-    case TmDecl {decl = DeclConDef t} then TmDecl {decl = DeclConDef {t with inexpr = rest}}
-    case TmDecl {decl = DeclType t} then TmDecl {decl = DeclType {t with inexpr = rest}}
-    case TmDecl {decl = DeclExt t} then TmDecl {decl = DeclExt {t with inexpr = rest}}
-    case _ then rest
-    end
-
-  sem liftRecursiveBindingH (bindings : [DeclLetRecord]) =
-  | TmDecl {decl = DeclLet t} ->
-    match liftRecursiveBindingH bindings t.body with (bindings, body) in
-    match t.body with TmLam _ then
-      let bind : DeclLetRecord =
-        { ident = t.ident, tyAnnot = t.tyAnnot, tyBody = t.tyBody
-        , body = body, info = t.info } in
-      let bindings = snoc bindings bind in
-      liftRecursiveBindingH bindings t.inexpr
-    else match liftRecursiveBindingH bindings t.inexpr with (bindings, inexpr) in
-      (bindings, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
-  | TmDecl {decl = DeclRecLets t} ->
-    let liftBinding : [DeclLetRecord] -> DeclLetRecord -> [DeclLetRecord] =
-      lam bindings. lam bind.
-      match liftRecursiveBindingH bindings bind.body with (bindings, body) in
-      snoc bindings {bind with body = body}
-    in
-    let bindings = foldl liftBinding bindings t.bindings in
-    liftRecursiveBindingH bindings t.inexpr
-  | t -> smapAccumL_Expr_Expr liftRecursiveBindingH bindings t
-
-  sem liftRecursiveBinding =
-  | TmDecl {decl = DeclRecLets t} /- : Expr -> Expr -/ ->
-    let liftBinding : [DeclLetRecord] -> DeclLetRecord -> [DeclLetRecord] =
-      lam bindings. lam bind.
-      match liftRecursiveBindingH bindings bind.body with (bindings, body) in
-      snoc bindings {bind with body = body}
-    in
-    let bindings = foldl liftBinding [] t.bindings in
-    TmDecl {decl = DeclRecLets {{t with bindings = bindings} with inexpr = unit_}}
-
-  sem liftGlobalH (lifted : [Expr]) =
-  | TmDecl {decl = DeclLet t} ->
-    match liftGlobalH lifted t.body with (lifted, body) in
-    match t.body with TmLam _ then
-      let lifted = snoc lifted (TmDecl {decl = DeclLet {{t with body = body}
-                                          with inexpr = unit_}}) in
-      liftGlobalH lifted t.inexpr
-    else match liftGlobalH lifted t.inexpr with (lifted, inexpr) in
-      (lifted, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
-  | TmDecl {decl = DeclRecLets t} ->
-    let lifted = snoc lifted (liftRecursiveBinding (TmDecl {decl = DeclRecLets t})) in
-    liftGlobalH lifted t.inexpr
-  | TmDecl {decl = DeclType t} ->
-    let lifted = snoc lifted (TmDecl {decl = DeclType {t with inexpr = unit_}}) in
-    liftGlobalH lifted t.inexpr
-  | TmDecl {decl = DeclConDef t} ->
-    let lifted = snoc lifted (TmDecl {decl = DeclConDef {t with inexpr = unit_}}) in
-    liftGlobalH lifted t.inexpr
-  | TmDecl {decl = DeclExt t} ->
-    let lifted = snoc lifted (TmDecl {decl = DeclExt {t with inexpr = unit_}}) in
-    liftGlobalH lifted t.inexpr
-  | t -> smapAccumL_Expr_Expr liftGlobalH lifted t
-
+  sem liftGlobal : Expr -> Expr
   sem liftGlobal =
-  | TmDecl {decl = DeclLet t} ->
-    match liftGlobalH [] t.body with (lifted, body) in
-    _bindLifted
-      lifted
-      (TmDecl {decl = DeclLet {{t with body = body} with inexpr = liftGlobal t.inexpr}})
-  | TmDecl {decl = DeclRecLets t} ->
-    let lifted = [liftRecursiveBinding (TmDecl {decl = DeclRecLets t})] in
-    _bindLifted lifted (liftGlobal t.inexpr)
-  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = liftGlobal t.inexpr}}
-  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = liftGlobal t.inexpr}}
-  | TmDecl {decl = DeclUtest t} ->
-    let optionLiftGlobalH = lam lifted. lam t.
-      match t with Some t then
-        match liftGlobalH lifted t with (lifted, t) in (lifted, Some t)
-      else (lifted, t)
-    in
-    match liftGlobalH [] t.test with (lifted, test) in
-    match liftGlobalH lifted t.expected with (lifted, expected) in
-    match optionLiftGlobalH lifted t.tusing with (lifted, tusing) in
-    match optionLiftGlobalH lifted t.tonfail with (lifted, tonfail) in
-    _bindLifted
-      lifted
-      (TmDecl {decl = DeclUtest {t with
-                test = test,
-                expected = expected,
-                tusing = tusing,
-                tonfail = tonfail,
-                next = liftGlobal t.next}})
-  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = liftGlobal t.inexpr}}
+  | TmDecl x ->
+    match smapAccumL_Decl_Expr liftGlobalH [] x.decl with (lifted, decl) in
+    let inexpr = liftGlobal x.inexpr in
+    bindall_ lifted (TmDecl {x with decl = decl, inexpr = inexpr})
+  | TmDecl (x & {decl = DeclRecLets t}) ->
+    let lifted = collectBindingsToRecLet t.info t.bindings in
+    bindall_ lifted (liftGlobal x.inexpr)
   | t ->
     match liftGlobalH [] t with (lifted, t) in
-    _bindLifted lifted t
+    bindall_ lifted t
+
+  sem getLetBindings : Decl -> Either [DeclLetRecord] Decl
+  sem getLetBindings =
+  | DeclLet x -> Left [x]
+  | DeclRecLets x -> Left x.bindings
+  | d -> Right d
+
+  sem collectBindingsToRecLet : Info -> [DeclLetRecord] -> [Decl]
+  sem collectBindingsToRecLet info = | bindings ->
+    let f = lam acc. lam bind.
+      match liftGlobalH acc bind.body with (acc, body) in
+      (acc, {bind with body = body}) in
+    match mapAccumL f [] bindings with (decls, bindings) in
+    let decls = snoc decls (DeclRecLets {info = info, bindings = bindings}) in
+    let decls = map getLetBindings decls in
+    match eitherPartition decls with (bindings, decls) in
+    snoc decls (DeclRecLets {bindings = join bindings, info = info})
+
+  sem liftGlobalH : [Decl] -> Expr -> ([Decl], Expr)
+  sem liftGlobalH lifted =
+  | t -> smapAccumL_Expr_Expr liftGlobalH lifted t
+  | TmDecl (x & {decl = DeclType _ | DeclConDef _ | DeclExt _}) ->
+    liftGlobalH (snoc lifted x.decl) x.inexpr
+  | TmDecl (x & {decl = DeclLet t}) ->
+    match liftGlobalH lifted t.body with (lifted, body) in
+    match t.body with TmLam _ then
+      let lifted = snoc lifted (DeclLet {t with body = body}) in
+      liftGlobalH lifted x.inexpr
+    else match liftGlobalH lifted x.inexpr with (lifted, inexpr) in
+    (lifted, TmDecl {x with decl = DeclLet {t with body = body}, inexpr = inexpr})
+  | TmDecl (x & {decl = DeclRecLets t}) ->
+    let newLifted = collectBindingsToRecLet t.info t.bindings in
+    liftGlobalH (concat lifted newLifted) x.inexpr
 end
 
 lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
@@ -483,19 +428,16 @@ lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
 
   sem replaceCapturedParametersH : Map Name (Map Name Name) -> Expr -> Expr
   sem replaceCapturedParametersH subMap =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let t =
       match mapLookup t.ident subMap with Some subs then
-        let body = substituteIdentifiers subs t.body in
-        let tyAnnot = substituteIdentifiersType subs t.tyAnnot in
-        let tyBody = substituteIdentifiersType subs t.tyBody in
         { t with body = substituteIdentifiers subs t.body
         , tyAnnot = substituteIdentifiersType subs t.tyAnnot
         , tyBody = substituteIdentifiersType subs t.tyBody
         }
       else t in
-    TmDecl {decl = DeclLet {t with inexpr = replaceCapturedParametersH subMap t.inexpr}}
-  | TmDecl {decl = DeclRecLets t} ->
+    TmDecl {x with decl = DeclLet t, inexpr = replaceCapturedParametersH subMap x.inexpr}
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let replaceCapturedParametersBinding = lam bind.
       match mapLookup bind.ident subMap with Some subs then
         { bind with body = substituteIdentifiers subs bind.body
@@ -505,8 +447,10 @@ lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
       else bind
     in
     let bindings = map replaceCapturedParametersBinding t.bindings in
-    TmDecl {decl = DeclRecLets {t with bindings = bindings,
-                      inexpr = replaceCapturedParametersH subMap t.inexpr}}
+    TmDecl
+    {x with decl = DeclRecLets {t with bindings = bindings}
+    , inexpr = replaceCapturedParametersH subMap x.inexpr
+    }
   | t -> smap_Expr_Expr (replaceCapturedParametersH subMap) t
 end
 
@@ -530,7 +474,7 @@ lang MExprLambdaLift =
 end
 
 lang MExprLambdaLiftAllowSpineCapture =
-  MExprLambdaLift + MExprAsDecl
+  MExprLambdaLift
 
   syn AllowCapture =
   | AllowCapture
@@ -602,11 +546,10 @@ lang MExprLambdaLiftAllowSpineCapture =
   | TmDecl {decl = DeclExt t} ->
     let state = {state with sols = mapInsert t.ident _solEmpty state.sols} in
     findFreeVariablesSpine shouldAllowCapture state t.inexpr
-  | tm ->
-    match exprAsDecl tm with Some (decl, inexpr) then
-      let state = sfold_Decl_Expr findFreeVariables state decl in
-      findFreeVariablesSpine shouldAllowCapture state inexpr
-    else findFreeVariables state tm
+  | TmDecl x ->
+    let state = sfold_Decl_Expr findFreeVariables state x.decl in
+    findFreeVariablesSpine shouldAllowCapture state x.inexpr
+  | tm -> findFreeVariables state tm
 
   sem liftLambdasWithSolutionsMaybeAllowSpineCapture : ({ty : Type, body : Expr} -> AllowCapture) -> Expr -> (Map Name FinalOrderedLamLiftSolution, Expr)
   sem liftLambdasWithSolutionsMaybeAllowSpineCapture shouldAllowCapture = | t ->
@@ -634,23 +577,23 @@ let preprocess = lam t. typeCheck (symbolize t) in
 let noLambdas = bind_ (ulet_ "x" (int_ 2)) unit_ in
 utest liftLambdas noLambdas with noLambdas using eqExpr in
 
-let innerFunction = preprocess (bindall_ [
+let innerFunction = preprocess (bind_ (
   ulet_ "f" (ulam_ "x"
     (bind_
       (ulet_ "g" (ulam_ "y" (addi_ (var_ "y") (int_ 2))))
-      (muli_ (app_ (var_ "g") (var_ "x")) (int_ 2)))),
-  app_ (var_ "f") (int_ 1)]) in
+      (muli_ (app_ (var_ "g") (var_ "x")) (int_ 2)))))
+  (app_ (var_ "f") (int_ 1))) in
 let expected = preprocess (bindall_ [
   ulet_ "g" (ulam_ "y" (addi_ (var_ "y") (int_ 2))),
-  ulet_ "f" (ulam_ "x" (muli_ (app_ (var_ "g") (var_ "x")) (int_ 2))),
-  app_ (var_ "f") (int_ 1)]) in
+  ulet_ "f" (ulam_ "x" (muli_ (app_ (var_ "g") (var_ "x")) (int_ 2)))]
+  (app_ (var_ "f") (int_ 1))) in
 utest liftLambdas innerFunction with expected using eqExpr in
 
-let factorial = preprocess (ureclets_ [
+let factorial = preprocess (bind_ (ureclets_ [
   ("fact", ulam_ "n" (
     if_ (eqi_ (var_ "n") (int_ 0))
       (int_ 1)
-      (muli_ (var_ "n") (app_ (var_ "fact") (subi_ (var_ "n") (int_ 1))))))]) in
+      (muli_ (var_ "n") (app_ (var_ "fact") (subi_ (var_ "n") (int_ 1))))))]) unit_) in
 utest liftLambdas factorial with factorial using eqExpr in
 
 let factorialWithHelper = preprocess (bindall_ [
@@ -661,9 +604,9 @@ let factorialWithHelper = preprocess (bindall_ [
           (var_ "acc")
           (appf2_ (var_ "work")
             (muli_ (var_ "acc") (var_ "n"))
-            (subi_ (var_ "n") (int_ 1))))))],
-    appf2_ (var_ "work") (int_ 1) (var_ "n")])),
-  app_ (var_ "fact") (int_ 4)]) in
+            (subi_ (var_ "n") (int_ 1))))))]]
+    (appf2_ (var_ "work") (int_ 1) (var_ "n"))))]
+  (app_ (var_ "fact") (int_ 4))) in
 let expected = preprocess (bindall_ [
   ureclets_ [
     ("work", ulam_ "acc" (ulam_ "n" (
@@ -672,145 +615,145 @@ let expected = preprocess (bindall_ [
         (appf2_ (var_ "work")
           (muli_ (var_ "acc") (var_ "n"))
           (subi_ (var_ "n") (int_ 1))))))],
-  ulet_ "fact" (ulam_ "n" (appf2_ (var_ "work") (int_ 1) (var_ "n"))),
-  app_ (var_ "fact") (int_ 4)]) in
+  ulet_ "fact" (ulam_ "n" (appf2_ (var_ "work") (int_ 1) (var_ "n")))]
+  (app_ (var_ "fact") (int_ 4))) in
 utest liftLambdas factorialWithHelper with expected using eqExpr in
 
 let liftFreeVars = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (bindall_ [
-    ulet_ "g" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))),
-    app_ (var_ "g") (int_ 2)])),
-  app_ (var_ "f") (int_ 3)]) in
+    ulet_ "g" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))]
+    (app_ (var_ "g") (int_ 2))))]
+  (app_ (var_ "f") (int_ 3))) in
 let expected = preprocess (bindall_ [
   ulet_ "g" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))),
-  ulet_ "f" (ulam_ "x" (appf2_ (var_ "g") (var_ "x") (int_ 2))),
-  app_ (var_ "f") (int_ 3)]) in
+  ulet_ "f" (ulam_ "x" (appf2_ (var_ "g") (var_ "x") (int_ 2)))]
+  (app_ (var_ "f") (int_ 3))) in
 utest liftLambdas liftFreeVars with expected using eqExpr in
 
-let deepNesting = preprocess (bindall_ [
-  ulet_ "f" (ulam_ "x" (bindall_ [
-    ulet_ "g" (ulam_ "y" (bindall_ [
+let deepNesting = preprocess (bind_ (
+  ulet_ "f" (ulam_ "x" (bind_ (
+    ulet_ "g" (ulam_ "y" (bind_ (
       ulet_ "h" (ulam_ "z" (
-        addi_ (var_ "y") (var_ "z"))),
-      app_ (var_ "h") (int_ 2)])),
-    app_ (var_ "g") (var_ "x")])),
-  app_ (var_ "f") (int_ 1)]) in
+        addi_ (var_ "y") (var_ "z"))))
+      (app_ (var_ "h") (int_ 2)))))
+    (app_ (var_ "g") (var_ "x")))))
+  (app_ (var_ "f") (int_ 1))) in
 let expected = preprocess (bindall_ [
   ulet_ "h" (ulam_ "y" (ulam_ "z" (addi_ (var_ "y") (var_ "z")))),
   ulet_ "g" (ulam_ "y" (appf2_ (var_ "h") (var_ "y") (int_ 2))),
-  ulet_ "f" (ulam_ "x" (app_ (var_ "g") (var_ "x"))),
-  app_ (var_ "f") (int_ 1)]) in
+  ulet_ "f" (ulam_ "x" (app_ (var_ "g") (var_ "x")))]
+  (app_ (var_ "f") (int_ 1))) in
 utest liftLambdas deepNesting with expected using eqExpr in
 
 let multipleInnerLets = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (bindall_ [
     ulet_ "g" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))),
-    ulet_ "h" (ulam_ "z" (addi_ (var_ "z") (var_ "x"))),
-    addi_ (app_ (var_ "g") (int_ 1)) (app_ (var_ "h") (int_ 2))])),
-  app_ (var_ "f") (int_ 1)]) in
+    ulet_ "h" (ulam_ "z" (addi_ (var_ "z") (var_ "x")))]
+    (addi_ (app_ (var_ "g") (int_ 1)) (app_ (var_ "h") (int_ 2)))))]
+  (app_ (var_ "f") (int_ 1))) in
 let expected = preprocess (bindall_ [
   ulet_ "g" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))),
   ulet_ "h" (ulam_ "x" (ulam_ "z" (addi_ (var_ "z") (var_ "x")))),
   ulet_ "f" (ulam_ "x" (
     addi_ (appf2_ (var_ "g") (var_ "x") (int_ 1))
-          (appf2_ (var_ "h") (var_ "x") (int_ 2)))),
-  app_ (var_ "f") (int_ 1)]) in
+          (appf2_ (var_ "h") (var_ "x") (int_ 2))))]
+  (app_ (var_ "f") (int_ 1))) in
 utest liftLambdas multipleInnerLets with expected using eqExpr in
 
 let letInReclet = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (bindall_ [
     ureclets_ [
       ("g", ulam_ "y" (bindall_ [
-        ulet_ "h" (ulam_ "z" (addi_ (var_ "z") (int_ 1))),
-        addi_ (app_ (var_ "h") (var_ "y")) (var_ "x")
-      ]))],
-    app_ (var_ "g") (int_ 1)
-  ])),
-  app_ (var_ "f") (int_ 4)]) in
+        ulet_ "h" (ulam_ "z" (addi_ (var_ "z") (int_ 1)))]
+        (addi_ (app_ (var_ "h") (var_ "y")) (var_ "x")
+      )))]]
+    (app_ (var_ "g") (int_ 1))
+  ))]
+  (app_ (var_ "f") (int_ 4))) in
 let expected = preprocess (bindall_ [
   ureclets_ [
     ("h", ulam_ "z" (addi_ (var_ "z") (int_ 1))),
     ("g", ulam_ "x" (ulam_ "y" (
       addi_ (app_ (var_ "h") (var_ "y")) (var_ "x"))))],
-  ulet_ "f" (ulam_ "x" (appf2_ (var_ "g") (var_ "x") (int_ 1))),
-  app_ (var_ "f") (int_ 4)]) in
+  ulet_ "f" (ulam_ "x" (appf2_ (var_ "g") (var_ "x") (int_ 1)))]
+  (app_ (var_ "f") (int_ 4))) in
 utest liftLambdas letInReclet with expected using eqExpr in
 
-let deepNestedRecursiveDefs = preprocess (ureclets_ [
+let deepNestedRecursiveDefs = preprocess (bind_ (ureclets_ [
   ("f1", ulam_ "x" (bindall_ [
     ulet_ "f2" (bindall_ [
       ureclets_ [("f3", ulam_ "x1" (addi_ (var_ "x1") (int_ 1)))],
       ureclets_ [
         ("f4", ulam_ "y" (bindall_ [
-          ulet_ "k" (ulam_ "x2" (app_ (var_ "f5") (var_ "x2"))),
-          addi_ (app_ (var_ "k") (var_ "x")) (var_ "y")])),
+          ulet_ "k" (ulam_ "x2" (app_ (var_ "f5") (var_ "x2")))]
+          (addi_ (app_ (var_ "k") (var_ "x")) (var_ "y")))),
         ("f5", ulam_ "x3" (app_ (var_ "f4") (subi_ (var_ "x3") (int_ 1))))
-      ],
-      addi_ (app_ (var_ "f3") (var_ "x"))
-            (app_ (var_ "f4") (int_ 2))]),
-    var_ "f2"]))]) in
-let expected = preprocess (ureclets_ [
+      ]]
+      (addi_ (app_ (var_ "f3") (var_ "x"))
+            (app_ (var_ "f4") (int_ 2))))]
+    (var_ "f2")))]) unit_) in
+let expected = preprocess (bind_ (ureclets_ [
   ("f3", ulam_ "x1" (addi_ (var_ "x1") (int_ 1))),
   ("k", ulam_ "x" (ulam_ "x2" (appf2_ (var_ "f5") (var_ "x") (var_ "x2")))),
   ("f4", ulam_ "x" (ulam_ "y" (addi_ (appf2_ (var_ "k") (var_ "x") (var_ "x")) (var_ "y")))),
   ("f5", ulam_ "x" (ulam_ "x3" (appf2_ (var_ "f4") (var_ "x") (subi_ (var_ "x3") (int_ 1))))),
   ("f1", ulam_ "x" (bindall_ [
     ulet_ "f2" (addi_ (app_ (var_ "f3") (var_ "x"))
-                      (appf2_ (var_ "f4") (var_ "x") (int_ 2))),
-    var_ "f2"]))]) in
+                      (appf2_ (var_ "f4") (var_ "x") (int_ 2)))]
+    (var_ "f2")))]) unit_) in
 utest liftLambdas deepNestedRecursiveDefs with expected using eqExpr in
 
 let fdef = ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))) in
 let fapp = bind_ fdef (app_ (var_ "f") (int_ 1)) in
 
 let liftUtest = preprocess (
-  utest_
+  bind_ (utest_
     (int_ 0)
-    fapp
+    fapp)
     unit_) in
 let expected = preprocess (
   bind_
     fdef
-    (utest_
+    (bind_ (utest_
       (int_ 0)
-      (app_ (var_ "f") (int_ 1))
+      (app_ (var_ "f") (int_ 1)))
       unit_)) in
 utest liftLambdas liftUtest with expected using eqExpr in
 
-let liftApp = preprocess (bindall_ [
+let liftApp = preprocess (
   app_
     (bind_
       (ulet_ "g" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))))
       (app_ (var_ "g") (int_ 2)))
-    fapp]) in
+    fapp) in
 let expected = preprocess (bindall_ [
   ulet_ "g" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))),
-  fdef,
-  app_
+  fdef]
+  (app_
     (app_ (var_ "g") (int_ 2))
-    (app_ (var_ "f") (int_ 1))]) in
+    (app_ (var_ "f") (int_ 1)))) in
 utest liftLambdas liftApp with expected using eqExpr in
 
 let liftSeq = preprocess (seq_ [fapp]) in
-let expected = preprocess (bindall_ [fdef, seq_ [app_ (var_ "f") (int_ 1)]]) in
+let expected = preprocess (bind_ fdef (seq_ [app_ (var_ "f") (int_ 1)])) in
 utest liftLambdas liftSeq with expected using eqExpr in
 
 let liftRecord = preprocess (urecord_ [("a", fapp), ("b", int_ 2)]) in
 let expected = preprocess (bindall_ [
-  fdef,
-  urecord_ [
+  fdef]
+  (urecord_ [
     ("a", app_ (var_ "f") (int_ 1)),
-    ("b", int_ 2)]]) in
+    ("b", int_ 2)])) in
 utest liftLambdas liftRecord with expected using eqExpr in
 
 let liftRecordUpdate = preprocess (bindall_ [
-  ulet_ "r" (urecord_ [("a", float_ 2.5), ("b", int_ 0)]),
-  recordupdate_ (var_ "r") "b" fapp
-  ]) in
+  ulet_ "r" (urecord_ [("a", float_ 2.5), ("b", int_ 0)])]
+  (recordupdate_ (var_ "r") "b" fapp
+  )) in
 let expected = preprocess (bindall_ [
   ulet_ "r" (urecord_ [("a", float_ 2.5), ("b", int_ 0)]),
-  fdef,
-  recordupdate_ (var_ "r") "b" (app_ (var_ "f") (int_ 1))]) in
+  fdef]
+  (recordupdate_ (var_ "r") "b" (app_ (var_ "f") (int_ 1)))) in
 utest liftLambdas liftRecordUpdate with expected using eqExpr in
 
 let liftMatchTarget = preprocess (
@@ -818,10 +761,10 @@ let liftMatchTarget = preprocess (
     (int_ 1)
     (int_ 2)) in
 let expected = preprocess (bindall_ [
-  fdef,
-  match_ (app_ (var_ "f") (int_ 1)) (pint_ 0)
+  fdef]
+  (match_ (app_ (var_ "f") (int_ 1)) (pint_ 0)
     (int_ 1)
-    (int_ 2)]) in
+    (int_ 2))) in
 utest liftLambdas liftMatchTarget with expected using eqExpr in
 
 let liftMatchThn = preprocess (
@@ -829,10 +772,10 @@ let liftMatchThn = preprocess (
     fapp
     (int_ 0)) in
 let expected = preprocess (bindall_ [
-  fdef,
-  match_ (int_ 3) (pint_ 3)
+  fdef]
+  (match_ (int_ 3) (pint_ 3)
     (app_ (var_ "f") (int_ 1))
-    (int_ 0)]) in
+    (int_ 0))) in
 utest liftLambdas liftMatchThn with expected using eqExpr in
 
 let liftMatchEls = preprocess (
@@ -840,25 +783,25 @@ let liftMatchEls = preprocess (
     (int_ 0)
     fapp) in
 let expected = preprocess (bindall_ [
-  fdef,
-  match_ (int_ 3) (pint_ 3)
+  fdef]
+  (match_ (int_ 3) (pint_ 3)
     (int_ 0)
-    (app_ (var_ "f") (int_ 1))]) in
+    (app_ (var_ "f") (int_ 1)))) in
 utest liftLambdas liftMatchEls with expected using eqExpr in
 
 let conAppLift = preprocess (bindall_ [
   type_ "Tree" [] (tyvariant_ []),
   condef_ "Leaf" (tyarrow_ tyint_ (tycon_ "Tree")),
-  ulet_ "x" (conapp_ "Leaf" fapp),
+  ulet_ "x" (conapp_ "Leaf" fapp)]
   unit_
-]) in
+) in
 let expected = preprocess (bindall_ [
   type_ "Tree" [] (tyvariant_ []),
   condef_ "Leaf" (tyarrow_ tyint_ (tycon_ "Tree")),
   fdef,
-  ulet_ "x" (conapp_ "Leaf" (app_ (var_ "f") (int_ 1))),
+  ulet_ "x" (conapp_ "Leaf" (app_ (var_ "f") (int_ 1)))]
   unit_
-]) in
+) in
 
 -- NOTE(larshum, 2022-09-15): Compare using eqString as equality of TmType has
 -- not been implemented.
@@ -866,19 +809,19 @@ utest expr2str (liftLambdas conAppLift) with expr2str expected using eqString in
 
 let anonymousFunctionLift = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (
-    app_ (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) (int_ 4))),
-  app_ (var_ "f") (int_ 2)]) in
+    app_ (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) (int_ 4)))]
+  (app_ (var_ "f") (int_ 2))) in
 let expected = preprocess (bindall_ [
   ulet_ "t" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))),
-  ulet_ "f" (ulam_ "x" (appf2_ (var_ "t") (var_ "x") (int_ 4))),
-  app_ (var_ "f") (int_ 2)]) in
+  ulet_ "f" (ulam_ "x" (appf2_ (var_ "t") (var_ "x") (int_ 4)))]
+  (app_ (var_ "f") (int_ 2))) in
 utest liftLambdas anonymousFunctionLift with expected using eqExpr in
 
 let anonymousMapLift = preprocess (
   map_ (ulam_ "x" (addi_ (var_ "x") (int_ 1))) (seq_ [int_ 0, int_ 7])) in
 let expected = preprocess (bindall_ [
-  ulet_ "t" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  map_ (var_ "t") (seq_ [int_ 0, int_ 7])]) in
+  ulet_ "t" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))]
+  (map_ (var_ "t") (seq_ [int_ 0, int_ 7]))) in
 utest liftLambdas anonymousMapLift with expected using eqExpr in
 
 let recursiveSystem = preprocess (bindall_ [
@@ -888,8 +831,8 @@ let recursiveSystem = preprocess (bindall_ [
   ureclets_ [
     ("f", ulam_ "x" (addi_ (app_ (var_ "g") (var_ "x")) (var_ "a"))),
     ("g", ulam_ "y" (addi_ (app_ (var_ "h") (var_ "y")) (var_ "b"))),
-    ("h", ulam_ "z" (addi_ (app_ (var_ "f") (var_ "z")) (var_ "c")))],
-  unit_]) in
+    ("h", ulam_ "z" (addi_ (app_ (var_ "f") (var_ "z")) (var_ "c")))]]
+  unit_) in
 let expected = preprocess (bindall_ [
   ulet_ "a" (int_ 1),
   ulet_ "b" (int_ 2),
@@ -903,73 +846,75 @@ let expected = preprocess (bindall_ [
             (var_ "b"))),
     ("h", ulams_ ["a", "b", "c", "z"] (
       addi_ (appSeq_ (var_ "f") [var_ "a", var_ "b", var_ "c", var_ "z"])
-            (var_ "c")))],
-  unit_]) in
+            (var_ "c")))]]
+  unit_) in
 utest liftLambdas recursiveSystem with expected using eqExpr in
 
-let boundInMatchPat = preprocess (bindall_ [
+let boundInMatchPat = preprocess (bind_ (
   ulet_ "f" (ulam_ "x" (
     match_ (var_ "x") (pvar_ "y")
       (bind_
         (ulet_ "g" (ulam_ "z" (addi_ (var_ "y") (var_ "z"))))
         (app_ (var_ "g") (var_ "x")))
-      (int_ 0)))]) in
+      (int_ 0)))) unit_) in
 let expected = preprocess (bindall_ [
   ulet_ "g" (ulam_ "y" (ulam_ "z" (addi_ (var_ "y") (var_ "z")))),
   ulet_ "f" (ulam_ "x" (
     match_ (var_ "x") (pvar_ "y")
       (appf2_ (var_ "g") (var_ "y") (var_ "x"))
-      (int_ 0)))]) in
+      (int_ 0)))] unit_) in
 utest liftLambdas boundInMatchPat with expected using eqExpr in
 
 let nestedFreeVar = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (bindall_ [
     ulet_ "g" (ulam_ "y" (bindall_ [
-      ulet_ "h" (ulam_ "z" (addi_ (var_ "x") (var_ "z"))),
-      app_ (var_ "h") (var_ "y")])),
-    app_ (var_ "g") (var_ "x")]))]) in
+      ulet_ "h" (ulam_ "z" (addi_ (var_ "x") (var_ "z")))]
+      (app_ (var_ "h") (var_ "y"))))]
+    (app_ (var_ "g") (var_ "x"))))]
+  unit_) in
 let expected = preprocess (bindall_ [
   ulet_ "h" (ulam_ "x" (ulam_ "z" (addi_ (var_ "x") (var_ "z")))),
   ulet_ "g" (ulam_ "x" (ulam_ "y" (appf2_ (var_ "h") (var_ "x") (var_ "y")))),
-  ulet_ "f" (ulam_ "x" (appf2_ (var_ "g") (var_ "x") (var_ "x")))]) in
+  ulet_ "f" (ulam_ "x" (appf2_ (var_ "g") (var_ "x") (var_ "x")))]
+  unit_) in
 utest liftLambdas nestedFreeVar with expected using eqExpr in
 
 let letMultiParam = preprocess (bindall_ [
   ulet_ "a" (int_ 2),
   ulet_ "b" (int_ 6),
   ulet_ "f" (ulam_ "x" (
-    addi_ (addi_ (var_ "a") (var_ "b")) (var_ "x"))),
-  app_ (var_ "f") (int_ 7)]) in
+    addi_ (addi_ (var_ "a") (var_ "b")) (var_ "x")))]
+  (app_ (var_ "f") (int_ 7))) in
 let expected = preprocess (bindall_ [
   ulet_ "a" (int_ 2),
   ulet_ "b" (int_ 6),
   ulet_ "f" (ulam_ "a" (ulam_ "b" (ulam_ "x" (
-    addi_ (addi_ (var_ "a") (var_ "b")) (var_ "x"))))),
-  appf3_ (var_ "f") (var_ "a") (var_ "b") (int_ 7)]) in
+    addi_ (addi_ (var_ "a") (var_ "b")) (var_ "x")))))]
+  (appf3_ (var_ "f") (var_ "a") (var_ "b") (int_ 7))) in
 utest liftLambdas letMultiParam with expected using eqExpr in
 
 let nestedMap = preprocess (bindall_ [
-  ulet_ "s" (seq_ [seq_ [int_ 1, int_ 2, int_ 3]]),
-  map_
+  ulet_ "s" (seq_ [seq_ [int_ 1, int_ 2, int_ 3]])]
+  (map_
     (ulam_ "s" (map_ (ulam_ "x" (addi_ (var_ "x") (int_ 1))) (var_ "s")))
-    (var_ "s")]) in
+    (var_ "s"))) in
 let expected = preprocess (bindall_ [
   ulet_ "s" (seq_ [seq_ [int_ 1, int_ 2, int_ 3]]),
   ulet_ "t1" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  ulet_ "t2" (ulam_ "s" (map_ (var_ "t1") (var_ "s"))),
-  map_ (var_ "t2") (var_ "s")]) in
+  ulet_ "t2" (ulam_ "s" (map_ (var_ "t1") (var_ "s")))]
+  (map_ (var_ "t2") (var_ "s"))) in
 utest liftLambdas nestedMap with expected using eqExpr in
 
 let nestedAnonymousLambdas = preprocess (bindall_ [
   ulet_ "s" (seq_ [int_ 1, int_ 2, int_ 3]),
-  ulet_ "x" (int_ 0),
-  map_
+  ulet_ "x" (int_ 0)]
+  (map_
     (ulam_ "y" (bindall_ [
       ulet_ "s" (map_ (ulam_ "x" (addi_ (var_ "x") (var_ "y"))) (var_ "s")),
       ulet_ "s" (map_ (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) (var_ "s")),
-      ulet_ "s" (map_ (ulam_ "z" (addi_ (var_ "z") (int_ 1))) (var_ "s")),
-      var_ "s"]))
-    (var_ "s")]) in
+      ulet_ "s" (map_ (ulam_ "z" (addi_ (var_ "z") (int_ 1))) (var_ "s"))]
+      (var_ "s")))
+    (var_ "s"))) in
 let expected = preprocess (bindall_ [
   ulet_ "s" (seq_ [int_ 1, int_ 2, int_ 3]),
   ulet_ "x" (int_ 0),
@@ -979,23 +924,23 @@ let expected = preprocess (bindall_ [
   ulet_ "t4" (ulam_ "s" (ulam_ "x" (ulam_ "y" (bindall_ [
     ulet_ "s" (map_ (app_ (var_ "t1") (var_ "y")) (var_ "s")),
     ulet_ "s" (map_ (app_ (var_ "t2") (var_ "x")) (var_ "s")),
-    ulet_ "s" (map_ (var_ "t3") (var_ "s")),
-    var_ "s"])))),
-  map_ (appf2_ (var_ "t4") (var_ "s") (var_ "x")) (var_ "s")]) in
+    ulet_ "s" (map_ (var_ "t3") (var_ "s"))]
+    (var_ "s")))))]
+  (map_ (appf2_ (var_ "t4") (var_ "s") (var_ "x")) (var_ "s"))) in
 utest liftLambdas nestedAnonymousLambdas with expected using eqExpr in
 
 let nestedMultiArgLambda = preprocess (bindall_ [
-  ulet_ "s" (seq_ [seq_ [int_ 1, int_ 2, int_ 3]]),
-  map_
+  ulet_ "s" (seq_ [seq_ [int_ 1, int_ 2, int_ 3]])]
+  (map_
     (ulam_ "y"
       (foldl_ (ulam_ "acc" (ulam_ "e" (addi_ (var_ "acc") (var_ "e"))))
               (int_ 0) (var_ "y")))
-    (var_ "s")]) in
+    (var_ "s"))) in
 let expected = preprocess (bindall_ [
   ulet_ "s" (seq_ [seq_ [int_ 1, int_ 2, int_ 3]]),
   ulet_ "t1" (ulam_ "acc" (ulam_ "e" (addi_ (var_ "acc") (var_ "e")))),
-  ulet_ "t2" (ulam_ "y" (foldl_ (var_ "t1") (int_ 0) (var_ "y"))),
-  map_ (var_ "t2") (var_ "s")]) in
+  ulet_ "t2" (ulam_ "y" (foldl_ (var_ "t1") (int_ 0) (var_ "y")))]
+  (map_ (var_ "t2") (var_ "s"))) in
 utest liftLambdas nestedMultiArgLambda with expected using eqExpr in
 
 let nestedReclets = preprocess (bindall_ [
@@ -1007,37 +952,37 @@ let nestedReclets = preprocess (bindall_ [
             if_ (eqi_ (var_ "y") (var_ "z"))
                 (appf1_ (var_ "inner_foo") (addi_ (var_ "z") (int_ 1)))
                 (bindall_ [
-                  ureclet_ "deep_foo" (ulam_ "i" (bindall_ [
+                  ureclet_ "deep_foo" (ulam_ "i" (
                     if_ (eqi_ (var_ "i") (var_ "z"))
                         (unit_)
                         (bindall_ [
-                          ulet_ "" (get_ (var_ "mylist") (var_ "i")),
-                          appf1_ (var_ "deep_foo")
+                          ulet_ "" (get_ (var_ "mylist") (var_ "i"))]
+                          (appf1_ (var_ "deep_foo")
                                  (addi_ (var_ "i")
                                         (int_ 1))
-                        ])
-                  ])),
-                  appf1_ (var_ "deep_foo") (int_ 0)
-                ])
-          )),
-          appf1_ (var_ "inner_foo") (int_ 10)
-        ])
-  )))),
-  appf3_ (var_ "foo") (int_ 11) (int_ 12) (seq_ [int_ 1, int_ 2, int_ 3])
-  ]) in
+                        ))
+                  ))]
+                  (appf1_ (var_ "deep_foo") (int_ 0)
+                ))
+          ))]
+          (appf1_ (var_ "inner_foo") (int_ 10)
+        ))
+  ))))]
+  (appf3_ (var_ "foo") (int_ 11) (int_ 12) (seq_ [int_ 1, int_ 2, int_ 3])
+  )) in
 let expected = preprocess (bindall_ [
   ureclets_ [
     ("deep_foo", (ulam_ "mylist" (ulam_ "z" (ulam_ "i" (
       if_ (eqi_ (var_ "i") (var_ "z"))
           unit_
           (bindall_ [
-            ulet_ "" (get_ (var_ "mylist") (var_ "i")),
-            appf3_ (var_ "deep_foo")
+            ulet_ "" (get_ (var_ "mylist") (var_ "i"))]
+            (appf3_ (var_ "deep_foo")
                    (var_ "mylist")
                    (var_ "z")
                    (addi_ (var_ "i")
                           (int_ 1))
-          ])
+          ))
     ))))),
     ("inner_foo", (ulam_ "y" (ulam_ "mylist" (ulam_ "z" (
               if_ (eqi_ (var_ "y") (var_ "z"))
@@ -1055,22 +1000,23 @@ let expected = preprocess (bindall_ [
     if_ (eqi_ (var_ "x") (int_ 10))
         (unit_)
         (appf3_ (var_ "inner_foo") (var_ "y") (var_ "mylist") (int_ 10))
-  )))),
-  appf3_ (var_ "foo") (int_ 11) (int_ 12) (seq_ [int_ 1, int_ 2, int_ 3])
-  ]) in
+  ))))]
+  (appf3_ (var_ "foo") (int_ 11) (int_ 12) (seq_ [int_ 1, int_ 2, int_ 3])
+  )) in
 utest liftLambdas nestedReclets with expected using eqExpr in
 
 
 let types = preprocess
-  (ulet_ "f" (ulam_ "s"
+  (bind_ (ulet_ "f" (ulam_ "s"
     (bind_
       (ulet_ "g" (ulam_ "x" (snoc_ (var_ "s") (var_ "x"))))
-      (foldl_ (uconst_ (CConcat ())) (seq_ []) (map_ (var_ "g") (var_ "s")))))) in
+      (foldl_ (uconst_ (CConcat ())) (seq_ []) (map_ (var_ "g") (var_ "s")))))) unit_) in
 let expected = preprocess
   (bindall_ [
     ulet_ "g" (ulam_ "s" (ulam_ "x" (snoc_ (var_ "s") (var_ "x")))),
     ulet_ "f" (ulam_ "s"
-      (foldl_ (uconst_ (CConcat ())) (seq_ []) (map_ (app_ (var_ "g") (var_ "s")) (var_ "s"))))]) in
+      (foldl_ (uconst_ (CConcat ())) (seq_ []) (map_ (app_ (var_ "g") (var_ "s")) (var_ "s"))))]
+   unit_) in
 
 -- NOTE(larshum, 2022-09-15): Test that the expressions are equal and that the
 -- let-bodies are given equivalent types.
@@ -1078,8 +1024,8 @@ utest liftLambdas types with expected using eqExpr in
 
 let nestedUtest = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (
-    utest_ (var_ "x") (int_ 0) (
-    addi_ (var_ "x") (int_ 1))))
-]) in
+    bind_ (utest_ (var_ "x") (int_ 0))
+    (addi_ (var_ "x") (int_ 1))))
+] unit_) in
 utest liftLambdas nestedUtest with nestedUtest using eqExpr in
 ()

--- a/src/stdlib/mexpr/lamlift.mc
+++ b/src/stdlib/mexpr/lamlift.mc
@@ -482,7 +482,7 @@ lang MExprLambdaLiftAllowSpineCapture =
 
   sem findFreeVariablesSpine : ({ty : Type, body : Expr} -> AllowCapture) -> LambdaLiftState -> Expr -> LambdaLiftState
   sem findFreeVariablesSpine shouldAllowCapture state =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let state =
       match t.body with TmLam _ then
         -- NOTE(vipa, 2023-10-09): A let-bound lambda, find a solution
@@ -506,8 +506,8 @@ lang MExprLambdaLiftAllowSpineCapture =
       let tyvars = concat (stripTyAll t.tyAnnot).0 (stripTyAll t.tyBody).0 in
       foldl (lam acc. lam pair. {acc with tyVars = mapInsert pair.0 pair.1 acc.tyVars}) state tyvars in
     let state = findFreeVariables state t.body in
-    findFreeVariablesSpine shouldAllowCapture state t.inexpr
-  | tm & TmDecl {decl = DeclRecLets t} -> recursive
+    findFreeVariablesSpine shouldAllowCapture state x.inexpr
+  | tm & TmDecl (x & {decl = DeclRecLets t}) -> recursive
     let insertInitialSolution = lam state. lam binding.
       let sol = findFreeVariablesInBody state _solEmpty binding.body in
       {state with sols = mapInsert binding.ident sol state.sols} in
@@ -542,10 +542,10 @@ lang MExprLambdaLiftAllowSpineCapture =
     let sccs = digraphTarjan g in
     let state = propagateFunNames state (reverse sccs) in
     let state = foldl findFreeVariablesBinding state t.bindings in
-    findFreeVariablesSpine shouldAllowCapture state t.inexpr
-  | TmDecl {decl = DeclExt t} ->
+    findFreeVariablesSpine shouldAllowCapture state x.inexpr
+  | TmDecl (x & {decl = DeclExt t}) ->
     let state = {state with sols = mapInsert t.ident _solEmpty state.sols} in
-    findFreeVariablesSpine shouldAllowCapture state t.inexpr
+    findFreeVariablesSpine shouldAllowCapture state x.inexpr
   | TmDecl x ->
     let state = sfold_Decl_Expr findFreeVariables state x.decl in
     findFreeVariablesSpine shouldAllowCapture state x.inexpr

--- a/src/stdlib/mexpr/load-runtime.mc
+++ b/src/stdlib/mexpr/load-runtime.mc
@@ -16,24 +16,8 @@ lang MExprLoadRuntime = BootParser + MExprSym + MExprTypeCheck
 
   sem mergeWithHeader : Expr -> Expr -> Expr
   sem mergeWithHeader ast =
-  | TmDecl {decl = DeclLet t} ->
-    TmDecl {decl = DeclLet {t with inexpr = mergeWithHeader ast t.inexpr,
-                  ty = tyTm ast}}
-  | TmDecl {decl = DeclRecLets t} ->
-    TmDecl {decl = DeclRecLets {t with inexpr = mergeWithHeader ast t.inexpr,
-                      ty = tyTm ast}}
-  | TmDecl {decl = DeclType t} ->
-    TmDecl {decl = DeclType {t with inexpr = mergeWithHeader ast t.inexpr,
-                   ty = tyTm ast}}
-  | TmDecl {decl = DeclConDef t} ->
-    TmDecl {decl = DeclConDef {t with inexpr = mergeWithHeader ast t.inexpr,
-                     ty = tyTm ast}}
-  | TmDecl {decl = DeclUtest t} ->
-    TmDecl {decl = DeclUtest {t with next = mergeWithHeader ast t.next, ty = tyTm ast}}
-  | TmDecl {decl = DeclExt t} ->
-    TmDecl {decl = DeclExt {t with inexpr = mergeWithHeader ast t.inexpr,
-                  ty = tyTm ast}}
+  | TmDecl x ->
+    TmDecl {x with inexpr = mergeWithHeader ast x.inexpr, ty = tyTm ast}
   | _ -> ast
 
 end
-

--- a/src/stdlib/mexpr/load-runtime.mc
+++ b/src/stdlib/mexpr/load-runtime.mc
@@ -16,23 +16,23 @@ lang MExprLoadRuntime = BootParser + MExprSym + MExprTypeCheck
 
   sem mergeWithHeader : Expr -> Expr -> Expr
   sem mergeWithHeader ast =
-  | TmLet t ->
-    TmLet {t with inexpr = mergeWithHeader ast t.inexpr,
-                  ty = tyTm ast}
-  | TmRecLets t ->
-    TmRecLets {t with inexpr = mergeWithHeader ast t.inexpr,
-                      ty = tyTm ast}
-  | TmType t ->
-    TmType {t with inexpr = mergeWithHeader ast t.inexpr,
-                   ty = tyTm ast}
-  | TmConDef t ->
-    TmConDef {t with inexpr = mergeWithHeader ast t.inexpr,
-                     ty = tyTm ast}
-  | TmUtest t ->
-    TmUtest {t with next = mergeWithHeader ast t.next, ty = tyTm ast}
-  | TmExt t ->
-    TmExt {t with inexpr = mergeWithHeader ast t.inexpr,
-                  ty = tyTm ast}
+  | TmDecl {decl = DeclLet t} ->
+    TmDecl {decl = DeclLet {t with inexpr = mergeWithHeader ast t.inexpr,
+                  ty = tyTm ast}}
+  | TmDecl {decl = DeclRecLets t} ->
+    TmDecl {decl = DeclRecLets {t with inexpr = mergeWithHeader ast t.inexpr,
+                      ty = tyTm ast}}
+  | TmDecl {decl = DeclType t} ->
+    TmDecl {decl = DeclType {t with inexpr = mergeWithHeader ast t.inexpr,
+                   ty = tyTm ast}}
+  | TmDecl {decl = DeclConDef t} ->
+    TmDecl {decl = DeclConDef {t with inexpr = mergeWithHeader ast t.inexpr,
+                     ty = tyTm ast}}
+  | TmDecl {decl = DeclUtest t} ->
+    TmDecl {decl = DeclUtest {t with next = mergeWithHeader ast t.next, ty = tyTm ast}}
+  | TmDecl {decl = DeclExt t} ->
+    TmDecl {decl = DeclExt {t with inexpr = mergeWithHeader ast t.inexpr,
+                  ty = tyTm ast}}
   | _ -> ast
 
 end

--- a/src/stdlib/mexpr/monomorphize.mc
+++ b/src/stdlib/mexpr/monomorphize.mc
@@ -349,15 +349,15 @@ lang MonomorphizeCollect =
 
   sem recordPolymorphicDefinitions : MonoEnv -> Expr -> MonoEnv
   sem recordPolymorphicDefinitions env =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let env =
       match t.tyBody with TyAll _ then
         {env with funEnv = mapInsert t.ident (defaultInstEntry t.tyBody) env.funEnv}
       else env
     in
     let env = recordPolymorphicDefinitions env t.body in
-    recordPolymorphicDefinitions env t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+    recordPolymorphicDefinitions env x.inexpr
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let recordBind = lam env. lam bind.
       let env =
         match bind.tyBody with TyAll _ then
@@ -367,8 +367,8 @@ lang MonomorphizeCollect =
       recordPolymorphicDefinitions env bind.body
     in
     let env = foldl recordBind env t.bindings in
-    recordPolymorphicDefinitions env t.inexpr
-  | TmDecl {decl = DeclType t} ->
+    recordPolymorphicDefinitions env x.inexpr
+  | TmDecl (x & {decl = DeclType t}) ->
     let env =
       if not (null t.params) then
         -- NOTE(larshum, 2023-08-03): We construct a polymorphic type
@@ -385,14 +385,14 @@ lang MonomorphizeCollect =
         {env with typeEnv = mapInsert t.ident (defaultInstEntry polyType) env.typeEnv}
       else env
     in
-    recordPolymorphicDefinitions env t.inexpr
-  | TmDecl {decl = DeclConDef t} ->
+    recordPolymorphicDefinitions env x.inexpr
+  | TmDecl (x & {decl = DeclConDef t}) ->
     let env =
       match t.tyIdent with TyAll _ then
         {env with conEnv = mapInsert t.ident (defaultInstEntry t.tyIdent) env.conEnv}
       else env
     in
-    recordPolymorphicDefinitions env t.inexpr
+    recordPolymorphicDefinitions env x.inexpr
   | ast -> sfold_Expr_Expr recordPolymorphicDefinitions env ast
 
   sem collectInstantiationsExpr : Set Instantiation -> MonoEnv -> Expr -> MonoEnv
@@ -421,11 +421,11 @@ lang MonomorphizeCollect =
       {env with funEnv = mapInsert t.ident instEntry env.funEnv}
     else
       env
-  | TmDecl {decl = DeclLet t} ->
-    let env = collectInstantiationsExpr instantiations env t.inexpr in
+  | TmDecl (x & {decl = DeclLet t}) ->
+    let env = collectInstantiationsExpr instantiations env x.inexpr in
     let env = collectInstantiationsType instantiations env t.tyAnnot in
     let env = collectInstantiationsType instantiations env t.tyBody in
-    let env = collectInstantiationsType instantiations env t.ty in
+    let env = collectInstantiationsType instantiations env x.ty in
     let instantiations =
       match mapLookup t.ident env.funEnv with Some instEntry then
         -- NOTE(larshum, 2023-08-03): For the body of the let-expression, we
@@ -446,7 +446,7 @@ lang MonomorphizeCollect =
         instantiations
     in
     collectInstantiationsExpr instantiations env t.body
-  | TmDecl {decl = DeclRecLets t} ->
+  | tm & TmDecl (x & {decl = DeclRecLets t}) ->
     let bindMap : Map Name DeclLetRecord =
       mapFromSeq nameCmp (map (lam bind. (bind.ident, bind)) t.bindings)
     in
@@ -489,13 +489,13 @@ lang MonomorphizeCollect =
       else
         env
     in
-    let env = collectInstantiationsExpr instantiations env t.inexpr in
-    let g = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
+    let env = collectInstantiationsExpr instantiations env x.inexpr in
+    let g = constructCallGraph tm in
     let sccs = digraphTarjan g in
     collectInstantiationsPerScc instantiations env g (reverse sccs)
-  | TmDecl {decl = DeclConDef t} ->
-    let env = collectInstantiationsExpr instantiations env t.inexpr in
-    let env = collectInstantiationsType instantiations env t.ty in
+  | TmDecl (x & {decl = DeclConDef t}) ->
+    let env = collectInstantiationsExpr instantiations env x.inexpr in
+    let env = collectInstantiationsType instantiations env x.ty in
     match mapLookup t.ident env.conEnv with Some conInstEntry then
       -- NOTE(larshum, 2023-08-03): We propagate the monomorphic instantiations
       -- of the constructor to its variant type.
@@ -639,8 +639,8 @@ lang MonomorphizeApply = MonomorphizeInstantiate + MonomorphizeResymbolize + App
     in
     TmVar {t with ident = ident,
                   ty = applyMonomorphizationTypeLabel env t.ty}
-  | TmDecl {decl = DeclLet t} ->
-    let inexpr = applyMonomorphizationExpr env t.inexpr in
+  | TmDecl (x & {decl = DeclLet t}) ->
+    let inexpr = applyMonomorphizationExpr env x.inexpr in
     match mapLookup t.ident env.funEnv with Some instEntry then
       -- NOTE(larshum, 2023-08-03): The let-binding is a polymorphic function.
       -- We create once instance for each instantiation stored the entry.
@@ -649,20 +649,31 @@ lang MonomorphizeApply = MonomorphizeInstantiate + MonomorphizeResymbolize + App
           let body = monomorphizeBody env inst t.body in
           let tyAnnot = monomorphizeType env inst t.tyAnnot in
           let tyBody = monomorphizeTypeLabel env inst t.tyBody in
-          let ty = monomorphizeTypeLabel env inst t.ty in
-          TmDecl {decl = DeclLet {
-            ident = newId, tyAnnot = tyAnnot, tyBody = tyBody,
-            body = body, inexpr = acc, ty = tyTm acc, info = t.info}})
+          let ty = monomorphizeTypeLabel env inst x.ty in
+          TmDecl
+          {x with decl = DeclLet
+            {t with ident = newId
+            , tyAnnot = tyAnnot
+            , tyBody = tyBody
+            , body = body
+            }
+          , inexpr = acc
+          , ty = tyTm acc
+          })
         inexpr instEntry.map
     else
       -- NOTE(larshum, 2023-08-03): The let-binding is already monomorphic, so
       -- we recurse directly into its body.
-      TmDecl {decl = DeclLet {t with tyAnnot = applyMonomorphizationType env t.tyAnnot,
-                    tyBody = applyMonomorphizationType env t.tyBody,
-                    body = applyMonomorphization env t.body,
-                    inexpr = inexpr,
-                    ty = applyMonomorphizationType env t.ty}}
-  | TmDecl {decl = DeclRecLets t} ->
+      TmDecl
+      {x with decl = DeclLet
+        {t with tyAnnot = applyMonomorphizationType env t.tyAnnot
+        , tyBody = applyMonomorphizationType env t.tyBody
+        , body = applyMonomorphization env t.body
+        }
+      , inexpr = inexpr
+      , ty = applyMonomorphizationType env x.ty
+      }
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let applyMonomorphizationBinding = lam env. lam acc. lam bind.
       match mapLookup bind.ident env.funEnv with Some instEntry then
         mapFoldWithKey
@@ -681,39 +692,54 @@ lang MonomorphizeApply = MonomorphizeInstantiate + MonomorphizeResymbolize + App
       else
         snoc acc bind
     in
-    let inexpr = applyMonomorphizationExpr env t.inexpr in
+    let inexpr = applyMonomorphizationExpr env x.inexpr in
     let bindings = foldl (applyMonomorphizationBinding env) [] t.bindings in
-    TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr}}
-  | TmDecl {decl = DeclType t} ->
-    let inexpr = applyMonomorphizationExpr env t.inexpr in
+    TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr}
+  | TmDecl (x & {decl = DeclType t}) ->
+    let inexpr = applyMonomorphizationExpr env x.inexpr in
     match mapLookup t.ident env.typeEnv with Some instEntry then
       mapFoldWithKey
         (lam acc. lam inst. lam newId.
           let tyIdent = monomorphizeType env inst t.tyIdent in
-          let ty = monomorphizeType env inst t.ty in
-          TmDecl {decl = DeclType {
-            ident = newId, params = [], tyIdent = tyIdent,
-            inexpr = acc, ty = ty, info = t.info }})
+          let ty = monomorphizeType env inst x.ty in
+          TmDecl
+          {x with decl = DeclType
+            {t with ident = newId
+            , params = []
+            , tyIdent = tyIdent
+            }
+          , inexpr = acc
+          , ty = ty
+          })
         inexpr instEntry.map
     else
-        TmDecl {decl = DeclType {t with tyIdent = applyMonomorphizationType env t.tyIdent,
-                       inexpr = inexpr,
-                       ty = applyMonomorphizationTypeLabel env t.ty}}
-  | TmDecl {decl = DeclConDef t} ->
-    let inexpr = applyMonomorphizationExpr env t.inexpr in
+      TmDecl
+      {x with decl = DeclType {t with tyIdent = applyMonomorphizationType env t.tyIdent}
+      , inexpr = inexpr
+      , ty = applyMonomorphizationTypeLabel env x.ty
+      }
+  | TmDecl (x & {decl = DeclConDef t}) ->
+    let inexpr = applyMonomorphizationExpr env x.inexpr in
     match mapLookup t.ident env.conEnv with Some instEntry then
       mapFoldWithKey
         (lam acc. lam inst. lam newId.
           let tyIdent = monomorphizeType env inst t.tyIdent in
-          let ty = monomorphizeType env inst t.ty in
-          TmDecl {decl = DeclConDef {
-            ident = newId, tyIdent = tyIdent, inexpr = acc,
-            ty = ty, info = t.info }})
+          let ty = monomorphizeType env inst x.ty in
+          TmDecl
+          {x with decl = DeclConDef
+            {t with ident = newId
+            , tyIdent = tyIdent
+            }
+          , inexpr = acc
+          , ty = ty
+          })
         inexpr instEntry.map
     else
-      TmDecl {decl = DeclConDef {t with tyIdent = applyMonomorphizationType env t.tyIdent,
-                       inexpr = inexpr,
-                       ty = applyMonomorphizationTypeLabel env t.ty}}
+      TmDecl
+      {x with decl = DeclConDef {t with tyIdent = applyMonomorphizationType env t.tyIdent}
+      , inexpr = inexpr
+      , ty = applyMonomorphizationTypeLabel env x.ty
+      }
   | TmConApp t ->
     let ident =
       match mapLookup t.ident env.conEnv with Some instEntry then
@@ -835,10 +861,13 @@ lang MExprMonomorphizeTest =
     if forAll (lam bind. distinctSymbolsExpr syms bind.body) t.bindings
     then Some syms
     else None ()
-  | DeclType t -> if setMem t.ident syms then Some (setInsert t.ident syms) else None ()
-  | DeclConDef t -> if setMem t.ident syms then Some (setInsert t.ident syms) else None ()
-  | DeclExt t -> if setMem t.ident syms then Some (setInsert t.ident syms) else None ()
-  | d -> Some syms
+  | DeclType t -> if setMem t.ident syms then None () else Some (setInsert t.ident syms)
+  | DeclConDef t -> if setMem t.ident syms then None () else Some (setInsert t.ident syms)
+  | DeclExt t -> if setMem t.ident syms then None () else Some (setInsert t.ident syms)
+  | d ->
+    if sfold_Decl_Expr (lam acc. lam tm. if acc then distinctSymbolsExpr syms tm else false) true d
+    then Some syms
+    else None ()
 
   sem distinctSymbolsExpr : Set Name -> Expr -> Bool
   sem distinctSymbolsExpr syms =
@@ -862,9 +891,9 @@ in
 
 -- Monomorphic function example
 let monoFun = preprocess (bindall_ [
-  ulet_ "addOne" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  utuple_ [app_ (var_ "addOne") (int_ 1), app_ (var_ "addOne") (int_ 2)]
-]) in
+  ulet_ "addOne" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))]
+  (utuple_ [app_ (var_ "addOne") (int_ 1), app_ (var_ "addOne") (int_ 2)]
+)) in
 utest isMonomorphic monoFun with true in
 let result = monomorphize monoFun in
 utest isMonomorphic result with true in
@@ -873,9 +902,9 @@ utest monoFun with result using eqExpr in
 -- Polymorphic identity function
 let id = nameSym "id" in
 let polyIdentity = preprocess (bindall_ [
-  nulet_ id (ulam_ "x" (var_ "x")),
-  utuple_ [app_ (nvar_ id) (int_ 2), app_ (nvar_ id) (float_ 2.5)]
-]) in
+  nulet_ id (ulam_ "x" (var_ "x"))]
+  (utuple_ [app_ (nvar_ id) (int_ 2), app_ (nvar_ id) (float_ 2.5)]
+)) in
 let env = collectInstantiations polyIdentity in
 utest mapSize env.funEnv with 1 in
 utest mapMem id env.funEnv with true in
@@ -884,16 +913,16 @@ utest isMonomorphic result with true in
 utest distinctSymbols result with true in
 let expected = preprocess (bindall_ [
   ulet_ "id_float" (ulam_ "x" (var_ "x")),
-  ulet_ "id_int" (ulam_ "x" (var_ "x")),
-  utuple_ [app_ (var_ "id_int") (int_ 2), app_ (var_ "id_float") (float_ 2.5)]
-]) in
+  ulet_ "id_int" (ulam_ "x" (var_ "x"))]
+  (utuple_ [app_ (var_ "id_int") (int_ 2), app_ (var_ "id_float") (float_ 2.5)]
+)) in
 utest result with expected using eqExpr in
 
 -- Unused function variable
 let unused = preprocess (bindall_ [
-  ulet_ "f" (ulam_ "x" (int_ 0)),
-  create_ (int_ 2) (var_ "f")
-]) in
+  ulet_ "f" (ulam_ "x" (int_ 0))]
+  (create_ (int_ 2) (var_ "f")
+)) in
 let env = collectInstantiations unused in
 utest mapSize env.funEnv with 1 in
 let result = applyMonomorphization env unused in
@@ -906,9 +935,9 @@ let f = nameSym "f" in
 let g = nameSym "g" in
 let seqPoly = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (var_ "x")),
-  nulet_ g (ulam_ "x" (app_ (nvar_ f) (var_ "x"))),
-  utuple_ [app_ (nvar_ g) (int_ 2), app_ (nvar_ f) (float_ 2.5)]
-]) in
+  nulet_ g (ulam_ "x" (app_ (nvar_ f) (var_ "x")))]
+  (utuple_ [app_ (nvar_ g) (int_ 2), app_ (nvar_ f) (float_ 2.5)]
+)) in
 let env = collectInstantiations seqPoly in
 utest mapSize env.funEnv with 2 in
 utest mapMem f env.funEnv with true in
@@ -919,9 +948,9 @@ utest distinctSymbols result with true in
 let expected = preprocess (bindall_ [
   ulet_ "f_float" (ulam_ "x" (var_ "x")),
   ulet_ "f_int" (ulam_ "x" (var_ "x")),
-  ulet_ "g_int" (ulam_ "x" (app_ (var_ "f_int") (var_ "x"))),
-  utuple_ [app_ (var_ "g_int") (int_ 2), app_ (var_ "f_float") (float_ 2.5)]
-]) in
+  ulet_ "g_int" (ulam_ "x" (app_ (var_ "f_int") (var_ "x")))]
+  (utuple_ [app_ (var_ "g_int") (int_ 2), app_ (var_ "f_float") (float_ 2.5)]
+)) in
 utest result with expected using eqExpr in
 
 -- Nested polymorphism where the inner function is polymorphic with the same
@@ -929,16 +958,16 @@ utest result with expected using eqExpr in
 let h = nameSym "h" in
 let nestedOuterPoly = preprocess (bindall_ [
   nulet_ f (ulam_ "g" (ulam_ "s" (bindall_ [
-    nulet_ h (ulam_ "x" (app_ (var_ "g") (var_ "x"))),
-    map_ (nvar_ h) (var_ "s")
-  ]))),
+    nulet_ h (ulam_ "x" (app_ (var_ "g") (var_ "x")))]
+    (map_ (nvar_ h) (var_ "s")
+  )))),
   ulet_ "addOne" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  ulet_ "addHalf" (ulam_ "x" (addf_ (var_ "x") (float_ 0.5))),
-  utuple_ [
+  ulet_ "addHalf" (ulam_ "x" (addf_ (var_ "x") (float_ 0.5)))]
+  (utuple_ [
     appf2_ (nvar_ f) (var_ "addOne") (seq_ [int_ 2]),
     appf2_ (nvar_ f) (var_ "addHalf") (seq_ [float_ 2.5])
   ]
-]) in
+)) in
 let env = collectInstantiations nestedOuterPoly in
 utest mapSize env.funEnv with 1 in
 utest mapMem f env.funEnv with true in
@@ -949,33 +978,33 @@ let expected = preprocess (bindall_ [
   let_ "f_float"
     (tyarrows_ [tyarrow_ tyfloat_ tyfloat_, tyseq_ tyfloat_, tyseq_ tyfloat_])
     (ulam_ "g" (ulam_ "s" (bindall_ [
-      ulet_ "h" (ulam_ "x" (app_ (var_ "g") (var_ "x"))),
-      map_ (var_ "h") (var_ "s")
-  ]))),
+      ulet_ "h" (ulam_ "x" (app_ (var_ "g") (var_ "x")))]
+      (map_ (var_ "h") (var_ "s")
+  )))),
   let_ "f_int"
     (tyarrows_ [tyarrow_ tyint_ tyint_, tyseq_ tyint_, tyseq_ tyint_])
     (ulam_ "g" (ulam_ "s" (bindall_ [
-      ulet_ "h" (ulam_ "x" (app_ (var_ "g") (var_ "x"))),
-      map_ (var_ "h") (var_ "s")
-  ]))),
+      ulet_ "h" (ulam_ "x" (app_ (var_ "g") (var_ "x")))]
+      (map_ (var_ "h") (var_ "s")
+  )))),
   ulet_ "addOne" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  ulet_ "addHalf" (ulam_ "x" (addf_ (var_ "x") (float_ 0.5))),
-  utuple_ [
+  ulet_ "addHalf" (ulam_ "x" (addf_ (var_ "x") (float_ 0.5)))]
+  (utuple_ [
     appf2_ (var_ "f_int") (var_ "addOne") (seq_ [int_ 2]),
     appf2_ (var_ "f_float") (var_ "addHalf") (seq_ [float_ 2.5])
   ]
-]) in
+)) in
 utest result with expected using eqExpr in
 
 -- Polymorphism in both functions, but it is only used in the inner one (i.e.,
 -- only the inner one should be specialized).
 let innerPoly = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (ulam_ "y" (bindall_ [
-    nulet_ g (ulam_ "z" (var_ "z")),
-    utuple_ [app_ (nvar_ g) (var_ "x"), app_ (nvar_ g) (var_ "y")]
-  ]))),
-  appf2_ (var_ "f") (int_ 2) (float_ 2.5)
-]) in
+    nulet_ g (ulam_ "z" (var_ "z"))]
+    (utuple_ [app_ (nvar_ g) (var_ "x"), app_ (nvar_ g) (var_ "y")]
+  ))))]
+  (appf2_ (var_ "f") (int_ 2) (float_ 2.5)
+)) in
 let env = collectInstantiations innerPoly in
 utest mapSize env.funEnv with 2 in
 utest mapMem g env.funEnv with true in
@@ -985,11 +1014,11 @@ utest distinctSymbols result with true in
 let expected = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (ulam_ "y" (bindall_ [
     ulet_ "g_float" (ulam_ "z" (var_ "z")),
-    ulet_ "g_int" (ulam_ "z" (var_ "z")),
-    utuple_ [app_ (var_ "g_int") (var_ "x"), app_ (var_ "g_float") (var_ "y")]
-  ]))),
-  appf2_ (var_ "f") (int_ 2) (float_ 2.5)
-]) in
+    ulet_ "g_int" (ulam_ "z" (var_ "z"))]
+    (utuple_ [app_ (var_ "g_int") (var_ "x"), app_ (var_ "g_float") (var_ "y")]
+  ))))]
+  (appf2_ (var_ "f") (int_ 2) (float_ 2.5)
+)) in
 utest result with expected using eqExpr in
 
 -- Nested polymorphism where the inner and outer functions are polymorphic over
@@ -998,14 +1027,14 @@ utest result with expected using eqExpr in
 -- function.
 let nestedPoly = preprocess (bindall_ [
   nulet_ f (ulam_ "x" (ulam_ "y" (bindall_ [
-    nulet_ g (ulam_ "z" (var_ "z")),
-    utuple_ [app_ (nvar_ g) (var_ "x"), app_ (nvar_ g) (var_ "y")]
-  ]))),
-  utuple_ [
+    nulet_ g (ulam_ "z" (var_ "z"))]
+    (utuple_ [app_ (nvar_ g) (var_ "x"), app_ (nvar_ g) (var_ "y")]
+  ))))]
+  (utuple_ [
     appf2_ (nvar_ f) (int_ 2) (float_ 2.5),
     appf2_ (nvar_ f) (float_ 2.5) (int_ 2)
   ]
-]) in
+)) in
 let env = collectInstantiations nestedPoly in
 utest mapSize env.funEnv with 2 in
 utest mapMem f env.funEnv with true in
@@ -1025,12 +1054,12 @@ let recursion = preprocess (bindall_ [
         (seq_ [])
         (cons_
           (app_ (var_ "g") (head_ (var_ "s")))
-          (appf2_ (var_ "f") (var_ "g") (tail_ (var_ "s"))))))) ],
-  utuple_ [
+          (appf2_ (var_ "f") (var_ "g") (tail_ (var_ "s"))))))) ]]
+  (utuple_ [
     appf2_ (var_ "f") (ulam_ "x" (addi_ (var_ "x") (int_ 1))) (seq_ [int_ 1, int_ 2]),
     appf2_ (var_ "f") (ulam_ "x" (negf_ (var_ "x"))) (seq_ [float_ 1.0, float_ 2.0])
   ]
-]) in
+)) in
 let env = collectInstantiations recursion in
 utest mapSize env.funEnv with 1 in
 let result = applyMonomorphization env recursion in
@@ -1055,11 +1084,11 @@ let mutrec = preprocess (bindall_ [
           (appf2_ (var_ "maphd") (var_ "f") (var_ "t"))
           (app_ (var_ "f") (var_ "h")))
         (seq_ []))))
-  ],
-  appf2_ (var_ "maphd")
+  ]]
+  (appf2_ (var_ "maphd")
     (ulam_ "x" (addi_ (var_ "x") (int_ 1)))
     (seq_ [int_ 1, int_ 2, int_ 3])
-]) in
+)) in
 let env = collectInstantiations mutrec in
 utest mapSize env.funEnv with 2 in
 let result = applyMonomorphization env mutrec in
@@ -1092,8 +1121,8 @@ let mutrec3 = preprocess (bindall_ [
           (appf2_ (var_ "f2") (var_ "f") (var_ "t"))
           (app_ (var_ "f") (var_ "h")))
         (seq_ []))))
-  ],
-  utuple_ [
+  ]]
+  (utuple_ [
     appf2_ (var_ "f2")
       (ulam_ "x" (addi_ (var_ "x") (int_ 1)))
       (seq_ [int_ 1, int_ 2, int_ 3, int_ 4]),
@@ -1101,7 +1130,7 @@ let mutrec3 = preprocess (bindall_ [
       (ulam_ "x" (addf_ (var_ "x") (float_ 1.5)))
       (seq_ [float_ 2., float_ 3., float_ 4., float_ 5.])
   ]
-]) in
+)) in
 let env = collectInstantiations mutrec3 in
 utest mapSize env.funEnv with 3 in
 let result = applyMonomorphization env mutrec3 in
@@ -1118,13 +1147,13 @@ let polyOption = preprocess (bindall_ [
   condef_ "None" (tyall_ "a" (tyarrow_ tyunit_ (tyapp_ (tycon_ "Option") (tyvar_ "a")))),
   ulet_ "isSome" (ulam_ "o" (
     match_ (var_ "o") (pcon_ "Some" pvarw_) true_ false_
-  )),
-  seq_ [
+  ))]
+  (seq_ [
     app_ (var_ "isSome") (conapp_ "Some" (int_ 2)),
     app_ (var_ "isSome") (conapp_ "Some" (float_ 2.5)),
     app_ (var_ "isSome") (conapp_ "None" uunit_)
   ]
-]) in
+)) in
 let env = collectInstantiations polyOption in
 utest mapSize env.funEnv with 1 in
 utest mapSize env.conEnv with 2 in
@@ -1147,9 +1176,9 @@ let polyAlias = preprocess (bindall_ [
       (tyarrow_ (tyapps_ (tycon_ "Pair") [tyvar_ "a", tyvar_ "b"]) (tyvar_ "b"))))
     (ulam_ "p" (tupleproj_ 1 (var_ "p"))),
   ulet_ "x" (utuple_ [int_ 2, float_ 2.5]),
-  ulet_ "y" (utuple_ [float_ 2.5, int_ 2]),
-  seq_ [app_ (var_ "fst") (var_ "x"), app_ (var_ "snd") (var_ "y")]
-]) in
+  ulet_ "y" (utuple_ [float_ 2.5, int_ 2])]
+  (seq_ [app_ (var_ "fst") (var_ "x"), app_ (var_ "snd") (var_ "y")]
+)) in
 let env = collectInstantiations polyAlias in
 utest mapSize env.typeEnv with 1 in
 let result = applyMonomorphization env polyAlias in
@@ -1159,9 +1188,7 @@ utest eval {env = evalEnvEmpty ()} (typeCheck result)
 with seq_ [int_ 2, int_ 2] using eqExpr in
 
 -- Polymorphic anonymous function
-let polyAnon = preprocess (bindall_ [
-  ulam_ "x" (var_ "x")
-]) in
+let polyAnon = preprocess (ulam_ "x" (var_ "x")) in
 let result = monomorphize polyAnon in
 utest isMonomorphic result with true in
 utest distinctSymbols result with true in

--- a/src/stdlib/mexpr/monomorphize.mc
+++ b/src/stdlib/mexpr/monomorphize.mc
@@ -215,6 +215,48 @@ lang MonomorphizeResymbolize = Monomorphize
   sem resymbolizeBindings =
   | ast -> resymbolizeBindingsExpr (mapEmpty nameCmp) ast
 
+  sem resymbolizeBindingsDecl : Map Name Name -> Decl -> (Map Name Name, Decl)
+  sem resymbolizeBindingsDecl nameMap =
+  | d -> (nameMap, smap_Decl_Expr (resymbolizeBindingsExpr nameMap) d)
+  | DeclLet t ->
+    let body = resymbolizeBindingsExpr nameMap t.body in
+    let newId = nameSetNewSym t.ident in
+    let nameMap = mapInsert t.ident newId nameMap in
+    ( nameMap
+    , DeclLet
+      { t with ident = newId
+      , tyAnnot = resymbolizeBindingsType nameMap t.tyAnnot
+      , tyBody = resymbolizeBindingsType nameMap t.tyBody
+      , body = body
+      }
+    )
+  | DeclRecLets t ->
+    let addNewIdBinding = lam nameMap. lam bind.
+      let newId = nameSetNewSym bind.ident in
+      (mapInsert bind.ident newId nameMap, {bind with ident = newId})
+    in
+    match mapAccumL addNewIdBinding nameMap t.bindings with (nameMap, bindings) in
+    let resymbolizeBind = lam bind.
+      {bind with tyAnnot = resymbolizeBindingsType nameMap bind.tyAnnot,
+                 tyBody = resymbolizeBindingsType nameMap bind.tyBody,
+                 body = resymbolizeBindingsExpr nameMap bind.body}
+    in
+    let bindings = map resymbolizeBind bindings in
+    (nameMap, DeclRecLets {t with bindings = bindings})
+  | DeclType t ->
+    let newId = nameSetNewSym t.ident in
+    let nameMap = mapInsert t.ident newId nameMap in
+    ( nameMap
+    , DeclType
+      { t with ident = newId
+      , tyIdent = resymbolizeBindingsType nameMap t.tyIdent
+      }
+    )
+  | DeclConDef t ->
+    let newId = nameSetNewSym t.ident in
+    let nameMap = mapInsert t.ident newId nameMap in
+    (nameMap, DeclConDef {t with ident = newId, tyIdent = resymbolizeBindingsType nameMap t.tyIdent})
+
   sem resymbolizeBindingsExpr : Map Name Name -> Expr -> Expr
   sem resymbolizeBindingsExpr nameMap =
   | TmVar t ->
@@ -231,44 +273,10 @@ lang MonomorphizeResymbolize = Monomorphize
                   tyParam = resymbolizeBindingsType nameMap t.tyParam,
                   body = resymbolizeBindingsExpr nameMap t.body,
                   ty = resymbolizeBindingsType nameMap t.ty}
-  | TmLet t ->
-    let body = resymbolizeBindingsExpr nameMap t.body in
-    let newId = nameSetNewSym t.ident in
-    let nameMap = mapInsert t.ident newId nameMap in
-    TmLet {t with ident = newId,
-                  tyAnnot = resymbolizeBindingsType nameMap t.tyAnnot,
-                  tyBody = resymbolizeBindingsType nameMap t.tyBody,
-                  body = body,
-                  inexpr = resymbolizeBindingsExpr nameMap t.inexpr,
-                  ty = resymbolizeBindingsType nameMap t.ty}
-  | TmRecLets t ->
-    let addNewIdBinding = lam nameMap. lam bind.
-      let newId = nameSetNewSym bind.ident in
-      (mapInsert bind.ident newId nameMap, {bind with ident = newId})
-    in
-    match mapAccumL addNewIdBinding nameMap t.bindings with (nameMap, bindings) in
-    let resymbolizeBind = lam bind.
-      {bind with tyAnnot = resymbolizeBindingsType nameMap bind.tyAnnot,
-                 tyBody = resymbolizeBindingsType nameMap bind.tyBody,
-                 body = resymbolizeBindingsExpr nameMap bind.body}
-    in
-    let bindings = map resymbolizeBind bindings in
-    TmRecLets {t with bindings = bindings,
-                      inexpr = resymbolizeBindingsExpr nameMap t.inexpr,
-                      ty = resymbolizeBindingsType nameMap t.ty}
-  | TmType t ->
-    let newId = nameSetNewSym t.ident in
-    let nameMap = mapInsert t.ident newId nameMap in
-    TmType {t with ident = newId,
-                   tyIdent = resymbolizeBindingsType nameMap t.tyIdent,
-                   inexpr = resymbolizeBindingsExpr nameMap t.inexpr,
-                   ty = resymbolizeBindingsType nameMap t.ty}
-  | TmConDef t ->
-    let newId = nameSetNewSym t.ident in
-    let nameMap = mapInsert t.ident newId nameMap in
-    TmConDef {t with ident = newId,
-                     inexpr = resymbolizeBindingsExpr nameMap t.inexpr,
-                     ty = resymbolizeBindingsType nameMap t.ty}
+  | TmDecl t ->
+    match resymbolizeBindingsDecl nameMap t.decl with (nameMap, decl) in
+    let inexpr = resymbolizeBindingsExpr nameMap t.inexpr in
+    TmDecl {t with decl = decl, inexpr = inexpr}
   | TmConApp t ->
     let newId =
       match mapLookup t.ident nameMap with Some newId then newId
@@ -439,7 +447,7 @@ lang MonomorphizeCollect =
     in
     collectInstantiationsExpr instantiations env t.body
   | TmRecLets t ->
-    let bindMap : Map Name RecLetBinding =
+    let bindMap : Map Name DeclLetRecord =
       mapFromSeq nameCmp (map (lam bind. (bind.ident, bind)) t.bindings)
     in
     recursive let collectInstantiationsPerScc = lam inst. lam env. lam g. lam sccs.
@@ -812,34 +820,36 @@ lang MExprMonomorphizeTest =
   -- all duplicated definitions.
   sem distinctSymbols : Expr -> Bool
   sem distinctSymbols =
-  | ast -> distinctSymbolsExpr (setEmpty nameCmp) true ast
+  | ast -> distinctSymbolsExpr (setEmpty nameCmp) ast
 
-  sem distinctSymbolsExpr : Set Name -> Bool -> Expr -> Bool
-  sem distinctSymbolsExpr syms acc =
+  sem distinctSymbolsDecl : Set Name -> Decl -> Option (Set Name)
+  sem distinctSymbolsDecl syms =
+  | DeclLet t ->
+    if setMem t.ident syms then None () else
+    if distinctSymbolsExpr syms t.body
+    then Some (setInsert t.ident syms)
+    else None ()
+  | DeclRecLets t ->
+    if any (lam bind. setMem bind.ident syms) t.bindings then None () else
+    let syms = foldl (lam syms. lam bind. setInsert bind.ident syms) syms t.bindings in
+    if forAll (lam bind. distinctSymbolsExpr syms bind.body) t.bindings
+    then Some syms
+    else None ()
+  | DeclType t -> if setMem t.ident syms then Some (setInsert t.ident syms) else None ()
+  | DeclConDef t -> if setMem t.ident syms then Some (setInsert t.ident syms) else None ()
+  | DeclExt t -> if setMem t.ident syms then Some (setInsert t.ident syms) else None ()
+  | d -> Some syms
+
+  sem distinctSymbolsExpr : Set Name -> Expr -> Bool
+  sem distinctSymbolsExpr syms =
   | TmLam t ->
     if setMem t.ident syms then false
-    else distinctSymbolsExpr (setInsert t.ident syms) acc t.body
-  | TmLet t ->
-    if setMem t.ident syms then false
-    else
-      let acc = distinctSymbolsExpr syms acc t.body in
-      distinctSymbolsExpr (setInsert t.ident syms) acc t.inexpr
-  | TmRecLets t ->
-    if any (lam bind. setMem bind.ident syms) t.bindings then false
-    else
-      let syms = foldl (lam syms. lam bind. setInsert bind.ident syms) syms t.bindings in
-      let acc = foldl (lam acc. lam bind. distinctSymbolsExpr syms acc bind.body) acc t.bindings in
-      distinctSymbolsExpr syms acc t.inexpr
-  | TmType t ->
-    if setMem t.ident syms then false
-    else distinctSymbolsExpr (setInsert t.ident syms) acc t.inexpr
-  | TmConDef t ->
-    if setMem t.ident syms then false
-    else distinctSymbolsExpr (setInsert t.ident syms) acc t.inexpr
-  | TmExt t ->
-    if setMem t.ident syms then false
-    else distinctSymbolsExpr (setInsert t.ident syms) acc t.inexpr
-  | t -> sfold_Expr_Expr (distinctSymbolsExpr syms) acc t
+    else distinctSymbolsExpr (setInsert t.ident syms) t.body
+  | TmDecl x ->
+    match distinctSymbolsDecl syms x.decl with Some syms
+    then distinctSymbolsExpr syms x.inexpr
+    else false
+  | t -> sfold_Expr_Expr (lam acc. lam tm. if acc then distinctSymbolsExpr syms tm else acc) true t
 end
 
 mexpr

--- a/src/stdlib/mexpr/monomorphize.mc
+++ b/src/stdlib/mexpr/monomorphize.mc
@@ -349,7 +349,7 @@ lang MonomorphizeCollect =
 
   sem recordPolymorphicDefinitions : MonoEnv -> Expr -> MonoEnv
   sem recordPolymorphicDefinitions env =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let env =
       match t.tyBody with TyAll _ then
         {env with funEnv = mapInsert t.ident (defaultInstEntry t.tyBody) env.funEnv}
@@ -357,7 +357,7 @@ lang MonomorphizeCollect =
     in
     let env = recordPolymorphicDefinitions env t.body in
     recordPolymorphicDefinitions env t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let recordBind = lam env. lam bind.
       let env =
         match bind.tyBody with TyAll _ then
@@ -368,7 +368,7 @@ lang MonomorphizeCollect =
     in
     let env = foldl recordBind env t.bindings in
     recordPolymorphicDefinitions env t.inexpr
-  | TmType t ->
+  | TmDecl {decl = DeclType t} ->
     let env =
       if not (null t.params) then
         -- NOTE(larshum, 2023-08-03): We construct a polymorphic type
@@ -386,7 +386,7 @@ lang MonomorphizeCollect =
       else env
     in
     recordPolymorphicDefinitions env t.inexpr
-  | TmConDef t ->
+  | TmDecl {decl = DeclConDef t} ->
     let env =
       match t.tyIdent with TyAll _ then
         {env with conEnv = mapInsert t.ident (defaultInstEntry t.tyIdent) env.conEnv}
@@ -421,7 +421,7 @@ lang MonomorphizeCollect =
       {env with funEnv = mapInsert t.ident instEntry env.funEnv}
     else
       env
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let env = collectInstantiationsExpr instantiations env t.inexpr in
     let env = collectInstantiationsType instantiations env t.tyAnnot in
     let env = collectInstantiationsType instantiations env t.tyBody in
@@ -446,7 +446,7 @@ lang MonomorphizeCollect =
         instantiations
     in
     collectInstantiationsExpr instantiations env t.body
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let bindMap : Map Name DeclLetRecord =
       mapFromSeq nameCmp (map (lam bind. (bind.ident, bind)) t.bindings)
     in
@@ -490,10 +490,10 @@ lang MonomorphizeCollect =
         env
     in
     let env = collectInstantiationsExpr instantiations env t.inexpr in
-    let g = constructCallGraph (TmRecLets t) in
+    let g = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
     let sccs = digraphTarjan g in
     collectInstantiationsPerScc instantiations env g (reverse sccs)
-  | TmConDef t ->
+  | TmDecl {decl = DeclConDef t} ->
     let env = collectInstantiationsExpr instantiations env t.inexpr in
     let env = collectInstantiationsType instantiations env t.ty in
     match mapLookup t.ident env.conEnv with Some conInstEntry then
@@ -639,7 +639,7 @@ lang MonomorphizeApply = MonomorphizeInstantiate + MonomorphizeResymbolize + App
     in
     TmVar {t with ident = ident,
                   ty = applyMonomorphizationTypeLabel env t.ty}
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let inexpr = applyMonomorphizationExpr env t.inexpr in
     match mapLookup t.ident env.funEnv with Some instEntry then
       -- NOTE(larshum, 2023-08-03): The let-binding is a polymorphic function.
@@ -650,19 +650,19 @@ lang MonomorphizeApply = MonomorphizeInstantiate + MonomorphizeResymbolize + App
           let tyAnnot = monomorphizeType env inst t.tyAnnot in
           let tyBody = monomorphizeTypeLabel env inst t.tyBody in
           let ty = monomorphizeTypeLabel env inst t.ty in
-          TmLet {
+          TmDecl {decl = DeclLet {
             ident = newId, tyAnnot = tyAnnot, tyBody = tyBody,
-            body = body, inexpr = acc, ty = tyTm acc, info = t.info})
+            body = body, inexpr = acc, ty = tyTm acc, info = t.info}})
         inexpr instEntry.map
     else
       -- NOTE(larshum, 2023-08-03): The let-binding is already monomorphic, so
       -- we recurse directly into its body.
-      TmLet {t with tyAnnot = applyMonomorphizationType env t.tyAnnot,
+      TmDecl {decl = DeclLet {t with tyAnnot = applyMonomorphizationType env t.tyAnnot,
                     tyBody = applyMonomorphizationType env t.tyBody,
                     body = applyMonomorphization env t.body,
                     inexpr = inexpr,
-                    ty = applyMonomorphizationType env t.ty}
-  | TmRecLets t ->
+                    ty = applyMonomorphizationType env t.ty}}
+  | TmDecl {decl = DeclRecLets t} ->
     let applyMonomorphizationBinding = lam env. lam acc. lam bind.
       match mapLookup bind.ident env.funEnv with Some instEntry then
         mapFoldWithKey
@@ -683,37 +683,37 @@ lang MonomorphizeApply = MonomorphizeInstantiate + MonomorphizeResymbolize + App
     in
     let inexpr = applyMonomorphizationExpr env t.inexpr in
     let bindings = foldl (applyMonomorphizationBinding env) [] t.bindings in
-    TmRecLets {t with bindings = bindings, inexpr = inexpr}
-  | TmType t ->
+    TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr}}
+  | TmDecl {decl = DeclType t} ->
     let inexpr = applyMonomorphizationExpr env t.inexpr in
     match mapLookup t.ident env.typeEnv with Some instEntry then
       mapFoldWithKey
         (lam acc. lam inst. lam newId.
           let tyIdent = monomorphizeType env inst t.tyIdent in
           let ty = monomorphizeType env inst t.ty in
-          TmType {
+          TmDecl {decl = DeclType {
             ident = newId, params = [], tyIdent = tyIdent,
-            inexpr = acc, ty = ty, info = t.info })
+            inexpr = acc, ty = ty, info = t.info }})
         inexpr instEntry.map
     else
-        TmType {t with tyIdent = applyMonomorphizationType env t.tyIdent,
+        TmDecl {decl = DeclType {t with tyIdent = applyMonomorphizationType env t.tyIdent,
                        inexpr = inexpr,
-                       ty = applyMonomorphizationTypeLabel env t.ty}
-  | TmConDef t ->
+                       ty = applyMonomorphizationTypeLabel env t.ty}}
+  | TmDecl {decl = DeclConDef t} ->
     let inexpr = applyMonomorphizationExpr env t.inexpr in
     match mapLookup t.ident env.conEnv with Some instEntry then
       mapFoldWithKey
         (lam acc. lam inst. lam newId.
           let tyIdent = monomorphizeType env inst t.tyIdent in
           let ty = monomorphizeType env inst t.ty in
-          TmConDef {
+          TmDecl {decl = DeclConDef {
             ident = newId, tyIdent = tyIdent, inexpr = acc,
-            ty = ty, info = t.info })
+            ty = ty, info = t.info }})
         inexpr instEntry.map
     else
-      TmConDef {t with tyIdent = applyMonomorphizationType env t.tyIdent,
+      TmDecl {decl = DeclConDef {t with tyIdent = applyMonomorphizationType env t.tyIdent,
                        inexpr = inexpr,
-                       ty = applyMonomorphizationTypeLabel env t.ty}
+                       ty = applyMonomorphizationTypeLabel env t.ty}}
   | TmConApp t ->
     let ident =
       match mapLookup t.ident env.conEnv with Some instEntry then

--- a/src/stdlib/mexpr/parser.mc
+++ b/src/stdlib/mexpr/parser.mc
@@ -374,10 +374,21 @@ lang LetParser =
     let e1 : ParseResult Expr = parseExprMain r3.pos 0 r3.str in
     let r4 : StrPos = matchKeyword "in" e1.pos e1.str in
     let e2 : ParseResult Expr = parseExprMain r4.pos 0 r4.str in
-    {val = TmDecl {decl = DeclLet {ident = nameNoSym r2.val, tyAnnot = tyunknown_, tyBody = tyunknown_,
-                  body = e1.val, inexpr = e2.val, ty = tyunknown_,
-                  info = makeInfo p e2.pos},}
-     pos = e2.pos, str = e2.str}
+    { val = TmDecl
+      { decl = DeclLet
+        { ident = nameNoSym r2.val
+        , tyAnnot = tyunknown_
+        , tyBody = tyunknown_
+        , body = e1.val
+        , info = makeInfo p e2.pos
+        }
+      , inexpr = e2.val
+      , ty = tyunknown_
+      , info = makeInfo p e2.pos
+      }
+    , pos = e2.pos
+    , str = e2.str
+    }
 end
 
 

--- a/src/stdlib/mexpr/parser.mc
+++ b/src/stdlib/mexpr/parser.mc
@@ -365,7 +365,7 @@ end
 
 -- Parsing let expressions
 lang LetParser =
-  ExprParser + IdentParser + KeywordUtils + LetAst + UnknownTypeAst
+  ExprParser + IdentParser + KeywordUtils + LetDeclAst + UnknownTypeAst
   sem nextIdent (p: Pos) (xs: String) =
   | "let" ->
     let r : StrPos = eatWSAC (advanceCol p 3) xs in

--- a/src/stdlib/mexpr/parser.mc
+++ b/src/stdlib/mexpr/parser.mc
@@ -374,9 +374,9 @@ lang LetParser =
     let e1 : ParseResult Expr = parseExprMain r3.pos 0 r3.str in
     let r4 : StrPos = matchKeyword "in" e1.pos e1.str in
     let e2 : ParseResult Expr = parseExprMain r4.pos 0 r4.str in
-    {val = TmLet {ident = nameNoSym r2.val, tyAnnot = tyunknown_, tyBody = tyunknown_,
+    {val = TmDecl {decl = DeclLet {ident = nameNoSym r2.val, tyAnnot = tyunknown_, tyBody = tyunknown_,
                   body = e1.val, inexpr = e2.val, ty = tyunknown_,
-                  info = makeInfo p e2.pos},
+                  info = makeInfo p e2.pos},}
      pos = e2.pos, str = e2.str}
 end
 

--- a/src/stdlib/mexpr/pprint.mc
+++ b/src/stdlib/mexpr/pprint.mc
@@ -235,6 +235,10 @@ lang PrettyPrint = IdentifierPrettyPrint + MExprAst
   | expr ->
     match pprintCode 0 env expr with (_,str) in str
 
+  sem declToString (env: PprintEnv) =
+  | decl ->
+    match pprintDeclCode 0 env decl with (_,str) in str
+
   sem exprToStringKeywords (keywords: [String]) =
   | expr ->
     let addName = lam env. lam name.
@@ -255,6 +259,9 @@ lang PrettyPrint = IdentifierPrettyPrint + MExprAst
 
   sem expr2str =
   | expr -> exprToString pprintEnvEmpty expr
+
+  sem decl2str =
+  | decl -> declToString pprintEnvEmpty decl
 
   sem type2str =
   | ty -> typeToString pprintEnvEmpty ty
@@ -556,7 +563,7 @@ lang DataDeclPrettyPrint = PrettyPrint + DataDeclAst
       then None ()
       else Some x.tyIdent in
     match optionMapAccum (getTypeStringCode indent) env tyIdent with (env, ty) in
-    let ty = optionMapOr "" (concat " : ") ty in
+    let ty = optionMapOr "" (concat ": ") ty in
     (env, join ["con ", str, ty])
 end
 

--- a/src/stdlib/mexpr/pprint.mc
+++ b/src/stdlib/mexpr/pprint.mc
@@ -221,6 +221,9 @@ lang PrettyPrint = IdentifierPrettyPrint + MExprAst
 
   sem pprintCode (indent : Int) (env: PprintEnv) =
   -- Intentionally left blank
+  sem pprintDeclCode : Int -> PprintEnv -> Decl -> (PprintEnv, String)
+  sem pprintDeclCode indent env =
+  -- Intentionally left blank
   sem getPatStringCode (indent : Int) (env: PprintEnv) =
   -- Intentionally left blank
   sem getTypeStringCode (indent : Int) (env : PprintEnv) =
@@ -416,10 +419,23 @@ lang RecordPrettyPrint = PrettyPrint + RecordAst
                      " }"])
 end
 
-lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
+lang DeclPrettyPrint = PrettyPrint + DeclAst
   sem isAtomic =
-  | TmLet _ -> false
+  | TmDecl _ -> false
 
+  sem pprintCode indent env =
+  | TmDecl x ->
+    match pprintDeclCode indent env x.decl with (env, decl) in
+    match pprintCode indent env x.inexpr with (env, inexpr) in
+    let inSep = if gti (length decl) env.optSingleLineLimit
+      then pprintNewline indent
+      else " " in
+    ( env
+    , join [decl, inSep, "in", pprintNewline indent, inexpr]
+    )
+end
+
+lang LetPrettyPrint = PrettyPrint + LetDeclAst + UnknownTypeAst
   sem pprintLetAssignmentCode (indent : Int) (env: PprintEnv) =
   | {ident = ident, body = body, tyAnnot = tyAnnot} ->
     match pprintEnvGetStr env ident with (env,baseStr) in
@@ -437,10 +453,18 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
     (env,
      join ["let ", pprintVarString baseStr, tyStr, " =", bodySep, bodyStr])
 
+  sem pprintDeclCode (indent : Int) (env : PprintEnv) =
+  | DeclLet t ->
+    pprintLetAssignmentCode indent env {
+      ident = t.ident,
+      body = t.body,
+      tyAnnot = t.tyAnnot
+    }
+
   sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmLet t ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     match pprintEnvGetStr env t.ident with (env,baseStr) in
-    match pprintCode indent env t.inexpr with (env,inexpr) in
+    match pprintCode indent env x.inexpr with (env,inexpr) in
     if eqString baseStr "" then
       match printParen (pprintIncr indent) env t.body with (env,body)
       in (env, join [body, pprintNewline indent, "; ", inexpr])
@@ -458,88 +482,48 @@ lang LetPrettyPrint = PrettyPrint + LetAst + UnknownTypeAst
              pprintNewline indent, inexpr])
 end
 
-lang ExtPrettyPrint = PrettyPrint + ExtAst + UnknownTypeAst
-  sem isAtomic =
-  | TmExt _ -> false
-
-  sem getTypeStringCode (indent : Int) (env : PprintEnv) =
-  -- Intentionally left blank
-
-  sem pprintExtCode (indent : Int) (env: PprintEnv) =
-  | {ident = ident, tyIdent = tyIdent, effect = effect} ->
-    match pprintVarName env ident with (env,str) in
-    match getTypeStringCode indent env tyIdent with (env,ty) in
-      let e = if effect then "!" else "" in
+lang ExtPrettyPrint = PrettyPrint + ExtDeclAst + UnknownTypeAst
+  sem pprintDeclCode indent env =
+  | DeclExt x ->
+    match pprintVarName env x.ident with (env,str) in
+    match getTypeStringCode indent env x.tyIdent with (env,ty) in
+      let e = if x.effect then "!" else "" in
       (env,
        join ["external ", str, e, " : ", ty])
-
-  sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmExt t ->
-    match pprintExtCode indent env {
-      ident = t.ident, tyIdent = t.tyIdent, effect = t.effect}
-    with (env, extStr) in
-    match pprintCode indent env t.inexpr with (env,inexpr) in
-    (env, join [extStr, pprintNewline indent,
-                "in", pprintNewline indent,
-                inexpr])
 end
 
-lang TypePrettyPrint = PrettyPrint + TypeAst + UnknownTypeAst + VariantTypeAst
-  sem isAtomic =
-  | TmType _ -> false
-
-  sem pprintTypeCode (indent : Int) (env : PprintEnv) =
-  | {ident = ident, params = params, tyIdent = tyIdent} ->
-    match pprintTypeName env ident with (env,identStr) in
-    match mapAccumL pprintEnvGetStr env params with (env, paramsStr) in
+lang TypePrettyPrint = PrettyPrint + TypeDeclAst + UnknownTypeAst + VariantTypeAst
+  sem pprintDeclCode indent env =
+  | DeclType x ->
+    match pprintTypeName env x.ident with (env,identStr) in
+    match mapAccumL pprintEnvGetStr env x.params with (env, paramsStr) in
     let paramStr = strJoin " " (cons "" paramsStr) in
-    match tyIdent with TyVariant _ then
+    match x.tyIdent with TyVariant _ then
       (env, join ["type ", identStr, paramStr])
     else
-      match getTypeStringCode indent env tyIdent with (env, tyIdentStr) in
+      match getTypeStringCode indent env x.tyIdent with (env, tyIdentStr) in
       (env, join ["type ", identStr, paramStr, " =",
                 pprintNewline (pprintIncr indent),
                 tyIdentStr])
-
-  sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmType t ->
-    match pprintTypeCode indent env {
-      ident = t.ident, params = t.params, tyIdent = t.tyIdent}
-    with (env, typeStr) in
-    match pprintCode indent env t.inexpr with (env,inexpr) in
-    (env, join [
-      typeStr, pprintNewline indent,
-      "in", pprintNewline indent,
-      inexpr])
 end
 
-lang RecLetsPrettyPrint = PrettyPrint + LetPrettyPrint + RecLetsAst + UnknownTypeAst
-  sem isAtomic =
-  | TmRecLets _ -> false
+lang RecLetsPrettyPrint = PrettyPrint + LetPrettyPrint + RecLetsDeclAst
+  sem pprintCode indent env =
+  | TmDecl {decl = DeclRecLets {bindings = []}, inexpr = inexpr} ->
+    pprintCode indent env inexpr
 
-  sem pprintRecLetsCode (indent : Int) (env : PprintEnv) =
-  | bindings ->
+  sem pprintDeclCode indent env =
+  | DeclRecLets x ->
     let i = indent in
     let ii = pprintIncr i in
-    let f = lam env. lam bind : RecLetBinding.
+    let f = lam env. lam bind : DeclLetRecord.
       pprintLetAssignmentCode ii env {
         ident = bind.ident, body = bind.body, tyAnnot = bind.tyAnnot}
     in
-    match mapAccumL f env bindings with (env,bindingStrs) in
+    match mapAccumL f env x.bindings with (env,bindingStrs) in
     let joinedBindings = strJoin (pprintNewline ii) bindingStrs in
     (env,join ["recursive", pprintNewline ii,
                joinedBindings])
-
-  sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmRecLets t ->
-    match pprintCode indent env t.inexpr with (env,inexpr) in
-    match t.bindings with [] then
-      (env, inexpr)
-    else
-      match pprintRecLetsCode indent env t.bindings with (env, recletStr) in
-      (env, join [recletStr, pprintNewline indent,
-                  "in", pprintNewline indent,
-                  inexpr])
 end
 
 lang ConstPrettyPrint = PrettyPrint + ConstAst
@@ -555,27 +539,25 @@ end
 
 lang DataPrettyPrint = PrettyPrint + DataAst + UnknownTypeAst
   sem isAtomic =
-  | TmConDef _ -> false
   | TmConApp _ -> false
 
-  sem pprintConDefCode (indent : Int) (env : PprintEnv) =
-  | {ident = ident, tyIdent = tyIdent} ->
-    match pprintConName env ident with (env, str) in
-    match getTypeStringCode indent env tyIdent with (env, ty) in
-    let ty = if eqString ty "Unknown" then "" else concat ": " ty in
-    (env, join ["con ", str, ty])
-
   sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmConDef t ->
-    match pprintConDefCode indent env {ident = t.ident, tyIdent = t.tyIdent}
-    with (env, conStrTy) in
-    match pprintCode indent env t.inexpr with (env,inexpr) in
-    (env,join [conStrTy, " in", pprintNewline indent, inexpr])
-
   | TmConApp t ->
     match pprintConName env t.ident with (env,str) in
     match printParen (pprintIncr indent) env t.body with (env,body) in
     (env, join [str, pprintNewline (pprintIncr indent), body])
+end
+
+lang DataDeclPrettyPrint = PrettyPrint + DataDeclAst
+  sem pprintDeclCode indent env =
+  | DeclConDef x ->
+    match pprintConName env x.ident with (env, str) in
+    let tyIdent = match x.tyIdent with TyUnknown _
+      then None ()
+      else Some x.tyIdent in
+    match optionMapAccum (getTypeStringCode indent) env tyIdent with (env, ty) in
+    let ty = optionMapOr "" (concat " : ") ty in
+    (env, join ["con ", str, ty])
 end
 
 lang MatchPrettyPrint = PrettyPrint + MatchAst
@@ -674,32 +656,20 @@ lang RecordProjectionSyntaxSugarPrettyPrint = MExprIdentifierPrettyPrint +
     else pprintTmMatchIn indent env t
 end
 
-lang UtestPrettyPrint = PrettyPrint + UtestAst
-  sem isAtomic =
-  | TmUtest _ -> false
-
-  sem pprintUtestCode (indent : Int) (env : PprintEnv) =
-  | {test = test, expected = expected, tusing = tusing} ->
-    match pprintCode indent env test with (env,testStr) in
-    match pprintCode indent env expected with (env,expectedStr) in
+lang UtestPrettyPrint = PrettyPrint + UtestDeclAst
+  sem pprintDeclCode indent env =
+  | DeclUtest x ->
+    match pprintCode indent env x.test with (env,testStr) in
+    match pprintCode indent env x.expected with (env,expectedStr) in
     match
       optionMapOr (env,"") (
         lam tusing.
           match pprintCode indent env tusing with (env,tusingStr) in
           (env,join [pprintNewline indent, "using ", tusingStr])
-        ) tusing
+        ) x.tusing
     with (env,tusingStr) in
     (env,join ["utest ", testStr, pprintNewline indent,
                "with ", expectedStr, tusingStr])
-
-  sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmUtest t ->
-    match pprintUtestCode indent env {
-      test = t.test, expected = t.expected, tusing = t.tusing}
-    with (env, utestStr) in
-    match pprintCode indent env t.next with (env,next) in
-    (env,join [utestStr, pprintNewline indent,
-               "in", pprintNewline indent, next])
 end
 
 lang SeqPrettyPrint = PrettyPrint + SeqAst + ConstPrettyPrint + CharAst
@@ -1334,17 +1304,12 @@ lang ReprSubstPrettyPrint = PrettyPrint + ReprSubstAst
 end
 
 lang OpDeclPrettyPrint = PrettyPrint + OpDeclAst
-  sem isAtomic =
-  | TmOpDecl _ -> false
-
-  sem pprintCode indent env =
-  | TmOpDecl x ->
+  sem pprintDeclCode indent env =
+  | DeclOp x ->
     match pprintEnvGetStr env x.ident with (env, ident) in
-    match pprintCode indent env x.inexpr with (env, inexpr) in
     match getTypeStringCode indent env x.tyAnnot with (env, ty) in
     (env,
-     join ["letop ", pprintVarString ident, " : ", ty, " in",
-           pprintNewline indent, inexpr])
+     join ["letop ", pprintVarString ident, " : ", ty])
 end
 
 lang OpVarPrettyPrint = PrettyPrint + OpVarAst
@@ -1358,40 +1323,29 @@ lang OpVarPrettyPrint = PrettyPrint + OpVarAst
 end
 
 lang OpImplPrettyPrint = PrettyPrint + OpImplAst
-  sem isAtomic =
-  | TmOpImpl _ -> false
-
-  sem pprintCode indent env =
-  | TmOpImpl x ->
+  sem pprintDeclCode indent env =
+  | DeclOpImpl x ->
     let newIndent = pprintIncr indent in
     match pprintEnvGetStr env x.ident with (env, ident) in
     match getTypeStringCode newIndent env x.specType with (env, specType) in
     match pprintCode newIndent env x.body with (env, body) in
-    match pprintCode indent env x.inexpr with (env, inexpr) in
     let start = concat (pprintNewline indent) "* " in
     let str = join
       [ "letimpl<scope:", int2string x.reprScope, ">[", float2string x.selfCost, "] "
       , ident, " : ", specType, " ="
       , pprintNewline newIndent, body
-      , pprintNewline indent, "in"
-      , pprintNewline indent, inexpr
       ] in
     (env, str)
 end
 
 lang ReprDeclPrettyPrint = PrettyPrint + ReprDeclAst
-  sem isAtomic =
-  | TmReprDecl _ -> false
-
-  sem pprintCode indent env =
-  | TmReprDecl x ->
+  sem pprintDeclCode indent env =
+  | DeclRepr x ->
     match pprintEnvGetStr env x.ident with (env, ident) in
     match getTypeStringCode indent env x.pat with (env, pat) in
     match getTypeStringCode indent env x.repr with (env, repr) in
-    match pprintCode indent env x.inexpr with (env, inexpr) in
     let str = join
-      [ "repr ", ident, " {", pat, " = ", repr, "} in"
-      , pprintNewline indent, inexpr
+      [ "repr ", ident, " {", pat, " = ", repr, "}"
       ] in
     (env, str)
 end
@@ -1466,9 +1420,12 @@ lang MExprPrettyPrint =
 
   -- Terms
   VarPrettyPrint + AppPrettyPrint + LamPrettyPrint + RecordPrettyPrint +
-  LetPrettyPrint + TypePrettyPrint + RecLetsPrettyPrint + ConstPrettyPrint +
-  DataPrettyPrint + MatchPrettyPrint + UtestPrettyPrint + SeqPrettyPrint +
-  NeverPrettyPrint + ExtPrettyPrint +
+  DeclPrettyPrint + ConstPrettyPrint + DataPrettyPrint + MatchPrettyPrint +
+  SeqPrettyPrint + NeverPrettyPrint +
+
+  -- Decls
+  LetPrettyPrint + TypePrettyPrint + RecLetsPrettyPrint + DataDeclPrettyPrint +
+  UtestPrettyPrint + ExtPrettyPrint +
 
   -- Constants
   IntPrettyPrint + ArithIntPrettyPrint + ShiftIntPrettyPrint +
@@ -1548,11 +1505,12 @@ let func_foo =
               addi_ (var_ "b") (var_ "x")
             )
           ),
-          ulet_ "babar" (int_ 3),
-          addi_ (app_ (var_ "bar")
+          ulet_ "babar" (int_ 3)
+        ]
+        ( addi_ (app_ (var_ "bar")
                       (var_ "babar"))
                 (var_ "a")
-        ]
+        )
       )
     )
   )
@@ -1631,7 +1589,7 @@ let func_myconb = condef_ "myConB" (tytuple_ [tybool_, tyint_]) in
 let func_mycona_mycona =
   let n1 = nameSym "MyConA" in
   let n2 = nameSym "MyConA" in
-  bindall_ [nucondef_ n1, nucondef_ n2]
+  bindall_ [nucondef_ n1, nucondef_ n2] unit_
 in
 
 -- let isconb : Bool = lam c : #con"myConB".
@@ -1704,14 +1662,14 @@ in
 let n1 = nameSym "var" in
 let n2 = nameSym "var" in
 let var_var =
-  bindall_ [nulet_ n1 (int_ 1), nulet_ n2 (int_ 2), addi_ (nvar_ n1) (nvar_ n2)]
+  bindall_ [nulet_ n1 (int_ 1), nulet_ n2 (int_ 2)] (addi_ (nvar_ n1) (nvar_ n2))
 in
 
 -- let #var"" = 1 in let #var"1" = 2 in addi #var"" #var"1"
 let n1 = nameSym "" in
 let n2 = nameSym "" in
 let empty_empty =
-  bindall_ [nulet_ n1 (int_ 1), nulet_ n2 (int_ 2), addi_ (nvar_ n1) (nvar_ n2)]
+  bindall_ [nulet_ n1 (int_ 1), nulet_ n2 (int_ 2)] (addi_ (nvar_ n1) (nvar_ n2))
 in
 
 -- external addi : Int -> Int -> Int in addi
@@ -1725,20 +1683,20 @@ let external_addi_effect =
 in
 
 let sample_ast =
-  bindall_ [
-    func_foo,
-    func_factorial,
-    funcs_evenodd,
-    func_recget,
-    func_recconcs,
-    func_mycona,
+  foldr1 semi_ [
+    bind_ func_foo unit_,
+    bind_ func_factorial unit_,
+    bind_ funcs_evenodd unit_,
+    bind_ func_recget unit_,
+    bind_ func_recconcs unit_,
+    bind_ func_mycona unit_,
     func_mycona_mycona,
-    func_myconb,
-    func_isconb,
-    func_addone,
-    func_beginsWithBinaryDigit,
-    func_pedanticIsSome,
-    func_is123,
+    bind_ func_myconb unit_,
+    bind_ func_isconb unit_,
+    bind_ func_addone unit_,
+    bind_ func_beginsWithBinaryDigit unit_,
+    bind_ func_pedanticIsSome unit_,
+    bind_ func_is123 unit_,
     var_var,
     empty_empty,
     external_addi,

--- a/src/stdlib/mexpr/profiling.mc
+++ b/src/stdlib/mexpr/profiling.mc
@@ -205,7 +205,7 @@ lang MExprProfileInstrument = MExprAst + BootParser
       else env in
     collectToplevelFunctions env t.inexpr
   | TmRecLets t ->
-    let collectBinding : ProfileEnv -> RecLetBinding -> ProfileEnv =
+    let collectBinding : ProfileEnv -> DeclLetRecord -> ProfileEnv =
       lam env. lam binding.
       match binding.body with TmLam _ then
         let idx = mapSize env in
@@ -233,7 +233,7 @@ lang MExprProfileInstrument = MExprAst + BootParser
                 with inexpr = instrumentProfilingH env t.inexpr}
     else TmLet {t with inexpr = instrumentProfilingH env t.inexpr}
   | TmRecLets t ->
-    let instrumentBinding : RecLetBinding -> RecLetBinding =
+    let instrumentBinding : DeclLetRecord -> DeclLetRecord =
       lam binding.
       match mapLookup binding.ident env with Some (idx, _) then
         {binding with body = instrumentProfilingCalls idx binding.body}

--- a/src/stdlib/mexpr/profiling.mc
+++ b/src/stdlib/mexpr/profiling.mc
@@ -197,14 +197,14 @@ let getProfilerReportCode = lam.
 
 lang MExprProfileInstrument = MExprAst + BootParser
   sem collectToplevelFunctions (env : ProfileEnv) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let env =
       match t.body with TmLam _ then
         let idx = mapSize env in
         mapInsert t.ident (idx, t.info) env
       else env in
     collectToplevelFunctions env t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let collectBinding : ProfileEnv -> DeclLetRecord -> ProfileEnv =
       lam env. lam binding.
       match binding.body with TmLam _ then
@@ -227,24 +227,24 @@ lang MExprProfileInstrument = MExprAst + BootParser
       var_ "tmp"]
 
   sem instrumentProfilingH (env : ProfileEnv) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     match mapLookup t.ident env with Some (idx, _) then
-      TmLet {{t with body = instrumentProfilingCalls idx t.body}
-                with inexpr = instrumentProfilingH env t.inexpr}
-    else TmLet {t with inexpr = instrumentProfilingH env t.inexpr}
-  | TmRecLets t ->
+      TmDecl {decl = DeclLet {{t with body = instrumentProfilingCalls idx t.body}
+                with inexpr = instrumentProfilingH env t.inexpr}}
+    else TmDecl {decl = DeclLet {t with inexpr = instrumentProfilingH env t.inexpr}}
+  | TmDecl {decl = DeclRecLets t} ->
     let instrumentBinding : DeclLetRecord -> DeclLetRecord =
       lam binding.
       match mapLookup binding.ident env with Some (idx, _) then
         {binding with body = instrumentProfilingCalls idx binding.body}
       else binding
     in
-    TmRecLets {{t with bindings = map instrumentBinding t.bindings}
-                  with inexpr = instrumentProfilingH env t.inexpr}
-  | TmType t -> TmType {t with inexpr = instrumentProfilingH env t.inexpr}
-  | TmConDef t -> TmConDef {t with inexpr = instrumentProfilingH env t.inexpr}
-  | TmUtest t -> TmUtest {t with next = instrumentProfilingH env t.next}
-  | TmExt t -> TmExt {t with inexpr = instrumentProfilingH env t.inexpr}
+    TmDecl {decl = DeclRecLets {{t with bindings = map instrumentBinding t.bindings}
+                  with inexpr = instrumentProfilingH env t.inexpr}}
+  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = instrumentProfilingH env t.inexpr}}
+  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = instrumentProfilingH env t.inexpr}}
+  | TmDecl {decl = DeclUtest t} -> TmDecl {decl = DeclUtest {t with next = instrumentProfilingH env t.next}}
+  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = instrumentProfilingH env t.inexpr}}
   | t -> t
 
   sem instrumentProfiling =

--- a/src/stdlib/mexpr/profiling.mc
+++ b/src/stdlib/mexpr/profiling.mc
@@ -197,14 +197,17 @@ let getProfilerReportCode = lam.
 
 lang MExprProfileInstrument = MExprAst + BootParser
   sem collectToplevelFunctions (env : ProfileEnv) =
-  | TmDecl {decl = DeclLet t} ->
+  | _ -> env
+  | TmDecl x ->
+    collectToplevelFunctions env x.inexpr
+  | TmDecl (x & {decl = DeclLet t}) ->
     let env =
       match t.body with TmLam _ then
         let idx = mapSize env in
         mapInsert t.ident (idx, t.info) env
       else env in
-    collectToplevelFunctions env t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+    collectToplevelFunctions env x.inexpr
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let collectBinding : ProfileEnv -> DeclLetRecord -> ProfileEnv =
       lam env. lam binding.
       match binding.body with TmLam _ then
@@ -213,8 +216,7 @@ lang MExprProfileInstrument = MExprAst + BootParser
       else env
     in
     let env = foldl collectBinding env t.bindings in
-    collectToplevelFunctions env t.inexpr
-  | t -> sfold_Expr_Expr collectToplevelFunctions env t
+    collectToplevelFunctions env x.inexpr
 
   sem instrumentProfilingCalls (functionIndex : Int) =
   | TmLam t ->
@@ -223,38 +225,42 @@ lang MExprProfileInstrument = MExprAst + BootParser
     bindall_ [
       ulet_ "" (app_ (var_ "pushCallStack") (int_ functionIndex)),
       ulet_ "tmp" t,
-      ulet_ "" (app_ (var_ "popCallStack") unit_),
-      var_ "tmp"]
+      ulet_ "" (app_ (var_ "popCallStack") unit_)]
+      (var_ "tmp")
 
   sem instrumentProfilingH (env : ProfileEnv) =
-  | TmDecl {decl = DeclLet t} ->
-    match mapLookup t.ident env with Some (idx, _) then
-      TmDecl {decl = DeclLet {{t with body = instrumentProfilingCalls idx t.body}
-                with inexpr = instrumentProfilingH env t.inexpr}}
-    else TmDecl {decl = DeclLet {t with inexpr = instrumentProfilingH env t.inexpr}}
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
+    match mapLookup t.ident env with Some (idx, _)
+    then TmDecl
+      { x with decl = DeclLet {t with body = instrumentProfilingCalls idx t.body}
+      , inexpr = instrumentProfilingH env x.inexpr
+      }
+    else TmDecl {x with inexpr = instrumentProfilingH env x.inexpr}
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let instrumentBinding : DeclLetRecord -> DeclLetRecord =
       lam binding.
       match mapLookup binding.ident env with Some (idx, _) then
         {binding with body = instrumentProfilingCalls idx binding.body}
       else binding
-    in
-    TmDecl {decl = DeclRecLets {{t with bindings = map instrumentBinding t.bindings}
-                  with inexpr = instrumentProfilingH env t.inexpr}}
-  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = instrumentProfilingH env t.inexpr}}
-  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = instrumentProfilingH env t.inexpr}}
-  | TmDecl {decl = DeclUtest t} -> TmDecl {decl = DeclUtest {t with next = instrumentProfilingH env t.next}}
-  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = instrumentProfilingH env t.inexpr}}
+    in TmDecl
+    {x with decl = DeclRecLets {t with bindings = map instrumentBinding t.bindings}
+    , inexpr = instrumentProfilingH env x.inexpr
+    }
+  | TmDecl x -> TmDecl {x with inexpr = instrumentProfilingH env x.inexpr}
   | t -> t
 
   sem instrumentProfiling =
   | t ->
     let emptyEnv = mapEmpty nameCmp in
     let env = collectToplevelFunctions emptyEnv t in
-    bindall_ [
-      parseMExprStringKeywordsExn [] (_profilerInitStr env),
-      ulet_ "" (instrumentProfilingH env t),
-      getProfilerReportCode ()]
+    let initDecls =
+      recursive let work = lam acc. lam tm.
+        match tm with TmDecl x
+        then work (snoc acc x.decl) x.inexpr
+        else acc in
+      work [] (parseMExprStringKeywordsExn [] (_profilerInitStr env)) in
+    bindall_ (snoc initDecls (ulet_ "" (instrumentProfilingH env t)))
+      (getProfilerReportCode ())
 end
 
 lang TestLang = MExprProfileInstrument + MExprSym + MExprEval
@@ -274,9 +280,8 @@ let t = bindall_ [
       if_ (leqi_ (var_ "n") (int_ 0))
         (true_)
         (app_ (var_ "nonsense") (subi_ (var_ "n") (int_ 1)))))],
-  ulet_ "f" (ulam_ "x" (app_ (var_ "fact") (addi_ (var_ "x") (int_ 3)))),
-  app_ (var_ "f") (int_ 4)
-] in
+  ulet_ "f" (ulam_ "x" (app_ (var_ "fact") (addi_ (var_ "x") (int_ 3))))]
+  (app_ (var_ "f") (int_ 4)) in
 let t = instrumentProfiling t in
 eval (evalCtxEmpty ()) (symbolize t);
 utest fileExists profilingResultFileName with true in

--- a/src/stdlib/mexpr/remove-ascription.mc
+++ b/src/stdlib/mexpr/remove-ascription.mc
@@ -5,7 +5,7 @@ include "eq.mc"
 lang MExprRemoveTypeAscription = MExprAst
   sem removeTypeAscription : Expr -> Expr
   sem removeTypeAscription =
-  | (TmLet {ident = idLet, body = body, inexpr = TmVar {ident = idExpr}}) & letexpr ->
+  | (TmDecl {decl = DeclLet {ident = idLet, body = body, inexpr = TmVar {ident = idExpr}}}) & letexpr ->
     if nameEq idLet idExpr then
       removeTypeAscription body
     else smap_Expr_Expr removeTypeAscription letexpr

--- a/src/stdlib/mexpr/remove-ascription.mc
+++ b/src/stdlib/mexpr/remove-ascription.mc
@@ -5,7 +5,7 @@ include "eq.mc"
 lang MExprRemoveTypeAscription = MExprAst
   sem removeTypeAscription : Expr -> Expr
   sem removeTypeAscription =
-  | (TmDecl {decl = DeclLet {ident = idLet, body = body, inexpr = TmVar {ident = idExpr}}}) & letexpr ->
+  | (TmDecl {decl = DeclLet {ident = idLet, body = body}, inexpr = TmVar {ident = idExpr}}) & letexpr ->
     if nameEq idLet idExpr then
       removeTypeAscription body
     else smap_Expr_Expr removeTypeAscription letexpr

--- a/src/stdlib/mexpr/repr-ast.mc
+++ b/src/stdlib/mexpr/repr-ast.mc
@@ -70,36 +70,25 @@ lang ReprSubstAst = Ast
    (acc, TySubst { x with arg = arg })
 end
 
-lang OpDeclAst = Ast + LetAst + NeverAst + UnknownTypeAst
-  syn Expr =
-  | TmOpDecl { info : Info, ident : Name, tyAnnot : Type, ty : Type, inexpr : Expr }
+lang OpDeclAst = Ast
+  syn Decl =
+  | DeclOp { info : Info, ident : Name, tyAnnot : Type }
 
-  sem tyTm =
-  | TmOpDecl x -> x.ty
+  sem declWithInfo info =
+  | DeclOp x -> DeclOp {x with info = info}
 
-  sem withType ty =
-  | TmOpDecl x -> TmOpDecl {x with ty = ty}
+  sem infoDecl =
+  | DeclOp x -> x.info
 
-  sem withInfo info =
-  | TmOpDecl x -> TmOpDecl {x with info = info}
-
-  sem infoTm =
-  | TmOpDecl x -> x.info
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmOpDecl x ->
-    match f acc x.inexpr with (env, inexpr) in
-    (env, TmOpDecl {x with inexpr = inexpr})
-
-  sem smapAccumL_Expr_Type f acc =
-  | TmOpDecl x ->
+  sem smapAccumL_Decl_Type f acc =
+  | DeclOp x ->
     match f acc x.tyAnnot with (env, tyAnnot) in
-    (env, TmOpDecl {x with tyAnnot = tyAnnot})
+    (env, DeclOp {x with tyAnnot = tyAnnot})
 end
 
 type ImplId = Int
 lang OpImplAst = Ast
-  type TmOpImplRec = use Ast in
+  type DeclOpImplRec = use Ast in
     { ident : Name
     , implId : ImplId
     , reprScope : Int
@@ -108,32 +97,23 @@ lang OpImplAst = Ast
     , body : Expr
     , specType : Type
     , delayedReprUnifications : [(ReprVar, ReprVar)]
-    , inexpr : Expr
-    , ty : Type
     , info : Info
     }
-  syn Expr =
-  | TmOpImpl TmOpImplRec
+  syn Decl =
+  | DeclOpImpl DeclOpImplRec
 
-  sem tyTm =
-  | TmOpImpl x -> x.ty
+  sem infoDecl =
+  | DeclOpImpl x -> x.info
 
-  sem withType ty =
-  | TmOpImpl x -> TmOpImpl {x with ty = ty}
-
-  sem infoTm =
-  | TmOpImpl x -> x.info
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmOpImpl x ->
+  sem smapAccumL_Decl_Expr f acc =
+  | DeclOpImpl x ->
     match f acc x.body with (acc, body) in
-    match f acc x.inexpr with (acc, inexpr) in
-    (acc, TmOpImpl {x with body = body, inexpr = inexpr})
+    (acc, DeclOpImpl {x with body = body})
 
-  sem smapAccumL_Expr_Type f acc =
-  | TmOpImpl x ->
+  sem smapAccumL_Decl_Type f acc =
+  | DeclOpImpl x ->
     match f acc x.specType with (acc, specType) in
-    (acc, TmOpImpl {x with specType = specType})
+    (acc, DeclOpImpl {x with specType = specType})
 end
 
 lang OpVarAst = Ast
@@ -156,38 +136,25 @@ end
 
 lang ReprDeclAst = Ast
   syn Expr =
-  | TmReprDecl
+  | DeclRepr
     { ident : Name
     , vars : [Name]
     , pat : Type
     , repr : Type
-    , ty : Type
-    , inexpr : Expr
     , info : Info
     }
 
-  sem tyTm =
-  | TmReprDecl x -> x.ty
+  sem infoDecl =
+  | DeclRepr x -> x.info
 
-  sem withType ty =
-  | TmReprDecl x -> TmReprDecl {x with ty = ty}
-
-  sem infoTm =
-  | TmReprDecl x -> x.info
-
-  sem withInfo info =
-  | TmReprDecl x -> TmReprDecl {x with info = info}
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmReprDecl x ->
-    match f acc x.inexpr with (acc, inexpr) in
-    (acc, TmReprDecl {x with inexpr = inexpr})
+  sem declWithInfo info =
+  | DeclRepr x -> DeclRepr {x with info = info}
 
   sem smapAccumL_Expr_Type f acc =
-  | TmReprDecl x ->
+  | DeclRepr x ->
     match f acc x.pat with (acc, pat) in
     match f acc x.repr with (acc, repr) in
-    (acc, TmReprDecl {x with pat = pat, repr = repr})
+    (acc, DeclRepr {x with pat = pat, repr = repr})
 end
 
 lang RepTypesAst = ReprTypeAst + ReprSubstAst + OpDeclAst + OpImplAst + OpVarAst + ReprDeclAst + TyWildAst

--- a/src/stdlib/mexpr/repr-ast.mc
+++ b/src/stdlib/mexpr/repr-ast.mc
@@ -135,7 +135,7 @@ lang OpVarAst = Ast
 end
 
 lang ReprDeclAst = Ast
-  syn Expr =
+  syn Decl =
   | DeclRepr
     { ident : Name
     , vars : [Name]
@@ -150,7 +150,7 @@ lang ReprDeclAst = Ast
   sem declWithInfo info =
   | DeclRepr x -> DeclRepr {x with info = info}
 
-  sem smapAccumL_Expr_Type f acc =
+  sem smapAccumL_Decl_Type f acc =
   | DeclRepr x ->
     match f acc x.pat with (acc, pat) in
     match f acc x.repr with (acc, repr) in

--- a/src/stdlib/mexpr/reptypes.mc
+++ b/src/stdlib/mexpr/reptypes.mc
@@ -30,8 +30,9 @@ lang LamRepTypesAnalysis = TypeCheck + LamAst + SubstituteNewReprs
 end
 
 lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplAst + OpDeclAst + NonExpansive + MetaVarDisableGeneralize
+
   sem typeCheckExpr env =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let newLvl = addi 1 env.currentLvl in
     let isValue = nonExpansive true t.body in
     let shouldBeOp = if env.reptypes.inImpl
@@ -56,7 +57,7 @@ lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplA
       match gen env.currentLvl (mapEmpty nameCmp) tyBody with (tyBody, _) in
       let env = _insertVar t.ident tyBody env in
       let env = {env with reptypes = {env.reptypes with opNamesInScope = mapInsert t.ident (None ()) env.reptypes.opNamesInScope}} in
-      let inexpr = typeCheckExpr env t.inexpr in
+      let inexpr = typeCheckExpr env x.inexpr in
       let ty = tyTm inexpr in
       TmDecl
       { decl = DeclOp
@@ -64,19 +65,24 @@ lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplA
         , tyAnnot = tyBody
         , info = t.info
         }
+      , info = x.info
       , ty = ty
-      , inexpr = TmDecl {decl = DeclOpImpl { ident = t.ident
-        , implId = negi 1
-        , selfCost = 1.0
-        , body = body
-        , specType = tyBody
-        , delayedReprUnifications = delayedReprUnifications
+      , inexpr = TmDecl
+        { decl = DeclOpImpl
+          { ident = t.ident
+          , implId = negi 1
+          , selfCost = 1.0
+          , body = body
+          , specType = tyBody
+          , delayedReprUnifications = delayedReprUnifications
+          , reprScope = reprScope
+          , metaLevel = env.currentLvl
+          , info = t.info
+          }
         , inexpr = inexpr
-        , ty = ty
-        , reprScope = reprScope
-        , metaLevel = env.currentLvl
         , info = t.info
-        }}
+        , ty = ty
+        }
       }
     else
       -- Keep it as a Let in the current reprScope, use normal inference
@@ -103,16 +109,15 @@ lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplA
           weakenMetaVars env.currentLvl tyBody;
           (body, tyBody)
         with (body, tyBody) in
-      let inexpr = typeCheckExpr (_insertVar t.ident tyBody env) t.inexpr in
-      TmDecl {decl = DeclLet {t with body = body,
-                    tyBody = tyBody,
-                    inexpr = inexpr,
-                    ty = tyTm inexpr}}
+      let inexpr = typeCheckExpr (_insertVar t.ident tyBody env) x.inexpr in
+      TmDecl { x with decl = DeclLet {t with body = body, tyBody = tyBody}
+             , inexpr = inexpr, ty = tyTm inexpr
+             }
 end
 
 lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsDeclAst + MetaVarDisableGeneralize + RecordAst + OpImplAst + OpDeclAst + RepTypesHelpers + NonExpansive + SubstituteNewReprs + PropagateTypeAnnot + SubstituteUnknown + ResolveType
   sem typeCheckExpr env =
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let newLvl = addi 1 env.currentLvl in
     -- First: Generate a new environment containing the recursive bindings
     let recLetEnvIteratee = lam acc. lam b: DeclLetRecord.
@@ -164,8 +169,8 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsDeclAst + MetaVarDisableGenera
       ((newEnv, newTyVars), {b with tyBody = tyBody})
     in
     match mapAccumL envIteratee (env, tyVars) bindings with ((env, _), bindings) in
-    let inexpr = typeCheckExpr env t.inexpr in
-    TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr, ty = tyTm inexpr}}
+    let inexpr = typeCheckExpr env x.inexpr in
+    TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr, ty = tyTm inexpr}
 -- NOTE(vipa, 2024-04-22): This currently just uses the normal
 -- type-checking for TmRecLets. In the end we want to infer when
 -- something should be replaced with a letop and letimpl pair, but the
@@ -352,7 +357,7 @@ end
 
 lang OpImplRepTypesAnalysis = TypeCheck + OpImplAst + ResolveType + SubstituteNewReprs + RepTypesHelpers + ApplyReprSubsts
   sem typeCheckExpr env =
-  | TmDecl {decl = DeclOpImpl x} ->
+  | TmDecl (t & {decl = DeclOpImpl x}) ->
     let typeCheckBody = lam env.
       let env = {env with reptypes = {env.reptypes with inImpl = true}} in
       let newLvl = addi 1 env.currentLvl in
@@ -373,12 +378,15 @@ lang OpImplRepTypesAnalysis = TypeCheck + OpImplAst + ResolveType + SubstituteNe
     in
     match withNewReprScope env (lam env. typeCheckBody env)
       with (x, reprScope, []) in
-    let inexpr = typeCheckExpr env x.inexpr in
-    TmDecl {decl = DeclOpImpl { x with reprScope = reprScope
-    , metaLevel = env.currentLvl
+    let inexpr = typeCheckExpr env t.inexpr in
+    TmDecl
+    { t with decl = DeclOpImpl
+      { x with reprScope = reprScope
+      , metaLevel = env.currentLvl
+      }
     , inexpr = inexpr
     , ty = tyTm inexpr
-    }}
+    }
 end
 
 -- NOTE(vipa, 2023-06-26): The RepTypes analysis is essentially
@@ -841,7 +849,7 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
   | tm & TmOpVar x ->
     match addOpUse state.options.debugSolveProcess global state.branch state.topQuery x with (branch, topQuery) in
     ({state with branch = branch, topQuery = topQuery}, tm)
-  | TmDecl {decl = DeclOpImpl x} ->
+  | TmDecl (t & {decl = DeclOpImpl x}) ->
     let implId = state.nextId in
     let state = {state with nextId = addi state.nextId 1} in
     recursive let addSubstsToUni = lam oUni. lam ty.
@@ -881,15 +889,13 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
       printLn (json2string (opImplDebugJson opImpl))
      else ());
     let newBranch = addImpl global state.branch opImpl in
-    match collectForReprSolve global {state with branch = newBranch} x.inexpr
+    match collectForReprSolve global {state with branch = newBranch} t.inexpr
       with (newState, inexpr) in
     -- NOTE(vipa, 2023-10-25): Here we restore the old branch, since
     -- any new solutions attained along the new branch might use this
     -- new impl, which isn't in scope in whatever we're returning to
     ( {newState with branch = state.branch}
-    , TmDecl {decl = DeclOpImpl { x with implId = implId
-      , inexpr = inexpr
-      }}
+    , TmDecl {t with decl = DeclOpImpl {x with implId = implId}, inexpr = inexpr}
     )
 
   sem findOpUses : [TmOpVarRec] -> Expr -> [TmOpVarRec]
@@ -940,17 +946,21 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
     ( {state with remainingSolutions = remainingSolutions}
     , TmVar {ident = name, ty = x.ty, info = x.info, frozen = x.frozen}
     )
-  | TmDecl {decl = DeclOpImpl x} ->
-    match concretizeAlt state x.inexpr with (state, inexpr) in
+  | TmDecl (t & {decl = DeclOpImpl x}) ->
+    match concretizeAlt state t.inexpr with (state, inexpr) in
     let reqs = mapLookupOr [] x.implId state.requests in
-    let wrap = lam req. lam inexpr. TmDecl {decl = DeclLet { ident = req.solName
-      , tyAnnot = tyunknown_
-      , tyBody = tyTm req.body
-      , body = req.body
+    let wrap = lam req. lam inexpr. TmDecl
+      { decl = DeclLet
+        { ident = req.solName
+        , tyAnnot = tyunknown_
+        , tyBody = tyTm req.body
+        , body = req.body
+        , info = x.info
+        }
       , inexpr = inexpr
       , ty = tyTm inexpr
       , info = x.info
-      }} in
+      } in
     let res = foldr wrap inexpr reqs in
     let state = {state with requests = mapRemove x.implId state.requests} in
     (state, res)
@@ -8249,9 +8259,9 @@ lang DumpRepTypesProblem = RepTypesFragments
   sem dumpRepTypesProblemWork : (String -> ()) -> [(Name, Type)] -> Expr -> [(Name, Type)]
   sem dumpRepTypesProblemWork output acc =
   | TmOpVar x -> snoc acc (x.ident, x.ty)
-  | TmDecl {decl = DeclOpImpl x} ->
+  | TmDecl (t & {decl = DeclOpImpl x}) ->
     dumpRepTypesProblemRoot output x.reprScope x.body;
-    dumpRepTypesProblemWork output acc x.inexpr
+    dumpRepTypesProblemWork output acc t.inexpr
   | tm -> sfold_Expr_Expr (dumpRepTypesProblemWork output) acc tm
 
   sem clearAndCollectReprs : [ReprVar] -> Type -> ([ReprVar], Type)

--- a/src/stdlib/mexpr/reptypes.mc
+++ b/src/stdlib/mexpr/reptypes.mc
@@ -29,7 +29,7 @@ lang LamRepTypesAnalysis = TypeCheck + LamAst + SubstituteNewReprs
     TmLam {t with body = body, tyParam = tyParam, ty = tyLam}
 end
 
-lang LetRepTypesAnalysis = TypeCheck + LetAst + SubstituteNewReprs + OpImplAst + OpDeclAst + NonExpansive + MetaVarDisableGeneralize
+lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplAst + OpDeclAst + NonExpansive + MetaVarDisableGeneralize
   sem typeCheckExpr env =
   | TmLet t ->
     let newLvl = addi 1 env.currentLvl in
@@ -109,7 +109,7 @@ lang LetRepTypesAnalysis = TypeCheck + LetAst + SubstituteNewReprs + OpImplAst +
                     ty = tyTm inexpr}
 end
 
-lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize + RecordAst + OpImplAst + OpDeclAst + RepTypesHelpers + NonExpansive + SubstituteNewReprs + PropagateTypeAnnot + SubstituteUnknown + ResolveType
+lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsDeclAst + MetaVarDisableGeneralize + RecordAst + OpImplAst + OpDeclAst + RepTypesHelpers + NonExpansive + SubstituteNewReprs + PropagateTypeAnnot + SubstituteUnknown + ResolveType
   sem typeCheckExpr env =
   | TmRecLets t ->
     let newLvl = addi 1 env.currentLvl in
@@ -768,7 +768,7 @@ let defaultReprSolverOptions : ReprSolverOptions =
   , solutionCacheFile = None ()
   }
 
-lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + VarAst + LetAst + OpDeclAst + ReprDeclAst + ReprTypeAst + UnifyPure + AliasTypeAst + PrettyPrint + ReprSubstAst + RepTypesHelpers
+lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + VarAst + LetDeclAst + OpDeclAst + ReprDeclAst + ReprTypeAst + UnifyPure + AliasTypeAst + PrettyPrint + ReprSubstAst + RepTypesHelpers
   -- Top interface, meant to be used outside --
   sem reprSolve : ReprSolverOptions -> Expr -> [Expr]
   sem reprSolve options = | tm ->

--- a/src/stdlib/mexpr/reptypes.mc
+++ b/src/stdlib/mexpr/reptypes.mc
@@ -31,7 +31,7 @@ end
 
 lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplAst + OpDeclAst + NonExpansive + MetaVarDisableGeneralize
   sem typeCheckExpr env =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let newLvl = addi 1 env.currentLvl in
     let isValue = nonExpansive true t.body in
     let shouldBeOp = if env.reptypes.inImpl
@@ -103,15 +103,15 @@ lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplA
           (body, tyBody)
         with (body, tyBody) in
       let inexpr = typeCheckExpr (_insertVar t.ident tyBody env) t.inexpr in
-      TmLet {t with body = body,
+      TmDecl {decl = DeclLet {t with body = body,
                     tyBody = tyBody,
                     inexpr = inexpr,
-                    ty = tyTm inexpr}
+                    ty = tyTm inexpr}}
 end
 
 lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsDeclAst + MetaVarDisableGeneralize + RecordAst + OpImplAst + OpDeclAst + RepTypesHelpers + NonExpansive + SubstituteNewReprs + PropagateTypeAnnot + SubstituteUnknown + ResolveType
   sem typeCheckExpr env =
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let newLvl = addi 1 env.currentLvl in
     -- First: Generate a new environment containing the recursive bindings
     let recLetEnvIteratee = lam acc. lam b: DeclLetRecord.
@@ -164,7 +164,7 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsDeclAst + MetaVarDisableGenera
     in
     match mapAccumL envIteratee (env, tyVars) bindings with ((env, _), bindings) in
     let inexpr = typeCheckExpr env t.inexpr in
-    TmRecLets {t with bindings = bindings, inexpr = inexpr, ty = tyTm inexpr}
+    TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr, ty = tyTm inexpr}}
 -- NOTE(vipa, 2024-04-22): This currently just uses the normal
 -- type-checking for TmRecLets. In the end we want to infer when
 -- something should be replaced with a letop and letimpl pair, but the
@@ -944,15 +944,14 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
   | TmOpImpl x ->
     match concretizeAlt state x.inexpr with (state, inexpr) in
     let reqs = mapLookupOr [] x.implId state.requests in
-    let wrap = lam req. lam inexpr. TmLet
-      { ident = req.solName
+    let wrap = lam req. lam inexpr. TmDecl {decl = DeclLet { ident = req.solName
       , tyAnnot = tyunknown_
       , tyBody = tyTm req.body
       , body = req.body
       , inexpr = inexpr
       , ty = tyTm inexpr
       , info = x.info
-      } in
+      }} in
     let res = foldr wrap inexpr reqs in
     let state = {state with requests = mapRemove x.implId state.requests} in
     (state, res)
@@ -8317,6 +8316,6 @@ lang PrintMostFrequentRepr = RepTypesFragments + MExprAst
 
   sem hasInExpr : Expr -> Bool
   sem hasInExpr =
-  | TmLet _ | TmRecLets _ | TmExt _ | TmType _ | TmConDef _ | TmOpDecl _ | TmOpImpl _ -> true
+  | TmDecl {decl = DeclLet _} | TmDecl {decl = DeclRecLets _} | TmDecl {decl = DeclExt _} | TmDecl {decl = DeclType _} | TmDecl {decl = DeclConDef _} | TmOpDecl _ | TmOpImpl _ -> true
   | _ -> false
 end

--- a/src/stdlib/mexpr/reptypes.mc
+++ b/src/stdlib/mexpr/reptypes.mc
@@ -58,13 +58,14 @@ lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplA
       let env = {env with reptypes = {env.reptypes with opNamesInScope = mapInsert t.ident (None ()) env.reptypes.opNamesInScope}} in
       let inexpr = typeCheckExpr env t.inexpr in
       let ty = tyTm inexpr in
-      TmOpDecl
-      { info = t.info
-      , ident = t.ident
-      , tyAnnot = tyBody
-      , ty = ty
-      , inexpr = TmOpImpl
+      TmDecl
+      { decl = DeclOp
         { ident = t.ident
+        , tyAnnot = tyBody
+        , info = t.info
+        }
+      , ty = ty
+      , inexpr = TmDecl {decl = DeclOpImpl { ident = t.ident
         , implId = negi 1
         , selfCost = 1.0
         , body = body
@@ -75,7 +76,7 @@ lang LetRepTypesAnalysis = TypeCheck + LetDeclAst + SubstituteNewReprs + OpImplA
         , reprScope = reprScope
         , metaLevel = env.currentLvl
         , info = t.info
-        }
+        }}
       }
     else
       -- Keep it as a Let in the current reprScope, use normal inference
@@ -351,7 +352,7 @@ end
 
 lang OpImplRepTypesAnalysis = TypeCheck + OpImplAst + ResolveType + SubstituteNewReprs + RepTypesHelpers + ApplyReprSubsts
   sem typeCheckExpr env =
-  | TmOpImpl x ->
+  | TmDecl {decl = DeclOpImpl x} ->
     let typeCheckBody = lam env.
       let env = {env with reptypes = {env.reptypes with inImpl = true}} in
       let newLvl = addi 1 env.currentLvl in
@@ -373,12 +374,11 @@ lang OpImplRepTypesAnalysis = TypeCheck + OpImplAst + ResolveType + SubstituteNe
     match withNewReprScope env (lam env. typeCheckBody env)
       with (x, reprScope, []) in
     let inexpr = typeCheckExpr env x.inexpr in
-    TmOpImpl
-    { x with reprScope = reprScope
+    TmDecl {decl = DeclOpImpl { x with reprScope = reprScope
     , metaLevel = env.currentLvl
     , inexpr = inexpr
     , ty = tyTm inexpr
-    }
+    }}
 end
 
 -- NOTE(vipa, 2023-06-26): The RepTypes analysis is essentially
@@ -841,7 +841,7 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
   | tm & TmOpVar x ->
     match addOpUse state.options.debugSolveProcess global state.branch state.topQuery x with (branch, topQuery) in
     ({state with branch = branch, topQuery = topQuery}, tm)
-  | TmOpImpl x ->
+  | TmDecl {decl = DeclOpImpl x} ->
     let implId = state.nextId in
     let state = {state with nextId = addi state.nextId 1} in
     recursive let addSubstsToUni = lam oUni. lam ty.
@@ -887,17 +887,16 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
     -- any new solutions attained along the new branch might use this
     -- new impl, which isn't in scope in whatever we're returning to
     ( {newState with branch = state.branch}
-    , TmOpImpl
-      { x with implId = implId
+    , TmDecl {decl = DeclOpImpl { x with implId = implId
       , inexpr = inexpr
-      }
+      }}
     )
 
   sem findOpUses : [TmOpVarRec] -> Expr -> [TmOpVarRec]
   sem findOpUses acc =
   | tm -> sfold_Expr_Expr findOpUses acc tm
   | TmOpVar x -> snoc acc x
-  | TmOpImpl x -> errorSingle [x.info]
+  | TmDecl {decl = DeclOpImpl x} -> errorSingle [x.info]
     "This impl is nested within another impl, which the current solver doesn't handle."
 
   -- Insert selected solutions --
@@ -933,7 +932,7 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
   sem concretizeAlt : ConcreteState -> Expr -> (ConcreteState, Expr)
   sem concretizeAlt state =
   | tm -> smapAccumL_Expr_Expr concretizeAlt state tm
-  | TmOpDecl {inexpr = inexpr} | TmReprDecl {inexpr = inexpr} ->
+  | TmDecl {decl = DeclOp _ | DeclRepr _, inexpr = inexpr} ->
     concretizeAlt state inexpr
   | TmOpVar x ->
     match state.remainingSolutions with [sol] ++ remainingSolutions in
@@ -941,7 +940,7 @@ lang RepTypesSolveAndReconstruct = RepTypesShallowSolverInterface + OpImplAst + 
     ( {state with remainingSolutions = remainingSolutions}
     , TmVar {ident = name, ty = x.ty, info = x.info, frozen = x.frozen}
     )
-  | TmOpImpl x ->
+  | TmDecl {decl = DeclOpImpl x} ->
     match concretizeAlt state x.inexpr with (state, inexpr) in
     let reqs = mapLookupOr [] x.implId state.requests in
     let wrap = lam req. lam inexpr. TmDecl {decl = DeclLet { ident = req.solName
@@ -8250,7 +8249,7 @@ lang DumpRepTypesProblem = RepTypesFragments
   sem dumpRepTypesProblemWork : (String -> ()) -> [(Name, Type)] -> Expr -> [(Name, Type)]
   sem dumpRepTypesProblemWork output acc =
   | TmOpVar x -> snoc acc (x.ident, x.ty)
-  | TmOpImpl x ->
+  | TmDecl {decl = DeclOpImpl x} ->
     dumpRepTypesProblemRoot output x.reprScope x.body;
     dumpRepTypesProblemWork output acc x.inexpr
   | tm -> sfold_Expr_Expr (dumpRepTypesProblemWork output) acc tm
@@ -8280,8 +8279,8 @@ lang PrintMostFrequentRepr = RepTypesFragments + MExprAst
 
   sem printIfExprHasRepr : Symbol -> Expr -> ()
   sem printIfExprHasRepr reprSymbol =
-  | TmOpDecl x -> printIfExprHasRepr reprSymbol x.inexpr
-  | TmOpImpl x -> printIfExprHasRepr reprSymbol x.inexpr
+  | TmDecl {decl = DeclOp x} -> printIfExprHasRepr reprSymbol x.inexpr
+  | TmDecl {decl = DeclOpImpl x} -> printIfExprHasRepr reprSymbol x.inexpr
   | tm ->
     -- (if hasInExpr tm
     --  then ()
@@ -8316,6 +8315,6 @@ lang PrintMostFrequentRepr = RepTypesFragments + MExprAst
 
   sem hasInExpr : Expr -> Bool
   sem hasInExpr =
-  | TmDecl {decl = DeclLet _} | TmDecl {decl = DeclRecLets _} | TmDecl {decl = DeclExt _} | TmDecl {decl = DeclType _} | TmDecl {decl = DeclConDef _} | TmOpDecl _ | TmOpImpl _ -> true
+  | TmDecl {decl = DeclLet _} | TmDecl {decl = DeclRecLets _} | TmDecl {decl = DeclExt _} | TmDecl {decl = DeclType _} | TmDecl {decl = DeclConDef _} | TmDecl {decl = DeclOp _} | TmDecl {decl = DeclOpImpl _} -> true
   | _ -> false
 end

--- a/src/stdlib/mexpr/reptypes.mc
+++ b/src/stdlib/mexpr/reptypes.mc
@@ -114,7 +114,7 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
   | TmRecLets t ->
     let newLvl = addi 1 env.currentLvl in
     -- First: Generate a new environment containing the recursive bindings
-    let recLetEnvIteratee = lam acc. lam b: RecLetBinding.
+    let recLetEnvIteratee = lam acc. lam b: DeclLetRecord.
       let tyAnnot = resolveType t.info env false b.tyBody in
       let tyAnnot = substituteNewReprs env tyAnnot in
       let tyBody = substituteUnknown t.info {env with currentLvl = newLvl} (Poly ()) tyAnnot in
@@ -129,7 +129,7 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
       mapFoldWithKey (lam vs. lam v. lam k. mapInsert v (newLvl, k) vs) recLetEnv.tyVarEnv tyVars in
 
     -- Second: Type check the body of each binding in the new environment
-    let typeCheckBinding = lam b: RecLetBinding.
+    let typeCheckBinding = lam b: DeclLetRecord.
       let body =
         if nonExpansive true b.body then
           let newEnv = {recLetEnv with currentLvl = newLvl, tyVarEnv = newTyVarEnv} in
@@ -148,7 +148,7 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
     let bindings = map typeCheckBinding bindings in
 
     -- Third: Produce a new environment with generalized types
-    let envIteratee = lam acc. lam b : RecLetBinding.
+    let envIteratee = lam acc. lam b : DeclLetRecord.
       match
         if nonExpansive true b.body then
           (if env.disableRecordPolymorphism then
@@ -176,7 +176,7 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
 --     let typeCheckRecLets = lam env. lam t.
 --       let newLvl = addi 1 env.currentLvl in
 --       -- Build env with the recursive bindings
---       let recLetEnvIteratee = lam acc. lam b: RecLetBinding.
+--       let recLetEnvIteratee = lam acc. lam b: DeclLetRecord.
 --         let tyBody = substituteNewReprs env b.tyBody in
 --         let vars = if nonExpansive true b.body then (stripTyAll tyBody).0 else [] in
 --         let newEnv = _insertVar b.ident tyBody acc.0 in
@@ -190,7 +190,7 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
 --         tyVars in
 
 --       -- Type check each body
---       let typeCheckBinding = lam b: RecLetBinding.
+--       let typeCheckBinding = lam b: DeclLetRecord.
 --         let body =
 --           if nonExpansive true b.body then
 --             let newEnv = {recLetEnv with currentLvl = newLvl, tyVarEnv = newTyVarEnv} in
@@ -207,7 +207,7 @@ lang RecLetsRepTypesAnalysis = TypeCheck + RecLetsAst + MetaVarDisableGeneralize
 --       let bindings = map typeCheckBinding bindings in
 
 --       -- Build env with generalized types
---       let envIteratee = lam acc. lam b : RecLetBinding.
+--       let envIteratee = lam acc. lam b : DeclLetRecord.
 --         match
 --           if nonExpansive true b.body then
 --             (if env.disableRecordPolymorphism then

--- a/src/stdlib/mexpr/runtime-check.mc
+++ b/src/stdlib/mexpr/runtime-check.mc
@@ -104,7 +104,7 @@ lang MExprRuntimeCheck = MExprAst + MExprArity + MExprCmp + MExprPrettyPrint
     else setInsert t.val used
   | t -> sfold_Expr_Expr collectUsedRuntimeCheckedIntrinsics used t
 
-  sem defineRuntimeCheckedFunction : Name -> (Const, Name) -> Expr
+  sem defineRuntimeCheckedFunction : Name -> (Const, Name) -> Decl
   sem defineRuntimeCheckedFunction errId =
   | (intrinsic, id) ->
     -- NOTE(larshum, 2021-11-29): We don't store an info field for the
@@ -124,10 +124,10 @@ lang MExprRuntimeCheck = MExprAst + MExprArity + MExprCmp + MExprPrettyPrint
     let callBody = appSeq_ (uconst_ intrinsic) (map (lam a. var_ a) intrinsicArgs) in
     let infoId = "i" in
     let checks = map (generateCheck infoId) conditions in
-    let body = bindall_ (snoc checks callBody) in
+    let body = bindall_ checks callBody in
     nulet_ id (ulams_ (cons infoId intrinsicArgs) body)
 
-  sem defineRuntimeCheckedFunctions : [Const] -> (Map Const Name, Expr)
+  sem defineRuntimeCheckedFunctions : [Const] -> (Map Const Name, [Decl])
   sem defineRuntimeCheckedFunctions =
   | used ->
     let errorFunctionId = nameSym "errfn" in
@@ -142,7 +142,7 @@ lang MExprRuntimeCheck = MExprAst + MExprArity + MExprCmp + MExprPrettyPrint
     let intrinsicMap : Map Const Name = mapFromSeq cmpConst usedWithId in
     let runtimeCheckedFunctions =
       map (defineRuntimeCheckedFunction errorFunctionId) usedWithId in
-    (intrinsicMap, bindall_ (join [[errorFunction], runtimeCheckedFunctions]))
+    (intrinsicMap, cons errorFunction runtimeCheckedFunctions)
 
   sem callRuntimeCheckedFunctions : Map Const Name -> Expr -> Expr
   sem callRuntimeCheckedFunctions intrinsicIds =
@@ -172,7 +172,7 @@ lang MExprRuntimeCheck = MExprAst + MExprArity + MExprCmp + MExprPrettyPrint
       let used = setToSeq used in
       match defineRuntimeCheckedFunctions used with (intrinsicIds, functions) in
       let t = callRuntimeCheckedFunctions intrinsicIds t in
-      bind_ functions t
+      bindall_ functions t
 end
 
 lang TestLang = MExprRuntimeCheck + MExprPrettyPrint + MExprEq
@@ -195,7 +195,7 @@ let expectedDivi =
       (if_ (_nonZeroCond (var_ "1")) unit_ (err _divByZeroMsg)))
     (divi_ (var_ "0") (var_ "1")))))) in
 utest defineRuntimeCheckedFunction errorFunctionId (CDivi (), divId)
-with expectedDivi using eqExpr in
+with expectedDivi using eqDecl in
 
 let headId = id (CHead ()) in
 let expectedHead =
@@ -204,22 +204,22 @@ let expectedHead =
       (if_ (_nonEmptySequenceCond (var_ "0")) unit_ (err _headEmptyMsg)))
     (head_ (var_ "0"))))) in
 utest defineRuntimeCheckedFunction errorFunctionId (CHead (), headId)
-with expectedHead using eqExpr in
+with expectedHead using eqDecl in
 
 let subseqId = id (CSubsequence ()) in
 let expectedSubseq =
   ulet_ "_subsequence" (ulam_ "i" (ulam_ "0" (ulam_ "1" (ulam_ "2" (bindall_ [
     ulet_ ""
       (if_ (_nonNegativeCond (var_ "1"))
-        unit_ 
+        unit_
         (err _subseqNegativeIndexMsg)),
     ulet_ ""
       (if_ (_nonNegativeCond (var_ "2"))
         unit_
-        (err _subseqNegativeLenMsg)),
-    subsequence_ (var_ "0") (var_ "1") (var_ "2")]))))) in
+        (err _subseqNegativeLenMsg))]
+    (subsequence_ (var_ "0") (var_ "1") (var_ "2"))))))) in
 utest defineRuntimeCheckedFunction errorFunctionId (CSubsequence (), subseqId)
-with expectedSubseq using eqExpr in
+with expectedSubseq using eqDecl in
 
 let tensorGetId = id (CTensorGetExn ()) in
 let expectedTensorGet =
@@ -231,9 +231,9 @@ let expectedTensorGet =
     ulet_ ""
       (if_ (_tensorIdxShapeCond (var_ "0") (var_ "1"))
         unit_
-        (err _tensorShapeMismatchMsg)),
-    utensorGetExn_ (var_ "0") (var_ "1")])))) in
+        (err _tensorShapeMismatchMsg))]
+    (utensorGetExn_ (var_ "0") (var_ "1")))))) in
 utest defineRuntimeCheckedFunction errorFunctionId (CTensorGetExn (), tensorGetId)
-with expectedTensorGet using eqExpr in
+with expectedTensorGet using eqDecl in
 
 ()

--- a/src/stdlib/mexpr/shallow-patterns.mc
+++ b/src/stdlib/mexpr/shallow-patterns.mc
@@ -308,7 +308,7 @@ lang ShallowBase = Ast + NamedPat
         branches
         fallthrough
         (lam name. lam spat. lam t. lam e. mkMatch name t e spat) in
-    bindall_ (snoc lets lowered)
+    bindall_ lets lowered
 end
 
 lang ShallowAnd = ShallowBase + AndPat
@@ -669,7 +669,7 @@ lang ShallowSeq = ShallowBase + SeqTotPat + SeqEdgePat
         in nulet_ name expr) in
     match_ (nvar_ scrutinee)
       (withInfoPat x.info (withTypePat x.ty (pseqtot_ (map npvar_ x.elements))))
-      (bindall_ (snoc slices t))
+      (bindall_ slices t)
       e
   | SPatSeqGE x ->
     let letFrom_ = lam n. lam i. nulet_ n (get_ (nvar_ scrutinee) i) in
@@ -704,7 +704,7 @@ lang ShallowSeq = ShallowBase + SeqTotPat + SeqEdgePat
         in nulet_ name expr) in
     let len = if deref needLen then [nulet_ lenName (length_ (nvar_ scrutinee))] else [] in
     match_ (nvar_ scrutinee) (withInfoPat x.info (withTypePat x.ty (pseqedgew_ (make x.minLength pvarw_) [])))
-      (bindall_ (join [pres, len, slices, posts, [t]]))
+      (bindall_ (join [pres, len, slices, posts]) t)
       e
 
   sem shallowIsInfallible =
@@ -778,8 +778,8 @@ lang LowerNestedPatterns = CollectBranches + ShallowBase
         let elseId = nameSym "_elsBranch" in
         bindall_ [
           nulet_ elseId (ulam_ "" (lowerAll fallthrough)),
-          nulet_ targetId (lowerAll expr),
-          lowerToExpr targetId (map f branches) (app_ (nvar_ elseId) uunit_)]
+          nulet_ targetId (lowerAll expr)]
+        (lowerToExpr targetId (map f branches) (app_ (nvar_ elseId) uunit_))
       else match target with Right name then
         lowerToExpr name (map f branches) (lowerAll fallthrough)
       else never

--- a/src/stdlib/mexpr/side-effect.mc
+++ b/src/stdlib/mexpr/side-effect.mc
@@ -151,11 +151,11 @@ lang MExprSideEffect =
   | TmRecLets t ->
     -- NOTE(larshum, 2022-02-01): The call graph implementation stores bindings
     -- by name, not index, so we need to use a map for binding lookup.
-    let bindMap : Map Name RecLetBinding =
+    let bindMap : Map Name DeclLetRecord =
       mapFromSeq nameCmp
-        (map (lam bind : RecLetBinding. (bind.ident, bind)) t.bindings) in
+        (map (lam bind : DeclLetRecord. (bind.ident, bind)) t.bindings) in
     let sideEffectsScc = lam env : SideEffectEnv. lam scc : [Name].
-      let sccBindings : [RecLetBinding] =
+      let sccBindings : [DeclLetRecord] =
         foldl
           (lam acc. lam id. optionMapOr acc (snoc acc) (mapLookup id bindMap))
           []
@@ -167,12 +167,12 @@ lang MExprSideEffect =
       -- each other.
       let sccHasSideEffect =
         foldl
-          (lam acc : Bool. lam bind : RecLetBinding.
+          (lam acc : Bool. lam bind : DeclLetRecord.
             exprHasSideEffectH env false acc bind.body)
           false sccBindings in
       -- Update the entries for all the bindings in this SCC.
       foldl
-        (lam env : SideEffectEnv. lam bind : RecLetBinding.
+        (lam env : SideEffectEnv. lam bind : DeclLetRecord.
           let lambdaCount = countArityExpr 0 bind.body in
           updateSideEffectEnv env bind.ident lambdaCount sccHasSideEffect)
       env sccBindings in
@@ -181,7 +181,7 @@ lang MExprSideEffect =
     let env = foldl sideEffectsScc env (reverse sccs) in
     let env =
       foldl
-        (lam env : SideEffectEnv. lam bind : RecLetBinding.
+        (lam env : SideEffectEnv. lam bind : DeclLetRecord.
           constructSideEffectEnvH env bind.body)
         env t.bindings in
     constructSideEffectEnvH env t.inexpr

--- a/src/stdlib/mexpr/side-effect.mc
+++ b/src/stdlib/mexpr/side-effect.mc
@@ -142,13 +142,13 @@ lang MExprSideEffect =
   | t -> constructSideEffectEnvH (sideEffectEnvEmpty ()) t
 
   sem constructSideEffectEnvH (env : SideEffectEnv) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let bodySideEffect = exprHasSideEffectH env false false t.body in
     let lambdaCount = countArityExpr 0 t.body in
     let env = updateSideEffectEnv env t.ident lambdaCount bodySideEffect in
     let env = constructSideEffectEnvH env t.body in
     constructSideEffectEnvH env t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     -- NOTE(larshum, 2022-02-01): The call graph implementation stores bindings
     -- by name, not index, so we need to use a map for binding lookup.
     let bindMap : Map Name DeclLetRecord =
@@ -176,7 +176,7 @@ lang MExprSideEffect =
           let lambdaCount = countArityExpr 0 bind.body in
           updateSideEffectEnv env bind.ident lambdaCount sccHasSideEffect)
       env sccBindings in
-    let g : Digraph Name Int = constructCallGraph (TmRecLets t) in
+    let g : Digraph Name Int = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
     let sccs = digraphTarjan g in
     let env = foldl sideEffectsScc env (reverse sccs) in
     let env =
@@ -185,7 +185,7 @@ lang MExprSideEffect =
           constructSideEffectEnvH env bind.body)
         env t.bindings in
     constructSideEffectEnvH env t.inexpr
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     let lambdaCount = countArityType 0 t.tyIdent in
     let env = updateSideEffectEnv env t.ident lambdaCount t.effect in
     constructSideEffectEnvH env t.inexpr

--- a/src/stdlib/mexpr/side-effect.mc
+++ b/src/stdlib/mexpr/side-effect.mc
@@ -99,7 +99,7 @@ lang ConstSideEffect = ConstSideEffectBase + MExprAst
   | CBootParserGetId _ | CBootParserGetTerm _ | CBootParserGetType _
   | CBootParserGetString _ | CBootParserGetInt _ | CBootParserGetFloat _
   | CBootParserGetListLength _ | CBootParserGetConst _ | CBootParserGetPat _
-  | CBootParserGetCopat _ 
+  | CBootParserGetCopat _
   | CBootParserGetInfo _ -> true
 end
 
@@ -142,13 +142,13 @@ lang MExprSideEffect =
   | t -> constructSideEffectEnvH (sideEffectEnvEmpty ()) t
 
   sem constructSideEffectEnvH (env : SideEffectEnv) =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let bodySideEffect = exprHasSideEffectH env false false t.body in
     let lambdaCount = countArityExpr 0 t.body in
     let env = updateSideEffectEnv env t.ident lambdaCount bodySideEffect in
     let env = constructSideEffectEnvH env t.body in
-    constructSideEffectEnvH env t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+    constructSideEffectEnvH env x.inexpr
+  | tm & TmDecl (x & {decl = DeclRecLets t}) ->
     -- NOTE(larshum, 2022-02-01): The call graph implementation stores bindings
     -- by name, not index, so we need to use a map for binding lookup.
     let bindMap : Map Name DeclLetRecord =
@@ -176,7 +176,7 @@ lang MExprSideEffect =
           let lambdaCount = countArityExpr 0 bind.body in
           updateSideEffectEnv env bind.ident lambdaCount sccHasSideEffect)
       env sccBindings in
-    let g : Digraph Name Int = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
+    let g : Digraph Name Int = constructCallGraph tm in
     let sccs = digraphTarjan g in
     let env = foldl sideEffectsScc env (reverse sccs) in
     let env =
@@ -184,11 +184,11 @@ lang MExprSideEffect =
         (lam env : SideEffectEnv. lam bind : DeclLetRecord.
           constructSideEffectEnvH env bind.body)
         env t.bindings in
-    constructSideEffectEnvH env t.inexpr
-  | TmDecl {decl = DeclExt t} ->
+    constructSideEffectEnvH env x.inexpr
+  | TmDecl (x & {decl = DeclExt t}) ->
     let lambdaCount = countArityType 0 t.tyIdent in
     let env = updateSideEffectEnv env t.ident lambdaCount t.effect in
-    constructSideEffectEnvH env t.inexpr
+    constructSideEffectEnvH env x.inexpr
   | t -> sfold_Expr_Expr constructSideEffectEnvH env t
 
   sem countArityExpr (count : Int) =
@@ -230,8 +230,8 @@ let y = nameSym "y" in
 let bindings = bindall_ [
   nulet_ a (ref_ (int_ 2)),
   nulet_ b (nulam_ x (addi_ (nvar_ x) (deref_ (nvar_ x)))),
-  nulet_ c (nulam_ x (nulam_ y (addi_ (nvar_ x) (nvar_ y)))),
-  appf2_ (nvar_ c) (int_ 2) (app_ (nvar_ b) (int_ 3))] in
+  nulet_ c (nulam_ x (nulam_ y (addi_ (nvar_ x) (nvar_ y))))]
+  (appf2_ (nvar_ c) (int_ 2) (app_ (nvar_ b) (int_ 3))) in
 let env : SideEffectEnv = constructSideEffectEnv bindings in
 match env with {sideEffectId = sideEffectId, arityId = arityId} in
 utest setToSeq sideEffectId with [a, b] using eqSeq nameEq in
@@ -250,8 +250,8 @@ let reclets = bindall_ [
     (b, nulam_ x (addi_ (app_ (nvar_ a) (int_ 3)) (app_ (nvar_ c) (nvar_ x)))),
     (c, nulam_ x (bind_ (nulet_ d (wallTimeMs_ (nvar_ x))) (app_ (nvar_ b) (int_ 2))))],
   nulet_ y (app_ (nvar_ b) (int_ 3)),
-  nulet_ z (app_ (nvar_ a) (int_ 2)),
-  int_ 0] in
+  nulet_ z (app_ (nvar_ a) (int_ 2))]
+  (int_ 0) in
 let env : SideEffectEnv = constructSideEffectEnv reclets in
 match env with {sideEffectId = sideEffectId, arityId = arityId} in
 utest setToSeq sideEffectId with [b, c, y, d] using eqSeq nameEq in
@@ -263,8 +263,8 @@ let exts = bindall_ [
   next_ a false (tyarrow_ tyint_ tyint_),
   next_ b true (tyarrow_ tyint_ tyint_),
   nulet_ x (app_ (nvar_ a) (int_ 4)),
-  nulet_ y (app_ (nvar_ b) (int_ 3)),
-  addi_ (nvar_ x) (nvar_ y)] in
+  nulet_ y (app_ (nvar_ b) (int_ 3))]
+  (addi_ (nvar_ x) (nvar_ y)) in
 let env : SideEffectEnv = constructSideEffectEnv exts in
 match env with {sideEffectId = sideEffectId, arityId = arityId} in
 utest setToSeq sideEffectId with [b, y] using eqSeq nameEq in

--- a/src/stdlib/mexpr/symbolize.mc
+++ b/src/stdlib/mexpr/symbolize.mc
@@ -203,6 +203,13 @@ lang Sym = Ast + SymLookup
     let t = smap_Expr_Type (symbolizeType env) t in
     t
 
+  sem symbolizeDecl : SymEnv -> Decl -> (SymEnv, Decl)
+  sem symbolizeDecl env =
+  | d ->
+    let d = smap_Decl_Expr (symbolizeExpr env) d in
+    let d = smap_Decl_Type (symbolizeType env) d in
+    (env, d)
+
   sem symbolizeType : SymEnv -> Type -> Type
   sem symbolizeType env =
   | t -> smap_Type_Type (symbolizeType env) t
@@ -243,7 +250,11 @@ lang Sym = Ast + SymLookup
   -- Add top-level identifiers (along the spine of the program) in `t`
   -- to the given environment.
   sem addTopNames (env : SymEnv) =
-  | t -> env
+  | _ -> env
+
+  sem declAddDefinition : SymEnv -> Decl -> SymEnv
+  sem declAddDefinition env =
+  | _ -> env
 end
 
 lang VarSym = Sym + VarAst
@@ -267,15 +278,30 @@ lang LamSym = Sym + LamAst + VarSym
                   body = symbolizeExpr (symbolizeUpdateVarEnv env varEnv) t.body}
 end
 
-lang LetSym = Sym + LetAst + AllTypeAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmLet t ->
+lang DeclSym = Sym + DeclAst
+  sem symbolizeExpr env =
+  | TmDecl x ->
+    match symbolizeDecl env x.decl with (env, decl) in
+    let inexpr = symbolizeExpr env x.inexpr in
+    TmDecl {x with decl = decl, inexpr = inexpr}
+
+  sem addTopNames (env : SymEnv) =
+  | TmDecl x ->
+    let env = declAddDefinition env x.decl in
+    addTopNames env x.inexpr
+end
+
+lang LetSym = Sym + LetDeclAst + AllTypeAst
+  sem symbolizeDecl (env : SymEnv) =
+  | DeclLet t ->
     match symbolizeTyAnnot env t.tyAnnot with (tyVarEnv, tyAnnot) in
     match setSymbol env.currentEnv.varEnv t.ident with (varEnv, ident) in
-    TmLet {t with ident = ident,
-                  tyAnnot = tyAnnot,
-                  body = symbolizeExpr (symbolizeUpdateTyVarEnv env tyVarEnv) t.body,
-                  inexpr = symbolizeExpr (symbolizeUpdateVarEnv env varEnv) t.inexpr}
+    let decl = DeclLet
+      {t with ident = ident
+      , tyAnnot = tyAnnot
+      , body = symbolizeExpr (symbolizeUpdateTyVarEnv env tyVarEnv) t.body
+      } in
+    (symbolizeUpdateVarEnv env varEnv, decl)
 
   sem symbolizeTyAnnot : SymEnv -> Type -> (Map String Name, Type)
   sem symbolizeTyAnnot env =
@@ -285,15 +311,15 @@ lang LetSym = Sym + LetAst + AllTypeAst
     (foldl (lam env. lam nk. mapInsert (nameGetStr nk.0) nk.0 env)
        env.currentEnv.tyVarEnv vars, symbolized)
 
-  sem addTopNames (env : SymEnv) =
-  | TmLet t ->
+  sem declAddDefinition env =
+  | DeclLet t ->
     let varEnv = mapInsert (nameGetStr t.ident) t.ident env.currentEnv.varEnv in
-    addTopNames (symbolizeUpdateVarEnv env varEnv) t.inexpr
+    symbolizeUpdateVarEnv env varEnv
 end
 
-lang RecLetsSym = Sym + RecLetsAst + LetSym
-  sem symbolizeExpr (env : SymEnv) =
-  | TmRecLets t ->
+lang RecLetsSym = Sym + RecLetsDeclAst + LetSym
+  sem symbolizeDecl (env : SymEnv) =
+  | DeclRecLets t ->
     -- Generate fresh symbols for all identifiers and add to the environment
     let setSymbolIdent = lam env. lam b.
       match setSymbol env b.ident with (env, ident) in
@@ -309,54 +335,58 @@ lang RecLetsSym = Sym + RecLetsAst + LetSym
                           tyAnnot = tyAnnot})
         bindings in
 
-    TmRecLets {t with bindings = bindings,
-                      inexpr = symbolizeExpr newEnv t.inexpr}
+    (newEnv, DeclRecLets {t with bindings = bindings})
 
-  sem addTopNames (env : SymEnv) =
-  | TmRecLets t ->
+  sem declAddDefinition env =
+  | DeclRecLets t ->
     let varEnv =
       foldr (lam b. mapInsert (nameGetStr b.ident) b.ident) env.currentEnv.varEnv t.bindings in
-    addTopNames (symbolizeUpdateVarEnv env varEnv) t.inexpr
+    symbolizeUpdateVarEnv env varEnv
 end
 
-lang ExtSym = Sym + ExtAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmExt t ->
+lang ExtSym = Sym + ExtDeclAst
+  sem symbolizeDecl (env : SymEnv) =
+  | DeclExt t ->
     let setName = if env.ignoreExternals then lam x. lam y. (x, y) else setSymbol in
     match setName env.currentEnv.varEnv t.ident with (varEnv, ident) in
-    TmExt {t with ident = ident,
-                  inexpr = symbolizeExpr (symbolizeUpdateVarEnv env varEnv) t.inexpr,
-                  tyIdent = symbolizeType env t.tyIdent}
+    ( symbolizeUpdateVarEnv env varEnv
+    , DeclExt {t with ident = ident, tyIdent = symbolizeType env t.tyIdent}
+    )
 
-  sem addTopNames (env : SymEnv) =
-  | TmExt t ->
+  sem declAddDefinition (env : SymEnv) =
+  | DeclExt t ->
     let varEnv = mapInsert (nameGetStr t.ident) t.ident env.currentEnv.varEnv in
-    addTopNames (symbolizeUpdateVarEnv env varEnv) t.inexpr
+    symbolizeUpdateVarEnv env varEnv
 end
 
-lang TypeSym = Sym + TypeAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmType t ->
+lang TypeSym = Sym + TypeDeclAst
+  sem symbolizeDecl (env : SymEnv) =
+  | DeclType t ->
     match setSymbol env.currentEnv.tyConEnv t.ident with (tyConEnv, ident) in
     match mapAccumL setSymbol env.currentEnv.tyVarEnv t.params with (tyVarEnv, params) in
-    TmType {t with ident = ident,
-                   params = params,
-                   tyIdent = symbolizeType (symbolizeUpdateTyVarEnv env tyVarEnv) t.tyIdent,
-                   inexpr = symbolizeExpr (symbolizeUpdateTyConEnv env tyConEnv) t.inexpr}
+    ( symbolizeUpdateTyConEnv env tyConEnv
+    , DeclType
+      {t with ident = ident
+      , params = params
+      , tyIdent = symbolizeType (symbolizeUpdateTyVarEnv env tyVarEnv) t.tyIdent
+      }
+    )
 
-  sem addTopNames (env : SymEnv) =
-  | TmType t ->
+  sem declAddDefinition (env : SymEnv) =
+  | DeclType t ->
     let tyConEnv = mapInsert (nameGetStr t.ident) t.ident env.currentEnv.tyConEnv in
-    addTopNames (symbolizeUpdateTyConEnv env tyConEnv) t.inexpr
+    symbolizeUpdateTyConEnv env tyConEnv
 end
 
-lang DataSym = Sym + DataAst
-  sem symbolizeExpr (env : SymEnv) =
-  | TmConDef t ->
+lang DataSym = Sym + DataAst + DataDeclAst
+  sem symbolizeDecl (env : SymEnv) =
+  | DeclConDef t ->
     match setSymbol env.currentEnv.conEnv t.ident with (conEnv, ident) in
-    TmConDef {t with ident = ident,
-                     tyIdent = symbolizeType env t.tyIdent,
-                     inexpr = symbolizeExpr (symbolizeUpdateConEnv env conEnv) t.inexpr}
+    ( symbolizeUpdateConEnv env conEnv
+    , DeclConDef {t with ident = ident, tyIdent = symbolizeType env t.tyIdent}
+    )
+
+  sem symbolizeExpr env =
   | TmConApp t ->
     let ident =
       getSymbol {kind = "constructor",
@@ -367,10 +397,10 @@ lang DataSym = Sym + DataAst
     TmConApp {t with ident = ident,
                      body = symbolizeExpr env t.body}
 
-  sem addTopNames (env : SymEnv) =
-  | TmConDef t ->
+  sem declAddDefinition (env : SymEnv) =
+  | DeclConDef t ->
     let conEnv = mapInsert (nameGetStr t.ident) t.ident env.currentEnv.conEnv in
-    addTopNames (symbolizeUpdateConEnv env conEnv) t.inexpr
+    symbolizeUpdateConEnv env conEnv
 end
 
 lang MatchSym = Sym + MatchAst
@@ -385,8 +415,8 @@ lang MatchSym = Sym + MatchAst
 end
 
 lang OpImplSym = OpImplAst + Sym + LetSym
-  sem symbolizeExpr env =
-  | TmOpImpl x ->
+  sem symbolizeDecl env =
+  | DeclOpImpl x ->
     let ident = getSymbol
       { kind = "variable"
       , info = [x.info]
@@ -396,13 +426,12 @@ lang OpImplSym = OpImplAst + Sym + LetSym
       x.ident in
     match symbolizeTyAnnot env x.specType with (tyVarEnv, specType) in
     let body = symbolizeExpr (symbolizeUpdateTyVarEnv env tyVarEnv) x.body in
-    let inexpr = symbolizeExpr env x.inexpr in
-    TmOpImpl {x with ident = ident, body = body, specType = specType, inexpr = inexpr}
+    (env, DeclOpImpl {x with ident = ident, body = body, specType = specType})
 end
 
 lang OpDeclSym = OpDeclAst + Sym + OpImplAst + ReprDeclAst + OpImplSym
-  sem symbolizeExpr env =
-  | TmOpDecl x ->
+  sem symbolizeDecl env =
+  | DeclOp x ->
     let symbolizeReprDecl = lam reprEnv. lam binding.
       match mapAccumL setSymbol env.currentEnv.tyVarEnv binding.1 .vars with (tyVarEnv, vars) in
       let newEnv = (symbolizeUpdateTyVarEnv env tyVarEnv) in
@@ -416,26 +445,26 @@ lang OpDeclSym = OpDeclAst + Sym + OpImplAst + ReprDeclAst + OpImplSym
       in (reprEnv, res) in
 
     match setSymbol env.currentEnv.varEnv x.ident with (varEnv, ident) in
-    let newEnv = symbolizeUpdateVarEnv env varEnv in
-    let inexpr = symbolizeExpr newEnv x.inexpr in
-    TmOpDecl
+    ( symbolizeUpdateVarEnv env varEnv
+    , DeclOp
       { x with ident = ident
       , tyAnnot = symbolizeType env x.tyAnnot
-      , inexpr = inexpr
       , ty = symbolizeType env x.ty
       }
+    )
 end
 
 lang ReprTypeSym = Sym + ReprDeclAst
   sem symbolizeExpr env =
-  | TmReprDecl x ->
+  | DeclRepr x ->
     match setSymbol env.currentEnv.reprEnv x.ident with (reprEnv, ident) in
     match mapAccumL setSymbol env.currentEnv.tyVarEnv x.vars with (tyVarEnv, vars) in
     let rhsEnv = (symbolizeUpdateTyVarEnv env tyVarEnv) in
     let pat = symbolizeType rhsEnv x.pat in
     let repr = symbolizeType rhsEnv x.repr in
-    let inexpr = symbolizeExpr (symbolizeUpdateReprEnv env reprEnv) x.inexpr in
-    TmReprDecl {x with ident = ident, pat = pat, repr = repr, vars = vars, inexpr = inexpr}
+    ( symbolizeUpdateReprEnv env reprEnv
+    , DeclRepr {x with ident = ident, pat = pat, repr = repr, vars = vars}
+    )
 end
 
 lang OpVarSym = OpVarAst + Sym
@@ -627,7 +656,10 @@ end
 lang MExprSym =
 
   -- Default implementations (Terms)
-  RecordAst + ConstAst + UtestAst + SeqAst + NeverAst + AppAst +
+  RecordAst + ConstAst + SeqAst + NeverAst + AppAst +
+
+  -- Default implementations (Decls)
+  UtestDeclAst +
 
   -- Default implementations (Types)
   UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +
@@ -640,8 +672,10 @@ lang MExprSym =
   SeqTotPat + RecordPat + IntPat + CharPat + BoolPat + AndPat + OrPat +
 
   -- Non-default implementations (Terms)
-  VarSym + LamSym + LetSym + ExtSym + TypeSym + RecLetsSym + DataSym +
-  MatchSym +
+  VarSym + LamSym + DataSym + MatchSym + DeclSym +
+
+  -- Non-default implementations (Decls)
+  LetSym + ExtSym + TypeSym + RecLetsSym +
 
   -- Non-default implementations (Types)
   VariantTypeSym + ConTypeSym + DataTypeSym + VarTypeSym + AllTypeSym +
@@ -670,6 +704,34 @@ lang SymCheck = MExprSym
   sem isFullySymbolized =
   | ast -> isFullySymbolizedExpr ast ()
 
+  sem isFullySymbolizedDecl : Decl -> () -> Bool
+  sem isFullySymbolizedDecl =
+  | DeclLet l ->
+    foldl _and (lam. true) [
+      lam. nameHasSym l.ident,
+      isFullySymbolizedType l.tyAnnot,
+      isFullySymbolizedExpr l.body
+    ]
+  | DeclRecLets l ->
+    let isFullySymbolizedBinding = lam b.
+      _and (lam. nameHasSym b.ident)
+        (_and
+           (isFullySymbolizedType b.tyAnnot)
+           (isFullySymbolizedExpr b.body))
+    in
+    foldl _and (lam. true) (map isFullySymbolizedBinding l.bindings)
+  | DeclType l ->
+    _and (lam. nameHasSym l.ident) (_and
+          (lam. (forAll nameHasSym l.params))
+          (isFullySymbolizedType l.tyIdent))
+  | DeclExt l ->
+    _and (lam. nameHasSym l.ident) (isFullySymbolizedType l.tyIdent)
+  | DeclConDef l ->
+    _and (lam. nameHasSym l.ident) (isFullySymbolizedType l.tyIdent)
+  | d ->
+    _and (sfold_Decl_Expr (_andFold isFullySymbolizedExpr) (lam. true) d)
+      (sfold_Decl_Type (_andFold isFullySymbolizedType) (lam. true) d)
+
   sem isFullySymbolizedExpr : Expr -> () -> Bool
   sem isFullySymbolizedExpr =
   | TmVar t -> lam. nameHasSym t.ident
@@ -678,39 +740,10 @@ lang SymCheck = MExprSym
       (_and
          (isFullySymbolizedType t.tyAnnot)
          (isFullySymbolizedExpr t.body))
-  | TmLet t ->
-    _and (lam. nameHasSym t.ident)
-      (_and (isFullySymbolizedType t.tyAnnot)
-         (_and
-            (isFullySymbolizedExpr t.body)
-            (isFullySymbolizedExpr t.inexpr)))
-  | TmRecLets t ->
-    let isFullySymbolizedBinding = lam b.
-      _and (lam. nameHasSym b.ident)
-        (_and
-           (isFullySymbolizedType b.tyAnnot)
-           (isFullySymbolizedExpr b.body))
-    in
-    _and
-      (foldl (_andFold isFullySymbolizedBinding) (lam. true) t.bindings)
-      (isFullySymbolizedExpr t.inexpr)
-  | TmType t ->
-    _and (lam. forAll nameHasSym t.params)
-      (_and
-         (isFullySymbolizedType t.tyIdent)
-         (isFullySymbolizedExpr t.inexpr))
-  | TmConDef t ->
-    _and (lam. nameHasSym t.ident)
-      (_and
-         (isFullySymbolizedType t.tyIdent)
-         (isFullySymbolizedExpr t.inexpr))
   | TmConApp t ->
     _and (lam. nameHasSym t.ident) (isFullySymbolizedExpr t.body)
-  | TmExt t ->
-    _and (lam. nameHasSym t.ident)
-      (_and
-         (isFullySymbolizedType t.tyIdent)
-         (isFullySymbolizedExpr t.inexpr))
+  | TmDecl x ->
+    _and (isFullySymbolizedDecl x.decl) (isFullySymbolizedExpr x.inexpr)
   | t ->
     _and (sfold_Expr_Expr (_andFold isFullySymbolizedExpr) (lam. true) t)
       (_and
@@ -772,9 +805,8 @@ utest testSymbolize letin false with true in
 
 let lettypein = bindall_ [
   type_ "Type" [] tystr_,
-  type_ "Type" [] (tycon_ "Type"),
-  lam_ "Type" (tycon_ "Type") (var_ "Type")
-] in
+  type_ "Type" [] (tycon_ "Type")
+] (lam_ "Type" (tycon_ "Type") (var_ "Type")) in
 utest testSymbolize lettypein false with true in
 
 let rlets =
@@ -812,10 +844,10 @@ let litpat =
     uunit_ in
 utest testSymbolize litpat false with true in
 
-let ut = utest_ base base base in
+let ut = bind_ (utest_ base base) unit_ in
 utest testSymbolize ut false with true in
 
-let utu = utestu_ base base base (uconst_ (CEqi{})) in
+let utu = bind_ (utestu_ base base (uconst_ (CEqi{}))) unit_ in
 utest testSymbolize utu false with true in
 
 let seq = seq_ [base, data, const, utu] in
@@ -839,15 +871,15 @@ utest testSymbolize matchoredge false with true in
 
 let lettyvar = let_ "f" (tyall_ "a" (tyarrow_ (tyvar_ "a") (tyvar_ "a")))
                         (lam_ "x" (tyvar_ "a") (var_ "x")) in
-utest testSymbolize lettyvar false with true in
+utest testSymbolize (bind_ lettyvar unit_) false with true in
 
 -- NOTE(larshum, 2023-01-20): This test checks that the type parameters of a
 -- type application are not erased when the constructor is a free variable.
-let tyconApps = bindall_ [
+let tyconApps = bind_ (
   let_ "f"
     (tyall_ "a" (tyarrow_ (tyapp_ (tycon_ "Con") (tyvar_ "a")) (tyvar_ "a")))
     (ulam_ "x" never_)
-] in
+) unit_ in
 utest expr2str (symbolizeAllowFree tyconApps) with expr2str tyconApps using eqString in
 
 ()

--- a/src/stdlib/mexpr/symbolize.mc
+++ b/src/stdlib/mexpr/symbolize.mc
@@ -449,13 +449,12 @@ lang OpDeclSym = OpDeclAst + Sym + OpImplAst + ReprDeclAst + OpImplSym
     , DeclOp
       { x with ident = ident
       , tyAnnot = symbolizeType env x.tyAnnot
-      , ty = symbolizeType env x.ty
       }
     )
 end
 
 lang ReprTypeSym = Sym + ReprDeclAst
-  sem symbolizeExpr env =
+  sem symbolizeDecl env =
   | DeclRepr x ->
     match setSymbol env.currentEnv.reprEnv x.ident with (reprEnv, ident) in
     match mapAccumL setSymbol env.currentEnv.tyVarEnv x.vars with (tyVarEnv, vars) in

--- a/src/stdlib/mexpr/type-annot.mc
+++ b/src/stdlib/mexpr/type-annot.mc
@@ -351,14 +351,14 @@ lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsAst + LamAst + Unkn
     -- Add mapping from binding identifier to annotated type before doing type
     -- annotations of the bindings. This is to make annotations work for
     -- mutually recursive functions, given correct type annotations.
-    let foldBindingInit = lam acc. lam binding : RecLetBinding.
+    let foldBindingInit = lam acc. lam binding : DeclLetRecord.
       mapInsert binding.ident binding.tyBody acc
     in
     -- Add mapping from binding identifier to the inferred type.
-    let foldBindingAfter = lam acc. lam binding : RecLetBinding.
+    let foldBindingAfter = lam acc. lam binding : DeclLetRecord.
       mapInsert binding.ident binding.tyBody acc
     in
-    let annotBinding = lam env : TypeEnv. lam binding : RecLetBinding.
+    let annotBinding = lam env : TypeEnv. lam binding : DeclLetRecord.
       let body = match binding.tyBody with TyUnknown _ then binding.body else
         match inspectType binding.tyBody with tyBody in
         propagateExpectedType env.tyEnv (tyBody, binding.body) in
@@ -835,9 +835,9 @@ let recLets = typeAnnot (bindall_ [
 utest tyTm recLets with tyunit_ using eqType in
 
 (match recLets with TmRecLets {bindings = bindings} then
-  let b0 : RecLetBinding = get bindings 0 in
-  let b1 : RecLetBinding = get bindings 1 in
-  let b2 : RecLetBinding = get bindings 2 in
+  let b0 : DeclLetRecord = get bindings 0 in
+  let b1 : DeclLetRecord = get bindings 1 in
+  let b2 : DeclLetRecord = get bindings 2 in
   let xTy = tyarrow_ tyunit_ tyint_ in
   let yTy = tyarrow_ tyunit_ tyint_ in
   let zTy = tyarrow_ tyunit_ tyint_ in

--- a/src/stdlib/mexpr/type-annot.mc
+++ b/src/stdlib/mexpr/type-annot.mc
@@ -284,7 +284,7 @@ lang TypePropagation = TypeAnnot
   | (_, t) -> t
 end
 
-lang LetTypeAnnot = TypeAnnot + TypePropagation + LetAst +  UnknownTypeAst + AllTypeAst
+lang LetTypeAnnot = TypeAnnot + TypePropagation + LetDeclAst +  UnknownTypeAst + AllTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmLet t ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
@@ -309,12 +309,12 @@ lang LetTypeAnnot = TypeAnnot + TypePropagation + LetAst +  UnknownTypeAst + All
     else never
 end
 
-lang PropagateLetType = TypePropagation + LetAst
+lang PropagateLetType = TypePropagation + LetDeclAst
   sem propagateExpectedType (tyEnv : Map Name Type) =
   | (ty, TmLet t) -> TmLet {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}
 end
 
-lang PropagateRecLetsType = TypePropagation + RecLetsAst
+lang PropagateRecLetsType = TypePropagation + RecLetsDeclAst
   sem propagateExpectedType (tyEnv : Map Name Type) =
   | (ty, TmRecLets t) -> TmRecLets {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}
 end
@@ -334,7 +334,7 @@ lang PropagateArrowLambda = TypePropagation + FunTypeAst + LamAst
       errorSingle [t.info] msg
 end
 
-lang ExpTypeAnnot = TypeAnnot + ExtAst
+lang ExpTypeAnnot = TypeAnnot + ExtDeclAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmExt t ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
@@ -345,7 +345,7 @@ lang ExpTypeAnnot = TypeAnnot + ExtAst
     else never
 end
 
-lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsAst + LamAst + UnknownTypeAst + AllTypeAst
+lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsDeclAst + LamAst + UnknownTypeAst + AllTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmRecLets t ->
     -- Add mapping from binding identifier to annotated type before doing type
@@ -430,7 +430,7 @@ lang RecordTypeAnnot = TypeAnnot + RecordAst + RecordTypeAst
                         with ty = tyTm rec}
 end
 
-lang TypeTypeAnnot = TypeAnnot + TypeAst
+lang TypeTypeAnnot = TypeAnnot + TypeDeclAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmType t ->
     let tyEnv = mapInsert t.ident t.tyIdent env.tyEnv in
@@ -501,7 +501,7 @@ lang MatchTypeAnnot = TypeAnnot + MatchAst + MExprEq
     else never
 end
 
-lang UtestTypeAnnot = TypeAnnot + UtestAst + MExprEq
+lang UtestTypeAnnot = TypeAnnot + UtestDeclAst + MExprEq
   sem typeAnnotExpr (env : TypeEnv) =
   | TmUtest t ->
     let test = typeAnnotExpr env t.test in

--- a/src/stdlib/mexpr/type-annot.mc
+++ b/src/stdlib/mexpr/type-annot.mc
@@ -286,7 +286,7 @@ end
 
 lang LetTypeAnnot = TypeAnnot + TypePropagation + LetDeclAst +  UnknownTypeAst + AllTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
       let body = match t.tyBody with TyUnknown _ then t.body else
         match inspectType t.tyBody with tyBody in
@@ -294,11 +294,15 @@ lang LetTypeAnnot = TypeAnnot + TypePropagation + LetDeclAst +  UnknownTypeAst +
       let body = typeAnnotExpr env body in
       match compatibleType tyEnv t.tyBody (tyTm body) with Some tyBody then
         let env = {env with varEnv = mapInsert t.ident tyBody varEnv} in
-        let inexpr = typeAnnotExpr env t.inexpr in
-        TmDecl {decl = DeclLet {t with tyBody = tyBody,
-                      body = withType tyBody body,
-                      inexpr = inexpr,
-                      ty = tyTm inexpr}}
+        let inexpr = typeAnnotExpr env x.inexpr in
+        TmDecl
+        {x with decl = DeclLet
+          {t with tyBody = tyBody
+          , body = withType tyBody body
+          }
+        , inexpr = inexpr
+        , ty = tyTm inexpr
+        }
       else
         let msg = join [
           "Inconsistent type annotation of let-expression\n",
@@ -309,14 +313,9 @@ lang LetTypeAnnot = TypeAnnot + TypePropagation + LetDeclAst +  UnknownTypeAst +
     else never
 end
 
-lang PropagateLetType = TypePropagation + LetDeclAst
-  sem propagateExpectedType (tyEnv : Map Name Type) =
-  | (ty, TmDecl {decl = DeclLet t}) -> TmDecl {decl = DeclLet {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}}
-end
-
-lang PropagateRecLetsType = TypePropagation + RecLetsDeclAst
-  sem propagateExpectedType (tyEnv : Map Name Type) =
-  | (ty, TmDecl {decl = DeclRecLets t}) -> TmDecl {decl = DeclRecLets {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}}
+lang PropagateDeclType = TypePropagation + DeclAst
+  sem propagateExpectedType tyEnv =
+  | (ty, TmDecl x) -> TmDecl {x with inexpr = propagateExpectedType tyEnv (ty, x.inexpr)}
 end
 
 lang PropagateArrowLambda = TypePropagation + FunTypeAst + LamAst
@@ -336,18 +335,17 @@ end
 
 lang ExpTypeAnnot = TypeAnnot + ExtDeclAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmDecl {decl = DeclExt t} ->
+  | TmDecl (x & {decl = DeclExt t}) ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
       let env = {env with varEnv = mapInsert t.ident t.tyIdent varEnv} in
-      let inexpr = typeAnnotExpr env t.inexpr in
-      TmDecl {decl = DeclExt {{t with inexpr = inexpr}
-                with ty = tyTm inexpr}}
+      let inexpr = typeAnnotExpr env x.inexpr in
+      TmDecl {x with inexpr = inexpr, ty = tyTm inexpr}
     else never
 end
 
 lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsDeclAst + LamAst + UnknownTypeAst + AllTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     -- Add mapping from binding identifier to annotated type before doing type
     -- annotations of the bindings. This is to make annotations work for
     -- mutually recursive functions, given correct type annotations.
@@ -383,10 +381,10 @@ lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsDeclAst + LamAst + 
       let env = {env with varEnv = foldl foldBindingInit varEnv t.bindings} in
       let bindings = map (annotBinding env) t.bindings in
       let env = {env with varEnv = foldl foldBindingAfter varEnv bindings} in
-      let inexpr = typeAnnotExpr env t.inexpr in
-      TmDecl {decl = DeclRecLets {{{t with bindings = bindings}
-                     with inexpr = inexpr}
-                     with ty = tyTm inexpr}}
+      let inexpr = typeAnnotExpr env x.inexpr in
+      TmDecl {x with decl = DeclRecLets {t with bindings = bindings}
+                     , inexpr = inexpr
+                     , ty = tyTm inexpr}
     else never
 end
 
@@ -432,21 +430,19 @@ end
 
 lang TypeTypeAnnot = TypeAnnot + TypeDeclAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmDecl {decl = DeclType t} ->
+  | TmDecl (x & {decl = DeclType t}) ->
     let tyEnv = mapInsert t.ident t.tyIdent env.tyEnv in
-    let inexpr = typeAnnotExpr {env with tyEnv = tyEnv} t.inexpr in
-    TmDecl {decl = DeclType {{t with inexpr = inexpr}
-               with ty = tyTm inexpr}}
+    let inexpr = typeAnnotExpr {env with tyEnv = tyEnv} x.inexpr in
+    TmDecl {x with inexpr = inexpr, ty = tyTm inexpr}
 end
 
 lang DataTypeAnnot = TypeAnnot + DataAst + MExprEq
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmDecl {decl = DeclConDef t} ->
+  | TmDecl (x & {decl = DeclConDef t}) ->
     match env with {conEnv = conEnv} then
       let env = {env with conEnv = mapInsert t.ident t.tyIdent conEnv} in
-      let inexpr = typeAnnotExpr env t.inexpr in
-      TmDecl {decl = DeclConDef {{t with inexpr = inexpr}
-                   with ty = tyTm inexpr}}
+      let inexpr = typeAnnotExpr env x.inexpr in
+      TmDecl {x with inexpr = inexpr, ty = tyTm inexpr}
     else never
   | TmConApp t ->
     let body = typeAnnotExpr env t.body in
@@ -503,10 +499,10 @@ end
 
 lang UtestTypeAnnot = TypeAnnot + UtestDeclAst + MExprEq
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmDecl {decl = DeclUtest t} ->
+  | TmDecl (x & {decl = DeclUtest t}) ->
     let test = typeAnnotExpr env t.test in
     let expected = typeAnnotExpr env t.expected in
-    let next = typeAnnotExpr env t.next in
+    let inexpr = typeAnnotExpr env x.inexpr in
     let tusing = optionMap (typeAnnotExpr env) t.tusing in
     let tonfail = optionMap (typeAnnotExpr env) t.tonfail in
     let failMsgType = lam eqFun : Bool. lam ty.
@@ -615,7 +611,7 @@ lang UtestTypeAnnot = TypeAnnot + UtestDeclAst + MExprEq
         ] in
         errorSingle [t.info] msg
     in
-    TmDecl {decl = DeclUtest {t with next = next, ty = tyTm next}}
+    TmDecl {x with inexpr = inexpr, ty = tyTm inexpr, decl = DeclUtest t}
 end
 
 lang NeverTypeAnnot = TypeAnnot + NeverAst
@@ -770,7 +766,7 @@ lang MExprTypeAnnot =
   IntCompatibleType + FloatCompatibleType + CharCompatibleType +
   FunCompatibleType + SeqCompatibleType + TensorCompatibleType +
   RecordCompatibleType + VariantCompatibleType + AppCompatibleType +
-  PropagateArrowLambda + PropagateLetType + VarCompatibleType +
+  PropagateDeclType + PropagateArrowLambda + VarCompatibleType +
   AllCompatibleType + AliasCompatibleType +
 
   -- Terms
@@ -811,9 +807,8 @@ with  tyarrow_ tyint_ tyint_
 using eqType in
 
 let badApp = bindall_ [
-  nulet_ x (int_ 5),
-  app_ (nvar_ x) (float_ 3.14)
-] in
+  nulet_ x (int_ 5)]
+  (app_ (nvar_ x) (float_ 3.14)) in
 utest tyTm (typeAnnot badApp) with tyunknown_ using eqType in
 
 let lamConstantReturnType = nulam_ x (int_ 0) in
@@ -829,9 +824,9 @@ let recLets = typeAnnot (bindall_ [
     (x, tyarrow_ tyunit_ tyint_, nlam_ n tyunit_ (app_ (nvar_ y) uunit_)),
     (y, tyunknown_, nlam_ n tyunit_ (app_ (nvar_ x) uunit_)),
     (z, tyunknown_, nlam_ n tyunit_ (addi_ (app_ (nvar_ y) uunit_) (int_ 1)))
-  ],
+  ]]
   uunit_
-]) in
+) in
 utest tyTm recLets with tyunit_ using eqType in
 
 (match recLets with TmDecl {decl = DeclRecLets {bindings = bindings}} then
@@ -895,17 +890,16 @@ utest tyTm (typeAnnot typeDecl) with tyunit_ using eqType in
 
 let conApp = bindall_ [
   ntype_ n [] tyunknown_,
-  ncondef_ x (tyarrow_ tyint_ (ntycon_ n)),
-  nconapp_ x (int_ 4)
-] in
+  ncondef_ x (tyarrow_ tyint_ (ntycon_ n))]
+  (nconapp_ x (int_ 4)) in
 utest tyTm (typeAnnot conApp) with ntycon_ n using eqType in
 
 let matchInteger = typeAnnot (bindall_ [
-  nulet_ x (int_ 0),
-  match_ (nvar_ x) (pint_ 0) (nvar_ x) (addi_ (nvar_ x) (int_ 1))
-]) in
+  nulet_ x (int_ 0)]
+  (match_ (nvar_ x) (pint_ 0) (nvar_ x) (addi_ (nvar_ x) (int_ 1))
+)) in
 utest tyTm matchInteger with tyint_ using eqType in
-(match matchInteger with TmDecl {decl = DeclLet {inexpr = TmMatch t}} then
+(match matchInteger with TmDecl {inexpr = TmMatch t, decl = DeclLet _} then
   utest tyTm t.target with tyint_ using eqType in
   utest tyTm t.thn with tyint_ using eqType in
   utest tyTm t.els with tyint_ using eqType in
@@ -923,26 +917,26 @@ utest tyTm matchDistinct with tyunknown_ using eqType in
   ()
 else never);
 
-let utestAnnot = typeAnnot (
-  utest_ (int_ 0) (int_ 1) (char_ 'c')
-) in
+let utestAnnot = typeAnnot (bind_ (
+  utest_ (int_ 0) (int_ 1)
+) (char_ 'c')) in
 utest tyTm utestAnnot with tychar_ using eqType in
-(match utestAnnot with TmDecl {decl = DeclUtest t} then
+(match utestAnnot with TmDecl {decl = DeclUtest t, inexpr = inexpr} then
   utest tyTm t.test with tyint_ using eqType in
   utest tyTm t.expected with tyint_ using eqType in
-  utest tyTm t.next with tychar_ using eqType in
+  utest tyTm inexpr with tychar_ using eqType in
   ()
 else never);
 
 utest tyTm (typeAnnot never_) with tyunknown_ using eqType in
 
 -- Test that types are propagated through patterns in match expressions
-let matchSeq = bindall_ [
+let matchSeq =
   match_ (seq_ [str_ "a", str_ "b", str_ "c", str_ "d"])
     (pseqedge_ [pseqtot_ [pchar_ 'a']] "mid" [pseqtot_ [pchar_ 'd']])
     (var_ "mid")
     never_
-] in
+in
 utest tyTm (typeAnnot (symbolize matchSeq)) with tyseq_ tystr_ using eqType in
 
 let matchTree = bindall_ [
@@ -953,7 +947,7 @@ let matchTree = bindall_ [
     conapp_ "Leaf" (seq_ [int_ 1, int_ 2, int_ 3]),
     conapp_ "Branch" (utuple_ [
       conapp_ "Leaf" (seq_ [int_ 2]),
-      conapp_ "Leaf" (seq_ [])])])),
+      conapp_ "Leaf" (seq_ [])])]))]
   (match_ (var_ "t")
     (pcon_ "Branch" (ptuple_ [pvar_ "lhs", pvar_ "rhs"]))
     (match_ (var_ "lhs")
@@ -961,7 +955,7 @@ let matchTree = bindall_ [
       (var_ "n")
       never_)
     never_)
-] in
+in
 utest tyTm (typeAnnot (symbolize matchTree)) with tyseq_ tyint_ using eqType in
 
 ()

--- a/src/stdlib/mexpr/type-annot.mc
+++ b/src/stdlib/mexpr/type-annot.mc
@@ -286,7 +286,7 @@ end
 
 lang LetTypeAnnot = TypeAnnot + TypePropagation + LetDeclAst +  UnknownTypeAst + AllTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
       let body = match t.tyBody with TyUnknown _ then t.body else
         match inspectType t.tyBody with tyBody in
@@ -295,10 +295,10 @@ lang LetTypeAnnot = TypeAnnot + TypePropagation + LetDeclAst +  UnknownTypeAst +
       match compatibleType tyEnv t.tyBody (tyTm body) with Some tyBody then
         let env = {env with varEnv = mapInsert t.ident tyBody varEnv} in
         let inexpr = typeAnnotExpr env t.inexpr in
-        TmLet {t with tyBody = tyBody,
+        TmDecl {decl = DeclLet {t with tyBody = tyBody,
                       body = withType tyBody body,
                       inexpr = inexpr,
-                      ty = tyTm inexpr}
+                      ty = tyTm inexpr}}
       else
         let msg = join [
           "Inconsistent type annotation of let-expression\n",
@@ -311,12 +311,12 @@ end
 
 lang PropagateLetType = TypePropagation + LetDeclAst
   sem propagateExpectedType (tyEnv : Map Name Type) =
-  | (ty, TmLet t) -> TmLet {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}
+  | (ty, TmDecl {decl = DeclLet t}) -> TmDecl {decl = DeclLet {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}}
 end
 
 lang PropagateRecLetsType = TypePropagation + RecLetsDeclAst
   sem propagateExpectedType (tyEnv : Map Name Type) =
-  | (ty, TmRecLets t) -> TmRecLets {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}
+  | (ty, TmDecl {decl = DeclRecLets t}) -> TmDecl {decl = DeclRecLets {t with inexpr = propagateExpectedType tyEnv (ty, t.inexpr)}}
 end
 
 lang PropagateArrowLambda = TypePropagation + FunTypeAst + LamAst
@@ -336,18 +336,18 @@ end
 
 lang ExpTypeAnnot = TypeAnnot + ExtDeclAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     match env with {varEnv = varEnv, tyEnv = tyEnv} then
       let env = {env with varEnv = mapInsert t.ident t.tyIdent varEnv} in
       let inexpr = typeAnnotExpr env t.inexpr in
-      TmExt {{t with inexpr = inexpr}
-                with ty = tyTm inexpr}
+      TmDecl {decl = DeclExt {{t with inexpr = inexpr}
+                with ty = tyTm inexpr}}
     else never
 end
 
 lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsDeclAst + LamAst + UnknownTypeAst + AllTypeAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     -- Add mapping from binding identifier to annotated type before doing type
     -- annotations of the bindings. This is to make annotations work for
     -- mutually recursive functions, given correct type annotations.
@@ -384,9 +384,9 @@ lang RecLetsTypeAnnot = TypeAnnot + TypePropagation + RecLetsDeclAst + LamAst + 
       let bindings = map (annotBinding env) t.bindings in
       let env = {env with varEnv = foldl foldBindingAfter varEnv bindings} in
       let inexpr = typeAnnotExpr env t.inexpr in
-      TmRecLets {{{t with bindings = bindings}
+      TmDecl {decl = DeclRecLets {{{t with bindings = bindings}
                      with inexpr = inexpr}
-                     with ty = tyTm inexpr}
+                     with ty = tyTm inexpr}}
     else never
 end
 
@@ -432,21 +432,21 @@ end
 
 lang TypeTypeAnnot = TypeAnnot + TypeDeclAst
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmType t ->
+  | TmDecl {decl = DeclType t} ->
     let tyEnv = mapInsert t.ident t.tyIdent env.tyEnv in
     let inexpr = typeAnnotExpr {env with tyEnv = tyEnv} t.inexpr in
-    TmType {{t with inexpr = inexpr}
-               with ty = tyTm inexpr}
+    TmDecl {decl = DeclType {{t with inexpr = inexpr}
+               with ty = tyTm inexpr}}
 end
 
 lang DataTypeAnnot = TypeAnnot + DataAst + MExprEq
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmConDef t ->
+  | TmDecl {decl = DeclConDef t} ->
     match env with {conEnv = conEnv} then
       let env = {env with conEnv = mapInsert t.ident t.tyIdent conEnv} in
       let inexpr = typeAnnotExpr env t.inexpr in
-      TmConDef {{t with inexpr = inexpr}
-                   with ty = tyTm inexpr}
+      TmDecl {decl = DeclConDef {{t with inexpr = inexpr}
+                   with ty = tyTm inexpr}}
     else never
   | TmConApp t ->
     let body = typeAnnotExpr env t.body in
@@ -503,7 +503,7 @@ end
 
 lang UtestTypeAnnot = TypeAnnot + UtestDeclAst + MExprEq
   sem typeAnnotExpr (env : TypeEnv) =
-  | TmUtest t ->
+  | TmDecl {decl = DeclUtest t} ->
     let test = typeAnnotExpr env t.test in
     let expected = typeAnnotExpr env t.expected in
     let next = typeAnnotExpr env t.next in
@@ -615,7 +615,7 @@ lang UtestTypeAnnot = TypeAnnot + UtestDeclAst + MExprEq
         ] in
         errorSingle [t.info] msg
     in
-    TmUtest {t with next = next, ty = tyTm next}
+    TmDecl {decl = DeclUtest {t with next = next, ty = tyTm next}}
 end
 
 lang NeverTypeAnnot = TypeAnnot + NeverAst
@@ -834,7 +834,7 @@ let recLets = typeAnnot (bindall_ [
 ]) in
 utest tyTm recLets with tyunit_ using eqType in
 
-(match recLets with TmRecLets {bindings = bindings} then
+(match recLets with TmDecl {decl = DeclRecLets {bindings = bindings}} then
   let b0 : DeclLetRecord = get bindings 0 in
   let b1 : DeclLetRecord = get bindings 1 in
   let b2 : DeclLetRecord = get bindings 2 in
@@ -905,7 +905,7 @@ let matchInteger = typeAnnot (bindall_ [
   match_ (nvar_ x) (pint_ 0) (nvar_ x) (addi_ (nvar_ x) (int_ 1))
 ]) in
 utest tyTm matchInteger with tyint_ using eqType in
-(match matchInteger with TmLet {inexpr = TmMatch t} then
+(match matchInteger with TmDecl {decl = DeclLet {inexpr = TmMatch t}} then
   utest tyTm t.target with tyint_ using eqType in
   utest tyTm t.thn with tyint_ using eqType in
   utest tyTm t.els with tyint_ using eqType in
@@ -927,7 +927,7 @@ let utestAnnot = typeAnnot (
   utest_ (int_ 0) (int_ 1) (char_ 'c')
 ) in
 utest tyTm utestAnnot with tychar_ using eqType in
-(match utestAnnot with TmUtest t then
+(match utestAnnot with TmDecl {decl = DeclUtest t} then
   utest tyTm t.test with tyint_ using eqType in
   utest tyTm t.expected with tyint_ using eqType in
   utest tyTm t.next with tychar_ using eqType in

--- a/src/stdlib/mexpr/type-check.mc
+++ b/src/stdlib/mexpr/type-check.mc
@@ -1107,7 +1107,8 @@ lang OpDeclTypeCheck = OpDeclAst + TypeCheck + ResolveType + SubstituteNewReprs
     let lvl = env.currentLvl in
     let tyAnnot = resolveType x.info env false x.tyAnnot in
     let tyAnnot = substituteNewReprs env tyAnnot in
-    ( { env with reptypes =
+    ( _insertVar x.ident tyAnnot
+      { env with reptypes =
         { env.reptypes with opNamesInScope = mapInsert x.ident (None ()) env.reptypes.opNamesInScope
         }
       }

--- a/src/stdlib/mexpr/type-check.mc
+++ b/src/stdlib/mexpr/type-check.mc
@@ -772,7 +772,14 @@ lang TypeCheck = TCUnify + Generalize + RemoveMetaVar
   | tm ->
     dprint tm;
     print "\n";
-    error "Unmatched term expression in 'typeCheckExpr'"
+    errorSingle [infoTm tm] "Unmatched term expression in 'typeCheckExpr'"
+
+  sem typeCheckDecl : TCEnv -> Decl -> (TCEnv, Decl)
+  sem typeCheckDecl env =
+  | d ->
+    dprint d;
+    print "\n";
+    errorSingle [infoDecl d] "Unmatched decl in 'typeCheckDecl'"
 end
 
 lang PatTypeCheck = TCUnify
@@ -1082,25 +1089,43 @@ lang AppTypeCheck = TypeCheck + AppAst
     TmApp {t with lhs = lhs, rhs = rhs, ty = tyRes}
 end
 
-lang OpDeclTypeCheck = OpDeclAst + TypeCheck + ResolveType + SubstituteNewReprs
+lang DeclTypeCheck = TypeCheck + DeclAst
   sem typeCheckExpr env =
-  | TmOpDecl x ->
+  | TmDecl x ->
+    let preLvl = env.currentLvl in
+    match typeCheckDecl env x.decl with (env, decl) in
+    let inexpr = typeCheckExpr env x.inexpr in
+    (if gti env.currentLvl preLvl then
+      unify env [infoDecl x.decl, infoTm inexpr] (newpolyvar preLvl x.info) (tyTm inexpr)
+     else ());
+    TmDecl {x with decl = decl, inexpr = inexpr, ty = tyTm inexpr}
+end
+
+lang OpDeclTypeCheck = OpDeclAst + TypeCheck + ResolveType + SubstituteNewReprs
+  sem typeCheckDecl env =
+  | DeclOp x ->
     let lvl = env.currentLvl in
     let tyAnnot = resolveType x.info env false x.tyAnnot in
     let tyAnnot = substituteNewReprs env tyAnnot in
-    let env = {env with reptypes = {env.reptypes with opNamesInScope = mapInsert x.ident (None ()) env.reptypes.opNamesInScope}} in
-    let inexpr = typeCheckExpr (_insertVar x.ident tyAnnot env) x.inexpr in
-    TmOpDecl {x with inexpr = inexpr, ty = tyTm inexpr, tyAnnot = tyAnnot}
+    ( { env with reptypes =
+        { env.reptypes with opNamesInScope = mapInsert x.ident (None ()) env.reptypes.opNamesInScope
+        }
+      }
+    , DeclOp {x with tyAnnot = tyAnnot}
+    )
 end
 
 lang ReprDeclTypeCheck = ReprDeclAst + TypeCheck + ResolveType + WildToMeta
-  sem typeCheckExpr env =
-  | TmReprDecl x ->
+  sem typeCheckDecl env =
+  | DeclRepr x ->
     let pat = resolveType x.info env false x.pat in
     let repr = resolveType x.info env false x.repr in
-    let env = {env with reptypes = {env.reptypes with reprEnv = mapInsert x.ident {vars = x.vars, pat = pat, repr = repr} env.reptypes.reprEnv}} in
-    let inexpr = typeCheckExpr env x.inexpr in
-    TmReprDecl {x with inexpr = inexpr, ty = tyTm inexpr, pat = pat, repr = repr}
+    ( { env with reptypes =
+        { env.reptypes with reprEnv = mapInsert x.ident {vars = x.vars, pat = pat, repr = repr} env.reptypes.reprEnv
+        }
+      }
+    , DeclRepr {x with pat = pat, repr = repr}
+    )
 end
 
 lang PropagateTypeAnnot = FunTypeAst + LamAst + UnknownTypeAst + AllTypeAst
@@ -1114,10 +1139,10 @@ lang PropagateTypeAnnot = FunTypeAst + LamAst + UnknownTypeAst + AllTypeAst
 end
 
 lang LetTypeCheck =
-  TypeCheck + LetAst + LamAst + FunTypeAst + ResolveType + SubstituteUnknown +
+  TypeCheck + LetDeclAst + LamAst + FunTypeAst + ResolveType + SubstituteUnknown +
   NonExpansive + MetaVarDisableGeneralize + PropagateTypeAnnot + SubstituteNewReprs
-  sem typeCheckExpr env =
-  | TmLet t ->
+  sem typeCheckDecl env =
+  | DeclLet t ->
     let newLvl = addi 1 env.currentLvl in
     let tyAnnot = resolveType t.info env false t.tyAnnot in
     let tyAnnot = substituteNewReprs env tyAnnot in
@@ -1142,12 +1167,13 @@ lang LetTypeCheck =
         weakenMetaVars env.currentLvl tyBody;
         (body, tyBody)
     with (body, tyBody) in
-    let inexpr = typeCheckExpr (_insertVar t.ident tyBody env) t.inexpr in
-    TmLet {t with body = body,
-                  tyAnnot = tyAnnot,
-                  tyBody = tyBody,
-                  inexpr = inexpr,
-                  ty = tyTm inexpr}
+    ( _insertVar t.ident tyBody env
+    , DeclLet
+      {t with body = body
+      , tyAnnot = tyAnnot
+      , tyBody = tyBody
+      }
+    )
 end
 
 lang ApplyReprSubsts = TypeCheck + WildToMeta + ReprSubstAst
@@ -1185,8 +1211,8 @@ lang ApplyReprSubsts = TypeCheck + WildToMeta + ReprSubstAst
 end
 
 lang OpImplTypeCheck = OpImplAst + TypeCheck + ResolveType + PropagateTypeAnnot + SubstituteNewReprs + WildToMeta + ApplyReprSubsts + SubstituteUnknown
-  sem typeCheckExpr env =
-  | TmOpImpl x ->
+  sem typeCheckDecl env =
+  | DeclOpImpl x ->
     match mapLookup x.ident env.varEnv with Some ty then
       if optionIsSome (mapLookup x.ident env.reptypes.opNamesInScope) then
         let newLvl = addi 1 env.currentLvl in
@@ -1231,13 +1257,12 @@ lang OpImplTypeCheck = OpImplAst + TypeCheck + ResolveType + PropagateTypeAnnot 
           {x with body = body, delayedReprUnifications = delayedReprUnifications, specType = specType} in
         match withNewReprScope env (lam env. typeCheckBody env)
           with (x, reprScope, []) in
-        let inexpr = typeCheckExpr env x.inexpr in
-        TmOpImpl
-        { x with reprScope = reprScope
-        , metaLevel = newLvl
-        , inexpr = inexpr
-        , ty = tyTm inexpr
-        }
+        ( env
+        , DeclOpImpl
+          { x with reprScope = reprScope
+          , metaLevel = newLvl
+          }
+        )
       else
         let msg = join
           [ "* Encountered implementation of a non-operation: "
@@ -1254,14 +1279,14 @@ lang OpImplTypeCheck = OpImplAst + TypeCheck + ResolveType + PropagateTypeAnnot 
       errorSingle [x.info] msg
 end
 
-lang RecLetsTypeCheck = TypeCheck + RecLetsAst + MetaVarDisableGeneralize + PropagateTypeAnnot + SubstituteUnknown + ResolveType + SubstituteNewReprs
-  sem typeCheckExpr env =
-  | TmRecLets t ->
+lang RecLetsTypeCheck = TypeCheck + RecLetsDeclAst + MetaVarDisableGeneralize + PropagateTypeAnnot + SubstituteUnknown + ResolveType + SubstituteNewReprs
+  sem typeCheckDecl env =
+  | DeclRecLets t ->
     -- NOTE(aathn, 2024-05-24): This code assumes that each recursive let-binding
     -- is a syntactic lambda, so that generalization is always safe.
     let newLvl = addi 1 env.currentLvl in
     -- First: Generate a new environment containing the recursive bindings
-    let recLetEnvIteratee = lam acc. lam b: RecLetBinding.
+    let recLetEnvIteratee = lam acc. lam b: DeclLetRecord.
       let tyAnnot = resolveType t.info env false b.tyAnnot in
       let tyAnnot = substituteNewReprs env tyAnnot in
       let tyBody = substituteUnknown t.info {env with currentLvl = newLvl} (Poly ()) tyAnnot in
@@ -1276,7 +1301,7 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst + MetaVarDisableGeneralize + Prop
     let newEnv = {recLetEnv with currentLvl = newLvl, tyVarEnv = newTyVarEnv} in
 
     -- Second: Type check the body of each binding in the new environment
-    let typeCheckBinding = lam b: RecLetBinding.
+    let typeCheckBinding = lam b: DeclLetRecord.
       let body =
         let body = typeCheckExpr newEnv (propagateTyAnnot (b.body, b.tyAnnot)) in
         -- Unify the inferred type of the body with the annotated one
@@ -1291,15 +1316,16 @@ lang RecLetsTypeCheck = TypeCheck + RecLetsAst + MetaVarDisableGeneralize + Prop
      else ());
 
     -- Third: Produce a new environment with generalized types
-    let envIteratee = lam acc. lam b : RecLetBinding.
+    let envIteratee = lam acc. lam b : DeclLetRecord.
       match gen env.currentLvl acc.1 b.tyBody with (tyBody, vars) in
       let newEnv = _insertVar b.ident tyBody acc.0 in
       let newTyVars = foldr (uncurry mapInsert) acc.1 vars in
       ((newEnv, newTyVars), {b with tyBody = tyBody})
     in
     match mapAccumL envIteratee (env, tyVars) bindings with ((env, _), bindings) in
-    let inexpr = typeCheckExpr env t.inexpr in
-    TmRecLets {t with bindings = bindings, inexpr = inexpr, ty = tyTm inexpr}
+    ( env
+    , DeclRecLets {t with bindings = bindings}
+    )
 end
 
 lang MatchTypeCheck = TypeCheck + PatTypeCheck + MatchAst + NormPatMatch
@@ -1388,21 +1414,18 @@ lang RecordUpdateTypeCheck = TypeCheck + RecordAst + RecordTypeAst
     TmRecordUpdate {t with rec = rec, value = value, ty = tyTm rec}
 end
 
-lang TypeTypeCheck = TypeCheck + TypeAst + VariantTypeAst + ResolveType
-  sem typeCheckExpr env =
-  | TmType t ->
+lang TypeTypeCheck = TypeCheck + TypeDeclAst + VariantTypeAst + ResolveType
+  sem typeCheckDecl env =
+  | DeclType t ->
     let tyIdent = resolveType t.info env false t.tyIdent in
     -- NOTE(aathn, 2023-05-08): Aliases are treated as the underlying
     -- type and do not need to be scope checked.
     let newLvl =
       match tyIdent with !TyVariant _ then addi 1 env.currentLvl else 0 in
     let newTyConEnv = mapInsert t.ident (newLvl, t.params, tyIdent) env.tyConEnv in
-    let inexpr =
-      typeCheckExpr {env with currentLvl = addi 1 env.currentLvl,
-                              tyConEnv = newTyConEnv,
-                              reptypes = env.reptypes} t.inexpr in
-    unify env [t.info, infoTm inexpr] (newpolyvar env.currentLvl t.info) (tyTm inexpr);
-    TmType {t with tyIdent = tyIdent, inexpr = inexpr, ty = tyTm inexpr}
+    ( {env with currentLvl = addi 1 env.currentLvl, tyConEnv = newTyConEnv}
+    , DeclType {t with tyIdent = tyIdent}
+    )
 end
 
 lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + ResolveType + SubstituteNewReprs
@@ -1446,8 +1469,8 @@ lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + ResolveType + Substitute
       else errorSingle [info] (msg ())
     else errorSingle [info] (msg ())
 
-  sem typeCheckExpr env =
-  | TmConDef t ->
+  sem typeCheckDecl env =
+  | DeclConDef t ->
     let tyIdent = resolveType t.info env false t.tyIdent in
     let tyIdent = substituteNewReprs env tyIdent in
     match _makeConstructorType t.info env.disableConstructorTypes t.ident tyIdent
@@ -1460,17 +1483,14 @@ lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + ResolveType + Substitute
         (setFold (lam m. lam t. mapInsert t (setOfSeq nameCmp [target]) m)
                  (mapEmpty nameCmp) tydeps) in
     let newLvl = addi 1 env.currentLvl in
-    let inexpr =
-      typeCheckExpr
-        {env with currentLvl = newLvl,
-                  conEnv = mapInsert t.ident (newLvl, tyIdent) env.conEnv,
-                  typeDeps = mapUnionWith setUnion tydeps env.typeDeps,
-                  conDeps  = mapInsertWith setUnion target
-                               (setOfSeq nameCmp [t.ident]) env.conDeps}
-        t.inexpr
-    in
-    unify env [t.info, infoTm inexpr] (newpolyvar env.currentLvl t.info) (tyTm inexpr);
-    TmConDef {t with tyIdent = tyIdent, inexpr = inexpr, ty = tyTm inexpr}
+    ( { env with currentLvl = newLvl
+      , conEnv = mapInsert t.ident (newLvl, tyIdent) env.conEnv
+      , typeDeps = mapUnionWith setUnion tydeps env.typeDeps
+      , conDeps  = mapInsertWith setUnion target (setOfSeq nameCmp [t.ident]) env.conDeps
+      }
+    , DeclConDef {t with tyIdent = tyIdent}
+    )
+  sem typeCheckExpr env =
   | TmConApp t ->
     let body = typeCheckExpr env t.body in
     match mapLookup t.ident env.conEnv with Some (_, lty) then
@@ -1498,12 +1518,11 @@ lang DataTypeCheck = TypeCheck + DataAst + FunTypeAst + ResolveType + Substitute
       errorSingle [t.info] msg
 end
 
-lang UtestTypeCheck = TypeCheck + UtestAst
-  sem typeCheckExpr env =
-  | TmUtest t ->
+lang UtestTypeCheck = TypeCheck + UtestDeclAst
+  sem typeCheckDecl env =
+  | DeclUtest t ->
     let test = typeCheckExpr env t.test in
     let expected = typeCheckExpr env t.expected in
-    let next = typeCheckExpr env t.next in
     let tusing = optionMap (typeCheckExpr env) t.tusing in
     let tonfail = optionMap (typeCheckExpr env) t.tonfail in
     (switch (tusing, tonfail)
@@ -1521,12 +1540,14 @@ lang UtestTypeCheck = TypeCheck + UtestAst
      case (None _, None _) then
        unify env [infoTm test, infoTm expected] (tyTm test) (tyTm expected)
      end);
-    TmUtest {t with test = test
-            , expected = expected
-            , next = next
-            , tusing = tusing
-            , tonfail = tonfail
-            , ty = tyTm next}
+    ( env
+    , DeclUtest
+      {t with test = test
+      , expected = expected
+      , tusing = tusing
+      , tonfail = tonfail
+      }
+    )
 end
 
 lang NeverTypeCheck = TypeCheck + NeverAst + IsEmpty
@@ -1612,14 +1633,14 @@ lang PlaceholderTypeCheck = TypeCheck + PlaceholderAst
     TmPlaceholder {t with ty = newpolyvar env.currentLvl t.info}
 end
 
-lang ExtTypeCheck = TypeCheck + ExtAst + ResolveType
-  sem typeCheckExpr env =
-  | TmExt t ->
+lang ExtTypeCheck = TypeCheck + ExtDeclAst + ResolveType
+  sem typeCheckDecl env =
+  | DeclExt t ->
     -- TODO(vipa, 2023-06-15): Error if a RepType shows up in an external definition?
     let tyIdent = resolveType t.info env true t.tyIdent in
-    let env = {env with varEnv = mapInsert t.ident tyIdent env.varEnv} in
-    let inexpr = typeCheckExpr env t.inexpr in
-    TmExt {t with tyIdent = tyIdent, inexpr = inexpr, ty = tyTm inexpr}
+    ( {env with varEnv = mapInsert t.ident tyIdent env.varEnv}
+    , DeclExt {t with tyIdent = tyIdent}
+    )
 end
 
 ---------------------------
@@ -1774,7 +1795,7 @@ lang MExprTypeCheckMost =
   -- Terms
   AppTypeCheck + MatchTypeCheck + ConstTypeCheck + SeqTypeCheck +
   RecordTypeCheck + TypeTypeCheck + DataTypeCheck + UtestTypeCheck +
-  NeverTypeCheck + ExtTypeCheck + PlaceholderTypeCheck +
+  NeverTypeCheck + ExtTypeCheck + PlaceholderTypeCheck + DeclTypeCheck +
 
   -- Patterns
   NamedPatTypeCheck + SeqTotPatTypeCheck + SeqEdgePatTypeCheck +
@@ -1995,7 +2016,7 @@ let idbody_ = ulam_ "y" (var_ "y") in
 let tyid_ = tyall_ "a" (tyarrow_ a a) in
 let id_ = ("id", tyid_) in
 
-let idsbody_ = bind_ idbody_ (seq_ [freeze_ (var_ "id")]) in
+-- let idsbody_ = bind_ idbody_ (seq_ [freeze_ (var_ "id")]) in
 let tyids_ = tyseq_ tyid_ in
 let ids_ = ("ids", tyids_) in
 
@@ -2143,18 +2164,17 @@ let tests = [
 
   -- Other tests
   {name = "RecLets1",
-   tm = bindall_ [
+   tm = bind_ (
      ureclets_ [
        ("x", ulam_ "n" (app_ (var_ "y") false_)),
        ("y", ulam_ "n" (app_ (var_ "x") false_))
-     ],
-     var_ "x"
-   ],
+     ])
+     (var_ "x"),
    ty = tyarrow_ tybool_ fa,
    env = []},
 
   {name = "RecLets2",
-   tm = bindall_ [
+   tm = bind_ (
      ureclets_ [
        ("even", ulam_ "n"
                   (if_ (eqi_ (var_ "n") (int_ 0))
@@ -2164,20 +2184,18 @@ let tests = [
                  (if_ (eqi_ (var_ "n") (int_ 0))
                     false_
                     (app_ (var_ "even") (subi_ (var_ "n") (int_ 1)))))
-     ],
-     var_ "even"
-   ],
+     ])
+     (var_ "even"),
    ty = tyarrow_ tyint_ tybool_,
    env = []},
 
   {name = "RecLets3",
-   tm = bindall_ [
-     ureclets_ [
+   tm = bind_
+     (ureclets_ [
        ("f", ulam_ "x" (var_ "x")),
        ("g", ulam_ "x" (app_ (var_ "f") (var_ "x")))
-     ],
-     app_ (var_ "g") (int_ 1)
-   ],
+     ])
+     (app_ (var_ "g") (int_ 1)),
    ty = tyint_,
    env = []},
 
@@ -2297,36 +2315,37 @@ let tests = [
      type_ "Tree" [] (tyvariant_ []),
      condef_ "Branch" (tyarrow_ (tytuple_ [tycon_ "Tree", tycon_ "Tree"])
                          (tycon_ "Tree")),
-     condef_ "Leaf" (tyarrow_ (tyseq_ tyint_) (tycon_ "Tree")),
-     match_
-       (conapp_ "Branch" (utuple_ [
-         conapp_ "Leaf" (seq_ [int_ 1, int_ 2, int_ 3]),
-         conapp_ "Branch" (utuple_ [
-           conapp_ "Leaf" (seq_ [int_ 2]),
-           conapp_ "Leaf" (seq_ [])])]))
-       (pcon_ "Branch" (ptuple_ [pcon_ "Leaf" (pvar_ "n"), pvar_ "rhs"]))
-       (var_ "n")
-       never_
-   ],
+     condef_ "Leaf" (tyarrow_ (tyseq_ tyint_) (tycon_ "Tree"))
+   ]
+   (match_
+     (conapp_ "Branch" (utuple_ [
+       conapp_ "Leaf" (seq_ [int_ 1, int_ 2, int_ 3]),
+       conapp_ "Branch" (utuple_ [
+         conapp_ "Leaf" (seq_ [int_ 2]),
+         conapp_ "Leaf" (seq_ [])])]))
+     (pcon_ "Branch" (ptuple_ [pcon_ "Leaf" (pvar_ "n"), pvar_ "rhs"]))
+     (var_ "n")
+     never_
+   ),
    ty = tyseq_ tyint_,
    env = []},
 
   {name = "Type1",
    tm = bindall_ [
      type_ "Foo" [] (tyrecord_ [("x", tyint_)]),
-     ulet_ "f" (lam_ "r" (tycon_ "Foo") (recordupdate_ (var_ "r") "x" (int_ 1))),
-     app_ (var_ "f") (urecord_ [("x", int_ 0)])
-   ],
+     ulet_ "f" (lam_ "r" (tycon_ "Foo") (recordupdate_ (var_ "r") "x" (int_ 1)))
+   ]
+     (app_ (var_ "f") (urecord_ [("x", int_ 0)])),
    ty = tyrecord_ [("x", tyint_)],
    env = []},
 
   {name = "Utest1",
-   tm = utest_ (int_ 1) (addi_ (int_ 0) (int_ 1)) false_,
+   tm = bind_ (utest_ (int_ 1) (addi_ (int_ 0) (int_ 1))) false_,
    ty = tybool_,
    env = []},
 
   {name = "Utest2",
-   tm = utestu_ (int_ 1) true_ false_ (ulam_ "x" idbody_),
+   tm = bind_ (utestu_ (int_ 1) true_ (ulam_ "x" idbody_)) false_,
    ty = tybool_,
    env = []},
 

--- a/src/stdlib/mexpr/type-lift.mc
+++ b/src/stdlib/mexpr/type-lift.mc
@@ -190,7 +190,7 @@ end
 lang TypeTypeLift = TypeLift + TypeDeclAst + VariantTypeAst + UnknownTypeAst +
                     VariantNameTypeAst + RecordTypeAst
   sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmDecl {decl = DeclType t} ->
+  | TmDecl (x & {decl = DeclType t}) ->
     let tyIdent =
       match t.tyIdent with TyUnknown t2 then tyWithInfo t2.info (tyvariant_ [])
       else t.tyIdent
@@ -211,13 +211,13 @@ lang TypeTypeLift = TypeLift + TypeDeclAst + VariantTypeAst + UnknownTypeAst +
         env
       else {env with typeEnv = assocSeqInsert t.ident tyIdent env.typeEnv}
     in
-    match typeLiftExpr env t.inexpr with (env, inexpr) in
+    match typeLiftExpr env x.inexpr with (env, inexpr) in
     (env, inexpr)
 end
 
 lang DataTypeLift = TypeLift + DataAst + FunTypeAst + ConTypeAst + AppTypeAst
   sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmDecl {decl = DeclConDef t} ->
+  | TmDecl (x & {decl = DeclConDef t}) ->
     recursive let unwrapTypeVarIdent = lam ty : Type.
       match ty with TyCon t then Some t.ident
       else match ty with TyApp t then unwrapTypeVarIdent t.lhs
@@ -240,7 +240,7 @@ lang DataTypeLift = TypeLift + DataAst + FunTypeAst + ConTypeAst + AppTypeAst
         else env
       else env
     in
-    match typeLiftExpr env t.inexpr with (env, inexpr) then
+    match typeLiftExpr env x.inexpr with (env, inexpr) then
       (env, inexpr)
     else never
 end
@@ -351,9 +351,9 @@ let eqEnv = lam lenv. lam renv.
 in
 
 let unitNotLifted = typeCheck (symbolize (bindall_ [
-  ulet_ "x" (int_ 2),
+  ulet_ "x" (int_ 2)]
   uunit_
-])) in
+)) in
 match typeLift unitNotLifted with (env, t) in
 utest env with [] using eqEnv in
 utest t with unitNotLifted using eqExpr in
@@ -361,9 +361,9 @@ utest t with unitNotLifted using eqExpr in
 let noVariantsOrRecords = typeCheck (symbolize (bindall_ [
   ulet_ "x" (int_ 3),
   ulet_ "y" (int_ 2),
-  ulet_ "z" (addi_ (var_ "x") (var_ "y")),
-  var_ "z"
-])) in
+  ulet_ "z" (addi_ (var_ "x") (var_ "y"))]
+  (var_ "z"
+))) in
 match typeLift noVariantsOrRecords with (env, t) in
 utest env with [] using eqEnv in
 utest t with noVariantsOrRecords using eqExpr in
@@ -376,9 +376,9 @@ let variant = typeCheck (symbolize (bindall_ [
   ncondef_ branchName (tyarrow_ (tytuple_ [
     ntycon_ treeName,
     ntycon_ treeName]) (ntycon_ treeName)),
-  ncondef_ leafName (tyarrow_ tyint_ (ntycon_ treeName)),
+  ncondef_ leafName (tyarrow_ tyint_ (ntycon_ treeName))]
   uunit_
-])) in
+)) in
 match typeLift variant with (_, t) in
 utest t with uunit_ using eqExpr in
 
@@ -394,9 +394,9 @@ let variantWithRecords = typeCheck (symbolize (bindall_ [
   ncondef_ branchName (tyarrow_ (tyrecord_ [
     ("lhs", ntycon_ treeName),
     ("rhs", ntycon_ treeName)]) (ntycon_ treeName)),
-  ncondef_ leafName (tyarrow_ tyint_ (ntycon_ treeName)),
+  ncondef_ leafName (tyarrow_ tyint_ (ntycon_ treeName))]
   lastTerm
-])) in
+)) in
 match typeLift variantWithRecords with (env, t) in
 let recid = fst (get env 0) in
 let expectedEnv = [
@@ -419,9 +419,9 @@ let nestedRecord = typeCheck (symbolize (bindall_ [
       ("z", uunit_)
     ]),
     ("b", int_ 7)
-  ]),
+  ])]
   uunit_
-])) in
+)) in
 match typeLift nestedRecord with (env, t) in
 let fstid = fst (get env 0) in
 let sndid = fst (get env 1) in
@@ -440,9 +440,9 @@ utest env with expectedEnv using eqEnv in
 utest t with nestedRecord using eqExpr in
 
 let nestedSeq = typeCheck (symbolize (bindall_ [
-  ulet_ "s" (seq_ [seq_ [seq_ [int_ 2]], seq_ [seq_ [int_ 3]]]),
+  ulet_ "s" (seq_ [seq_ [seq_ [int_ 2]], seq_ [seq_ [int_ 3]]])]
   uunit_
-])) in
+)) in
 match typeLift nestedSeq with (env, t) in
 let fstid = fst (get env 0) in
 let sndid = fst (get env 1) in
@@ -457,9 +457,9 @@ utest t with nestedSeq using eqExpr in
 
 let recordsSameFieldsDifferentTypes = typeCheck (symbolize (bindall_ [
   ulet_ "x" (urecord_ [("a", int_ 0), ("b", int_ 1)]),
-  ulet_ "y" (urecord_ [("a", int_ 2), ("b", true_)]),
+  ulet_ "y" (urecord_ [("a", int_ 2), ("b", true_)])]
   uunit_
-])) in
+)) in
 match typeLift recordsSameFieldsDifferentTypes with (env, t) in
 let fstid = fst (get env 0) in
 let sndid = fst (get env 1) in
@@ -472,9 +472,9 @@ utest t with recordsSameFieldsDifferentTypes using eqExpr in
 
 let recordsSameFieldsSameTypes = typeCheck (symbolize (bindall_ [
   ulet_ "x" (urecord_ [("a", int_ 0), ("b", int_ 1)]),
-  ulet_ "y" (urecord_ [("a", int_ 3), ("b", int_ 6)]),
+  ulet_ "y" (urecord_ [("a", int_ 3), ("b", int_ 6)])]
   uunit_
-])) in
+)) in
 match typeLift recordsSameFieldsSameTypes with (env, t) in
 let recid = fst (get env 0) in
 let expectedEnv = [
@@ -493,9 +493,9 @@ match assocSeqLookup {eq=nameEq} ident env with Some recordTy in
 utest recordTy with tyTm record using eqType in
 
 let recordUpdate = typeCheck (symbolize (bindall_ [
-  ulet_ "x" (urecord_ [("a", int_ 0), ("b", int_ 1)]),
-  recordupdate_ (var_ "x") "a" (int_ 2)
-])) in
+  ulet_ "x" (urecord_ [("a", int_ 0), ("b", int_ 1)])]
+  (recordupdate_ (var_ "x") "a" (int_ 2)
+))) in
 let recordType = tyrecord_ [("a", tyint_), ("b", tyint_)] in
 match typeLift recordUpdate with (env, t) in
 match t with TmDecl {decl = DeclLet {tyBody = TyCon {ident = ident}}} in
@@ -512,9 +512,9 @@ let typeAliases = typeCheck (symbolize (bindall_ [
   ulet_ "env" (urecord_ [
     ("global", seq_ [utuple_ [str_ "x", int_ 4]]),
     ("local", seq_ [utuple_ [str_ "a", int_ 0]])
-  ]),
-  var_ "env"
-])) in
+  ])]
+  (var_ "env"
+))) in
 match typeLift typeAliases with (env, t) in
 -- Note that records and variants are added to the front of the environment
 -- as they are processed, so the last record in the given term will be first
@@ -546,12 +546,12 @@ let recordTypeInBindingAnnotation = symbolize (bindall_ [
   reclet_ "gcd" (tyarrow_ tupleTy tyint_)
     (ulam_ "x" (bindall_ [
       ulet_ "a" (tupleproj_ 0 (var_ "x")),
-      ulet_ "b" (tupleproj_ 1 (var_ "x")),
-      if_ (eqi_ (var_ "b") (int_ 0))
+      ulet_ "b" (tupleproj_ 1 (var_ "x"))]
+      (if_ (eqi_ (var_ "b") (int_ 0))
         (var_ "a")
-        (app_ (var_ "gcd") (utuple_ [var_ "b", modi_ (var_ "a") (var_ "b")]))])),
-  app_ (var_ "gcd") (utuple_ [int_ 7, int_ 14])
-]) in
+        (app_ (var_ "gcd") (utuple_ [var_ "b", modi_ (var_ "a") (var_ "b")])))))]
+  (app_ (var_ "gcd") (utuple_ [int_ 7, int_ 14])
+)) in
 match typeLift recordTypeInBindingAnnotation with (env, t) in
 utest length env with 1 using eqi in
 

--- a/src/stdlib/mexpr/type-lift.mc
+++ b/src/stdlib/mexpr/type-lift.mc
@@ -187,7 +187,7 @@ lang TypeLiftAddRecordToEnv = TypeLift + RecordTypeAst
   -- | ty -> (env, ty) -- NOTE(dlunde,2021-10-06): I commented this out, so that it gives an error if a TyRecord is not supplied (less error-prone)
 end
 
-lang TypeTypeLift = TypeLift + TypeAst + VariantTypeAst + UnknownTypeAst +
+lang TypeTypeLift = TypeLift + TypeDeclAst + VariantTypeAst + UnknownTypeAst +
                     VariantNameTypeAst + RecordTypeAst
   sem typeLiftExpr (env : TypeLiftEnv) =
   | TmType t ->
@@ -309,8 +309,8 @@ lang MExprTypeLift =
   MExprCmp +
 
   -- Default implementations (Terms)
-  VarAst + AppAst + LamAst + LetAst + RecLetsAst + ConstAst + SeqAst +
-  UtestAst + NeverAst + ExtAst +
+  VarAst + AppAst + LamAst + LetDeclAst + RecLetsDeclAst + ConstAst + SeqAst +
+  UtestDeclAst + NeverAst + ExtDeclAst +
 
   -- Default implementations (Types)
   UnknownTypeAst + BoolTypeAst + IntTypeAst + FloatTypeAst + CharTypeAst +

--- a/src/stdlib/mexpr/type-lift.mc
+++ b/src/stdlib/mexpr/type-lift.mc
@@ -190,7 +190,7 @@ end
 lang TypeTypeLift = TypeLift + TypeDeclAst + VariantTypeAst + UnknownTypeAst +
                     VariantNameTypeAst + RecordTypeAst
   sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmType t ->
+  | TmDecl {decl = DeclType t} ->
     let tyIdent =
       match t.tyIdent with TyUnknown t2 then tyWithInfo t2.info (tyvariant_ [])
       else t.tyIdent
@@ -217,7 +217,7 @@ end
 
 lang DataTypeLift = TypeLift + DataAst + FunTypeAst + ConTypeAst + AppTypeAst
   sem typeLiftExpr (env : TypeLiftEnv) =
-  | TmConDef t ->
+  | TmDecl {decl = DeclConDef t} ->
     recursive let unwrapTypeVarIdent = lam ty : Type.
       match ty with TyCon t then Some t.ident
       else match ty with TyApp t then unwrapTypeVarIdent t.lhs
@@ -498,7 +498,7 @@ let recordUpdate = typeCheck (symbolize (bindall_ [
 ])) in
 let recordType = tyrecord_ [("a", tyint_), ("b", tyint_)] in
 match typeLift recordUpdate with (env, t) in
-match t with TmLet {tyBody = TyCon {ident = ident}} in
+match t with TmDecl {decl = DeclLet {tyBody = TyCon {ident = ident}}} in
 match assocSeqLookup {eq=nameEq} ident env with Some ty in
 utest ty with recordType using eqType in
 

--- a/src/stdlib/mexpr/utest-generate.mc
+++ b/src/stdlib/mexpr/utest-generate.mc
@@ -855,7 +855,7 @@ lang MExprUtestGenerate =
                  info = _utestInfo} )
 
   sem generatePrettyPrintBindingsH : Info -> UtestEnv -> Type
-                                  -> (UtestEnv, [RecLetBinding])
+                                  -> (UtestEnv, [DeclLetRecord])
   sem generatePrettyPrintBindingsH info env =
   | (TySeq {ty = elemTy} | TyTensor {ty = elemTy}) & ty ->
     if setMem ty env.pprintDef then
@@ -902,7 +902,7 @@ lang MExprUtestGenerate =
     , TmRecLets {bindings = binds, inexpr = _unit, ty = _unitTy, info = _utestInfo} )
 
   sem generateEqualityBindingsH : Info -> UtestEnv -> Type
-                               -> (UtestEnv, [RecLetBinding])
+                               -> (UtestEnv, [DeclLetRecord])
   sem generateEqualityBindingsH info env =
   | (TySeq {ty = elemTy} | TyTensor {ty = elemTy}) & ty ->
     if setMem ty env.eqDef then

--- a/src/stdlib/mexpr/utest-generate.mc
+++ b/src/stdlib/mexpr/utest-generate.mc
@@ -188,21 +188,6 @@ let _unit = _record [] _unitTy
 let _recbind = lam id. lam ty. lam body.
   use MExprAst in
   {ident = id, tyAnnot = ty, tyBody = ty, body = body, info = _utestInfo}
-recursive let _bind = lam f. lam bind. lam expr.
-  use MExprAst in
-  let ty = tyTm expr in
-  switch bind
-  case TmDecl {decl = DeclLet t} then TmDecl {decl = DeclLet {t with inexpr = _bind f t.inexpr expr, ty = ty}}
-  case TmDecl {decl = DeclRecLets t} then TmDecl {decl = DeclRecLets {t with inexpr = _bind f t.inexpr expr, ty = ty}}
-  case TmDecl {decl = DeclType t} then TmDecl {decl = DeclType {t with inexpr = _bind f t.inexpr expr, ty = ty}}
-  case TmDecl {decl = DeclConDef t} then TmDecl {decl = DeclConDef {t with inexpr = _bind f t.inexpr expr, ty = ty}}
-  case TmDecl {decl = DeclExt t} then TmDecl {decl = DeclExt {t with inexpr = _bind f t.inexpr expr, ty = ty}}
-  case _ then f bind expr
-  end
-end
-let _binds = lam bindings.
-  use MExprAst in
-  foldr1 (_bind (lam. lam expr. expr)) bindings
 let _apps = lam fun. lam args.
   use MExprAst in
   foldl
@@ -844,15 +829,15 @@ lang MExprUtestGenerate =
   -- definitions for each subtype required to support pretty-printing all
   -- types in the provided sequence. If the user provided a custom on-fail
   -- printing function, we do not generate any bindings.
-  sem generatePrettyPrintBindings : Info -> UtestEnv -> [Type] -> Option Expr -> (UtestEnv, Expr)
+  sem generatePrettyPrintBindings : Info -> UtestEnv -> [Type] -> Option Expr -> (UtestEnv, Option Decl)
   sem generatePrettyPrintBindings info env types =
-  | Some _ -> (env, _unit)
+  | Some _ -> (env, None ())
   | None _ ->
     let types = map unwrapAlias types in
     match mapAccumL (generatePrettyPrintBindingsH info) env types with (env, binds) in
     ( env
-    , TmDecl {decl = DeclRecLets {bindings = join binds, inexpr = _unit, ty = _unitTy,
-                 info = _utestInfo}} )
+    , Some (DeclRecLets {bindings = join binds, info = _utestInfo})
+    )
 
   sem generatePrettyPrintBindingsH : Info -> UtestEnv -> Type
                                   -> (UtestEnv, [DeclLetRecord])
@@ -892,14 +877,15 @@ lang MExprUtestGenerate =
   -- function (i.e., the tusing field is Some), we do not generate any
   -- bindings.
   sem generateEqualityBindings : Info -> UtestEnv -> Type -> Option Expr
-                              -> (UtestEnv, Expr)
+                              -> (UtestEnv, Option Decl)
   sem generateEqualityBindings info env ty =
-  | Some _ -> (env, _unit)
+  | Some _ -> (env, None ())
   | None _ ->
     let ty = unwrapAlias ty in
     match generateEqualityBindingsH info env ty with (env, binds) in
     ( env
-    , TmDecl {decl = DeclRecLets {bindings = binds, inexpr = _unit, ty = _unitTy, info = _utestInfo}} )
+    , Some (DeclRecLets {bindings = binds, info = _utestInfo})
+    )
 
   sem generateEqualityBindingsH : Info -> UtestEnv -> Type
                                -> (UtestEnv, [DeclLetRecord])
@@ -936,7 +922,7 @@ lang MExprUtestGenerate =
   -- for nested utests.
   sem replaceUtests : UtestEnv -> Expr -> (UtestEnv, Expr)
   sem replaceUtests env =
-  | TmDecl {decl = DeclUtest t} ->
+  | TmDecl (x & {decl = DeclUtest t}) ->
     let info = _stringLit (info2str t.info) in
     let usingStr =
       _stringLit
@@ -988,24 +974,20 @@ lang MExprUtestGenerate =
 
     match replaceUtests env t.test with (_, test) in
     match replaceUtests env t.expected with (_, expected) in
-    match replaceUtests env t.next with (env, next) in
+    match replaceUtests env x.inexpr with (env, next) in
     let testExpr =
       _apps utestRunner [info, usingStr, ppfn, eqfn, test, expected]
     in
-    let utestBinds = TmDecl {decl = DeclLet {
-      ident = nameNoSym "", tyAnnot = _unitTy, tyBody = _unitTy,
-      body = testExpr, inexpr = next, ty = tyTm next, info = t.info
-    }} in
-    (env, _binds [eqBinds, ppBinds, utestBinds])
-  | TmDecl {decl = DeclType t} ->
+    (env, bindall_ (filterOption [eqBinds, ppBinds]) (semi_ testExpr next))
+  | TmDecl (x & {decl = DeclType t}) ->
     let env =
       match t.tyIdent with TyVariant _ then
         {env with variants = mapInsert t.ident (mapEmpty nameCmp) env.variants}
       else env
     in
-    match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmDecl {decl = DeclType {t with inexpr = inexpr}})
-  | TmDecl {decl = DeclConDef t} ->
+    match replaceUtests env x.inexpr with (env, inexpr) in
+    (env, TmDecl {x with inexpr = inexpr})
+  | TmDecl (x & {decl = DeclConDef t}) ->
     recursive let extractVariantType = lam ty.
       match ty with TyAll {ty = innerTy} then extractVariantType innerTy
       else match ty with TyArrow {to = to} then extractVariantType to
@@ -1017,20 +999,20 @@ lang MExprUtestGenerate =
     let constrs = lookupVariant ident env t.info in
     let constrs = mapInsert t.ident t.tyIdent constrs in
     let env = {env with variants = mapInsert ident constrs env.variants} in
-    match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmDecl {decl = DeclConDef {t with inexpr = inexpr}})
-  | TmDecl {decl = DeclLet t} ->
+    match replaceUtests env x.inexpr with (env, inexpr) in
+    (env, TmDecl {x with inexpr = inexpr})
+  | TmDecl (x & {decl = DeclLet t}) ->
     match replaceUtests env t.body with (_, body) in
-    match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmDecl {decl = DeclLet {t with body = body, inexpr = inexpr}})
-  | TmDecl {decl = DeclRecLets t} ->
+    match replaceUtests env x.inexpr with (env, inexpr) in
+    (env, TmDecl {x with decl = DeclLet {t with body = body}, inexpr = inexpr})
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let replaceBinding = lam env. lam bind.
       match replaceUtests env bind.body with (env, body) in
       (env, {bind with body = body})
     in
     match mapAccumL replaceBinding env t.bindings with (_, bindings) in
-    match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr}})
+    match replaceUtests env x.inexpr with (env, inexpr) in
+    (env, TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr})
   | t -> smapAccumL_Expr_Expr replaceUtests env t
 
   -- Inserts utest runtime code at the tail of the program. In case any test
@@ -1039,24 +1021,9 @@ lang MExprUtestGenerate =
   -- evaluated, regardless of whether tests failed or not.
   sem insertUtestTail : Expr -> Expr
   sem insertUtestTail =
-  | TmDecl {decl = DeclLet t} ->
-    let inexpr = insertUtestTail t.inexpr in
-    TmDecl {decl = DeclLet {t with inexpr = inexpr, ty = tyTm inexpr}}
-  | TmDecl {decl = DeclRecLets t} ->
-    let inexpr = insertUtestTail t.inexpr in
-    TmDecl {decl = DeclRecLets {t with inexpr = inexpr, ty = tyTm inexpr}}
-  | TmDecl {decl = DeclType t} ->
-    let inexpr = insertUtestTail t.inexpr in
-    TmDecl {decl = DeclType {t with inexpr = inexpr, ty = tyTm inexpr}}
-  | TmDecl {decl = DeclConDef t} ->
-    let inexpr = insertUtestTail t.inexpr in
-    TmDecl {decl = DeclConDef {t with inexpr = inexpr, ty = tyTm inexpr}}
-  | TmDecl {decl = DeclUtest t} ->
-    let next = insertUtestTail t.next in
-    TmDecl {decl = DeclUtest {t with next = next, ty = tyTm next}}
-  | TmDecl {decl = DeclExt t} ->
-    let inexpr = insertUtestTail t.inexpr in
-    TmDecl {decl = DeclExt {t with inexpr = inexpr, ty = tyTm inexpr}}
+  | TmDecl x ->
+    let inexpr = insertUtestTail x.inexpr in
+    TmDecl {x with inexpr = inexpr, ty = tyTm inexpr}
   | t ->
     let exitOnFailure =
       _var (utestExitOnFailureName ()) (_tyarrows [tyTm t, tyTm t]) in
@@ -1065,7 +1032,7 @@ lang MExprUtestGenerate =
 
   sem stripUtests : Expr -> Expr
   sem stripUtests =
-  | TmDecl {decl = DeclUtest t} -> stripUtests t.next
+  | TmDecl (x & {decl = DeclUtest _}) -> stripUtests x.inexpr
   | t -> smap_Expr_Expr stripUtests t
 
   sem generateUtest : Bool -> Expr -> Expr
@@ -1089,6 +1056,11 @@ use TestLang in
 
 let emptyEnv = utestEnvEmpty () in
 
+let maybeBind_ = lam binds. lam tm.
+  match binds with Some bind
+  then bind_ bind tm
+  else tm in
+
 let eval = lam env. lam e.
   let e = mergeWithHeader e (loadUtestRuntime ()) in
   eval (evalCtxEmpty ()) e
@@ -1098,14 +1070,14 @@ let evalEquality : UtestEnv -> Type -> Expr -> Expr -> Expr =
   lam env. lam ty. lam l. lam r.
   match getEqualityExpr (NoInfo ()) env ty with (env, expr) in
   match generateEqualityBindings (NoInfo ()) env ty (None ()) with (env, binds) in
-  eval env (bind_ binds (appf2_ expr l r))
+  eval env (maybeBind_ binds (appf2_ expr l r))
 in
 
 let evalPrettyPrint : UtestEnv -> Type -> Expr -> Expr =
   lam env. lam ty. lam t.
   match getPrettyPrintExpr (NoInfo ()) env ty with (env, expr) in
   match generatePrettyPrintBindings (NoInfo ()) env [ty] (None ()) with (env, binds) in
-  eval env (bind_ binds (app_ expr t))
+  eval env (maybeBind_ binds (app_ expr t))
 in
 
 let i1 = const_ tyint_ (CInt {val = 1}) in

--- a/src/stdlib/mexpr/utest-generate.mc
+++ b/src/stdlib/mexpr/utest-generate.mc
@@ -192,11 +192,11 @@ recursive let _bind = lam f. lam bind. lam expr.
   use MExprAst in
   let ty = tyTm expr in
   switch bind
-  case TmLet t then TmLet {t with inexpr = _bind f t.inexpr expr, ty = ty}
-  case TmRecLets t then TmRecLets {t with inexpr = _bind f t.inexpr expr, ty = ty}
-  case TmType t then TmType {t with inexpr = _bind f t.inexpr expr, ty = ty}
-  case TmConDef t then TmConDef {t with inexpr = _bind f t.inexpr expr, ty = ty}
-  case TmExt t then TmExt {t with inexpr = _bind f t.inexpr expr, ty = ty}
+  case TmDecl {decl = DeclLet t} then TmDecl {decl = DeclLet {t with inexpr = _bind f t.inexpr expr, ty = ty}}
+  case TmDecl {decl = DeclRecLets t} then TmDecl {decl = DeclRecLets {t with inexpr = _bind f t.inexpr expr, ty = ty}}
+  case TmDecl {decl = DeclType t} then TmDecl {decl = DeclType {t with inexpr = _bind f t.inexpr expr, ty = ty}}
+  case TmDecl {decl = DeclConDef t} then TmDecl {decl = DeclConDef {t with inexpr = _bind f t.inexpr expr, ty = ty}}
+  case TmDecl {decl = DeclExt t} then TmDecl {decl = DeclExt {t with inexpr = _bind f t.inexpr expr, ty = ty}}
   case _ then f bind expr
   end
 end
@@ -851,8 +851,8 @@ lang MExprUtestGenerate =
     let types = map unwrapAlias types in
     match mapAccumL (generatePrettyPrintBindingsH info) env types with (env, binds) in
     ( env
-    , TmRecLets {bindings = join binds, inexpr = _unit, ty = _unitTy,
-                 info = _utestInfo} )
+    , TmDecl {decl = DeclRecLets {bindings = join binds, inexpr = _unit, ty = _unitTy,
+                 info = _utestInfo}} )
 
   sem generatePrettyPrintBindingsH : Info -> UtestEnv -> Type
                                   -> (UtestEnv, [DeclLetRecord])
@@ -899,7 +899,7 @@ lang MExprUtestGenerate =
     let ty = unwrapAlias ty in
     match generateEqualityBindingsH info env ty with (env, binds) in
     ( env
-    , TmRecLets {bindings = binds, inexpr = _unit, ty = _unitTy, info = _utestInfo} )
+    , TmDecl {decl = DeclRecLets {bindings = binds, inexpr = _unit, ty = _unitTy, info = _utestInfo}} )
 
   sem generateEqualityBindingsH : Info -> UtestEnv -> Type
                                -> (UtestEnv, [DeclLetRecord])
@@ -936,7 +936,7 @@ lang MExprUtestGenerate =
   -- for nested utests.
   sem replaceUtests : UtestEnv -> Expr -> (UtestEnv, Expr)
   sem replaceUtests env =
-  | TmUtest t ->
+  | TmDecl {decl = DeclUtest t} ->
     let info = _stringLit (info2str t.info) in
     let usingStr =
       _stringLit
@@ -992,20 +992,20 @@ lang MExprUtestGenerate =
     let testExpr =
       _apps utestRunner [info, usingStr, ppfn, eqfn, test, expected]
     in
-    let utestBinds = TmLet {
+    let utestBinds = TmDecl {decl = DeclLet {
       ident = nameNoSym "", tyAnnot = _unitTy, tyBody = _unitTy,
       body = testExpr, inexpr = next, ty = tyTm next, info = t.info
-    } in
+    }} in
     (env, _binds [eqBinds, ppBinds, utestBinds])
-  | TmType t ->
+  | TmDecl {decl = DeclType t} ->
     let env =
       match t.tyIdent with TyVariant _ then
         {env with variants = mapInsert t.ident (mapEmpty nameCmp) env.variants}
       else env
     in
     match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmType {t with inexpr = inexpr})
-  | TmConDef t ->
+    (env, TmDecl {decl = DeclType {t with inexpr = inexpr}})
+  | TmDecl {decl = DeclConDef t} ->
     recursive let extractVariantType = lam ty.
       match ty with TyAll {ty = innerTy} then extractVariantType innerTy
       else match ty with TyArrow {to = to} then extractVariantType to
@@ -1018,19 +1018,19 @@ lang MExprUtestGenerate =
     let constrs = mapInsert t.ident t.tyIdent constrs in
     let env = {env with variants = mapInsert ident constrs env.variants} in
     match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmConDef {t with inexpr = inexpr})
-  | TmLet t ->
+    (env, TmDecl {decl = DeclConDef {t with inexpr = inexpr}})
+  | TmDecl {decl = DeclLet t} ->
     match replaceUtests env t.body with (_, body) in
     match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmLet {t with body = body, inexpr = inexpr})
-  | TmRecLets t ->
+    (env, TmDecl {decl = DeclLet {t with body = body, inexpr = inexpr}})
+  | TmDecl {decl = DeclRecLets t} ->
     let replaceBinding = lam env. lam bind.
       match replaceUtests env bind.body with (env, body) in
       (env, {bind with body = body})
     in
     match mapAccumL replaceBinding env t.bindings with (_, bindings) in
     match replaceUtests env t.inexpr with (env, inexpr) in
-    (env, TmRecLets {t with bindings = bindings, inexpr = inexpr})
+    (env, TmDecl {decl = DeclRecLets {t with bindings = bindings, inexpr = inexpr}})
   | t -> smapAccumL_Expr_Expr replaceUtests env t
 
   -- Inserts utest runtime code at the tail of the program. In case any test
@@ -1039,24 +1039,24 @@ lang MExprUtestGenerate =
   -- evaluated, regardless of whether tests failed or not.
   sem insertUtestTail : Expr -> Expr
   sem insertUtestTail =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let inexpr = insertUtestTail t.inexpr in
-    TmLet {t with inexpr = inexpr, ty = tyTm inexpr}
-  | TmRecLets t ->
+    TmDecl {decl = DeclLet {t with inexpr = inexpr, ty = tyTm inexpr}}
+  | TmDecl {decl = DeclRecLets t} ->
     let inexpr = insertUtestTail t.inexpr in
-    TmRecLets {t with inexpr = inexpr, ty = tyTm inexpr}
-  | TmType t ->
+    TmDecl {decl = DeclRecLets {t with inexpr = inexpr, ty = tyTm inexpr}}
+  | TmDecl {decl = DeclType t} ->
     let inexpr = insertUtestTail t.inexpr in
-    TmType {t with inexpr = inexpr, ty = tyTm inexpr}
-  | TmConDef t ->
+    TmDecl {decl = DeclType {t with inexpr = inexpr, ty = tyTm inexpr}}
+  | TmDecl {decl = DeclConDef t} ->
     let inexpr = insertUtestTail t.inexpr in
-    TmConDef {t with inexpr = inexpr, ty = tyTm inexpr}
-  | TmUtest t ->
+    TmDecl {decl = DeclConDef {t with inexpr = inexpr, ty = tyTm inexpr}}
+  | TmDecl {decl = DeclUtest t} ->
     let next = insertUtestTail t.next in
-    TmUtest {t with next = next, ty = tyTm next}
-  | TmExt t ->
+    TmDecl {decl = DeclUtest {t with next = next, ty = tyTm next}}
+  | TmDecl {decl = DeclExt t} ->
     let inexpr = insertUtestTail t.inexpr in
-    TmExt {t with inexpr = inexpr, ty = tyTm inexpr}
+    TmDecl {decl = DeclExt {t with inexpr = inexpr, ty = tyTm inexpr}}
   | t ->
     let exitOnFailure =
       _var (utestExitOnFailureName ()) (_tyarrows [tyTm t, tyTm t]) in
@@ -1065,7 +1065,7 @@ lang MExprUtestGenerate =
 
   sem stripUtests : Expr -> Expr
   sem stripUtests =
-  | TmUtest t -> stripUtests t.next
+  | TmDecl {decl = DeclUtest t} -> stripUtests t.next
   | t -> smap_Expr_Expr stripUtests t
 
   sem generateUtest : Bool -> Expr -> Expr

--- a/src/stdlib/mexpr/utils.mc
+++ b/src/stdlib/mexpr/utils.mc
@@ -17,51 +17,44 @@ lang MExprSubstitute = MExprAst
   sem subIdent replacements =
   | id -> optionGetOrElse (lam. id) (mapLookup id replacements)
 
+  sem substituteIdentifiersSDecl : Map Name Name -> Decl -> Decl
+  sem substituteIdentifiersSDecl replacements =
+  | d -> d
+  | DeclLet x -> DeclLet {x with ident = subIdent replacements x.ident}
+  | DeclRecLets x ->
+    let f = lam bind. {bind with ident = subIdent replacements bind.ident} in
+    DeclRecLets {x with bindings = map f x.bindings}
+  | DeclType x -> DeclType
+    { x with ident = subIdent replacements x.ident
+    , params = map (subIdent replacements) x.params
+    }
+  | DeclConDef x -> DeclConDef {x with ident = subIdent replacements x.ident}
+  | DeclExt x -> DeclExt {x with ident = subIdent replacements x.ident}
+
   sem substituteIdentifiersExpr : Map Name Name -> Expr -> Expr
   sem substituteIdentifiersExpr replacements =
   | TmVar t -> TmVar {t with ident = subIdent replacements t.ident}
   | TmConApp t ->
-    TmConApp {t with ident = subIdent replacements t.ident,
-                     body = substituteIdentifiersExpr replacements t.body,
-                     ty = substituteIdentifiersType replacements t.ty}
-  | TmDecl {decl = DeclLet t} ->
-    TmDecl {decl = DeclLet {t with ident = subIdent replacements t.ident,
-                  tyAnnot = substituteIdentifiersType replacements t.tyAnnot,
-                  tyBody = substituteIdentifiersType replacements t.tyBody,
-                  body = substituteIdentifiersExpr replacements t.body,
-                  inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                  ty = substituteIdentifiersType replacements t.ty}}
+    let ast = TmConApp {t with ident = subIdent replacements t.ident} in
+    let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
+    let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
+    withType (substituteIdentifiersType replacements (tyTm ast)) ast
   | TmLam t ->
-    TmLam {t with ident = subIdent replacements t.ident,
-                  tyAnnot = substituteIdentifiersType replacements t.tyAnnot,
-                  tyParam = substituteIdentifiersType replacements t.tyParam,
-                  body = substituteIdentifiersExpr replacements t.body,
-                  ty = substituteIdentifiersType replacements t.ty}
-  | TmDecl {decl = DeclType t} ->
-    TmDecl {decl = DeclType {t with ident = subIdent replacements t.ident,
-                   tyIdent = substituteIdentifiersType replacements t.tyIdent,
-                   inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                   ty = substituteIdentifiersType replacements t.ty}}
-  | TmDecl {decl = DeclConDef t} ->
-    TmDecl {decl = DeclConDef {t with ident = subIdent replacements t.ident,
-                     tyIdent = substituteIdentifiersType replacements t.tyIdent,
-                     inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                     ty = substituteIdentifiersType replacements t.ty}}
-  | TmDecl {decl = DeclExt t} ->
-    TmDecl {decl = DeclExt {t with ident = subIdent replacements t.ident,
-                  tyIdent = substituteIdentifiersType replacements t.tyIdent,
-                  inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                  ty = substituteIdentifiersType replacements t.ty}}
-  | TmDecl {decl = DeclRecLets t} ->
-    let subBinding = lam bind.
-      {bind with ident = subIdent replacements bind.ident,
-                 body = substituteIdentifiersExpr replacements bind.body,
-                 tyAnnot = substituteIdentifiersType replacements bind.tyAnnot,
-                 tyBody = substituteIdentifiersType replacements bind.tyBody}
-    in
-    TmDecl {decl = DeclRecLets {t with bindings = map subBinding t.bindings,
-                      inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                      ty = substituteIdentifiersType replacements t.ty}}
+    let ast = TmLam {t with ident = subIdent replacements t.ident} in
+    let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
+    let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
+    withType (substituteIdentifiersType replacements (tyTm ast)) ast
+  | TmDecl x ->
+    let ast = TmDecl {x with decl = substituteIdentifiersSDecl replacements x.decl} in
+    let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
+    let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
+    withType (substituteIdentifiersType replacements (tyTm ast)) ast
   | ast ->
     let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
     let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
@@ -118,11 +111,11 @@ lang MExprFindSym = MExprAst
 
   sem findNamesOfStringsExpr : Map String Int -> Map Int Name -> Expr -> Map Int Name
   sem findNamesOfStringsExpr strs acc =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let acc = checkIdentifier strs acc t.ident in
     let acc = findNamesOfStringsExpr strs acc t.body in
-    findNamesOfStringsExpr strs acc t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+    findNamesOfStringsExpr strs acc x.inexpr
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let findNamesBinding = lam acc. lam binding.
       checkIdentifier strs acc binding.ident
     in
@@ -131,13 +124,15 @@ lang MExprFindSym = MExprAst
     in
     let acc = foldl findNamesBinding acc t.bindings in
     let acc = foldl findNamesBindingBody acc t.bindings in
-    findNamesOfStringsExpr strs acc t.inexpr
-  | TmDecl {decl = DeclType {ident = ident, tyIdent = tyIdent, inexpr = inexpr}}
-  | TmDecl {decl = DeclConDef {ident = ident, tyIdent = tyIdent, inexpr = inexpr}}
-  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr}} ->
+    findNamesOfStringsExpr strs acc x.inexpr
+  | TmDecl (x & {decl
+    = DeclType {ident = ident, tyIdent = tyIdent}
+    | DeclConDef {ident = ident, tyIdent = tyIdent}
+    | DeclExt {ident = ident, tyIdent = tyIdent}
+    }) ->
     let acc = checkIdentifier strs acc ident in
     let acc = findNamesOfStringsType strs acc tyIdent in
-    findNamesOfStringsExpr strs acc inexpr
+    findNamesOfStringsExpr strs acc x.inexpr
   | t -> sfold_Expr_Expr (findNamesOfStringsExpr strs) acc t
 
   sem findNamesOfStringsType : Map String Int -> Map Int Name -> Type -> Map Int Name
@@ -170,9 +165,9 @@ let expr = lam id. bindall_ [
   ureclets_ [(id, var_ id)],
   type_ id [] (tyapp_ (tycon_ id) tyint_),
   condef_ id (tyarrow_ tyint_ (tycon_ id)),
-  ext_ id false tyunknown_,
-  conapp_ id (int_ 2)
-] in
+  ext_ id false tyunknown_]
+  (conapp_ id (int_ 2))
+in
 let replace = mapFromSeq nameCmp [(nameNoSym "x", nameNoSym "y")] in
 utest pp (substituteIdentifiers replace (expr "x")) with pp (expr "y") using eqString in
 

--- a/src/stdlib/mexpr/utils.mc
+++ b/src/stdlib/mexpr/utils.mc
@@ -24,44 +24,44 @@ lang MExprSubstitute = MExprAst
     TmConApp {t with ident = subIdent replacements t.ident,
                      body = substituteIdentifiersExpr replacements t.body,
                      ty = substituteIdentifiersType replacements t.ty}
-  | TmLet t ->
-    TmLet {t with ident = subIdent replacements t.ident,
+  | TmDecl {decl = DeclLet t} ->
+    TmDecl {decl = DeclLet {t with ident = subIdent replacements t.ident,
                   tyAnnot = substituteIdentifiersType replacements t.tyAnnot,
                   tyBody = substituteIdentifiersType replacements t.tyBody,
                   body = substituteIdentifiersExpr replacements t.body,
                   inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                  ty = substituteIdentifiersType replacements t.ty}
+                  ty = substituteIdentifiersType replacements t.ty}}
   | TmLam t ->
     TmLam {t with ident = subIdent replacements t.ident,
                   tyAnnot = substituteIdentifiersType replacements t.tyAnnot,
                   tyParam = substituteIdentifiersType replacements t.tyParam,
                   body = substituteIdentifiersExpr replacements t.body,
                   ty = substituteIdentifiersType replacements t.ty}
-  | TmType t ->
-    TmType {t with ident = subIdent replacements t.ident,
+  | TmDecl {decl = DeclType t} ->
+    TmDecl {decl = DeclType {t with ident = subIdent replacements t.ident,
                    tyIdent = substituteIdentifiersType replacements t.tyIdent,
                    inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                   ty = substituteIdentifiersType replacements t.ty}
-  | TmConDef t ->
-    TmConDef {t with ident = subIdent replacements t.ident,
+                   ty = substituteIdentifiersType replacements t.ty}}
+  | TmDecl {decl = DeclConDef t} ->
+    TmDecl {decl = DeclConDef {t with ident = subIdent replacements t.ident,
                      tyIdent = substituteIdentifiersType replacements t.tyIdent,
                      inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                     ty = substituteIdentifiersType replacements t.ty}
-  | TmExt t ->
-    TmExt {t with ident = subIdent replacements t.ident,
+                     ty = substituteIdentifiersType replacements t.ty}}
+  | TmDecl {decl = DeclExt t} ->
+    TmDecl {decl = DeclExt {t with ident = subIdent replacements t.ident,
                   tyIdent = substituteIdentifiersType replacements t.tyIdent,
                   inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                  ty = substituteIdentifiersType replacements t.ty}
-  | TmRecLets t ->
+                  ty = substituteIdentifiersType replacements t.ty}}
+  | TmDecl {decl = DeclRecLets t} ->
     let subBinding = lam bind.
       {bind with ident = subIdent replacements bind.ident,
                  body = substituteIdentifiersExpr replacements bind.body,
                  tyAnnot = substituteIdentifiersType replacements bind.tyAnnot,
                  tyBody = substituteIdentifiersType replacements bind.tyBody}
     in
-    TmRecLets {t with bindings = map subBinding t.bindings,
+    TmDecl {decl = DeclRecLets {t with bindings = map subBinding t.bindings,
                       inexpr = substituteIdentifiersExpr replacements t.inexpr,
-                      ty = substituteIdentifiersType replacements t.ty}
+                      ty = substituteIdentifiersType replacements t.ty}}
   | ast ->
     let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
     let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
@@ -118,11 +118,11 @@ lang MExprFindSym = MExprAst
 
   sem findNamesOfStringsExpr : Map String Int -> Map Int Name -> Expr -> Map Int Name
   sem findNamesOfStringsExpr strs acc =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let acc = checkIdentifier strs acc t.ident in
     let acc = findNamesOfStringsExpr strs acc t.body in
     findNamesOfStringsExpr strs acc t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let findNamesBinding = lam acc. lam binding.
       checkIdentifier strs acc binding.ident
     in
@@ -132,9 +132,9 @@ lang MExprFindSym = MExprAst
     let acc = foldl findNamesBinding acc t.bindings in
     let acc = foldl findNamesBindingBody acc t.bindings in
     findNamesOfStringsExpr strs acc t.inexpr
-  | TmType {ident = ident, tyIdent = tyIdent, inexpr = inexpr}
-  | TmConDef {ident = ident, tyIdent = tyIdent, inexpr = inexpr}
-  | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr} ->
+  | TmDecl {decl = DeclType {ident = ident, tyIdent = tyIdent, inexpr = inexpr}}
+  | TmDecl {decl = DeclConDef {ident = ident, tyIdent = tyIdent, inexpr = inexpr}}
+  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr}} ->
     let acc = checkIdentifier strs acc ident in
     let acc = findNamesOfStringsType strs acc tyIdent in
     findNamesOfStringsExpr strs acc inexpr

--- a/src/stdlib/mlang/ast-builder.mc
+++ b/src/stdlib/mlang/ast-builder.mc
@@ -9,52 +9,30 @@ include "extrec/ast.mc"
 
 -- Extending the bind function for mlang expressions
 
-let base_kind_ = BaseKind () 
-let sumext_kind_ = SumExtKind () 
-
-recursive let mlang_bindF_ = 
-  use MLangAst in
-  use ExtRecordAst in
-  lam f : Expr -> Expr -> Expr. lam letexpr. lam expr.
-  bindF_ (lam letexpr. lam expr.
-    match letexpr with TmUse t then
-      TmUse {t with inexpr = mlang_bindF_ f t.inexpr expr}
-    else match letexpr with TmRecField t then
-      TmRecField {t with inexpr = mlang_bindF_ f t.inexpr expr} 
-    else match letexpr with TmRecType t then
-      TmRecType {t with inexpr = mlang_bindF_ f t.inexpr expr} 
-    else
-      f letexpr expr -- Insert at the end of the chain
-  ) letexpr expr
-end
-
-let bind_ = mlang_bindF_ (lam. lam expr. expr)
-
-let bindall_ = use MLangAst in
-  lam exprs.
-  foldr1 bind_ exprs
+let base_kind_ = BaseKind ()
+let sumext_kind_ = SumExtKind ()
 
 
 -- Extended expressions --
 
-let nuse_ = use UseAst in
+let nuse_ = use UseDeclAst in
   lam n.
-  TmUse {ident = n, inexpr = uunit_, ty = tyunknown_, info = NoInfo {}}
+  DeclUse {ident = n, info = NoInfo {}}
 
-let use_ = use UseAst in
+let use_ =
   lam s.
   nuse_ (nameNoSym s)
 
 --  Extended types --
 
-let ntyuse_ = use TyUseAst in 
-  lam n : Name. lam inty : Type. 
+let ntyuse_ = use TyUseAst in
+  lam n : Name. lam inty : Type.
   TyUse {ident = n,
          info = NoInfo {},
          inty = inty}
 
-let tyuse_ = use TyUseAst in 
-  lam s : String. lam inty : Type. 
+let tyuse_ = use TyUseAst in
+  lam s : String. lam inty : Type.
   TyUse {ident = nameNoSym s,
          info = NoInfo {},
          inty = inty}
@@ -115,10 +93,10 @@ let decl_syn_ext_ = use MLangAst in
   lam s. lam defs: [(String, Type)].
   decl_nsyn_ false (nameNoSym s) defs
 
-let decl_syn_params_ = use MLangAst in 
+let decl_syn_params_ = use MLangAst in
   lam s : String. lam ss : [String]. lam defs : [(String, Type)].
   DeclSyn {ident = nameNoSym s,
-           defs = map (lam t. {ident = nameNoSym t.0, 
+           defs = map (lam t. {ident = nameNoSym t.0,
                                tyIdent = t.1,
                                tyName = nameNoSym (concat s "Type")}) defs,
            params = map nameNoSym ss,
@@ -137,9 +115,9 @@ let decl_semty_ = use MLangAst in
   lam s. lam ty.
   decl_nsemty_ (nameNoSym s) ty
 
-let decl_semty_cases_ = use MLangAst in 
+let decl_semty_cases_ = use MLangAst in
   lam s. lam ty. lam cases.
-  let n = nameNoSym s in 
+  let n = nameNoSym s in
   DeclSem {ident = n, tyAnnot = ty,
            tyBody = tyunknown_, includes = [],
            args = Some [],
@@ -147,9 +125,9 @@ let decl_semty_cases_ = use MLangAst in
            info = NoInfo {},
            declKind = base_kind_}
 
-let decl_sem_args_ty_cases_ = use MLangAst in 
+let decl_sem_args_ty_cases_ = use MLangAst in
   lam s : String. lam args : [(String, Type)]. lam ty : Type. lam cases.
-  let n = nameNoSym s in 
+  let n = nameNoSym s in
   DeclSem {ident = n, tyAnnot = ty,
            tyBody = tyunknown_, includes = [],
            args = Some (map (lam t. {ident = nameNoSym t.0, tyAnnot = t.1}) args),
@@ -181,111 +159,6 @@ let decl_sem_ext_ = use MLangAst in
 let decl_usem_ = use MLangAst in
   lam s. lam uargs: [String]. lam cases.
   decl_nusem_ (nameNoSym s) (map nameNoSym uargs) cases
-
-
-let decl_nlet_ = use MLangAst in
-  lam n. lam ty. lam body.
-  DeclLet {ident = n,
-           tyAnnot = ty,
-           tyBody = ty,
-           body = body,
-           info = NoInfo ()}
-
-let decl_let_ = use MLangAst in
-  lam s. lam ty. lam body.
-  decl_nlet_ (nameNoSym s) ty body
-
-let decl_nulet_ = use MLangAst in
-  lam n. lam body.
-  decl_nlet_ n tyunknown_ body
-
-let decl_ulet_ = use MLangAst in
-  lam s. lam body.
-  decl_let_ s tyunknown_ body
-
-
-let decl_ntype_ = use MLangAst in
-  lam n. lam params. lam ty.
-  DeclType {ident = n,
-            params = params,
-            tyIdent = ty,
-            info = NoInfo ()}
-
-let decl_type_ = use MLangAst in
-  lam s. lam params. lam ty.
-  decl_ntype_ (nameNoSym s) (map nameNoSym params) ty
-
-
-let decl_nreclets_ = use MLangAst in
-  lam bs: [(Name, Type, Expr)].
-  let bindings = map (lam b.
-    {ident = b.0, tyAnnot = b.1, tyBody = b.1,
-     body = b.2, info = NoInfo ()}
-  ) bs in
-  DeclRecLets {bindings = bindings, info = NoInfo ()}
-
-let decl_reclets_ = use MLangAst in
-  lam bs: [(String, Type, Expr)].
-  decl_nreclets_ (map (lam b. (nameNoSym b.0, b.1, b.2)) bs)
-
-let decl_nureclets_ = use MLangAst in
-  lam bs: [(Name, Expr)].
-  decl_nreclets_ (map (lam b. (b.0, tyunknown_, b.1)) bs)
-
-let decl_ureclets_ = use MLangAst in
-  lam bs: [(String, Expr)].
-  decl_reclets_ (map (lam b. (b.0, tyunknown_, b.1)) bs)
-
-let decl_reclet_ = use MLangAst in
-  lam s. lam ty. lam body.
-  decl_reclets_ [(s, ty, body)]
-
-let decl_ureclet_ = use MLangAst in
-  lam s. lam body.
-  decl_ureclets_ [(s, body)]
-
-
-let decl_ncondef_ = use MLangAst in
-  lam n. lam ty.
-  DeclConDef {ident = n, tyIdent = ty, info = NoInfo ()}
-
-let decl_condef_ = use MLangAst in
-  lam s. lam ty.
-  decl_ncondef_ (nameNoSym s) ty
-
-let decl_nucondef_ = use MLangAst in
-  lam n.
-  decl_ncondef_ n tyunknown_
-
-let decl_ucondef_ = use MLangAst in
-  lam s.
-  decl_condef_ s tyunknown_
-
-
-let decl_utestuf_ = use MLangAst in
-  lam t. lam e. lam u. lam f.
-  DeclUtest {test = t, expected = e, tusing = Some u, tonfail = Some f, info = NoInfo ()}
-
-let decl_utestu_ = use MLangAst in
-  lam t. lam e. lam u.
-  DeclUtest {test = t, expected = e, tusing = Some u, tonfail = None (), info = NoInfo ()}
-
-let decl_utestf_ = use MLangAst in
-  lam t. lam e. lam f.
-  DeclUtest {test = t, expected = e, tusing = None (), tonfail = Some f, info = NoInfo ()}
-
-let decl_utest_ = use MLangAst in
-  lam t. lam e.
-  DeclUtest {test = t, expected = e, tusing = None (), tonfail = None (), info = NoInfo ()}
-
-
-let decl_next_ = use MLangAst in
-  lam n. lam e. lam ty.
-  DeclExt {ident = n, tyIdent = ty, effect = e, info = NoInfo ()}
-
-let decl_ext_ = use MLangAst in
-  lam s. lam e. lam ty.
-  decl_next_ (nameNoSym s) e ty
 
 
 let decl_include_ = use MLangAst in

--- a/src/stdlib/mlang/ast.mc
+++ b/src/stdlib/mlang/ast.mc
@@ -27,30 +27,16 @@ type DeclKind
 con BaseKind : () -> DeclKind
 con SumExtKind : () -> DeclKind
 
--- TmUse --
-lang UseAst = Ast
-  syn Expr =
-  | TmUse {ident : Name,
-           inexpr : Expr,
-           ty : Type,
-           info : Info}
+-- DeclUse --
+lang UseDeclAst = Ast
+  syn Decl =
+  | DeclUse {ident : Name, info : Info}
 
-  sem infoTm =
-  | TmUse t -> t.info
+  sem infoDecl =
+  | DeclUse t -> t.info
 
-  sem tyTm =
-  | TmUse t -> t.ty
-
-  sem withInfo (info : Info) =
-  | TmUse t -> TmUse {t with info = info}
-
-  sem withType (ty : Type) =
-  | TmUse t -> TmUse {t with ty = ty}
-
-  sem smapAccumL_Expr_Expr f acc =
-  | TmUse t ->
-    match f acc t.inexpr with (acc, inexpr) in
-    (acc, TmUse {t with inexpr = inexpr})
+  sem declWithInfo (info : Info) =
+  | DeclUse t -> DeclUse {t with info = info}
 end
 
 lang TyUseAst = Ast
@@ -64,58 +50,6 @@ lang TyUseAst = Ast
 
   sem tyWithInfo info =
   | TyUse t -> TyUse {t with info = info}
-end
-
--- Base fragment for MLang declarations --
-lang DeclAst = Ast
-  syn Decl = -- intentionally left blank
-
-  sem infoDecl: Decl -> Info
-  sem declWithInfo: Info -> Decl -> Decl
-
-  sem smapAccumL_Decl_Decl : all acc. (acc -> Decl -> (acc, Decl)) -> acc -> Decl -> (acc, Decl)
-  sem smapAccumL_Decl_Decl f acc = | d -> (acc, d)
-  sem smapAccumL_Decl_Expr : all acc. (acc -> Expr -> (acc, Expr)) -> acc -> Decl -> (acc, Decl)
-  sem smapAccumL_Decl_Expr f acc = | d -> (acc, d)
-  sem smapAccumL_Decl_Type : all acc. (acc -> Type -> (acc, Type)) -> acc -> Decl -> (acc, Decl)
-  sem smapAccumL_Decl_Type f acc = | d -> (acc, d)
-  sem smapAccumL_Decl_Pat : all acc. (acc -> Pat -> (acc, Pat)) -> acc -> Decl -> (acc, Decl)
-  sem smapAccumL_Decl_Pat f acc = | d -> (acc, d)
-
-  sem smap_Decl_Decl : (Decl -> Decl) -> Decl -> Decl
-  sem smap_Decl_Decl f = | d -> (smapAccumL_Decl_Decl (lam. lam a. ((), f a)) () d).1
-
-  sem sfold_Decl_Decl : all acc. (acc -> Decl -> acc) -> acc -> Decl -> acc
-  sem sfold_Decl_Decl f acc = | d -> (smapAccumL_Decl_Decl (lam acc. lam a. (f acc a, a)) acc d).0
-
-  sem smap_Decl_Expr : (Expr -> Expr) -> Decl -> Decl
-  sem smap_Decl_Expr f = | d -> (smapAccumL_Decl_Expr (lam. lam a. ((), f a)) () d).1
-
-  sem sfold_Decl_Expr : all acc. (acc -> Expr -> acc) -> acc -> Decl -> acc
-  sem sfold_Decl_Expr f acc = | d -> (smapAccumL_Decl_Expr (lam acc. lam a. (f acc a, a)) acc d).0
-
-  sem smap_Decl_Type : (Type -> Type) -> Decl -> Decl
-  sem smap_Decl_Type f = | d -> (smapAccumL_Decl_Type (lam. lam a. ((), f a)) () d).1
-
-  sem sfold_Decl_Type : all acc. (acc -> Type -> acc) -> acc -> Decl -> acc
-  sem sfold_Decl_Type f acc = | d -> (smapAccumL_Decl_Type (lam acc. lam a. (f acc a, a)) acc d).0
-
-  sem smap_Decl_Pat : (Pat -> Pat) -> Decl -> Decl
-  sem smap_Decl_Pat f = | d -> (smapAccumL_Decl_Pat (lam. lam a. ((), f a)) () d).1
-
-  sem sfold_Decl_Pat : all acc. (acc -> Pat -> acc) -> acc -> Decl -> acc
-  sem sfold_Decl_Pat f acc = | d -> (smapAccumL_Decl_Pat (lam acc. lam a. (f acc a, a)) acc d).0
-end
-
--- TODO(vipa, 2024-11-26): This enables working more or less as though
--- https://github.com/miking-lang/miking/issues/826 were already
--- implemented.
-lang ExprAsDecl = DeclAst
-  sem exprAsDecl : Expr -> Option (Decl, Expr)
-  sem exprAsDecl =
-  | _ -> None ()
-
-  sem declAsExpr : Expr -> Decl -> Expr
 end
 
 -- DeclLang --
@@ -190,6 +124,7 @@ lang SynProdExtDeclAst = DeclAst
     match mapAccumL f acc x.individualExts with (acc, individualExts) in
     (acc, SynDeclProdExt {x with individualExts = individualExts})
 end
+
 -- DeclSem --
 lang SemDeclAst = DeclAst
   type DeclSemType = {ident : Name,
@@ -237,257 +172,6 @@ lang SemDeclAst = DeclAst
       (acc, {c with pat = pat}) in
     match mapAccumL fcase acc x.cases with (acc, cases) in
     (acc, DeclSem {x with cases = cases})
-end
-
-
--- DeclLet --
-lang LetDeclAst = DeclAst
-  syn Decl =
-  | DeclLet {ident : Name,
-             tyAnnot : Type,
-             tyBody : Type,
-             body : Expr,
-             info: Info}
-
-  sem infoDecl =
-  | DeclLet d -> d.info
-
-  sem declWithInfo info =
-  | DeclLet d -> DeclLet {d with info = info}
-
-  sem smapAccumL_Decl_Expr f acc =
-  | DeclLet x ->
-    match f acc x.body with (acc, body) in
-    (acc, DeclLet {x with body = body})
-
-  sem smapAccumL_Decl_Type f acc =
-  | DeclLet x ->
-    match f acc x.tyAnnot with (acc, tyAnnot) in
-    match f acc x.tyBody with (acc, tyBody) in
-    (acc, DeclLet {x with tyAnnot = tyAnnot, tyBody = tyBody})
-end
-
-lang LetAsDecl = ExprAsDecl + LetAst + LetDeclAst
-  sem exprAsDecl =
-  | TmLet x -> Some
-    ( DeclLet {ident = x.ident, tyAnnot = x.tyAnnot, tyBody = x.tyBody, body = x.body, info = x.info}
-    , x.inexpr
-    )
-
-  sem declAsExpr inexpr =
-  | DeclLet x -> TmLet
-    { ident = x.ident
-    , tyAnnot = x.tyAnnot
-    , tyBody = x.tyBody
-    , body = x.body
-    , info = x.info
-    , inexpr = inexpr
-    , ty = tyTm inexpr
-    }
-end
-
--- DeclType --
-lang TypeDeclAst = DeclAst
-  syn Decl =
-  | DeclType {ident : Name,
-              params : [Name],
-              tyIdent : Type,
-              info : Info}
-
-  sem infoDecl =
-  | DeclType d -> d.info
-
-  sem declWithInfo info =
-  | DeclType d -> DeclType {d with info = info}
-
-  sem smapAccumL_Decl_Type f acc =
-  | DeclType x ->
-    match f acc x.tyIdent with (acc, tyIdent) in
-    (acc, DeclType {x with tyIdent = tyIdent})
-end
-
-lang TypeAsDecl = ExprAsDecl + TypeAst + TypeDeclAst
-  sem exprAsDecl =
-  | TmType x -> Some
-    ( DeclType {ident = x.ident, params = x.params, tyIdent = x.tyIdent, info = x.info}
-    , x.inexpr
-    )
-
-  sem declAsExpr inexpr =
-  | DeclType x -> TmType
-    { ident = x.ident
-    , params = x.params
-    , tyIdent = x.tyIdent
-    , info = x.info
-    , inexpr = inexpr
-    , ty = tyTm inexpr
-    }
-  end
-
--- DeclRecLets --
-lang RecLetsDeclAst = DeclAst + RecLetsAst
-  syn Decl =
-  | DeclRecLets {bindings : [RecLetBinding],
-                 info : Info}
-
-  sem infoDecl =
-  | DeclRecLets d -> d.info
-
-  sem declWithInfo info =
-  | DeclRecLets d -> DeclRecLets {d with info = info}
-
-  sem smapAccumL_Decl_Type f acc =
-  | DeclRecLets x ->
-    let fbinding = lam acc. lam b.
-      match f acc b.tyAnnot with (acc, tyAnnot) in
-      match f acc b.tyBody with (acc, tyBody) in
-      (acc, {b with tyAnnot = tyAnnot, tyBody = tyBody}) in
-    match mapAccumL fbinding acc x.bindings with (acc, bindings) in
-    (acc, DeclRecLets {x with bindings = bindings})
-
-  sem smapAccumL_Decl_Expr f acc =
-  | DeclRecLets x ->
-    let fbinding = lam acc. lam b.
-      match f acc b.body with (acc, body) in
-      (acc, {b with body = body}) in
-    match mapAccumL fbinding acc x.bindings with (acc, bindings) in
-    (acc, DeclRecLets {x with bindings = bindings})
-end
-
-lang RecLetsAsDecl = ExprAsDecl + RecLetsAst + RecLetsDeclAst
-  sem exprAsDecl =
-  | TmRecLets x -> Some
-    ( DeclRecLets {info = x.info, bindings = x.bindings}
-    , x.inexpr
-    )
-
-  sem declAsExpr inexpr =
-  | DeclRecLets x -> TmRecLets
-    { bindings = x.bindings
-    , info = x.info
-    , inexpr = inexpr
-    , ty = tyTm inexpr
-    }
-end
-
--- DeclConDef --
-lang DataDeclAst = DeclAst
-  syn Decl =
-  | DeclConDef {ident : Name,
-                tyIdent : Type,
-                info : Info}
-
-  sem infoDecl =
-  | DeclConDef d -> d.info
-
-  sem declWithInfo info =
-  | DeclConDef d -> DeclConDef {d with info = info}
-
-  sem smapAccumL_Decl_Type f acc =
-  | DeclConDef x ->
-    match f acc x.tyIdent with (acc, tyIdent) in
-    (acc, DeclConDef {x with tyIdent = tyIdent})
-end
-
-lang DataAsDecl = ExprAsDecl + DataAst + DataDeclAst
-  sem exprAsDecl =
-  | TmConDef x -> Some
-    ( DeclConDef {ident = x.ident, tyIdent = x.tyIdent, info = x.info}
-    , x.inexpr
-    )
-
-  sem declAsExpr inexpr =
-  | DeclConDef x -> TmConDef
-    { ident = x.ident
-    , tyIdent = x.tyIdent
-    , info = x.info
-    , inexpr = inexpr
-    , ty = tyTm inexpr
-    }
-end
-
--- DeclUtest --
-lang UtestDeclAst = DeclAst
-  syn Decl =
-  | DeclUtest {test : Expr,
-               expected : Expr,
-               tusing : Option Expr,
-               tonfail : Option Expr,
-               info : Info}
-
-  sem infoDecl =
-  | DeclUtest d -> d.info
-
-  sem declWithInfo info =
-  | DeclUtest d -> DeclUtest {d with info = info}
-
-  sem smapAccumL_Decl_Expr f acc =
-  | DeclUtest x ->
-    match f acc x.test with (acc, test) in
-    match f acc x.expected with (acc, expected) in
-    match optionMapAccum f acc x.tusing with (acc, tusing) in
-    match optionMapAccum f acc x.tonfail with (acc, tonfail) in
-    (acc, DeclUtest {x with test = test,
-                            expected = expected,
-                            tusing = tusing,
-                            tonfail = tonfail})
-end
-
-lang UtestAsDecl = ExprAsDecl + UtestAst + UtestDeclAst
-  sem exprAsDecl =
-  | TmUtest x -> Some
-    ( DeclUtest {test = x.test, expected = x.expected, tusing = x.tusing, tonfail = x.tonfail, info = x.info}
-    , x.next
-    )
-
-  sem declAsExpr inexpr =
-  | DeclUtest x -> TmUtest
-    { test = x.test
-    , expected = x.expected
-    , tusing = x.tusing
-    , tonfail = x.tonfail
-    , info = x.info
-    , next = inexpr
-    , ty = tyTm inexpr
-    }
-end
-
--- DeclExt --
-lang ExtDeclAst = DeclAst
-  syn Decl =
-  | DeclExt {ident : Name,
-             tyIdent : Type,
-             effect : Bool,
-             info : Info}
-
-  sem infoDecl =
-  | DeclExt d -> d.info
-
-  sem declWithInfo info =
-  | DeclExt d -> DeclExt {d with info = info}
-
-  sem smapAccumL_Decl_Type f acc =
-  | DeclExt x ->
-    match f acc x.tyIdent with (acc, tyIdent) in
-    (acc, DeclExt {x with tyIdent = tyIdent})
-end
-
-lang ExtAsDecl = ExprAsDecl + ExtAst + ExtDeclAst
-  sem exprAsDecl =
-  | TmExt x -> Some
-    ( DeclExt {ident = x.ident, tyIdent = x.tyIdent, effect = x.effect, info = x.info}
-    , x.inexpr
-    )
-
-  sem declAsExpr inexpr =
-  | DeclExt x -> TmExt
-    { ident = x.ident
-    , tyIdent = x.tyIdent
-    , effect = x.effect
-    , info = x.info
-    , inexpr = inexpr
-    , ty = tyTm inexpr
-    }
 end
 
 -- DeclInclude --
@@ -538,19 +222,9 @@ lang MLangAst =
   MLangTopLevel
 
   -- Additional expressions
-  + UseAst
 
   -- Declarations
   + LangDeclAst + SynDeclAst + SemDeclAst + LetDeclAst + TypeDeclAst
   + RecLetsDeclAst + DataDeclAst + UtestDeclAst + ExtDeclAst + IncludeDeclAst
-  + TyUseAst
-end
-
-lang MExprAsDecl
-  = LetAsDecl
-  + TypeAsDecl
-  + RecLetsAsDecl
-  + DataAsDecl
-  + UtestAsDecl
-  + ExtAsDecl
+  + UseDeclAst + TyUseAst
 end

--- a/src/stdlib/mlang/boot-parser.mc
+++ b/src/stdlib/mlang/boot-parser.mc
@@ -95,23 +95,23 @@ lang BootParserMLang = BootParser + MLangAst + CosemDeclAst
 
   sem mergeCosems : [Decl] -> [Decl]
   sem mergeCosems =| decls ->
-    let work = lam acc : ([Decl], Map String Decl). lam decl : Decl. 
-      match acc with (res, m) in 
-      match decl with DeclCosem s1 then 
-        let str = nameGetStr s1.ident in 
+    let work = lam acc : ([Decl], Map String Decl). lam decl : Decl.
+      match acc with (res, m) in
+      match decl with DeclCosem s1 then
+        let str = nameGetStr s1.ident in
         match mapLookup str m with Some (DeclCosem s2) then
           match s1.tyAnnot with TyUnknown _ then
-            let m = mapRemove str m in 
+            let m = mapRemove str m in
             (res, mapInsert str (DeclCosem {s1 with tyAnnot = s2.tyAnnot}) m)
-          else 
-            let m = mapRemove str m in 
+          else
+            let m = mapRemove str m in
             (res, mapInsert str (DeclCosem {s1 with args = s2.args, cases = s2.cases}) m)
-        else 
+        else
           (res, mapInsert str decl m)
-      else 
+      else
         (cons decl res, m)
-    in 
-    match foldl work ([], mapEmpty cmpString) decls with (res, m) in 
+    in
+    match foldl work ([], mapEmpty cmpString) decls with (res, m) in
     concat res (mapValues m)
 
 
@@ -121,17 +121,17 @@ lang BootParserMLang = BootParser + MLangAst + CosemDeclAst
     let nCons = glistlen d 0 in
     let nParams = if eqi nCons 0 then 0 else glistlen d 1 in
 
-    let parseCon = lam i. 
-      let ident = gname d (addi i 1) in 
-      let ty = gtype d i in 
-      let tyName = nameNoSym (concat (gstr d (addi i 1)) "Type") in 
+    let parseCon = lam i.
+      let ident = gname d (addi i 1) in
+      let ty = gtype d i in
+      let tyName = nameNoSym (concat (gstr d (addi i 1)) "Type") in
       {ident = ident, tyIdent = ty, tyName = tyName}
-    in 
+    in
 
-    let kind = switch gint d 0 
-      case 0 then base_kind_ 
-      case 1 then sumext_kind_ 
-    end in 
+    let kind = switch gint d 0
+      case 0 then base_kind_
+      case 1 then sumext_kind_
+    end in
 
     DeclSyn {ident = gname d 0,
              includes = [],
@@ -139,10 +139,10 @@ lang BootParserMLang = BootParser + MLangAst + CosemDeclAst
              params = map (lam i. gname d (addi (addi 1 nCons) i)) (range 0 nParams 1),
              info = ginfo d 0,
              declKind = kind}
-  | 703 -> 
-    let nCases = glistlen d 0 in 
-    let nArgs = glistlen d 1 in 
-    let parseCase = lam i. 
+  | 703 ->
+    let nCases = glistlen d 0 in
+    let nArgs = glistlen d 1 in
+    let parseCase = lam i.
       {pat = gpat d i, thn = gterm d i}
     in
     let parseArg = (lam i. {ident = gname d i, tyAnnot = gtype d i}) in
@@ -153,10 +153,10 @@ lang BootParserMLang = BootParser + MLangAst + CosemDeclAst
       Some (map (lam i. {ident = gname d i, tyAnnot = gtype d i}) (range 1 (addi 1 nArgs) 1))
     in
 
-    let kind = switch gint d 0 
-      case 0 then base_kind_ 
-      case 1 then sumext_kind_ 
-    end in 
+    let kind = switch gint d 0
+      case 0 then base_kind_
+      case 1 then sumext_kind_
+    end in
 
     DeclSem {ident = gname d 0,
              tyAnnot = gtype d 0,
@@ -185,9 +185,9 @@ lang BootParserMLang = BootParser + MLangAst + CosemDeclAst
       matchDecl a (bootParserGetId a)
     in
 
-    let decls = map parseDecl (range 0 nDecls 1) in 
-    let decls = reverse (mergeSems decls) in 
-    let decls = reverse (mergeCosems decls) in 
+    let decls = map parseDecl (range 0 nDecls 1) in
+    let decls = reverse (mergeSems decls) in
+    let decls = reverse (mergeCosems decls) in
 
 
 
@@ -232,11 +232,12 @@ lang BootParserMLang = BootParser + MLangAst + CosemDeclAst
              info = ginfo d 0}
 
   sem matchTerm t =
-  | 116 ->
-    TmUse {info = ginfo t 0,
-           inexpr = gterm t 0,
-           ty = tyunknown_,
-           ident = gname t 0}
+  | 116 -> TmDecl
+    { decl = DeclUse {ident = gname t 0, info = ginfo t 0}
+    , inexpr = gterm t 0
+    , info = ginfo t 0
+    , ty = tyunknown_
+    }
 
   sem matchType t =
   | 214 ->
@@ -529,7 +530,7 @@ let str = strJoin "\n" [
   "()"
 ] in
 let p = parseProgram str in
-match p.expr with TmUse u in
+match p.expr with TmDecl {decl = DeclUse u} in
 utest nameGetStr u.ident with "L" in
 
 -- Test TyUse parsing
@@ -584,7 +585,7 @@ let str = strJoin "\n" [
   "mexpr",
   "()"
 ] in
-let p = parseProgram str in 
+let p = parseProgram str in
 -- printLn (mlang2str p) ;
 
 ()

--- a/src/stdlib/mlang/compile.mc
+++ b/src/stdlib/mlang/compile.mc
@@ -136,7 +136,7 @@ lang DeclCompiler = DeclAst + Ast + MExprSubstitute
   sem compileDecl : CompilationContext -> Decl -> CompilationResult
 end
 
-lang LetDeclCompiler = DeclCompiler + LetDeclAst + LetAst
+lang LetDeclCompiler = DeclCompiler + LetDeclAst + LetDeclAst
   sem compileDecl ctx = 
   | DeclLet d -> result.ok (
     withExpr ctx (TmLet {ident = d.ident,
@@ -148,7 +148,7 @@ lang LetDeclCompiler = DeclCompiler + LetDeclAst + LetAst
                          inexpr = uunit_}))
 end
 
-lang RecletsDeclCompiler = DeclCompiler + RecLetsDeclAst + RecLetsAst
+lang RecletsDeclCompiler = DeclCompiler + RecLetsDeclAst + RecLetsDeclAst
   sem compileDecl ctx = 
   | DeclRecLets d -> result.ok (
     withExpr ctx (TmRecLets {bindings = d.bindings,
@@ -157,7 +157,7 @@ lang RecletsDeclCompiler = DeclCompiler + RecLetsDeclAst + RecLetsAst
                              info = d.info}))
 end
 
-lang UtestDeclCompiler = DeclCompiler + UtestDeclAst + UtestAst
+lang UtestDeclCompiler = DeclCompiler + UtestDeclAst + UtestDeclAst
   sem compileDecl ctx = 
   | DeclUtest d -> result.ok (
     withExpr ctx (TmUtest {test = d.test,
@@ -169,7 +169,7 @@ lang UtestDeclCompiler = DeclCompiler + UtestDeclAst + UtestAst
                            info = d.info}))
 end
 
-lang TypeDeclCompiler = DeclCompiler + TypeDeclAst + TypeAst
+lang TypeDeclCompiler = DeclCompiler + TypeDeclAst + TypeDeclAst
   sem compileDecl ctx = 
   | DeclType d -> 
     result.ok (withExpr ctx (TmType {ident = d.ident,
@@ -190,7 +190,7 @@ lang ConDefDeclCompiler = DeclCompiler + DataDeclAst + DataAst
                             inexpr = uunit_}))
 end
 
-lang ExtDeclCompiler = DeclCompiler + ExtDeclAst + ExtAst
+lang ExtDeclCompiler = DeclCompiler + ExtDeclAst + ExtDeclAst
   sem compileDecl ctx = 
   -- TODO(voorberg, 2024-04-23): Add test case for the compilation of externals.
   | DeclExt d -> result.ok (
@@ -202,7 +202,7 @@ lang ExtDeclCompiler = DeclCompiler + ExtDeclAst + ExtAst
                          inexpr = uunit_}))
 end
 
-lang SynTypeDeclCompiler = SynDeclAst + TypeAst
+lang SynTypeDeclCompiler = SynDeclAst + TypeDeclAst
   sem compileSynType : CompilationContext -> Decl -> CompilationContext
   sem compileSynType ctx =
   | DeclSyn s ->

--- a/src/stdlib/mlang/compile.mc
+++ b/src/stdlib/mlang/compile.mc
@@ -1,6 +1,6 @@
--- The MLangCompiler compiles a `MLangProgram` into a single `Expr`. 
--- 
--- Before the MLangCompiler can be used to lower MLang to MExpr, the following 
+-- The MLangCompiler compiles a `MLangProgram` into a single `Expr`.
+--
+-- Before the MLangCompiler can be used to lower MLang to MExpr, the following
 -- transformations must have been performed (in order) as prerequisites:
 -- (0) All `DeclInclude`s must have been handled by `include-handler.mc`.
 -- (1) All constants that have been parsed as TmVars should be transformed
@@ -18,7 +18,7 @@
 -- (2) For each langauge fragment, a syntax declaration is turned into
 --     a TmType if syntax definition is the base of this syntax and constructor
 --     defintions are converted to TmConDefs.
--- (3) All of the semantic functions in a Reclets are turned into a TmReclet. 
+-- (3) All of the semantic functions in a Reclets are turned into a TmReclet.
 --     The cases of a semantic functions are converted into a chain of TmMatch
 --     expressions based on the orderning that computed in `composition-check.mc`
 --     We also perform subtitution on the name of semantic functions, arguments,
@@ -43,23 +43,23 @@ include "error.mc"
 include "set.mc"
 include "result.mc"
 
-let data_ = lam ident : Name. 
-  use DataKindAst in 
-  let types = mapEmpty nameCmp in 
-  let types = mapInsert ident {lower = setEmpty nameCmp, upper = None ()} types in 
+let data_ = lam ident : Name.
+  use DataKindAst in
+  let types = mapEmpty nameCmp in
+  let types = mapInsert ident {lower = setEmpty nameCmp, upper = None ()} types in
   Data {types = types}
 
 type CompilationContext = use MLangAst in {
   -- Accumulator of compilation result
-  exprs: [Expr],
+  decls: [Decl],
 
   -- Accumulator of expressions that must be at the top level
   -- I.e. declarations of open sum types and open product types.
-  toplevelExprs : [Expr],
+  toplevelDecls : [Decl],
 
   compositionCheckEnv : CompositionCheckEnv,
 
-  -- A map from identifier strings of semantic functions to the 
+  -- A map from identifier strings of semantic functions to the
   -- symbolized names that the function has in different fragments.
   semSymbols : Map String [Name],
 
@@ -74,15 +74,15 @@ type CompilationContext = use MLangAst in {
   globalFields : Map Name Type
 }
 
-let mergeRecordTypes = lam l. lam r. 
-  use RecordTypeAst in 
-  match (l, r) with (TyRecord left, TyRecord right) in 
+let mergeRecordTypes = lam l. lam r.
+  use RecordTypeAst in
+  match (l, r) with (TyRecord left, TyRecord right) in
   TyRecord {left with fields = mapUnion left.fields right.fields}
 
-let _emptyCompilationContext : CompositionCheckEnv -> CompilationContext = 
+let _emptyCompilationContext : CompositionCheckEnv -> CompilationContext =
   lam env : CompositionCheckEnv. {
-    exprs = [],
-    toplevelExprs = [],
+    decls = [],
+    toplevelDecls = [],
     compositionCheckEnv = env,
     semSymbols = mapEmpty cmpString,
     conToExtType = mapEmpty nameCmp,
@@ -92,29 +92,29 @@ let _emptyCompilationContext : CompositionCheckEnv -> CompilationContext =
     globalFields = mapEmpty nameCmp
 }
 
-let withExpr = lam ctx. lam expr. 
-  {ctx with exprs = snoc ctx.exprs expr}
+let withDecl = lam ctx. lam decl.
+  {ctx with decls = snoc ctx.decls decl}
 
-let withToplevelExpr = lam ctx. lam expr. 
-  {ctx with toplevelExprs = snoc ctx.toplevelExprs expr}
+let withTopLevelDecl = lam ctx. lam decl.
+  {ctx with toplevelDecls = snoc ctx.toplevelDecls decl}
 
 let withSemSymbol = lam ctx : CompilationContext. lam n : Name.
-  let s = nameGetStr n in 
-  let newValue = match mapLookup s ctx.semSymbols with Some names 
-                 then cons n names 
+  let s = nameGetStr n in
+  let newValue = match mapLookup s ctx.semSymbols with Some names
+                 then cons n names
                  else [n]
   in
   {ctx with semSymbols = mapInsert s newValue ctx.semSymbols}
 
-let createPairsForSubst = lam env. lam origLang. lam targetLang.  
-  match mapLookup origLang env.compositionCheckEnv.langToSems with Some origNames in 
-  match mapLookup targetLang env.compositionCheckEnv.langToSems with Some targetNames in 
+let createPairsForSubst = lam env. lam origLang. lam targetLang.
+  match mapLookup origLang env.compositionCheckEnv.langToSems with Some origNames in
+  match mapLookup targetLang env.compositionCheckEnv.langToSems with Some targetNames in
 
-  let origSet = setOfSeq nameCmp origNames in 
-  let targetPairs = map (lam n. (nameGetStr n, n)) targetNames in 
-  let targetMap = mapFromSeq cmpString targetPairs in 
+  let origSet = setOfSeq nameCmp origNames in
+  let targetPairs = map (lam n. (nameGetStr n, n)) targetNames in
+  let targetMap = mapFromSeq cmpString targetPairs in
 
-  let origs = setToSeq origSet in 
+  let origs = setToSeq origSet in
 
   map (lam n. (n, match mapLookup (nameGetStr n) targetMap with Some x in x)) origs
 
@@ -123,13 +123,13 @@ con FoundIncludeError : {info : Info, path: String} -> CompilationError
 
 type CompilationWarning
 
-type CompilationResult = Result CompilationWarning CompilationError CompilationContext 
+type CompilationResult = Result CompilationWarning CompilationError CompilationContext
 
-let isTypeDecl = use MLangAst in 
+let isTypeDecl = use MLangAst in
   lam d. match d with DeclType _ then true else false
-let isSynDecl = use MLangAst in 
+let isSynDecl = use MLangAst in
   lam d. match d with DeclSyn _ then true else false
-let isSemDecl = use MLangAst in 
+let isSemDecl = use MLangAst in
   lam d. match d with DeclSem _ then true else false
 
 lang DeclCompiler = DeclAst + Ast + MExprSubstitute
@@ -137,69 +137,57 @@ lang DeclCompiler = DeclAst + Ast + MExprSubstitute
 end
 
 lang LetDeclCompiler = DeclCompiler + LetDeclAst + LetDeclAst
-  sem compileDecl ctx = 
+  sem compileDecl ctx =
   | DeclLet d -> result.ok (
-    withExpr ctx (TmDecl {decl = DeclLet {ident = d.ident,
+    withDecl ctx (DeclLet {ident = d.ident,
                          tyAnnot = d.tyAnnot,
                          tyBody = d.tyBody,
                          body = d.body,
-                         info = d.info,
-                         ty = tyunknown_,
-                         inexpr = uunit_}}))
+                         info = d.info}))
 end
 
 lang RecletsDeclCompiler = DeclCompiler + RecLetsDeclAst + RecLetsDeclAst
-  sem compileDecl ctx = 
+  sem compileDecl ctx =
   | DeclRecLets d -> result.ok (
-    withExpr ctx (TmDecl {decl = DeclRecLets {bindings = d.bindings,
-                             inexpr = uunit_,
-                             ty = tyunknown_,
-                             info = d.info}}))
+    withDecl ctx (DeclRecLets {bindings = d.bindings,
+                             info = d.info}))
 end
 
 lang UtestDeclCompiler = DeclCompiler + UtestDeclAst + UtestDeclAst
-  sem compileDecl ctx = 
+  sem compileDecl ctx =
   | DeclUtest d -> result.ok (
-    withExpr ctx (TmDecl {decl = DeclUtest {test = d.test,
+    withDecl ctx (DeclUtest {test = d.test,
                            expected = d.expected,
-                           next = uunit_,
                            tusing = d.tusing,
                            tonfail = None (),
-                           ty = tyunknown_,
-                           info = d.info}}))
+                           info = d.info}))
 end
 
 lang TypeDeclCompiler = DeclCompiler + TypeDeclAst + TypeDeclAst
-  sem compileDecl ctx = 
-  | DeclType d -> 
-    result.ok (withExpr ctx (TmDecl {decl = DeclType {ident = d.ident,
+  sem compileDecl ctx =
+  | DeclType d ->
+    result.ok (withDecl ctx (DeclType {ident = d.ident,
                                      params = d.params,
                                      tyIdent = d.tyIdent,
-                                     info = d.info,
-                                     ty = tyunknown_,
-                                     inexpr = uunit_}}))
+                                     info = d.info}))
 end
 
 lang ConDefDeclCompiler = DeclCompiler + DataDeclAst + DataAst
-  sem compileDecl ctx = 
+  sem compileDecl ctx =
   | DeclConDef d -> result.ok (
-    withExpr ctx (TmDecl {decl = DeclConDef {ident = d.ident,
+    withDecl ctx (DeclConDef {ident = d.ident,
                             tyIdent = d.tyIdent,
-                            info = d.info,
-                            ty = tyunknown_,
-                            inexpr = uunit_}}))
+                            info = d.info}))
 end
 
 lang ExtDeclCompiler = DeclCompiler + ExtDeclAst + ExtDeclAst
-  sem compileDecl ctx = 
+  sem compileDecl ctx =
   -- TODO(voorberg, 2024-04-23): Add test case for the compilation of externals.
   | DeclExt d -> result.ok (
-    withExpr ctx (TmDecl {decl = DeclExt {ident = d.ident,
+    withDecl ctx (DeclExt {ident = d.ident,
                          tyIdent = d.tyIdent,
                          effect = d.effect,
-                         info = d.info,
-                         ty = tyunknown_,
-                         inexpr = uunit_}}))
+                         info = d.info}))
 end
 
 lang SynTypeDeclCompiler = SynDeclAst + TypeDeclAst
@@ -209,35 +197,33 @@ lang SynTypeDeclCompiler = SynDeclAst + TypeDeclAst
     -- We only include a type definition if this is the base declaration of
     -- a syntax type. To check that something is a base syn definition,
     -- we check that it does not include any other definitions.
-    if null s.includes then 
-      withToplevelExpr ctx (TmDecl {decl = DeclType {ident = s.ident,
+    if null s.includes then
+      withTopLevelDecl ctx (DeclType {ident = s.ident,
                                     params = s.params,
                                     tyIdent = tyvariant_ [],
-                                    inexpr = uunit_,
-                                    ty = tyunknown_,
-                                    info = s.info}})
-    else 
+                                    info = s.info})
+    else
       ctx
 end
 
 lang SemDeclCompiler = SemDeclAst + MExprAst + DeclCompiler
-  sem compileSem langStr ctx semNames = 
-  | DeclSem d -> 
-    -- If this semantic function does not have a type annotation, copy the 
+  sem compileSem langStr ctx semNames =
+  | DeclSem d ->
+    -- If this semantic function does not have a type annotation, copy the
     -- type annotation from the base semantic function.
     let baseIdent = (match mapLookup (langStr, nameGetStr d.ident) ctx.compositionCheckEnv.baseMap with Some ident in ident) in
-    let baseTyAnnot = match mapLookup baseIdent ctx.compositionCheckEnv.semBaseToTyAnnot with Some ty in ty in 
-    let tyAnnot = match d.tyAnnot with TyUnknown _ then baseTyAnnot else d.tyAnnot in 
+    let baseTyAnnot = match mapLookup baseIdent ctx.compositionCheckEnv.semBaseToTyAnnot with Some ty in ty in
+    let tyAnnot = match d.tyAnnot with TyUnknown _ then baseTyAnnot else d.tyAnnot in
 
     -- Create substitution function for param aliasing
-    let args = match d.args with Some args then args else [] in 
-    let argsIdents : [Name] = map (lam a. a.ident) args in 
+    let args = match d.args with Some args then args else [] in
+    let argsIdents : [Name] = map (lam a. a.ident) args in
 
-    let targetName = nameSym "target" in 
-    let target = nvar_ targetName in 
+    let targetName = nameSym "target" in
+    let target = nvar_ targetName in
 
-    recursive 
-      let compileBody = lam cases : [{pat : Pat, thn : Expr}]. 
+    recursive
+      let compileBody = lam cases : [{pat : Pat, thn : Expr}].
         match cases with [h] ++ t then
           TmMatch {target = target,
                    pat = h.pat,
@@ -246,59 +232,59 @@ lang SemDeclCompiler = SemDeclAst + MExprAst + DeclCompiler
                    ty = tyunknown_,
                    info = d.info}
         -- else (error_ (str_ "Inexhaustive match!"))
-        else 
-          let s = join ["Inexhaustive match in ", langStr, ".", nameGetStr d.ident, "!\n"] in 
+        else
+          let s = join ["Inexhaustive match in ", langStr, ".", nameGetStr d.ident, "!\n"] in
           semi_ (print_ (str_ s)) (inever_ d.info)
-    in 
-    let compileBodyHelper = lam cases : [{pat : Pat, thn : Expr}]. 
-      if null cases then 
+    in
+    let compileBodyHelper = lam cases : [{pat : Pat, thn : Expr}].
+      if null cases then
         error_ (str_ (join ["Semantic function without cases: ", langStr, ".", nameGetStr d.ident, "!\n"]))
       else
-        compileBody cases 
+        compileBody cases
     in
-    let cases = match mapLookup (langStr, nameGetStr d.ident) ctx.compositionCheckEnv.semPatMap 
+    let cases = match mapLookup (langStr, nameGetStr d.ident) ctx.compositionCheckEnv.semPatMap
                 with Some x then x
                 else error "CompositionCheckEnv must contain the ordered cases for all semantic functions!"
     in
 
-    let curTyVarSymbols = match mapLookup (langStr, nameGetStr d.ident) ctx.compositionCheckEnv.semTyVarMap with Some ns in ns in  
+    let curTyVarSymbols = match mapLookup (langStr, nameGetStr d.ident) ctx.compositionCheckEnv.semTyVarMap with Some ns in ns in
 
     -- Substitute parameters, sem symbols and type variables.
-    -- 
+    --
     -- We substitute the parameters because semantic functions are allowed
-    -- to have different parameter names than the sems they include as long 
-    -- as the amount of parameters is the same (this is checked by 
+    -- to have different parameter names than the sems they include as long
+    -- as the amount of parameters is the same (this is checked by
     -- composition-check.mc). To handle the case in which the parameter names
     -- are different, we must perform a substitution.
-    -- 
+    --
     -- For any included cases, we look at the origin language of this case. Any
     -- sem names belonging to the origin language are substituted to the name
     -- of the language fragment we are compiling. We do not just substitute the
     -- name of the current sem, but of all sems in the langauge fragment in order
-    -- to properly handle mutual recursion. 
+    -- to properly handle mutual recursion.
     --
     -- Since semantic funtions can have different type annotations introducing
     -- different symbols, and these symbols may be used in the case bodies,
     -- we also substitute these symbols.
     let work = lam c.
-      let origArgs : Option [Name] = match mapLookup c.orig ctx.compositionCheckEnv.semArgsMap with Some args in args in 
+      let origArgs : Option [Name] = match mapLookup c.orig ctx.compositionCheckEnv.semArgsMap with Some args in args in
       let origArgs : [Name] = match origArgs with Some args then args else [] in
 
-      let origTyVarSymbols = match mapLookup c.orig ctx.compositionCheckEnv.semTyVarMap with Some ns in ns in 
+      let origTyVarSymbols = match mapLookup c.orig ctx.compositionCheckEnv.semTyVarMap with Some ns in ns in
 
       let pairs = join [
         zip origArgs argsIdents,
         createPairsForSubst ctx c.orig.0 langStr,
         zip origTyVarSymbols curTyVarSymbols
-      ] in 
+      ] in
 
-      let subst = mapFromSeq nameCmp pairs in 
-      {c with thn = substituteIdentifiersExpr subst c.thn} in 
+      let subst = mapFromSeq nameCmp pairs in
+      {c with thn = substituteIdentifiersExpr subst c.thn} in
     let cases = map work cases in
 
     let cases = map (lam c. {thn = c.thn, pat = c.pat}) cases in
-    let body = compileBodyHelper cases in 
-    recursive let compileArgs = lam args. 
+    let body = compileBodyHelper cases in
+    recursive let compileArgs = lam args.
           match args with [h] ++ t then
             TmLam {ident = h.ident,
                    tyAnnot = h.tyAnnot,
@@ -313,15 +299,15 @@ lang SemDeclCompiler = SemDeclAst + MExprAst + DeclCompiler
                    body = body,
                    ty = tyunknown_,
                    info = d.info}
-    in 
-    let result = compileArgs (optionGetOrElse (lam. []) d.args) in 
-    match d.args with Some _ then 
+    in
+    let result = compileArgs (optionGetOrElse (lam. []) d.args) in
+    match d.args with Some _ then
       {ident = d.ident,
       tyAnnot = tyAnnot,
       tyBody = tyunknown_,
       body = result,
       info = d.info}
-    else 
+    else
       {ident = d.ident,
       tyAnnot = tyAnnot,
       tyBody = tyunknown_,
@@ -329,216 +315,212 @@ lang SemDeclCompiler = SemDeclAst + MExprAst + DeclCompiler
       info = d.info}
 end
 
-lang MLangSynDefCompiler = SynDeclAst + MExprAst 
-  sem compileMLangSynDefs langStr ctx = 
-  | DeclSyn s -> 
-    match mapLookup (langStr, nameGetStr s.ident) ctx.compositionCheckEnv.baseMap 
-    with Some baseIdent in 
+lang MLangSynDefCompiler = SynDeclAst + MExprAst
+  sem compileMLangSynDefs langStr ctx =
+  | DeclSyn s ->
+    match mapLookup (langStr, nameGetStr s.ident) ctx.compositionCheckEnv.baseMap
+    with Some baseIdent in
 
     -- Wrap a type in a tyall for each parameter
-    let forallWrapper = lam ty. foldr ntyall_ ty s.params in 
+    let forallWrapper = lam ty. foldr ntyall_ ty s.params in
 
     -- Apply the type variables to the type constructor on the rhs of tyIdent
     let rhs = foldl (lam ty. lam n. tyapp_ ty (ntyvar_ n)) (ntycon_ baseIdent) s.params in
 
     let compileDef = lam ctx. lam def.
-      withExpr ctx (TmDecl {decl = DeclConDef {ident = def.ident,
+      withDecl ctx (DeclConDef {ident = def.ident,
                               tyIdent = forallWrapper (tyarrow_ def.tyIdent rhs),
-                              info = s.info,
-                              ty = tyunknown_,
-                              inexpr = uunit_}}) in 
+                              info = s.info}) in
 
-    foldl compileDef ctx s.defs    
+    foldl compileDef ctx s.defs
 end
 
-lang MLangLangDeclCompiler = DeclCompiler + LangDeclAst + MExprAst + SemDeclAst + 
+lang MLangLangDeclCompiler = DeclCompiler + LangDeclAst + MExprAst + SemDeclAst +
                              SynDeclAst + TypeDeclAst + SynTypeDeclCompiler +
                              SemDeclCompiler + MLangSynDefCompiler
-  sem compileDecl ctx = 
-  | DeclLang l -> 
+  sem compileDecl ctx =
+  | DeclLang l ->
     let langStr = nameGetStr l.ident in
 
-    let typeDecls = filter isTypeDecl l.decls in 
-    let synDecls = filter isSynDecl l.decls in 
-    let semDecls = filter isSemDecl l.decls in 
+    let typeDecls = filter isTypeDecl l.decls in
+    let synDecls = filter isSynDecl l.decls in
+    let semDecls = filter isSemDecl l.decls in
 
-    let nameSeq =  (map (lam s. match s with DeclSem s in (nameGetStr s.ident, s.ident)) semDecls) in 
-    let semNames = mapFromSeq cmpString nameSeq in 
+    let nameSeq =  (map (lam s. match s with DeclSem s in (nameGetStr s.ident, s.ident)) semDecls) in
+    let semNames = mapFromSeq cmpString nameSeq in
 
-    let ctx = foldl withSemSymbol ctx (map (lam s. match s with DeclSem s in s.ident) semDecls) in 
+    let ctx = foldl withSemSymbol ctx (map (lam s. match s with DeclSem s in s.ident) semDecls) in
 
-    let ctx = foldl compileSynType ctx synDecls in 
+    let ctx = foldl compileSynType ctx synDecls in
     let res = result.foldlM compileDecl ctx typeDecls in
-    let res = result.map (lam ctx. foldl (compileMLangSynDefs langStr) ctx synDecls) res in 
+    let res = result.map (lam ctx. foldl (compileMLangSynDefs langStr) ctx synDecls) res in
 
     let compileSemToResult : CompilationContext -> [Decl] -> CompilationContext
       = lam ctx. lam sems.
-        let semBindings = map (compileSem langStr ctx semNames) sems in 
-        withExpr ctx (TmDecl {decl = DeclRecLets {bindings = semBindings,
-                                 inexpr = uunit_, 
-                                 ty = tyunknown_,
-                                 info = l.info}})
+        let semBindings = map (compileSem langStr ctx semNames) sems in
+        withDecl ctx (DeclRecLets {bindings = semBindings,
+                                 info = l.info})
     in
     result.map (lam ctx. compileSemToResult ctx semDecls) res
-  | DeclSyn s -> 
+  | DeclSyn s ->
     error "Unexpected DeclSyn"
-  | DeclSem s -> 
+  | DeclSem s ->
     error "Unexpected DeclSem!"
-end 
+end
 
 lang MLangTopLevelCompiler = MLangTopLevel + DeclCompiler + LangDeclAst + SynDeclAst
   sem _gatherBaseSemNames : Set Name -> Decl -> Set Name
   sem _gatherBaseSemNames acc =
-  | DeclLang d -> 
-    foldl _gatherBaseSemNames acc d.decls 
-  | DeclSyn {includes = [], ident = ident} -> 
+  | DeclLang d ->
+    foldl _gatherBaseSemNames acc d.decls
+  | DeclSyn {includes = [], ident = ident} ->
     setInsert ident acc
   | _ -> acc
-  
 
-  sem compileProg : CompilationContext -> MLangProgram -> CompilationResult
-  sem compileProg ctx = 
-  | prog -> 
-    let ctx = {ctx with allBaseSyns = foldl _gatherBaseSemNames (setEmpty nameCmp) prog.decls} in 
+
+  sem compileProg : CompilationContext -> MLangProgram -> Result CompilationWarning CompilationError (CompilationContext, Expr)
+  sem compileProg ctx =
+  | prog ->
+    let ctx = {ctx with allBaseSyns = foldl _gatherBaseSemNames (setEmpty nameCmp) prog.decls} in
 
     let res = result.foldlM compileDecl ctx prog.decls in
-    result.map (lam ctx. withExpr ctx prog.expr) res
+    result.map (lam ctx. (ctx, prog.expr)) res
 end
 
-lang MLangCompilerWihtoutLang = MLangAst + MExprAst + MLangTopLevelCompiler + 
-                                ExtDeclCompiler + ConDefDeclCompiler + 
+lang MLangCompilerWihtoutLang = MLangAst + MExprAst + MLangTopLevelCompiler +
+                                ExtDeclCompiler + ConDefDeclCompiler +
                                 TypeDeclCompiler + UtestDeclCompiler +
                                 RecletsDeclCompiler + LetDeclCompiler
   sem compile : CompilationContext -> MLangProgram -> Result CompilationWarning CompilationError Expr
-  sem compile ctx =| prog -> 
+  sem compile ctx =| prog ->
     match result.consume (compileProg ctx prog) with (_, res) in
     switch res
-      case Left err then 
+      case Left err then
         result.err (head err)
-      case Right ctx then 
-        result.ok (bindall_ (concat ctx.toplevelExprs ctx.exprs))
+      case Right (ctx, expr) then
+        result.ok (bindall_ (concat ctx.toplevelDecls ctx.decls) expr)
     end
 end
 
 lang MLangCompiler = MLangCompilerWihtoutLang + MLangLangDeclCompiler
 end
 
-lang TestLang = MLangCompiler + MLangSym + MLangCompositionCheck + 
+lang TestLang = MLangCompiler + MLangSym + MLangCompositionCheck +
                 MExprPrettyPrint + MExprEval + MExprEq end
 
 mexpr
-use TestLang in 
-use LanguageComposer in 
+use TestLang in
+use LanguageComposer in
 
-let simpleEval = lam e. eval (evalCtxEmpty ()) e in 
+let simpleEval = lam e. eval (evalCtxEmpty ()) e in
 
-let testCompile = lam p. 
-  let p = composeProgram p in 
-  match symbolizeMLang symEnvDefault p with (_, p) in 
-  match result.consume (checkComposition p) with (_, res) in 
+let testCompile = lam p.
+  let p = composeProgram p in
+  match symbolizeMLang symEnvDefault p with (_, p) in
+  match result.consume (checkComposition p) with (_, res) in
 
   match res with Left errs then (use MLangCompositionCheck in iter raiseError errs; never )
   else match res with Right env in
-  let ctx = _emptyCompilationContext env in 
-  let res = result.consume (compile ctx p) in 
-  match res with (_, rhs) in 
+  let ctx = _emptyCompilationContext env in
+  let res = result.consume (compile ctx p) in
+  match res with (_, rhs) in
   match rhs with Right expr in expr
 in
 
-let testError = lam p. 
-  match symbolizeMLang symEnvDefault p with (_, p) in 
-  match result.consume (checkComposition p) with (_, res) in 
+let testError = lam p.
+  match symbolizeMLang symEnvDefault p with (_, p) in
+  match result.consume (checkComposition p) with (_, res) in
   match res with Right env in
-  let ctx = _emptyCompilationContext env in 
-  let res = result.consume (compile ctx p) in 
-  match res with (_, rhs) in 
+  let ctx = _emptyCompilationContext env in
+  let res = result.consume (compile ctx p) in
+  match res with (_, rhs) in
   match rhs with Left errs in errs
 in
 
 let testEval = lam p.
   simpleEval (testCompile p)
-in 
+in
 
 -- Test simple let binding
 let p : MLangProgram = {
     decls = [
-        decl_ulet_ "x" (int_ 1)
+        ulet_ "x" (int_ 1)
     ],
     expr = var_ "x"
-} in 
-utest testEval p with int_ 1 using eqExpr in 
+} in
+utest testEval p with int_ 1 using eqExpr in
 
 -- Test recursive let bindings through mutually recursive odd/even
-let odd = (ulam_ "x" 
-  (if_ 
+let odd = (ulam_ "x"
+  (if_
     (eqi_ (var_ "x") (int_ 0))
     (false_)
     (appf1_ (var_ "even") (subi_ (var_ "x") (int_ 1)))))
-in 
-let even = (ulam_ "x" 
-  (if_ 
+in
+let even = (ulam_ "x"
+  (if_
     (eqi_ (var_ "x") (int_ 0))
     (true_)
     (appf1_ (var_ "odd") (subi_ (var_ "x") (int_ 1)))))
-in 
+in
 let p : MLangProgram = {
     decls = [
-        decl_ureclets_ [("odd", odd), ("even", even)]
+        ureclets_ [("odd", odd), ("even", even)]
     ],
     expr = appf1_ (var_ "odd") (int_ 9)
-} in 
-utest testEval p with true_ using eqExpr in 
+} in
+utest testEval p with true_ using eqExpr in
 let p : MLangProgram = {
     decls = [
-        decl_ureclets_ [("odd", odd), ("even", even)]
+        ureclets_ [("odd", odd), ("even", even)]
     ],
     expr = appf1_ (var_ "odd") (int_ 10)
-} in 
-utest testEval p with false_ using eqExpr in 
+} in
+utest testEval p with false_ using eqExpr in
 
 -- Test Utest
 let p : MLangProgram = {
     decls = [
-        decl_utest_ (int_ 3) (addi_ (int_ 1) (int_ 2))
+        utest_ (int_ 3) (addi_ (int_ 1) (int_ 2))
     ],
     expr = uunit_
-} in 
-let expected : Expr = utest_ (int_ 3) (addi_ (int_ 1) (int_ 2)) uunit_ in 
-utest testCompile p with expected using eqExpr in 
+} in
+let expected : Expr = bind_ (utest_ (int_ 3) (addi_ (int_ 1) (int_ 2))) uunit_ in
+utest testCompile p with expected using eqExpr in
 
 -- Test Declype and DeclConDef
 let p : MLangProgram = {
     decls = [
-      decl_type_ "Foo" [] (tyvariant_ []),
-      decl_condef_ "Bar"
+      type_ "Foo" [] (tyvariant_ []),
+      condef_ "Bar"
         (tyarrow_ tyint_ (tycon_ "Foo"))
       ],
-    expr = matchex_ 
+    expr = matchex_
       (conapp_ "Bar" (int_ 1))
       (pcon_ "Bar" (pvar_ "x"))
       (addi_ (var_ "x") (int_ 1))
-} in 
-let res = testCompile p in 
-utest testEval p with int_ 2 using eqExpr in 
+} in
+let res = testCompile p in
+utest testEval p with int_ 2 using eqExpr in
 
 -- Test basic semantic function
 let p : MLangProgram = {
     decls = [
         decl_lang_ "L1" [
-            decl_sem_ 
+            decl_sem_
                 "f"
                 [("x", tyint_)]
                 [(pvar_ "y", addi_ (var_ "x") (var_ "y"))]
         ]
     ],
     expr = bind_ (use_ "L1") (appf2_ (var_ "f") (int_ 10) (int_ 20))
-} in 
-utest testEval p with int_ 30 using eqExpr in 
+} in
+utest testEval p with int_ 30 using eqExpr in
 
 -- Test semantic function with pattern that must be ordered
 -- Since the 2nd pattern is a strict subset of the first,
 -- the first pattern is checked first and only if this is not a match
--- do we fall through to the first pattern. 
+-- do we fall through to the first pattern.
 let fsem = decl_sem_ "f" [] [(por_ (pint_ 1) (pint_ 2), int_ -1),
                              (pint_ 2, int_ 1)]
 in
@@ -547,53 +529,53 @@ let p : MLangProgram = {
         decl_lang_ "L1" [fsem]
     ],
     expr = bind_ (use_ "L1") (appf1_ (var_ "f") (int_ 2))
-} in 
-utest testEval p with int_ 1 using eqExpr in 
+} in
+utest testEval p with int_ 1 using eqExpr in
 
 let p : MLangProgram = {
     decls = [
         decl_lang_ "L1" [fsem]
     ],
     expr = bind_ (use_ "L1") (appf1_ (var_ "f") (int_ 1))
-} in 
+} in
 utest testEval p with int_ -1 using eqExpr in
 
 -- Test DeclSyn and DeclSem using a small arithmetic language
-let exprSyn = decl_syn_ "Expr" [("IntExpr", tyint_), 
-                                ("AddExpr", tytuple_ [tycon_ "Expr", tycon_ "Expr"])] in 
+let exprSyn = decl_syn_ "Expr" [("IntExpr", tyint_),
+                                ("AddExpr", tytuple_ [tycon_ "Expr", tycon_ "Expr"])] in
 let evalSem = decl_sem_ "eval" [] [(pcon_ "IntExpr" (pvar_ "i"), var_ "i"),
-                                   (pcon_ "AddExpr" (ptuple_ [pvar_ "lhs", pvar_ "rhs"]), 
-                                    addi_ (appf1_ (var_ "eval") (var_ "lhs")) (appf1_ (var_ "eval") (var_ "rhs")))] in 
+                                   (pcon_ "AddExpr" (ptuple_ [pvar_ "lhs", pvar_ "rhs"]),
+                                    addi_ (appf1_ (var_ "eval") (var_ "lhs")) (appf1_ (var_ "eval") (var_ "rhs")))] in
 
 let p : MLangProgram = {
     decls = [
         decl_lang_ "MyIntArith" [exprSyn, evalSem]
     ],
-    expr = bind_ (use_ "MyIntArith") 
-                 (appf1_ (var_ "eval") 
+    expr = bind_ (use_ "MyIntArith")
+                 (appf1_ (var_ "eval")
                          (conapp_ "AddExpr" (utuple_ [(conapp_ "IntExpr" (int_ 40)),
                                                       (conapp_ "IntExpr" (int_ 2))])))
-} in 
+} in
 utest testEval p with int_ 42 using eqExpr in
 
 -- Test Sum Extension
-let baseSyn = decl_syn_ "Expr" [("IntExpr", tyint_), 
-                                ("AddExpr", tytuple_ [tycon_ "Expr", tycon_ "Expr"])] in 
+let baseSyn = decl_syn_ "Expr" [("IntExpr", tyint_),
+                                ("AddExpr", tytuple_ [tycon_ "Expr", tycon_ "Expr"])] in
 let baseSem = decl_sem_ "eval" [] [(pcon_ "IntExpr" (pvar_ "i"), var_ "i"),
-                                   (pcon_ "AddExpr" (ptuple_ [pvar_ "lhs", pvar_ "rhs"]), 
-                                    addi_ (appf1_ (var_ "eval") (var_ "lhs")) (appf1_ (var_ "eval") (var_ "rhs")))] in 
-let sugarSyn = decl_syn_ext_ "Expr" [("IncrExpr", tycon_ "Expr")] in 
-let sugarEval = decl_sem_ext_ "eval" [] [(pcon_ "IncrExpr" (pvar_ "e"), addi_ (int_ 1) (appf1_ (var_ "eval") (var_ "e")))] in 
+                                   (pcon_ "AddExpr" (ptuple_ [pvar_ "lhs", pvar_ "rhs"]),
+                                    addi_ (appf1_ (var_ "eval") (var_ "lhs")) (appf1_ (var_ "eval") (var_ "rhs")))] in
+let sugarSyn = decl_syn_ext_ "Expr" [("IncrExpr", tycon_ "Expr")] in
+let sugarEval = decl_sem_ext_ "eval" [] [(pcon_ "IncrExpr" (pvar_ "e"), addi_ (int_ 1) (appf1_ (var_ "eval") (var_ "e")))] in
 let p : MLangProgram = {
     decls = [
         decl_lang_ "MyIntArith" [baseSyn, baseSem],
         decl_langi_ "SugaredIntArith" ["MyIntArith"] [sugarSyn, sugarEval]
     ],
-    expr = bind_ (use_ "SugaredIntArith") 
-                 (appf1_ (var_ "eval") 
+    expr = bind_ (use_ "SugaredIntArith")
+                 (appf1_ (var_ "eval")
                          (conapp_ "IncrExpr" (conapp_ "AddExpr" (utuple_ [(conapp_ "IntExpr" (int_ 20)),
                                                       (conapp_ "IntExpr" (int_ 2))]))))
-} in 
+} in
 utest testEval p with int_ 23 using eqExpr in
 
 let p : MLangProgram = {
@@ -602,10 +584,10 @@ let p : MLangProgram = {
         decl_langi_ "SugaredIntArith" ["MyIntArith"] [sugarSyn, sugarEval]
     ],
     expr = bind_ (use_ "SugaredIntArith")
-                 (appf1_ (var_ "eval") 
+                 (appf1_ (var_ "eval")
                          (conapp_ "AddExpr" (utuple_ [(conapp_ "IncrExpr" (conapp_ "IntExpr" (int_ 21))),
                                                       (conapp_ "IntExpr" (int_ 1))])))
-} in 
+} in
 utest testEval p with int_ 23 using eqExpr in
 
 -- Test semantic function with different paremeter names
@@ -621,29 +603,29 @@ let p : MLangProgram = {
     expr = bind_ (use_ "L1")
                  (addi_ ((appf2_ (var_ "f") (int_ 10) (int_ 0)))
                         ((appf2_ (var_ "f") (int_ 10) (int_ 1))))
-} in 
+} in
 utest testEval p with int_ 0 using eqExpr in
 
 -- Test language composition under quantified type variables
 let p : MLangProgram = {
     decls = [
         decl_lang_ "L0" [
-          decl_semty_cases_ 
-            "f" 
+          decl_semty_cases_
+            "f"
             (tyall_ "a" (tyarrow_ (tyvar_ "a") (tyvar_ "a")))
             [(pvar_ "x", bind_ (let_ "y" (tyvar_ "a") (var_ "x")) (var_ "y"))]
         ],
         decl_langi_ "L1" ["L0"] []
     ],
     expr = bind_ (use_ "L1") (appf1_ (var_ "f") (int_ 0))
-} in 
+} in
 utest testEval p with int_ 0 using eqExpr in
 
 -- Test language composition is correctly renaming bound recursive functions.
 let decls = [
   decl_lang_ "L0" [
     decl_sem_
-      "isodd" 
+      "isodd"
       []
       [(pvar_ "x", if_ (eqi_ (int_ 0) (var_ "x")) false_ (appf1_ (var_ "iseven") (subi_ (var_ "x") (int_ 1))))],
     decl_sem_
@@ -653,19 +635,19 @@ let decls = [
   ],
   decl_langi_ "L1" ["L0"] [
     decl_sem_ext_
-      "iseven" 
+      "iseven"
       []
       [(pvar_ "x", if_ (eqi_ (int_ 0) (var_ "x")) true_ (appf1_ (var_ "isodd") (subi_ (var_ "x") (int_ 1))))]
   ]
-] in 
+] in
 let p : MLangProgram = {
     decls = decls,
     expr = bind_ (use_ "L1") (appf1_ (var_ "iseven") (int_ 12))
-} in 
+} in
 utest testEval p with true_ using eqExpr in
 let p : MLangProgram = {
     decls = decls,
     expr = bind_ (use_ "L1") (appf1_ (var_ "iseven") (int_ 11))
-} in 
+} in
 utest testEval p with false_ using eqExpr in
 ()

--- a/src/stdlib/mlang/compile.mc
+++ b/src/stdlib/mlang/compile.mc
@@ -139,67 +139,67 @@ end
 lang LetDeclCompiler = DeclCompiler + LetDeclAst + LetDeclAst
   sem compileDecl ctx = 
   | DeclLet d -> result.ok (
-    withExpr ctx (TmLet {ident = d.ident,
+    withExpr ctx (TmDecl {decl = DeclLet {ident = d.ident,
                          tyAnnot = d.tyAnnot,
                          tyBody = d.tyBody,
                          body = d.body,
                          info = d.info,
                          ty = tyunknown_,
-                         inexpr = uunit_}))
+                         inexpr = uunit_}}))
 end
 
 lang RecletsDeclCompiler = DeclCompiler + RecLetsDeclAst + RecLetsDeclAst
   sem compileDecl ctx = 
   | DeclRecLets d -> result.ok (
-    withExpr ctx (TmRecLets {bindings = d.bindings,
+    withExpr ctx (TmDecl {decl = DeclRecLets {bindings = d.bindings,
                              inexpr = uunit_,
                              ty = tyunknown_,
-                             info = d.info}))
+                             info = d.info}}))
 end
 
 lang UtestDeclCompiler = DeclCompiler + UtestDeclAst + UtestDeclAst
   sem compileDecl ctx = 
   | DeclUtest d -> result.ok (
-    withExpr ctx (TmUtest {test = d.test,
+    withExpr ctx (TmDecl {decl = DeclUtest {test = d.test,
                            expected = d.expected,
                            next = uunit_,
                            tusing = d.tusing,
                            tonfail = None (),
                            ty = tyunknown_,
-                           info = d.info}))
+                           info = d.info}}))
 end
 
 lang TypeDeclCompiler = DeclCompiler + TypeDeclAst + TypeDeclAst
   sem compileDecl ctx = 
   | DeclType d -> 
-    result.ok (withExpr ctx (TmType {ident = d.ident,
+    result.ok (withExpr ctx (TmDecl {decl = DeclType {ident = d.ident,
                                      params = d.params,
                                      tyIdent = d.tyIdent,
                                      info = d.info,
                                      ty = tyunknown_,
-                                     inexpr = uunit_}))
+                                     inexpr = uunit_}}))
 end
 
 lang ConDefDeclCompiler = DeclCompiler + DataDeclAst + DataAst
   sem compileDecl ctx = 
   | DeclConDef d -> result.ok (
-    withExpr ctx (TmConDef {ident = d.ident,
+    withExpr ctx (TmDecl {decl = DeclConDef {ident = d.ident,
                             tyIdent = d.tyIdent,
                             info = d.info,
                             ty = tyunknown_,
-                            inexpr = uunit_}))
+                            inexpr = uunit_}}))
 end
 
 lang ExtDeclCompiler = DeclCompiler + ExtDeclAst + ExtDeclAst
   sem compileDecl ctx = 
   -- TODO(voorberg, 2024-04-23): Add test case for the compilation of externals.
   | DeclExt d -> result.ok (
-    withExpr ctx (TmExt {ident = d.ident,
+    withExpr ctx (TmDecl {decl = DeclExt {ident = d.ident,
                          tyIdent = d.tyIdent,
                          effect = d.effect,
                          info = d.info,
                          ty = tyunknown_,
-                         inexpr = uunit_}))
+                         inexpr = uunit_}}))
 end
 
 lang SynTypeDeclCompiler = SynDeclAst + TypeDeclAst
@@ -210,12 +210,12 @@ lang SynTypeDeclCompiler = SynDeclAst + TypeDeclAst
     -- a syntax type. To check that something is a base syn definition,
     -- we check that it does not include any other definitions.
     if null s.includes then 
-      withToplevelExpr ctx (TmType {ident = s.ident,
+      withToplevelExpr ctx (TmDecl {decl = DeclType {ident = s.ident,
                                     params = s.params,
                                     tyIdent = tyvariant_ [],
                                     inexpr = uunit_,
                                     ty = tyunknown_,
-                                    info = s.info})
+                                    info = s.info}})
     else 
       ctx
 end
@@ -342,11 +342,11 @@ lang MLangSynDefCompiler = SynDeclAst + MExprAst
     let rhs = foldl (lam ty. lam n. tyapp_ ty (ntyvar_ n)) (ntycon_ baseIdent) s.params in
 
     let compileDef = lam ctx. lam def.
-      withExpr ctx (TmConDef {ident = def.ident,
+      withExpr ctx (TmDecl {decl = DeclConDef {ident = def.ident,
                               tyIdent = forallWrapper (tyarrow_ def.tyIdent rhs),
                               info = s.info,
                               ty = tyunknown_,
-                              inexpr = uunit_}) in 
+                              inexpr = uunit_}}) in 
 
     foldl compileDef ctx s.defs    
 end
@@ -374,10 +374,10 @@ lang MLangLangDeclCompiler = DeclCompiler + LangDeclAst + MExprAst + SemDeclAst 
     let compileSemToResult : CompilationContext -> [Decl] -> CompilationContext
       = lam ctx. lam sems.
         let semBindings = map (compileSem langStr ctx semNames) sems in 
-        withExpr ctx (TmRecLets {bindings = semBindings,
+        withExpr ctx (TmDecl {decl = DeclRecLets {bindings = semBindings,
                                  inexpr = uunit_, 
                                  ty = tyunknown_,
-                                 info = l.info})
+                                 info = l.info}})
     in
     result.map (lam ctx. compileSemToResult ctx semDecls) res
   | DeclSyn s -> 

--- a/src/stdlib/mlang/loader.mc
+++ b/src/stdlib/mlang/loader.mc
@@ -140,7 +140,7 @@ lang MCorePathResolution = MCoreLoader
     ({path = resolved, env = env}, loader)
 end
 
-lang BootParserLoader = MCorePathResolution + DeclAst + ExprAsDecl + BootParser
+lang BootParserLoader = MCorePathResolution + DeclAst + BootParser
   + LetDeclAst + RecLetsDeclAst + TypeDeclAst + DataDeclAst + ExtDeclAst
   + MLangPrettyPrint + AstToJson
   type LoaderRec =
@@ -193,7 +193,7 @@ lang BootParserLoader = MCorePathResolution + DeclAst + ExprAsDecl + BootParser
   sem buildFullAst = | loader & Loader x ->
     match foldl (lam loader. lam cb. _preBuildFullAst loader cb) loader x.hooks
       with loader & Loader x in
-    let ast = foldr (lam decl. lam cont. declAsExpr cont decl) unit_ x.decls in
+    let ast = foldr bind_ unit_ x.decls in
     foldl (lam ast. lam cb. _postBuildFullAst loader ast cb) ast x.hooks
 
   sem _fileType = | _ ++ ".mc" -> FMCore ()
@@ -214,7 +214,7 @@ lang BootParserLoader = MCorePathResolution + DeclAst + ExprAsDecl + BootParser
       } in
     let ast = parseMCoreFile args path in
     recursive let f = lam decls. lam ast.
-      match exprAsDecl ast with Some (decl, ast)
+      match ast with TmDecl {decl = decl, inexpr = ast}
       then f (snoc decls decl) ast
       else decls in
     match _addDeclsByFile loader (f [] ast) with loader & Loader x in
@@ -358,7 +358,7 @@ lang BootParserLoader = MCorePathResolution + DeclAst + ExprAsDecl + BootParser
 end
 
 lang MCoreLoader
-  = MCorePathResolution + BootParserLoader + MExprAsDecl
+  = MCorePathResolution + BootParserLoader
   + MExprSym + MLangSym
   + MExprTypeCheck + MLangTypeCheck
 end

--- a/src/stdlib/mlang/pprint.mc
+++ b/src/stdlib/mlang/pprint.mc
@@ -22,17 +22,11 @@ lang MLangIdentifierPrettyPrint = IdentifierPrettyPrint
 end
 
 
-lang UsePrettyPrint = PrettyPrint + UseAst + MLangIdentifierPrettyPrint
-  sem isAtomic =
-  | TmUse _ -> false
-
-  sem pprintCode (indent : Int) (env: PprintEnv) =
-  | TmUse t ->
+lang UsePrettyPrint = PrettyPrint + UseDeclAst + MLangIdentifierPrettyPrint
+  sem pprintDeclCode (indent : Int) (env: PprintEnv) =
+  | DeclUse t ->
     match pprintLangName env t.ident with (env,ident) in
-    match pprintCode indent env t.inexpr with (env,inexpr) in
-    (env, join ["use ", ident, pprintNewline indent,
-                "in", pprintNewline indent,
-                inexpr])
+    (env, join ["use ", ident])
 end
 
 lang TyUsePrettyPrint = MExprPrettyPrint + TyUseAst + MLangIdentifierPrettyPrint
@@ -78,11 +72,7 @@ lang QualifiedNamePrettyPrint = MExprPrettyPrint + QualifiedTypeAst +
 end
 
 
-lang DeclPrettyPrint = PrettyPrint + MLangIdentifierPrettyPrint + DeclAst
-  sem pprintDeclCode : Int -> PprintEnv -> Decl -> (PprintEnv, String)
-  sem pprintDeclCode indent env =
-  -- Intentionally left blank
-
+lang LangDeclPrettyPrint = PrettyPrint + LangDeclAst + MLangIdentifierPrettyPrint
   sem pprintDeclSequenceCode : Int -> PprintEnv -> [Decl] -> (PprintEnv, String)
   sem pprintDeclSequenceCode (indent : Int) (env : PprintEnv) =
   | decls ->
@@ -93,10 +83,7 @@ lang DeclPrettyPrint = PrettyPrint + MLangIdentifierPrettyPrint + DeclAst
     ) (env, []) decls in
     match declFoldResult with (env, declStrings) in
     (env, strJoin (pprintNewline indent) declStrings)
-end
 
-
-lang LangDeclPrettyPrint = DeclPrettyPrint + LangDeclAst
   sem pprintDeclCode (indent : Int) (env : PprintEnv) =
   | DeclLang t ->
     match pprintLangName env t.ident with (env, langNameStr) in
@@ -122,7 +109,7 @@ lang LangDeclPrettyPrint = DeclPrettyPrint + LangDeclAst
 end
 
 
-lang SynDeclPrettyPrint = DeclPrettyPrint + SynDeclAst + DataPrettyPrint
+lang SynDeclPrettyPrint = PrettyPrint + SynDeclAst + DataPrettyPrint
   sem pprintDeclCode (indent : Int) (env : PprintEnv) =
   | DeclSyn t ->
     match pprintTypeName env t.ident with (env, typeNameStr) in
@@ -146,7 +133,7 @@ lang SynDeclPrettyPrint = DeclPrettyPrint + SynDeclAst + DataPrettyPrint
                   (cons (join ["syn ", typeNameStr, params, eqSym]) defStrings))
 end
 
-lang SemDeclPrettyPrint = DeclPrettyPrint + SemDeclAst + UnknownTypeAst
+lang SemDeclPrettyPrint = PrettyPrint + SemDeclAst + UnknownTypeAst
   sem pprintDeclCode (indent : Int) (env : PprintEnv) =
   | DeclSem t ->
     match pprintEnvGetStr env t.ident with (env, baseStr) in
@@ -196,69 +183,14 @@ lang SemDeclPrettyPrint = DeclPrettyPrint + SemDeclAst + UnknownTypeAst
     (env, strJoin "\n" (mapOption identity [mDecl, mImpl]))
 end
 
-lang LetDeclPrettyPrint = DeclPrettyPrint + LetDeclAst + LetPrettyPrint
-  sem pprintDeclCode (indent : Int) (env : PprintEnv) =
-  | DeclLet t ->
-    pprintLetAssignmentCode indent env {
-      ident = t.ident,
-      body = t.body,
-      tyAnnot = t.tyAnnot
-    }
-end
 
-
-lang TypeDeclPrettyPrint = DeclPrettyPrint + TypeDeclAst + TypePrettyPrint
-  sem pprintDeclCode (indent : Int) (env : PprintEnv) =
-  | DeclType t ->
-    pprintTypeCode indent env {
-      ident = t.ident,
-      params = t.params,
-      tyIdent = t.tyIdent
-    }
-end
-
-
-lang RecLetsDeclPrettyPrint = DeclPrettyPrint + RecLetsDeclAst + RecLetsPrettyPrint
-  sem pprintDeclCode (indent : Int) (env : PprintEnv) =
-  | DeclRecLets t ->
-    match t.bindings with [] then
-      (env, "let #var\"\" = ()")
-    else
-      match pprintRecLetsCode indent env t.bindings with (env, recletStr) in
-      (env, join [recletStr, pprintNewline indent, "end"])
-end
-
-
-lang DataDeclPrettyPrint = DeclPrettyPrint + DataDeclAst + DataPrettyPrint
-  sem pprintDeclCode (indent : Int) (env : PprintEnv) =
-  | DeclConDef t ->
-    pprintConDefCode indent env {ident = t.ident, tyIdent = t.tyIdent}
-end
-
-
-lang UtestDeclPrettyPrint = DeclPrettyPrint + UtestDeclAst + UtestPrettyPrint
-  sem pprintDeclCode (indent : Int) (env : PprintEnv) =
-  | DeclUtest t ->
-    pprintUtestCode indent env {
-      test = t.test, expected = t.expected, tusing = t.tusing}
-end
-
-
-lang ExtDeclPrettyPrint = DeclPrettyPrint + ExtDeclAst + ExtPrettyPrint
-  sem pprintDeclCode (indent : Int) (env : PprintEnv) =
-  | DeclExt t ->
-    pprintExtCode indent env {
-      ident = t.ident, tyIdent = t.tyIdent, effect = t.effect}
-end
-
-
-lang IncludeDeclPrettyPrint = DeclPrettyPrint + IncludeDeclAst
+lang IncludeDeclPrettyPrint = PrettyPrint + IncludeDeclAst
   sem pprintDeclCode (indent : Int) (env : PprintEnv) =
   | DeclInclude t -> (env, join ["include \"", escapeString t.path, "\""])
 end
 
 
-lang MLangTopLevelPrettyPrint = DeclPrettyPrint + MLangTopLevel
+lang MLangTopLevelPrettyPrint = PrettyPrint + MLangTopLevel
   sem mlang2str : MLangProgram -> String
   sem mlang2str =
   | prog -> match pprintMLangProgram 0 pprintEnvEmpty prog with (_, s) in s
@@ -277,10 +209,8 @@ lang MLangPrettyPrint = MExprPrettyPrint +
   UsePrettyPrint + TyUsePrettyPrint + QualifiedNamePrettyPrint +
 
   -- Declarations
-  DeclPrettyPrint + LangDeclPrettyPrint + SynDeclPrettyPrint +
-  SemDeclPrettyPrint + LetDeclPrettyPrint + TypeDeclPrettyPrint +
-  RecLetsDeclPrettyPrint + DataDeclPrettyPrint + UtestDeclPrettyPrint +
-  ExtDeclPrettyPrint + IncludeDeclPrettyPrint +
+  LangDeclPrettyPrint + SynDeclPrettyPrint + SemDeclPrettyPrint +
+  IncludeDeclPrettyPrint +
 
 
   -- Top-level pretty printer
@@ -300,8 +230,8 @@ let prog: MLangProgram = {
     decl_langi_ "Test1" [] [],
     decl_langi_ "test2" ["Test1"] [],
     decl_langi_ "The 3rd Test" ["Test1", "test2"] [],
-    decl_ext_ "my_external" false (tyarrow_ tyfloat_ tystr_),
-    decl_ext_ "my_external2" true (tyarrow_ tyint_ tystr_),
+    ext_ "my_external" false (tyarrow_ tyfloat_ tystr_),
+    ext_ "my_external2" true (tyarrow_ tyint_ tystr_),
     decl_lang_ "Foo" [
       decl_syn_ "Bar" [
         ("Apple", tyint_),
@@ -310,32 +240,32 @@ let prog: MLangProgram = {
       decl_usem_ "getFruit" ["x"] [
         (pcon_ "Apple" (pvar_ "i"), appf1_ (var_ "int2string") (var_ "i")),
         (pcon_ "Pear" (pvar_ "fs"),
-         bindall_ [
-           ulet_ "strJoin" (unit_),
-           appf2_ (var_ "strJoin")
+         bind_
+           (ulet_ "strJoin" (unit_))
+           (appf2_ (var_ "strJoin")
                   (var_ "x")
-                  (appf2_ (var_ "map") (var_ "float2string") (var_ "fs"))
-         ])
+                  (appf2_ (var_ "map") (var_ "float2string") (var_ "fs")))
+         )
       ]
     ],
-    decl_type_ "MyType" ["x"] tyunknown_,
-    decl_condef_ "MyCon" (tyall_ "x" (tyarrows_ [tyseq_ (tyvar_ "x"), tyapp_ (tycon_ "MyType") (tyvar_ "x")])),
-    decl_ureclets_ [
+    type_ "MyType" ["x"] tyunknown_,
+    condef_ "MyCon" (tyall_ "x" (tyarrows_ [tyseq_ (tyvar_ "x"), tyapp_ (tycon_ "MyType") (tyvar_ "x")])),
+    ureclets_ [
       ("rec_foo", ulams_ ["x"] (appf1_ (var_ "printLn") (var_ "x"))),
       ("rec_bar", ulams_ ["y"] (appf2_ (var_ "concat") (var_ "y") (var_ "y")))
     ],
-    decl_ureclets_ [
+    ureclets_ [
       ("rec_babar", ulams_ ["z"] (seq_ [var_ "z"]))
     ],
-    decl_ureclets_ [],
-    decl_utest_ (appf1_ (var_ "rec_babar") (int_ 5)) (seq_ [int_ 5]),
-    decl_ulet_ "foo" (
-      ulams_ ["x", "y"] (bindall_ [
-        use_ "Foo",
-        concat_ (appf1_ (var_ "getFruit")
+    ureclets_ [],
+    utest_ (appf1_ (var_ "rec_babar") (int_ 5)) (seq_ [int_ 5]),
+    ulet_ "foo" (
+      ulams_ ["x", "y"] (bind_
+        (use_ "Foo")
+        (concat_ (appf1_ (var_ "getFruit")
                         (conapp_ "Apple" (var_ "x")))
-                (appf1_ (var_ "float2string") (var_ "y"))
-      ])
+                (appf1_ (var_ "float2string") (var_ "y")))
+      )
     )
   ],
   expr = appf1_ (var_ "printLn")
@@ -352,8 +282,8 @@ let prog2: MLangProgram = {
     decl_langi_ "Test1" [] [],
     decl_langi_ "test2" ["Test1"] [],
     decl_langi_ "The 3rd Test" ["Test1", "test2"] [],
-    decl_ext_ "my_external" false (tyarrow_ tyfloat_ tystr_),
-    decl_ext_ "my_external2" true (tyarrow_ tyint_ tystr_),
+    ext_ "my_external" false (tyarrow_ tyfloat_ tystr_),
+    ext_ "my_external2" true (tyarrow_ tyint_ tystr_),
     decl_lang_ "Foo" [
       decl_syn_ "Bar" [
         ("Apple", tyint_),
@@ -362,32 +292,32 @@ let prog2: MLangProgram = {
       decl_usem_ "getFruit" ["x"] [
         (pcon_ "Apple" (pvar_ "i"), appf1_ (var_ "int2string") (var_ "i")),
         (pcon_ "Pear" (pvar_ "fs"),
-         bindall_ [
-           ulet_ "strJoin" (unit_),
-           appf2_ (var_ "strJoin")
+         bind_
+           (ulet_ "strJoin" unit_)
+           (appf2_ (var_ "strJoin")
                   (var_ "x")
-                  (appf2_ (var_ "map") (var_ "float2string") (var_ "fs"))
-         ])
+                  (appf2_ (var_ "map") (var_ "float2string") (var_ "fs")))
+         )
       ]
     ],
-    decl_type_ "MyType" ["x"] tyunknown_,
-    decl_condef_ "MyCon" (tyall_ "x" (tyarrows_ [tyseq_ (tyvar_ "x"), tyapp_ (tycon_ "MyType") (tyvar_ "x")])),
-    decl_ureclets_ [
+    type_ "MyType" ["x"] tyunknown_,
+    condef_ "MyCon" (tyall_ "x" (tyarrows_ [tyseq_ (tyvar_ "x"), tyapp_ (tycon_ "MyType") (tyvar_ "x")])),
+    ureclets_ [
       ("rec_foo", ulams_ ["x"] (appf1_ (var_ "printLn") (var_ "x"))),
       ("rec_bar", ulams_ ["y"] (appf2_ (var_ "concat") (var_ "y") (var_ "y")))
     ],
-    decl_ureclets_ [
+    ureclets_ [
       ("rec_babar", ulams_ ["z"] (seq_ [var_ "z"]))
     ],
-    decl_ureclets_ [],
-    decl_utest_ (appf1_ (var_ "rec_babar") (int_ 5)) (seq_ [int_ 5]),
-    decl_ulet_ "foo" (
-      ulams_ ["x", "y"] (bindall_ [
-        use_ "Foo",
-        concat_ (appf1_ (var_ "getFruit")
+    ureclets_ [],
+    utest_ (appf1_ (var_ "rec_babar") (int_ 5)) (seq_ [int_ 5]),
+    ulet_ "foo" (
+      ulams_ ["x", "y"] (bind_
+        (use_ "Foo")
+        (concat_ (appf1_ (var_ "getFruit")
                         (conapp_ "Apple" (var_ "x")))
-                (appf1_ (var_ "float2string") (var_ "y"))
-      ])
+                (appf1_ (var_ "float2string") (var_ "y")))
+      )
     )
   ],
   expr = appf1_ (var_ "printLn")

--- a/src/stdlib/mlang/prune-unused-langs.mc
+++ b/src/stdlib/mlang/prune-unused-langs.mc
@@ -9,14 +9,14 @@ include "name.mc"
 lang PruneUnusedLangs = MLangAst + MExprAst + ExtRecAst
   sem pruneProgram : Set String -> MLangProgram -> MLangProgram
   sem pruneProgram usedLangs =
-  | prog -> 
+  | prog ->
     {prog with decls = map (pruneDecl usedLangs) prog.decls}
 
-  sem pruneDecl : Set String -> Decl -> Decl 
-  sem pruneDecl usedLangs = 
-  | DeclLang d & decl -> 
-    if setMem (nameGetStr d.ident) usedLangs then 
-      decl 
+  sem pruneDecl : Set String -> Decl -> Decl
+  sem pruneDecl usedLangs =
+  | DeclLang d & decl ->
+    if setMem (nameGetStr d.ident) usedLangs then
+      decl
     else
       DeclLang {d with decls = filter filterUnusedLangFragment d.decls}
   | decl -> decl
@@ -27,42 +27,42 @@ lang PruneUnusedLangs = MLangAst + MExprAst + ExtRecAst
   | DeclCosem _ -> false
   | _ -> true
 
-  sem collectUsedLangs_Prog : MLangProgram -> Set String 
-  sem collectUsedLangs_Prog = 
-  | prog -> 
-    let acc = setEmpty cmpString in 
-    let acc = foldl collectUsedLangs_Decl acc prog.decls in 
+  sem collectUsedLangs_Prog : MLangProgram -> Set String
+  sem collectUsedLangs_Prog =
+  | prog ->
+    let acc = setEmpty cmpString in
+    let acc = foldl collectUsedLangs_Decl acc prog.decls in
     collectUsedLangs_Expr acc prog.expr
 
   sem collectUsedLangs_Decl : Set String -> Decl -> Set String
-  sem collectUsedLangs_Decl acc = 
-  | decl -> 
-    let acc = sfold_Decl_Decl collectUsedLangs_Decl acc decl in 
-    let acc = sfold_Decl_Expr collectUsedLangs_Expr acc decl in 
+  sem collectUsedLangs_Decl acc =
+  | decl ->
+    let acc = sfold_Decl_Decl collectUsedLangs_Decl acc decl in
+    let acc = sfold_Decl_Expr collectUsedLangs_Expr acc decl in
     sfold_Decl_Type collectUsedLangs_Type acc decl
 
   sem collectUsedLangs_Expr : Set String -> Expr -> Set String
-  sem collectUsedLangs_Expr acc = 
-  | TmUse t & tm -> 
-    let acc = setInsert (nameGetStr t.ident) acc in 
-    let acc = sfold_Expr_Expr collectUsedLangs_Expr acc t.inexpr in 
-    sfold_Expr_Type collectUsedLangs_Type acc tm 
-  | tm -> 
-    let acc = sfold_Expr_Expr collectUsedLangs_Expr acc tm in 
-    sfold_Expr_Type collectUsedLangs_Type acc tm 
+  sem collectUsedLangs_Expr acc =
+  | TmDecl (x & {decl = DeclUse t}) & tm ->
+    let acc = setInsert (nameGetStr t.ident) acc in
+    let acc = sfold_Expr_Expr collectUsedLangs_Expr acc x.inexpr in
+    sfold_Expr_Type collectUsedLangs_Type acc tm
+  | tm ->
+    let acc = sfold_Expr_Expr collectUsedLangs_Expr acc tm in
+    sfold_Expr_Type collectUsedLangs_Type acc tm
 
   sem collectUsedLangs_Type : Set String -> Type -> Set String
-  sem collectUsedLangs_Type acc = 
-  | TyUse t -> 
-    let acc = setInsert (nameGetStr t.ident) acc in 
+  sem collectUsedLangs_Type acc =
+  | TyUse t ->
+    let acc = setInsert (nameGetStr t.ident) acc in
     sfold_Type_Type collectUsedLangs_Type acc t.inty
-  | ty -> 
+  | ty ->
     sfold_Type_Type collectUsedLangs_Type acc ty
 end
 
-mexpr 
-use MLangAst in 
-use PruneUnusedLangs in 
-let prog = {decls = [], expr = uunit_} in 
+mexpr
+use MLangAst in
+use PruneUnusedLangs in
+let prog = {decls = [], expr = uunit_} in
 pruneProgram prog ;
 ()

--- a/src/stdlib/mlang/symbolize.mc
+++ b/src/stdlib/mlang/symbolize.mc
@@ -41,13 +41,18 @@ let name2pair : Name -> (String, Name) = lam n.
 let updateEnv : SymEnv -> NameEnv -> SymEnv = lam symEnv. lam langEnv.
   {symEnv with currentEnv = mergeNameEnv (symEnv.currentEnv) langEnv}
 
-lang TmUseSym = Sym + UseAst
+lang DeclUseSym = Sym + UseDeclAst + DeclAst
   sem symbolizeExpr env =
-  | TmUse t ->
+  | TmDecl {decl = d & DeclUse _, inexpr = inexpr} ->
+    match symbolizeDecl env d with (env, _) in
+    symbolizeExpr env inexpr
+
+  sem symbolizeDecl env =
+  | d & DeclUse t ->
     -- TODO: Prevent TmUse <lang> in that specific lang.
     match mapLookup (nameGetStr t.ident) env.langEnv with Some langEnv
       then
-        symbolizeExpr (updateEnv env langEnv) t.inexpr
+        (updateEnv env langEnv, d)
       else
         symLookupError
           env.langEnv
@@ -70,84 +75,6 @@ end
 
 lang DeclSym = DeclAst + Sym
   sem symbolizeDecl : SymEnv -> Decl -> (SymEnv, Decl)
-end
-
-lang DeclLetSym = DeclSym + LetDeclAst + LetSym
-  sem symbolizeDecl env =
-  | DeclLet t ->
-    match symbolizeTyAnnot env t.tyAnnot with (tyVarEnv, tyAnnot) in
-    match setSymbol env.currentEnv.varEnv t.ident with (varEnv, ident) in
-    let decl = DeclLet {t with ident = ident,
-                        tyAnnot = tyAnnot,
-                        body = symbolizeExpr (symbolizeUpdateTyVarEnv env tyVarEnv) t.body} in
-    (symbolizeUpdateVarEnv env varEnv, decl)
-end
-
-lang DeclTypeSym = DeclSym + TypeDeclAst
-  sem symbolizeDecl env =
-  | DeclType t ->
-    match setSymbol env.currentEnv.tyConEnv t.ident with (tyConEnv, ident) in
-    match mapAccumL setSymbol env.currentEnv.tyVarEnv t.params with (tyVarEnv, params) in
-    let decl = DeclType {t with ident = ident,
-                                params = params,
-                                tyIdent = symbolizeType (symbolizeUpdateTyVarEnv env tyVarEnv) t.tyIdent} in
-    (symbolizeUpdateTyConEnv env tyConEnv, decl)
-end
-
-
-lang DeclRecLetsSym = DeclSym + RecLetsDeclAst + LetSym
-  sem symbolizeDecl env =
-  | DeclRecLets t ->
-    -- Generate fresh symbols for all identifiers and add to the environment
-    let setSymbolIdent = lam env. lam b.
-      match setSymbol env b.ident with (env, ident) in
-      (env, {b with ident = ident})
-    in
-
-    match mapAccumL setSymbolIdent env.currentEnv.varEnv t.bindings with (varEnv, bindings) in
-    let newEnv = symbolizeUpdateVarEnv env varEnv in
-
-    -- Symbolize all bodies with the new environment
-    let bindings =
-    map (lam b. match symbolizeTyAnnot env b.tyAnnot with (tyVarEnv, tyAnnot) in
-                {b with body = symbolizeExpr (symbolizeUpdateTyVarEnv newEnv tyVarEnv) b.body,
-                        tyAnnot = tyAnnot})  bindings in
-
-    (newEnv, DeclRecLets {t with bindings = bindings})
-end
-
-lang DeclConDefSym = DeclSym + DataDeclAst
-  sem symbolizeDecl env =
-  | DeclConDef t ->
-    match setSymbol env.currentEnv.conEnv t.ident with (conEnv, ident) in
-
-    let decl = DeclConDef {t with ident = ident,
-                                  tyIdent = symbolizeType env t.tyIdent} in
-    (symbolizeUpdateConEnv env conEnv, decl)
-end
-
-lang DeclUtestSym = DeclSym + UtestDeclAst
-  sem symbolizeDecl env =
-  | DeclUtest t ->
-    -- This can be rewritten to use a shallow map on declarations. E.g.
-    -- smap (symbolizeExpr env) (DeclUtest t)
-    let decl = DeclUtest {t with test = symbolizeExpr env t.test,
-                                  expected = symbolizeExpr env t.expected,
-                                  tusing = optionMap (symbolizeExpr env) t.tusing} in
-    (env, decl)
-end
-
-lang DeclExtSym = DeclSym + ExtDeclAst
-  sem symbolizeDecl env =
-  | DeclExt t & d->
-    if env.ignoreExternals then
-      (env, d)
-    else
-      match setSymbol env.currentEnv.varEnv t.ident with (varEnv, ident) in
-      let decl = DeclExt {t with ident = ident,
-                                 tyIdent = symbolizeType env t.tyIdent} in
-      let env = symbolizeUpdateVarEnv env varEnv in
-      (env, decl)
 end
 
 lang DeclSynSym = DeclSym + SynDeclAst
@@ -342,9 +269,7 @@ lang MLangProgramSym = MLangTopLevel + DeclSym
 end
 
 lang MLangSymWihoutLang = MLangAst + MExprSym +
-                          TmUseSym + TyUseSym +
-                          DeclLetSym + DeclTypeSym + DeclRecLetsSym +
-                          DeclConDefSym + DeclUtestSym + DeclExtSym +
+                          DeclUseSym + TyUseSym +
                           MLangProgramSym
 end
 
@@ -352,12 +277,8 @@ lang MLangSym = MLangSymWihoutLang + DeclMLangLangSym
 end
 
 lang TestLangWithoutLang = MLangSymWihoutLang + SymCheck + MLangPrettyPrint
-  sem isFullySymbolizedExpr =
-  | TmUse t ->
-    error "Symbolization should get rid of all occurrences of TmUse!"
-
-  sem isFullySymbolizedDecl : Decl -> () -> Bool
   sem isFullySymbolizedDecl =
+  | DeclUse _ -> error "Symbolization should get rid of all occurrences of DeclUse!"
   | DeclLang l ->
     _and (lam. nameHasSym l.ident) (_and
         (lam. forAll nameHasSym l.includes)
@@ -384,18 +305,6 @@ lang TestLangWithoutLang = MLangSymWihoutLang + SymCheck + MLangPrettyPrint
       foldl (_andFold isFullySymbolizedPat) (lam. true) casePats,
       foldl (_andFold isFullySymbolizedExpr) (lam. true) caseThns
     ]
-  | DeclLet l ->
-    foldl _and (lam. true) [
-      lam. nameHasSym l.ident,
-      isFullySymbolizedType l.tyAnnot,
-      isFullySymbolizedExpr l.body
-    ]
-  | DeclType l ->
-    _and (lam. nameHasSym l.ident) (_and
-          (lam. (forAll nameHasSym l.params))
-          (isFullySymbolizedType l.tyIdent))
-  | DeclConDef l ->
-    _and (lam. nameHasSym l.ident) (isFullySymbolizedType l.tyIdent)
 
   sem isFullySymbolizedType =
   | TyUse _ -> error "Symbolization should get rid of TyUse!"
@@ -472,7 +381,7 @@ let p : MLangProgram = {
   decls = [
     decl_lang_ "L1" [
       decl_syn_ "Foo" [("Baz", tyint_), ("BazBaz", tychar_)],
-      decl_type_ "Bar" [] tyint_,
+      type_ "Bar" [] tyint_,
       decl_sem_ "f" [] []
     ]
   ],
@@ -490,9 +399,9 @@ utest nameHasSym l.ident with true in
 -- Test DeclType wand DeclConDef with polymorhpic parameters
 let p : MLangProgram = {
   decls = [
-    decl_type_ "Option" ["a"] (tyvariant_ []),
-    decl_condef_ "None" (tyall_ "a" (tyarrow_ tyunit_ (tyapp_ (tycon_ "Option") (tyvar_ "a")))),
-    decl_condef_ "Some" (tyall_ "a" (tyarrow_ (tyvar_ "a") (tyapp_ (tycon_ "Option") (tyvar_ "a"))))
+    type_ "Option" ["a"] (tyvariant_ []),
+    condef_ "None" (tyall_ "a" (tyarrow_ tyunit_ (tyapp_ (tycon_ "Option") (tyvar_ "a")))),
+    condef_ "Some" (tyall_ "a" (tyarrow_ (tyvar_ "a") (tyapp_ (tycon_ "Option") (tyvar_ "a"))))
   ],
   expr = uunit_
 } in
@@ -504,7 +413,7 @@ let p : MLangProgram = {
   decls = [
     decl_lang_ "L1" [
       decl_syn_ "Foo" [("Baz", tyint_), ("BazBaz", tychar_)],
-      decl_type_ "Bar" [] tyint_,
+      type_ "Bar" [] tyint_,
       decl_sem_ "f" [] []
     ],
     decl_langi_ "L2" ["L1"] [
@@ -685,7 +594,7 @@ utest isFullySymbolizedProgram p () with true in
 
 -- Test type variable, 'all', and let type annotations
 let p : MLangProgram = {
-  decls = [decl_let_ "id"
+  decls = [let_ "id"
                      (tyall_ "a" (tyarrow_ (tyvar_ "a") (tyvar_ "a")))
                      (lam_ "x" (tyvar_ "a") (var_ "x"))],
   expr = appf1_ (var_ "id") (int_ 1)
@@ -720,7 +629,7 @@ utest isFullySymbolizedProgram p () with true in
 -- Test usage of type defined outside of language used in language
 let p : MLangProgram = {
   decls = [
-    decl_type_ "Foo" [] tyint_,
+    type_ "Foo" [] tyint_,
     decl_lang_ "SomeListLang" [
       decl_syn_ "MyList" [("Nil", tycon_ "Foo")]
     ]
@@ -735,9 +644,9 @@ utest isFullySymbolizedProgram p () with true in
 let p : MLangProgram = {
   decls = [
     decl_lang_ "SomeLang" [
-      decl_type_ "Foo" [] tyint_
+      type_ "Foo" [] tyint_
     ],
-    decl_type_ "Bar" [] (tyuse_ "SomeLang" (tycon_ "Foo"))
+    type_ "Bar" [] (tyuse_ "SomeLang" (tycon_ "Foo"))
   ],
   expr = uunit_
 } in
@@ -750,7 +659,7 @@ utest isFullySymbolizedProgram p () with true in
 let p : MLangProgram = {
   decls = [
     decl_lang_ "SomeLang" [
-      decl_type_ "Foo" [] tyint_
+      type_ "Foo" [] tyint_
     ],
     decl_langi_ "OtherLang" ["SomeLang"] [
       decl_syn_ "Baz" [("Bar", tycon_ "Foo")]
@@ -787,9 +696,9 @@ let p : MLangProgram = {
     decl_lang_ "L" [
       decl_semty_cases_ "f"
                         (tyall_ "a" (tyarrow_ (tyvar_ "a") tyint_))
-                        [(pvarw_, let_ "x"
+                        [(pvarw_, bind_ (let_ "x"
                                         (tyarrow_ (tyvar_ "a") tyint_)
-                                        (int_ 10))]
+                                        (int_ 10)) unit_)]
       ]
   ],
   expr = uunit_
@@ -802,12 +711,12 @@ utest isFullySymbolizedProgram p () with true in
 let p : MLangProgram = {
   decls = [
     decl_lang_ "L" [
-      decl_type_ "T" ["a"] (tyarrow_ (tyvar_ "a") tyint_),
+      type_ "T" ["a"] (tyarrow_ (tyvar_ "a") tyint_),
       decl_semty_cases_ "f"
                         (tyall_ "a" (tyarrow_ (tyvar_ "a") tyint_))
-                        [(pvarw_, let_ "x"
+                        [(pvarw_, bind_ (let_ "x"
                                         (tyarrow_ (tyvar_ "a") (tyapp_ (tycon_ "T") (tyvar_ "a")))
-                                        (int_ 10))]
+                                        (int_ 10)) unit_)]
       ]
   ],
   expr = uunit_

--- a/src/stdlib/mlang/type-check.mc
+++ b/src/stdlib/mlang/type-check.mc
@@ -13,96 +13,6 @@ lang DeclTypeCheck = TypeCheck + DeclAst
   sem typeCheckDecl : TCEnv -> Decl -> (TCEnv, Decl)
 end
 
-lang DeclUtestTypeCheck = DeclTypeCheck + UtestDeclAst
-  sem typeCheckDecl env =
-  | DeclUtest t ->
-    let test = typeCheckExpr env t.test in
-    let expected = typeCheckExpr env t.expected in
-    let tusing = optionMap (typeCheckExpr env) t.tusing in
-
-    (switch tusing
-      case Some tu then
-        unify env [infoTm test, infoTm expected, infoTm tu]
-          (tyarrows_ [tyTm test, tyTm expected, tybool_]) (tyTm tu)
-      case None _ then
-        unify env [infoTm test, infoTm expected] (tyTm test) (tyTm expected)
-    end);
-    (env, DeclUtest {t with test = test, expected = expected, tusing = tusing})
-end
-
-lang DeclConDefTypeCheck = DeclTypeCheck + DataDeclAst + DataTypeCheck
-  sem typeCheckDecl env =
-  | DeclConDef t ->
-    let tyIdent = resolveType t.info env false t.tyIdent in
-    let tyIdent = substituteNewReprs env tyIdent in
-
-    match _makeConstructorType t.info env.disableConstructorTypes t.ident tyIdent
-    with (target, tydeps, tyIdent) in
-
-    let tydeps =
-      mapInsert target tydeps
-        (setFold (lam m. lam t. mapInsert t (setOfSeq nameCmp [target]) m)
-                 (mapEmpty nameCmp) tydeps) in
-
-    let env = {env with conEnv = mapInsert t.ident (0, tyIdent) env.conEnv,
-                        typeDeps = mapUnionWith setUnion tydeps env.typeDeps,
-                        conDeps = mapInsertWith setUnion target
-                               (setOfSeq nameCmp [t.ident]) env.conDeps} in
-
-    (env, DeclConDef {t with tyIdent = tyIdent})
-end
-
-lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst +
-                            MetaVarDisableGeneralize + PropagateTypeAnnot +
-                            SubstituteUnknown + ResolveType +
-                            SubstituteNewReprs
-  sem typeCheckDecl env =
-  | DeclRecLets t ->
-    -- NOTE(aathn, 2024-05-24): This code assumes that each recursive let-binding
-    -- is a syntactic lambda, so that generalization is always safe.
-    let newLvl = addi 1 env.currentLvl in
-    -- First: Generate a new environment containing the recursive bindings
-    let recLetEnvIteratee = lam acc. lam b: DeclLetRecord.
-      let tyAnnot = resolveType t.info env false b.tyAnnot in
-      let tyAnnot = substituteNewReprs env tyAnnot in
-      let tyBody = substituteUnknown t.info {env with currentLvl = newLvl} (Poly ()) tyAnnot in
-      let newEnv = _insertVar b.ident tyBody acc.0 in
-      let newTyVars = foldr (uncurry mapInsert) acc.1 (stripTyAll tyBody).0 in
-      ((newEnv, newTyVars), {b with tyAnnot = tyAnnot, tyBody = tyBody})
-    in
-    match mapAccumL recLetEnvIteratee (env, mapEmpty nameCmp) t.bindings
-    with ((recLetEnv, tyVars), bindings) in
-    let newTyVarEnv =
-      mapFoldWithKey (lam vs. lam v. lam k. mapInsert v (newLvl, k) vs) recLetEnv.tyVarEnv tyVars in
-    let newEnv = {recLetEnv with currentLvl = newLvl, tyVarEnv = newTyVarEnv} in
-
-    -- Second: Type check the body of each binding in the new environment
-    let typeCheckBinding = lam b: DeclLetRecord.
-      let body =
-        let body = typeCheckExpr newEnv (propagateTyAnnot (b.body, b.tyAnnot)) in
-        -- Unify the inferred type of the body with the annotated one
-        unify newEnv [infoTy b.tyAnnot, infoTm body] (stripTyAll b.tyBody).1 (tyTm body);
-        body
-      in
-      {b with body = body}
-    in
-    let bindings = map typeCheckBinding bindings in
-    (if env.disableRecordPolymorphism then
-       iter (lam b. disableRecordGeneralize env.currentLvl b.tyBody) bindings
-     else ());
-
-    -- Third: Produce a new environment with generalized types
-    let envIteratee = lam acc. lam b : DeclLetRecord.
-      match gen env.currentLvl acc.1 b.tyBody with (tyBody, vars) in
-      let newEnv = _insertVar b.ident tyBody acc.0 in
-      let newTyVars = foldr (uncurry mapInsert) acc.1 vars in
-      ((newEnv, newTyVars), {b with tyBody = tyBody})
-    in
-    match mapAccumL envIteratee (env, tyVars) bindings with ((env, _), bindings) in
-    (env, DeclRecLets {t with bindings = bindings})
-end
-
-
 lang DeclSemTypeCheck = SemDeclAst + ResolveType + DeclTypeCheck +
                         SubstituteUnknown + ResolveType + SubstituteNewReprs +
                         PatTypeCheck
@@ -192,20 +102,6 @@ lang DeclLangTypeCheck = DeclTypeCheck + LangDeclAst + SemDeclAst + SynDeclAst +
     (env, DeclLang {d with decls = join [typeDecls, synDecls, semDecls]})
 end
 
-lang DeclTypeTypeCheck = DeclTypeCheck + TypeDeclAst + VariantTypeAst + ResolveType
-  sem typeCheckDecl env =
-  | DeclType d ->
-    -- A DeclType is treated exactly as a TmType in the MExpr type checker.
-    let tyIdent = resolveType d.info env false d.tyIdent in
-    -- let newLvl = match tyIdent with !TyVariant _ then addi 1 env.currentLvl else 0 in
-    -- figure out whether to keep this level
-    let newTyConEnv = mapInsert d.ident (0, d.params, tyIdent) env.tyConEnv in
-
-    let env = {env with tyConEnv = newTyConEnv} in
-
-    (env, DeclType {d with tyIdent = tyIdent})
-end
-
 lang DeclSynTypeCheck = DeclTypeCheck + SynDeclAst + ResolveType
   sem typeCheckDecl env =
   | DeclSyn d ->
@@ -227,15 +123,6 @@ lang DeclSynTypeCheck = DeclTypeCheck + SynDeclAst + ResolveType
     (env, DeclSyn {d with defs = defs})
 end
 
-lang DeclExtTypeCheck = DeclTypeCheck + ExtDeclAst + ResolveType
-  sem typeCheckDecl env =
-  | DeclExt t ->
-    -- TODO(vipa, 2023-06-15): Error if a RepType shows up in an external definition?
-    let tyIdent = resolveType t.info env true t.tyIdent in
-    let env = {env with varEnv = mapInsert t.ident tyIdent env.varEnv} in
-    (env, DeclExt {t with tyIdent = tyIdent})
-end
-
 lang ProgramTypeCheck = DeclTypeCheck + MLangTopLevel
   sem typeCheckProgram : MLangProgram -> MLangProgram
   sem typeCheckProgram =
@@ -246,9 +133,8 @@ lang ProgramTypeCheck = DeclTypeCheck + MLangTopLevel
 end
 
 lang MLangTypeCheck = ProgramTypeCheck + MExprTypeCheck + MLangPrettyPrint +
-                      DeclLetTypeCheck + DeclTypeTypeCheck + DeclSynTypeCheck +
-                      DeclLangTypeCheck + DeclUtestTypeCheck + DeclConDefTypeCheck +
-                      DeclRecLetsTypeCheck + DeclExtTypeCheck
+                      DeclSynTypeCheck +
+                      DeclLangTypeCheck
 
 end
 
@@ -261,7 +147,7 @@ use MyPPrintLang in
 use MLangSym in
 
 let p : MLangProgram = {
-  decls = [(decl_ulet_ "x" (int_ 10))],
+  decls = [(ulet_ "x" (int_ 10))],
   expr = addi_ (var_ "x") (int_ 1)
 } in
 
@@ -269,8 +155,8 @@ typeCheckProgram p ;
 
 let p : MLangProgram = {
   decls = [
-    decl_type_ "Foo" [] tyint_,
-    decl_let_ "x" (tycon_ "Foo") (int_ 50)
+    type_ "Foo" [] tyint_,
+    let_ "x" (tycon_ "Foo") (int_ 50)
   ],
   expr = (var_ "x")
 } in
@@ -282,7 +168,7 @@ let p : MLangProgram = {
     decl_lang_ "L0" [
       decl_syn_ "SomeSyn" [("Foo", tyint_), ("Bar", tystr_)]
     ],
-    decl_let_ "x" (tycon_ "SomeSyn") (conapp_ "Foo" (int_ 10))
+    let_ "x" (tycon_ "SomeSyn") (conapp_ "Foo" (int_ 10))
   ],
   expr = matchex_
       (var_ "x")
@@ -314,8 +200,8 @@ let p = typeCheckProgram p in
 
 let p : MLangProgram = {
   decls = [
-    decl_utest_ (int_ 1) (int_ 2),
-    decl_utestu_ (int_ 1) (int_ 2) (uconst_ (CNeqi ()))
+    utest_ (int_ 1) (int_ 2),
+    utestu_ (int_ 1) (int_ 2) (uconst_ (CNeqi ()))
   ],
   expr = uunit_
 } in
@@ -336,7 +222,7 @@ let even = (ulam_ "x"
 in
 let p : MLangProgram = {
     decls = [
-        decl_ureclets_ [("odd", odd), ("even", even)]
+        ureclets_ [("odd", odd), ("even", even)]
     ],
     expr = appf1_ (var_ "odd") (int_ 9)
 } in

--- a/src/stdlib/mlang/type-check.mc
+++ b/src/stdlib/mlang/type-check.mc
@@ -13,45 +13,6 @@ lang DeclTypeCheck = TypeCheck + DeclAst
   sem typeCheckDecl : TCEnv -> Decl -> (TCEnv, Decl)
 end
 
-lang DeclLetTypeCheck = DeclTypeCheck + LetDeclAst + LamAst + FunTypeAst + 
-                        ResolveType + SubstituteUnknown +
-                        NonExpansive + MetaVarDisableGeneralize + 
-                        PropagateTypeAnnot + SubstituteNewReprs
-  sem typeCheckDecl env =
-  | DeclLet d -> 
-    -- A DeclLet is treated exactly as a TmLet in the MExpr type checker.
-    let newLvl = addi 1 env.currentLvl in
-    let tyAnnot = resolveType d.info env false d.tyAnnot in
-    let tyAnnot = substituteNewReprs env tyAnnot in
-    let tyBody = substituteUnknown d.info {env with currentLvl = newLvl} (Poly ()) tyAnnot in
-    match
-      if nonExpansive true d.body then
-        match stripTyAll tyBody with (vars, stripped) in
-        let newTyVarEnv =
-          foldr (lam v. mapInsert v.0 (newLvl, v.1)) env.tyVarEnv vars in
-        let newEnv = {env with currentLvl = newLvl, tyVarEnv = newTyVarEnv} in
-        let body = typeCheckExpr newEnv (propagateTyAnnot (d.body, tyAnnot)) in
-        -- Unify the annotated type with the inferred one and generalize
-        unify newEnv [infoTy d.tyAnnot, infoTm body] stripped (tyTm body);
-        (if env.disableRecordPolymorphism then
-           disableRecordGeneralize env.currentLvl tyBody else ());
-        match gen env.currentLvl (mapEmpty nameCmp) tyBody with (tyBody, _) in
-        (body, tyBody)
-      else
-        let body = typeCheckExpr {env with currentLvl = newLvl} d.body in
-        unify env [infoTy d.tyAnnot, infoTm body] tyBody (tyTm body);
-        -- TODO(aathn, 2023-05-07): Relax value restriction
-        weakenMetaVars env.currentLvl tyBody;
-        (body, tyBody)
-    with (body, tyBody) in
-
-    let env = _insertVar d.ident tyBody env in 
-
-    (env, DeclLet {d with body = body,
-                          tyAnnot = tyAnnot,
-                          tyBody = tyBody})
-end
-
 lang DeclUtestTypeCheck = DeclTypeCheck + UtestDeclAst
   sem typeCheckDecl env =
   | DeclUtest t ->
@@ -59,18 +20,18 @@ lang DeclUtestTypeCheck = DeclTypeCheck + UtestDeclAst
     let expected = typeCheckExpr env t.expected in
     let tusing = optionMap (typeCheckExpr env) t.tusing in
 
-    (switch tusing 
-      case Some tu then 
-        unify env [infoTm test, infoTm expected, infoTm tu] 
+    (switch tusing
+      case Some tu then
+        unify env [infoTm test, infoTm expected, infoTm tu]
           (tyarrows_ [tyTm test, tyTm expected, tybool_]) (tyTm tu)
-      case None _ then 
+      case None _ then
         unify env [infoTm test, infoTm expected] (tyTm test) (tyTm expected)
     end);
     (env, DeclUtest {t with test = test, expected = expected, tusing = tusing})
 end
 
 lang DeclConDefTypeCheck = DeclTypeCheck + DataDeclAst + DataTypeCheck
-  sem typeCheckDecl env = 
+  sem typeCheckDecl env =
   | DeclConDef t ->
     let tyIdent = resolveType t.info env false t.tyIdent in
     let tyIdent = substituteNewReprs env tyIdent in
@@ -82,18 +43,18 @@ lang DeclConDefTypeCheck = DeclTypeCheck + DataDeclAst + DataTypeCheck
       mapInsert target tydeps
         (setFold (lam m. lam t. mapInsert t (setOfSeq nameCmp [target]) m)
                  (mapEmpty nameCmp) tydeps) in
-                 
+
     let env = {env with conEnv = mapInsert t.ident (0, tyIdent) env.conEnv,
                         typeDeps = mapUnionWith setUnion tydeps env.typeDeps,
                         conDeps = mapInsertWith setUnion target
-                               (setOfSeq nameCmp [t.ident]) env.conDeps} in 
+                               (setOfSeq nameCmp [t.ident]) env.conDeps} in
 
     (env, DeclConDef {t with tyIdent = tyIdent})
 end
 
-lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst + 
+lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst +
                             MetaVarDisableGeneralize + PropagateTypeAnnot +
-                            SubstituteUnknown + ResolveType + 
+                            SubstituteUnknown + ResolveType +
                             SubstituteNewReprs
   sem typeCheckDecl env =
   | DeclRecLets t ->
@@ -101,7 +62,7 @@ lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst +
     -- is a syntactic lambda, so that generalization is always safe.
     let newLvl = addi 1 env.currentLvl in
     -- First: Generate a new environment containing the recursive bindings
-    let recLetEnvIteratee = lam acc. lam b: RecLetBinding.
+    let recLetEnvIteratee = lam acc. lam b: DeclLetRecord.
       let tyAnnot = resolveType t.info env false b.tyAnnot in
       let tyAnnot = substituteNewReprs env tyAnnot in
       let tyBody = substituteUnknown t.info {env with currentLvl = newLvl} (Poly ()) tyAnnot in
@@ -116,7 +77,7 @@ lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst +
     let newEnv = {recLetEnv with currentLvl = newLvl, tyVarEnv = newTyVarEnv} in
 
     -- Second: Type check the body of each binding in the new environment
-    let typeCheckBinding = lam b: RecLetBinding.
+    let typeCheckBinding = lam b: DeclLetRecord.
       let body =
         let body = typeCheckExpr newEnv (propagateTyAnnot (b.body, b.tyAnnot)) in
         -- Unify the inferred type of the body with the annotated one
@@ -131,7 +92,7 @@ lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst +
      else ());
 
     -- Third: Produce a new environment with generalized types
-    let envIteratee = lam acc. lam b : RecLetBinding.
+    let envIteratee = lam acc. lam b : DeclLetRecord.
       match gen env.currentLvl acc.1 b.tyBody with (tyBody, vars) in
       let newEnv = _insertVar b.ident tyBody acc.0 in
       let newTyVars = foldr (uncurry mapInsert) acc.1 vars in
@@ -142,15 +103,15 @@ lang DeclRecLetsTypeCheck = DeclTypeCheck + RecLetsDeclAst +
 end
 
 
-lang DeclSemTypeCheck = SemDeclAst + ResolveType + DeclTypeCheck + 
-                        SubstituteUnknown + ResolveType + SubstituteNewReprs + 
+lang DeclSemTypeCheck = SemDeclAst + ResolveType + DeclTypeCheck +
+                        SubstituteUnknown + ResolveType + SubstituteNewReprs +
                         PatTypeCheck
   sem typeCheckSemDecls : TCEnv -> [DeclSemType] -> (TCEnv, [DeclSemType])
   sem typeCheckSemDecls env =
-  | sems -> 
-    -- First: Generate a new environment a type variable for each semantic 
+  | sems ->
+    -- First: Generate a new environment a type variable for each semantic
     -- function.
-    let semIteratee = lam acc. lam t : DeclSemType. 
+    let semIteratee = lam acc. lam t : DeclSemType.
       let tyAnnot = resolveType t.info env false t.tyAnnot in
       let tyAnnot = substituteNewReprs env tyAnnot in
       let tyBody = substituteUnknown t.info {env with currentLvl = 0} (Poly ()) tyAnnot in
@@ -166,41 +127,41 @@ lang DeclSemTypeCheck = SemDeclAst + ResolveType + DeclTypeCheck +
     let newEnv = {recLetEnv with currentLvl = 0, tyVarEnv = newTyVarEnv} in
 
     -- Second: Type check the body of each binding in the new environment
-    let typeCheckCase 
+    let typeCheckCase
       : Type -> TCEnv -> {pat : Pat, thn : Expr} -> {pat : Pat, thn : Expr}
-      = lam targetTy. lam env. lam c : {pat : Pat, thn : Expr}. 
+      = lam targetTy. lam env. lam c : {pat : Pat, thn : Expr}.
       match typeCheckPat env (mapEmpty nameCmp) c.pat with (patEnv, pat) in
-      let env = {env with varEnv = mapUnion env.varEnv patEnv} in 
+      let env = {env with varEnv = mapUnion env.varEnv patEnv} in
       unify env [NoInfo (), NoInfo ()] (tyPat pat) targetTy;
-      let thn = typeCheckExpr env c.thn in 
+      let thn = typeCheckExpr env c.thn in
       {pat = pat, thn = thn}
     in
 
-    let typeCheckSem = lam env : TCEnv. lam semType : DeclSemType. 
-      match semType.args with Some args in 
+    let typeCheckSem = lam env : TCEnv. lam semType : DeclSemType.
+      match semType.args with Some args in
 
-      let insertArg : TCEnv -> {ident : Name, tyAnnot : Type} -> (TCEnv, Type) = 
-        lam env. lam a. 
+      let insertArg : TCEnv -> {ident : Name, tyAnnot : Type} -> (TCEnv, Type) =
+        lam env. lam a.
 
-        let resultTy = substituteUnknown (NoInfo ()) env (Mono ()) a.tyAnnot in 
-        let resultEnv = _insertVar a.ident resultTy env in 
+        let resultTy = substituteUnknown (NoInfo ()) env (Mono ()) a.tyAnnot in
+        let resultEnv = _insertVar a.ident resultTy env in
         (resultEnv, resultTy)
       in
 
-      match mapAccumL insertArg env args with (env, tyParams) in 
+      match mapAccumL insertArg env args with (env, tyParams) in
 
-      let targetTy = newmetavar (Mono ()) 2 (NoInfo ())  in 
+      let targetTy = newmetavar (Mono ()) 2 (NoInfo ())  in
 
       let cases = map (lam c. typeCheckCase targetTy env c) semType.cases in
 
       let headThn = (head cases).thn in
       iter (lam c. unify env [NoInfo (), NoInfo ()] (tyTm headThn) (tyTm c.thn)) (tail cases);
 
-      let resultTy = tyarrow_ targetTy (tyTm headThn) in 
-      let resultTy = foldr tyarrow_ resultTy tyParams in 
+      let resultTy = tyarrow_ targetTy (tyTm headThn) in
+      let resultTy = foldr tyarrow_ resultTy tyParams in
       (env, {semType with cases = cases, tyBody = resultTy})
     in
-    match mapAccumL typeCheckSem newEnv sems with (newEnv, sems) in 
+    match mapAccumL typeCheckSem newEnv sems with (newEnv, sems) in
 
     let envIteratee = lam acc. lam s.
       match gen env.currentLvl acc.1 s.tyBody with (tyBody, vars) in
@@ -209,64 +170,64 @@ lang DeclSemTypeCheck = SemDeclAst + ResolveType + DeclTypeCheck +
       ((newEnv, newTyVars), {s with tyBody = tyBody})
     in
     match mapAccumL envIteratee (env, tyVars) sems with ((env, _), sems) in
-  
+
     (env, sems)
 end
 
 lang DeclLangTypeCheck = DeclTypeCheck + LangDeclAst + SemDeclAst + SynDeclAst +
                          TypeDeclAst + DeclSemTypeCheck
-  sem typeCheckDecl env = 
-  | DeclLang d -> 
-    let typeDecls = mapOption (lam d. match d with DeclType d then Some (DeclType d) else None ()) d.decls in 
-    let synDecls = mapOption (lam d. match d with DeclSyn d then Some (DeclSyn d) else None ()) d.decls in 
-    let semDeclTypes = mapOption (lam d. match d with DeclSem d then Some d else None ()) d.decls in 
+  sem typeCheckDecl env =
+  | DeclLang d ->
+    let typeDecls = mapOption (lam d. match d with DeclType d then Some (DeclType d) else None ()) d.decls in
+    let synDecls = mapOption (lam d. match d with DeclSyn d then Some (DeclSyn d) else None ()) d.decls in
+    let semDeclTypes = mapOption (lam d. match d with DeclSem d then Some d else None ()) d.decls in
 
-    match mapAccumL typeCheckDecl env typeDecls with (env, typeDecls) in 
+    match mapAccumL typeCheckDecl env typeDecls with (env, typeDecls) in
     match mapAccumL typeCheckDecl env synDecls with (env, synDecls) in
-    match typeCheckSemDecls env semDeclTypes with (env, semDeclTypes) in 
+    match typeCheckSemDecls env semDeclTypes with (env, semDeclTypes) in
 
 
-    let semDecls = map (lam x. DeclSem x) semDeclTypes in 
+    let semDecls = map (lam x. DeclSem x) semDeclTypes in
 
     (env, DeclLang {d with decls = join [typeDecls, synDecls, semDecls]})
 end
 
 lang DeclTypeTypeCheck = DeclTypeCheck + TypeDeclAst + VariantTypeAst + ResolveType
   sem typeCheckDecl env =
-  | DeclType d ->   
+  | DeclType d ->
     -- A DeclType is treated exactly as a TmType in the MExpr type checker.
     let tyIdent = resolveType d.info env false d.tyIdent in
     -- let newLvl = match tyIdent with !TyVariant _ then addi 1 env.currentLvl else 0 in
     -- figure out whether to keep this level
     let newTyConEnv = mapInsert d.ident (0, d.params, tyIdent) env.tyConEnv in
 
-    let env = {env with tyConEnv = newTyConEnv} in 
+    let env = {env with tyConEnv = newTyConEnv} in
 
     (env, DeclType {d with tyIdent = tyIdent})
 end
 
 lang DeclSynTypeCheck = DeclTypeCheck + SynDeclAst + ResolveType
-  sem typeCheckDecl env = 
+  sem typeCheckDecl env =
   | DeclSyn d ->
-    -- We add a tyConEnv to the env if this is the base syn definition. 
+    -- We add a tyConEnv to the env if this is the base syn definition.
     let env = if null d.includes then
       {env with tyConEnv = mapInsert d.ident (0, d.params, tyvariant_ []) env.tyConEnv}
     else
       env
-    in 
+    in
 
     let typeCheckDef = lam env. lam def.
-      let tyIdent = resolveType d.info env false def.tyIdent in 
-      let tyArrow = TyArrow {from = tyIdent, to = ntycon_ d.ident, info = d.info} in 
-      let env = {env with conEnv = mapInsert def.ident (0, tyArrow) env.conEnv} in 
+      let tyIdent = resolveType d.info env false def.tyIdent in
+      let tyArrow = TyArrow {from = tyIdent, to = ntycon_ d.ident, info = d.info} in
+      let env = {env with conEnv = mapInsert def.ident (0, tyArrow) env.conEnv} in
       (env, {def with tyIdent = tyIdent})
-    in 
+    in
 
-    match mapAccumL typeCheckDef env d.defs with (env, defs) in 
+    match mapAccumL typeCheckDef env d.defs with (env, defs) in
     (env, DeclSyn {d with defs = defs})
 end
 
-lang DeclExtTypeCheck = DeclTypeCheck + ExtDeclAst + ResolveType 
+lang DeclExtTypeCheck = DeclTypeCheck + ExtDeclAst + ResolveType
   sem typeCheckDecl env =
   | DeclExt t ->
     -- TODO(vipa, 2023-06-15): Error if a RepType shows up in an external definition?
@@ -278,33 +239,33 @@ end
 lang ProgramTypeCheck = DeclTypeCheck + MLangTopLevel
   sem typeCheckProgram : MLangProgram -> MLangProgram
   sem typeCheckProgram =
-  | program -> 
-    match mapAccumL typeCheckDecl typcheckEnvDefault program.decls with (env, decls) in 
-    let expr = typeCheckExpr env program.expr in 
+  | program ->
+    match mapAccumL typeCheckDecl typcheckEnvDefault program.decls with (env, decls) in
+    let expr = typeCheckExpr env program.expr in
     {decls = decls, expr = expr}
 end
 
-lang MLangTypeCheck = ProgramTypeCheck + MExprTypeCheck + MLangPrettyPrint + 
+lang MLangTypeCheck = ProgramTypeCheck + MExprTypeCheck + MLangPrettyPrint +
                       DeclLetTypeCheck + DeclTypeTypeCheck + DeclSynTypeCheck +
                       DeclLangTypeCheck + DeclUtestTypeCheck + DeclConDefTypeCheck +
                       DeclRecLetsTypeCheck + DeclExtTypeCheck
 
 end
 
-lang MyPPrintLang = MLangPrettyPrint + MExprPrettyPrint + MetaVarTypePrettyPrint 
+lang MyPPrintLang = MLangPrettyPrint + MExprPrettyPrint + MetaVarTypePrettyPrint
 end
 
 mexpr
-use MLangTypeCheck in 
+use MLangTypeCheck in
 use MyPPrintLang in
-use MLangSym in  
+use MLangSym in
 
 let p : MLangProgram = {
   decls = [(decl_ulet_ "x" (int_ 10))],
   expr = addi_ (var_ "x") (int_ 1)
-} in 
+} in
 
-typeCheckProgram p ; 
+typeCheckProgram p ;
 
 let p : MLangProgram = {
   decls = [
@@ -312,9 +273,9 @@ let p : MLangProgram = {
     decl_let_ "x" (tycon_ "Foo") (int_ 50)
   ],
   expr = (var_ "x")
-} in 
+} in
 
-typeCheckProgram p ; 
+typeCheckProgram p ;
 
 let p : MLangProgram = {
   decls = [
@@ -323,13 +284,13 @@ let p : MLangProgram = {
     ],
     decl_let_ "x" (tycon_ "SomeSyn") (conapp_ "Foo" (int_ 10))
   ],
-  expr = matchex_ 
+  expr = matchex_
       (var_ "x")
       (pcon_ "Foo" (pvar_ "x"))
       (addi_ (var_ "x") (int_ 1))
-} in 
+} in
 
-typeCheckProgram p ; 
+typeCheckProgram p ;
 
 let p : MLangProgram = {
   decls = [
@@ -346,9 +307,9 @@ let p : MLangProgram = {
   -- expr = app_ (var_ "f") (char_ 'c')
   -- expr = app_ (var_ "f") (int_ 1)
   expr = appf2_ (var_ "g") (int_ 1) (int_ 3)
-} in 
+} in
 
-let p = typeCheckProgram p in 
+let p = typeCheckProgram p in
 -- printLn (mlang2str p);
 
 let p : MLangProgram = {
@@ -357,27 +318,27 @@ let p : MLangProgram = {
     decl_utestu_ (int_ 1) (int_ 2) (uconst_ (CNeqi ()))
   ],
   expr = uunit_
-} in 
+} in
 
-let p = typeCheckProgram p in 
+let p = typeCheckProgram p in
 
-let odd = (ulam_ "x" 
-  (if_ 
+let odd = (ulam_ "x"
+  (if_
     (eqi_ (var_ "x") (int_ 0))
     (false_)
     (appf1_ (var_ "even") (subi_ (var_ "x") (int_ 1)))))
-in 
-let even = (ulam_ "x" 
-  (if_ 
+in
+let even = (ulam_ "x"
+  (if_
     (eqi_ (var_ "x") (int_ 0))
     (true_)
     (appf1_ (var_ "odd") (subi_ (var_ "x") (int_ 1)))))
-in 
+in
 let p : MLangProgram = {
     decls = [
         decl_ureclets_ [("odd", odd), ("even", even)]
     ],
     expr = appf1_ (var_ "odd") (int_ 9)
-} in 
-let p = typeCheckProgram p in 
+} in
+let p = typeCheckProgram p in
 ()

--- a/src/stdlib/ocaml/ast.mc
+++ b/src/stdlib/ocaml/ast.mc
@@ -338,7 +338,7 @@ lang OCamlAst =
   OCamlTopAst +
 
   -- Terms
-  VarAst + LamAst + AppAst + LetAst + RecLetsAst + RecordAst + OCamlMatch + OCamlTuple +
+  VarAst + LamAst + AppAst + LetDeclAst + RecLetsDeclAst + RecordAst + OCamlMatch + OCamlTuple +
   OCamlArray + OCamlData + OCamlRecord + OCamlRecordUpdate + OCamlLabel +
   OCamlLam + PlaceholderAst + 
 

--- a/src/stdlib/ocaml/external.mc
+++ b/src/stdlib/ocaml/external.mc
@@ -577,7 +577,7 @@ lang OCamlGenerateExternalNaive =
   OCamlDataConversionMExpr + OCamlChooseExternalImpl + ExtDeclAst
 
   sem chooseExternalImpls implsMap env =
-  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info}} ->
+  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent}, inexpr = inexpr, info = info} ->
     let identStr = nameGetStr ident in
     let impls = mapLookup identStr implsMap in
 

--- a/src/stdlib/ocaml/external.mc
+++ b/src/stdlib/ocaml/external.mc
@@ -577,7 +577,7 @@ lang OCamlGenerateExternalNaive =
   OCamlDataConversionMExpr + OCamlChooseExternalImpl + ExtDeclAst
 
   sem chooseExternalImpls implsMap env =
-  | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info} ->
+  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info}} ->
     let identStr = nameGetStr ident in
     let impls = mapLookup identStr implsMap in
 

--- a/src/stdlib/ocaml/external.mc
+++ b/src/stdlib/ocaml/external.mc
@@ -252,7 +252,7 @@ lang OCamlDataConversionHelpers =
 end
 
 lang OCamlDataConversionList = OCamlDataConversionHelpers + OCamlAst
-  + SeqTypeAst + UnknownTypeAst + ExtAst + LamAst
+  + SeqTypeAst + UnknownTypeAst + ExtDeclAst + LamAst
 
   sem convertDataInner info env t =
   | (OTyList {ty = ty1}, TySeq {ty = ty2}) ->
@@ -266,7 +266,7 @@ lang OCamlDataConversionList = OCamlDataConversionHelpers + OCamlAst
 end
 
 lang OCamlDataConversionArray = OCamlDataConversionHelpers + OCamlAst
-  + SeqTypeAst + UnknownTypeAst + ExtAst + LamAst
+  + SeqTypeAst + UnknownTypeAst + ExtDeclAst + LamAst
 
   sem convertDataInner info env t =
   | (TySeq {ty = ty1}, OTyArray {ty = ty2}) ->
@@ -407,7 +407,7 @@ lang OCamlDataConversionRecords = OCamlDataConversion + OCamlAst
 end
 
 lang OCamlDataConversionBigArray = OCamlDataConversionHelpers + OCamlAst
-  + TensorTypeAst + UnknownTypeAst + ExtAst + LamAst
+  + TensorTypeAst + UnknownTypeAst + ExtDeclAst + LamAst
 
   sem convertDataInner info env t =
   | (OTyBigarrayGenarray
@@ -574,7 +574,7 @@ end
 -- implementation with the lowest cost with respect to the type given at the
 -- external term definition.
 lang OCamlGenerateExternalNaive =
-  OCamlDataConversionMExpr + OCamlChooseExternalImpl + ExtAst
+  OCamlDataConversionMExpr + OCamlChooseExternalImpl + ExtDeclAst
 
   sem chooseExternalImpls implsMap env =
   | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info} ->

--- a/src/stdlib/ocaml/generate.mc
+++ b/src/stdlib/ocaml/generate.mc
@@ -80,11 +80,11 @@ lang OCamlTopGenerate = MExprAst + OCamlAst + OCamlGenerateExternalNaive
     else never
 
   sem generateTopsAndExpr (env : GenerateEnv) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let here = OTopLet { ident = t.ident, tyBody = t.tyBody, body = generate env t.body } in
     let later: ([Top], Expr) = generateTopsAndExpr env t.inexpr in
     (cons here later.0, later.1)
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let f = lam binding : DeclLetRecord.
       { ident = binding.ident
       , tyBody = binding.tyBody
@@ -93,7 +93,7 @@ lang OCamlTopGenerate = MExprAst + OCamlAst + OCamlGenerateExternalNaive
     let here = OTopRecLets { bindings = map f t.bindings } in
     let later: ([Top], Expr) = generateTopsAndExpr env t.inexpr in
     (cons here later.0, later.1)
-  | TmExt t ->
+  | TmDecl {decl = DeclExt t} ->
     match convertExternalBody env t.ident t.tyIdent t.info with body in
     let here = OTopLet { ident = t.ident, tyBody = t.tyIdent, body = body } in
     let later : ([Top], Expr) = generateTopsAndExpr env t.inexpr in
@@ -563,10 +563,10 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
       info = NoInfo ()
     }
   -- TmExt Generation
-  | TmExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info} ->
+  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info}} ->
     match convertExternalBody env ident tyIdent info with body in
     let inexpr = generate env inexpr in
-    TmLet {
+    TmDecl {decl = DeclLet {
       ident = ident,
       tyAnnot = tyIdent,
       tyBody = tyIdent,
@@ -574,7 +574,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
       inexpr = inexpr,
       ty = TyUnknown {info = info},
       info = info
-    }
+    }}
   | t -> smap_Expr_Expr (generate env) t
 end
 

--- a/src/stdlib/ocaml/generate.mc
+++ b/src/stdlib/ocaml/generate.mc
@@ -80,23 +80,23 @@ lang OCamlTopGenerate = MExprAst + OCamlAst + OCamlGenerateExternalNaive
     else never
 
   sem generateTopsAndExpr (env : GenerateEnv) =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let here = OTopLet { ident = t.ident, tyBody = t.tyBody, body = generate env t.body } in
-    let later: ([Top], Expr) = generateTopsAndExpr env t.inexpr in
+    let later: ([Top], Expr) = generateTopsAndExpr env x.inexpr in
     (cons here later.0, later.1)
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let f = lam binding : DeclLetRecord.
       { ident = binding.ident
       , tyBody = binding.tyBody
       , body = generate env binding.body
       } in
     let here = OTopRecLets { bindings = map f t.bindings } in
-    let later: ([Top], Expr) = generateTopsAndExpr env t.inexpr in
+    let later: ([Top], Expr) = generateTopsAndExpr env x.inexpr in
     (cons here later.0, later.1)
-  | TmDecl {decl = DeclExt t} ->
+  | TmDecl (x & {decl = DeclExt t}) ->
     match convertExternalBody env t.ident t.tyIdent t.info with body in
     let here = OTopLet { ident = t.ident, tyBody = t.tyIdent, body = body } in
-    let later : ([Top], Expr) = generateTopsAndExpr env t.inexpr in
+    let later : ([Top], Expr) = generateTopsAndExpr env x.inexpr in
     (cons here later.0, later.1)
   | t ->
     ([], generate env t)
@@ -258,8 +258,8 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst + OCamlTopGenerate
     in
     bindall_ [
       nulet_ targetId (objMagic (generate env t.target)),
-      nulet_ lenId (length_ (nvar_ targetId)),
-      _if cond thn (generate env t.els)]
+      nulet_ lenId (length_ (nvar_ targetId))]
+      (_if cond thn (generate env t.els))
   | TmMatch (t & {pat = PatRecord {bindings = bindings, ty = ty}}) ->
     if mapIsEmpty bindings then
       generate env t.thn
@@ -367,17 +367,13 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst + OCamlTopGenerate
     -- sequence, as this can be compiled more efficiently (in particular, for
     -- lists).
     let targetId = nameSym "_target" in
-    let headBind =
-      match getPatNamedId head with Some id then
-        nulet_ id (head_ (nvar_ targetId))
-      else uunit_
-    in
-    let tailBind =
-      match getPatName tail with Some id then
-        nulet_ id (tail_ (nvar_ targetId))
-      else uunit_
-    in
-    let thn = bindall_ [headBind, tailBind, generate env t.thn] in
+    let headBind = optionMap
+      (lam id. nulet_ id (head_ (nvar_ targetId)))
+      (getPatNamedId head) in
+    let tailBind = optionMap
+      (lam id. nulet_ id (tail_ (nvar_ targetId)))
+      (getPatName tail) in
+    let thn = bindall_ (filterOption [headBind, tailBind]) (generate env t.thn) in
     bind_
       (nulet_ targetId (objMagic (generate env t.target)))
       (_if (null_ (nvar_ targetId)) (generate env t.els) thn)
@@ -461,10 +457,10 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
           t.rec
       else (acc, rec)
     in
-    let f = lam binds. lam update.
+    let f = lam update.
       match update with (key, value) in
       let id = nameSym "_value" in
-      (bind_ (nulet_ id value) binds, (key, id))
+      (nulet_ id value, (key, id))
     in
     match collectNestedUpdates [] upd with (updateEntries, rec) in
     let ty = unwrapType t.ty in
@@ -476,7 +472,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
           let inlineRecordName = nameSym "rec" in
           -- NOTE(larshum, 2022-12-21): To ensure record updates are evaluated
           -- in declaration order, we add bindings for each of the inner values.
-          match mapAccumL f uunit_ (reverse updateEntries) with (binds, updates) in
+          match unzip (map f updateEntries) with (binds, updates) in
           let combinedUpdate = OTmConApp {
             ident = id,
             args = [ OTmRecordUpdate {
@@ -484,7 +480,7 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
               updates = map (lam u. match u with (sid, id) in (sid, nvar_ id)) updates
             } ]
           } in
-          let thn = bind_ binds combinedUpdate in
+          let thn = bindall_ binds combinedUpdate in
           _omatch_ rec
             [(OPatCon {ident = id, args = [npvar_ inlineRecordName]}, thn)]
         else
@@ -563,18 +559,21 @@ lang OCamlGenerate = MExprAst + OCamlAst + OCamlTopGenerate + OCamlMatchGenerate
       info = NoInfo ()
     }
   -- TmExt Generation
-  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent, inexpr = inexpr, info = info}} ->
+  | TmDecl {decl = DeclExt {ident = ident, tyIdent = tyIdent}, inexpr = inexpr, info = info} ->
     match convertExternalBody env ident tyIdent info with body in
     let inexpr = generate env inexpr in
-    TmDecl {decl = DeclLet {
-      ident = ident,
-      tyAnnot = tyIdent,
-      tyBody = tyIdent,
-      body = body,
+    TmDecl {
+      decl = DeclLet {
+        ident = ident,
+        tyAnnot = tyIdent,
+        tyBody = tyIdent,
+        body = body,
+        info = info
+      },
       inexpr = inexpr,
       ty = TyUnknown {info = info},
       info = info
-    }}
+    }
   | t -> smap_Expr_Expr (generate env) t
 end
 

--- a/src/stdlib/ocaml/generate.mc
+++ b/src/stdlib/ocaml/generate.mc
@@ -85,7 +85,7 @@ lang OCamlTopGenerate = MExprAst + OCamlAst + OCamlGenerateExternalNaive
     let later: ([Top], Expr) = generateTopsAndExpr env t.inexpr in
     (cons here later.0, later.1)
   | TmRecLets t ->
-    let f = lam binding : RecLetBinding.
+    let f = lam binding : DeclLetRecord.
       { ident = binding.ident
       , tyBody = binding.tyBody
       , body = generate env binding.body

--- a/src/stdlib/ocaml/pprint.mc
+++ b/src/stdlib/ocaml/pprint.mc
@@ -474,11 +474,11 @@ lang OCamlPrettyPrint =
     match collectParameters env t with (env, params, body) in
     match pprintCode (pprintIncr indent) env body with (env, body) in
     (env, join ["fun ", strJoin " " params, " ->", pprintNewline (pprintIncr indent), body])
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     match pprintVarName env t.ident with (env,str) in
     match collectParameters env t.body with (env, parameters, body) in
     match pprintCode (pprintIncr indent) env body with (env, body) in
-    match pprintCode indent env t.inexpr with (env, inexpr) in
+    match pprintCode indent env x.inexpr with (env, inexpr) in
     ( env
     , join
       [ "let ", str, join (map (cons ' ') parameters), " =", pprintNewline (pprintIncr indent)
@@ -532,8 +532,8 @@ lang OCamlPrettyPrint =
     match pprintUpdates env updates with (env, updates) in
     (env, join ["{ ", rec, pprintNewline i,
                 "with", pprintNewline i, updates, " }"])
-  | TmDecl {decl = DeclRecLets {bindings = [], inexpr = inexpr}} -> pprintCode indent env inexpr
-  | TmDecl {decl = DeclRecLets {bindings = bindings, inexpr = inexpr}} ->
+  | TmDecl {decl = DeclRecLets {bindings = []}, inexpr = inexpr} -> pprintCode indent env inexpr
+  | TmDecl {decl = DeclRecLets {bindings = bindings}, inexpr = inexpr} ->
     let f = lam env. lam bind.
       match pprintVarName env bind.ident with (env, ident) in
       match collectParameters env bind.body with (env, parameters, body) in
@@ -740,7 +740,7 @@ let testCharLiteral = char_ 'c' in
 let testFun = ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y"))) in
 
 let testLet =
-  bindall_ [ulet_ "x" (int_ 1), addi_ (var_ "x") (int_ 2)]
+  bind_ (ulet_ "x" (int_ 1)) (addi_ (var_ "x") (int_ 2))
 in
 
 let testRec =

--- a/src/stdlib/ocaml/pprint.mc
+++ b/src/stdlib/ocaml/pprint.mc
@@ -142,8 +142,8 @@ lang OCamlPrettyPrint =
   sem isAtomic =
   | TmPlaceholder _ -> true
   | TmLam _ -> false
-  | TmLet _ -> false
-  | TmRecLets _ -> false
+  | TmDecl {decl = DeclLet _} -> false
+  | TmDecl {decl = DeclRecLets _} -> false
   | TmRecord _ -> true
   | TmRecordUpdate _ -> true
   | OTmArray _ -> true
@@ -474,7 +474,7 @@ lang OCamlPrettyPrint =
     match collectParameters env t with (env, params, body) in
     match pprintCode (pprintIncr indent) env body with (env, body) in
     (env, join ["fun ", strJoin " " params, " ->", pprintNewline (pprintIncr indent), body])
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     match pprintVarName env t.ident with (env,str) in
     match collectParameters env t.body with (env, parameters, body) in
     match pprintCode (pprintIncr indent) env body with (env, body) in
@@ -532,8 +532,8 @@ lang OCamlPrettyPrint =
     match pprintUpdates env updates with (env, updates) in
     (env, join ["{ ", rec, pprintNewline i,
                 "with", pprintNewline i, updates, " }"])
-  | TmRecLets {bindings = [], inexpr = inexpr} -> pprintCode indent env inexpr
-  | TmRecLets {bindings = bindings, inexpr = inexpr} ->
+  | TmDecl {decl = DeclRecLets {bindings = [], inexpr = inexpr}} -> pprintCode indent env inexpr
+  | TmDecl {decl = DeclRecLets {bindings = bindings, inexpr = inexpr}} ->
     let f = lam env. lam bind.
       match pprintVarName env bind.ident with (env, ident) in
       match collectParameters env bind.body with (env, parameters, body) in

--- a/src/stdlib/ocaml/wrap-in-try-with.mc
+++ b/src/stdlib/ocaml/wrap-in-try-with.mc
@@ -14,17 +14,17 @@ lang OCamlTryWithWrap = MExprAst + OCamlAst
   | (OTopVariantTypeDecl _ | OTopCExternalDecl _) & t ->
     (acc.0, snoc acc.1 t)
   | OTopLet t ->
-    let letExpr = TmLet {
+    let letExpr = TmDecl {decl = DeclLet {
       ident = t.ident, tyAnnot = t.tyBody, tyBody = t.tyBody, body = t.body,
-      inexpr = unit_, ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
+      inexpr = unit_, ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}} in
     (bind_ acc.0 letExpr, acc.1)
   | OTopRecLets t ->
     let toDeclLetRecord = lam bind : OCamlTopBinding.
       { ident = bind.ident, tyAnnot = bind.tyBody, tyBody = bind.tyBody
       ,  body = bind.body, info = NoInfo ()} in
-    let recLetExpr = TmRecLets {
+    let recLetExpr = TmDecl {decl = DeclRecLets {
       bindings = map toDeclLetRecord t.bindings, inexpr = unit_,
-      ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
+      ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}} in
     (bind_ acc.0 recLetExpr, acc.1)
   | OTopExpr t -> (bind_ acc.0 t.expr, acc.1)
   | OTopTryWith t -> error "Nested try-with expressions currently not supported"

--- a/src/stdlib/ocaml/wrap-in-try-with.mc
+++ b/src/stdlib/ocaml/wrap-in-try-with.mc
@@ -19,11 +19,11 @@ lang OCamlTryWithWrap = MExprAst + OCamlAst
       inexpr = unit_, ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
     (bind_ acc.0 letExpr, acc.1)
   | OTopRecLets t ->
-    let toRecLetBinding = lam bind : OCamlTopBinding.
+    let toDeclLetRecord = lam bind : OCamlTopBinding.
       { ident = bind.ident, tyAnnot = bind.tyBody, tyBody = bind.tyBody
       ,  body = bind.body, info = NoInfo ()} in
     let recLetExpr = TmRecLets {
-      bindings = map toRecLetBinding t.bindings, inexpr = unit_,
+      bindings = map toDeclLetRecord t.bindings, inexpr = unit_,
       ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()} in
     (bind_ acc.0 recLetExpr, acc.1)
   | OTopExpr t -> (bind_ acc.0 t.expr, acc.1)

--- a/src/stdlib/ocaml/wrap-in-try-with.mc
+++ b/src/stdlib/ocaml/wrap-in-try-with.mc
@@ -8,30 +8,30 @@
 include "mexpr/ast.mc"
 include "mexpr/ast-builder.mc"
 include "ocaml/ast.mc"
+include "either.mc"
 
 lang OCamlTryWithWrap = MExprAst + OCamlAst
-  sem wrapTopInTryWith (acc : (Expr, [Top])) =
+  sem wrapTopInTryWith : Top -> Either Decl Top
+  sem wrapTopInTryWith =
   | (OTopVariantTypeDecl _ | OTopCExternalDecl _) & t ->
-    (acc.0, snoc acc.1 t)
+    Right t
   | OTopLet t ->
-    let letExpr = TmDecl {decl = DeclLet {
+    let letDecl = DeclLet {
       ident = t.ident, tyAnnot = t.tyBody, tyBody = t.tyBody, body = t.body,
-      inexpr = unit_, ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}} in
-    (bind_ acc.0 letExpr, acc.1)
+      info = NoInfo ()} in
+    Left letDecl
   | OTopRecLets t ->
     let toDeclLetRecord = lam bind : OCamlTopBinding.
       { ident = bind.ident, tyAnnot = bind.tyBody, tyBody = bind.tyBody
       ,  body = bind.body, info = NoInfo ()} in
-    let recLetExpr = TmDecl {decl = DeclRecLets {
-      bindings = map toDeclLetRecord t.bindings, inexpr = unit_,
-      ty = TyUnknown {info = NoInfo ()}, info = NoInfo ()}} in
-    (bind_ acc.0 recLetExpr, acc.1)
-  | OTopExpr t -> (bind_ acc.0 t.expr, acc.1)
+    let recLetDecl = DeclRecLets {bindings = map toDeclLetRecord t.bindings, info = NoInfo ()} in
+    Left recLetDecl
+  | OTopExpr t -> Left (nulet_ (nameSym "") t.expr)
   | OTopTryWith t -> error "Nested try-with expressions currently not supported"
 
   sem wrapInTryWith =
   | tops /- [Top] -/ ->
-    match foldl wrapTopInTryWith (unit_, []) tops with (tryExpr, tops) in
+    match eitherPartition (map wrapTopInTryWith tops) with (decls, tops) in
     let enableBacktracesTop = OTopLet {
       ident = nameSym "",
       tyBody = TyRecord {fields = mapEmpty cmpSID, info = NoInfo ()},
@@ -41,10 +41,11 @@ lang OCamlTryWithWrap = MExprAst + OCamlAst
       ulet_ "" (appf2_ (OTmVarExt {ident = "Printf.printf"})
         (OTmString {text = "MExpr runtime error: %s\\n"})
         (app_ (OTmVarExt {ident = "Printexc.to_string"}) (nvar_ excId))),
-      ulet_ "" (OTmExprExt {expr = "Printexc.print_backtrace Stdlib.stdout"}),
-      OTmExprExt {expr = "Stdlib.exit 1"}] in
+      ulet_ "" (OTmExprExt {expr = "Printexc.print_backtrace Stdlib.stdout"})]
+      (OTmExprExt {expr = "Stdlib.exit 1"}) in
+    match decls with decls ++ [DeclLet {body = body}] in
     let tryWithTop = OTopTryWith {
-      try = tryExpr,
+      try = bindall_ decls body,
       arms = [(npvar_ excId, withExpr)]} in
     snoc (cons enableBacktracesTop tops) tryWithTop
 end

--- a/src/stdlib/parser/gen-ast.mc
+++ b/src/stdlib/parser/gen-ast.mc
@@ -212,15 +212,14 @@ type GenInput =
   , fieldAccessors : [FieldAccessorRequest]
   }
 
-let _nulet_ = lam n. lam body. lam inexpr. use LetDeclAst in TmLet
-  { ident = n
+let _nulet_ = lam n. lam body. lam inexpr. use LetDeclAst in TmDecl {decl = DeclLet { ident = n
   , body = body
   , tyAnnot = tyunknown_
   , tyBody = tyunknown_
   , inexpr = inexpr
   , info = NoInfo ()
   , ty = tyunknown_
-  }
+  }}
 
 lang CarriedTypeHelpers = CarriedTypeBase + SemDeclAst + PrettyPrint
   sem _mkSmapAccumL : SFuncRequest -> Constructor -> Option Decl

--- a/src/stdlib/parser/gen-ast.mc
+++ b/src/stdlib/parser/gen-ast.mc
@@ -212,7 +212,7 @@ type GenInput =
   , fieldAccessors : [FieldAccessorRequest]
   }
 
-let _nulet_ = lam n. lam body. lam inexpr. use LetAst in TmLet
+let _nulet_ = lam n. lam body. lam inexpr. use LetDeclAst in TmLet
   { ident = n
   , body = body
   , tyAnnot = tyunknown_

--- a/src/stdlib/parser/gen-ast.mc
+++ b/src/stdlib/parser/gen-ast.mc
@@ -212,15 +212,6 @@ type GenInput =
   , fieldAccessors : [FieldAccessorRequest]
   }
 
-let _nulet_ = lam n. lam body. lam inexpr. use LetDeclAst in TmDecl {decl = DeclLet { ident = n
-  , body = body
-  , tyAnnot = tyunknown_
-  , tyBody = tyunknown_
-  , inexpr = inexpr
-  , info = NoInfo ()
-  , ty = tyunknown_
-  }}
-
 lang CarriedTypeHelpers = CarriedTypeBase + SemDeclAst + PrettyPrint
   sem _mkSmapAccumL : SFuncRequest -> Constructor -> Option Decl
   sem _mkSmapAccumL request =
@@ -542,9 +533,8 @@ lang CarriedRecord = CarriedTypeBase
              let fieldName = nameSym field in
              let constr = lam innerMost.
                match_
-                 (_nulet_
-                   fieldName
-                   (recordproj_ field (nvar_ valName))
+                 (bind_
+                   (nulet_ fieldName (recordproj_ field (nvar_ valName)))
                    (mkNew accName fieldName))
                  (ptuple_ [npvar_ accName, npvar_ fieldName])
                  (constr innerMost)

--- a/src/stdlib/parser/gen-op-ast.mc
+++ b/src/stdlib/parser/gen-op-ast.mc
@@ -141,7 +141,7 @@ let _mergeInfos_ : use Ast in [Expr] -> Expr = lam exprs. switch exprs
 let _nletin_ : use Ast in Name -> Type -> Expr -> Expr -> Expr
   = lam name. lam ty. lam val. lam body.
     use MExprAst in
-    TmLet {ident = name, tyAnnot = ty, tyBody = tyunknown_, body = val, inexpr = body, ty = tyunknown_, info = NoInfo ()}
+    TmDecl {decl = DeclLet {ident = name, tyAnnot = ty, tyBody = tyunknown_, body = val, inexpr = body, ty = tyunknown_, info = NoInfo ()}}
 
 let _nuletin_ : use Ast in Name -> Expr -> Expr -> Expr
   = lam name. lam val. lam body.

--- a/src/stdlib/parser/gen-op-ast.mc
+++ b/src/stdlib/parser/gen-op-ast.mc
@@ -141,7 +141,18 @@ let _mergeInfos_ : use Ast in [Expr] -> Expr = lam exprs. switch exprs
 let _nletin_ : use Ast in Name -> Type -> Expr -> Expr -> Expr
   = lam name. lam ty. lam val. lam body.
     use MExprAst in
-    TmDecl {decl = DeclLet {ident = name, tyAnnot = ty, tyBody = tyunknown_, body = val, inexpr = body, ty = tyunknown_, info = NoInfo ()}}
+    TmDecl
+    { decl = DeclLet
+      { ident = name
+      , tyAnnot = ty
+      , tyBody = tyunknown_
+      , body = val
+      , info = NoInfo ()
+      }
+    , inexpr = body
+    , ty = tyunknown_
+    , info = NoInfo ()
+    }
 
 let _nuletin_ : use Ast in Name -> Expr -> Expr -> Expr
   = lam name. lam val. lam body.
@@ -511,7 +522,7 @@ type WrapperInfo = use Ast in
   , addPrefix_ : Expr -> Expr -> Expr -> Expr
   , addPostfix_ : Expr -> Expr -> Expr -> Expr
   , finalize_ : Expr -> Expr -> Expr
-  , definitions : [Expr]
+  , definitions : [Decl]
   }
 
 let _mkBrWrappersFor
@@ -654,7 +665,7 @@ let _mkBrWrappers
         (lam acc. lam. lam wrapper: WrapperInfo. concat acc wrapper.definitions)
         []
         wrappers in
-      bindall_ (snoc definitions expr)
+      bindall_ definitions expr
     }
 
 

--- a/src/stdlib/parser/lrk.mc
+++ b/src/stdlib/parser/lrk.mc
@@ -667,7 +667,7 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
         stlAcc
     ) stackTypeLabel table.tokenConTypes in
 
-    let stackRecordExpr = 
+    let stackRecordExpr =
       let tytms = (mapFoldWithKey (lam acc: ([(String, Type)], [(String, Expr)]). lam ty: Type. lam label: String.
         match acc with (tys, tms) in
         let tys = cons (label, (tyseq_ ty)) tys in
@@ -762,25 +762,25 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
                       ulet_ "shiftStack" (recordproj_ stackLabel (nvar_ lamStacks)),
                       ulet_ "newTypeStack" (cons_ (nvar_ v) (var_ "shiftStack")),
                       ulet_ "newStacks" (recordupdate_ (nvar_ lamStacks) stackLabel (var_ "newTypeStack")),
-                      ulet_ "nextTokenResult" (appf1_ (binds.v_nextToken) (nvar_ lamLexerState)),
-                      matchall_ [
+                      ulet_ "nextTokenResult" (appf1_ (binds.v_nextToken) (nvar_ lamLexerState))]
+                      (matchall_ [
                         matchex_ (var_ "nextTokenResult") (npcon_ (binds.c_ResultOk) (prec_ [("value", pvar_ "lexres")])) (
                           bindall_ [
                             ulet_ "newLookahead" (snoc_ (nvar_ varRest) (recordproj_ "token" (var_ "lexres"))),
                             ulet_ "newLexerState" (recordproj_ "stream" (var_ "lexres")),
-                            ulet_ "newStateTrace" (cons_ (int_ shift.toIdx) (nvar_ lamStateTrace)),
-                            appf4_ (nvar_ parseFunctionIdent)
+                            ulet_ "newStateTrace" (cons_ (int_ shift.toIdx) (nvar_ lamStateTrace))]
+                            (appf4_ (nvar_ parseFunctionIdent)
                                    (var_ "newStacks")
                                    (var_ "newLexerState")
                                    (var_ "newStateTrace")
                                    (var_ "newLookahead")
-                          ]
+                          )
                         ),
                         matchex_ (var_ "nextTokenResult") (npcon_ (binds.c_ResultErr) (prec_ [("errors", pvar_ "errors"), ("warnings", pvar_ "warnings")])) (
                           nconapp_ (binds.c_ResultErr) (urecord_ [("errors", var_ "errors"), ("warnings", var_ "warnings")])
                         )
                       ]
-                    ]
+                    )
                   )
                 ) stateShifts in
 
@@ -829,27 +829,31 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
                       work (tyTm rule.action)
                     in
                     let returnLabel = mapLookupOrElse (lam. error "internal error (4)") actionRetType stackTypeLabel in
-                    bindall_ [
+                    bindall_ (join [
 
                       -- extract all stacks to variables
-                      bindall_ (map (lam lbl: String.
-                        ulet_ (concat "var" lbl) (recordproj_ lbl (nvar_ lamStacks))
-                      ) (distinct eqString (cons returnLabel stackLabels))),
+                      (map
+                        (lam lbl: String.
+                          ulet_ (concat "var" lbl) (recordproj_ lbl (nvar_ lamStacks)))
+                        (distinct eqString (cons returnLabel stackLabels))),
 
                       -- extract all values from the stacks and pop that value from the stack
                       -- and create the new production
-                      bindall_ (snoc
+                      (snoc
                         -- Stack semantics, so we pop in reverse order
-                        (reverse (mapi (lam i. lam lbl.
-                        bindall_ [
+                        (join (reverse (mapi (lam i. lam lbl.
+                        [
                           ulet_ (join ["tokenValue", int2string i]) (head_ (var_ (concat "var" lbl))),
                           ulet_ (concat "var" lbl) (tail_ (var_ (concat "var" lbl)))
                         ]
-                        ) stackLabels))
-                        (ulet_ "newProduce" (appSeq_ rule.action (cons (nvar_ varActionState) (mapi (lam i. lam. var_ (join ["tokenValue", int2string i])) stackLabels))))
-                      ),
-
-                      -- If we reduce on the entrypoint rule, then we return. Otherwise push to the stack and run the GOTO action
+                        ) stackLabels)))
+                        (ulet_ "newProduce"
+                          (appSeq_ rule.action
+                            (cons (nvar_ varActionState)
+                              (mapi (lam i. lam. var_ (join ["tokenValue", int2string i])) stackLabels))))
+                      )
+                    ])
+                    ( -- If we reduce on the entrypoint rule, then we return. Otherwise push to the stack and run the GOTO action
                       if eqi reduction.prodIdx table.entrypointProdIdx then (
                         #var"global: result.ok" (var_ "newProduce")
                       ) else (bindall_ [
@@ -863,15 +867,15 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
 
                         let varLookupName = mapLookupOrElse (lam. error "malformed parse table! (5)") rule.nt gotoLookupVarNames in
                         ulet_ "nextState" (get_ (nvar_ varLookupName) (var_ "currentState")),
-                        ulet_ "newStateTrace" (cons_ (var_ "nextState") (var_ "newStateTrace")),
+                        ulet_ "newStateTrace" (cons_ (var_ "nextState") (var_ "newStateTrace"))]
 
-                        appf4_ (nvar_ parseFunctionIdent)
+                        (appf4_ (nvar_ parseFunctionIdent)
                                (var_ "newStacks")
                                (nvar_ lamLexerState)
                                (var_ "newStateTrace")
                                (nvar_ lamLookahead)
-                      ])
-                    ]
+                      ))
+                    )
                   )
                 ) stateReductions in
 
@@ -942,21 +946,20 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
     in
 
     /---- Set up the expression ----/
-    let expr = bindall_ [
+    let expr = bindall_ (join [
       -- Set up the goto lookups and the initial action state
-      bindall_ (snoc (map (lam nt: Name.
-          let expr = mapLookupOrElse (lam. error "lrk PANIC") nt gotoLookupVarExpressions in
-          let binding = mapLookupOrElse (lam. error "lrk PANIC") nt gotoLookupVarNames in
-          nulet_ binding expr
-        ) (mapKeys gotoLookupVarNames))
-        (nulet_ varActionState table.syntaxDef.initActionState)
-      ),
+      (map (lam nt: Name.
+        let expr = mapLookupOrElse (lam. error "lrk PANIC") nt gotoLookupVarExpressions in
+        let binding = mapLookupOrElse (lam. error "lrk PANIC") nt gotoLookupVarNames in
+        nulet_ binding expr
+      ) (mapKeys gotoLookupVarNames)),
+      [nulet_ varActionState table.syntaxDef.initActionState],
 
       -- Initialize the stacks as lists
-      nlet_ varInitialStacks (tyTm stackRecordExpr) stackRecordExpr,
+      [nlet_ varInitialStacks (tyTm stackRecordExpr) stackRecordExpr],
 
       -- Initialize the state trace
-      nulet_ varInitialStateTrace (seq_ [int_ table.entrypointIdx]),
+      [nulet_ varInitialStateTrace (seq_ [int_ table.entrypointIdx])],
 
       /- Initialize the lookahead as
       let lookahead_check: Result w e (LexerStateType, [Tokens]) =
@@ -971,7 +974,7 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
         work lexerState [] k
       in
       -/
-      ulet_ "lookahead_check" (
+      [ulet_ "lookahead_check" (
         bindall_ [
           ureclet_ "work" (lams_ [("lhLexerState", tyunknown_),
                                   ("lhAcc", tyseq_ tokenType),
@@ -979,30 +982,30 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
             if_ (eqi_ (var_ "i") (int_ 0)) (
               #var"global: result.ok" (utuple_ [var_ "lhLexerState", var_ "lhAcc"])
             ) (bindall_ [
-              ulet_ "r" (appf1_ binds.v_nextToken (var_ "lhLexerState")),
-              matchall_ [
+              ulet_ "r" (appf1_ binds.v_nextToken (var_ "lhLexerState"))]
+              (matchall_ [
                 matchex_ (var_ "r") (npcon_ binds.c_ResultOk (prec_ [("value", pvar_ "lexres")])) (
                   bindall_ [
                     ulet_ "newLhAcc" (snoc_ (var_ "lhAcc") (recordproj_ "token" (var_ "lexres"))),
-                    ulet_ "newLhLexerState" (recordproj_ "stream" (var_ "lexres")),
-                    appf3_ (var_ "work")
+                    ulet_ "newLhLexerState" (recordproj_ "stream" (var_ "lexres"))]
+                    (appf3_ (var_ "work")
                            (var_ "newLhLexerState")
                            (var_ "newLhAcc")
                            (subi_ (var_ "i") (int_ 1))
-                  ]
+                  )
                 ),
                 matchex_ (var_ "r") (npcon_ binds.c_ResultErr (prec_ [("errors", pvar_ "errors"), ("warnings", pvar_ "warnings")])) (
                   nconapp_ binds.c_ResultErr (urecord_ [("errors", var_ "errors"), ("warnings", var_ "warnings")])
                 )
               ]
-            ])
-          )),
-          appf3_ (var_ "work")
+            ))
+          ))]
+          (appf3_ (var_ "work")
                  (binds.v_stream)
                  (seq_ [])
                  (int_ table.k_lookahead)
-        ]
-      ),
+        )
+      )]])
 
       /- Extract the lookahead and run the parser:
       match lookahead_check with ResultOk {value = (lexerState, lookahead)} then
@@ -1011,21 +1014,21 @@ lang LRParser = ContextFreeGrammar + TokenReprEOF + MExprAst + MExprCmp
       else match lookahead_check with ResultErr {errors = errors} in
         result.err errors
       -/
-      matchall_ [
+      (matchall_ [
         matchex_ (var_ "lookahead_check") (npcon_ binds.c_ResultOk (prec_ [("value", (ptuple_ [pvar_ "lhLexerState", pvar_ "lhLookahead"]))])) (
           bindall_ [
-            parseFunctionBody,
-            appf4_ (nvar_ parseFunctionIdent) (nvar_ varInitialStacks)
+            parseFunctionBody]
+            (appf4_ (nvar_ parseFunctionIdent) (nvar_ varInitialStacks)
                                               (var_ "lhLexerState")
                                               (nvar_ varInitialStateTrace)
                                               (var_ "lhLookahead")
-          ]
+          )
         ),
         matchex_ (var_ "lookahead_check") (npcon_ binds.c_ResultErr (prec_ [("errors", pvar_ "errors"), ("warnings", pvar_ "warnings")])) (
           nconapp_ binds.c_ResultErr (urecord_ [("errors", var_ "errors"), ("warnings", var_ "warnings")])
         )
       ]
-    ] in
+    ) in
     withType resultType expr
 end
 
@@ -1314,8 +1317,8 @@ foldl (lam. lam tc: LRTestCase.
                                      ("str", get_ (var_ "argv") (int_ 1))]),
         ulet_ "parse_result" (appf2_ (var_ "parse")
                                      (var_ "lexerState")
-                                     (var_ "wrappedNextToken")),
-        matchall_ [
+                                     (var_ "wrappedNextToken"))]
+        (matchall_ [
           matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
             appf1_ (var_ "print") (var_ "result")
           ),
@@ -1326,7 +1329,7 @@ foldl (lam. lam tc: LRTestCase.
                                  (appf1_ (var_ "mapValues") (var_ "errors"))))
           )
         ]
-      ]),
+      )),
       ""
     ] in
 

--- a/src/stdlib/parser/tool.mc
+++ b/src/stdlib/parser/tool.mc
@@ -1053,8 +1053,8 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
               (nulam_ seqName
                 (match_ (nvar_ seqName) pats
                   (bindall_
-                    (snoc toRebind
-                      (asDyn_ (wrap (urecord_ fields)))))
+                    toRebind
+                    (asDyn_ (wrap (urecord_ fields))))
                   never_))
           in
           let exprProduction = urecord_
@@ -1602,14 +1602,14 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
                   (nulam_ seqName
                     (match_ (nvar_ seqName) pats
                       (bindall_
-                        (snoc toRebind
-                          (asDyn_
-                            (nconapp_ conName
-                              (urecord_
-                                [ (infoFieldLabel, mergeInfos_ [lPartSym.info, ntSym.info, rPartSym.info])
-                                , (termsFieldLabel, seq_ [lPartSym.info, rPartSym.info])
-                                , ("inner", match_ ntVal (pseqtot_ [pvar_ "x"]) (var_ "x") never_)
-                                ])))))
+                        toRebind
+                        (asDyn_
+                          (nconapp_ conName
+                            (urecord_
+                              [ (infoFieldLabel, mergeInfos_ [lPartSym.info, ntSym.info, rPartSym.info])
+                              , (termsFieldLabel, seq_ [lPartSym.info, rPartSym.info])
+                              , ("inner", match_ ntVal (pseqtot_ [pvar_ "x"]) (var_ "x") never_)
+                              ]))))
                       never_))
               in
               let prod =
@@ -1841,22 +1841,25 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
           [ ("start", nvar_ start)
           , ("productions", genOpResult.wrapProductions (seq_ prods))
           ] in
-        let grammar = bindall_ (snoc nts grammar) in
+        let grammar = bindall_ nts grammar in
         let table = _uletin_ "target" (app_ (var_ "genParsingTable") grammar)
           (match_ (var_ "target") (pcon_ "Right" (pvar_ "table"))
             (var_ "table")
             never_) in
         use LetDeclAst in
-        use UseAst in
+        use UseDeclAst in
         DeclLet
           { ident = nameNoSym "_table"
           , tyAnnot = tyunknown_
           , tyBody = tyunknown_
-          , body = TmUse
-            { ident = composedParseFragmentName
-            , info = NoInfo ()
+          , body = TmDecl
+            { decl = DeclUse
+              { ident = composedParseFragmentName
+              , info = NoInfo ()
+              }
             , ty = tyunknown_
             , inexpr =  table
+            , info = NoInfo ()
             }
           , info = NoInfo ()
           }
@@ -1866,7 +1869,7 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
   let parseFunctions : Res [MDecl] =
     let f = lam start.
       use LetDeclAst in
-      use UseAst in
+      use UseDeclAst in
       use BootParser in
       let parse = parseMExprStringExn {_defaultBootParserParseMExprStringArg () with allowFree = true} in
       let body = parse
@@ -1891,8 +1894,11 @@ let runParserGenerator : {synFile : String, outFile : String} -> () = lam args.
         , tyBody = tyunknown_
         , body = ulam_ "filename"
           (ulam_ "content"
-            (TmUse
-              { ident = composedParseFragmentName
+            (TmDecl
+              { decl = DeclUse
+                { ident = composedParseFragmentName
+                , info = NoInfo ()
+                }
               , inexpr = body
               , ty = tyunknown_
               , info = NoInfo ()

--- a/src/stdlib/peval/compile.mc
+++ b/src/stdlib/peval/compile.mc
@@ -20,7 +20,7 @@ lang SpecializeCompile = SpecializeAst + MExprPEval + MExprAst
   sem createSpecExpr : Expr -> Expr -> Expr
   sem createSpecExpr deps =
   | TmLam {body = b} -> createSpecExpr deps b
-  | t -> bind_ deps t
+  | t -> oldBind_ deps t
 
   sem updateBody : Expr -> Expr -> Expr
   sem updateBody e =
@@ -93,13 +93,12 @@ lang SpecializeCompile = SpecializeAst + MExprPEval + MExprAst
     match specializePass names args (mapEmpty nameCmp) ast
     with (idMapping, ast) in
 
-    let ast = if gti (mapLength idMapping) 0 then
-      let symDefs = bindall_ (map (lam n:Name. nulet_ n (gensym_ uunit_))
-                  (mapValues idMapping)) in
-      bindall_ [
-          symDefs,
-          ast]
-    else ast in
+    let ast =
+      if gti (mapLength idMapping) 0 then
+        let symDefs = map (lam n:Name. nulet_ n (gensym_ uunit_))
+          (mapValues idMapping) in
+        bindall_ symDefs ast
+      else ast in
     ast
 
 end
@@ -141,45 +140,45 @@ in
 -- TyInt
 let unknownTyInt = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" tyint_ (specialize_ (var_ "x"))),
-    ulet_ "k" (app_ (var_ "p") (int_ 4)),
-    app_ (var_ "p") (int_ 12)
-]) in
+    ulet_ "k" (app_ (var_ "p") (int_ 4))]
+    (app_ (var_ "p") (int_ 12)
+)) in
 
 -- TyFloat
 let unknownTyFloat = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" tyfloat_ (specialize_ (var_ "x"))),
-    ulet_ "k" (app_ (var_ "p") (float_ 4.0)),
-    unit_
-]) in
+    ulet_ "k" (app_ (var_ "p") (float_ 4.0))]
+    (unit_
+)) in
 
 -- TyBool
 let unknownTyBool = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" tybool_ (specialize_ (var_ "x"))),
-    ulet_ "k" (app_ (var_ "p") (bool_ false)),
+    ulet_ "k" (app_ (var_ "p") (bool_ false))]
     unit_
-]) in
+) in
 
 -- TyChar
 let unknownTyChar = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" tychar_ (specialize_ (var_ "x"))),
-    ulet_ "k" (app_ (var_ "p") (char_ 'x')),
+    ulet_ "k" (app_ (var_ "p") (char_ 'x'))]
     unit_
-]) in
+) in
 
 -- TySeq
 let intseq = tyseq_ tyint_ in
 let unknownTySeq = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" intseq (specialize_ (var_ "x"))),
-    ulet_ "k" (app_ (var_ "p") (seq_ [int_ 1, int_ 2])),
+    ulet_ "k" (app_ (var_ "p") (seq_ [int_ 1, int_ 2]))]
     unit_
-]) in
+) in
 
 -- TyRec
 let t = tyrecord_ [("a", tyint_), ("b", tyint_)] in
 let unknownTyRec = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" t (specialize_ (var_ "x"))),
     ulet_ "k" (app_ (var_ "p") (urecord_ [("a",int_ 1), ("b", int_ 3)]))
-]) in
+] unit_) in
 
 -- TyRec with one unliftable field
 
@@ -187,7 +186,7 @@ let t = tyrecord_ [("a", tyint_), ("b", tyunknown_)] in
 let unknownTyRecUnknown = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" t (specialize_ (var_ "x"))),
     ulet_ "k" (app_ (var_ "p") (urecord_ [("a",int_ 1), ("b", int_ 3)]))
-]) in
+] unit_) in
 
 -- TyArrow
 
@@ -196,7 +195,7 @@ let unknownTyArrow = preprocess (bindall_ [
     ulet_ "p" (lam_ "x" t (specialize_ (var_ "x"))),
     ulet_ "id" (lam_ "x" (tyint_) (var_ "x")),
     ulet_ "k" (app_ (var_ "p") (var_ "id"))
-]) in
+] unit_) in
 
 let recursiveThing = preprocess (bindall_ [
     (ureclets_
@@ -215,25 +214,25 @@ let recursiveThing = preprocess (bindall_ [
               (if_ (lti_ (var_ "x") (int_ 0))
                  false_
                  (app_ (var_ "odd") (subi_ (var_ "x") (int_ 1))))))]),
-    ulet_ "ra" (specialize_ (app_ (var_ "odd") (int_ 4)))]) in
+    ulet_ "ra" (specialize_ (app_ (var_ "odd") (int_ 4)))] unit_) in
 
 let e = match_ (int_ 3) (pvar_ "wo") (int_ 5) (int_ 6) in
 let e = bind_ (ulet_ "x" (int_ 3)) (addi_ (int_ 4) (var_ "x")) in
 let distinctCalls = preprocess (bindall_ [
     ulet_ "k" (specialize_ (e))
-]) in
+] unit_) in
 
 let distinctCalls = preprocess (bindall_ [
-  ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
-  specialize_ (app_ (var_ "f") (int_ 1))
-]) in
+  ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3)))]
+  (specialize_ (app_ (var_ "f") (int_ 1))
+)) in
 
 let distinctCalls = preprocess (bindall_ [
     ulet_ "f" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))),
     ulet_ "p" (ulam_ "x" (
-        specialize_ (app_ (var_ "f") (var_ "x")))),
-    app_ (var_ "p") (int_ 4)
-]) in
+        specialize_ (app_ (var_ "f") (var_ "x"))))]
+    (app_ (var_ "p") (int_ 4)
+)) in
 
 match compileSpecialize unknownTyRecUnknown with ast in
 

--- a/src/stdlib/peval/compile.mc
+++ b/src/stdlib/peval/compile.mc
@@ -29,16 +29,16 @@ lang SpecializeCompile = SpecializeAst + MExprPEval + MExprAst
 
   sem rmCopy : Name -> Expr -> Expr
   sem rmCopy rm =
-  | TmLet t ->
+  | tm & TmDecl {decl = DeclLet t, inexpr = inexpr} ->
     if nameEq t.ident rm then
-      t.inexpr
-    else smap_Expr_Expr (rmCopy rm) (TmLet t)
+      inexpr
+    else smap_Expr_Expr (rmCopy rm) tm
   | t -> smap_Expr_Expr (rmCopy rm) t
 
   sem specializePass : SpecializeNames -> SpecializeArgs -> Map Name Name ->
                   Expr -> (Map Name Name, Expr)
   sem specializePass pnames args idMap =
-  | TmLet t ->
+  | tm & TmDecl (x & {decl = DeclLet t}) ->
     match mapLookup t.ident args.extractMap with Some e then
       -- Remove the copy of this let binding in the extracted bindings
       let e = rmCopy t.ident e in
@@ -63,8 +63,8 @@ lang SpecializeCompile = SpecializeAst + MExprPEval + MExprAst
       let fff = print_ ff in
       -- Update the specialize let-binding
       let bodyn = updateBody (semi_ fff never_) t.body in
-      (args.idMapping, TmLet {t with body = bodyn})
-    else smapAccumL_Expr_Expr (specializePass pnames args) idMap (TmLet t)
+      (args.idMapping, TmDecl {x with decl = DeclLet {t with body = bodyn}})
+    else smapAccumL_Expr_Expr (specializePass pnames args) idMap tm
   | t -> smapAccumL_Expr_Expr (specializePass pnames args) idMap t
 
   sem hasSpecializeTerm : Bool -> Expr -> Bool

--- a/src/stdlib/peval/extract.mc
+++ b/src/stdlib/peval/extract.mc
@@ -74,9 +74,9 @@ let extractSpecialize = lam t.
 in
 
 let noSpecializeCalls = preprocess (bindall_ [
-  ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  app_ (var_ "f") (int_ 2)
-]) in
+  ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))]
+  (app_ (var_ "f") (int_ 2)
+)) in
 match extractSpecialize noSpecializeCalls with (m, ast) in
 utest mapSize m with 0 in
 utest ast with int_ 0 using eqExpr in
@@ -84,14 +84,14 @@ utest ast with int_ 0 using eqExpr in
 let t = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "g" (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
-  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  specialize_ (app_ (var_ "h") (int_ 2))
-]) in
+  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x")))]
+  (specialize_ (app_ (var_ "h") (int_ 2))
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "h") (int_ 2))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "h") (int_ 2)))]
+  (int_ 0
+)) in
 match extractSpecialize t with (m, ast) in
 
 utest mapSize m with 1 in
@@ -100,15 +100,15 @@ utest ast with extracted using eqExpr in
 let t = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "g" (ulam_ "x" (muli_ (app_ (var_ "f") (var_ "x")) (int_ 2))),
-  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  specialize_ (app_ (var_ "g") (int_ 4))
-]) in
+  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x")))]
+  (specialize_ (app_ (var_ "g") (int_ 4))
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "g" (ulam_ "x" (muli_ (app_ (var_ "f") (var_ "x")) (int_ 2))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 4))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 4)))]
+  (int_ 0
+)) in
 match extractSpecialize t with (m, ast) in
 utest mapSize m with 1 in
 utest ast with extracted using eqExpr in
@@ -116,38 +116,38 @@ utest ast with extracted using eqExpr in
 let multipleCallsToSame = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "g" (ulam_ "x" (bindall_ [
-    ulet_ "y" (addi_ (var_ "x") (int_ 2)),
-    specialize_ (app_ (var_ "f") (var_ "y"))
-  ])),
-  ulet_ "h" (ulam_ "x" (specialize_ (app_ (var_ "f") (var_ "x")))),
-  addi_
+    ulet_ "y" (addi_ (var_ "x") (int_ 2))]
+    (specialize_ (app_ (var_ "f") (var_ "y"))
+  ))),
+  ulet_ "h" (ulam_ "x" (specialize_ (app_ (var_ "f") (var_ "x"))))]
+  (addi_
     (app_ (var_ "g") (int_ 1))
     (app_ (var_ "h") (int_ 3))
-]) in
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "t" (ulam_ "y" (ulam_ "" (app_ (var_ "f") (var_ "y")))),
-  ulet_ "t" (ulam_ "x" (ulam_ "" (app_ (var_ "f") (var_ "x")))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "x" (ulam_ "" (app_ (var_ "f") (var_ "x"))))]
+  (int_ 0
+)) in
 match extractSpecialize multipleCallsToSame with (m, ast) in
 utest mapSize m with 2 in
 utest ast with extracted using eqExpr in
 
 let distinctCalls = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
-  ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  addi_
+  ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))]
+  (addi_
     (specialize_ (app_ (var_ "f") (int_ 1)))
     (specialize_ (app_ (var_ "g") (int_ 0)))
-]) in
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "t" (ulam_ "t" (app_ (var_ "f") (int_ 1))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 0))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 0)))]
+  (int_ 0
+)) in
 match extractSpecialize distinctCalls with (m, ast) in
 utest mapSize m with 2 in
 utest ast with extracted using eqExpr in
@@ -156,33 +156,33 @@ let distinctCalls = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "h" (specialize_ (app_ (var_ "g") (int_ 1))),
-  ulet_ "z" (ulam_ "x" (app_ (var_ "f") (var_ "x"))),
+  ulet_ "z" (ulam_ "x" (app_ (var_ "f") (var_ "x")))]
   (specialize_ (app_ (var_ "z") (int_ 1)))
-]) in
+) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 1))),
   ulet_ "z" (ulam_ "x" (app_ (var_ "f") (var_ "x"))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "z") (int_ 1))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "z") (int_ 1)))]
+  (int_ 0
+)) in
 match extractSpecialize distinctCalls with (m, ast) in
 utest ast with extracted using eqExpr in
 
 let specializeVar = preprocess (bindall_ [
   ulet_ "foo" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))),
   -- Extraction does not work in this case
-  ulet_ "bar" (app_ (var_ "foo") (int_ 1)),
-  specialize_ (var_ "bar")
-]) in
+  ulet_ "bar" (app_ (var_ "foo") (int_ 1))]
+  (specialize_ (var_ "bar")
+)) in
 
 let expected = preprocess (bindall_ [
   ulet_ "foo" (ulam_ "x" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))),
   ulet_ "bar" (app_ (var_ "foo") (int_ 1)),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "bar") (int_ 3))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "bar") (int_ 3)))]
+  (int_ 0
+)) in
 
 
 match extractSpecialize specializeVar with (m, ast) in
@@ -192,16 +192,16 @@ let inRecursiveBinding = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
   ureclets_ [
     ("g", ulam_ "x" (app_ (var_ "f") (addi_ (var_ "x") (int_ 1)))),
-    ("h", ulam_ "x" (specialize_ (app_ (var_ "g") (var_ "x"))))],
-  app_ (var_ "h") (int_ 3)
-]) in
+    ("h", ulam_ "x" (specialize_ (app_ (var_ "g") (var_ "x"))))]]
+  (app_ (var_ "h") (int_ 3)
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
   ureclets_ [
-    ("g", ulam_ "x" (app_ (var_ "f") (addi_ (var_ "x") (int_ 1)))),
-    ("t", ulam_ "x" (ulam_ "" (app_ (var_ "g") (var_ "x"))))],
-  int_ 0
-]) in
+    ("t", ulam_ "x" (ulam_ "" (app_ (var_ "g") (var_ "x")))),
+    ("g", ulam_ "x" (app_ (var_ "f") (addi_ (var_ "x") (int_ 1))))]]
+  (int_ 0
+)) in
 match extractSpecialize inRecursiveBinding with (m, ast) in
 utest mapSize m with 1 in
 utest ast with extracted using eqExpr in
@@ -209,14 +209,13 @@ utest ast with extracted using eqExpr in
 let partialCalls = preprocess (bindall_ [
   ulet_ "g" (ulam_ "y" (ulam_ "x" (addi_ (var_ "x") (var_ "y")))),
   ulet_ "h" (specialize_ (app_ (var_ "g") (int_ 1)))
-]) in
+] unit_) in
 let extracted = preprocess (bindall_ [
   ulet_ "g" (ulam_ "y" (ulam_ "x" (addi_ (var_ "x") (var_ "y")))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 1))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 1)))]
+  (int_ 0
+)) in
 match extractSpecialize partialCalls with (m, ast) in
 utest ast with extracted using eqExpr in
 
 ()
-

--- a/src/stdlib/peval/include.mc
+++ b/src/stdlib/peval/include.mc
@@ -157,8 +157,8 @@ let includeBuiltins = mapValues builtinsMapping
 let includeConsNames =
   ["AppAst_TmApp", "LamAst_TmLam", "VarAst_TmVar", "RecordAst_TmRecord",
    "SeqAst_TmSeq", "ClosAst_TmClos", "ConstAst_TmConst", "ClosAst_Lazy",
-   "MatchAst_TmMatch", "LetAst_TmLet", "RecLetsAst_TmRecLets",
-   "DataAst_TmConDef", "DataAst_TmConApp", "TypeAst_TmType", "NeverAst_TmNever",
+   "MatchAst_TmMatch", "DeclAst_TmDecl", "LetDeclAst_DeclLet", "RecLetsDeclAst_DeclRecLets",
+   "DataDeclAst_DeclConDef", "DataAst_TmConApp", "TypeDeclAst_DeclType", "NeverAst_TmNever",
 
    -- Others
    "Cons", "Nil", "NoInfo", "Info",

--- a/src/stdlib/peval/lift.mc
+++ b/src/stdlib/peval/lift.mc
@@ -1,7 +1,7 @@
 -- Defines a set of language fragments for lifting MExpr constructs, including
 -- patterns and expressions. Semantically, liftExpr should satisfy
--- lower (liftExpr x) = x. The implementation uses the TmConApp term 
- 
+-- lower (liftExpr x) = x. The implementation uses the TmConApp term
+
 include "peval/extract.mc"
 include "peval/ast.mc"
 include "peval/utils.mc"
@@ -26,6 +26,10 @@ lang SpecializeLift = SpecializeAst + SpecializeUtils + MExprAst + ClosAst
   sem liftExpr : SpecializeNames -> SpecializeArgs -> Expr -> LiftResult
   sem liftExpr names args = | t ->
     error (join ["Don't know how to lift this yet: ", (expr2str t)])
+
+  sem liftDecl : SpecializeNames -> SpecializeArgs -> Decl -> LiftResult
+  sem liftDecl names args = | d ->
+    error (join ["Don't know how to lift this yet: ", decl2str d])
 
   sem liftExprAccum : SpecializeNames -> SpecializeArgs -> [Expr] -> (SpecializeArgs, [Expr])
   sem liftExprAccum names args =
@@ -379,20 +383,31 @@ lang SpecializeLiftMatch = SpecializeLift + MatchAst
 end
 
 
-lang SpecializeLiftLet = SpecializeLift + LetAst
-
+lang SpecializeLiftDecl = SpecializeLift + DeclAst
   sem liftExpr names args =
-  | TmLet {ident=ident, body=body, inexpr=inexpr, ty=ty, info=info} ->
-    match liftExprAccum names args [body, inexpr] with (args, [lBody, lInex]) in
+  | TmDecl x ->
+    match liftDecl names args x.decl with (args, decl) in
+    match liftExpr names args x.inexpr with (args, inexpr) in
+    let bindings =
+      [ ("decl", decl)
+      , ("inexpr", inexpr)
+      ] in
+    (args, createConAppExpr names tmDeclName bindings x.ty x.info)
+end
+
+lang SpecializeLiftLet = SpecializeLift + LetDeclAst
+  sem liftDecl names args =
+  | DeclLet {ident=ident, body=body, info=info} ->
+    match liftExpr names args body with (args, lBody) in
     match liftName names args ident with (args, lName) in
     let dummyType = liftType names tyunknown_ in
-    let bindings = [("ident", lName), ("body", lBody), ("inexpr", lInex),
+    let bindings = [("ident", lName), ("body", lBody),
                   ("tyAnnot", dummyType), ("tyBody", dummyType)] in
-    (args, createConAppExpr names tmLetName bindings ty info)
+    (args, createConAppInfo names declLetName bindings info)
 
 end
 
-lang SpecializeLiftRecLets = SpecializeLift + RecLetsAst
+lang SpecializeLiftRecLets = SpecializeLift + RecLetsDeclAst
 
   sem liftRecLetsBindings names args =
   | binds ->
@@ -408,23 +423,25 @@ lang SpecializeLiftRecLets = SpecializeLift + RecLetsAst
     let lBinds = seq_ lBinds in
     (args, lBinds)
 
-  sem liftExpr names args =
-  | TmRecLets {bindings = binds, inexpr = inexpr, ty=ty, info=info} ->
-    match liftExpr names args inexpr with (args, lInexpr) in
+  sem liftDecl names args =
+  | DeclRecLets {bindings = binds, ty=ty, info=info} ->
     match liftRecLetsBindings names args binds with (args, lBinds) in
-    let bindings = [("bindings", lBinds), ("inexpr", lInexpr)] in
-    (args, createConAppExpr names tmRecLetsName bindings ty info)
+    let bindings = [("bindings", lBinds)] in
+    (args, createConAppInfo names declRecLetsName bindings info)
 end
 
-lang SpecializeLiftDataAst = SpecializeLift + DataAst
+lang SpecializeLiftDataAst = SpecializeLift + DataAst + DataDeclAst
+  sem liftDecl names args =
+  | DeclConDef x ->
+    match liftName names args x.ident with (args, ident) in
+    let tyIdent = liftType names x.tyIdent in
+    let bindings =
+      [ ("ident", ident)
+      , ("tyIdent", tyIdent)
+      ] in
+    (args, createConAppInfo names declConDefName bindings x.info)
 
   sem liftExpr names args =
-  | TmConDef {ident=ident, tyIdent=tyId, inexpr=inexpr, ty=ty, info=info} ->
-    match liftName names args ident with (args, ident) in
-    match liftExpr names args inexpr with (args, inexpr) in
-    let tyId = liftType names tyId in
-    let bindings = [("ident", ident), ("tyIdent", tyId), ("inexpr", inexpr)] in
-    (args, createConAppExpr names tmConDefName bindings ty info)
   | TmConApp {ident=ident, body=body, ty=ty, info=info} ->
     match liftName names args ident with (args, ident) in
     match liftExpr names args body with (args, body) in
@@ -432,19 +449,16 @@ lang SpecializeLiftDataAst = SpecializeLift + DataAst
     (args, createConAppExpr names tmConAppName bindings ty info)
 end
 
-lang SpecializeLiftTypeAst = SpecializeLift + TypeAst
+lang SpecializeLiftTypeAst = SpecializeLift + TypeDeclAst
 
-  sem liftExpr names args =
-  | TmType {ident=ident, params=params, tyIdent=tyId, inexpr=inexpr,
-            ty=ty, info=info} ->
+  sem liftDecl names args =
+  | DeclType {ident=ident, params=params, tyIdent=tyId, info=info} ->
     match liftName names args ident with (args, ident) in
-    match (mapAccumL (lam args. lam name.
-      liftName names args name) args params) with (args, params) in
-    match liftExpr names args inexpr with (args, inexpr) in
+    match mapAccumL (liftName names) args params with (args, params) in
     let tyId = liftType names tyId in
     let bindings = [("ident", ident), ("tyIdent", tyId),
-                    ("params", seq_ params), ("inexpr", inexpr)] in
-    (args, createConAppExpr names tmTypeName bindings ty info)
+                    ("params", seq_ params)] in
+    (args, createConAppInfo names tmTypeName bindings info)
 end
 
 

--- a/src/stdlib/peval/lift.mc
+++ b/src/stdlib/peval/lift.mc
@@ -424,7 +424,7 @@ lang SpecializeLiftRecLets = SpecializeLift + RecLetsDeclAst
     (args, lBinds)
 
   sem liftDecl names args =
-  | DeclRecLets {bindings = binds, ty=ty, info=info} ->
+  | DeclRecLets {bindings = binds, info=info} ->
     match liftRecLetsBindings names args binds with (args, lBinds) in
     let bindings = [("bindings", lBinds)] in
     (args, createConAppInfo names declRecLetsName bindings info)
@@ -458,7 +458,7 @@ lang SpecializeLiftTypeAst = SpecializeLift + TypeDeclAst
     let tyId = liftType names tyId in
     let bindings = [("ident", ident), ("tyIdent", tyId),
                     ("params", seq_ params)] in
-    (args, createConAppInfo names tmTypeName bindings info)
+    (args, createConAppInfo names declTypeName bindings info)
 end
 
 
@@ -473,7 +473,7 @@ lang SpecializeLiftMExpr =
     SpecializeLiftApp + SpecializeLiftVar + SpecializeLiftRecord +
     SpecializeLiftSeq + SpecializeLiftConst + SpecializeLiftLam + SpecializeLiftSpecialize +
     SpecializeLiftMatch + SpecializeLiftLet + SpecializeLiftRecLets + SpecializeLiftDataAst +
-    SpecializeLiftTypeAst + SpecializeLiftNever
+    SpecializeLiftTypeAst + SpecializeLiftNever + SpecializeLiftDecl
 end
 
 
@@ -668,14 +668,18 @@ let newSymbol = match mapLookup someSym args.idMapping with Some t
 
 let ltype = liftType names tyunknown_ in
 
-let expected = nconapp_ (tmLetName names) (urecord_
-  [("ident", utuple_ [str_ "t", nvar_ newSymbol]),
-   ("body", _liftExpr names args (int_ 3)),
-   ("inexpr", _liftExpr names args (addi_ (int_ 4) (nvar_ someSym))),
-   ("tyAnnot", ltype),
-   ("tyBody", ltype),
-   ("ty", ltype),
-   ("info", liftInfo names (NoInfo ()))]) in
+let expected = nconapp_ (tmDeclName names) (urecord_
+  [ ("decl", nconapp_ (declLetName names) (urecord_
+    [ ("ident", utuple_ [str_ "t", nvar_ newSymbol])
+    , ("body", _liftExpr names args (int_ 3))
+    , ("tyAnnot", ltype)
+    , ("tyBody", ltype)
+    , ("info", liftInfo names (NoInfo ()))
+    ]))
+  , ("inexpr", _liftExpr names args (addi_ (int_ 4) (nvar_ someSym)))
+  , ("ty", ltype)
+  , ("info", liftInfo names (NoInfo ()))
+  ]) in
 
 utest expected with k using eqExpr in
 
@@ -696,7 +700,7 @@ let factorial = nureclets_ [
   (facSym, facBody)
 ] in
 
-match liftExpr names args factorial with (args, k) in
+match liftExpr names args (bind_ factorial unit_) with (args, k) in
 
 let newSymbol = match mapLookup facSym args.idMapping with Some t
   then t else someSym in
@@ -707,11 +711,15 @@ let lrl = [urecord_ [("ident", utuple_ [str_ "factorial", nvar_ newSymbol]),
   ("tyAnnot", ltype), ("tyBody", ltype), ("info", liftInfo names (NoInfo ())),
   ("body", _liftExpr names args facBody)]] in
 
-let expected = nconapp_ (tmRecLetsName names) (urecord_
-  [("bindings", seq_ lrl),
-   ("inexpr", _liftExpr names args (unit_)),
-   ("ty", ltype),
-   ("info", liftInfo names (NoInfo ()))]) in
+let expected = nconapp_ (tmDeclName names) (urecord_
+  [ ("decl", nconapp_ (declRecLetsName names) (urecord_
+    [ ("bindings", seq_ lrl)
+    , ("info", liftInfo names (NoInfo ()))
+    ]))
+  , ("inexpr", _liftExpr names args (unit_))
+  , ("ty", ltype)
+  , ("info", liftInfo names (NoInfo ()))
+  ]) in
 
 utest expected with k using eqExpr in
 
@@ -722,19 +730,23 @@ utest expected with k using eqExpr in
 let someName = nameSym "test" in
 let e = ncondef_ someName tyunknown_ in
 
-match liftExpr names args e with (args, k) in
+match liftExpr names args (bind_ e unit_) with (args, k) in
 
 let newSymbol = match mapLookup someName args.idMapping with Some t
   then t else someName in
 
 let dummyType = liftType names tyunknown_ in
 
-let expected = nconapp_ (tmConDefName names) (urecord_
-  [("ident", utuple_ [str_ "test", nvar_ newSymbol]),
-   ("tyIdent", dummyType),
-   ("ty", dummyType),
-   ("inexpr", _liftExpr names args uunit_),
-   ("info", liftInfo names (NoInfo ()))]) in
+let expected = nconapp_ (tmDeclName names) (urecord_
+  [ ("decl", nconapp_ (declConDefName names) (urecord_
+    [ ("ident", utuple_ [str_ "test", nvar_ newSymbol])
+    , ("tyIdent", dummyType)
+    , ("info", liftInfo names (NoInfo ()))
+    ]))
+  , ("ty", dummyType)
+  , ("inexpr", _liftExpr names args uunit_)
+  , ("info", liftInfo names (NoInfo ()))
+  ]) in
 
 utest expected with k using eqExpr in
 
@@ -752,7 +764,7 @@ let newSymbol = match mapLookup someName args.idMapping with Some t
 
 let dummyType = liftType names tyunknown_ in
 
-let expected = nconapp_ (tmTypeName names) (urecord_
+let expected = nconapp_ (declTypeName names) (urecord_
   [("ident", utuple_ [str_ "test", nvar_ newSymbol]),
    ("body", _liftExpr names args uunit_),
    ("ty", dummyType),
@@ -767,20 +779,24 @@ utest expected with k using eqExpr in
 let someName = nameSym "test" in
 let e = ntype_ someName [] tyunknown_ in
 
-match liftExpr names args e with (args, k) in
+match liftExpr names args (bind_ e unit_) with (args, k) in
 
 let newSymbol = match mapLookup someName args.idMapping with Some t
   then t else someName in
 
 let dummyType = liftType names tyunknown_ in
 
-let expected = nconapp_ (tmTypeName names) (urecord_
-  [("ident", utuple_ [str_ "test", nvar_ newSymbol]),
-   ("tyIdent", dummyType),
-   ("ty", dummyType),
-   ("inexpr", _liftExpr names args uunit_),
-   ("params", seq_ []),
-   ("info", liftInfo names (NoInfo ()))]) in
+let expected = nconapp_ (tmDeclName names) (urecord_
+  [ ("decl", nconapp_ (declTypeName names) (urecord_
+    [ ("ident", utuple_ [str_ "test", nvar_ newSymbol])
+    , ("tyIdent", dummyType)
+    , ("params", seq_ [])
+    , ("info", liftInfo names (NoInfo ()))
+    ]))
+  , ("inexpr", _liftExpr names args uunit_)
+  , ("ty", dummyType)
+  , ("info", liftInfo names (NoInfo ()))
+  ]) in
 
 utest expected with k using eqExpr in
 

--- a/src/stdlib/peval/peval.mc
+++ b/src/stdlib/peval/peval.mc
@@ -28,15 +28,13 @@ let astBuilder = lam info.
       ty = tyunknown_,
       frozen = false
     },
-    nulet = lam id. lam body. TmDecl {decl = DeclLet {
+    nulet = lam id. lam body. DeclLet {
       ident = id,
       tyAnnot = tyunknown_,
       tyBody = tyunknown_,
       body = body,
-      inexpr = uunit_,
-      ty = tyunknown_,
       info = info
-    },}
+    },
     int = lam n. uconst (CInt { val = n }),
     muli = app2 (uconst (CMuli ())),
     negi = app (uconst (CNegi ())),
@@ -213,7 +211,7 @@ lang LetPEval = PEval + ClosPAst + LetDeclAst
   | TmDecl {decl = DeclLet _} -> true
 
   sem pevalBindTop ctx k =
-  | TmDecl {decl = DeclLet r} ->
+  | TmDecl (x & {decl = DeclLet r}) ->
     pevalBind ctx
       (lam body.
         match body with TmClosP clspr then
@@ -222,35 +220,35 @@ lang LetPEval = PEval + ClosPAst + LetDeclAst
               evalEnvInsert
                 r.ident (TmClosP { clspr with ident = Some r.ident }) ctx.env
           } in
-          TmDecl {decl = DeclLet { r with body = body, inexpr = pevalBindTop ctx k r.inexpr }}
+          TmDecl {x with decl = DeclLet { r with body = body }, inexpr = pevalBindTop ctx k x.inexpr }
         else
           if pevalBindThis body then
-            TmDecl {decl = DeclLet { r with body = body, inexpr = pevalBindTop ctx k r.inexpr }}
+            TmDecl {x with decl = DeclLet { r with body = body }, inexpr = pevalBindTop ctx k x.inexpr }
           else
             pevalBindTop
-              { ctx with env = evalEnvInsert r.ident body ctx.env } k r.inexpr)
+              { ctx with env = evalEnvInsert r.ident body ctx.env } k x.inexpr)
       r.body
 
   sem pevalEval ctx k =
-  | TmDecl {decl = DeclLet r} ->
+  | TmDecl (x & {decl = DeclLet r}) ->
     pevalBind ctx
       (lam body.
         if pevalBindThis body then
-          TmDecl {decl = DeclLet { r with body = body, inexpr = pevalBind ctx k r.inexpr }}
+          TmDecl {x with decl = DeclLet { r with body = body }, inexpr = pevalBind ctx k x.inexpr }
         else
           pevalBind
-            { ctx with env = evalEnvInsert r.ident body ctx.env } k r.inexpr)
+            { ctx with env = evalEnvInsert r.ident body ctx.env } k x.inexpr)
       r.body
 
   sem pevalReadbackH ctx =
-  | TmDecl {decl = DeclLet r} ->
-    match pevalReadbackH ctx r.inexpr with (inexprCtx, inexpr) in
+  | TmDecl (x & {decl = DeclLet r}) ->
+    match pevalReadbackH ctx x.inexpr with (inexprCtx, inexpr) in
     match pevalReadbackH inexprCtx r.body with (ctx, body) in
     if setMem r.ident inexprCtx.freeVar then
-      (ctx, TmDecl {decl = DeclLet { r with body = body, inexpr = inexpr }})
+      (ctx, TmDecl {x with decl = DeclLet { r with body = body }, inexpr = inexpr })
     else
       if exprHasSideEffect ctx.effectEnv body then
-        (ctx, TmDecl {decl = DeclLet { r with body = body, inexpr = inexpr }})
+        (ctx, TmDecl {x with decl = DeclLet { r with body = body }, inexpr = inexpr })
       else
         (inexprCtx, inexpr)
 end
@@ -260,7 +258,7 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
   | TmDecl {decl = DeclRecLets _} -> true
 
   sem pevalBindTop ctx k =
-  | TmDecl {decl = DeclRecLets r} ->
+  | TmDecl (x & {decl = DeclRecLets r}) ->
     recursive let envPrime : Int -> Lazy EvalEnv = lam n. lam.
       let wraplambda = lam bind.
         if geqi n ctx.maxRecDepth then TmVar {
@@ -294,11 +292,9 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
         (lam bind. { bind with body = pevalBind ctx (lam x. x) bind.body })
         r.bindings
     in
-    TmDecl {decl = DeclRecLets {
-      r with
-      bindings = bindings,
-      inexpr = pevalBindTop { ctx with env = envPrime 0 () } k r.inexpr
-    }}
+    TmDecl {x with decl = DeclRecLets {r with bindings = bindings}
+      , inexpr = pevalBindTop { ctx with env = envPrime 0 () } k x.inexpr
+      }
 
   sem pevalEval ctx k =
   | TmDecl {decl = DeclRecLets _} ->
@@ -306,9 +302,9 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
       "Partial evaluation of non-top-level recursive let bindings is not safe"
 
   sem pevalReadbackH ctx =
-  | TmDecl {decl = DeclRecLets r} ->
+  | TmDecl (x & {decl = DeclRecLets r}) ->
     let fv = setOfSeq nameCmp (map (lam bind. bind.ident) r.bindings) in
-    match pevalReadbackH ctx r.inexpr with (inexprCtx, inexpr) in
+    match pevalReadbackH ctx x.inexpr with (inexprCtx, inexpr) in
     if
       forAll (lam bind. not (setMem bind.ident inexprCtx.freeVar)) r.bindings
     then
@@ -324,7 +320,7 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
         r.bindings
       with (ctx, bindings)
     in
-    (ctx, TmDecl {decl = DeclRecLets { r with bindings = bindings, inexpr = inexpr }})
+    (ctx, TmDecl {x with decl = DeclRecLets { r with bindings = bindings }, inexpr = inexpr })
 end
 
 lang RecordPEval = PEval + RecordAst + VarAst
@@ -363,10 +359,10 @@ lang TypePEval = PEval + TypeDeclAst
   | TmDecl {decl = DeclType _} -> true
 
   sem pevalBindTop ctx k =
-  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = pevalBindTop ctx k t.inexpr}}
+  | TmDecl (x & {decl = DeclType _}) -> TmDecl {x with inexpr = pevalBindTop ctx k x.inexpr}
 
   sem pevalEval ctx k =
-  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = pevalBind ctx k t.inexpr}}
+  | TmDecl (x & {decl = DeclType _}) -> TmDecl {x with inexpr = pevalBind ctx k x.inexpr}
 end
 
 lang DataPEval = PEval + DataAst
@@ -375,10 +371,10 @@ lang DataPEval = PEval + DataAst
   | TmConApp _ -> false
 
   sem pevalBindTop ctx k =
-  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = pevalBindTop ctx k t.inexpr}}
+  | TmDecl (x & {decl = DeclConDef _}) -> TmDecl {x with inexpr = pevalBindTop ctx k x.inexpr}
 
   sem pevalEval ctx k =
-  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = pevalBind ctx k t.inexpr}}
+  | TmDecl (x & {decl = DeclConDef _}) -> TmDecl {x with inexpr = pevalBind ctx k x.inexpr}
   | TmConApp t -> pevalBind ctx (lam body. k (TmConApp {t with body = body})) t.body
 end
 
@@ -477,35 +473,36 @@ lang UtestPEval = PEval + UtestDeclAst
   | TmDecl {decl = DeclUtest _} -> true
 
   sem pevalEval ctx k =
-  | TmDecl {decl = DeclUtest t} ->
+  | TmDecl (x & {decl = DeclUtest t}) ->
     pevalBind ctx
       (lam test.
          pevalBind ctx
            (lam expected.
-             let inner = lam x.
-               match x with (tusing, tonfail) in
-                TmDecl {decl = DeclUtest { t with
-                          test = test,
-                          expected = expected,
-                          next = pevalBind ctx k t.next,
-                          tusing = tusing,
-                          tonfail = tonfail
-                }}
-               in
-               switch (t.tusing, t.tonfail)
-               case (Some tusing, Some tonfail) then
-                 pevalBind ctx
-                   (lam tusing.
-                     pevalBind ctx
-                       (lam tonfail. inner (Some tusing, Some tonfail))
-                       tonfail)
-                   tusing
-               case (Some tusing, None ()) then
-                 pevalBind ctx (lam tusing. inner (Some tusing, None ())) tusing
-               case (None (), Some tonfail) then
-                 pevalBind ctx (lam tonfail. inner (None (), Some tonfail)) tonfail
-               case (None (), None ()) then inner (None (), None ())
-               end)
+             let inner = lam pair.
+               match pair with (tusing, tonfail) in
+               TmDecl
+               {x with decl = DeclUtest
+                 { t with test = test
+                 , expected = expected
+                 , tusing = tusing
+                 , tonfail = tonfail
+                 }
+               , inexpr = pevalBind ctx k x.inexpr
+               } in
+             switch (t.tusing, t.tonfail)
+             case (Some tusing, Some tonfail) then
+               pevalBind ctx
+                 (lam tusing.
+                   pevalBind ctx
+                     (lam tonfail. inner (Some tusing, Some tonfail))
+                     tonfail)
+                 tusing
+             case (Some tusing, None ()) then
+               pevalBind ctx (lam tusing. inner (Some tusing, None ())) tusing
+             case (None (), Some tonfail) then
+               pevalBind ctx (lam tonfail. inner (None (), Some tonfail)) tonfail
+             case (None (), None ()) then inner (None (), None ())
+             end)
            t.expected)
       t.test
 end
@@ -526,7 +523,7 @@ lang ExtPEval = PEval + ExtDeclAst
   | TmDecl {decl = DeclExt _} -> true
 
   sem pevalEval ctx k =
-  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = pevalBind ctx k t.inexpr}}
+  | TmDecl (x & {decl = DeclExt _}) -> TmDecl {x with inexpr = pevalBind ctx k x.inexpr}
 end
 
 lang ArithIntPEval = ArithIntEval + VarAst
@@ -684,7 +681,7 @@ type PEvalLetInlineOrRemove
 con PEvalLetInline : () -> PEvalLetInlineOrRemove
 con PEvalLetRemove : () -> PEvalLetInlineOrRemove
 
-lang PEvalLetInline = LetDeclAst + SideEffect
+lang PEvalLetInline = LetDeclAst + SideEffect + VarAst
   -- Inlines let-bindings that are only referred to once in the expression, and
   -- removes unused let-bindings. Assumes unique let-binding identifiers.
   sem pevalInlineLets : SideEffectEnv -> Expr -> Expr
@@ -695,15 +692,15 @@ lang PEvalLetInline = LetDeclAst + SideEffect
         switch t
         case TmVar r then
           mapFindOrElse (lam. t) r.ident env
-        case TmDecl {decl = DeclLet r} then
+        case TmDecl (x & {decl = DeclLet r}) then
           switch mapLookup r.ident marked
           case None _ then
             smap_Expr_Expr (subs marked env) t
           case Some (PEvalLetRemove _) then
-            subs marked env r.inexpr
+            subs marked env x.inexpr
           case Some (PEvalLetInline _) then
             let body = subs marked env r.body in
-            subs marked (mapInsert r.ident body env) r.inexpr
+            subs marked (mapInsert r.ident body env) x.inexpr
           end
         case t then smap_Expr_Expr (subs marked env) t
         end
@@ -717,11 +714,11 @@ lang PEvalLetInline = LetDeclAst + SideEffect
           match acc with (count, subsEnv) in
           switch t
           case TmVar r then (mapInsertWith addi r.ident 1 count, subsEnv)
-          case TmDecl {decl = DeclLet r} then
+          case TmDecl (x & {decl = DeclLet r}) then
             if exprHasSideEffect effectEnv r.body then
               sfold_Expr_Expr mark acc t
             else
-              match mark acc r.inexpr with (inexprCount, subsEnv) in
+              match mark acc x.inexpr with (inexprCount, subsEnv) in
               let identCount = mapFindOrElse (lam. 0) r.ident inexprCount in
               if gti identCount 0 then
                 -- This body IS NOT dead but we might substitute its identifier

--- a/src/stdlib/peval/peval.mc
+++ b/src/stdlib/peval/peval.mc
@@ -208,7 +208,7 @@ lang LamPEval = PEval + PEvalApply + VarAst + LamAst + ClosPAst + AppEval
       (ctx, b.nulam newident body)
 end
 
-lang LetPEval = PEval + ClosPAst + LetAst
+lang LetPEval = PEval + ClosPAst + LetDeclAst
   sem pevalBindThis =
   | TmLet _ -> true
 
@@ -255,7 +255,7 @@ lang LetPEval = PEval + ClosPAst + LetAst
         (inexprCtx, inexpr)
 end
 
-lang RecLetsPEval = PEval + RecLetsAst + ClosPAst + LamAst
+lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
   sem pevalBindThis =
   | TmRecLets _ -> true
 
@@ -358,7 +358,7 @@ lang RecordPEval = PEval + RecordAst + VarAst
       r1.rec
 end
 
-lang TypePEval = PEval + TypeAst
+lang TypePEval = PEval + TypeDeclAst
   sem pevalBindThis =
   | TmType _ -> true
 
@@ -472,7 +472,7 @@ lang MatchPEval =
   | p -> smapAccumL_Pat_Pat freshPattern env p
 end
 
-lang UtestPEval = PEval + UtestAst
+lang UtestPEval = PEval + UtestDeclAst
   sem pevalBindThis =
   | TmUtest _ -> true
 
@@ -521,7 +521,7 @@ lang NeverPEval = PEval + PEvalApply + NeverAst
   | (t & TmNever _, _) -> k t
 end
 
-lang ExtPEval = PEval + ExtAst
+lang ExtPEval = PEval + ExtDeclAst
   sem pevalBindThis =
   | TmExt _ -> true
 
@@ -684,7 +684,7 @@ type PEvalLetInlineOrRemove
 con PEvalLetInline : () -> PEvalLetInlineOrRemove
 con PEvalLetRemove : () -> PEvalLetInlineOrRemove
 
-lang PEvalLetInline = LetAst + SideEffect
+lang PEvalLetInline = LetDeclAst + SideEffect
   -- Inlines let-bindings that are only referred to once in the expression, and
   -- removes unused let-bindings. Assumes unique let-binding identifiers.
   sem pevalInlineLets : SideEffectEnv -> Expr -> Expr

--- a/src/stdlib/peval/peval.mc
+++ b/src/stdlib/peval/peval.mc
@@ -28,7 +28,7 @@ let astBuilder = lam info.
       ty = tyunknown_,
       frozen = false
     },
-    nulet = lam id. lam body. TmLet {
+    nulet = lam id. lam body. TmDecl {decl = DeclLet {
       ident = id,
       tyAnnot = tyunknown_,
       tyBody = tyunknown_,
@@ -36,7 +36,7 @@ let astBuilder = lam info.
       inexpr = uunit_,
       ty = tyunknown_,
       info = info
-    },
+    },}
     int = lam n. uconst (CInt { val = n }),
     muli = app2 (uconst (CMuli ())),
     negi = app (uconst (CNegi ())),
@@ -210,10 +210,10 @@ end
 
 lang LetPEval = PEval + ClosPAst + LetDeclAst
   sem pevalBindThis =
-  | TmLet _ -> true
+  | TmDecl {decl = DeclLet _} -> true
 
   sem pevalBindTop ctx k =
-  | TmLet r ->
+  | TmDecl {decl = DeclLet r} ->
     pevalBind ctx
       (lam body.
         match body with TmClosP clspr then
@@ -222,45 +222,45 @@ lang LetPEval = PEval + ClosPAst + LetDeclAst
               evalEnvInsert
                 r.ident (TmClosP { clspr with ident = Some r.ident }) ctx.env
           } in
-          TmLet { r with body = body, inexpr = pevalBindTop ctx k r.inexpr }
+          TmDecl {decl = DeclLet { r with body = body, inexpr = pevalBindTop ctx k r.inexpr }}
         else
           if pevalBindThis body then
-            TmLet { r with body = body, inexpr = pevalBindTop ctx k r.inexpr }
+            TmDecl {decl = DeclLet { r with body = body, inexpr = pevalBindTop ctx k r.inexpr }}
           else
             pevalBindTop
               { ctx with env = evalEnvInsert r.ident body ctx.env } k r.inexpr)
       r.body
 
   sem pevalEval ctx k =
-  | TmLet r ->
+  | TmDecl {decl = DeclLet r} ->
     pevalBind ctx
       (lam body.
         if pevalBindThis body then
-          TmLet { r with body = body, inexpr = pevalBind ctx k r.inexpr }
+          TmDecl {decl = DeclLet { r with body = body, inexpr = pevalBind ctx k r.inexpr }}
         else
           pevalBind
             { ctx with env = evalEnvInsert r.ident body ctx.env } k r.inexpr)
       r.body
 
   sem pevalReadbackH ctx =
-  | TmLet r ->
+  | TmDecl {decl = DeclLet r} ->
     match pevalReadbackH ctx r.inexpr with (inexprCtx, inexpr) in
     match pevalReadbackH inexprCtx r.body with (ctx, body) in
     if setMem r.ident inexprCtx.freeVar then
-      (ctx, TmLet { r with body = body, inexpr = inexpr })
+      (ctx, TmDecl {decl = DeclLet { r with body = body, inexpr = inexpr }})
     else
       if exprHasSideEffect ctx.effectEnv body then
-        (ctx, TmLet { r with body = body, inexpr = inexpr })
+        (ctx, TmDecl {decl = DeclLet { r with body = body, inexpr = inexpr }})
       else
         (inexprCtx, inexpr)
 end
 
 lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
   sem pevalBindThis =
-  | TmRecLets _ -> true
+  | TmDecl {decl = DeclRecLets _} -> true
 
   sem pevalBindTop ctx k =
-  | TmRecLets r ->
+  | TmDecl {decl = DeclRecLets r} ->
     recursive let envPrime : Int -> Lazy EvalEnv = lam n. lam.
       let wraplambda = lam bind.
         if geqi n ctx.maxRecDepth then TmVar {
@@ -294,19 +294,19 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
         (lam bind. { bind with body = pevalBind ctx (lam x. x) bind.body })
         r.bindings
     in
-    TmRecLets {
+    TmDecl {decl = DeclRecLets {
       r with
       bindings = bindings,
       inexpr = pevalBindTop { ctx with env = envPrime 0 () } k r.inexpr
-    }
+    }}
 
   sem pevalEval ctx k =
-  | TmRecLets _ ->
+  | TmDecl {decl = DeclRecLets _} ->
     error
       "Partial evaluation of non-top-level recursive let bindings is not safe"
 
   sem pevalReadbackH ctx =
-  | TmRecLets r ->
+  | TmDecl {decl = DeclRecLets r} ->
     let fv = setOfSeq nameCmp (map (lam bind. bind.ident) r.bindings) in
     match pevalReadbackH ctx r.inexpr with (inexprCtx, inexpr) in
     if
@@ -324,7 +324,7 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
         r.bindings
       with (ctx, bindings)
     in
-    (ctx, TmRecLets { r with bindings = bindings, inexpr = inexpr })
+    (ctx, TmDecl {decl = DeclRecLets { r with bindings = bindings, inexpr = inexpr }})
 end
 
 lang RecordPEval = PEval + RecordAst + VarAst
@@ -360,25 +360,25 @@ end
 
 lang TypePEval = PEval + TypeDeclAst
   sem pevalBindThis =
-  | TmType _ -> true
+  | TmDecl {decl = DeclType _} -> true
 
   sem pevalBindTop ctx k =
-  | TmType t -> TmType {t with inexpr = pevalBindTop ctx k t.inexpr}
+  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = pevalBindTop ctx k t.inexpr}}
 
   sem pevalEval ctx k =
-  | TmType t -> TmType {t with inexpr = pevalBind ctx k t.inexpr}
+  | TmDecl {decl = DeclType t} -> TmDecl {decl = DeclType {t with inexpr = pevalBind ctx k t.inexpr}}
 end
 
 lang DataPEval = PEval + DataAst
   sem pevalBindThis =
-  | TmConDef _ -> true
+  | TmDecl {decl = DeclConDef _} -> true
   | TmConApp _ -> false
 
   sem pevalBindTop ctx k =
-  | TmConDef t -> TmConDef {t with inexpr = pevalBindTop ctx k t.inexpr}
+  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = pevalBindTop ctx k t.inexpr}}
 
   sem pevalEval ctx k =
-  | TmConDef t -> TmConDef {t with inexpr = pevalBind ctx k t.inexpr}
+  | TmDecl {decl = DeclConDef t} -> TmDecl {decl = DeclConDef {t with inexpr = pevalBind ctx k t.inexpr}}
   | TmConApp t -> pevalBind ctx (lam body. k (TmConApp {t with body = body})) t.body
 end
 
@@ -474,23 +474,23 @@ end
 
 lang UtestPEval = PEval + UtestDeclAst
   sem pevalBindThis =
-  | TmUtest _ -> true
+  | TmDecl {decl = DeclUtest _} -> true
 
   sem pevalEval ctx k =
-  | TmUtest t ->
+  | TmDecl {decl = DeclUtest t} ->
     pevalBind ctx
       (lam test.
          pevalBind ctx
            (lam expected.
              let inner = lam x.
                match x with (tusing, tonfail) in
-                TmUtest { t with
+                TmDecl {decl = DeclUtest { t with
                           test = test,
                           expected = expected,
                           next = pevalBind ctx k t.next,
                           tusing = tusing,
                           tonfail = tonfail
-                }
+                }}
                in
                switch (t.tusing, t.tonfail)
                case (Some tusing, Some tonfail) then
@@ -523,10 +523,10 @@ end
 
 lang ExtPEval = PEval + ExtDeclAst
   sem pevalBindThis =
-  | TmExt _ -> true
+  | TmDecl {decl = DeclExt _} -> true
 
   sem pevalEval ctx k =
-  | TmExt t -> TmExt {t with inexpr = pevalBind ctx k t.inexpr}
+  | TmDecl {decl = DeclExt t} -> TmDecl {decl = DeclExt {t with inexpr = pevalBind ctx k t.inexpr}}
 end
 
 lang ArithIntPEval = ArithIntEval + VarAst
@@ -695,7 +695,7 @@ lang PEvalLetInline = LetDeclAst + SideEffect
         switch t
         case TmVar r then
           mapFindOrElse (lam. t) r.ident env
-        case TmLet r then
+        case TmDecl {decl = DeclLet r} then
           switch mapLookup r.ident marked
           case None _ then
             smap_Expr_Expr (subs marked env) t
@@ -717,7 +717,7 @@ lang PEvalLetInline = LetDeclAst + SideEffect
           match acc with (count, subsEnv) in
           switch t
           case TmVar r then (mapInsertWith addi r.ident 1 count, subsEnv)
-          case TmLet r then
+          case TmDecl {decl = DeclLet r} then
             if exprHasSideEffect effectEnv r.body then
               sfold_Expr_Expr mark acc t
             else

--- a/src/stdlib/peval/utils.mc
+++ b/src/stdlib/peval/utils.mc
@@ -98,20 +98,23 @@ lang SpecializeUtils = SpecializeAst + SpecializeInclude + MExprFindSym
   sem tmMatchName : SpecializeNames -> Name
   sem tmMatchName = | names -> getName (names.consNames) "MatchAst_TmMatch"
 
-  sem tmLetName : SpecializeNames -> Name
-  sem tmLetName = | names -> getName (names.consNames) "LetAst_TmLet"
+  sem tmDeclName : SpecializeNames -> Name
+  sem tmDeclName = | names -> getName (names.consNames) "DeclAst_TmDecl"
 
-  sem tmRecLetsName : SpecializeNames -> Name
-  sem tmRecLetsName = | names -> getName (names.consNames) "RecLetsAst_TmRecLets"
+  sem declLetName : SpecializeNames -> Name
+  sem declLetName = | names -> getName (names.consNames) "LetDeclAst_DeclLet"
 
-  sem tmConDefName : SpecializeNames -> Name
-  sem tmConDefName = | names -> getName (names.consNames) "DataAst_TmConDef"
+  sem declRecLetsName : SpecializeNames -> Name
+  sem declRecLetsName = | names -> getName (names.consNames) "RecLetsDeclAst_DeclRecLets"
+
+  sem declConDefName : SpecializeNames -> Name
+  sem declConDefName = | names -> getName (names.consNames) "DataDeclAst_DeclConDef"
 
   sem tmConAppName : SpecializeNames -> Name
   sem tmConAppName = | names -> getName (names.consNames) "DataAst_TmConApp"
 
-  sem tmTypeName : SpecializeNames -> Name
-  sem tmTypeName = | names -> getName (names.consNames) "TypeAst_TmType"
+  sem declTypeName : SpecializeNames -> Name
+  sem declTypeName = | names -> getName (names.consNames) "TypeDeclAst_DeclType"
 
   sem tmNeverName : SpecializeNames -> Name
   sem tmNeverName = | names -> getName (names.consNames) "NeverAst_TmNever"

--- a/src/stdlib/pmexpr/classify.mc
+++ b/src/stdlib/pmexpr/classify.mc
@@ -37,12 +37,10 @@ lang PMExprClassify = PMExprAst + PMExprExtractAccelerate + MExprCallGraph
     let emptyNameId = nameSym "" in
     (emptyNameId, classifyH (mapEmpty nameCmp) emptyNameId e)
 
-  sem classifyH : ClassificationEnv -> Name -> Expr -> ClassificationEnv
-  sem classifyH env id =
-  | TmDecl {decl = DeclLet t} ->
-    let env = classifyH env t.ident t.body in
-    classifyH env id t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+  sem classifyDecl : ClassificationEnv -> Name -> Decl -> ClassificationEnv
+  sem classifyDecl env id =
+  | DeclLet t -> classifyH env t.ident t.body
+  | DeclRecLets t ->
     let bindMap : Map Name DeclLetRecord =
       mapFromSeq nameCmp
         (map (lam bind. (bind.ident, bind)) t.bindings) in
@@ -68,14 +66,16 @@ lang PMExprClassify = PMExprAst + PMExprExtractAccelerate + MExprCallGraph
       foldl
         (lam env. lam bind. classifyH env bind.ident bind.body)
         env t.bindings in
-    let g : Digraph Name Int = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
+    let g : Digraph Name Int = constructCallGraph (bind_ (DeclRecLets t) unit_) in
     let sccs = digraphTarjan g in
-    let env = foldl f env (reverse sccs) in
-    classifyH env id t.inexpr
-  | TmDecl {decl = DeclType t} -> classifyH env id t.inexpr
-  | TmDecl {decl = DeclConDef t} -> classifyH env id t.inexpr
-  | TmDecl {decl = DeclUtest t} -> classifyH env id t.next
-  | TmDecl {decl = DeclExt t} -> classifyH env id t.inexpr
+    foldl f env (reverse sccs)
+  | DeclType _ | DeclConDef _ | DeclUtest _ | DeclExt _ -> env
+
+  sem classifyH : ClassificationEnv -> Name -> Expr -> ClassificationEnv
+  sem classifyH env id =
+  | TmDecl x ->
+    let env = classifyDecl env id x.decl in
+    classifyH env id x.inexpr
   | e ->
     let class = classifyBody env (Any ()) e in
     mapInsert id (infoTm e, class) env
@@ -148,7 +148,7 @@ let classifyExpr : Expr -> [(String, Class)] = lam expr.
     cmpResult
     (map
       (lam result. match result with (id, (_, class)) in (nameGetStr id, class))
-      (mapBindings classification))  
+      (mapBindings classification))
 in
 
 utest classifyExpr (addi_ (int_ 1) (int_ 2)) with [("", Any ())] in
@@ -163,7 +163,7 @@ let t = bindall_ [
     ("g", ulam_ "x" (app_ (var_ "h") (subi_ (var_ "x") (int_ 1)))),
     ("h", ulam_ "y" (app_ (var_ "f") (var_ "y")))
   ]
-] in
+] unit_ in
 utest classifyExpr t
 with [("", Any ()), ("f", Cuda ()), ("g", Cuda ()), ("h", Cuda ())] in
 

--- a/src/stdlib/pmexpr/classify.mc
+++ b/src/stdlib/pmexpr/classify.mc
@@ -43,7 +43,7 @@ lang PMExprClassify = PMExprAst + PMExprExtractAccelerate + MExprCallGraph
     let env = classifyH env t.ident t.body in
     classifyH env id t.inexpr
   | TmRecLets t ->
-    let bindMap : Map Name RecLetBinding =
+    let bindMap : Map Name DeclLetRecord =
       mapFromSeq nameCmp
         (map (lam bind. (bind.ident, bind)) t.bindings) in
     let f : ClassificationEnv -> [Name] -> ClassificationEnv = lam env. lam binds.

--- a/src/stdlib/pmexpr/classify.mc
+++ b/src/stdlib/pmexpr/classify.mc
@@ -39,10 +39,10 @@ lang PMExprClassify = PMExprAst + PMExprExtractAccelerate + MExprCallGraph
 
   sem classifyH : ClassificationEnv -> Name -> Expr -> ClassificationEnv
   sem classifyH env id =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let env = classifyH env t.ident t.body in
     classifyH env id t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let bindMap : Map Name DeclLetRecord =
       mapFromSeq nameCmp
         (map (lam bind. (bind.ident, bind)) t.bindings) in
@@ -68,14 +68,14 @@ lang PMExprClassify = PMExprAst + PMExprExtractAccelerate + MExprCallGraph
       foldl
         (lam env. lam bind. classifyH env bind.ident bind.body)
         env t.bindings in
-    let g : Digraph Name Int = constructCallGraph (TmRecLets t) in
+    let g : Digraph Name Int = constructCallGraph (TmDecl {decl = DeclRecLets t}) in
     let sccs = digraphTarjan g in
     let env = foldl f env (reverse sccs) in
     classifyH env id t.inexpr
-  | TmType t -> classifyH env id t.inexpr
-  | TmConDef t -> classifyH env id t.inexpr
-  | TmUtest t -> classifyH env id t.next
-  | TmExt t -> classifyH env id t.inexpr
+  | TmDecl {decl = DeclType t} -> classifyH env id t.inexpr
+  | TmDecl {decl = DeclConDef t} -> classifyH env id t.inexpr
+  | TmDecl {decl = DeclUtest t} -> classifyH env id t.next
+  | TmDecl {decl = DeclExt t} -> classifyH env id t.inexpr
   | e ->
     let class = classifyBody env (Any ()) e in
     mapInsert id (infoTm e, class) env

--- a/src/stdlib/pmexpr/compile.mc
+++ b/src/stdlib/pmexpr/compile.mc
@@ -41,8 +41,8 @@ let _futharkCheckRegularImpl =
   nlet_ _futharkCheckRegularId
     (ntyall_ a (tyarrow_ (tyseq_ (tyseq_ (ntyvar_ a))) tyunit_))
     (nlam_ s (tyseq_ (tyseq_ (ntyvar_ a))) (bindall_ [
-      nlet_ k tyint_ (length_ (head_ (nvar_ s))),
-      if_
+      nlet_ k tyint_ (length_ (head_ (nvar_ s)))]
+      (if_
         (foldl_
           (nlam_ x tybool_ (nlam_ y (tyseq_ (ntyvar_ a))
             (if_ (eqi_ (nvar_ k) (length_ (nvar_ y)))
@@ -51,25 +51,25 @@ let _futharkCheckRegularImpl =
             true_
             (tail_ (nvar_ s)))
         unit_
-        (error_ (str_ "Irregular sequence found"))]))
+        (error_ (str_ "Irregular sequence found")))))
 
 lang PMExprCompileWellFormedInstrumentation = VarAst
-  sem instrumentationMap : () -> Map Name Expr
+  sem instrumentationMap : () -> Map Name Decl
   sem instrumentationMap =
   | () ->
     mapFromSeq nameCmp [
       (_cudaCheckRankId, _cudaCheckRankImpl),
       (_futharkCheckRegularId, _futharkCheckRegularImpl)]
 
-  sem findUsedImplementations : Expr -> Map Name (Bool, Expr)
+  sem findUsedImplementations : Expr -> Map Name (Bool, Decl)
   sem findUsedImplementations =
   | ast ->
     findUsedImplementationsH
       (mapMapWithKey (lam. lam e. (false, e)) (instrumentationMap ()))
       ast
 
-  sem findUsedImplementationsH : Map Name (Bool, Expr) -> Expr
-                              -> Map Name (Bool, Expr)
+  sem findUsedImplementationsH : Map Name (Bool, Decl) -> Expr
+                              -> Map Name (Bool, Decl)
   sem findUsedImplementationsH acc =
   | TmVar t ->
     match mapLookup t.ident acc with Some entry then
@@ -116,14 +116,14 @@ lang PMExprCompileWellFormedBase =
   sem instrumentWellFormedChecks
     : Set Name -> WellFormedConfig -> Class -> Expr -> Expr
   sem instrumentWellFormedChecks accelerateIds config class =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let f = lam e.
       instrumentWellFormedChecks accelerateIds config class e in
     let body =
       if setMem t.ident accelerateIds then
         instrumentWellFormedChecksBody config t.body class
       else f t.body in
-    TmDecl {decl = DeclLet {t with body = body, inexpr = f t.inexpr}}
+    TmDecl {x with decl = DeclLet {t with body = body}, inexpr = f x.inexpr}
   | t -> smap_Expr_Expr (instrumentWellFormedChecks accelerateIds config class) t
 
   -- Performs compilation up to the point where well-formedness checks can be
@@ -240,8 +240,8 @@ lang PMExprFutharkWellFormed =
     else
       bindall_
         [ ulet_ "" (app_ (nvar_ _futharkCheckRegularId) (nvar_ id))
-        , ulet_ "" (iter_ (nulam_ innerId innerCheck) (nvar_ id))
-        , acc ]
+        , ulet_ "" (iter_ (nulam_ innerId innerCheck) (nvar_ id))]
+        acc
   | TySeq t -> acc
   | TyRecord t ->
     mapFoldWithKey
@@ -315,9 +315,10 @@ use TestLang in
 
 let fnid = nameSym "f" in
 let x = nameSym "x" in
-let t =
-  nlet_ fnid (tyarrow_ (tyseq_ (tyseq_ tyint_)) (tyseq_ (tyseq_ tyint_)))
-    (nlam_ x (tyseq_ (tyseq_ tyint_)) (nvar_ x))
+let t = bind_
+  (nlet_ fnid (tyarrow_ (tyseq_ (tyseq_ tyint_)) (tyseq_ (tyseq_ tyint_)))
+    (nlam_ x (tyseq_ (tyseq_ tyint_)) (nvar_ x)))
+  unit_
 in
 let ids = setOfSeq nameCmp [fnid] in
 let config = {dynamicChecks = true, tensorMaxRank = 3} in

--- a/src/stdlib/pmexpr/compile.mc
+++ b/src/stdlib/pmexpr/compile.mc
@@ -116,14 +116,14 @@ lang PMExprCompileWellFormedBase =
   sem instrumentWellFormedChecks
     : Set Name -> WellFormedConfig -> Class -> Expr -> Expr
   sem instrumentWellFormedChecks accelerateIds config class =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let f = lam e.
       instrumentWellFormedChecks accelerateIds config class e in
     let body =
       if setMem t.ident accelerateIds then
         instrumentWellFormedChecksBody config t.body class
       else f t.body in
-    TmLet {t with body = body, inexpr = f t.inexpr}
+    TmDecl {decl = DeclLet {t with body = body, inexpr = f t.inexpr}}
   | t -> smap_Expr_Expr (instrumentWellFormedChecks accelerateIds config class) t
 
   -- Performs compilation up to the point where well-formedness checks can be

--- a/src/stdlib/pmexpr/copy-analysis.mc
+++ b/src/stdlib/pmexpr/copy-analysis.mc
@@ -22,18 +22,18 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
   -- uninitialized constants.
   sem findUninitializedTensors : Set Name -> Expr -> Set Name
   sem findUninitializedTensors tensors =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let tensors =
       match t.body with TmApp {lhs = TmConst {val = CTensorCreateUninitInt _ |
                                                     CTensorCreateUninitFloat _}} then
         setInsert t.ident tensors
       else tensors in
     findUninitializedTensors tensors t.inexpr
-  | TmRecLets t -> findUninitializedTensors tensors t.inexpr
-  | TmType t -> findUninitializedTensors tensors t.inexpr
-  | TmConDef t -> findUninitializedTensors tensors t.inexpr
-  | TmUtest t -> findUninitializedTensors tensors t.next
-  | TmExt t -> findUninitializedTensors tensors t.inexpr
+  | TmDecl {decl = DeclRecLets t} -> findUninitializedTensors tensors t.inexpr
+  | TmDecl {decl = DeclType t} -> findUninitializedTensors tensors t.inexpr
+  | TmDecl {decl = DeclConDef t} -> findUninitializedTensors tensors t.inexpr
+  | TmDecl {decl = DeclUtest t} -> findUninitializedTensors tensors t.next
+  | TmDecl {decl = DeclExt t} -> findUninitializedTensors tensors t.inexpr
   | _ -> tensors
 
   sem eliminateTensorCopying
@@ -53,7 +53,7 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
 
   sem omitCopyUninitializedH : CopyAnalysisEnv -> Set Name -> Expr -> CopyAnalysisEnv
   sem omitCopyUninitializedH env used =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let f = lam x : (CopyStatus, Expr).
       match x with (status, arg) in
       match arg with TmVar {ident = ident} then
@@ -79,15 +79,15 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
       if mapMem t.ident env.accelerateData then used
       else setUnion (collectVariables t.body) used in
     omitCopyUninitializedH env used t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let collectBindingVariables = lam used. lam binding.
       setUnion (collectVariables binding.body) used in
     let used = foldl collectBindingVariables used t.bindings in
     omitCopyUninitializedH env used t.inexpr
-  | TmType t -> omitCopyUninitializedH env used t.inexpr
-  | TmConDef t -> omitCopyUninitializedH env used t.inexpr
-  | TmUtest t -> omitCopyUninitializedH env used t.next
-  | TmExt t -> omitCopyUninitializedH env used t.inexpr
+  | TmDecl {decl = DeclType t} -> omitCopyUninitializedH env used t.inexpr
+  | TmDecl {decl = DeclConDef t} -> omitCopyUninitializedH env used t.inexpr
+  | TmDecl {decl = DeclUtest t} -> omitCopyUninitializedH env used t.next
+  | TmDecl {decl = DeclExt t} -> omitCopyUninitializedH env used t.inexpr
   | _ -> env
 
   sem collectVariables : Expr -> Set Name
@@ -117,7 +117,7 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
   sem findAccelerateExclusiveTensorsH : CopyAnalysisEnv -> Set Name -> Expr
                                      -> CopyAnalysisEnv
   sem findAccelerateExclusiveTensorsH env used =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let f = lam x : (CopyStatus, Expr).
       match x with (status, arg) in
       match arg with TmVar {ident = ident} then
@@ -138,11 +138,11 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
         else env
       else env in
     findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmRecLets t -> findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmType t -> findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmConDef t -> findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmUtest t -> findAccelerateExclusiveTensorsH env used t.next
-  | TmExt t -> findAccelerateExclusiveTensorsH env used t.inexpr
+  | TmDecl {decl = DeclRecLets t} -> findAccelerateExclusiveTensorsH env used t.inexpr
+  | TmDecl {decl = DeclType t} -> findAccelerateExclusiveTensorsH env used t.inexpr
+  | TmDecl {decl = DeclConDef t} -> findAccelerateExclusiveTensorsH env used t.inexpr
+  | TmDecl {decl = DeclUtest t} -> findAccelerateExclusiveTensorsH env used t.next
+  | TmDecl {decl = DeclExt t} -> findAccelerateExclusiveTensorsH env used t.inexpr
   | _ -> env
 
   -- Collects a set of all variables that are used outside of accelerate
@@ -157,20 +157,20 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
       if mapMem ident env.accelerateData then used
       else collectVariables app
     else collectVariables app
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let used =
       if mapMem t.ident env.accelerateData then used
       else setUnion (collectVariables t.body) used in
     collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let collectBindingVariables = lam used. lam binding.
       if mapMem binding.ident env.accelerateData then used
       else setUnion (collectVariables binding.body) used in
     let used = foldl collectBindingVariables used t.bindings in
     collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmType t -> collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmConDef t -> collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmUtest t -> collectVariablesUsedOutsideAccelerate env used t.next
-  | TmExt t -> collectVariablesUsedOutsideAccelerate env used t.inexpr
+  | TmDecl {decl = DeclType t} -> collectVariablesUsedOutsideAccelerate env used t.inexpr
+  | TmDecl {decl = DeclConDef t} -> collectVariablesUsedOutsideAccelerate env used t.inexpr
+  | TmDecl {decl = DeclUtest t} -> collectVariablesUsedOutsideAccelerate env used t.next
+  | TmDecl {decl = DeclExt t} -> collectVariablesUsedOutsideAccelerate env used t.inexpr
   | _ -> used
 end

--- a/src/stdlib/pmexpr/copy-analysis.mc
+++ b/src/stdlib/pmexpr/copy-analysis.mc
@@ -22,18 +22,14 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
   -- uninitialized constants.
   sem findUninitializedTensors : Set Name -> Expr -> Set Name
   sem findUninitializedTensors tensors =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let tensors =
       match t.body with TmApp {lhs = TmConst {val = CTensorCreateUninitInt _ |
                                                     CTensorCreateUninitFloat _}} then
         setInsert t.ident tensors
       else tensors in
-    findUninitializedTensors tensors t.inexpr
-  | TmDecl {decl = DeclRecLets t} -> findUninitializedTensors tensors t.inexpr
-  | TmDecl {decl = DeclType t} -> findUninitializedTensors tensors t.inexpr
-  | TmDecl {decl = DeclConDef t} -> findUninitializedTensors tensors t.inexpr
-  | TmDecl {decl = DeclUtest t} -> findUninitializedTensors tensors t.next
-  | TmDecl {decl = DeclExt t} -> findUninitializedTensors tensors t.inexpr
+    findUninitializedTensors tensors x.inexpr
+  | TmDecl x -> findUninitializedTensors tensors x.inexpr
   | _ -> tensors
 
   sem eliminateTensorCopying
@@ -53,7 +49,7 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
 
   sem omitCopyUninitializedH : CopyAnalysisEnv -> Set Name -> Expr -> CopyAnalysisEnv
   sem omitCopyUninitializedH env used =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let f = lam x : (CopyStatus, Expr).
       match x with (status, arg) in
       match arg with TmVar {ident = ident} then
@@ -78,16 +74,14 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
       -- an accelerate binding.
       if mapMem t.ident env.accelerateData then used
       else setUnion (collectVariables t.body) used in
-    omitCopyUninitializedH env used t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+    omitCopyUninitializedH env used x.inexpr
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let collectBindingVariables = lam used. lam binding.
       setUnion (collectVariables binding.body) used in
     let used = foldl collectBindingVariables used t.bindings in
-    omitCopyUninitializedH env used t.inexpr
-  | TmDecl {decl = DeclType t} -> omitCopyUninitializedH env used t.inexpr
-  | TmDecl {decl = DeclConDef t} -> omitCopyUninitializedH env used t.inexpr
-  | TmDecl {decl = DeclUtest t} -> omitCopyUninitializedH env used t.next
-  | TmDecl {decl = DeclExt t} -> omitCopyUninitializedH env used t.inexpr
+    omitCopyUninitializedH env used x.inexpr
+  | TmDecl {decl = DeclType _ | DeclConDef _ | DeclUtest _ | DeclExt _, inexpr = inexpr} ->
+    omitCopyUninitializedH env used inexpr
   | _ -> env
 
   sem collectVariables : Expr -> Set Name
@@ -117,7 +111,7 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
   sem findAccelerateExclusiveTensorsH : CopyAnalysisEnv -> Set Name -> Expr
                                      -> CopyAnalysisEnv
   sem findAccelerateExclusiveTensorsH env used =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let f = lam x : (CopyStatus, Expr).
       match x with (status, arg) in
       match arg with TmVar {ident = ident} then
@@ -137,12 +131,8 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
           {env with accelerateData = accelerateData}
         else env
       else env in
-    findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmDecl {decl = DeclRecLets t} -> findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmDecl {decl = DeclType t} -> findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmDecl {decl = DeclConDef t} -> findAccelerateExclusiveTensorsH env used t.inexpr
-  | TmDecl {decl = DeclUtest t} -> findAccelerateExclusiveTensorsH env used t.next
-  | TmDecl {decl = DeclExt t} -> findAccelerateExclusiveTensorsH env used t.inexpr
+    findAccelerateExclusiveTensorsH env used x.inexpr
+  | TmDecl x -> findAccelerateExclusiveTensorsH env used x.inexpr
   | _ -> env
 
   -- Collects a set of all variables that are used outside of accelerate
@@ -157,20 +147,17 @@ lang PMExprTensorCopyAnalysis = PMExprAst + PMExprExtractAccelerate
       if mapMem ident env.accelerateData then used
       else collectVariables app
     else collectVariables app
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let used =
       if mapMem t.ident env.accelerateData then used
       else setUnion (collectVariables t.body) used in
-    collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+    collectVariablesUsedOutsideAccelerate env used x.inexpr
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let collectBindingVariables = lam used. lam binding.
       if mapMem binding.ident env.accelerateData then used
       else setUnion (collectVariables binding.body) used in
     let used = foldl collectBindingVariables used t.bindings in
-    collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmDecl {decl = DeclType t} -> collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmDecl {decl = DeclConDef t} -> collectVariablesUsedOutsideAccelerate env used t.inexpr
-  | TmDecl {decl = DeclUtest t} -> collectVariablesUsedOutsideAccelerate env used t.next
-  | TmDecl {decl = DeclExt t} -> collectVariablesUsedOutsideAccelerate env used t.inexpr
+    collectVariablesUsedOutsideAccelerate env used x.inexpr
+  | TmDecl x -> collectVariablesUsedOutsideAccelerate env used x.inexpr
   | _ -> used
 end

--- a/src/stdlib/pmexpr/demote.mc
+++ b/src/stdlib/pmexpr/demote.mc
@@ -54,12 +54,20 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
     let tid = nameSym "t" in
     let iid = nameSym "i" in
     let xid = nameSym "x" in
-    let aExpr = TmDecl {decl = DeclLet {
-      ident = aid, tyAnnot = tyTm t.as, tyBody = tyTm t.as, body = demoteParallel t.as,
-      inexpr = unit_, ty = tyresult, info = infoTm t.as}} in
-    let bExpr = TmDecl {decl = DeclLet {
-      ident = bid, tyAnnot = tyTm t.bs, tyBody = tyTm t.bs, body = demoteParallel t.bs,
-      inexpr = unit_, ty = tyresult, info = infoTm t.bs}} in
+    let aExpr = DeclLet
+      { ident = aid
+      , tyAnnot = tyTm t.as
+      , tyBody = tyTm t.as
+      , body = demoteParallel t.as
+      , info = infoTm t.as
+      } in
+    let bExpr = DeclLet
+      { ident = bid
+      , tyAnnot = tyTm t.bs
+      , tyBody = tyTm t.bs
+      , body = demoteParallel t.bs
+      , info = infoTm t.bs
+      } in
     let access = lam seqId. lam seqTy. lam elemTy.
       TmApp {
         lhs = TmApp {
@@ -69,28 +77,42 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
         rhs = TmVar {ident = iid, ty = TyInt {info = t.info}, info = t.info,
                      frozen = false},
         ty = elemTy, info = t.info} in
-    let tExpr = TmDecl {decl = DeclLet {
-      ident = tid, tyAnnot = tyseqtuple, tyBody = tyseqtuple,
-      body = TmApp {
-        lhs = TmApp {
-          lhs = TmConst {val = CCreate (), ty = tyuk, info = t.info},
-          rhs = TmApp {
-            lhs = TmConst {val = CLength (), ty = tyuk, info = t.info},
-            rhs = TmVar {ident = aid, ty = tyTm t.as, info = t.info,
-                         frozen = false},
-            ty = TyInt {info = t.info}, info = t.info},
-          ty = tyuk, info = t.info},
-        rhs = TmLam {
-          ident = iid,
-          tyAnnot = TyInt {info = t.info}, tyParam = TyInt {info = t.info},
-          body = TmRecord {
-            bindings = mapFromSeq cmpSID [
-              (stringToSid "0", access aid (tyTm t.as) lty),
-              (stringToSid "1", access bid (tyTm t.bs) rty)],
-            ty = tytuple, info = t.info},
-          ty = tytuple, info = t.info},
-        ty = tyseqtuple, info = t.info},
-      inexpr = unit_, ty = tyresult, info = t.info}} in
+    let tExpr = DeclLet
+      { ident = tid
+      , tyAnnot = tyseqtuple
+      , tyBody = tyseqtuple
+      , body = TmApp
+        { lhs = TmApp
+          { lhs = TmConst {val = CCreate (), ty = tyuk, info = t.info}
+          , rhs = TmApp
+            { lhs = TmConst {val = CLength (), ty = tyuk, info = t.info}
+            , rhs = TmVar {ident = aid, ty = tyTm t.as, info = t.info, frozen = false}
+            , ty = TyInt {info = t.info}
+            , info = t.info
+            }
+          , ty = tyuk
+          , info = t.info
+          }
+        , rhs = TmLam
+          { ident = iid
+          , tyAnnot = TyInt {info = t.info}
+          , tyParam = TyInt {info = t.info}
+          , body = TmRecord
+            { bindings = mapFromSeq cmpSID
+              [ (stringToSid "0", access aid (tyTm t.as) lty)
+              , (stringToSid "1", access bid (tyTm t.bs) rty)
+              ]
+            , ty = tytuple
+            , info = t.info
+            }
+          , ty = tytuple
+          , info = t.info
+          }
+        , ty = tyseqtuple
+        , info = t.info
+        }
+      , info = t.info
+      } in
     let projection = lam key. lam id. lam ty.
       let keySid = stringToSid key in
       let x = nameSym "x" in
@@ -121,7 +143,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
         ty = tyuk, info = t.info},
       rhs = TmVar {ident = tid, ty = tyseqtuple, info = t.info, frozen = false},
       ty = TySeq {ty = tyuk, info = t.info}, info = t.info} in
-    bindall_ [aExpr, bExpr, tExpr, mapExpr]
+    bindall_ [aExpr, bExpr, tExpr] mapExpr
 end
 
 lang PMExprDemoteReduce = PMExprDemoteBase + PMExprAst
@@ -188,21 +210,33 @@ lang PMExprDemoteLoop = PMExprDemoteBase + PMExprAst
       ty = tyint_, info = t.info} in
     let tIdent = nameSym "t" in
     let tVar = TmVar {ident = tIdent, ty = accTy, info = t.info, frozen = false} in
-    let thnExpr = TmDecl {decl = DeclLet {
-      ident = tIdent,
-      tyAnnot = accTy,
-      tyBody = accTy,
-      body = TmApp {
-        lhs = TmApp {
-          lhs = f, rhs = acc, ty = arrowType tyint_ accTy, info = t.info},
-        rhs = i, ty = accTy, info = t.info},
-      inexpr = TmApp {
-        lhs = TmApp {
-          lhs = TmVar {ident = loopId, ty = loopTy, info = t.info, frozen = false},
-          rhs = tVar, ty = arrowType tyint_ accTy, info = t.info},
-        rhs = incrementIterExpr,
-        ty = accTy, info = t.info},
-      ty = accTy, info = t.info}} in
+    let thnExpr = TmDecl
+      { decl = DeclLet
+        { ident = tIdent
+        , tyAnnot = accTy
+        , tyBody = accTy
+        , body = TmApp
+          { lhs = TmApp {lhs = f, rhs = acc, ty = arrowType tyint_ accTy, info = t.info}
+          , rhs = i
+          , ty = accTy
+          , info = t.info
+          }
+        , info = t.info
+        }
+      , inexpr = TmApp
+        { lhs = TmApp
+          { lhs = TmVar {ident = loopId, ty = loopTy, info = t.info, frozen = false}
+          , rhs = tVar
+          , ty = arrowType tyint_ accTy
+          , info = t.info
+          }
+        , rhs = incrementIterExpr
+        , ty = accTy
+        , info = t.info
+        }
+      , ty = accTy
+      , info = t.info
+      } in
     let loopBindingDef = {
       ident = loopId, tyAnnot = loopTy, tyBody = loopTy, info = t.info,
       body = TmLam {
@@ -218,18 +252,34 @@ lang PMExprDemoteLoop = PMExprDemoteBase + PMExprAst
             ty = accTy, info = t.info},
           ty = arrowType tyint_ accTy, info = t.info},
         ty = loopTy, info = t.info}} in
-    TmDecl {decl = DeclRecLets {
-      bindings = [loopBindingDef],
-      inexpr = TmApp {
-        lhs = TmApp {
-          lhs = TmVar {
-            ident = loopId, ty = loopTy, info = t.info, frozen = false},
-          rhs = t.ne,
-          ty = arrowType tyint_ accTy, info = t.info},
-        rhs = TmConst {
-          val = CInt {val = 0}, ty = TyInt {info = t.info}, info = t.info},
-        ty = accTy, info = t.info},
-      ty = accTy, info = t.info}}
+    TmDecl
+    { decl = DeclRecLets
+      { bindings = [loopBindingDef]
+      , info = t.info
+      }
+    , inexpr = TmApp
+      { lhs = TmApp
+        { lhs = TmVar
+          { ident = loopId
+          , ty = loopTy
+          , info = t.info
+          , frozen = false
+          }
+        , rhs = t.ne
+        , ty = arrowType tyint_ accTy
+        , info = t.info
+        }
+      , rhs = TmConst
+        { val = CInt {val = 0}
+        , ty = TyInt {info = t.info}
+        , info = t.info
+        }
+      , ty = accTy
+      , info = t.info
+      }
+    , ty = accTy
+    , info = t.info
+    }
 end
 
 lang PMExprDemotePrintFloat = PMExprDemoteBase
@@ -272,10 +322,10 @@ with bindall_ [
   ulet_ "t"
     (create_ (length_ (var_ "a"))
       (ulam_ "i" (utuple_ [get_ (var_ "a") (var_ "i"),
-                           get_ (var_ "b") (var_ "i")]))),
-  map_
+                           get_ (var_ "b") (var_ "i")])))]
+  (map_
     (ulam_ "x" (addi_ (tupleproj_ 0 (var_ "x")) (tupleproj_ 1 (var_ "x"))))
-    (var_ "t")]
+    (var_ "t"))
 using eqExpr in
 
 utest demoteParallel (parallelReduce_ (uconst_ (CAddi ())) (int_ 0) (flatten_ s))
@@ -297,13 +347,13 @@ let loopRecLet = lam fn.
       (var_ "acc")))) in
 
 let accLoopDef = bindall_ [
-  loopRecLet foldlFn,
-  appf2_ (var_ "loop") acc (int_ 0)] in
+  loopRecLet foldlFn]
+  (appf2_ (var_ "loop") acc (int_ 0)) in
 utest demoteParallel (loopAcc_ acc n foldlFn) with accLoopDef using eqExpr in
 
 let loopDef = bindall_ [
-  loopRecLet (ulam_ "" f),
-  appf2_ (var_ "loop") unit_ (int_ 0)] in
+  loopRecLet (ulam_ "" f)]
+  (appf2_ (var_ "loop") unit_ (int_ 0)) in
 utest demoteParallel (loop_ n f) with loopDef using eqExpr in
 utest demoteParallel (parallelLoop_ n f) with loopDef using eqExpr in
 

--- a/src/stdlib/pmexpr/demote.mc
+++ b/src/stdlib/pmexpr/demote.mc
@@ -54,12 +54,12 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
     let tid = nameSym "t" in
     let iid = nameSym "i" in
     let xid = nameSym "x" in
-    let aExpr = TmLet {
+    let aExpr = TmDecl {decl = DeclLet {
       ident = aid, tyAnnot = tyTm t.as, tyBody = tyTm t.as, body = demoteParallel t.as,
-      inexpr = unit_, ty = tyresult, info = infoTm t.as} in
-    let bExpr = TmLet {
+      inexpr = unit_, ty = tyresult, info = infoTm t.as}} in
+    let bExpr = TmDecl {decl = DeclLet {
       ident = bid, tyAnnot = tyTm t.bs, tyBody = tyTm t.bs, body = demoteParallel t.bs,
-      inexpr = unit_, ty = tyresult, info = infoTm t.bs} in
+      inexpr = unit_, ty = tyresult, info = infoTm t.bs}} in
     let access = lam seqId. lam seqTy. lam elemTy.
       TmApp {
         lhs = TmApp {
@@ -69,7 +69,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
         rhs = TmVar {ident = iid, ty = TyInt {info = t.info}, info = t.info,
                      frozen = false},
         ty = elemTy, info = t.info} in
-    let tExpr = TmLet {
+    let tExpr = TmDecl {decl = DeclLet {
       ident = tid, tyAnnot = tyseqtuple, tyBody = tyseqtuple,
       body = TmApp {
         lhs = TmApp {
@@ -90,7 +90,7 @@ lang PMExprDemoteMap2 = PMExprDemoteBase
             ty = tytuple, info = t.info},
           ty = tytuple, info = t.info},
         ty = tyseqtuple, info = t.info},
-      inexpr = unit_, ty = tyresult, info = t.info} in
+      inexpr = unit_, ty = tyresult, info = t.info}} in
     let projection = lam key. lam id. lam ty.
       let keySid = stringToSid key in
       let x = nameSym "x" in
@@ -188,7 +188,7 @@ lang PMExprDemoteLoop = PMExprDemoteBase + PMExprAst
       ty = tyint_, info = t.info} in
     let tIdent = nameSym "t" in
     let tVar = TmVar {ident = tIdent, ty = accTy, info = t.info, frozen = false} in
-    let thnExpr = TmLet {
+    let thnExpr = TmDecl {decl = DeclLet {
       ident = tIdent,
       tyAnnot = accTy,
       tyBody = accTy,
@@ -202,7 +202,7 @@ lang PMExprDemoteLoop = PMExprDemoteBase + PMExprAst
           rhs = tVar, ty = arrowType tyint_ accTy, info = t.info},
         rhs = incrementIterExpr,
         ty = accTy, info = t.info},
-      ty = accTy, info = t.info} in
+      ty = accTy, info = t.info}} in
     let loopBindingDef = {
       ident = loopId, tyAnnot = loopTy, tyBody = loopTy, info = t.info,
       body = TmLam {
@@ -218,7 +218,7 @@ lang PMExprDemoteLoop = PMExprDemoteBase + PMExprAst
             ty = accTy, info = t.info},
           ty = arrowType tyint_ accTy, info = t.info},
         ty = loopTy, info = t.info}} in
-    TmRecLets {
+    TmDecl {decl = DeclRecLets {
       bindings = [loopBindingDef],
       inexpr = TmApp {
         lhs = TmApp {
@@ -229,7 +229,7 @@ lang PMExprDemoteLoop = PMExprDemoteBase + PMExprAst
         rhs = TmConst {
           val = CInt {val = 0}, ty = TyInt {info = t.info}, info = t.info},
         ty = accTy, info = t.info},
-      ty = accTy, info = t.info}
+      ty = accTy, info = t.info}}
 end
 
 lang PMExprDemotePrintFloat = PMExprDemoteBase

--- a/src/stdlib/pmexpr/extract.mc
+++ b/src/stdlib/pmexpr/extract.mc
@@ -115,21 +115,30 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
       info = info} in
     let env = {env with functions = mapInsert accelerateIdent functionData env.functions} in
     let funcType = TyArrow {from = paramTy, to = retType, info = info} in
-    let accelerateLet =
-      TmDecl {decl = DeclLet {
-        ident = accelerateIdent,
-        tyAnnot = funcType,
-        tyBody = funcType,
-        body = TmLam {
-          ident = paramId, tyAnnot = paramTy, tyParam = paramTy, body = t.e,
-          ty = TyArrow {from = paramTy, to = retType, info = info},
-          info = info},
-        inexpr = TmApp {
-          lhs = TmVar {ident = accelerateIdent, ty = funcType, info = info, frozen = false},
-          rhs = TmConst {val = CInt {val = 0}, ty = paramTy, info = info},
-          ty = retType,
-          info = info},
-        ty = retType, info = info}}
+    let accelerateLet = TmDecl
+      { decl = DeclLet
+        { ident = accelerateIdent
+        , tyAnnot = funcType
+        , tyBody = funcType
+        , body = TmLam
+          { ident = paramId
+          , tyAnnot = paramTy
+          , tyParam = paramTy
+          , body = t.e
+          , ty = TyArrow {from = paramTy, to = retType, info = info}
+          , info = info
+          }
+        , info = info
+        }
+      , inexpr = TmApp
+        { lhs = TmVar {ident = accelerateIdent, ty = funcType, info = info, frozen = false}
+        , rhs = TmConst {val = CInt {val = 0}, ty = paramTy, info = info}
+        , ty = retType
+        , info = info
+        }
+      , ty = retType
+      , info = info
+      }
     in
     (env, accelerateLet)
 
@@ -169,18 +178,18 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
 
   sem eliminateDummyParameterH (solutions : Map Name (Map Name Type))
                                (accelerated : Map Name AccelerateData) =
-  | TmDecl {decl = DeclLet t} ->
-    let inexpr = eliminateDummyParameterH solutions accelerated t.inexpr in
+  | TmDecl (x & {decl = DeclLet t}) ->
+    let inexpr = eliminateDummyParameterH solutions accelerated x.inexpr in
     if mapMem t.ident accelerated then
       match mapLookup t.ident solutions with Some idSols then
         if gti (mapSize idSols) 0 then
-          TmDecl {decl = DeclLet {{{t with tyBody = eliminateInnermostParameterType t.tyBody}
+          TmDecl {x with decl = DeclLet {{t with tyBody = eliminateInnermostParameterType t.tyBody}
                      with body = eliminateInnermostLambda t.body}
-                     with inexpr = inexpr}}
-        else TmDecl {decl = DeclLet {t with inexpr = inexpr}}
-      else TmDecl {decl = DeclLet {t with inexpr = inexpr}}
-    else TmDecl {decl = DeclLet {t with inexpr = inexpr}}
-  | TmDecl {decl = DeclRecLets t} ->
+                     , inexpr = inexpr}
+        else TmDecl {x with inexpr = inexpr}
+      else TmDecl {x with inexpr = inexpr}
+    else TmDecl {x with inexpr = inexpr}
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let isAccelerateBinding = lam bind : DeclLetRecord.
       if mapMem bind.ident accelerated then
         match mapLookup bind.ident solutions with Some idSols then
@@ -198,21 +207,25 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
               (tyBody, body)
             else (bind.tyBody, bind.body)
           with (tyBody, body) in
-          TmDecl {decl = DeclLet {
-            ident = bind.ident,
-            tyAnnot = tyBody,
-            tyBody = tyBody,
-            body = body,
-            inexpr = acc,
-            ty = tyTm acc,
-            info = bind.info}}
+          TmDecl
+          { decl = DeclLet
+            { ident = bind.ident
+            , tyAnnot = tyBody
+            , tyBody = tyBody
+            , body = body
+            , info = bind.info
+            }
+          , inexpr = acc
+          , ty = tyTm acc
+          , info = bind.info
+          }
         else acc
       else acc
     in
-    let inexpr = eliminateDummyParameterH solutions accelerated t.inexpr in
+    let inexpr = eliminateDummyParameterH solutions accelerated x.inexpr in
     match partition isAccelerateBinding t.bindings with (accelerated, bindings) in
-    TmDecl {decl = DeclRecLets {{t with bindings = bindings}
-                  with inexpr = foldl eliminateBinding inexpr accelerated}}
+    TmDecl {x with decl = DeclRecLets {t with bindings = bindings}
+                  , inexpr = foldl eliminateBinding inexpr accelerated}
   | t -> smap_Expr_Expr (eliminateDummyParameterH solutions accelerated) t
 
   sem eliminateInnermostParameterType =
@@ -247,9 +260,9 @@ let extractAccelerate = lam t.
 in
 
 let noAccelerateCalls = preprocess (bindall_ [
-  ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  app_ (var_ "f") (int_ 2)
-]) in
+  ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))]
+  (app_ (var_ "f") (int_ 2)
+)) in
 match extractAccelerate noAccelerateCalls with (m, ast) in
 utest mapSize m with 0 in
 utest ast with int_ 0 using eqExpr in
@@ -257,14 +270,14 @@ utest ast with int_ 0 using eqExpr in
 let t = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "g" (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
-  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  accelerate_ (app_ (var_ "h") (int_ 2))
-]) in
+  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x")))]
+  (accelerate_ (app_ (var_ "h") (int_ 2))
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "h") (int_ 2))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "h") (int_ 2)))]
+  (int_ 0
+)) in
 match extractAccelerate t with (m, ast) in
 utest mapSize m with 1 in
 utest ast with extracted using eqExpr in
@@ -272,15 +285,15 @@ utest ast with extracted using eqExpr in
 let t = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "g" (ulam_ "x" (muli_ (app_ (var_ "f") (var_ "x")) (int_ 2))),
-  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x"))),
-  accelerate_ (app_ (var_ "g") (int_ 4))
-]) in
+  ulet_ "h" (ulam_ "x" (subi_ (int_ 1) (var_ "x")))]
+  (accelerate_ (app_ (var_ "g") (int_ 4))
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "g" (ulam_ "x" (muli_ (app_ (var_ "f") (var_ "x")) (int_ 2))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 4))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 4)))]
+  (int_ 0
+)) in
 match extractAccelerate t with (m, ast) in
 utest mapSize m with 1 in
 utest ast with extracted using eqExpr in
@@ -288,38 +301,38 @@ utest ast with extracted using eqExpr in
 let multipleCallsToSame = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "g" (ulam_ "x" (bindall_ [
-    ulet_ "y" (addi_ (var_ "x") (int_ 2)),
-    accelerate_ (app_ (var_ "f") (var_ "y"))
-  ])),
-  ulet_ "h" (ulam_ "x" (accelerate_ (app_ (var_ "f") (var_ "x")))),
-  addi_
+    ulet_ "y" (addi_ (var_ "x") (int_ 2))]
+    (accelerate_ (app_ (var_ "f") (var_ "y"))
+  ))),
+  ulet_ "h" (ulam_ "x" (accelerate_ (app_ (var_ "f") (var_ "x"))))]
+  (addi_
     (app_ (var_ "g") (int_ 1))
     (app_ (var_ "h") (int_ 3))
-]) in
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "t" (ulam_ "y" (ulam_ "" (app_ (var_ "f") (var_ "y")))),
-  ulet_ "t" (ulam_ "x" (ulam_ "" (app_ (var_ "f") (var_ "x")))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "x" (ulam_ "" (app_ (var_ "f") (var_ "x"))))]
+  (int_ 0
+)) in
 match extractAccelerate multipleCallsToSame with (m, ast) in
 utest mapSize m with 2 in
 utest ast with extracted using eqExpr in
 
 let distinctCalls = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
-  ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
-  addi_
+  ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1)))]
+  (addi_
     (accelerate_ (app_ (var_ "f") (int_ 1)))
     (accelerate_ (app_ (var_ "g") (int_ 0)))
-]) in
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 3))),
   ulet_ "g" (ulam_ "x" (addi_ (var_ "x") (int_ 1))),
   ulet_ "t" (ulam_ "t" (app_ (var_ "f") (int_ 1))),
-  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 0))),
-  int_ 0
-]) in
+  ulet_ "t" (ulam_ "t" (app_ (var_ "g") (int_ 0)))]
+  (int_ 0
+)) in
 match extractAccelerate distinctCalls with (m, ast) in
 utest mapSize m with 2 in
 utest ast with extracted using eqExpr in
@@ -328,18 +341,18 @@ let inRecursiveBinding = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
   ureclets_ [
     ("g", ulam_ "x" (app_ (var_ "f") (addi_ (var_ "x") (int_ 1)))),
-    ("h", ulam_ "x" (accelerate_ (app_ (var_ "g") (var_ "x"))))],
-  app_ (var_ "h") (int_ 3)
-]) in
+    ("h", ulam_ "x" (accelerate_ (app_ (var_ "g") (var_ "x"))))]]
+  (app_ (var_ "h") (int_ 3)
+)) in
 let extracted = preprocess (bindall_ [
   ulet_ "f" (ulam_ "x" (muli_ (var_ "x") (int_ 2))),
   ureclets_ [
-    ("g", ulam_ "x" (app_ (var_ "f") (addi_ (var_ "x") (int_ 1)))),
-    ("t", ulam_ "x" (ulam_ "" (app_ (var_ "g") (var_ "x"))))],
-  int_ 0
-]) in
+    ("t", ulam_ "x" (ulam_ "" (app_ (var_ "g") (var_ "x")))),
+    ("g", ulam_ "x" (app_ (var_ "f") (addi_ (var_ "x") (int_ 1))))]]
+  (int_ 0
+)) in
 match extractAccelerate inRecursiveBinding with (m, ast) in
 utest mapSize m with 1 in
-utest ast with extracted using eqExpr in
+utest ast with extracted using eqExpr else lam l. lam r. strJoin "\n" [expr2str l, expr2str r] in
 
 ()

--- a/src/stdlib/pmexpr/extract.mc
+++ b/src/stdlib/pmexpr/extract.mc
@@ -181,14 +181,14 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
       else TmLet {t with inexpr = inexpr}
     else TmLet {t with inexpr = inexpr}
   | TmRecLets t ->
-    let isAccelerateBinding = lam bind : RecLetBinding.
+    let isAccelerateBinding = lam bind : DeclLetRecord.
       if mapMem bind.ident accelerated then
         match mapLookup bind.ident solutions with Some idSols then
           true
         else false
       else false
     in
-    let eliminateBinding = lam acc. lam bind : RecLetBinding.
+    let eliminateBinding = lam acc. lam bind : DeclLetRecord.
       if mapMem bind.ident accelerated then
         match mapLookup bind.ident solutions with Some idSols then
           match

--- a/src/stdlib/pmexpr/extract.mc
+++ b/src/stdlib/pmexpr/extract.mc
@@ -116,7 +116,7 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
     let env = {env with functions = mapInsert accelerateIdent functionData env.functions} in
     let funcType = TyArrow {from = paramTy, to = retType, info = info} in
     let accelerateLet =
-      TmLet {
+      TmDecl {decl = DeclLet {
         ident = accelerateIdent,
         tyAnnot = funcType,
         tyBody = funcType,
@@ -129,7 +129,7 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
           rhs = TmConst {val = CInt {val = 0}, ty = paramTy, info = info},
           ty = retType,
           info = info},
-        ty = retType, info = info}
+        ty = retType, info = info}}
     in
     (env, accelerateLet)
 
@@ -169,18 +169,18 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
 
   sem eliminateDummyParameterH (solutions : Map Name (Map Name Type))
                                (accelerated : Map Name AccelerateData) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let inexpr = eliminateDummyParameterH solutions accelerated t.inexpr in
     if mapMem t.ident accelerated then
       match mapLookup t.ident solutions with Some idSols then
         if gti (mapSize idSols) 0 then
-          TmLet {{{t with tyBody = eliminateInnermostParameterType t.tyBody}
+          TmDecl {decl = DeclLet {{{t with tyBody = eliminateInnermostParameterType t.tyBody}
                      with body = eliminateInnermostLambda t.body}
-                     with inexpr = inexpr}
-        else TmLet {t with inexpr = inexpr}
-      else TmLet {t with inexpr = inexpr}
-    else TmLet {t with inexpr = inexpr}
-  | TmRecLets t ->
+                     with inexpr = inexpr}}
+        else TmDecl {decl = DeclLet {t with inexpr = inexpr}}
+      else TmDecl {decl = DeclLet {t with inexpr = inexpr}}
+    else TmDecl {decl = DeclLet {t with inexpr = inexpr}}
+  | TmDecl {decl = DeclRecLets t} ->
     let isAccelerateBinding = lam bind : DeclLetRecord.
       if mapMem bind.ident accelerated then
         match mapLookup bind.ident solutions with Some idSols then
@@ -198,21 +198,21 @@ lang PMExprExtractAccelerate = PMExprAst + MExprExtract
               (tyBody, body)
             else (bind.tyBody, bind.body)
           with (tyBody, body) in
-          TmLet {
+          TmDecl {decl = DeclLet {
             ident = bind.ident,
             tyAnnot = tyBody,
             tyBody = tyBody,
             body = body,
             inexpr = acc,
             ty = tyTm acc,
-            info = bind.info}
+            info = bind.info}}
         else acc
       else acc
     in
     let inexpr = eliminateDummyParameterH solutions accelerated t.inexpr in
     match partition isAccelerateBinding t.bindings with (accelerated, bindings) in
-    TmRecLets {{t with bindings = bindings}
-                  with inexpr = foldl eliminateBinding inexpr accelerated}
+    TmDecl {decl = DeclRecLets {{t with bindings = bindings}
+                  with inexpr = foldl eliminateBinding inexpr accelerated}}
   | t -> smap_Expr_Expr (eliminateDummyParameterH solutions accelerated) t
 
   sem eliminateInnermostParameterType =

--- a/src/stdlib/pmexpr/inline-higher-order.mc
+++ b/src/stdlib/pmexpr/inline-higher-order.mc
@@ -19,10 +19,10 @@ lang PMExprInlineFunctions = PMExprAst + PMExprVariableSub
   sem collectBindingUseCount : PMExprInlineMap -> Expr -> PMExprInlineMap
   sem collectBindingUseCount useCount =
   | TmVar t -> _incrementUseCount useCount t.ident
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     let useCount = mapInsert t.ident (t.body, 0) useCount in
     let useCount = collectBindingUseCount useCount t.body in
-    collectBindingUseCount useCount t.inexpr
+    collectBindingUseCount useCount x.inexpr
   | t -> sfold_Expr_Expr collectBindingUseCount useCount t
 
   sem _repeatInline : PMExprInlineMap -> Set Name -> Expr -> (Set Name, Expr)
@@ -68,9 +68,9 @@ lang PMExprInlineFunctions = PMExprAst + PMExprVariableSub
 
   sem removeInlinedFunctions : Set Name -> Expr -> Expr
   sem removeInlinedFunctions inlined =
-  | TmDecl {decl = DeclLet t} ->
-    if setMem t.ident inlined then removeInlinedFunctions inlined t.inexpr
-    else TmDecl {decl = DeclLet {t with inexpr = removeInlinedFunctions inlined t.inexpr}}
+  | TmDecl (x & {decl = DeclLet t}) ->
+    if setMem t.ident inlined then removeInlinedFunctions inlined x.inexpr
+    else TmDecl {x with inexpr = removeInlinedFunctions inlined x.inexpr}
   | t -> smap_Expr_Expr (removeInlinedFunctions inlined) t
 
   sem inlineHigherOrderFunctions : Expr -> Expr

--- a/src/stdlib/pmexpr/inline-higher-order.mc
+++ b/src/stdlib/pmexpr/inline-higher-order.mc
@@ -19,7 +19,7 @@ lang PMExprInlineFunctions = PMExprAst + PMExprVariableSub
   sem collectBindingUseCount : PMExprInlineMap -> Expr -> PMExprInlineMap
   sem collectBindingUseCount useCount =
   | TmVar t -> _incrementUseCount useCount t.ident
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let useCount = mapInsert t.ident (t.body, 0) useCount in
     let useCount = collectBindingUseCount useCount t.body in
     collectBindingUseCount useCount t.inexpr
@@ -68,9 +68,9 @@ lang PMExprInlineFunctions = PMExprAst + PMExprVariableSub
 
   sem removeInlinedFunctions : Set Name -> Expr -> Expr
   sem removeInlinedFunctions inlined =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     if setMem t.ident inlined then removeInlinedFunctions inlined t.inexpr
-    else TmLet {t with inexpr = removeInlinedFunctions inlined t.inexpr}
+    else TmDecl {decl = DeclLet {t with inexpr = removeInlinedFunctions inlined t.inexpr}}
   | t -> smap_Expr_Expr (removeInlinedFunctions inlined) t
 
   sem inlineHigherOrderFunctions : Expr -> Expr

--- a/src/stdlib/pmexpr/nested-accelerate.mc
+++ b/src/stdlib/pmexpr/nested-accelerate.mc
@@ -28,16 +28,14 @@ lang PMExprNestedAccelerate = PMExprAst
 
   sem containsNestedAccelerate : Set Name -> Expr -> ()
   sem containsNestedAccelerate env =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     checkIdentifiers env t.body;
-    containsNestedAccelerate env t.inexpr
-  | TmDecl {decl = DeclRecLets t} ->
+    containsNestedAccelerate env x.inexpr
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     iter (lam bind. checkIdentifiers env bind.body) t.bindings;
-    containsNestedAccelerate env t.inexpr
-  | TmDecl {decl = DeclType t} -> containsNestedAccelerate env t.inexpr
-  | TmDecl {decl = DeclConDef t} -> containsNestedAccelerate env t.inexpr
-  | TmDecl {decl = DeclUtest t} -> containsNestedAccelerate env t.next
-  | TmDecl {decl = DeclExt t} -> containsNestedAccelerate env t.inexpr
+    containsNestedAccelerate env x.inexpr
+  | TmDecl {decl = DeclType _ | DeclConDef _ | DeclUtest _ | DeclExt _, inexpr = inexpr} ->
+    containsNestedAccelerate env inexpr
   | _ -> ()
 
   sem checkNestedAccelerate : Set Name -> Expr -> ()

--- a/src/stdlib/pmexpr/nested-accelerate.mc
+++ b/src/stdlib/pmexpr/nested-accelerate.mc
@@ -28,16 +28,16 @@ lang PMExprNestedAccelerate = PMExprAst
 
   sem containsNestedAccelerate : Set Name -> Expr -> ()
   sem containsNestedAccelerate env =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     checkIdentifiers env t.body;
     containsNestedAccelerate env t.inexpr
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     iter (lam bind. checkIdentifiers env bind.body) t.bindings;
     containsNestedAccelerate env t.inexpr
-  | TmType t -> containsNestedAccelerate env t.inexpr
-  | TmConDef t -> containsNestedAccelerate env t.inexpr
-  | TmUtest t -> containsNestedAccelerate env t.next
-  | TmExt t -> containsNestedAccelerate env t.inexpr
+  | TmDecl {decl = DeclType t} -> containsNestedAccelerate env t.inexpr
+  | TmDecl {decl = DeclConDef t} -> containsNestedAccelerate env t.inexpr
+  | TmDecl {decl = DeclUtest t} -> containsNestedAccelerate env t.next
+  | TmDecl {decl = DeclExt t} -> containsNestedAccelerate env t.inexpr
   | _ -> ()
 
   sem checkNestedAccelerate : Set Name -> Expr -> ()

--- a/src/stdlib/pmexpr/parallel-patterns.mc
+++ b/src/stdlib/pmexpr/parallel-patterns.mc
@@ -165,11 +165,11 @@ let eliminateUnusedLetExpressions : use Ast in Expr -> Expr =
   recursive let work = lam acc. lam expr.
     match expr with TmVar {ident = ident} then
       (setInsert ident acc, expr)
-    else match expr with TmDecl {decl = DeclLet t} then
-      match work acc t.inexpr with (acc, inexpr) in
+    else match expr with TmDecl (x & {decl = DeclLet t}) then
+      match work acc x.inexpr with (acc, inexpr) in
       if setMem t.ident acc then
         let acc = collectVariables acc t.body in
-        (acc, TmDecl {decl = DeclLet {t with inexpr = inexpr}})
+        (acc, TmDecl {x with inexpr = inexpr})
       else (acc, inexpr)
     else smapAccumL_Expr_Expr work acc expr
   in
@@ -215,7 +215,7 @@ let mapPattern : () -> Pattern =
                    info = info, frozen = false})
         ] in
         let els = substituteVariables subMap els in
-        let els = eliminateUnusedLetExpressions (bind_ els fResultVar) in
+        let els = eliminateUnusedLetExpressions (oldBind_ els fResultVar) in
         let fType = TyArrow {
           from = tyTm headExpr, to = tyTm els, info = infoTm els} in
         let innerAppType = TyArrow {
@@ -308,7 +308,7 @@ let map2Pattern : () -> Pattern =
                    info = info, frozen = false})
         ] in
         let els = substituteVariables subMap els in
-        let els = eliminateUnusedLetExpressions (bind_ els fResultVar) in
+        let els = eliminateUnusedLetExpressions (oldBind_ els fResultVar) in
         TmMap2 {
           f = TmLam {
             ident = x, tyAnnot = tyTm headFstExpr, tyParam = tyTm headFstExpr,
@@ -418,7 +418,7 @@ let reducePattern : () -> Pattern =
       let els = substituteVariables subMap els in
       let fResultVar = TmVar {ident = fResultId, ty = tyTm fResultExpr,
                               info = infoTm fResultExpr, frozen = false} in
-      let els = eliminateUnusedLetExpressions (bind_ els fResultVar) in
+      let els = eliminateUnusedLetExpressions (oldBind_ els fResultVar) in
       let elemTy = tyTm headExpr in
       let accTy = tyTm accExpr in
       let f = TmLam {

--- a/src/stdlib/pmexpr/parallel-patterns.mc
+++ b/src/stdlib/pmexpr/parallel-patterns.mc
@@ -165,11 +165,11 @@ let eliminateUnusedLetExpressions : use Ast in Expr -> Expr =
   recursive let work = lam acc. lam expr.
     match expr with TmVar {ident = ident} then
       (setInsert ident acc, expr)
-    else match expr with TmLet t then
+    else match expr with TmDecl {decl = DeclLet t} then
       match work acc t.inexpr with (acc, inexpr) in
       if setMem t.ident acc then
         let acc = collectVariables acc t.body in
-        (acc, TmLet {t with inexpr = inexpr})
+        (acc, TmDecl {decl = DeclLet {t with inexpr = inexpr}})
       else (acc, inexpr)
     else smapAccumL_Expr_Expr work acc expr
   in

--- a/src/stdlib/pmexpr/parallel-rewrite.mc
+++ b/src/stdlib/pmexpr/parallel-rewrite.mc
@@ -5,7 +5,7 @@ include "pmexpr/promote.mc"
 lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
   sem tryPatterns (patterns : [Pattern]) =
   | t ->
-    let binding : RecLetBinding = t in
+    let binding : DeclLetRecord = t in
     let n = length patterns in
     recursive let tryPattern = lam i.
       if lti i n then
@@ -30,7 +30,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
     -- Collect the parameters
     let replacements =
       foldl
-        (lam replacements. lam binding : RecLetBinding.
+        (lam replacements. lam binding : DeclLetRecord.
           match functionParametersAndBody binding.body with (params, _) then
             match tryPatterns patterns binding with Some replacement then
               mapInsert binding.ident (params, replacement) replacements
@@ -42,7 +42,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
     -- Remove bindings that have been replaced by parallel patterns
     let retainedBindings =
       filter
-        (lam binding : RecLetBinding.
+        (lam binding : DeclLetRecord.
           optionIsNone (mapLookup binding.ident replacements))
         t.bindings in
 
@@ -53,7 +53,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
       -- bindings that remain.
       let bindings =
         map
-          (lam binding : RecLetBinding.
+          (lam binding : DeclLetRecord.
             match parallelPatternRewriteH patterns replacements binding.body
             with (_, body) in
             {binding with body = body})

--- a/src/stdlib/pmexpr/parallel-rewrite.mc
+++ b/src/stdlib/pmexpr/parallel-rewrite.mc
@@ -26,7 +26,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
 
   sem parallelPatternRewriteH (patterns : [Pattern])
                               (replacements : Map Name ([(Name, Type, Info)], Expr)) =
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     -- Collect the parameters
     let replacements =
       foldl
@@ -63,8 +63,8 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
       -- remaining part of the tree).
       match parallelPatternRewriteH patterns replacements t.inexpr
       with (replacements, inexpr) in
-      (replacements, TmRecLets {{t with bindings = bindings}
-                                   with inexpr = inexpr})
+      (replacements, TmDecl {decl = DeclRecLets {{t with bindings = bindings}
+                                   with inexpr = inexpr}})
   | (TmApp {info = info}) & t ->
     let performSubstitution : Expr -> [(Name, Type, Info)] -> [Expr] -> Expr =
       lam e. lam params. lam args.
@@ -151,7 +151,7 @@ let preprocess : Expr -> Expr = lam e.
 in
 
 let recletBindingCount : Expr -> Int = lam e.
-  match e with TmRecLets t then
+  match e with TmDecl {decl = DeclRecLets t} then
     length t.bindings
   else 0
 in

--- a/src/stdlib/pmexpr/parallel-rewrite.mc
+++ b/src/stdlib/pmexpr/parallel-rewrite.mc
@@ -26,7 +26,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
 
   sem parallelPatternRewriteH (patterns : [Pattern])
                               (replacements : Map Name ([(Name, Type, Info)], Expr)) =
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     -- Collect the parameters
     let replacements =
       foldl
@@ -47,7 +47,7 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
         t.bindings in
 
     if null retainedBindings then
-      parallelPatternRewriteH patterns replacements t.inexpr
+      parallelPatternRewriteH patterns replacements x.inexpr
     else
       -- Replace applications on replaced bindings within the bodies of the
       -- bindings that remain.
@@ -61,10 +61,10 @@ lang PMExprParallelPattern = PMExprAst + PMExprPromote + PMExprVariableSub
 
       -- Apply on the inexpr of the recursive let-expression (apply on the
       -- remaining part of the tree).
-      match parallelPatternRewriteH patterns replacements t.inexpr
+      match parallelPatternRewriteH patterns replacements x.inexpr
       with (replacements, inexpr) in
-      (replacements, TmDecl {decl = DeclRecLets {{t with bindings = bindings}
-                                   with inexpr = inexpr}})
+      (replacements, TmDecl { x with decl = DeclRecLets {t with bindings = bindings}
+                            , inexpr = inexpr})
   | (TmApp {info = info}) & t ->
     let performSubstitution : Expr -> [(Name, Type, Info)] -> [Expr] -> Expr =
       lam e. lam params. lam args.
@@ -126,7 +126,7 @@ lang TestLang =
   sem isAtomic =
   | TmMap2 _ -> false
   | TmParallelReduce _ -> false
-  
+
   sem pprintCode (indent : Int) (env : PprintEnv) =
   | TmMap2 t ->
     match printParen indent env t.f with (env, f) in
@@ -172,7 +172,7 @@ let h = nameSym "h" in
 let t = nameSym "t" in
 let addOne = nameSym "addOne" in
 let x = nameSym "x" in
-let expr = preprocess (nreclets_ [
+let expr = preprocess (bind_ (nreclets_ [
   (map, tyunknown_, nulam_ f (nulam_ s (
     match_ (nvar_ s)
       (pseqtot_ [])
@@ -185,7 +185,7 @@ let expr = preprocess (nreclets_ [
   (addOne, tyunknown_, nulam_ s (
     appf2_ (nvar_ map) (nulam_ x (addi_ (nvar_ x) (int_ 1))) (nvar_ s)
   ))
-]) in
+]) unit_) in
 let expr = parallelPatternRewrite patterns expr in
 utest recletBindingCount expr with 1 in
 utest containsParallelKeyword expr with true in
@@ -207,7 +207,7 @@ let expr = preprocess (bindall_ [
           (nvar_ acc)
           never_))))],
   ulet_ "sum" (appf2_ (nvar_ red) (int_ 0) (seq_ [int_ 1, int_ 2, int_ 3]))
-]) in
+] unit_) in
 let expr = parallelPatternRewrite patterns expr in
 utest recletBindingCount expr with 0 in
 utest containsParallelKeyword expr with true in
@@ -231,7 +231,7 @@ let expr = preprocess (bindall_ [
       (int_ 0)
       (uconst_ (CAddi ()))
       (seq_ [int_ 1, int_ 2, int_ 3]))
-]) in
+] unit_) in
 let expr = parallelPatternRewrite patterns expr in
 utest recletBindingCount expr with 0 in
 utest containsParallelKeyword expr with true in

--- a/src/stdlib/pmexpr/pattern-match.mc
+++ b/src/stdlib/pmexpr/pattern-match.mc
@@ -312,7 +312,7 @@ recursive
                          -> PatternMatchState -> Option PatternMatchState =
     use PMExprAst in
     lam bindingIdent. lam params. lam expr. lam state.
-    match expr with TmDecl {decl = DeclLet {ident = ident, body = body, inexpr = inexpr}} then
+    match expr with TmDecl {decl = DeclLet {ident = ident, body = body}, inexpr = inexpr} then
       let updatedState =
         optionGetOrElse
           (lam. updateVariableDependencies state ident body (None ()))
@@ -337,8 +337,8 @@ recursive
             (matchVariablePattern expr state pvar)
         else None ()
       else None ()
-    else match expr with TmDecl {decl = DeclRecLets t} then
-      matchAtomicPatterns bindingIdent params t.inexpr state
+    else match expr with TmDecl (x & {decl = DeclRecLets _}) then
+      matchAtomicPatterns bindingIdent params x.inexpr state
     else None ()
 end
 
@@ -411,7 +411,7 @@ let f = nameSym "f" in
 let s = nameSym "s" in
 let h = nameSym "h" in
 let t = nameSym "t" in
-let expr = typeCheck (preprocess (nreclets_ [
+let expr = typeCheck (preprocess (bind_ (nreclets_ [
   (map, tyunknown_, nlam_ f (tyarrow_ tyint_ tyint_) (nulam_ s (
     match_ (nvar_ s)
       (pseqtot_ [])
@@ -420,7 +420,7 @@ let expr = typeCheck (preprocess (nreclets_ [
         (pseqedgen_ [npvar_ h] t [])
         (cons_ (app_ (nvar_ f) (head_ (nvar_ s)))
                (appf2_ (nvar_ map) (nvar_ f) (tail_ (nvar_ s))))
-        never_))))])) in
+        never_))))]) unit_)) in
 let mapPat = getMapPattern () in
 let mapPatternMatchResult = matchBindingsWithPattern expr mapPat in
 let fst = optionGetOrElse (lam. never) (get mapPatternMatchResult 0) in
@@ -436,7 +436,7 @@ let acc = nameSym "acc" in
 let s2 = nameSym "s" in
 let h2 = nameSym "h" in
 let t2 = nameSym "t" in
-let expr = preprocess (nreclets_ [
+let expr = preprocess (bind_ (nreclets_ [
   (map2id, tyunknown_, nulam_ acc (nulam_ s (nulam_ s2 (
     match_ (nvar_ s)
       (pseqtot_ [])
@@ -455,7 +455,7 @@ let expr = preprocess (nreclets_ [
             never_)
           never_))
   ))))
-]) in
+]) unit_) in
 let map2Pat = getMap2Pattern () in
 let map2PatternMatchResult = matchBindingsWithPattern expr map2Pat in
 let fst = optionGetOrElse (lam. never) (get map2PatternMatchResult 0) in
@@ -465,7 +465,7 @@ using optionEq eqExpr in
 utest mapSize fst with 19 in
 
 let fold = nameSym "fold" in
-let expr = preprocess (nreclets_ [
+let expr = preprocess (bind_ (nreclets_ [
   (fold, tyunknown_, nulam_ f (nulam_ acc (nulam_ s (
     match_ (nvar_ s)
       (pseqedgen_ [npvar_ h] t [])
@@ -477,7 +477,7 @@ let expr = preprocess (nreclets_ [
         (pseqtot_ [])
         (nvar_ acc)
         never_)))))
-]) in
+]) unit_) in
 let reducePat = getReducePattern () in
 let reducePatternMatchResult = matchBindingsWithPattern expr reducePat in
 let fst = optionGetOrElse (lam. never) (get reducePatternMatchResult 0) in

--- a/src/stdlib/pmexpr/pattern-match.mc
+++ b/src/stdlib/pmexpr/pattern-match.mc
@@ -363,7 +363,7 @@ let constructLookup : use Ast in PatternMatchState -> Map VarPattern (Name, Expr
 
 let matchPattern =
   use PMExprAst in
-  lam binding : RecLetBinding. lam pattern : Pattern.
+  lam binding : DeclLetRecord. lam pattern : Pattern.
   let initState =
     {{emptyPatternMatchState pattern
         with active = pattern.activePatterns}

--- a/src/stdlib/pmexpr/pattern-match.mc
+++ b/src/stdlib/pmexpr/pattern-match.mc
@@ -312,7 +312,7 @@ recursive
                          -> PatternMatchState -> Option PatternMatchState =
     use PMExprAst in
     lam bindingIdent. lam params. lam expr. lam state.
-    match expr with TmLet {ident = ident, body = body, inexpr = inexpr} then
+    match expr with TmDecl {decl = DeclLet {ident = ident, body = body, inexpr = inexpr}} then
       let updatedState =
         optionGetOrElse
           (lam. updateVariableDependencies state ident body (None ()))
@@ -337,7 +337,7 @@ recursive
             (matchVariablePattern expr state pvar)
         else None ()
       else None ()
-    else match expr with TmRecLets t then
+    else match expr with TmDecl {decl = DeclRecLets t} then
       matchAtomicPatterns bindingIdent params t.inexpr state
     else None ()
 end
@@ -394,7 +394,7 @@ in
 
 let matchBindingsWithPattern : Expr -> Pattern -> [PatternMatchResult] =
   lam recLets. lam pattern.
-  match recLets with TmRecLets {bindings = bindings} then
+  match recLets with TmDecl {decl = DeclRecLets {bindings = bindings}} then
     map (lam binding. matchPattern binding pattern) bindings
   else never
 in

--- a/src/stdlib/pmexpr/promote.mc
+++ b/src/stdlib/pmexpr/promote.mc
@@ -10,10 +10,10 @@ lang PMExprPromote = PMExprAst + PMExprFunctionProperties
   sem getInnerFunction =
   | TmLam t -> getInnerFunction t.body
   | TmApp t -> getInnerFunction t.lhs
-  | TmLet (t & {inexpr = TmVar {ident = id}}) ->
+  | TmDecl {decl = DeclLet (t & {inexpr = TmVar {ident = id}})} ->
     if nameEq t.ident id then
       getInnerFunction t.body
-    else TmLet t
+    else TmDecl {decl = DeclLet t}
   | t -> t
 
   sem argumentsHaveSameType =

--- a/src/stdlib/pmexpr/promote.mc
+++ b/src/stdlib/pmexpr/promote.mc
@@ -10,10 +10,10 @@ lang PMExprPromote = PMExprAst + PMExprFunctionProperties
   sem getInnerFunction =
   | TmLam t -> getInnerFunction t.body
   | TmApp t -> getInnerFunction t.lhs
-  | TmDecl {decl = DeclLet (t & {inexpr = TmVar {ident = id}})} ->
+  | tm & TmDecl {decl = DeclLet t, inexpr = TmVar {ident = id}} ->
     if nameEq t.ident id then
       getInnerFunction t.body
-    else TmDecl {decl = DeclLet t}
+    else tm
   | t -> t
 
   sem argumentsHaveSameType =

--- a/src/stdlib/pmexpr/replace-accelerate.mc
+++ b/src/stdlib/pmexpr/replace-accelerate.mc
@@ -145,14 +145,14 @@ lang PMExprReplaceAccelerate =
         else convertAccelerateParameters env acc t
       else (acc, t)
     else (acc, t)
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     if mapMem t.ident accelerated then
       replaceAccelerateH accelerated env acc t.inexpr
     else
       match replaceAccelerateH accelerated env acc t.body with (acc, body) in
       match replaceAccelerateH accelerated env acc t.inexpr with (acc, inexpr) in
-      (acc, TmLet {{t with body = body} with inexpr = inexpr})
-  | TmRecLets t ->
+      (acc, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
+  | TmDecl {decl = DeclRecLets t} ->
     let removeAccelerateBindings : DeclLetRecord -> Option DeclLetRecord =
       lam bind.
       if mapMem bind.ident accelerated then None ()
@@ -165,7 +165,7 @@ lang PMExprReplaceAccelerate =
     match replaceAccelerateH accelerated env acc t.inexpr with (acc, inexpr) in
     let bindings = mapOption removeAccelerateBindings t.bindings in
     match mapAccumL replaceBindings acc bindings with (acc, bindings) in
-    (acc, TmRecLets {{t with bindings = bindings} with inexpr = inexpr})
+    (acc, TmDecl {decl = DeclRecLets {{t with bindings = bindings} with inexpr = inexpr}})
   | t ->
     smapAccumL_Expr_Expr (replaceAccelerateH accelerated env) acc t
 end

--- a/src/stdlib/pmexpr/replace-accelerate.mc
+++ b/src/stdlib/pmexpr/replace-accelerate.mc
@@ -145,14 +145,14 @@ lang PMExprReplaceAccelerate =
         else convertAccelerateParameters env acc t
       else (acc, t)
     else (acc, t)
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     if mapMem t.ident accelerated then
-      replaceAccelerateH accelerated env acc t.inexpr
+      replaceAccelerateH accelerated env acc x.inexpr
     else
       match replaceAccelerateH accelerated env acc t.body with (acc, body) in
-      match replaceAccelerateH accelerated env acc t.inexpr with (acc, inexpr) in
-      (acc, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
-  | TmDecl {decl = DeclRecLets t} ->
+      match replaceAccelerateH accelerated env acc x.inexpr with (acc, inexpr) in
+      (acc, TmDecl {x with decl = DeclLet {t with body = body}, inexpr = inexpr})
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let removeAccelerateBindings : DeclLetRecord -> Option DeclLetRecord =
       lam bind.
       if mapMem bind.ident accelerated then None ()
@@ -162,10 +162,10 @@ lang PMExprReplaceAccelerate =
       match replaceAccelerateH accelerated env acc bind.body with (acc, body) in
       (acc, {bind with body = body})
     in
-    match replaceAccelerateH accelerated env acc t.inexpr with (acc, inexpr) in
+    match replaceAccelerateH accelerated env acc x.inexpr with (acc, inexpr) in
     let bindings = mapOption removeAccelerateBindings t.bindings in
     match mapAccumL replaceBindings acc bindings with (acc, bindings) in
-    (acc, TmDecl {decl = DeclRecLets {{t with bindings = bindings} with inexpr = inexpr}})
+    (acc, TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr})
   | t ->
     smapAccumL_Expr_Expr (replaceAccelerateH accelerated env) acc t
 end

--- a/src/stdlib/pmexpr/replace-accelerate.mc
+++ b/src/stdlib/pmexpr/replace-accelerate.mc
@@ -153,12 +153,12 @@ lang PMExprReplaceAccelerate =
       match replaceAccelerateH accelerated env acc t.inexpr with (acc, inexpr) in
       (acc, TmLet {{t with body = body} with inexpr = inexpr})
   | TmRecLets t ->
-    let removeAccelerateBindings : RecLetBinding -> Option RecLetBinding =
+    let removeAccelerateBindings : DeclLetRecord -> Option DeclLetRecord =
       lam bind.
       if mapMem bind.ident accelerated then None ()
       else Some bind
     in
-    let replaceBindings = lam acc. lam bind : RecLetBinding.
+    let replaceBindings = lam acc. lam bind : DeclLetRecord.
       match replaceAccelerateH accelerated env acc bind.body with (acc, body) in
       (acc, {bind with body = body})
     in

--- a/src/stdlib/pmexpr/tailrecursion.mc
+++ b/src/stdlib/pmexpr/tailrecursion.mc
@@ -81,12 +81,12 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
     let binding : DeclLetRecord = t in
     recursive let findExpressionsAtTailPosition : Expr -> [Expr] = lam expr.
       match expr with TmLam t then findExpressionsAtTailPosition t.body
-      else match expr with TmLet t then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmRecLets t then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmType t then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmConDef t then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmUtest t then findExpressionsAtTailPosition t.next
-      else match expr with TmExt t then findExpressionsAtTailPosition t.inexpr
+      else match expr with TmDecl {decl = DeclLet t} then findExpressionsAtTailPosition t.inexpr
+      else match expr with TmDecl {decl = DeclRecLets t} then findExpressionsAtTailPosition t.inexpr
+      else match expr with TmDecl {decl = DeclType t} then findExpressionsAtTailPosition t.inexpr
+      else match expr with TmDecl {decl = DeclConDef t} then findExpressionsAtTailPosition t.inexpr
+      else match expr with TmDecl {decl = DeclUtest t} then findExpressionsAtTailPosition t.next
+      else match expr with TmDecl {decl = DeclExt t} then findExpressionsAtTailPosition t.inexpr
       else match expr with TmMatch t then
         concat
           (findExpressionsAtTailPosition t.thn)
@@ -181,18 +181,18 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
     recursive let rewriteTailRecursive : Expr -> Expr = lam expr.
       match expr with TmLam t then
         TmLam {t with body = rewriteTailRecursive t.body}
-      else match expr with TmLet t then
-        TmLet {t with inexpr = rewriteTailRecursive t.inexpr}
-      else match expr with TmRecLets t then
-        TmRecLets {t with inexpr = rewriteTailRecursive t.inexpr}
-      else match expr with TmType t then
-        TmType {t with inexpr = rewriteTailRecursive t.inexpr}
-      else match expr with TmConDef t then
-        TmConDef {t with inexpr = rewriteTailRecursive t.inexpr}
-      else match expr with TmUtest t then
-        TmUtest {t with next = rewriteTailRecursive t.next}
-      else match expr with TmExt t then
-        TmExt {t with inexpr = rewriteTailRecursive t.inexpr}
+      else match expr with TmDecl {decl = DeclLet t} then
+        TmDecl {decl = DeclLet {t with inexpr = rewriteTailRecursive t.inexpr}}
+      else match expr with TmDecl {decl = DeclRecLets t} then
+        TmDecl {decl = DeclRecLets {t with inexpr = rewriteTailRecursive t.inexpr}}
+      else match expr with TmDecl {decl = DeclType t} then
+        TmDecl {decl = DeclType {t with inexpr = rewriteTailRecursive t.inexpr}}
+      else match expr with TmDecl {decl = DeclConDef t} then
+        TmDecl {decl = DeclConDef {t with inexpr = rewriteTailRecursive t.inexpr}}
+      else match expr with TmDecl {decl = DeclUtest t} then
+        TmDecl {decl = DeclUtest {t with next = rewriteTailRecursive t.next}}
+      else match expr with TmDecl {decl = DeclExt t} then
+        TmDecl {decl = DeclExt {t with inexpr = rewriteTailRecursive t.inexpr}}
       else match expr with TmMatch t then
         TmMatch {{t with thn = rewriteTailRecursive t.thn}
                     with els = rewriteTailRecursive t.els}
@@ -260,7 +260,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
     match mapLookup t.ident subMap with Some subFn then
       (subMap, subFn t.info)
     else (subMap, TmVar t)
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let tailRecursiveBinding = lam subMap. lam binding : DeclLetRecord.
       optionGetOrElse
         (lam. (subMap, binding))
@@ -280,7 +280,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
 
       -- Translate calls to rewritten bindings in the inexpr term.
       match tailRecursiveH subMap t.inexpr with (subMap, inexpr) then
-        (subMap, TmRecLets {{t with bindings = bindings} with inexpr = inexpr})
+        (subMap, TmDecl {decl = DeclRecLets {{t with bindings = bindings} with inexpr = inexpr}})
       else never
     else never
   | t -> smapAccumL_Expr_Expr tailRecursiveH subMap t

--- a/src/stdlib/pmexpr/tailrecursion.mc
+++ b/src/stdlib/pmexpr/tailrecursion.mc
@@ -81,12 +81,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
     let binding : DeclLetRecord = t in
     recursive let findExpressionsAtTailPosition : Expr -> [Expr] = lam expr.
       match expr with TmLam t then findExpressionsAtTailPosition t.body
-      else match expr with TmDecl {decl = DeclLet t} then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmDecl {decl = DeclRecLets t} then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmDecl {decl = DeclType t} then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmDecl {decl = DeclConDef t} then findExpressionsAtTailPosition t.inexpr
-      else match expr with TmDecl {decl = DeclUtest t} then findExpressionsAtTailPosition t.next
-      else match expr with TmDecl {decl = DeclExt t} then findExpressionsAtTailPosition t.inexpr
+      else match expr with TmDecl x then findExpressionsAtTailPosition x.inexpr
       else match expr with TmMatch t then
         concat
           (findExpressionsAtTailPosition t.thn)
@@ -181,18 +176,8 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
     recursive let rewriteTailRecursive : Expr -> Expr = lam expr.
       match expr with TmLam t then
         TmLam {t with body = rewriteTailRecursive t.body}
-      else match expr with TmDecl {decl = DeclLet t} then
-        TmDecl {decl = DeclLet {t with inexpr = rewriteTailRecursive t.inexpr}}
-      else match expr with TmDecl {decl = DeclRecLets t} then
-        TmDecl {decl = DeclRecLets {t with inexpr = rewriteTailRecursive t.inexpr}}
-      else match expr with TmDecl {decl = DeclType t} then
-        TmDecl {decl = DeclType {t with inexpr = rewriteTailRecursive t.inexpr}}
-      else match expr with TmDecl {decl = DeclConDef t} then
-        TmDecl {decl = DeclConDef {t with inexpr = rewriteTailRecursive t.inexpr}}
-      else match expr with TmDecl {decl = DeclUtest t} then
-        TmDecl {decl = DeclUtest {t with next = rewriteTailRecursive t.next}}
-      else match expr with TmDecl {decl = DeclExt t} then
-        TmDecl {decl = DeclExt {t with inexpr = rewriteTailRecursive t.inexpr}}
+      else match expr with TmDecl x then
+        TmDecl {x with inexpr = rewriteTailRecursive x.inexpr}
       else match expr with TmMatch t then
         TmMatch {{t with thn = rewriteTailRecursive t.thn}
                     with els = rewriteTailRecursive t.els}
@@ -260,7 +245,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
     match mapLookup t.ident subMap with Some subFn then
       (subMap, subFn t.info)
     else (subMap, TmVar t)
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let tailRecursiveBinding = lam subMap. lam binding : DeclLetRecord.
       optionGetOrElse
         (lam. (subMap, binding))
@@ -279,8 +264,8 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
           bindings in
 
       -- Translate calls to rewritten bindings in the inexpr term.
-      match tailRecursiveH subMap t.inexpr with (subMap, inexpr) then
-        (subMap, TmDecl {decl = DeclRecLets {{t with bindings = bindings} with inexpr = inexpr}})
+      match tailRecursiveH subMap x.inexpr with (subMap, inexpr) then
+        (subMap, TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr})
       else never
     else never
   | t -> smapAccumL_Expr_Expr tailRecursiveH subMap t
@@ -308,8 +293,8 @@ let fact = preprocess (bindall_ [
       if_ (leqi_ (var_ "n") (int_ 1))
         (int_ 1)
         (muli_ (var_ "n") (app_ (var_ "fact") (subi_ (var_ "n") (int_ 1))))
-    ))],
-  app_ (var_ "fact") (int_ 10)]) in
+    ))]]
+  (app_ (var_ "fact") (int_ 10))) in
 let factTr = preprocess (bindall_ [
   ureclets_ [
     ("fact", ulam_ "acc" (ulam_ "n" (
@@ -318,20 +303,20 @@ let factTr = preprocess (bindall_ [
         (appf2_ (var_ "fact")
           (muli_ (var_ "acc") (var_ "n"))
           (subi_ (var_ "n") (int_ 1)))
-    )))],
-  (appf2_ (var_ "fact") (int_ 1) (int_ 10))]) in
+    )))]]
+  (appf2_ (var_ "fact") (int_ 1) (int_ 10))) in
 utest tailRecursive fact with factTr using eqExpr in
 utest tailRecursive factTr with factTr using eqExpr in
 
-let filter = preprocess (ureclets_ [
+let filter = preprocess (bind_ (ureclets_ [
   ("filter", ulam_ "p" (ulam_ "s" (
     if_ (null_ (var_ "s"))
       (seq_ [])
       (if_ (app_ (var_ "p") (head_ (var_ "s")))
         (concat_ (seq_ [head_ (var_ "s")])
                  (appf2_ (var_ "filter") (var_ "p") (tail_ (var_ "s"))))
-        (appf2_ (var_ "filter") (var_ "p") (tail_ (var_ "s")))))))]) in
-let filterTr = preprocess (ureclets_ [
+        (appf2_ (var_ "filter") (var_ "p") (tail_ (var_ "s")))))))]) unit_) in
+let filterTr = preprocess (bind_ (ureclets_ [
   ("filter", ulam_ "acc" (ulam_ "p" (ulam_ "s" (
     if_ (null_ (var_ "s"))
       (var_ "acc")
@@ -342,18 +327,18 @@ let filterTr = preprocess (ureclets_ [
         (concat_
           (var_ "acc")
           (appf3_ (var_ "filter") (seq_ []) (var_ "p")
-                                  (tail_ (var_ "s")))))))))]) in
+                                  (tail_ (var_ "s")))))))))]) unit_) in
 utest tailRecursive filter with filterTr using eqExpr in
 
-let fib = preprocess (ureclets_ [
+let fib = preprocess (bind_ (ureclets_ [
   ("fib", ulam_ "n" (
     if_ (eqi_ (var_ "n") (int_ 0))
       (int_ 0)
       (if_ (eqi_ (var_ "n") (int_ 1))
         (int_ 1)
         (addi_ (app_ (var_ "fib") (subi_ (var_ "n") (int_ 1)))
-               (app_ (var_ "fib") (subi_ (var_ "n") (int_ 2)))))))]) in
-let fibTr = preprocess (ureclets_ [
+               (app_ (var_ "fib") (subi_ (var_ "n") (int_ 2)))))))]) unit_) in
+let fibTr = preprocess (bind_ (ureclets_ [
   ("fib", ulam_ "acc" (ulam_ "n" (
     if_ (eqi_ (var_ "n") (int_ 0))
       (var_ "acc")
@@ -362,22 +347,22 @@ let fibTr = preprocess (ureclets_ [
         (appf2_ (var_ "fib")
           (addi_ (appf2_ (var_ "fib") (int_ 0)
                  (subi_ (var_ "n") (int_ 2))) (var_ "acc"))
-          (subi_ (var_ "n") (int_ 1)))))))]) in
+          (subi_ (var_ "n") (int_ 1)))))))]) unit_) in
 utest tailRecursive fib with fibTr using eqExpr in
 utest tailRecursive fibTr with fibTr using eqExpr in
 
-let map0 = preprocess (ureclets_ [
+let map0 = preprocess (bind_ (ureclets_ [
   ("map0", ulam_ "f" (ulam_ "s" (
     match_ (var_ "s") (pseqedge_ [pvar_ "h"] "t" [])
       (concat_ (seq_ [app_ (var_ "f") (var_ "h")]) (appf2_ (var_ "map0") (var_ "f") (var_ "t")))
-      (seq_ [int_ 0]))))]) in
-let map0Tr = preprocess (ureclets_ [
+      (seq_ [int_ 0]))))]) unit_) in
+let map0Tr = preprocess (bind_ (ureclets_ [
   ("map0", ulam_ "acc" (ulam_ "f" (ulam_ "s" (
     match_ (var_ "s") (pseqedge_ [pvar_ "h"] "t" [])
       (appf3_ (var_ "map0")
         (concat_ (var_ "acc") (seq_ [app_ (var_ "f") (var_ "h")]))
         (var_ "f") (var_ "t"))
-      (concat_ (var_ "acc") (seq_ [int_ 0]))))))]) in
+      (concat_ (var_ "acc") (seq_ [int_ 0]))))))]) unit_) in
 utest tailRecursive map0 with map0Tr using eqExpr in
 utest tailRecursive map0Tr with map0Tr using eqExpr in
 

--- a/src/stdlib/pmexpr/tailrecursion.mc
+++ b/src/stdlib/pmexpr/tailrecursion.mc
@@ -78,7 +78,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
   -- the given binding into a tail-recursive form. Otherwise, None is returned.
   sem getTailRecursiveRewriteEnv =
   | t ->
-    let binding : RecLetBinding = t in
+    let binding : DeclLetRecord = t in
     recursive let findExpressionsAtTailPosition : Expr -> [Expr] = lam expr.
       match expr with TmLam t then findExpressionsAtTailPosition t.body
       else match expr with TmLet t then findExpressionsAtTailPosition t.inexpr
@@ -126,7 +126,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
   sem toTailRecursiveForm (env : TailRecursiveEnv) =
   | t ->
     -- env = {binop : Expr, ne : Expr, leftArgRecursion : Bool}
-    let binding : RecLetBinding = t in
+    let binding : DeclLetRecord = t in
 
     -- Generate a new symbol for the name so that we can easily identify calls
     -- to which we need to add an accumulator argument.
@@ -232,11 +232,11 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
 
   sem tailRecursiveRewrite (subMap : Map Name (Info -> Expr)) =
   | t ->
-    let t : RecLetBinding = t in
+    let t : DeclLetRecord = t in
     match getTailRecursiveRewriteEnv t with Some env then
       let env : TailRecursiveEnv = env in
       match toTailRecursiveForm env t with Some tailRecursiveBinding then
-        let binding : RecLetBinding = tailRecursiveBinding in
+        let binding : DeclLetRecord = tailRecursiveBinding in
         let oldIdent = t.ident in
         let replacementFunctionCall = lam info.
           TmApp {
@@ -261,7 +261,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
       (subMap, subFn t.info)
     else (subMap, TmVar t)
   | TmRecLets t ->
-    let tailRecursiveBinding = lam subMap. lam binding : RecLetBinding.
+    let tailRecursiveBinding = lam subMap. lam binding : DeclLetRecord.
       optionGetOrElse
         (lam. (subMap, binding))
         (tailRecursiveRewrite subMap binding)
@@ -272,7 +272,7 @@ lang PMExprTailRecursion = PMExprAst + PMExprFunctionProperties +
       -- Translate calls to rewritten bindings within each binding.
       let bindings =
         map
-          (lam bind : RecLetBinding.
+          (lam bind : DeclLetRecord.
             match tailRecursiveH subMap bind.body with (_, body) then
               {bind with body = body}
             else never)

--- a/src/stdlib/pmexpr/utest-size-constraint.mc
+++ b/src/stdlib/pmexpr/utest-size-constraint.mc
@@ -23,25 +23,25 @@ lang PMExprUtestSizeConstraint = PMExprAst
     findDimension params (addi dim 1) s
 
   sem replaceUtestsWithSizeConstraintH (params : Map Name Type) =
-  | TmDecl {decl = DeclUtest t} ->
+  | TmDecl (x & {decl = DeclUtest t}) ->
     let generateSizeEquality = lam s1 : Expr. lam s2 : Expr.
       match findDimension params 1 s1 with Some (x1, d1) then
         match findDimension params 1 s2 with Some (x2, d2) then
           let ty = tyWithInfo t.info tyunit_ in
-          let inexpr = replaceUtestsWithSizeConstraintH params t.next in
+          let inexpr = replaceUtestsWithSizeConstraintH params x.inexpr in
           let eq = TmParallelSizeEquality {x1 = x1, d1 = d1, x2 = x2, d2 = d2,
                                            ty = ty, info = t.info} in
           Some (TmDecl {decl = DeclLet {ident = nameNoSym "", tyAnnot = ty, tyBody = ty, body = eq,
-                       inexpr = inexpr, ty = t.ty, info = t.info}})
+                       info = t.info}, inexpr = inexpr, ty = x.ty, info = x.info})
         else None ()
       else None () in
     let generateSizeCoercion = lam s : Expr. lam id : Name. lam sizeId : Name.
-      let inexpr = replaceUtestsWithSizeConstraintH params t.next in
+      let inexpr = replaceUtestsWithSizeConstraintH params x.inexpr in
       let coercion =
         TmParallelSizeCoercion {e = s, size = sizeId,
                                 ty = tyTm s, info = infoTm s} in
       TmDecl {decl = DeclLet {ident = id, tyAnnot = tyTm s, tyBody = tyTm s, body = coercion,
-             inexpr = inexpr, ty = t.ty, info = t.info}} in
+             info = t.info}, inexpr = inexpr, ty = x.ty, info = x.info} in
     let result =
       match t.tusing with None _ | Some (TmConst {val = CEqi _}) then
         let p = (t.test, t.expected) in
@@ -59,7 +59,7 @@ lang PMExprUtestSizeConstraint = PMExprAst
         else None ()
       else None () in
     match result with Some e then e
-    else replaceUtestsWithSizeConstraintH params t.next
+    else replaceUtestsWithSizeConstraintH params x.inexpr
   | t -> smap_Expr_Expr (replaceUtestsWithSizeConstraintH params) t
 
   sem replaceUtestsWithSizeConstraint =
@@ -76,7 +76,7 @@ lang PMExprUtestSizeConstraint = PMExprAst
     match extractLambdas (mapEmpty nameCmp) (TmLam t) with (params, body) in
     let newBody = replaceUtestsWithSizeConstraintH params body in
     replaceFunctionBody newBody (TmLam t)
-  | TmDecl {decl = DeclUtest t} -> replaceUtestsWithSizeConstraint t.next
+  | TmDecl (x & {decl = DeclUtest _}) -> replaceUtestsWithSizeConstraint x.inexpr
   | t -> smap_Expr_Expr replaceUtestsWithSizeConstraint t
 end
 
@@ -91,7 +91,7 @@ let preprocess = lam t.
   typeCheck (symbolize t)
 in
 
-let topLevelUtest = preprocess (utest_ (addi_ (int_ 1) (int_ 1)) (int_ 2) unit_) in
+let topLevelUtest = preprocess (bind_ (utest_ (addi_ (int_ 1) (int_ 1)) (int_ 2)) unit_) in
 utest replaceUtestsWithSizeConstraint topLevelUtest with unit_ using eqExpr in
 
 let s = nameSym "s" in
@@ -104,16 +104,16 @@ let exampleTerm = lam inexpr.
       inexpr) in
 
 let utestImplicitUsing = preprocess
-  (exampleTerm (utest_ (length_ (nvar_ s)) (nvar_ n) unit_)) in
-let expected = exampleTerm (nulet_ s (parallelSizeCoercion_ (nvar_ s) n)) in
+  (exampleTerm (bind_ (utest_ (length_ (nvar_ s)) (nvar_ n)) unit_)) in
+let expected = exampleTerm (bind_ (nulet_ s (parallelSizeCoercion_ (nvar_ s) n)) unit_) in
 utest replaceUtestsWithSizeConstraint utestImplicitUsing with expected using eqExpr in
 
 let utestExplicitEqi = preprocess (exampleTerm
-  (utestu_ (length_ (nvar_ s)) (nvar_ n) unit_ (uconst_ (CEqi ())))) in
+  (bind_ (utestu_ (length_ (nvar_ s)) (nvar_ n) (uconst_ (CEqi ()))) unit_)) in
 utest replaceUtestsWithSizeConstraint utestExplicitEqi with expected using eqExpr in
 
 let utestExplicitNonEqi = preprocess (exampleTerm (
-  utestu_ (length_ (nvar_ s)) (nvar_ n) unit_ (uconst_ (CGti ())))) in
+  bind_ (utestu_ (length_ (nvar_ s)) (nvar_ n) (uconst_ (CGti ()))) unit_)) in
 let expected = exampleTerm unit_ in
 utest replaceUtestsWithSizeConstraint utestExplicitNonEqi with expected using eqExpr in
 
@@ -121,18 +121,18 @@ let s1 = nameSym "s1" in
 let s2 = nameSym "s2" in
 let utestSizeEquality = preprocess
   (nlam_ s1 (tyseq_ tyint_) (nlam_ s2 (tyseq_ tyint_)
-    (utest_ (length_ (nvar_ s1)) (length_ (nvar_ s2)) unit_))) in
+    (bind_ (utest_ (length_ (nvar_ s1)) (length_ (nvar_ s2))) unit_))) in
 let expected =
   nlam_ s1 (tyseq_ tyint_) (nlam_ s2 (tyseq_ tyint_)
-    (ulet_ "" (parallelSizeEquality_ s1 1 s2 1))) in
+    (bind_ (ulet_ "" (parallelSizeEquality_ s1 1 s2 1)) unit_)) in
 utest replaceUtestsWithSizeConstraint utestSizeEquality with expected using eqExpr in
 
 let utestSizeEqMultiDim = preprocess
   (nlam_ s1 (tyseq_ (tyseq_ (tyseq_ tyint_))) (nlam_ s2 (tyseq_ (tyseq_ tyint_))
-    (utest_ (length_ (head_ (nvar_ s2))) (length_ (head_ (head_ (nvar_ s1)))) unit_))) in
+    (bind_ (utest_ (length_ (head_ (nvar_ s2))) (length_ (head_ (head_ (nvar_ s1))))) unit_))) in
 let expected =
   nlam_ s1 (tyseq_ tyint_) (nlam_ s2 (tyseq_ tyint_)
-    (ulet_ "" (parallelSizeEquality_ s2 2 s1 3))) in
+    (bind_ (ulet_ "" (parallelSizeEquality_ s2 2 s1 3)) unit_)) in
 utest replaceUtestsWithSizeConstraint utestSizeEqMultiDim with expected using eqExpr in
 
 ()

--- a/src/stdlib/pmexpr/utest-size-constraint.mc
+++ b/src/stdlib/pmexpr/utest-size-constraint.mc
@@ -23,7 +23,7 @@ lang PMExprUtestSizeConstraint = PMExprAst
     findDimension params (addi dim 1) s
 
   sem replaceUtestsWithSizeConstraintH (params : Map Name Type) =
-  | TmUtest t ->
+  | TmDecl {decl = DeclUtest t} ->
     let generateSizeEquality = lam s1 : Expr. lam s2 : Expr.
       match findDimension params 1 s1 with Some (x1, d1) then
         match findDimension params 1 s2 with Some (x2, d2) then
@@ -31,8 +31,8 @@ lang PMExprUtestSizeConstraint = PMExprAst
           let inexpr = replaceUtestsWithSizeConstraintH params t.next in
           let eq = TmParallelSizeEquality {x1 = x1, d1 = d1, x2 = x2, d2 = d2,
                                            ty = ty, info = t.info} in
-          Some (TmLet {ident = nameNoSym "", tyAnnot = ty, tyBody = ty, body = eq,
-                       inexpr = inexpr, ty = t.ty, info = t.info})
+          Some (TmDecl {decl = DeclLet {ident = nameNoSym "", tyAnnot = ty, tyBody = ty, body = eq,
+                       inexpr = inexpr, ty = t.ty, info = t.info}})
         else None ()
       else None () in
     let generateSizeCoercion = lam s : Expr. lam id : Name. lam sizeId : Name.
@@ -40,8 +40,8 @@ lang PMExprUtestSizeConstraint = PMExprAst
       let coercion =
         TmParallelSizeCoercion {e = s, size = sizeId,
                                 ty = tyTm s, info = infoTm s} in
-      TmLet {ident = id, tyAnnot = tyTm s, tyBody = tyTm s, body = coercion,
-             inexpr = inexpr, ty = t.ty, info = t.info} in
+      TmDecl {decl = DeclLet {ident = id, tyAnnot = tyTm s, tyBody = tyTm s, body = coercion,
+             inexpr = inexpr, ty = t.ty, info = t.info}} in
     let result =
       match t.tusing with None _ | Some (TmConst {val = CEqi _}) then
         let p = (t.test, t.expected) in
@@ -76,7 +76,7 @@ lang PMExprUtestSizeConstraint = PMExprAst
     match extractLambdas (mapEmpty nameCmp) (TmLam t) with (params, body) in
     let newBody = replaceUtestsWithSizeConstraintH params body in
     replaceFunctionBody newBody (TmLam t)
-  | TmUtest t -> replaceUtestsWithSizeConstraint t.next
+  | TmDecl {decl = DeclUtest t} -> replaceUtestsWithSizeConstraint t.next
   | t -> smap_Expr_Expr replaceUtestsWithSizeConstraint t
 end
 

--- a/src/stdlib/tuning/call-graph.mc
+++ b/src/stdlib/tuning/call-graph.mc
@@ -56,7 +56,7 @@ let _handleApps = use AppAst in use VarAst in
 -- node exactly once and each time potentially perform a graph union operation,
 -- which we assume has complexity O(|F|). V is the set of nodes in the AST and F
 -- is the set of nodes in the call graph (i.e. set of functions in the AST).
-lang HoleCallGraph = LetAst + AppAst + LamAst + RecLetsAst
+lang HoleCallGraph = LetDeclAst + AppAst + LamAst + RecLetsDeclAst
   sem toCallGraph =
   | arg ->
     let gempty = digraphAddVertex callGraphTop

--- a/src/stdlib/tuning/call-graph.mc
+++ b/src/stdlib/tuning/call-graph.mc
@@ -67,13 +67,13 @@ lang HoleCallGraph = LetDeclAst + AppAst + LamAst + RecLetsDeclAst
     digraphAddEdges edges g
 
   sem _findVertices (vertices: [NameInfo]) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     concat
       (_handleLetVertex _findVertices
         {ident = t.ident, body = t.body, info = t.info})
       (_findVertices vertices t.inexpr)
 
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let res =
       foldl (lam acc. lam b : DeclLetRecord.
                concat acc
@@ -88,15 +88,15 @@ lang HoleCallGraph = LetDeclAst + AppAst + LamAst + RecLetsDeclAst
 
   sem _findEdges (cg : CallGraph) (prev : NameInfo) (name2info : Map Name Info)
                  (edges : [(NameInfo, NameInfo, NameInfo)]) =
-  | TmLet ({body = TmApp a} & t) ->
+  | TmDecl {decl = DeclLet ({body = TmApp a} & t)} ->
     let resBody = _handleApps (t.ident, t.info) _findEdges prev cg name2info t.body in
     concat resBody (_findEdges cg prev name2info edges t.inexpr)
 
-  | TmLet ({body = TmLam lm} & t) ->
+  | TmDecl {decl = DeclLet ({body = TmLam lm} & t)} ->
     let resBody = _findEdges cg (t.ident, t.info) name2info edges lm.body in
     concat resBody (_findEdges cg prev name2info [] t.inexpr)
 
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let res =
       let handleBinding = lam g. lam b : DeclLetRecord.
         match b with { body = TmLam { body = lambody }, ident = ident, info = info } then

--- a/src/stdlib/tuning/call-graph.mc
+++ b/src/stdlib/tuning/call-graph.mc
@@ -75,7 +75,7 @@ lang HoleCallGraph = LetAst + AppAst + LamAst + RecLetsAst
 
   | TmRecLets t ->
     let res =
-      foldl (lam acc. lam b : RecLetBinding.
+      foldl (lam acc. lam b : DeclLetRecord.
                concat acc
                  (_handleLetVertex _findVertices
                    {ident = b.ident, body = b.body, info = b.info}))
@@ -98,7 +98,7 @@ lang HoleCallGraph = LetAst + AppAst + LamAst + RecLetsAst
 
   | TmRecLets t ->
     let res =
-      let handleBinding = lam g. lam b : RecLetBinding.
+      let handleBinding = lam g. lam b : DeclLetRecord.
         match b with { body = TmLam { body = lambody }, ident = ident, info = info } then
           _findEdges g (ident, info) name2info [] lambody
         else

--- a/src/stdlib/tuning/call-graph.mc
+++ b/src/stdlib/tuning/call-graph.mc
@@ -67,20 +67,20 @@ lang HoleCallGraph = LetDeclAst + AppAst + LamAst + RecLetsDeclAst
     digraphAddEdges edges g
 
   sem _findVertices (vertices: [NameInfo]) =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = DeclLet t}) ->
     concat
       (_handleLetVertex _findVertices
         {ident = t.ident, body = t.body, info = t.info})
-      (_findVertices vertices t.inexpr)
+      (_findVertices vertices x.inexpr)
 
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let res =
       foldl (lam acc. lam b : DeclLetRecord.
                concat acc
                  (_handleLetVertex _findVertices
                    {ident = b.ident, body = b.body, info = b.info}))
             [] t.bindings
-    in concat res (_findVertices vertices t.inexpr)
+    in concat res (_findVertices vertices x.inexpr)
 
   | tm ->
 --    sfold_Expr_Expr concat [] (smap_Expr_Expr _findVertices tm)
@@ -88,15 +88,15 @@ lang HoleCallGraph = LetDeclAst + AppAst + LamAst + RecLetsDeclAst
 
   sem _findEdges (cg : CallGraph) (prev : NameInfo) (name2info : Map Name Info)
                  (edges : [(NameInfo, NameInfo, NameInfo)]) =
-  | TmDecl {decl = DeclLet ({body = TmApp a} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({body = TmApp a} & t)}) ->
     let resBody = _handleApps (t.ident, t.info) _findEdges prev cg name2info t.body in
-    concat resBody (_findEdges cg prev name2info edges t.inexpr)
+    concat resBody (_findEdges cg prev name2info edges x.inexpr)
 
-  | TmDecl {decl = DeclLet ({body = TmLam lm} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({body = TmLam lm} & t)}) ->
     let resBody = _findEdges cg (t.ident, t.info) name2info edges lm.body in
-    concat resBody (_findEdges cg prev name2info [] t.inexpr)
+    concat resBody (_findEdges cg prev name2info [] x.inexpr)
 
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let res =
       let handleBinding = lam g. lam b : DeclLetRecord.
         match b with { body = TmLam { body = lambody }, ident = ident, info = info } then
@@ -104,7 +104,7 @@ lang HoleCallGraph = LetDeclAst + AppAst + LamAst + RecLetsDeclAst
         else
           _findEdges g prev name2info [] b.body
       in foldl (lam acc. lam b. concat acc (handleBinding cg b)) [] t.bindings
-    in concat res (_findEdges cg prev name2info edges t.inexpr)
+    in concat res (_findEdges cg prev name2info edges x.inexpr)
 
   | tm ->
     sfold_Expr_Expr (_findEdges cg prev name2info) edges tm
@@ -157,8 +157,9 @@ let constant = {
 } in
 
 -- let foo = lam x. x in ()
+let identityDecl = ulet_ "foo" (ulam_ "x" (var_ "x")) in
 let identity = {
-  ast = ulet_ "foo" (ulam_ "x" (var_ "x")),
+  ast = bind_ identityDecl unit_,
   expected = uunit_,
   vs = ["top", "foo"],
   calls = []
@@ -167,8 +168,10 @@ let identity = {
 -- let foo = lam x. x in
 -- let bar = lam x. foo x in ()
 let funCall = {
-  ast = bind_ (ulet_ "foo" (ulam_ "x" (var_ "x")))
-              (ulet_ "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))),
+  ast = bindall_
+    [ ulet_ "foo" (ulam_ "x" (var_ "x"))
+    , ulet_ "bar" (ulam_ "x" (app_ (var_ "foo") (var_ "x")))
+    ] unit_,
   expected = uunit_,
   vs = ["top", "foo", "bar"],
   calls = [("bar", "foo")]
@@ -178,10 +181,10 @@ let funCall = {
 -- let bar = lam x. addi (foo x) (foo x) in
 -- bar 1
 let ast =
-  bindall_ [identity.ast,
+  bindall_ [identityDecl,
             ulet_ "bar" (ulam_ "x" (addi_ (app_ (var_ "foo") (var_ "x"))
-                                         (app_ (var_ "foo") (var_ "x")))),
-            (app_ (var_ "bar") (int_ 1))] in
+                                         (app_ (var_ "foo") (var_ "x"))))]
+    ((app_ (var_ "bar") (int_ 1))) in
 let callSameFunctionTwice = {
   ast = ast,
   expected = int_ 2,
@@ -207,7 +210,7 @@ let twoArgs = {
 --     addi (bar b) a
 -- in ()
 let innerFun = {
-  ast = ulet_ "foo" (ulam_ "a" (ulam_ "b" (
+  ast = bind_ (ulet_ "foo" (ulam_ "a" (ulam_ "b" (
           let bar = ulet_ "bar" (ulam_ "x"
                          (addi_ (var_ "b") (var_ "x"))) in
           let babar = ulet_ "b" (int_ 3) in
@@ -215,7 +218,7 @@ let innerFun = {
           bind_ babar (
             addi_ (app_ (var_ "bar")
                         (var_ "b"))
-                  (var_ "a")))))),
+                  (var_ "a"))))))) unit_,
   expected = uunit_,
   vs = ["top", "foo", "bar"],
   calls = [("foo", "bar")]
@@ -227,7 +230,7 @@ let innerFun = {
 let letWithFunCall = {
   ast = let foo = ulet_ "foo" (ulam_ "x" (var_ "x")) in
         let a = ulet_ "a" (app_ (var_ "foo") (int_ 1)) in
-        bind_ (bind_ foo a) (var_ "a"),
+        bind_ foo (bind_ a (var_ "a")),
   expected = int_ 1,
   vs = ["top", "foo"],
   calls = [("top", "foo")]
@@ -288,8 +291,8 @@ let evenOdd ={
 let hiddenCall = {
   ast = bindall_ [
           ulet_ "bar" (ulam_ "y" (var_ "y")),
-          ulet_ "foo" (ulam_ "f" (ulam_ "x" (app_ (var_ "f") (var_ "x")))),
-          appf2_ (var_ "foo") (var_ "bar") (int_ 1)],
+          ulet_ "foo" (ulam_ "f" (ulam_ "x" (app_ (var_ "f") (var_ "x"))))]
+          (appf2_ (var_ "foo") (var_ "bar") (int_ 1)),
   expected = int_ 1,
   vs = ["top", "foo", "bar"],
   calls = [("top", "foo")]

--- a/src/stdlib/tuning/context-expansion.mc
+++ b/src/stdlib/tuning/context-expansion.mc
@@ -98,7 +98,7 @@ lang ContextExpand = HoleAst
 
   sem _contextExpandWithLookup (env : CallCtxEnv) (lookup : Int -> Expr) =
   -- Hole: lookup the value depending on call history.
-  | TmLet ({ body = TmHole { depth = depth }, ident = ident} & t) ->
+  | TmDecl {decl = DeclLet ({ body = TmHole { depth = depth }, ident = ident} & t)} ->
     let lookupGlobal = lam info.
       lookup (callCtxHole2Idx (ident, info) [] env)
     in
@@ -116,8 +116,8 @@ lang ContextExpand = HoleAst
         else
           -- Context-sensitive hole without any incoming calls
           lookupGlobal t.info
-    in TmLet {{t with body = body}
-                 with inexpr = _contextExpandWithLookup env lookup t.inexpr}
+    in TmDecl {decl = DeclLet {{t with body = body}
+                 with inexpr = _contextExpandWithLookup env lookup t.inexpr}}
 
   | tm ->
     smap_Expr_Expr (_contextExpandWithLookup env lookup) tm

--- a/src/stdlib/tuning/context-expansion.mc
+++ b/src/stdlib/tuning/context-expansion.mc
@@ -98,7 +98,7 @@ lang ContextExpand = HoleAst
 
   sem _contextExpandWithLookup (env : CallCtxEnv) (lookup : Int -> Expr) =
   -- Hole: lookup the value depending on call history.
-  | TmDecl {decl = DeclLet ({ body = TmHole { depth = depth }, ident = ident} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ body = TmHole { depth = depth }, ident = ident} & t)}) ->
     let lookupGlobal = lam info.
       lookup (callCtxHole2Idx (ident, info) [] env)
     in
@@ -116,8 +116,8 @@ lang ContextExpand = HoleAst
         else
           -- Context-sensitive hole without any incoming calls
           lookupGlobal t.info
-    in TmDecl {decl = DeclLet {{t with body = body}
-                 with inexpr = _contextExpandWithLookup env lookup t.inexpr}}
+    in TmDecl { x with decl = DeclLet {t with body = body}
+              , inexpr = _contextExpandWithLookup env lookup x.inexpr}
 
   | tm ->
     smap_Expr_Expr (_contextExpandWithLookup env lookup) tm
@@ -224,6 +224,11 @@ lang ContextExpand = HoleAst
 
     use MExprSym in
     let impl = symbolize impl in
+    let implDecls =
+      recursive let work = lam acc. lam tm. match tm with TmDecl x
+        then work (snoc acc x.decl) x.inexpr
+        else acc in
+      work [] impl in
 
     let getName : String -> Expr -> Name = lam s. lam expr.
       use MExprFindSym in
@@ -241,23 +246,23 @@ lang ContextExpand = HoleAst
     let p = nameSym "p" in
     let nbr = nameSym "n" in
     bindall_
-    [ impl
-    -- Parse tune file
-    , nulet_ fileContent (readFile_ (str_ tuneFile))
-    , nulet_ strVals (appf2_ (nvar_ strSplitName) (str_ "\n")
-        (app_ (nvar_ strTrimName) (nvar_ fileContent)))
-    , nulet_ nbr (app_ (nvar_ string2intName) (head_ (nvar_ strVals)))
-    , nulet_ strVals (subsequence_ (nvar_ strVals) (int_ 1) (nvar_ nbr))
-    , let x = nameSym "x" in
-      nulet_ strVals (map_ (nulam_ x
-        (get_ (appf2_ (nvar_ strSplitName) (str_ ": ") (nvar_ x)) (int_ 1)))
-        (nvar_ strVals))
-    -- Convert strings into values
-    , nulet_ contextExpansionTableName (map_ (nvar_ string2intName) (nvar_ strVals))
-    -- Convert table into a tensor (for constant-time lookups)
-    , nulet_ contextExpansionTableName (app_ (nvar_ seq2TensorName) (nvar_ contextExpansionTableName))
-    , tm
-    ]
+      (concat implDecls
+      -- Parse tune file
+      [ nulet_ fileContent (readFile_ (str_ tuneFile))
+      , nulet_ strVals (appf2_ (nvar_ strSplitName) (str_ "\n")
+          (app_ (nvar_ strTrimName) (nvar_ fileContent)))
+      , nulet_ nbr (app_ (nvar_ string2intName) (head_ (nvar_ strVals)))
+      , nulet_ strVals (subsequence_ (nvar_ strVals) (int_ 1) (nvar_ nbr))
+      , let x = nameSym "x" in
+        nulet_ strVals (map_ (nulam_ x
+          (get_ (appf2_ (nvar_ strSplitName) (str_ ": ") (nvar_ x)) (int_ 1)))
+          (nvar_ strVals))
+      -- Convert strings into values
+      , nulet_ contextExpansionTableName (map_ (nvar_ string2intName) (nvar_ strVals))
+      -- Convert table into a tensor (for constant-time lookups)
+      , nulet_ contextExpansionTableName (app_ (nvar_ seq2TensorName) (nvar_ contextExpansionTableName))
+      ])
+      tm
 end
 
 lang MExprHoles = HoleAst + GraphColoring + ContextExpand + MExprSym + MExprANF

--- a/src/stdlib/tuning/dependency-analysis.mc
+++ b/src/stdlib/tuning/dependency-analysis.mc
@@ -69,7 +69,7 @@ lang DependencyAnalysis = MExprHoleCFA
   sem buildDependencies (cur : NameInfo) (env : CallCtxEnv)
                         (data : Map Name (Set AbsVal))
                         (acc : (DependencyGraph, Int)) =
-  | TmLet ({ident = ident} & t) ->
+  | TmDecl {decl = DeclLet ({ident = ident} & t)} ->
     match acc with (graph, measCount) in
     let graph : DependencyGraph = graph in
 
@@ -157,10 +157,10 @@ lang DependencyAnalysis = MExprHoleCFA
 
     match buildDependencies curBody env data acc t.body with (acc, body) in
     match buildDependencies cur env data acc t.inexpr with (acc, inexpr) in
-    (acc, TmLet {{t with body = body} with inexpr = inexpr})
+    (acc, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
 
   -- Possibly update cur inside bodies of bindings
-  | TmRecLets ({ bindings = bindings, inexpr = inexpr } & t) ->
+  | TmDecl {decl = DeclRecLets ({ bindings = bindings, inexpr = inexpr } & t)} ->
     match
       mapAccumL (lam acc : (DependencyGraph, Int). lam bind : DeclLetRecord.
         let curBody =
@@ -177,8 +177,8 @@ lang DependencyAnalysis = MExprHoleCFA
     with (acc, newBinds) in
     match buildDependencies cur env data acc inexpr with (acc, inexpr) in
     ( acc,
-      TmRecLets {{t with bindings = newBinds}
-                    with inexpr = inexpr})
+      TmDecl {decl = DeclRecLets {{t with bindings = newBinds}
+                    with inexpr = inexpr}})
 
   | t ->
     smapAccumL_Expr_Expr (buildDependencies cur env data) acc t

--- a/src/stdlib/tuning/dependency-analysis.mc
+++ b/src/stdlib/tuning/dependency-analysis.mc
@@ -162,7 +162,7 @@ lang DependencyAnalysis = MExprHoleCFA
   -- Possibly update cur inside bodies of bindings
   | TmRecLets ({ bindings = bindings, inexpr = inexpr } & t) ->
     match
-      mapAccumL (lam acc : (DependencyGraph, Int). lam bind : RecLetBinding.
+      mapAccumL (lam acc : (DependencyGraph, Int). lam bind : DeclLetRecord.
         let curBody =
           match bind with {body = TmLam lm, ident = ident} then
             if graphHasVertex (ident, t.info) env.callGraph then

--- a/src/stdlib/tuning/dependency-analysis.mc
+++ b/src/stdlib/tuning/dependency-analysis.mc
@@ -69,7 +69,7 @@ lang DependencyAnalysis = MExprHoleCFA
   sem buildDependencies (cur : NameInfo) (env : CallCtxEnv)
                         (data : Map Name (Set AbsVal))
                         (acc : (DependencyGraph, Int)) =
-  | TmDecl {decl = DeclLet ({ident = ident} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ident = ident} & t)}) ->
     match acc with (graph, measCount) in
     let graph : DependencyGraph = graph in
 
@@ -156,11 +156,11 @@ lang DependencyAnalysis = MExprHoleCFA
     in
 
     match buildDependencies curBody env data acc t.body with (acc, body) in
-    match buildDependencies cur env data acc t.inexpr with (acc, inexpr) in
-    (acc, TmDecl {decl = DeclLet {{t with body = body} with inexpr = inexpr}})
+    match buildDependencies cur env data acc x.inexpr with (acc, inexpr) in
+    (acc, TmDecl {x with decl = DeclLet {t with body = body}, inexpr = inexpr})
 
   -- Possibly update cur inside bodies of bindings
-  | TmDecl {decl = DeclRecLets ({ bindings = bindings, inexpr = inexpr } & t)} ->
+  | TmDecl (x & {decl = DeclRecLets ({ bindings = bindings } & t), inexpr = inexpr}) ->
     match
       mapAccumL (lam acc : (DependencyGraph, Int). lam bind : DeclLetRecord.
         let curBody =
@@ -177,8 +177,8 @@ lang DependencyAnalysis = MExprHoleCFA
     with (acc, newBinds) in
     match buildDependencies cur env data acc inexpr with (acc, inexpr) in
     ( acc,
-      TmDecl {decl = DeclRecLets {{t with bindings = newBinds}
-                    with inexpr = inexpr}})
+      TmDecl { x with decl = DeclRecLets {t with bindings = newBinds}
+             , inexpr = inexpr})
 
   | t ->
     smapAccumL_Expr_Expr (buildDependencies cur env data) acc t

--- a/src/stdlib/tuning/graph-coloring.mc
+++ b/src/stdlib/tuning/graph-coloring.mc
@@ -518,7 +518,7 @@ lang GraphColoring = HoleAst + HoleCallGraph
 
   | TmRecLets ({ bindings = bindings, inexpr = inexpr } & t) ->
     match
-      mapAccumL (lam env : CallCtxEnv. lam bind : RecLetBinding.
+      mapAccumL (lam env : CallCtxEnv. lam bind : DeclLetRecord.
         let curBody =
           match bind with { body = TmLam lm } then (bind.ident, bind.info)
           else cur
@@ -569,7 +569,7 @@ lang GraphColoring = HoleAst + HoleCallGraph
 
   | TmRecLets ({ bindings = bindings, inexpr = inexpr } & t) ->
     let newBinds = foldl
-      (lam acc : [RecLetBinding]. lam bind : RecLetBinding.
+      (lam acc : [DeclLetRecord]. lam bind : DeclLetRecord.
         match bind with { body = TmLam lm } then
           match mapLookup bind.ident pub2priv
           with Some local then
@@ -601,7 +601,7 @@ lang GraphColoring = HoleAst + HoleCallGraph
 
   | TmRecLets t ->
     concat
-      (foldl (lam acc. lam bind: RecLetBinding.
+      (foldl (lam acc. lam bind: DeclLetRecord.
          let cur =
            match bind with { body = TmLam lm } then (bind.ident, bind.info)
            else cur

--- a/src/stdlib/tuning/graph-coloring.mc
+++ b/src/stdlib/tuning/graph-coloring.mc
@@ -96,7 +96,7 @@ let _findLetBinding : Name -> use Ast in Expr -> Option (use Ast in Expr) =
   lam name. lam expr.
     recursive let findLetBindingH = lam acc. lam expr.
       match acc with Some e then Some e
-      else match expr with TmLet {ident = ident, body = body, inexpr = inexpr}
+      else match expr with TmDecl {decl = DeclLet {ident = ident, body = body, inexpr = inexpr}}
       then
         if nameEq ident name then Some body
         else match findLetBindingH acc body with Some b then Some b
@@ -476,13 +476,13 @@ lang GraphColoring = HoleAst + HoleCallGraph
   -- updating incoming variables before function calls.
   sem _maintainCallCtx (eqPaths : Map NameInfo [Path]) (cur : NameInfo) (env : CallCtxEnv) =
   -- Application: caller updates incoming variable of callee
-  | TmLet ({ body = TmApp a } & t) ->
+  | TmDecl {decl = DeclLet ({ body = TmApp a } & t)} ->
     match
       match _maintainCallCtx eqPaths cur env t.inexpr with (env, inexpr) in
       match _maintainCallCtx eqPaths cur env t.body with (env, body) in
       ( env,
-        TmLet {{t with inexpr = inexpr}
-                  with body = body})
+        TmDecl {decl = DeclLet {{t with inexpr = inexpr}
+                  with body = body}})
     with (env, le) in
     let env : CallCtxEnv = env in
     -- Track call only if edge is part of the call graph
@@ -501,22 +501,22 @@ lang GraphColoring = HoleAst + HoleCallGraph
       else (env, le) -- not an application with TmVar
     else (env, le) -- caller not part of call graph
 
-  | TmLet ({ body = TmHole { depth = depth }, ident = ident} & t) ->
+  | TmDecl {decl = DeclLet ({ body = TmHole { depth = depth }, ident = ident} & t)} ->
     let paths = mapFindExn (ident, t.info) eqPaths in
     let env = callCtxAddHole t.body (ident, t.info) paths cur env in
     match _maintainCallCtx eqPaths cur env t.inexpr with (env, inexpr) in
-    (env, TmLet {t with inexpr = inexpr})
+    (env, TmDecl {decl = DeclLet {t with inexpr = inexpr}})
 
   -- Function definitions: possibly update cur inside body of function
-  | TmLet ({ body = TmLam lm } & t) ->
+  | TmDecl {decl = DeclLet ({ body = TmLam lm } & t)} ->
     let curBody = (t.ident, t.info) in
     match _maintainCallCtx eqPaths curBody env t.body with (env, body) in
     match _maintainCallCtx eqPaths cur env t.inexpr with (env, inexpr) in
     ( env,
-      TmLet {{t with body = body}
-                with inexpr = inexpr})
+      TmDecl {decl = DeclLet {{t with body = body}
+                with inexpr = inexpr}})
 
-  | TmRecLets ({ bindings = bindings, inexpr = inexpr } & t) ->
+  | TmDecl {decl = DeclRecLets ({ bindings = bindings, inexpr = inexpr } & t)} ->
     match
       mapAccumL (lam env : CallCtxEnv. lam bind : DeclLetRecord.
         let curBody =
@@ -529,8 +529,8 @@ lang GraphColoring = HoleAst + HoleCallGraph
     with (env, newBinds) in
     match _maintainCallCtx eqPaths cur env inexpr with (env, inexpr) in
     ( env,
-      TmRecLets {{t with bindings = newBinds}
-                    with inexpr = inexpr})
+      TmDecl {decl = DeclRecLets {{t with bindings = newBinds}
+                    with inexpr = inexpr}})
   | tm ->
     smapAccumL_Expr_Expr (_maintainCallCtx eqPaths cur) env tm
 
@@ -539,35 +539,35 @@ lang GraphColoring = HoleAst + HoleCallGraph
   -- forward the call to the public functions to their private equivalent.
   sem _replacePublic (pub2priv : Map Name Name) =
   -- Function call: forward call for public function
-  | TmLet ({ body = TmApp a } & t) ->
+  | TmDecl {decl = DeclLet ({ body = TmApp a } & t)} ->
     match _appGetCallee (TmApp a) with Some callee then
       match callee with (callee, _) then
         match mapLookup callee pub2priv
         with Some local then
-          TmLet {{t with body = _appSetCallee (TmApp a) local}
-                    with inexpr = _replacePublic pub2priv t.inexpr}
-        else TmLet {t with inexpr = _replacePublic pub2priv t.inexpr}
+          TmDecl {decl = DeclLet {{t with body = _appSetCallee (TmApp a) local}
+                    with inexpr = _replacePublic pub2priv t.inexpr}}
+        else TmDecl {decl = DeclLet {t with inexpr = _replacePublic pub2priv t.inexpr}}
       else never
-    else TmLet {t with inexpr = _replacePublic pub2priv t.inexpr}
+    else TmDecl {decl = DeclLet {t with inexpr = _replacePublic pub2priv t.inexpr}}
 
   -- Function definition: create private equivalent of public functions
-  | TmLet ({ body = TmLam lm } & t) & tm ->
+  | TmDecl {decl = DeclLet ({ body = TmLam lm } & t)} & tm ->
     match mapLookup t.ident pub2priv
     with Some local then
       match _forwardCall local (_replacePublic pub2priv) {ident = t.ident, body = t.body}
       with (priv, pub) then
         let pubAndRest =
-          TmLet {{{t with ident = pub.ident}
+          TmDecl {decl = DeclLet {{{t with ident = pub.ident}
                      with body = pub.body}
-                     with inexpr = _replacePublic pub2priv t.inexpr}
-        in TmLet {{{t with ident = priv.ident}
+                     with inexpr = _replacePublic pub2priv t.inexpr}}
+        in TmDecl {decl = DeclLet {{{t with ident = priv.ident}
                       with body = priv.body}
-                      with inexpr = pubAndRest}
+                      with inexpr = pubAndRest}}
       else never
-    else TmLet {{t with inexpr = _replacePublic pub2priv t.inexpr}
-                   with body = _replacePublic pub2priv t.body}
+    else TmDecl {decl = DeclLet {{t with inexpr = _replacePublic pub2priv t.inexpr}
+                   with body = _replacePublic pub2priv t.body}}
 
-  | TmRecLets ({ bindings = bindings, inexpr = inexpr } & t) ->
+  | TmDecl {decl = DeclRecLets ({ bindings = bindings, inexpr = inexpr } & t)} ->
     let newBinds = foldl
       (lam acc : [DeclLetRecord]. lam bind : DeclLetRecord.
         match bind with { body = TmLam lm } then
@@ -583,23 +583,23 @@ lang GraphColoring = HoleAst + HoleCallGraph
           else cons bind acc
         else cons bind acc)
       [] bindings
-    in TmRecLets {{t with bindings = newBinds}
-                     with inexpr = _replacePublic pub2priv t.inexpr}
+    in TmDecl {decl = DeclRecLets {{t with bindings = newBinds}
+                     with inexpr = _replacePublic pub2priv t.inexpr}}
 
   | tm -> smap_Expr_Expr (_replacePublic pub2priv) tm
 
   -- Finds the home vertex and equivalence path for each hole.
   sem _eqPaths (g : CallGraph) (public : [NameInfo]) (cur : NameInfo) (acc: [EqPaths]) =
-  | TmLet ({body = TmHole {depth = depth}, ident = ident} & t) ->
+  | TmDecl {decl = DeclLet ({body = TmHole {depth = depth}, ident = ident} & t)} ->
     let paths = eqPaths g cur depth public in
     cons {id=(ident, t.info), home=cur, eqPaths=paths}
       (_eqPaths g public cur acc t.inexpr)
 
-  | TmLet ({ body = TmLam lm } & t) ->
+  | TmDecl {decl = DeclLet ({ body = TmLam lm } & t)} ->
     concat (_eqPaths g public (t.ident, t.info) acc t.body)
            (_eqPaths g public cur [] t.inexpr)
 
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     concat
       (foldl (lam acc. lam bind: DeclLetRecord.
          let cur =

--- a/src/stdlib/tuning/graph-coloring.mc
+++ b/src/stdlib/tuning/graph-coloring.mc
@@ -96,7 +96,7 @@ let _findLetBinding : Name -> use Ast in Expr -> Option (use Ast in Expr) =
   lam name. lam expr.
     recursive let findLetBindingH = lam acc. lam expr.
       match acc with Some e then Some e
-      else match expr with TmDecl {decl = DeclLet {ident = ident, body = body, inexpr = inexpr}}
+      else match expr with TmDecl {decl = DeclLet {ident = ident, body = body}, inexpr = inexpr}
       then
         if nameEq ident name then Some body
         else match findLetBindingH acc body with Some b then Some b
@@ -262,7 +262,7 @@ let callCtxHole2Idx : NameInfo -> [NameInfo] -> CallCtxEnv -> Int =
       mapFindExn path (mapFindExn nameInfo hole2idx)
     else never
 
-let callCtxDeclareIncomingVars : Int -> CallCtxEnv -> [use Ast in Expr] =
+let callCtxDeclareIncomingVars : Int -> CallCtxEnv -> [use Ast in Decl] =
   lam init : Int. lam env : CallCtxEnv.
     match env with { threadPoolInfo = threadPoolInfo } then
       switch threadPoolInfo
@@ -289,9 +289,9 @@ let callCtxReadIncomingVar : Name -> CallCtxEnv -> use Ast in Expr =
         let idxName = nameSym "idx" in
         bindall_
         [ nulet_ idxName (app_
-          (deref_ (nvar_ id2idxName)) uunit_)
-        , deref_ (tensorGetExn_ tyunknown_ (nvar_ iv) (seq_ [nvar_ idxName]))
-        ]
+          (deref_ (nvar_ id2idxName)) uunit_)]
+        ( deref_ (tensorGetExn_ tyunknown_ (nvar_ iv) (seq_ [nvar_ idxName]))
+        )
       case None () then
         deref_ (nvar_ iv)
       end
@@ -305,9 +305,9 @@ let callCtxModifyIncomingVar : Name -> Int -> CallCtxEnv -> use Ast in Expr =
         let idxName = nameSym "idx" in
         bindall_
         [ nulet_ idxName (app_
-          (deref_ (nvar_ id2idxName)) uunit_)
-        , modref_ (tensorGetExn_ tyunknown_ (nvar_ iv) (seq_ [nvar_ idxName])) (int_ v)
-        ]
+          (deref_ (nvar_ id2idxName)) uunit_)]
+        ( modref_ (tensorGetExn_ tyunknown_ (nvar_ iv) (seq_ [nvar_ idxName])) (int_ v)
+        )
       case None () then
         modref_ (nvar_ iv) (int_ v)
       end
@@ -460,13 +460,8 @@ lang GraphColoring = HoleAst + HoleCallGraph
     let env = callCtxInit publicFns pruned tm in
 
     -- Declare the incoming variables
-    let incVars =
-      let exprs =
-        callCtxDeclareIncomingVars _incUndef env in
-      if null exprs then uunit_
-      else bindall_ exprs
-    in
-    let tm = bind_ incVars tm in
+    let incVars = callCtxDeclareIncomingVars _incUndef env in
+    let tm = bindall_ incVars tm in
 
     -- Transform program to maintain the call history when needed
     match _maintainCallCtx eqPathsMap callGraphTop env tm with (env, prog) in
@@ -476,13 +471,13 @@ lang GraphColoring = HoleAst + HoleCallGraph
   -- updating incoming variables before function calls.
   sem _maintainCallCtx (eqPaths : Map NameInfo [Path]) (cur : NameInfo) (env : CallCtxEnv) =
   -- Application: caller updates incoming variable of callee
-  | TmDecl {decl = DeclLet ({ body = TmApp a } & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ body = TmApp a } & t)}) ->
     match
-      match _maintainCallCtx eqPaths cur env t.inexpr with (env, inexpr) in
+      match _maintainCallCtx eqPaths cur env x.inexpr with (env, inexpr) in
       match _maintainCallCtx eqPaths cur env t.body with (env, body) in
       ( env,
-        TmDecl {decl = DeclLet {{t with inexpr = inexpr}
-                  with body = body}})
+        TmDecl { x with decl = DeclLet {t with body = body}
+               , inexpr = inexpr})
     with (env, le) in
     let env : CallCtxEnv = env in
     -- Track call only if edge is part of the call graph
@@ -501,22 +496,22 @@ lang GraphColoring = HoleAst + HoleCallGraph
       else (env, le) -- not an application with TmVar
     else (env, le) -- caller not part of call graph
 
-  | TmDecl {decl = DeclLet ({ body = TmHole { depth = depth }, ident = ident} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ body = TmHole { depth = depth }, ident = ident} & t)}) ->
     let paths = mapFindExn (ident, t.info) eqPaths in
     let env = callCtxAddHole t.body (ident, t.info) paths cur env in
-    match _maintainCallCtx eqPaths cur env t.inexpr with (env, inexpr) in
-    (env, TmDecl {decl = DeclLet {t with inexpr = inexpr}})
+    match _maintainCallCtx eqPaths cur env x.inexpr with (env, inexpr) in
+    (env, TmDecl {x with inexpr = inexpr})
 
   -- Function definitions: possibly update cur inside body of function
-  | TmDecl {decl = DeclLet ({ body = TmLam lm } & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ body = TmLam lm } & t)}) ->
     let curBody = (t.ident, t.info) in
     match _maintainCallCtx eqPaths curBody env t.body with (env, body) in
-    match _maintainCallCtx eqPaths cur env t.inexpr with (env, inexpr) in
+    match _maintainCallCtx eqPaths cur env x.inexpr with (env, inexpr) in
     ( env,
-      TmDecl {decl = DeclLet {{t with body = body}
-                with inexpr = inexpr}})
+      TmDecl { x with decl = DeclLet {t with body = body}
+             , inexpr = inexpr})
 
-  | TmDecl {decl = DeclRecLets ({ bindings = bindings, inexpr = inexpr } & t)} ->
+  | TmDecl (x & {decl = DeclRecLets ({ bindings = bindings } & t), inexpr = inexpr}) ->
     match
       mapAccumL (lam env : CallCtxEnv. lam bind : DeclLetRecord.
         let curBody =
@@ -529,8 +524,8 @@ lang GraphColoring = HoleAst + HoleCallGraph
     with (env, newBinds) in
     match _maintainCallCtx eqPaths cur env inexpr with (env, inexpr) in
     ( env,
-      TmDecl {decl = DeclRecLets {{t with bindings = newBinds}
-                    with inexpr = inexpr}})
+      TmDecl { x with decl = DeclRecLets {t with bindings = newBinds}
+             , inexpr = inexpr})
   | tm ->
     smapAccumL_Expr_Expr (_maintainCallCtx eqPaths cur) env tm
 
@@ -539,35 +534,33 @@ lang GraphColoring = HoleAst + HoleCallGraph
   -- forward the call to the public functions to their private equivalent.
   sem _replacePublic (pub2priv : Map Name Name) =
   -- Function call: forward call for public function
-  | TmDecl {decl = DeclLet ({ body = TmApp a } & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ body = TmApp a } & t)}) ->
     match _appGetCallee (TmApp a) with Some callee then
       match callee with (callee, _) then
         match mapLookup callee pub2priv
         with Some local then
-          TmDecl {decl = DeclLet {{t with body = _appSetCallee (TmApp a) local}
-                    with inexpr = _replacePublic pub2priv t.inexpr}}
-        else TmDecl {decl = DeclLet {t with inexpr = _replacePublic pub2priv t.inexpr}}
+          TmDecl { x with decl = DeclLet {t with body = _appSetCallee (TmApp a) local}
+                 , inexpr = _replacePublic pub2priv x.inexpr}
+        else TmDecl {x with inexpr = _replacePublic pub2priv x.inexpr}
       else never
-    else TmDecl {decl = DeclLet {t with inexpr = _replacePublic pub2priv t.inexpr}}
+    else TmDecl {x with inexpr = _replacePublic pub2priv x.inexpr}
 
   -- Function definition: create private equivalent of public functions
-  | TmDecl {decl = DeclLet ({ body = TmLam lm } & t)} & tm ->
+  | TmDecl (x & {decl = DeclLet ({ body = TmLam lm } & t)}) & tm ->
     match mapLookup t.ident pub2priv
     with Some local then
       match _forwardCall local (_replacePublic pub2priv) {ident = t.ident, body = t.body}
       with (priv, pub) then
         let pubAndRest =
-          TmDecl {decl = DeclLet {{{t with ident = pub.ident}
-                     with body = pub.body}
-                     with inexpr = _replacePublic pub2priv t.inexpr}}
-        in TmDecl {decl = DeclLet {{{t with ident = priv.ident}
-                      with body = priv.body}
-                      with inexpr = pubAndRest}}
+          TmDecl { x with decl = DeclLet {t with ident = pub.ident, body = pub.body}
+                 , inexpr = _replacePublic pub2priv x.inexpr}
+        in TmDecl { x with decl = DeclLet {t with ident = priv.ident, body = priv.body}
+                  , inexpr = pubAndRest}
       else never
-    else TmDecl {decl = DeclLet {{t with inexpr = _replacePublic pub2priv t.inexpr}
-                   with body = _replacePublic pub2priv t.body}}
+    else TmDecl { x with decl = DeclLet {t with body = _replacePublic pub2priv t.body}
+                , inexpr = _replacePublic pub2priv x.inexpr}
 
-  | TmDecl {decl = DeclRecLets ({ bindings = bindings, inexpr = inexpr } & t)} ->
+  | TmDecl (x & {decl = DeclRecLets ({ bindings = bindings } & t), inexpr = inexpr}) ->
     let newBinds = foldl
       (lam acc : [DeclLetRecord]. lam bind : DeclLetRecord.
         match bind with { body = TmLam lm } then
@@ -583,23 +576,23 @@ lang GraphColoring = HoleAst + HoleCallGraph
           else cons bind acc
         else cons bind acc)
       [] bindings
-    in TmDecl {decl = DeclRecLets {{t with bindings = newBinds}
-                     with inexpr = _replacePublic pub2priv t.inexpr}}
+    in TmDecl { x with decl = DeclRecLets {t with bindings = newBinds}
+              , inexpr = _replacePublic pub2priv x.inexpr}
 
   | tm -> smap_Expr_Expr (_replacePublic pub2priv) tm
 
   -- Finds the home vertex and equivalence path for each hole.
   sem _eqPaths (g : CallGraph) (public : [NameInfo]) (cur : NameInfo) (acc: [EqPaths]) =
-  | TmDecl {decl = DeclLet ({body = TmHole {depth = depth}, ident = ident} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({body = TmHole {depth = depth}, ident = ident} & t)}) ->
     let paths = eqPaths g cur depth public in
     cons {id=(ident, t.info), home=cur, eqPaths=paths}
-      (_eqPaths g public cur acc t.inexpr)
+      (_eqPaths g public cur acc x.inexpr)
 
-  | TmDecl {decl = DeclLet ({ body = TmLam lm } & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ body = TmLam lm } & t)}) ->
     concat (_eqPaths g public (t.ident, t.info) acc t.body)
-           (_eqPaths g public cur [] t.inexpr)
+           (_eqPaths g public cur [] x.inexpr)
 
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     concat
       (foldl (lam acc. lam bind: DeclLetRecord.
          let cur =
@@ -607,7 +600,7 @@ lang GraphColoring = HoleAst + HoleCallGraph
            else cur
          in concat acc (_eqPaths g public cur [] bind.body))
          [] t.bindings)
-      (_eqPaths g public cur acc t.inexpr)
+      (_eqPaths g public cur acc x.inexpr)
 
   | tm ->
     sfold_Expr_Expr (_eqPaths g public cur) acc tm

--- a/src/stdlib/tuning/hole-cfa.mc
+++ b/src/stdlib/tuning/hole-cfa.mc
@@ -215,7 +215,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
   sem generateHoleConstraints (graph: CFAGraphInit) =
   | _ -> graph
     -- Holes
-  | TmLet { ident = ident, body = TmHole _, info = info} ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmHole _, info = info}} ->
     match graph with {graphData = graphData} in
     match graphData with Some (HoleCtxInfo {contextMap = contextMap}) then
       let ident = name2intAcc graph.ia info ident in
@@ -226,7 +226,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
       let cstr = CstrInit {lhs = av, rhs = ident } in
       { graph with cstrs = cons cstr graph.cstrs }
     else errorSingle [info] "Expected context information"
-  | TmLet { ident = ident, body = TmConst { val = c }, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmConst { val = c }, info = info }} ->
     let arity = constArity c in
     let cstrs =
       if eqi arity 0 then []
@@ -235,7 +235,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
                rhs = name2intAcc graph.ia info ident } ]
     in
     { graph with cstrs = concat cstrs graph.cstrs }
-  | TmLet { ident = ident, body = TmApp app, info = info } ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmApp app, info = info }} ->
     match app.lhs with TmVar l then
       match app.rhs with TmVar r then
         let lhs = name2intAcc graph.ia l.info l.ident in
@@ -248,7 +248,7 @@ lang MExprHoleCFA = HoleAst + MExprCFA + MExprArity
         { graph with cstrs = concat cstrs graph.cstrs }
       else errorSingle [infoTm app.rhs] "Not a TmVar in application"
     else errorSingle [infoTm app.lhs] "Not a TmVar in application"
-  | TmLet { ident = ident, body = TmIndependent t, info = info} ->
+  | TmDecl {decl = DeclLet { ident = ident, body = TmIndependent t, info = info}} ->
     match t.lhs with TmVar lhs then
       match t.rhs with TmVar rhs then
         let lhs = name2intAcc graph.ia lhs.info lhs.ident in

--- a/src/stdlib/tuning/instrumentation.mc
+++ b/src/stdlib/tuning/instrumentation.mc
@@ -73,7 +73,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
   -- Recursive helper for instrument
   sem instrumentH (env : CallCtxEnv) (graph : DependencyGraph) (str2name : String -> Name) =
   | TmRecLets r ->
-    let lets : [Name] = map (lam b: RecLetBinding. b.ident) r.bindings in
+    let lets : [Name] = map (lam b: DeclLetRecord. b.ident) r.bindings in
     match lets with [] then instrumentH env graph str2name r.inexpr
     else
       -- Identify a reclet by the ident of its first binding
@@ -128,7 +128,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
           -- Contains a tail call?
           if setMem (head ids) tailCallsSet then
             -- Yes, acquire lock. The lock is released in a base case.
-            (ids, lam e. bindSemi_ (app_ (nvar_ acquireLock) id) e)
+            (ids, lam e. semi_ (app_ (nvar_ acquireLock) id) e)
           else
             -- No, acquire and release lock directly after.
             let f = lam e.
@@ -168,7 +168,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
     let releaseExpr =
       if null ids then uunit_ else
       let releaseLock = str2name "releaseLock" in
-      foldr1 bindSemi_ (map (lam id. app_ (nvar_ releaseLock) (int_ id)) ids)
+      foldr1 semi_ (map (lam id. app_ (nvar_ releaseLock) (int_ id)) ids)
     in
     let semi = nameSym "" in
     bindall_

--- a/src/stdlib/tuning/instrumentation.mc
+++ b/src/stdlib/tuning/instrumentation.mc
@@ -51,12 +51,9 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
     let expr = instrumentH env graph str2name t in
 
     -- Put together the final AST
-    let ast =
-      bindall_
-      [ header
-      , bindSemi_ expr footer
-      , appf2_ (nvar_ dumpToFile) (nvar_ (str2name "log")) (nvar_ (str2name "lock"))
-      ]
+    let ast = foldr oldBindSemi_
+      (appf2_ (nvar_ dumpToFile) (nvar_ (str2name "log")) (nvar_ (str2name "lock")))
+      [header, expr, footer]
     in
     let res = {fileName = fileName, cleanup = lam. sysTempDirDelete tempDir (); ()} in
     (res, ast)
@@ -72,9 +69,9 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
 
   -- Recursive helper for instrument
   sem instrumentH (env : CallCtxEnv) (graph : DependencyGraph) (str2name : String -> Name) =
-  | TmDecl {decl = DeclRecLets r} ->
+  | tm & TmDecl (x & {decl = DeclRecLets r}) ->
     let lets : [Name] = map (lam b: DeclLetRecord. b.ident) r.bindings in
-    match lets with [] then instrumentH env graph str2name r.inexpr
+    match lets with [] then instrumentH env graph str2name x.inexpr
     else
       -- Identify a reclet by the ident of its first binding
       let reclet = head lets in
@@ -100,7 +97,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
         in
         (ids, lam x. x)
       in
-      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmDecl {decl = DeclRecLets r}) with
+      match tailPositionsReclet baseCase tailCall letexpr ids acc tm with
       (tailCalls, _) in
       let tailCallsSet = setOfSeq subi tailCalls in
       let tailCalls = setToSeq tailCallsSet in
@@ -132,39 +129,35 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
           else
             -- No, acquire and release lock directly after.
             let f = lam e.
-              match e with TmDecl {decl = DeclLet t} in
-              let expr = TmDecl {decl = DeclLet {t with inexpr = uunit_}} in
+              match e with TmDecl (x & {decl = decl & DeclLet _}) in
               let i = nameSym "iid" in
               let semi = nameSym "" in
               bindall_
               [ nulet_ i id
               , nulet_ semi (app_ (nvar_ acquireLock) (nvar_ i))
-              , expr
-              , nulet_ semi (app_ (nvar_ releaseLock) (nvar_ i))
-              , t.inexpr
-              ]
+              , decl
+              , nulet_ semi (app_ (nvar_ releaseLock) (nvar_ i))]
+              x.inexpr
             in (ids, f)
         else ([], lam x. x)
       in
-      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmDecl {decl = DeclRecLets r})
-      with (_, TmDecl {decl = DeclRecLets r}) in
-      TmDecl {decl = DeclRecLets {r with inexpr = instrumentH env graph str2name r.inexpr}}
+      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmDecl {x with decl = DeclRecLets r})
+      with (_, TmDecl (x & {decl = DeclRecLets r})) in
+      TmDecl {x with inexpr = instrumentH env graph str2name x.inexpr}
 
-  | TmDecl {decl = DeclLet t} ->
+  | tm & TmDecl (x & {decl = decl & DeclLet t}) ->
     match mapLookup t.ident graph.measuringPoints with Some tree then
       let ids = prefixTreeGetIds tree [] in
-      let expr = TmDecl {decl = DeclLet {t with inexpr = uunit_}} in
-      let id = idExpr (infoTm (TmDecl {decl = DeclLet t})) t.ident graph env tree ids in
-      instrumentPoint env graph str2name expr t.inexpr id
-    else smap_Expr_Expr (instrumentH env graph str2name) (TmDecl {decl = DeclLet t})
+      let id = idExpr t.info t.ident graph env tree ids in
+      instrumentPoint env graph str2name decl x.inexpr id
+    else smap_Expr_Expr (instrumentH env graph str2name) tm
   | t -> smap_Expr_Expr (instrumentH env graph str2name) t
 
 
   sem instrumentBaseCase (ids: [Int]) (str2name: String -> Name) =
-  | TmDecl {decl = DeclLet t} ->
+  | TmDecl (x & {decl = decl & DeclLet t}) ->
     -- Instrument a base case: Release locks of _all_ measuring points that
     -- have tail-recursive calls.
-    let expr = TmDecl {decl = DeclLet {t with inexpr = uunit_}} in
     let releaseExpr =
       if null ids then uunit_ else
       let releaseLock = str2name "releaseLock" in
@@ -172,25 +165,23 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
     in
     let semi = nameSym "" in
     bindall_
-    [ expr
-    , nulet_ semi releaseExpr
-    , t.inexpr
-    ]
+    [ decl
+    , nulet_ semi releaseExpr]
+    x.inexpr
 
   -- Insert instrumentation code around a measuring point. Assumes that the
   -- point does not contain any tail calls.
   sem instrumentPoint (env : CallCtxEnv) (graph : DependencyGraph)
-        (str2name : String -> Name) (expr : Expr) (inexpr : Expr) =
+        (str2name : String -> Name) (decl : Decl) (inexpr : Expr) =
   | id ->
     let i = nameSym "iid" in
     let semi = nameSym "" in
     bindall_
     [ nulet_ i id
     , nulet_ semi (app_ (nvar_ (str2name "acquireLock")) (nvar_ i))
-    , expr
-    , nulet_ semi (app_ (nvar_ (str2name "releaseLock")) (nvar_ i))
-    , instrumentH env graph str2name inexpr
-    ]
+    , decl
+    , nulet_ semi (app_ (nvar_ (str2name "releaseLock")) (nvar_ i))]
+    (instrumentH env graph str2name inexpr)
 
   sem instrumentHeader =
   | (size, offset) ->

--- a/src/stdlib/tuning/instrumentation.mc
+++ b/src/stdlib/tuning/instrumentation.mc
@@ -72,7 +72,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
 
   -- Recursive helper for instrument
   sem instrumentH (env : CallCtxEnv) (graph : DependencyGraph) (str2name : String -> Name) =
-  | TmRecLets r ->
+  | TmDecl {decl = DeclRecLets r} ->
     let lets : [Name] = map (lam b: DeclLetRecord. b.ident) r.bindings in
     match lets with [] then instrumentH env graph str2name r.inexpr
     else
@@ -93,14 +93,14 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
         let ids =
           if not (null ids) then ids
           else
-            match expr with TmLet t in
+            match expr with TmDecl {decl = DeclLet t} in
             match mapLookup t.ident graph.measuringPoints with Some tree then
               prefixTreeGetIds tree []
             else []
         in
         (ids, lam x. x)
       in
-      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmRecLets r) with
+      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmDecl {decl = DeclRecLets r}) with
       (tailCalls, _) in
       let tailCallsSet = setOfSeq subi tailCalls in
       let tailCalls = setToSeq tailCallsSet in
@@ -120,7 +120,7 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
       let letexpr = lam ids. lam expr.
         -- Check if a let expression is a measuring point
         if not (null ids) then (ids, lam x. x) else
-        match expr with TmLet t in
+        match expr with TmDecl {decl = DeclLet t} in
         match mapLookup t.ident graph.measuringPoints with Some tree then
           -- Found measuring point
           let ids = prefixTreeGetIds tree [] in
@@ -132,8 +132,8 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
           else
             -- No, acquire and release lock directly after.
             let f = lam e.
-              match e with TmLet t in
-              let expr = TmLet {t with inexpr = uunit_} in
+              match e with TmDecl {decl = DeclLet t} in
+              let expr = TmDecl {decl = DeclLet {t with inexpr = uunit_}} in
               let i = nameSym "iid" in
               let semi = nameSym "" in
               bindall_
@@ -146,25 +146,25 @@ lang Instrumentation = MExprAst + HoleAst + TailPositions
             in (ids, f)
         else ([], lam x. x)
       in
-      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmRecLets r)
-      with (_, TmRecLets r) in
-      TmRecLets {r with inexpr = instrumentH env graph str2name r.inexpr}
+      match tailPositionsReclet baseCase tailCall letexpr ids acc (TmDecl {decl = DeclRecLets r})
+      with (_, TmDecl {decl = DeclRecLets r}) in
+      TmDecl {decl = DeclRecLets {r with inexpr = instrumentH env graph str2name r.inexpr}}
 
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     match mapLookup t.ident graph.measuringPoints with Some tree then
       let ids = prefixTreeGetIds tree [] in
-      let expr = TmLet {t with inexpr = uunit_} in
-      let id = idExpr (infoTm (TmLet t)) t.ident graph env tree ids in
+      let expr = TmDecl {decl = DeclLet {t with inexpr = uunit_}} in
+      let id = idExpr (infoTm (TmDecl {decl = DeclLet t})) t.ident graph env tree ids in
       instrumentPoint env graph str2name expr t.inexpr id
-    else smap_Expr_Expr (instrumentH env graph str2name) (TmLet t)
+    else smap_Expr_Expr (instrumentH env graph str2name) (TmDecl {decl = DeclLet t})
   | t -> smap_Expr_Expr (instrumentH env graph str2name) t
 
 
   sem instrumentBaseCase (ids: [Int]) (str2name: String -> Name) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     -- Instrument a base case: Release locks of _all_ measuring points that
     -- have tail-recursive calls.
-    let expr = TmLet {t with inexpr = uunit_} in
+    let expr = TmDecl {decl = DeclLet {t with inexpr = uunit_}} in
     let releaseExpr =
       if null ids then uunit_ else
       let releaseLock = str2name "releaseLock" in

--- a/src/stdlib/tuning/nested.mc
+++ b/src/stdlib/tuning/nested.mc
@@ -162,14 +162,14 @@ lang NestedMeasuringPoints = MExprHoleCFA
       -- Lambda expression not reachable, we are done.
       acc
 
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmApp app } & t)} ->
-    let resInexpr = _measEnclosingLam data avLams cur acc t.inexpr in
+  | TmDecl (x & {decl = DeclLet { ident = ident, body = TmApp app }}) ->
+    let resInexpr = _measEnclosingLam data avLams cur acc x.inexpr in
     match mapLookup ident data with Some eholes then
       concat [(ident, eholes, cur)] resInexpr
     else resInexpr
 
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)} ->
-    let resInexpr = _measEnclosingLam data avLams cur acc t.inexpr in
+  | TmDecl (x & {decl = DeclLet { ident = ident, body = TmMatch m }}) ->
+    let resInexpr = _measEnclosingLam data avLams cur acc x.inexpr in
     let resMatch = sfold_Expr_Expr (_measEnclosingLam data avLams cur) [] (TmMatch m) in
     match mapLookup ident data with Some eholes then
       join [[(ident, eholes, cur)], resInexpr, resMatch]
@@ -191,10 +191,10 @@ lang NestedMeasuringPoints = MExprHoleCFA
   -- A match is the only type of measuring point that can have a nested
   -- measuring point, since it is the only one that consists of several
   -- subexpressions.
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)}) ->
     let resInexpr =
       augmentDependencies
-        im env enclosingLam measInLam measSet data dataEholes callGraph acc t.inexpr
+        im env enclosingLam measInLam measSet data dataEholes callGraph acc x.inexpr
     in
     let resMatch = sfold_Expr_Expr (
         augmentDependencies im env enclosingLam measInLam measSet data dataEholes callGraph)
@@ -251,7 +251,7 @@ lang NestedMeasuringPoints = MExprHoleCFA
                            (dataEholes : Map Name [AbsVal])
                            (callGraph : Digraph Name Symbol)
                            (acc : [AbsVal]) =
-  | TmDecl {decl = DeclLet ({body = TmApp app} & t)} ->
+  | TmDecl (x & {decl = DeclLet ({body = TmApp app} & t)}) ->
     let resBody =
       match app.lhs with TmVar v then
         match mapLookup v.ident data with Some avs then
@@ -287,14 +287,14 @@ lang NestedMeasuringPoints = MExprHoleCFA
     let resLet = optionGetOr [] (mapLookup t.ident dataEholes) in
     let resInexpr = sfold_Expr_Expr
       (augmentDependenciesH ident im env enclosingLam measInLam measSet data dataEholes callGraph)
-      acc t.inexpr
+      acc x.inexpr
     in join [resBody, resLet, resInexpr]
 
-  | TmDecl {decl = DeclLet t} ->
+  | tm & TmDecl {decl = DeclLet t} ->
     let resLet = optionGetOr [] (mapLookup t.ident dataEholes) in
     let resRest = sfold_Expr_Expr
         (augmentDependenciesH ident im env enclosingLam measInLam measSet data dataEholes callGraph)
-        acc (TmDecl {decl = DeclLet t})
+        acc tm
     in concat resLet resRest
 
   | t ->
@@ -309,9 +309,9 @@ lang NestedMeasuringPoints = MExprHoleCFA
   sem collectSyntacticallyScoped (eholes : Map Name [AbsVal]) (acc : [Name]) =
   -- Need only consider match expressions, by same logic as for
   -- 'augmentDependencies'
-  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)} ->
+  | TmDecl (x & {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)}) ->
     -- Recurse inexpr and body
-    let resInexpr = collectSyntacticallyScoped eholes acc t.inexpr in
+    let resInexpr = collectSyntacticallyScoped eholes acc x.inexpr in
     let resMatch = sfold_Expr_Expr (collectSyntacticallyScoped eholes)
         [] (TmMatch m)
     in
@@ -328,10 +328,10 @@ lang NestedMeasuringPoints = MExprHoleCFA
 
   -- Return the measuring points syntactically scoped in an expression
   sem collectSyntacticallyScopedH (eholes : Map Name [AbsVal]) (acc: [Name]) =
-  | TmDecl {decl = DeclLet t} ->
+  | tm & TmDecl {decl = DeclLet t} ->
     let resLet = if mapMem t.ident eholes then [t.ident] else [] in
     let resRest = sfold_Expr_Expr (collectSyntacticallyScopedH eholes)
-        acc (TmDecl {decl = DeclLet t})
+        acc tm
     in concat resLet resRest
 
   | t ->

--- a/src/stdlib/tuning/nested.mc
+++ b/src/stdlib/tuning/nested.mc
@@ -147,7 +147,7 @@ lang NestedMeasuringPoints = MExprHoleCFA
       in concat res acc
     else errorSingle [infoTm t.lhs] "Not a TmVar in application"
 
-  | TmExt t -> acc
+  | TmDecl {decl = DeclExt t} -> acc
 
   | t ->
     sfold_Expr_Expr (_callGraphEdges im data avLams cur) acc t
@@ -162,13 +162,13 @@ lang NestedMeasuringPoints = MExprHoleCFA
       -- Lambda expression not reachable, we are done.
       acc
 
-  | TmLet ({ ident = ident, body = TmApp app } & t) ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmApp app } & t)} ->
     let resInexpr = _measEnclosingLam data avLams cur acc t.inexpr in
     match mapLookup ident data with Some eholes then
       concat [(ident, eholes, cur)] resInexpr
     else resInexpr
 
-  | TmLet ({ ident = ident, body = TmMatch m } & t) ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)} ->
     let resInexpr = _measEnclosingLam data avLams cur acc t.inexpr in
     let resMatch = sfold_Expr_Expr (_measEnclosingLam data avLams cur) [] (TmMatch m) in
     match mapLookup ident data with Some eholes then
@@ -191,7 +191,7 @@ lang NestedMeasuringPoints = MExprHoleCFA
   -- A match is the only type of measuring point that can have a nested
   -- measuring point, since it is the only one that consists of several
   -- subexpressions.
-  | TmLet ({ ident = ident, body = TmMatch m } & t) ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)} ->
     let resInexpr =
       augmentDependencies
         im env enclosingLam measInLam measSet data dataEholes callGraph acc t.inexpr
@@ -251,7 +251,7 @@ lang NestedMeasuringPoints = MExprHoleCFA
                            (dataEholes : Map Name [AbsVal])
                            (callGraph : Digraph Name Symbol)
                            (acc : [AbsVal]) =
-  | TmLet ({body = TmApp app} & t) ->
+  | TmDecl {decl = DeclLet ({body = TmApp app} & t)} ->
     let resBody =
       match app.lhs with TmVar v then
         match mapLookup v.ident data with Some avs then
@@ -290,11 +290,11 @@ lang NestedMeasuringPoints = MExprHoleCFA
       acc t.inexpr
     in join [resBody, resLet, resInexpr]
 
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let resLet = optionGetOr [] (mapLookup t.ident dataEholes) in
     let resRest = sfold_Expr_Expr
         (augmentDependenciesH ident im env enclosingLam measInLam measSet data dataEholes callGraph)
-        acc (TmLet t)
+        acc (TmDecl {decl = DeclLet t})
     in concat resLet resRest
 
   | t ->
@@ -309,7 +309,7 @@ lang NestedMeasuringPoints = MExprHoleCFA
   sem collectSyntacticallyScoped (eholes : Map Name [AbsVal]) (acc : [Name]) =
   -- Need only consider match expressions, by same logic as for
   -- 'augmentDependencies'
-  | TmLet ({ ident = ident, body = TmMatch m } & t) ->
+  | TmDecl {decl = DeclLet ({ ident = ident, body = TmMatch m } & t)} ->
     -- Recurse inexpr and body
     let resInexpr = collectSyntacticallyScoped eholes acc t.inexpr in
     let resMatch = sfold_Expr_Expr (collectSyntacticallyScoped eholes)
@@ -328,10 +328,10 @@ lang NestedMeasuringPoints = MExprHoleCFA
 
   -- Return the measuring points syntactically scoped in an expression
   sem collectSyntacticallyScopedH (eholes : Map Name [AbsVal]) (acc: [Name]) =
-  | TmLet t ->
+  | TmDecl {decl = DeclLet t} ->
     let resLet = if mapMem t.ident eholes then [t.ident] else [] in
     let resRest = sfold_Expr_Expr (collectSyntacticallyScopedH eholes)
-        acc (TmLet t)
+        acc (TmDecl {decl = DeclLet t})
     in concat resLet resRest
 
   | t ->

--- a/src/stdlib/tuning/tail-positions.mc
+++ b/src/stdlib/tuning/tail-positions.mc
@@ -15,7 +15,7 @@ lang TailPositions = MExprAst
     -> b -> a -> Expr
     -> (a, Expr)
   sem tailPositionsReclet baseCase tailCall letexpr lacc acc =
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets t}) ->
     let lets: [Name] = map (lam b: DeclLetRecord. b.ident) t.bindings in
     let lets = setOfSeq nameCmp lets in
     match mapAccumL (lam acc: a. lam b: DeclLetRecord.
@@ -24,7 +24,7 @@ lang TailPositions = MExprAst
         in (acc, {b with body = body})
       ) acc t.bindings
     with (acc, bindings) in
-    (acc, TmDecl {decl = DeclRecLets {t with bindings = bindings}})
+    (acc, TmDecl {x with decl = DeclRecLets {t with bindings = bindings}})
 
   | t ->
     smapAccumL_Expr_Expr (tailPositionsReclet baseCase tailCall letexpr lacc) acc t
@@ -53,20 +53,20 @@ lang TailPositions = MExprAst
     match acc with (_, tacc, lacc) in
     let helperLetExpr = bind_ (nulet_ v.ident t.body) t.body in
     (acc, TmLam { t with body = baseCase tacc lacc helperLetExpr })
-  | TmDecl {decl = DeclRecLets t} ->
+  | TmDecl (x & {decl = DeclRecLets _}) ->
     match acc with (env, tacc, lacc) in
-    match tailPositionsReclet baseCase tailCall letexpr lacc tacc (TmDecl {decl = DeclRecLets t})
-    with (tacc, TmDecl {decl = DeclRecLets t}) in
-    match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc) t.inexpr
+    match tailPositionsReclet baseCase tailCall letexpr lacc tacc (TmDecl x)
+    with (tacc, TmDecl (x & {decl = DeclRecLets t})) in
+    match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc) x.inexpr
     with (acc, inexpr) in
-    (acc, TmDecl {decl = DeclRecLets {t with inexpr = inexpr}})
-  | TmDecl {decl = DeclLet t} ->
+    (acc, TmDecl {x with inexpr = inexpr})
+  | TmDecl (x & {decl = DeclLet t}) ->
     match acc with (env, tacc, lacc0) in
-    match letexpr lacc0 (TmDecl {decl = DeclLet t}) with (lacc, prepend) in
+    match letexpr lacc0 (TmDecl x) with (lacc, prepend) in
     let acc = (env, tacc, lacc) in
     match
-    switch t
-    case { inexpr = TmVar vin } then
+    switch (t.body, x.inexpr)
+    case (_, TmVar vin) then
       -- The case 'let t = ... in t', i.e. the body of the let is in tail
       -- position.
       if nameEq vin.ident t.ident then
@@ -76,8 +76,8 @@ lang TailPositions = MExprAst
         case { body = TmApp {lhs = TmVar vlhs} } then
           if setMem vlhs.ident env then
             match tailCall tacc lacc t.body with (tacc, body) in
-            ((env, tacc, lacc), TmDecl {decl = DeclLet { t with body = body }})
-          else (acc, baseCase tacc lacc (TmDecl {decl = DeclLet t}))
+            ((env, tacc, lacc), TmDecl {x with decl = DeclLet { t with body = body }})
+          else (acc, baseCase tacc lacc (TmDecl {x with decl = DeclLet t}))
         -- Match: one of the branches returns a variable?
         case { body = TmMatch m } then
           match
@@ -93,31 +93,31 @@ lang TailPositions = MExprAst
             else visitTailPositions baseCase tailCall letexpr acc m.els
           with (acc, els) in
           let body = TmMatch {{m with thn = thn} with els = els} in
-          (acc, TmDecl {decl = DeclLet {t with body = body}})
+          (acc, TmDecl {x with decl = DeclLet {t with body = body}})
         -- All other cases
         case _ then
           if tailPositionBaseCase t.body then
-            (acc, baseCase tacc lacc (TmDecl {decl = DeclLet t}))
+            (acc, baseCase tacc lacc (TmDecl {x with decl = DeclLet t}))
           else
             smapAccumL_Expr_Expr (
-              visitTailPositions baseCase tailCall letexpr) acc (TmDecl {decl = DeclLet t})
+              visitTailPositions baseCase tailCall letexpr) acc (TmDecl {x with decl = DeclLet t})
         end
       else
         -- No, only the variable being returned is in tail position.
-        let helperLetExpr = bind_ (nulet_ vin.ident t.inexpr) t.inexpr in
-        (acc, TmDecl {decl = DeclLet {t with inexpr = baseCase tacc lacc helperLetExpr}})
+        let helperLetExpr = bind_ (nulet_ vin.ident x.inexpr) x.inexpr in
+        (acc, TmDecl {x with inexpr = baseCase tacc lacc helperLetExpr})
     -- Redefinition of recursive functions
-    case ({body = (TmApp {lhs = TmVar v} | TmVar v)}) & (!{inexpr = TmVar _}) then
+    case (TmApp {lhs = TmVar v} | TmVar v, !TmVar _) then
       let env =
         if setMem v.ident env then
           setInsert t.ident env
         else env
       in
-      match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc0) t.inexpr
+      match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc0) x.inexpr
       with (acc, inexpr) in
-      (acc, TmDecl {decl = DeclLet { t with inexpr = inexpr }})
+      (acc, TmDecl { x with inexpr = inexpr })
     case _ then
-      smapAccumL_Expr_Expr (visitTailPositions baseCase tailCall letexpr) (env, tacc, lacc0) (TmDecl {decl = DeclLet t})
+      smapAccumL_Expr_Expr (visitTailPositions baseCase tailCall letexpr) (env, tacc, lacc0) (TmDecl x)
     end
     with (acc, expr) in
     (acc, prepend expr)
@@ -164,7 +164,7 @@ in
 
 let letexprNoop = lam lacc. lam e. (lacc, lam x. x) in
 let baseCaseInexpr = lam inexpr. lam. lam. lam x.
-  match x with TmDecl {decl = DeclLet t} in TmDecl {decl = DeclLet {t with inexpr = inexpr}}
+  match x with TmDecl (x & {decl = DeclLet t}) in TmDecl {x with inexpr = inexpr}
 in
 
 -- Base cases

--- a/src/stdlib/tuning/tail-positions.mc
+++ b/src/stdlib/tuning/tail-positions.mc
@@ -16,9 +16,9 @@ lang TailPositions = MExprAst
     -> (a, Expr)
   sem tailPositionsReclet baseCase tailCall letexpr lacc acc =
   | TmRecLets t ->
-    let lets: [Name] = map (lam b: RecLetBinding. b.ident) t.bindings in
+    let lets: [Name] = map (lam b: DeclLetRecord. b.ident) t.bindings in
     let lets = setOfSeq nameCmp lets in
-    match mapAccumL (lam acc: a. lam b: RecLetBinding.
+    match mapAccumL (lam acc: a. lam b: DeclLetRecord.
         match visitTailPositions baseCase tailCall letexpr (lets, acc, lacc) b.body
         with ((_,acc,_), body)
         in (acc, {b with body = body})
@@ -297,7 +297,7 @@ let letexpr = lam flag: Bool. lam e: Expr.
   match e with TmLet t in
   if flag then (true, lam x. x) else
     let newFlag = setMem (nameGetStr t.ident) strs in
-    if newFlag then (true, lam e. bindSemi_ (negi_ (int_ 1)) e)
+    if newFlag then (true, lam e. semi_ (negi_ (int_ 1)) e)
     else (false, lam x. x)
 in
 

--- a/src/stdlib/tuning/tail-positions.mc
+++ b/src/stdlib/tuning/tail-positions.mc
@@ -15,7 +15,7 @@ lang TailPositions = MExprAst
     -> b -> a -> Expr
     -> (a, Expr)
   sem tailPositionsReclet baseCase tailCall letexpr lacc acc =
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     let lets: [Name] = map (lam b: DeclLetRecord. b.ident) t.bindings in
     let lets = setOfSeq nameCmp lets in
     match mapAccumL (lam acc: a. lam b: DeclLetRecord.
@@ -24,7 +24,7 @@ lang TailPositions = MExprAst
         in (acc, {b with body = body})
       ) acc t.bindings
     with (acc, bindings) in
-    (acc, TmRecLets {t with bindings = bindings})
+    (acc, TmDecl {decl = DeclRecLets {t with bindings = bindings}})
 
   | t ->
     smapAccumL_Expr_Expr (tailPositionsReclet baseCase tailCall letexpr lacc) acc t
@@ -36,8 +36,8 @@ lang TailPositions = MExprAst
   | TmVar _ -> true
   | TmConApp _ -> true
   | TmSeq _ -> true
-  | TmType _ -> true
-  | TmConDef _ -> true
+  | TmDecl {decl = DeclType _} -> true
+  | TmDecl {decl = DeclConDef _} -> true
   | t -> false
 
   sem visitTailPositions : all a. all b.
@@ -53,16 +53,16 @@ lang TailPositions = MExprAst
     match acc with (_, tacc, lacc) in
     let helperLetExpr = bind_ (nulet_ v.ident t.body) t.body in
     (acc, TmLam { t with body = baseCase tacc lacc helperLetExpr })
-  | TmRecLets t ->
+  | TmDecl {decl = DeclRecLets t} ->
     match acc with (env, tacc, lacc) in
-    match tailPositionsReclet baseCase tailCall letexpr lacc tacc (TmRecLets t)
-    with (tacc, TmRecLets t) in
+    match tailPositionsReclet baseCase tailCall letexpr lacc tacc (TmDecl {decl = DeclRecLets t})
+    with (tacc, TmDecl {decl = DeclRecLets t}) in
     match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc) t.inexpr
     with (acc, inexpr) in
-    (acc, TmRecLets {t with inexpr = inexpr})
-  | TmLet t ->
+    (acc, TmDecl {decl = DeclRecLets {t with inexpr = inexpr}})
+  | TmDecl {decl = DeclLet t} ->
     match acc with (env, tacc, lacc0) in
-    match letexpr lacc0 (TmLet t) with (lacc, prepend) in
+    match letexpr lacc0 (TmDecl {decl = DeclLet t}) with (lacc, prepend) in
     let acc = (env, tacc, lacc) in
     match
     switch t
@@ -76,8 +76,8 @@ lang TailPositions = MExprAst
         case { body = TmApp {lhs = TmVar vlhs} } then
           if setMem vlhs.ident env then
             match tailCall tacc lacc t.body with (tacc, body) in
-            ((env, tacc, lacc), TmLet { t with body = body })
-          else (acc, baseCase tacc lacc (TmLet t))
+            ((env, tacc, lacc), TmDecl {decl = DeclLet { t with body = body }})
+          else (acc, baseCase tacc lacc (TmDecl {decl = DeclLet t}))
         -- Match: one of the branches returns a variable?
         case { body = TmMatch m } then
           match
@@ -93,19 +93,19 @@ lang TailPositions = MExprAst
             else visitTailPositions baseCase tailCall letexpr acc m.els
           with (acc, els) in
           let body = TmMatch {{m with thn = thn} with els = els} in
-          (acc, TmLet {t with body = body})
+          (acc, TmDecl {decl = DeclLet {t with body = body}})
         -- All other cases
         case _ then
           if tailPositionBaseCase t.body then
-            (acc, baseCase tacc lacc (TmLet t))
+            (acc, baseCase tacc lacc (TmDecl {decl = DeclLet t}))
           else
             smapAccumL_Expr_Expr (
-              visitTailPositions baseCase tailCall letexpr) acc (TmLet t)
+              visitTailPositions baseCase tailCall letexpr) acc (TmDecl {decl = DeclLet t})
         end
       else
         -- No, only the variable being returned is in tail position.
         let helperLetExpr = bind_ (nulet_ vin.ident t.inexpr) t.inexpr in
-        (acc, TmLet {t with inexpr = baseCase tacc lacc helperLetExpr})
+        (acc, TmDecl {decl = DeclLet {t with inexpr = baseCase tacc lacc helperLetExpr}})
     -- Redefinition of recursive functions
     case ({body = (TmApp {lhs = TmVar v} | TmVar v)}) & (!{inexpr = TmVar _}) then
       let env =
@@ -115,9 +115,9 @@ lang TailPositions = MExprAst
       in
       match visitTailPositions baseCase tailCall letexpr (env, tacc, lacc0) t.inexpr
       with (acc, inexpr) in
-      (acc, TmLet { t with inexpr = inexpr })
+      (acc, TmDecl {decl = DeclLet { t with inexpr = inexpr }})
     case _ then
-      smapAccumL_Expr_Expr (visitTailPositions baseCase tailCall letexpr) (env, tacc, lacc0) (TmLet t)
+      smapAccumL_Expr_Expr (visitTailPositions baseCase tailCall letexpr) (env, tacc, lacc0) (TmDecl {decl = DeclLet t})
     end
     with (acc, expr) in
     (acc, prepend expr)
@@ -164,7 +164,7 @@ in
 
 let letexprNoop = lam lacc. lam e. (lacc, lam x. x) in
 let baseCaseInexpr = lam inexpr. lam. lam. lam x.
-  match x with TmLet t in TmLet {t with inexpr = inexpr}
+  match x with TmDecl {decl = DeclLet t} in TmDecl {decl = DeclLet {t with inexpr = inexpr}}
 in
 
 -- Base cases
@@ -294,7 +294,7 @@ in
 let strs = setOfSeq cmpString ["aExpr","eExpr"] in
 
 let letexpr = lam flag: Bool. lam e: Expr.
-  match e with TmLet t in
+  match e with TmDecl {decl = DeclLet t} in
   if flag then (true, lam x. x) else
     let newFlag = setMem (nameGetStr t.ident) strs in
     if newFlag then (true, lam e. semi_ (negi_ (int_ 1)) e)

--- a/src/test/examples/parser/lrk-calclang.mc
+++ b/src/test/examples/parser/lrk-calclang.mc
@@ -167,8 +167,8 @@ end
       let_ "initLexerState" (tycon_ "Stream")
                         (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
                                    ("str", get_ (var_ "argv") (int_ 1))]),
-      let_ "parse_result" (tyTm parser) parser,
-      matchall_ [
+      let_ "parse_result" (tyTm parser) parser]
+      (matchall_ [
         matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
           appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
             str_ "success: \"", var_ "result", str_ "\""
@@ -187,7 +187,7 @@ end
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]
-    ]),
+    )),
     ""
   ] in
   let fname = match argv with [_, fname] ++ _

--- a/src/test/examples/parser/lrk-lr2.mc
+++ b/src/test/examples/parser/lrk-lr2.mc
@@ -97,8 +97,8 @@ case ResultOk {value = lrtable} then
       let_ "initLexerState" (tycon_ "Stream")
                         (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
                                    ("str", get_ (var_ "argv") (int_ 1))]),
-      let_ "parse_result" (tyTm parser) parser,
-      matchall_ [
+      let_ "parse_result" (tyTm parser) parser]
+      (matchall_ [
         matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
           appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
             str_ "success: ", appf1_ (var_ "seq2string") (var_ "result")
@@ -117,7 +117,7 @@ case ResultOk {value = lrtable} then
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]
-    ]),
+    )),
     ""
   ] in
   let fname = match argv with [_, fname] ++ _

--- a/src/test/examples/parser/lrk-nonll.mc
+++ b/src/test/examples/parser/lrk-nonll.mc
@@ -76,8 +76,8 @@ case ResultOk {value = lrtable} then
       let_ "initLexerState" (tycon_ "Stream")
                         (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
                                    ("str", get_ (var_ "argv") (int_ 1))]),
-      let_ "parse_result" (tyTm parser) parser,
-      matchall_ [
+      let_ "parse_result" (tyTm parser) parser]
+      (matchall_ [
         matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
           appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
             str_ "success: \"", var_ "result", str_ "\""
@@ -96,7 +96,7 @@ case ResultOk {value = lrtable} then
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]
-    ]),
+    )),
     ""
   ] in
   let fname = match argv with [_, fname] ++ _

--- a/src/test/examples/parser/lrk-parenlang.mc
+++ b/src/test/examples/parser/lrk-parenlang.mc
@@ -65,8 +65,8 @@ case ResultOk {value = lrtable} then
       let_ "initLexerState" (tycon_ "Stream")
                         (urecord_ [("pos", appf1_ (var_ "initPos") (str_ "file")),
                                    ("str", get_ (var_ "argv") (int_ 1))]),
-      let_ "parse_result" (tyTm parser) parser,
-      matchall_ [
+      let_ "parse_result" (tyTm parser) parser]
+      (matchall_ [
         matchex_ (var_ "parse_result") (pcon_ "ResultOk" (prec_ [("value", (pvar_ "result"))])) (
           appf1_ (var_ "printLn") (appf1_ (var_ "join") (seq_ [
             str_ "success: \"", var_ "result", str_ "\""
@@ -85,7 +85,7 @@ case ResultOk {value = lrtable} then
                                                 (appf1_ (var_ "mapValues") (var_ "errors"))))
         )
       ]
-    ]),
+    )),
     ""
   ] in
   let fname = match argv with [_, fname] ++ _

--- a/src/test/examples/pprint-chainmatch.mc
+++ b/src/test/examples/pprint-chainmatch.mc
@@ -20,9 +20,9 @@ let ast = bindall_ [
   ulet_ "_" (appf1_ (var_ "printLn")
                    (appf1_ (var_ "int2string")
                            (appf1_ (var_ "square")
-                                   (int_ 5)))),
+                                   (int_ 5))))]
   -- A long chained match expression
-  matchall_ (
+  (matchall_ (
     create nMatches (lam i: Int.
       matchex_ (var_ "foo") (pand_ (pint_ i) (pvar_ "x")) (
         bindall_ [
@@ -30,18 +30,18 @@ let ast = bindall_ [
                                                                      "y1" (int_ i))
                                                        "y2" (float_ 30.33))
                                         "y3" (str_ "in match")),
-            ulet_ "x2" (appf1_ (var_ "square") (var_ "x")),
-            appf1_ (var_ "printLn") (
+            ulet_ "x2" (appf1_ (var_ "square") (var_ "x"))]
+            (appf1_ (var_ "printLn") (
                 appf1_ (var_ "join") (seq_ [
                     str_ "foo is ",
                     appf1_ (var_ "int2string")
                            (var_ "x2")
                 ])
             )
-        ]
+        )
       )
     )
   )
-] in
+) in
 
 printLn (expr2str ast)

--- a/src/test/mexpr/pprint-eval.mc
+++ b/src/test/mexpr/pprint-eval.mc
@@ -25,11 +25,11 @@ use PPrintEvalTestLang in
 let testAsts: [Expr] = [
   bindall_ [
     ulet_ "a" (int_ 5),
-    ulet_ "b" (int_ 3),
-    addi_ (var_ "a") (var_ "b")
-  ],
+    ulet_ "b" (int_ 3)]
+    (addi_ (var_ "a") (var_ "b")
+  ),
   bindall_ [
-    ulet_ "f" (ulam_ "x" (bindall_ [
+    ulet_ "f" (ulam_ "x" (
       if_ (gti_ (var_ "x") (int_ 10)) ( --if
         subi_ (var_ "x") (int_ 10)
       ) (if_ (lti_ (var_ "x") (int_ 3)) ( -- else if
@@ -37,11 +37,11 @@ let testAsts: [Expr] = [
       ) ( -- else
         muli_ (var_ "x") (var_ "x")
       ))
-    ])),
+    )),
     ulet_ "a" (appf1_ (var_ "f") (int_ 5)),
-    ulet_ "b" (appf1_ (var_ "f") (int_ 1)),
-    addi_ (var_ "a") (var_ "b")
-  ]
+    ulet_ "b" (appf1_ (var_ "f") (int_ 1))]
+    (addi_ (var_ "a") (var_ "b")
+  )
 ] in
 
 let symeval: Expr -> Expr = lam e: Expr.
@@ -62,4 +62,3 @@ foldl (lam. lam sourceAst: Expr.
       utest "unexpected failure" with "" in ()
   )
 ) () testAsts
-

--- a/src/test/mexpr/records.mc
+++ b/src/test/mexpr/records.mc
@@ -27,9 +27,9 @@ let nested = {a = {b = 1}} in
 let arec = {nested.a with b = addi nested.a.b 1} in
 utest arec.b with 2 in
 
--- test order of evaluation for record expressions by observing side effects
+-- test order of evaluation for record update expressions by observing side effects
 let v = ref 0 in
-let r5 = {x = 10, y = 11, z = 12, a = 13} in
+let r5 = {x = 2, y = 1, z = 3, a = 0} in
 let r5mod = {r5 with
 	z = modref v (addi (deref v) 1); addi r5.z (deref v),
 	x = modref v (addi (deref v) 1); addi r5.x (deref v),
@@ -37,6 +37,6 @@ let r5mod = {r5 with
 	a = modref v (addi (deref v) 1); addi r5.a (deref v)
 } in
 
-utest r5mod with {x = 12, y = 14, z = 13, a = 17} in
+utest r5mod with {x = 4, y = 4, z = 4, a = 4} in
 
 ()


### PR DESCRIPTION
This PR implements #826 by adding a `TmDecl` term to `Expr`. Most of the changes are fairly direct translations to the new style (e.g., `TmLet {...}` to `TmDecl {decl = DeclLet {...}, ...}`), but I have also made some refactorings making use of the new structure to remove code and make things simpler.

As mentioned in the issue, the idea is to use `TmDecl` for everything where we have a "side-effect" followed by a single expression. For example, `TmMatch` does not fit this criteria (two options on how to continue), but `TmLet` (name-binding as a side-effect) and `TmUtest` (running a test) do.

- `ast-builder.mc` now makes `Decl`s when using, e.g., `let_`. The separate `mlang/ast-builder.mc` no longer has, e.g., `decl_let_`. Changed types:
  - `bind_ : Expr -> Expr -> Expr` becomes `bind_ : Decl -> Expr -> Expr` and can no longer implicitly lose AST nodes
  - `bindall_ : [Expr] -> Expr` becomes `bindall_ : [Decl] -> Expr -> Expr`.
- I chose to have `smap_Expr_Expr` for `TmDecl` use `smap_Decl_Expr` to make it behave as it used to, to minimize the number of hard to find semantic mismatches. We might want to change this later, or we might not, I'm not sure at this point.

I also accidentally snuck in an additional feature for `generate-pprint.mc`, the ability to register custom pprint functions for named (non-alias) types, similar to what's already available for `generate-json-serializers.mc`.

## Performance

This change increases the number of nodes in most ASTs, thus we expect there to be some impact on performance, both for runtime and memory. The runtime can perhaps be somewhat mitigated by simpler code that needs fewer checks, but the added pointer chasing and potential for cache misses and garbage collection seem likely to be greater.

Here are summary statistics over 10 runs for each step in the bootstrapping process, first before this PR, then after.

Step 1:
```
N	min	max	sum	mean	sd	sderr	 (before)
10	142.181	153.928	1497.55	149.755	3.18581	1.00744	
N	min	max	sum	mean	sd	sderr	 (after)
10	148.469	159.917	1539.17	153.917	3.87211	1.22447	
```

Step 2:
```
N	min	max	sum	mean	sd	sderr	 (before)
10	39.003	40.861	399.094	39.9094	0.645259	0.204049	
N	min	max	sum	mean	sd	sderr	 (after)
10	39.139	41.715	404.034	40.4034	0.826885	0.261484	
```

Step 3:
```
N	min	max	sum	mean	sd	sderr	 (before)
10	40.684	43.378	421.615	42.1615	0.841775	0.266193	
N	min	max	sum	mean	sd	sderr	 (after)
10	40.524	43.56	422.524	42.2524	0.854545	0.270231	
```

<details>

<summary>Data underlying the above</summary>

```
 2) [153.928s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [153.573s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [151.896s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [150.879s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [150.405s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [149.167s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [149.151s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [148.525s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [147.846s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [142.181s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
N	min	max	sum	mean	sd	sderr	
10	142.181	153.928	1497.55	149.755	3.18581	1.00744	

 1) [40.861s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [40.842s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [40.592s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [40.038s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.892s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.793s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.524s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.515s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.034s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.003s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
N	min	max	sum	mean	sd	sderr	
10	39.003	40.861	399.094	39.9094	0.645259	0.204049	

 0) [43.378s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [43.108s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.960s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.432s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.214s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.208s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [41.975s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [41.768s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [40.888s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [40.684s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
N	min	max	sum	mean	sd	sderr	
10	40.684	43.378	421.615	42.1615	0.841775	0.266193	

```

...and here's after:

```
 2) [159.917s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [159.486s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [156.838s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [156.257s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [153.694s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [152.899s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [151.850s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [150.682s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [149.079s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
 2) [148.469s] [build] src: ./boot eval main/mi-lite.mc -- 0 main/mi-lite.mc ../build/src/mi-lite        
N	min	max	sum	mean	sd	sderr	
10	148.469	159.917	1539.17	153.917	3.87211	1.22447	

 1) [41.715s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [41.528s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [41.132s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [40.945s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [40.300s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.975s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.843s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.800s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.657s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
 1) [39.139s] [build] src: ./mi-lite 1 main/mi.mc ../build/src/mi1                                       
N	min	max	sum	mean	sd	sderr	
10	39.139	41.715	404.034	40.4034	0.826885	0.261484	

 0) [43.560s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [43.280s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.844s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.566s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.174s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.138s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.125s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [42.078s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [41.235s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
 0) [40.524s] [build] src: ./mi1 compile main/mi.mc --output ../build/src/mi                             
N	min	max	sum	mean	sd	sderr	
10	40.524	43.56	422.524	42.2524	0.854545	0.270231	
```

</details>

In summary, we do indeed see a slowdown, most notably in the first step and then decreasing for later steps. The last step in particular is a slowdown of 0.09s on average, out of ~40s total, which seems quite acceptable.