### PR TITLE
Replace the `() -> a` Lazy in eval with the stdlib Lazy

### DIFF
--- a/src/stdlib/lazy.mc
+++ b/src/stdlib/lazy.mc
@@ -9,6 +9,9 @@ type Lazy a = Ref (LazyContainer a)
 let lazy : all a. (() -> a) -> Lazy a
   = lam f. ref (LazyFunc f)
 
+let lazyPure : all a. a -> Lazy a
+  = lam a. ref (LazyVal a)
+
 let lazyForce : all a. Lazy a -> a
   = lam l.
     switch deref l

--- a/src/stdlib/mexpr/eval.mc
+++ b/src/stdlib/mexpr/eval.mc
@@ -6,6 +6,7 @@ include "name.mc"
 include "list.mc"
 include "tensor.mc"
 include "map.mc"
+include "lazy.mc"
 
 include "info.mc"
 include "error.mc"
@@ -99,8 +100,6 @@ lang AppEval = Eval + AppAst
 end
 
 lang ClosAst = Ast + Eval + PrettyPrint + Eq
-  type Lazy a = () -> a
-
   syn Expr =
   | TmClos {ident : Name, body : Expr, env : Lazy EvalEnv, info : Info}
 
@@ -131,11 +130,11 @@ end
 lang LamEval = Eval + LamAst + ClosAst + AppEval
   sem apply ctx info =
   | (TmClos t, arg) ->
-    eval {ctx with env = evalEnvInsert t.ident arg (t.env ())} t.body
+    eval {ctx with env = evalEnvInsert t.ident arg (lazyForce t.env)} t.body
 
   sem eval ctx =
   | TmLam t ->
-    TmClos {ident = t.ident, body = t.body, env = lam. ctx.env, info = t.info}
+    TmClos {ident = t.ident, body = t.body, env = lazy (lam. ctx.env), info = t.info}
   | TmClos t -> TmClos t
 end
 
@@ -172,10 +171,10 @@ lang RecLetsEval =
 
   sem evalDecl ctx =
   | DeclRecLets t ->
-    recursive let envPrime : Lazy EvalEnv = lam.
+    recursive let envPrime : () -> EvalEnv = lam.
       let wraplambda = lam v.
         match v with TmLam t then
-          TmClos {ident = t.ident, body = t.body, env = envPrime, info = t.info}
+          TmClos {ident = t.ident, body = t.body, env = lazy envPrime, info = t.info}
         else
           errorSingle [infoTm v]
             "Right-hand side of recursive let must be a lambda"

--- a/src/stdlib/peval/include.mc
+++ b/src/stdlib/peval/include.mc
@@ -156,7 +156,7 @@ let includeBuiltins = mapValues builtinsMapping
 -- is in fact in the AST, but it may be subject to change (even if unlikely)
 let includeConsNames =
   ["AppAst_TmApp", "LamAst_TmLam", "VarAst_TmVar", "RecordAst_TmRecord",
-   "SeqAst_TmSeq", "ClosAst_TmClos", "ConstAst_TmConst", "ClosAst_Lazy",
+   "SeqAst_TmSeq", "ClosAst_TmClos", "ConstAst_TmConst",
    "MatchAst_TmMatch", "DeclAst_TmDecl", "LetDeclAst_DeclLet", "RecLetsDeclAst_DeclRecLets",
    "DataDeclAst_DeclConDef", "DataAst_TmConApp", "TypeDeclAst_DeclType", "NeverAst_TmNever",
 

--- a/src/stdlib/peval/peval.mc
+++ b/src/stdlib/peval/peval.mc
@@ -177,13 +177,13 @@ lang LamPEval = PEval + PEvalApply + VarAst + LamAst + ClosPAst + AppEval
       let ident = optionGetOrElse (lam. error "impossible") r.ident in
       let b = astBuilder r.cls.info in k (b.app (b.var ident) arg)
     else
-      let env = evalEnvInsert r.cls.ident arg (r.cls.env ()) in
+      let env = evalEnvInsert r.cls.ident arg (lazyForce r.cls.env) in
       pevalEval { ctx with env = env } k r.cls.body
 
   sem pevalEval ctx k =
   | TmLam r ->
     let cls =
-      { ident = r.ident, body = r.body, env = lam. ctx.env, info = r.info }
+      { ident = r.ident, body = r.body, env = lazy (lam. ctx.env), info = r.info }
     in
     k (TmClosP {
       cls = cls, ident = None (), isRecursive = false
@@ -197,7 +197,7 @@ lang LamPEval = PEval + PEvalApply + VarAst + LamAst + ClosPAst + AppEval
       ({ ctx with freeVar = setInsert ident ctx.freeVar }, b.var ident)
     else
       let newident = nameSetNewSym r.cls.ident in
-      let env = evalEnvInsert r.cls.ident (b.var newident) (r.cls.env ()) in
+      let env = evalEnvInsert r.cls.ident (b.var newident) (lazyForce r.cls.env) in
       match
         pevalReadbackH ctx
           (pevalBind { ctx with env = env } (lam x. x) r.cls.body)
@@ -259,7 +259,7 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
 
   sem pevalBindTop ctx k =
   | TmDecl (x & {decl = DeclRecLets r}) ->
-    recursive let envPrime : Int -> Lazy EvalEnv = lam n. lam.
+    recursive let envPrime : Int -> () -> EvalEnv = lam n. lam.
       let wraplambda = lam bind.
         if geqi n ctx.maxRecDepth then TmVar {
           ident = bind.ident,
@@ -272,7 +272,7 @@ lang RecLetsPEval = PEval + RecLetsDeclAst + ClosPAst + LamAst
             cls = {
               ident = r.ident,
               body = r.body,
-              env = envPrime (succ n),
+              env = lazy (envPrime (succ n)),
               info = r.info
             },
             ident = Some bind.ident,


### PR DESCRIPTION
I ran into a name conflict between the `Lazy` alias in `eval.mc` and the `Lazy` type of `lazy.mc`, so I figured I'd make sure we only have one type for it.