### PR TITLE
Make `foldl2` non-recursive (it recurses via `foldl` only)

### DIFF
--- a/src/stdlib/seq.mc
+++ b/src/stdlib/seq.mc
@@ -144,17 +144,18 @@ utest range 5 3 1 with [] using eqSeq eqi
 -- `foldl2 f acc seq1 seq2` left folds `f` over the first
 -- min(`length seq1`, `length seq2`) elements in `seq1` and `seq2`, accumuating
 -- on `acc`.
-recursive
 let foldl2 : all a. all b. all c. (a -> b -> c -> a) -> a -> [b] -> [c] -> a =
   lam f. lam acc. lam seq1. lam seq2.
-    let g = lam acc : (a, [b]). lam x2.
-      match acc with (acc, [x1] ++ xs1) then (f acc x1 x2, xs1)
-      else error "foldl2: Cannot happen!"
-    in
     if geqi (length seq1) (length seq2) then
+      let g = lam acc : (a, [b]). lam x2.
+        match acc with (acc, [x1] ++ xs1) then (f acc x1 x2, xs1)
+        else error "foldl2: Cannot happen!" in
       match foldl g (acc, seq1) seq2 with (acc, _) in acc
-    else foldl2 (lam acc. lam x1. lam x2. f acc x2 x1) acc seq2 seq1
-end
+    else
+      let g = lam acc : (a, [c]). lam x1.
+        match acc with (acc, [x2] ++ xs2) then (f acc x1 x2, xs2)
+        else error "foldl2: Cannot happen!" in
+      match foldl g (acc, seq2) seq1 with (acc, _) in acc
 
 utest foldl2 (lam a. lam x1. lam x2. snoc a (x1, x2)) [] [1, 2, 3] [4, 5, 6]
 with [(1, 4), (2, 5), (3, 6)]


### PR DESCRIPTION
The implementation of `foldl2` in the standard library is written as a `foldl` over the shorter of the two sequences rather than the more obvious recursive pattern matching implementation, I'm guessing as an optimization since `foldl` is faster than repeated pattern matching.

However, the previous implementation assumed the second argument to be shorter, doing a recursive call to `foldl2 (lam acc. lam x1. lam x2. f acc x2 x1) acc seq2 seq1` this is not the case. This is correct, and will at most do one recursive call. Unfortunately that implementation syntactically looks like something that might recurse an arbitrary number of times, creating new closures each time, which the current transformation for removing second-class functions in the treeppl graph transformation cannot handle.

This PR adds some minor code duplication to remove the recursive call.