### PR TITLE
Higher-order abstract syntax and a simple inlining pass

### DIFF
--- a/src/stdlib/mexpr/hoas.mc
+++ b/src/stdlib/mexpr/hoas.mc
@@ -1,0 +1,183 @@
+-- This file provides a simple implementation of higher-order abstract
+-- syntax, i.e., where we represent lambdas with actual functions. The
+-- implementation in this file is intended to simplify the
+-- construction of clean ASTs, rather than to truly work with HOAS
+-- throughout, hence the names `TempLam` and `TempFix`.
+--
+-- Assumptions:
+-- * Functions in `TempLam` and `TempFix` should be _linear_, i.e.,
+--   applying the function to an expression will not duplicate that
+--   expression, nor any part of it.
+-- * Functions in `TempLam` and `TempFix` should behave properly
+--   according to parametric polymorphism, i.e., they should produce a
+--   semantically equivalent expression no matter their
+--   argument. However, they are allowed to perform some reductions
+--   before returning an expressions, e.g., pattern matching on an
+--   input record by taking apart a `TmRecord` rather than producing a
+--   `TmMatch`.
+--
+-- There is also an extensible `_app` function (via `_app`), which
+-- semantically functions like `app_` from `ast-builder.mc`, but may
+-- reduce the application if posible.
+
+include "mexpr/ast.mc"
+include "mexpr/pprint.mc"
+
+lang TempLamAst = Ast + PrettyPrint
+  type TempFixRec =
+    { canMakeProgress : Expr -> Bool
+    , f : (Expr -> Expr) -> Expr -> Expr
+    , info : Info
+    , ty : Type
+    }
+  type TempLamRec =
+    { f : Expr -> Expr
+    , info : Info
+    , ty : Type
+    }
+  syn Expr =
+  | TempLam TempLamRec
+  | TempFix TempFixRec
+
+  sem tempLam_ : (Expr -> Expr) -> Expr
+  sem tempLam_ = | f ->
+    TempLam {f = f, info = NoInfo (), ty = TyUnknown {info = NoInfo ()}}
+
+  sem isAtomic =
+  | TempLam _ -> false
+  | TempFix _ -> false
+
+  sem pprintCode indent env =
+  | TempLam f ->
+    let x = nameSym "x" in
+    match pprintVarName env x with (env, str) in
+    match pprintCode (pprintIncr indent) env (f.f (nvar_ x)) with (env, body) in
+    ( env
+    , join ["/-temp-/lam ", str, ".", pprintNewline (pprintIncr indent), body]
+    )
+  | TempFix f ->
+    let x = nameSym "x" in
+    let fName = nameSym "f" in
+    match pprintVarName env fName with (env, fStr) in
+    match pprintVarName env x with (env, xStr) in
+    match pprintCode (pprintIncr indent) env (f.f (app_ (nvar_ fName)) (nvar_ x)) with (env, body) in
+    ( env
+    , join ["/-temp-/recursive let ", fStr, " = lam ", xStr, ".", pprintNewline (pprintIncr indent), body, " in ", fStr]
+    )
+
+  sem stripTempLam : Expr -> Expr
+  sem stripTempLam = | tm -> _stripTempLam ([], tm)
+
+  sem _defaultStripFix : [Expr] -> TempFixRec -> Expr
+  sem _defaultStripFix args = | x ->
+    let n = nameSym "n" in
+    let f = nameSym "f" in
+    TmDecl
+    { decl = DeclRecLets
+      { bindings =
+        [ { ident = f
+          , tyAnnot = tyunknown_
+          , tyBody = tyunknown_
+          , body = nulam_ n (stripTempLam (x.f (app_ (nvar_ f)) (nvar_ n)))
+          , info = x.info
+          }
+        ]
+      , info = x.info
+      }
+    , inexpr = appSeq_ (nvar_ f) args
+    , info = x.info
+    , ty = x.ty
+    }
+
+  sem _stripTempLam : ([Expr], Expr) -> Expr
+  sem _stripTempLam =
+  | ([arg] ++ args, TempLam f) ->
+    _stripTempLam (args, f.f arg)
+  | ([], TempLam f) ->
+    let n = nameSym "x" in
+    TmLam
+    { ident = n
+    , tyAnnot = tyunknown_
+    , tyParam = tyunknown_
+    , body = stripTempLam (f.f (nvar_ n))
+    , ty = tyunknown_
+    , info = NoInfo ()
+    }
+  | (allArgs & [arg] ++ args, f & TempFix x) ->
+    if x.canMakeProgress arg
+    then _stripTempLam (args, x.f (_app f) arg)
+    else _defaultStripFix allArgs x
+  | ([], TempFix x) ->
+    _defaultStripFix [] x
+  | (args, TmApp x) ->
+    _stripTempLam (cons (stripTempLam x.rhs) args, x.lhs)
+  | (args, TmDecl x) ->
+    let decl = smap_Decl_Expr stripTempLam x.decl in
+    let inexpr = _stripTempLam (args, x.inexpr) in
+    TmDecl {x with decl = decl, inexpr = inexpr}
+  | (args, tm) -> appSeq_ (smap_Expr_Expr stripTempLam tm) args
+
+  sem maybeEtaExpand : Expr -> {ident : Name, tyAnnot : Type, tyParam : Type, body : Expr, ty : Type, info : Info}
+  sem maybeEtaExpand =
+  | TmLam f -> f
+  | tm ->
+    let n = nameSym "x" in
+    { ident = n
+    , tyAnnot = tyunknown_
+    , tyParam = tyunknown_
+    , body = _app tm (nvar_ n)
+    , ty = tyTm tm
+    , info = infoTm tm
+    }
+
+  sem tyTm =
+  | TempLam _ -> TyUnknown {info = NoInfo ()}
+  | TempFix x -> x.ty
+
+  sem withType ty =
+  | tm & TempLam _ -> tm
+  | TempFix x -> TempFix {x with ty = ty}
+
+  sem infoTm =
+  | TempLam x -> x.info
+  | TempFix x -> x.info
+
+  sem withInfo info =
+  | TempLam x -> TempLam {x with info = info}
+  | TempFix x -> TempFix {x with info = info}
+
+  sem _app : Expr -> Expr -> Expr
+  sem _app l = | r -> _app_ (l, r)
+
+  sem _app_ : (Expr, Expr) -> Expr
+  sem _app_ =
+  -- we have a simple function, just apply it
+  | (TempLam f, x) -> f.f x
+  -- we have a simple recursive function, just apply it
+  | (f & TempFix f2, x) ->
+    if f2.canMakeProgress x
+    then f2.f (_app f) x
+    else app_ f x
+  -- mapSeq id = id
+  | (f & TmConst {val = CMap _}, x & TempLam f2) ->
+    if isIdentity f2.f then tempLam_ (lam x. x) else app_ f x
+  -- mapSeq f [x, ...] = [f x, ...]
+  | ( TmApp
+      { lhs = TmConst {val = CMap _}
+      , rhs = f
+      }
+    , TmSeq x
+    ) ->
+    TmSeq {x with tms = map (_app f) x.tms}
+  | (TmDecl f, x) ->
+    TmDecl {f with inexpr = _app f.inexpr x}
+  -- base case, just make the TmApp
+  | (f, x) -> app_ f x
+
+  sem isIdentity : (Expr -> Expr) -> Bool
+  sem isIdentity = | f ->
+    let n = nameSym "x" in
+    match f (nvar_ n) with TmVar {ident = ident}
+    then nameEq ident n
+    else false
+end

--- a/src/stdlib/mexpr/inline-single-use-simple.mc
+++ b/src/stdlib/mexpr/inline-single-use-simple.mc
@@ -1,0 +1,126 @@
+include "ast.mc"
+include "hoas.mc"
+
+-- This file implements a simple version of inlining, where every
+-- binding that is used exactly once is inlined.
+--
+-- Assumptions:
+-- * The AST to be processed either:
+--   * ...contains no side-effects at all, or
+--   * ...the side-effects commute, i.e., they can be re-ordered
+--     relative each other without changing the semantics of the
+--     program.
+--
+-- The implementation may leave behind `TempLam` nodes from
+-- `mexpr/hoas.mc` if any inlined functions appear without being fully
+-- applied. The implementation should pass over every node of the AST
+-- thrice: once to collect usage counts going down, once to collect
+-- definitions to inline later going up, and once to do inlining going
+-- down. Note also that function parameters of inlined functions may
+-- further get inlined if they are only used once in the function
+-- body.
+--
+-- The primary entry point is `inlineSingleUseLets`.
+
+lang InlineSingleUse = DeclAst + LetDeclAst + RecLetsDeclAst + VarAst + TempLamAst
+  syn InlineMap =
+  | InlineMap (Map Name (InlineMap -> Expr))
+  type InlineSingleUseState =
+    { useCounts : Map Name Int
+    , toInline : Map Name (InlineMap -> Expr)
+    }
+
+  sem inlineSingleUseLets : Expr -> Expr
+  sem inlineSingleUseLets = | tm ->
+    match collectSingleUses {useCounts = mapEmpty nameCmp, toInline = mapEmpty nameCmp} tm with (st, tm) in
+    insertSingleUses (InlineMap st.toInline) tm
+
+  sem collectSingleUses : InlineSingleUseState -> Expr -> (InlineSingleUseState, Expr)
+  sem collectSingleUses st =
+  | TmDecl (x & {decl = DeclLet l}) ->
+    match collectSingleUses st l.body with (st, body) in
+    match collectSingleUses st x.inexpr with (st, inexpr) in
+    let bodyIsSimple = sfold_Expr_Expr (lam. lam. false) true body in
+    match (bodyIsSimple, mapLookup l.ident st.useCounts) with (true, _) | (_, Some 1) then
+      ( { st with useCounts = mapRemove l.ident st.useCounts
+        , toInline = mapInsert l.ident (mkInlineable st.useCounts body) st.toInline
+        }
+      , inexpr
+      )
+    else (st, TmDecl {x with decl = DeclLet {l with body = body}, inexpr = inexpr})
+  | TmDecl (x & {decl = DeclRecLets l}) ->
+    let f = lam st. lam binding.
+      match collectSingleUses st binding.body with (st, body) in
+      (st, {binding with body = body}) in
+    match mapAccumL f st l.bindings with (st, bindings) in
+    match collectSingleUses st x.inexpr with (st, inexpr) in
+    let f = lam st. lam binding.
+      match mapLookup binding.ident st.useCounts with Some 1 then
+        ( { st with useCounts = mapRemove binding.ident st.useCounts
+          , toInline = mapInsert binding.ident (mkInlineable st.useCounts binding.body) st.toInline
+          }
+        , None ()
+        )
+      else (st, Some binding) in
+    match mapAccumL f st bindings with (st, bindings) in
+    match filterOption bindings with bindings & ![]
+    then (st, TmDecl {x with decl = DeclRecLets {l with bindings = bindings}, inexpr = inexpr})
+    else (st, inexpr)
+  | tm & TmVar x ->
+    ({st with useCounts = mapInsertWith addi x.ident 1 st.useCounts}, tm)
+  | tm -> smapAccumL_Expr_Expr collectSingleUses st tm
+
+  sem mkInlineable : Map Name Int -> Expr -> InlineMap -> Expr
+  sem mkInlineable useCounts =
+  | TmLam x ->
+    switch optionGetOr 0 (mapLookup x.ident useCounts)
+    case 1 then lam st.
+      match st with InlineMap toInline in
+      let f = lam arg.
+        let toInline = mapInsert x.ident (lam. arg) toInline in
+        mkInlineable useCounts x.body (InlineMap toInline) in
+      TempLam {f = f, info = x.info, ty = x.ty}
+    case 0 then lam st.
+      let f = lam. mkInlineable useCounts x.body st in
+      TempLam {f = f, info = x.info, ty = x.ty}
+    case _ then lam st.
+      let f = lam arg.
+        let isSimple = sfold_Expr_Expr (lam. lam. false) true arg in
+        if isSimple then
+          match st with InlineMap toInline in
+          let toInline = mapInsert x.ident (lam. arg) toInline in
+          mkInlineable useCounts x.body (InlineMap toInline)
+        else
+          let body = mkInlineable useCounts x.body st in
+          let mkBinding = lam body. TmDecl
+            { decl = DeclLet
+              { ident = x.ident
+              , tyAnnot = x.tyAnnot
+              , tyBody = x.tyParam
+              , body = arg
+              , info = x.info
+              }
+            , inexpr = body
+            , info = x.info
+            , ty = tyunknown_
+            } in
+          match body with TempLam f
+          then TempLam {f with f = lam bodyArg. mkBinding (f.f bodyArg)}
+          else mkBinding body in
+      TempLam {f = f, info = x.info, ty = x.ty}
+    end
+  | tm -> lam st. insertSingleUses st tm
+
+  sem insertSingleUses : InlineMap -> Expr -> Expr
+  sem insertSingleUses st =
+  | TmApp x ->
+    let lhs = insertSingleUses st x.lhs in
+    let rhs = insertSingleUses st x.rhs in
+    match lhs with TempLam f
+    then f.f rhs
+    else TmApp {x with lhs = lhs, rhs = rhs}
+  | tm & TmVar x ->
+    match st with InlineMap toInline in
+    optionGetOr tm (optionMap (lam f. f st) (mapLookup x.ident toInline))
+  | tm -> smap_Expr_Expr (insertSingleUses st) tm
+end


### PR DESCRIPTION
This PR adds a very simple version of higher-order abstract syntax, intended to make the construction of lean, easy-to-read ASTs simpler. The idea is to add a new term that semantically is the same as `TmLam`, except it's represented by an actual function. This function is allowed to do whatever it wants whenever it's given an argument, with two (necessarily unenforced) restrictions:
- The expression it builds should be semantically equivalent no matter its input.
- The argument expression (or it's sub-expressions) must not be duplicated in the returned function.

The PR also contains a simple inlining pass built on these terms, that simply finds all `let`-bindings that are referred exactly once and inlines them.

However, there are a number of design questions to consider before merging (hence draft):
- The `TempLam` and `TempFix` nodes currently only store their functions. This is enough to construct ASTs, but not to, e.g., call `tyTm`, `infoTm`, or any of the related setters. We could implement them by actually calling the functions with fabricated arguments, which is how pretty printing works, but it might mess with the intuition that `tyTm` and `infoTm` are cheap functions.
- Should we design these nodes to construct type annotated ASTs?
  - If so, what happens to polymorphism? Our type system does not allow polymorphic lambdas, only `let`-bound values may be polymorphic.
- Should we make them carry a string version of the name, so the pretty printing doesn't always use some variant of `x`?