### PR TITLE
Pin ocamlformat in flake.nix

### DIFF
--- a/misc/packaging/flake.nix
+++ b/misc/packaging/flake.nix
@@ -20,7 +20,7 @@
           devShells.default = pkgs.mkShell {
             name = "Miking dev shell";
             inputsFrom = [ packages.miking-lib packages.miking-unwrapped ];
-            buildInputs = [ pkgs.tup pkgs.ocamlformat ];
+            buildInputs = [ pkgs.tup pkgs.ocamlformat_0_24_1 ];
           };
         };
     in


### PR DESCRIPTION
This PR pins ocamlformat to the version we use.