### PR TITLE
Fix dprint when dealing with infix values (whatever that is)

### DIFF
--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -635,6 +635,7 @@ module IO = struct
       else if Obj.tag v = Obj.double_tag then
         string_of_float (Obj.obj v) ^ "\n"
       else if Obj.tag v = Obj.closure_tag then "<closure>\n"
+      else if Obj.tag v = Obj.infix_tag then "<infix>\n"
       else if Obj.tag v = Obj.unaligned_tag then "<unaligned>\n"
       else
         let istr = String.make indent ' ' in


### PR DESCRIPTION
I was getting segfaults when `dprint`ing some functions, it turns out they're now represented in some different way in the runtime. This change makes this other tag print opaquely, similar to closures.