### PR TITLE
Pair dist

### DIFF
--- a/src/stdlib/ext/arr-ext.ext-ocaml.mc
+++ b/src/stdlib/ext/arr-ext.ext-ocaml.mc
@@ -103,7 +103,7 @@ let arrExtMap =
         ty = tyall_ "a" (tyarrows_ [otyopaque_, tyvar_ "a", otyunit_])
       }
     ]),
-    ("externalExtArrOf", [
+    ("externalExtArrOfArr", [
       impl {
         expr = "(fun kind a -> Bigarray.Array1.of_array kind Bigarray.c_layout a)",
         ty = (tyarrows_ [otyopaque_, otyopaque_, otyopaque_])

--- a/src/stdlib/ext/arr-ext.ext-ocaml.mc
+++ b/src/stdlib/ext/arr-ext.ext-ocaml.mc
@@ -55,6 +55,12 @@ let arrExtMap =
         ty = otyopaque_
       }
     ]),
+    ("extArrKindInt", [
+      impl {
+        expr = "Bigarray.int",
+        ty = otyopaque_
+      }
+    ]),
     ("externalExtArrKind", [
       impl {
         expr = "Bigarray.Array1.kind",
@@ -95,6 +101,12 @@ let arrExtMap =
       impl {
         expr = "Bigarray.Array1.fill",
         ty = tyall_ "a" (tyarrows_ [otyopaque_, tyvar_ "a", otyunit_])
+      }
+    ]),
+    ("externalExtArrOf", [
+      impl {
+        expr = "(fun kind a -> Bigarray.Array1.of_array kind Bigarray.c_layout a)",
+        ty = (tyarrows_ [otyopaque_, otyopaque_, otyopaque_])
       }
     ])
   ]

--- a/src/stdlib/ext/arr-ext.mc
+++ b/src/stdlib/ext/arr-ext.mc
@@ -135,7 +135,7 @@ external externalExtArrGet : all a. ExtArr a -> Int -> a
 external externalExtArrSet ! : all a. ExtArr a -> Int -> a -> ()
 external externalExtArrCopy : all a. ExtArr a -> ExtArr a
 external externalExtArrFill : all a. ExtArr a -> a -> ()
-external externalExtArrOf : all a. ExtArrKind a -> Arr a -> ExtArr a
+external externalExtArrOfArr : all a. ExtArrKind a -> Arr a -> ExtArr a
 
 --------------------------------------------------------------------------------
 -- ExtArr interface
@@ -248,16 +248,16 @@ utest
   ()
   with ()
 
--- Build a one-dimensional Bigarray from a given array
-let extArrOf : all a. ExtArrKind a -> Arr a -> ExtArr a
-  = lam k. lam a. externalExtArrOf k a
+-- Build a one-dimensional external array from a given array
+let extArrOfArr : all a. ExtArrKind a -> Arr a -> ExtArr a
+  = lam k. lam a. externalExtArrOfArr k a
 
 utest
   let a = arrMakeUninitFloat 3 in
   arrSetExn a 0 1.0;
   arrSetExn a 1 2.0;
   arrSetExn a 2 3.0;
-  let bA = extArrOf extArrKindFloat64 a in
+  let bA = extArrOfArr extArrKindFloat64 a in
   utest extArrLength bA with 3 in
   utest extArrGetExn bA 0 with 1. in
   utest extArrGetExn bA 1 with 2. in

--- a/src/stdlib/ext/arr-ext.mc
+++ b/src/stdlib/ext/arr-ext.mc
@@ -135,6 +135,7 @@ external externalExtArrGet : all a. ExtArr a -> Int -> a
 external externalExtArrSet ! : all a. ExtArr a -> Int -> a -> ()
 external externalExtArrCopy : all a. ExtArr a -> ExtArr a
 external externalExtArrFill : all a. ExtArr a -> a -> ()
+external externalExtArrOf : all a. ExtArrKind a -> Arr a -> ExtArr a
 
 --------------------------------------------------------------------------------
 -- ExtArr interface
@@ -146,12 +147,15 @@ external extArrKindFloat32 : ExtArrKind Float
 -- Double precision float kind.
 external extArrKindFloat64 : ExtArrKind Float
 
+-- Integer kind
+external extArrKindInt : ExtArrKind Int
 
 -- Creates an external array of size `n` with uninitialized values.
 let extArrMakeUninit : all a. ExtArrKind a -> Int -> ExtArr a
   = lam kind. lam n. externalExtArrMakeUninit kind n
 
 utest extArrMakeUninit extArrKindFloat64 3; () with ()
+utest extArrMakeUninit extArrKindInt 3; () with ()
 
 
 -- Returns the array kind.
@@ -205,7 +209,7 @@ let extArrToSeq : all a. ExtArr a -> [a]
   = lam a. create (externalExtArrLength a) (externalExtArrGet a)
 
 utest extArrToSeq (extArrOfSeq extArrKindFloat64 [1., 2., 3.]) with [1., 2., 3.]
-
+utest extArrToSeq (extArrOfSeq extArrKindInt [1, 2, 3]) with [1, 2, 3]
 
 -- Copies external array.
 let extArrCopy : all a. ExtArr a -> ExtArr a
@@ -243,3 +247,23 @@ utest
   utest extArrGetExn a 2 with 1. in
   ()
   with ()
+
+-- Build a one-dimensional Bigarray from a given array
+let extArrOf : all a. ExtArrKind a -> Arr a -> ExtArr a
+  = lam k. lam a. externalExtArrOf k a
+
+utest
+  let a = arrMakeUninitFloat 3 in
+  arrSetExn a 0 1.0;
+  arrSetExn a 1 2.0;
+  arrSetExn a 2 3.0;
+  let bA = extArrOf extArrKindFloat64 a in
+  utest extArrLength bA with 3 in
+  utest extArrGetExn bA 0 with 1. in
+  utest extArrGetExn bA 1 with 2. in
+  utest extArrGetExn bA 2 with 3. in
+  () with ()
+
+
+
+

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -246,12 +246,12 @@ let indexOfUnion = lam pairSets. lam u.
       if eqSeq eqi v u then i else helper (addi i 1)
   in helper 0
 
-let pairPmf = lam p. lam pairSets. lam x.
+let treeInferenceCategoricalPmf = lam p. lam pairSets. lam x.
   let idx = indexOfUnion pairSets x in
   if lti idx 0 then 0.0 else get p idx
 
-let pairLogPmf = lam p. lam pairSets. lam x. log (pairPmf p pairSets x)
-let pairSample = lam p. lam pairSets.
+let treeInferenceCategoricalLogPmf = lam p. lam pairSets. lam x. log (treeInferenceCategoricalPmf p pairSets x)
+let treeInferenceCategoricalSample = lam p. lam pairSets.
   let index = categoricalSample p in
   let pair = get pairSets index in
   pair
@@ -390,7 +390,7 @@ utest exp (reciprocalLogPdf 4. 6. 5.) with 0.493260692475 using _eqf in
 utest reciprocalPdf 4. 6. 5. with 0.493260692475 using _eqf in
 utest reciprocalSample 0.5 0.7 with 0.5 using floatRange 0.5 0.7 in
 
--- Testing PairDist
+-- Testing treeInferenceCategorical
 let pairSetsTest = [[0,1],[1,2],[2,3]] in
 let pTest = [0.2, 0.5, 0.3] in
 -- indexOfUnion
@@ -398,13 +398,13 @@ utest indexOfUnion pairSetsTest [0,1] with 0 using eqi in
 utest indexOfUnion pairSetsTest [1,2] with 1 using eqi in
 utest indexOfUnion pairSetsTest [2,3] with 2 using eqi in
 utest indexOfUnion pairSetsTest [9,9] with negi 1 using eqi in
--- pairPmf / pairLogPmf
-utest pairPmf pTest pairSetsTest [2,3] with 0.3 using _eqf in
-utest pairPmf pTest pairSetsTest [9,9] with 0.0 using _eqf in
-utest pairLogPmf pTest pairSetsTest [0,1] with log 0.2 using _eqf in
-utest pairLogPmf pTest pairSetsTest [9,9] with negf inf using eqf in
+-- 
+utest treeInferenceCategoricalPmf pTest pairSetsTest [2,3] with 0.3 using _eqf in
+utest treeInferenceCategoricalPmf pTest pairSetsTest [9,9] with 0.0 using _eqf in
+utest treeInferenceCategoricalLogPmf pTest pairSetsTest [0,1] with log 0.2 using _eqf in
+utest treeInferenceCategoricalLogPmf pTest pairSetsTest [9,9] with negf inf using eqf in
 -- pairSample: result is one of the support pairs
-utest let s = pairSample pTest pairSetsTest in
+utest let s = treeInferenceCategoricalSample pTest pairSetsTest in
   any (lam x. eqSeq eqi x s) pairSetsTest
 with true in
 

--- a/src/stdlib/ext/dist-ext.mc
+++ b/src/stdlib/ext/dist-ext.mc
@@ -238,6 +238,24 @@ let reciprocalLogPdf : Float -> Float -> Float -> Float = lam a. lam b. lam x.
     else negf inf 
   else negf inf 
 
+-- Pair distribution
+let indexOfUnion = lam pairSets. lam u.
+  recursive let helper = lam i.
+    if eqi i (length pairSets) then negi 1
+    else let v = get pairSets i in
+      if eqSeq eqi v u then i else helper (addi i 1)
+  in helper 0
+
+let pairPmf = lam p. lam pairSets. lam x.
+  let idx = indexOfUnion pairSets x in
+  if lti idx 0 then 0.0 else get p idx
+
+let pairLogPmf = lam p. lam pairSets. lam x. log (pairPmf p pairSets x)
+let pairSample = lam p. lam pairSets.
+  let index = categoricalSample p in
+  let pair = get pairSets index in
+  pair
+
 -- Seed
 external externalSetSeed ! : Int -> ()
 let setSeed : Int -> () = lam seed.
@@ -371,6 +389,24 @@ utest reciprocalLogPdf 1. 2. 2.5 with negf inf using leqf in
 utest exp (reciprocalLogPdf 4. 6. 5.) with 0.493260692475 using _eqf in
 utest reciprocalPdf 4. 6. 5. with 0.493260692475 using _eqf in
 utest reciprocalSample 0.5 0.7 with 0.5 using floatRange 0.5 0.7 in
+
+-- Testing PairDist
+let pairSetsTest = [[0,1],[1,2],[2,3]] in
+let pTest = [0.2, 0.5, 0.3] in
+-- indexOfUnion
+utest indexOfUnion pairSetsTest [0,1] with 0 using eqi in
+utest indexOfUnion pairSetsTest [1,2] with 1 using eqi in
+utest indexOfUnion pairSetsTest [2,3] with 2 using eqi in
+utest indexOfUnion pairSetsTest [9,9] with negi 1 using eqi in
+-- pairPmf / pairLogPmf
+utest pairPmf pTest pairSetsTest [2,3] with 0.3 using _eqf in
+utest pairPmf pTest pairSetsTest [9,9] with 0.0 using _eqf in
+utest pairLogPmf pTest pairSetsTest [0,1] with log 0.2 using _eqf in
+utest pairLogPmf pTest pairSetsTest [9,9] with negf inf using eqf in
+-- pairSample: result is one of the support pairs
+utest let s = pairSample pTest pairSetsTest in
+  any (lam x. eqSeq eqi x s) pairSetsTest
+with true in
 
 -- Testing seed
 utest setSeed 0; uniformSample (); uniformSample ()


### PR DESCRIPTION
Adds pair distribution to the external library.
Pair distribution takes a list of possible pairs (their union, which was required for MCMC to work) and their associated weights and returns a pair. 