### PR TITLE
Make `boot` respect the ordering of MCORE_LIBS

### DIFF
--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -196,7 +196,7 @@ let namespaces : string NamespaceMap.t =
     | Some path ->
         path
         |> Str.split (Str.regexp ":")
-        |> List.to_seq
+        |> List.rev |> List.to_seq
         |> Seq.filter_map process_binding
     | None ->
         Seq.empty


### PR DESCRIPTION
In #959 I updated `stdlib/stdlib.mc` to prioritize earlier entries in `MCORE_LIBS` over later ones, but I forgot that the same logic exists in `boot`. This PR makes the two consistent.