### PR TITLE
Make MCORE_LIBS prioritize earlier entries

### DIFF
--- a/src/stdlib/stdlib.mc
+++ b/src/stdlib/stdlib.mc
@@ -13,7 +13,7 @@ let parseMCoreLibs : String -> Map String String = lam str.
   match str with "" then mapEmpty cmpString else
   let processBinding = lam acc. lam str.
     match strSplit "=" str with [lib, path] ++ paths
-    then mapInsert lib (strJoin "=" (cons path paths)) acc
+    then mapInsertWith (lam prev. lam. prev) lib (strJoin "=" (cons path paths)) acc
     else
       warnSingle [] (join
         [ "Invalid element of MCORE_LIBS: \""


### PR DESCRIPTION
This change makes the `MCORE_LIBS` environment variable behave a touch more like similar variables for other languages (or `PATH`): earlier entries are prioritized over later ones. Previously the behavior was the opposite.

This is relevant for the self-contained version of TreePPL (see https://github.com/treeppl/treeppl-python/issues/9), which adds its own versions of the various libraries to `MCORE_LIBS` before starting. Potential options for how to get the desired behavior there include:
- Look at the `MCORE_LIBS` in the users environment, remove entries for `stdlib`, `coreppl`, and `treeppl`, then add the correct ones. This removes duplicates, but is fiddly to get right in `bash`.
- Add entries to the end of the environment variable. This is inconsistent with other similar variables, which feels like a potential footgun.
- Add entries to the beginning of the environment variable, and merge this PR.

I would prefer the last option (hence this PR), since it's the most consistent with the rest of the world, and it shouldn't affect any normal setups.