### PR TITLE
Add reciprocal distribution

### DIFF
--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -203,7 +203,7 @@ let betabinLogPmf:Int -> Float -> Float -> Int -> Float = lam n. lam a. lam b. l
 let betabinPmf = lam n:Int. lam a: Float. lam b: Float. lam x:Int.
   exp (betabinLogPmf n a b x)
 
--- Reciprocal (or log uniform) distribution)
+-- Reciprocal (or log uniform) distribution
 let reciprocalSample : Float -> Float -> Float = lam a. lam b.
   let logSample = uniformContinuousSample (log a) (log b) in
   exp logSample
@@ -341,10 +341,10 @@ utest betabinSample 20 1. 1. with 0 using intRange 0 20 in
 
 -- Testing Reciprocal
 utest reciprocalLogPdf 1. 2. 1.5 with -0.038952187526 using _eqf in
-utest reciprocalLogPdf 1. 2. 2.5 with negf inf using _eqf in
+utest reciprocalLogPdf 1. 2. 2.5 with negf inf using leqf in
 utest exp (reciprocalLogPdf 4. 6. 5.) with 0.493260692475 using _eqf in
 utest reciprocalPdf 4. 6. 5. with 0.493260692475 using _eqf in
-utest reciprocalSample 0.5 0.7 with 0. using floatRange 0.5 0.7 in
+utest reciprocalSample 0.5 0.7 with 0.5 using floatRange 0.5 0.7 in
 
 -- Testing seed
 utest setSeed 0; uniformSample (); uniformSample ()

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -203,6 +203,23 @@ let betabinLogPmf:Int -> Float -> Float -> Int -> Float = lam n. lam a. lam b. l
 let betabinPmf = lam n:Int. lam a: Float. lam b: Float. lam x:Int.
   exp (betabinLogPmf n a b x)
 
+-- Reciprocal (or log uniform) distribution)
+let reciprocalSample : Float -> Float -> Float = lam a. lam b.
+  let logSample = uniformContinuousSample (log a) (log a) in
+  exp logSample
+
+let reciprocalPdf : Float -> Float -> Float -> Float = lam a. lam b. lam x.
+  if geqf x a then
+    if leqf x b then divf 1.0 (mulf (log (divf b a)) x)
+    else 0.
+  else 0.
+
+let reciprocalLogPdf : Float -> Float -> Float -> Float = lam a. lam b. lam x.
+  if geqf x a then
+    if leqf x b then negf (log (mulf (log (divf b a)) x))
+    else negf inf 
+  else negf inf 
+
 -- Seed
 external externalSetSeed ! : Int -> ()
 let setSeed : Int -> () = lam seed.
@@ -321,6 +338,13 @@ utest betabinLogPmf 5 1. 1. 2 with -1.79175946923 using _eqf in
 utest exp (betabinLogPmf 5 1. 1. 3) with 0.166666666667 using _eqf in
 utest betabinPmf 5 1. 1. 3 with 0.166666666667 using _eqf in
 utest betabinSample 20 1. 1. with 0 using intRange 0 20 in
+
+-- Testing Reciprocal
+utest reciprocalLogPdf 1. 2. 1.5 with -0.038952187526 using _eqf in
+utest reciprocalLogPdf 1. 2. 2.5 with negf inf using _eqf in
+utest exp (reciprocalLogPdf 4. 6. 5) with 0.493260692475 using _eqf in
+utest reciprocalPdf 4. 6. 5. with 0.493260692475 using _eqf in
+utest reciprocalSample 0.5 0.7 with 0. using floatRange 0.5 0.7 in
 
 -- Testing seed
 utest setSeed 0; uniformSample (); uniformSample ()

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -205,7 +205,7 @@ let betabinPmf = lam n:Int. lam a: Float. lam b: Float. lam x:Int.
 
 -- Reciprocal (or log uniform) distribution)
 let reciprocalSample : Float -> Float -> Float = lam a. lam b.
-  let logSample = uniformContinuousSample (log a) (log a) in
+  let logSample = uniformContinuousSample (log a) (log b) in
   exp logSample
 
 let reciprocalPdf : Float -> Float -> Float -> Float = lam a. lam b. lam x.
@@ -342,7 +342,7 @@ utest betabinSample 20 1. 1. with 0 using intRange 0 20 in
 -- Testing Reciprocal
 utest reciprocalLogPdf 1. 2. 1.5 with -0.038952187526 using _eqf in
 utest reciprocalLogPdf 1. 2. 2.5 with negf inf using _eqf in
-utest exp (reciprocalLogPdf 4. 6. 5) with 0.493260692475 using _eqf in
+utest exp (reciprocalLogPdf 4. 6. 5.) with 0.493260692475 using _eqf in
 utest reciprocalPdf 4. 6. 5. with 0.493260692475 using _eqf in
 utest reciprocalSample 0.5 0.7 with 0. using floatRange 0.5 0.7 in
 


### PR DESCRIPTION
This PR add the [reciprocal (log-uniform) distribution](https://en.wikipedia.org/wiki/Reciprocal_distribution). This distribution is used downstream by my implementation of the host-repertoire model in TreePPL: https://github.com/treeppl/treeppl/pull/106