### PR TITLE
Attribute grammars and invariant checking

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -26,6 +26,10 @@ include "mlang/main.mc"
 include "peval/compile.mc"
 include "mexpr/generate-pprint.mc"
 
+include "mexpr/invariants/in-scope.mc"
+include "mexpr/invariants/definitions.mc"
+include "mexpr/invariants/info.mc"
+
 include "extrec/main.mc"
 
 lang MCoreCompile =
@@ -41,7 +45,18 @@ lang MCoreCompile =
   SpecializeCompile +
   OldDPrintViaPprint + MExprGeneratePprint + GeneratePprintMissingCase +
   PprintTyAnnot + HtmlAnnotator +
-  MExprToJson
+  MExprToJson +
+
+  UnboundErrorAttr + DefinedAttr + WithoutInfoAttr
+  sem mkInvariantAttrs : () -> [Attr Loc]
+  sem mkInvariantAttrs = | _ ->
+    let scope =
+      {_scopeEmpty () with tyConstructors = setOfSeq nameCmp (mapValues builtinTypeNames)} in
+    [ InScopeAttr (filledThunk scope)
+    , UnboundErrorAttr (mkThunk (lazyPure "UnboundErrorAttr#root"))
+    , WithoutInfoAttr (mkThunk (lazyPure "WithoutInfoAttr#root"))
+    , DefinedAttr (mkThunk (lazyPure "DefinedAttr#root"))
+    ]
 end
 
 lang TyAnnotFull = MExprPrettyPrint + TyAnnot + HtmlAnnotator + MetaVarTypePrettyPrint
@@ -63,7 +78,7 @@ let insertTunedOrDefaults = lam options : Options. lam ast. lam file.
 
 let compileWithUtests = lam options : Options. lam sourcePath. lam ast.
   use MCoreCompile in
-    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases mkInvariantAttrs in
 
     -- If option --debug-profile, insert instrumented profiling expressions
     -- in AST
@@ -160,7 +175,7 @@ let compile = lam files. lam options : Options. lam args.
     iter (compileExtendedMLangToOcaml options compileWithUtests) files
   else
     let compileFile = lam file.
-      let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
+      let log = mkPhaseLogState options.debugDumpPhases options.debugPhases mkInvariantAttrs in
       let ast = parseParseMCoreFile {
         keepUtests = options.runTests,
         pruneExternalUtests = not options.disablePruneExternalUtests,

--- a/src/stdlib/extrec/main.mc
+++ b/src/stdlib/extrec/main.mc
@@ -185,7 +185,7 @@ lang BigPipeline = BigIncludeHandler +
     smap_Expr_Expr stripTypes e
 
   sem compileExtendedMLangToOcaml options runner =| filepath ->
-    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases (lam. []) in
 
     let p = parseAndHandleIncludes filepath in
     endPhaseStatsProg log "parsing-include-handling" p;

--- a/src/stdlib/mexpr/attribute-grammar.mc
+++ b/src/stdlib/mexpr/attribute-grammar.mc
@@ -1,0 +1,632 @@
+-- This file provides an extensible language fragment for computing
+-- attributes associated with each node in an AST, lazily.
+--
+-- The main entry point for computing attributes is `processAst`,
+-- which takes a list of attributes to compute, and an AST to compute
+-- over. The given attributes are considered associated with the root
+-- of the AST. Note that attributes are currently not attached to the
+-- AST after computation, i.e., the only meaningful use is to do
+-- analyses over the entire tree in the form of attributes on the root
+-- node.
+--
+-- The interface centers around the `Attr` type, which is meant to be
+-- extended with one new constructor per attribute. Each attribute
+-- should contain exactly a `Thunk a`, where `a` is the type of the
+-- attribute. Values of this type is used in one of two ways:
+-- * As a sort of key for getting the attribute with the same
+--   constructor from somewhere else, e.g., `getAttrExpr (ExampleAttr
+--   noThunk) x.body`. These uses only look at the constructor, not
+--   the carried data, thus `noThunk` can be used safely.
+-- * As a carrier for the thunk representing the attribute. These must
+--   contain a real thunk, either from `mkThunk` or `filledThunk`.
+--
+-- Writing an attribute entails:
+-- 1. Adding a constructor to `syn Attr loc`.
+-- 2. Implementing `newAttr` and `attrKindToString.
+-- 3. Implementing `processAttr*` for the desired AST types. This can
+--    use some helpers:
+--    * `getAttrEnv` for getting other attributes of the current node,
+--      and `getAttr*` for getting attributes of children.
+--    * `willWrite` and `willRead` to record which thunks (attributes)
+--      will be written to and read from.
+--    * `simpleSynthesized*` and `simpleInherited*` for simple AST
+--      cases, i.e., those that would be covered by `smap` in other
+--      semantic functions.
+--
+-- See `CountAttribute` in this file for a very simple synthesized
+-- attribute, or `DeclaredHere` and `InScopeAttr` in
+-- `invariants/in-scope.mc` for a mildly more complicated interplay
+-- between a synthesized and inherited attribute.
+
+include "mexpr/ast.mc"
+include "mexpr/pprint.mc"
+include "lazy.mc"
+include "thunk.mc"
+
+lang AttributeGrammar = Ast + DeclAst + PrettyPrint
+  -- Each `Attr` is expected to contain exactly a `Thunk` of whatever
+  -- the carried value is
+  syn Attr loc =
+
+  syn Loc =
+  | LocExpr Expr
+  | LocType Type
+  | LocDecl Decl
+  | LocPat Pat
+
+  sem loc2str : Loc -> String
+  sem loc2str =
+  | LocExpr x -> expr2str x
+  | LocType x -> type2str x
+  | LocDecl x -> decl2str x
+  | LocPat x -> pat2str x
+
+  type InvEnv loc = Map Int (Attr loc)
+
+  type InvState =
+    { willWrite : [ThunkMeta]
+    }
+
+  -- === external interface ===
+
+  -- Setup lazy computations in the given attributes to compute them
+  -- as though they were attached to the root node of the given
+  -- AST. Note that input attributes will be deduplicated, thus it's
+  -- recommended to use `getAttrEnv` on the returned value rather than
+  -- retain references to the original attributes, to make it easier
+  -- to extensibly request which attributes should be computed.
+  sem processAst : [Attr Loc] -> Expr -> InvEnv Loc
+  sem processAst attrs = | tm ->
+    let env = mapFromSeq subi (map (lam x. (constructorTag x, x)) attrs) in
+    processExpr env tm;
+    env
+
+  -- === interface for implementing an attribute ===
+
+  sem getAttrEnv : all loc. Attr loc -> InvEnv loc -> Attr loc
+  sem getAttrEnv attr = | env ->
+    -- TODO(vipa, 2026-03-02): Make a somewhat more informative error
+    -- if this fails. That should only happen if the attribute wasn't
+    -- propagated from above previously, which is a programmer error,
+    -- but a relatively easy one to make.
+    match mapLookup (constructorTag attr) env with Some attr in
+    attr
+
+  sem getAttrExpr : all loc. Attr loc -> Expr -> Attr loc
+  sem getAttrExpr attr = | tm ->
+    match tm with TmWithEnv x in
+    let tag = constructorTag attr in
+    -- NOTE(vipa, 2026-03-02): The type-variable `loc` will always be
+    -- instantiated as `Loc`, it's quantified to ensure that no `Attr`
+    -- may look at it directly, thus this `unsafeCoerce` is safe.
+    let unwrapEnv : Ref (InvEnv Loc) -> Ref (InvEnv loc) = unsafeCoerce in
+    let env = unwrapEnv x.env in
+    match mapLookup tag (deref env) with Some found then found else
+    let new = newAttr (lazy (lam. join [attrKindToString attr, "#", lazyForce x.label])) attr in
+    (if neqi tag (constructorTag new) then
+      error "Compiler error: newAttr returned different constructorTag"
+     else ());
+    modref env (mapInsert tag new (deref env));
+    new
+
+  sem getAttrType : all loc. Attr loc -> Type -> Attr loc
+  sem getAttrType attr = | tm ->
+    match tm with TyWithEnv x in
+    let tag = constructorTag attr in
+    -- NOTE(vipa, 2026-03-02): The type-variable `loc` will always be
+    -- instantiated as `Loc`, it's quantified to ensure that no `Attr`
+    -- may look at it directly, thus this `unsafeCoerce` is safe.
+    let unwrapEnv : Ref (InvEnv Loc) -> Ref (InvEnv loc) = unsafeCoerce in
+    let env = unwrapEnv x.env in
+    match mapLookup tag (deref env) with Some attr then attr else
+    let attr = newAttr (lazy (lam. join [attrKindToString attr, "#", lazyForce x.label])) attr in
+    (if neqi tag (constructorTag attr) then
+      error "Compiler error: newAttr returned different constructorTag"
+     else ());
+    modref env (mapInsert tag attr (deref env));
+    attr
+
+  sem getAttrDecl : all loc. Attr loc -> Decl -> Attr loc
+  sem getAttrDecl attr = | tm ->
+    match tm with DeclWithEnv x in
+    let tag = constructorTag attr in
+    -- NOTE(vipa, 2026-03-02): The type-variable `loc` will always be
+    -- instantiated as `Loc`, it's quantified to ensure that no `Attr`
+    -- may look at it directly, thus this `unsafeCoerce` is safe.
+    let unwrapEnv : Ref (InvEnv Loc) -> Ref (InvEnv loc) = unsafeCoerce in
+    let env = unwrapEnv x.env in
+    match mapLookup tag (deref env) with Some attr then attr else
+    let attr = newAttr (lazy (lam. join [attrKindToString attr, "#", lazyForce x.label])) attr in
+    (if neqi tag (constructorTag attr) then
+      error "Compiler error: newAttr returned different constructorTag"
+     else ());
+    modref env (mapInsert tag attr (deref env));
+    attr
+
+  sem getAttrPat : all loc. Attr loc -> Pat -> Attr loc
+  sem getAttrPat attr = | tm ->
+    match tm with PatWithEnv x in
+    let tag = constructorTag attr in
+    -- NOTE(vipa, 2026-03-02): The type-variable `loc` will always be
+    -- instantiated as `Loc`, it's quantified to ensure that no `Attr`
+    -- may look at it directly, thus this `unsafeCoerce` is safe.
+    let unwrapEnv : Ref (InvEnv Loc) -> Ref (InvEnv loc) = unsafeCoerce in
+    let env = unwrapEnv x.env in
+    match mapLookup tag (deref env) with Some attr then attr else
+    let attr = newAttr (lazy (lam. join [attrKindToString attr, "#", lazyForce x.label])) attr in
+    (if neqi tag (constructorTag attr) then
+      error "Compiler error: newAttr returned different constructorTag"
+     else ());
+    modref env (mapInsert tag attr (deref env));
+    attr
+
+  sem willWrite : all a. InvState -> Thunk a -> (InvState, a -> ())
+  sem willWrite st = | thunk ->
+    ( { st with willWrite = snoc st.willWrite {lazy = thunk.lazy, blackhole = thunk.blackhole} }
+    , thunk.write
+    )
+
+  sem willRead : all a. InvState -> Thunk a -> (InvState, () -> a)
+  sem willRead st = | thunk ->
+    (st, thunk.read)
+
+  -- === semantic functions to be implemented by each attribute ===
+
+  sem newAttr : all loc. Lazy String -> Attr loc -> Attr loc
+  sem attrKindToString : all loc. Attr loc -> String
+
+  -- Each `processAttr*` is given:
+  -- * An `env` containing the attributes to be computed for this
+  --   node. `getAttrEnv` can be used to access other attributes here.
+  -- * A `st`, which is used to record which attributes are
+  --   read/written by this invocation.
+  -- * An opaque `loc`, which can be stored in an attribute to record
+  --   where in the AST the attribute was computed.
+  -- * A pair of the current node and the attribute to be computed,
+  --   used for dispatch.
+  --
+  -- `processAttr*` should then returned an updated `st` and the
+  -- function that actually computes the attribute by reading/writing
+  -- from/to the previously recorded attributes.
+  sem processAttrExpr : all loc. InvEnv loc -> InvState -> loc -> (Expr, Attr loc) -> (InvState, () -> ())
+  sem processAttrExpr env st loc =
+  | (tm, attr) -> errorSingle [infoTm tm]
+    (join ["Missing case in processAttrExpr for ", attrKindToString attr, " for: ", expr2str tm])
+  sem processAttrDecl : all loc. InvEnv loc -> InvState -> loc -> (Decl, Attr loc) -> (InvState, () -> ())
+  sem processAttrDecl env st loc =
+  | (decl, attr) -> errorSingle [infoDecl decl]
+    (join ["Missing case in processAttrDecl for ", attrKindToString attr, " for: ", decl2str decl])
+  sem processAttrType : all loc. InvEnv loc -> InvState -> loc -> (Type, Attr loc) -> (InvState, () -> ())
+  sem processAttrType env st loc =
+  | (ty, attr) -> errorSingle [infoTy ty]
+    (join ["Missing case in processAttrType for ", attrKindToString attr, " for: ", type2str ty])
+  sem processAttrPat : all loc. InvEnv loc -> InvState -> loc -> (Pat, Attr loc) -> (InvState, () -> ())
+  sem processAttrPat env st loc =
+  | (pat, attr) -> errorSingle [infoPat pat]
+    (join ["Missing case in processAttrPat for ", attrKindToString attr, " for: ", pat2str pat])
+
+  -- === alternate interfaces === ---
+
+  type SimpleSynthesizedF ast attr
+    = all loc. InvState -- The current InvState value
+    -> (ast, Attr loc) -- The current node and attribute to write
+    -> (Attr loc -> Thunk attr) -- An accessor for the current attribute, can assume it's the correct type
+    -> attr -- An empty attribute, should be an identity element for the next operation
+    -> (attr -> attr -> attr) -- A merging operation, should *probably* be commutative, or at least that it doesn't matter if the argument order differs
+    -> (attr -> attr) -- Add data from the current node, *after* reading from children
+    -> (InvState, () -> ())
+
+  type SimpleInheritedF ast attr
+    = all loc. InvState -- The current InvState value
+    -> (ast, Attr loc) -- The current node and attribute to read from
+    -> (Attr loc -> Thunk attr) -- An accessor for the current attribute, can assume it's the correct type
+    -> (attr -> attr) -- Add data from the current node, *before* pushing to children
+    -> (InvState, () -> ())
+
+  sem simpleSynthesizedExpr : all attr. SimpleSynthesizedF Expr attr
+  sem simpleSynthesizedExpr st here openAttr zero plus = | addHere ->
+    match here with (tm, attr) in
+    match willWrite st (openAttr attr) with (st, writeHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, gets) in
+      match willRead st (openAttr (getAttr x)) with (st, get) in
+      (st, snoc gets get) in
+    let acc = (st, []) in
+    let acc = match tm with TmDecl x
+      then f (getAttrDecl attr) acc x.decl
+      else acc in
+    let acc = sfold_Expr_Expr (f (getAttrExpr attr)) acc tm in
+    let acc = sfold_Expr_Type (f (getAttrType attr)) acc tm in
+    let acc = sfold_Expr_Pat (f (getAttrPat attr)) acc tm in
+    match acc with (st, gets) in
+    ( st
+    , lam.
+      let below = foldl (lam attr. lam f. plus attr (f ())) zero gets in
+      writeHere (addHere below)
+    )
+
+  sem simpleSynthesizedDecl : all attr. SimpleSynthesizedF Decl attr
+  sem simpleSynthesizedDecl st here openAttr zero plus = | addHere ->
+    match here with (decl, attr) in
+    match willWrite st (openAttr attr) with (st, writeHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, gets) in
+      match willRead st (openAttr (getAttr x)) with (st, get) in
+      (st, snoc gets get) in
+    let acc = (st, []) in
+    let acc = sfold_Decl_Expr (f (getAttrExpr attr)) acc decl in
+    let acc = sfold_Decl_Type (f (getAttrType attr)) acc decl in
+    match acc with (st, gets) in
+    ( st
+    , lam.
+      writeHere (addHere (foldl (lam attr. lam f. plus attr (f ())) zero gets))
+    )
+
+  sem simpleSynthesizedType : all attr. SimpleSynthesizedF Type attr
+  sem simpleSynthesizedType st here openAttr zero plus = | addHere ->
+    match here with (ty, attr) in
+    match willWrite st (openAttr attr) with (st, writeHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, gets) in
+      match willRead st (openAttr (getAttr x)) with (st, get) in
+      (st, snoc gets get) in
+    let acc = (st, []) in
+    let acc = sfold_Type_Type (f (getAttrType attr)) acc ty in
+    match acc with (st, gets) in
+    ( st
+    , lam.
+      writeHere (addHere (foldl (lam attr. lam f. plus attr (f ())) zero gets))
+    )
+
+  sem simpleSynthesizedPat : all attr. SimpleSynthesizedF Pat attr
+  sem simpleSynthesizedPat st here openAttr zero plus = | addHere ->
+    match here with (pat, attr) in
+    match willWrite st (openAttr attr) with (st, writeHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, gets) in
+      match willRead st (openAttr (getAttr x)) with (st, get) in
+      (st, snoc gets get) in
+    let acc = (st, []) in
+    let acc = sfold_Pat_Pat (f (getAttrPat attr)) acc pat in
+    match acc with (st, gets) in
+    ( st
+    , lam.
+      writeHere (addHere (foldl (lam attr. lam f. plus attr (f ())) zero gets))
+    )
+
+  sem simpleInheritedExpr : all attr. SimpleInheritedF Expr attr
+  sem simpleInheritedExpr st here openAttr = | addHere ->
+    match here with (tm, attr) in
+    match willRead st (openAttr attr) with (st, readHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, writes) in
+      match willWrite st (openAttr (getAttr x)) with (st, write) in
+      (st, snoc writes write) in
+    let acc = (st, []) in
+    let acc = match tm with TmDecl x
+      then f (getAttrDecl attr) acc x.decl
+      else acc in
+    let acc = sfold_Expr_Expr (f (getAttrExpr attr)) acc tm in
+    let acc = sfold_Expr_Type (f (getAttrType attr)) acc tm in
+    let acc = sfold_Expr_Pat (f (getAttrPat attr)) acc tm in
+    match acc with (st, writes) in
+    ( st
+    , lam.
+      let data = addHere (readHere ()) in
+      for_ writes (lam w. w data)
+    )
+
+  sem simpleInheritedDecl : all attr. SimpleInheritedF Decl attr
+  sem simpleInheritedDecl st here openAttr = | addHere ->
+    match here with (decl, attr) in
+    match willRead st (openAttr attr) with (st, readHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, writes) in
+      match willWrite st (openAttr (getAttr x)) with (st, write) in
+      (st, snoc writes write) in
+    let acc = (st, []) in
+    let acc = sfold_Decl_Expr (f (getAttrExpr attr)) acc decl in
+    let acc = sfold_Decl_Type (f (getAttrType attr)) acc decl in
+    match acc with (st, writes) in
+    ( st
+    , lam.
+      let data = addHere (readHere ()) in
+      for_ writes (lam w. w data)
+    )
+
+  sem simpleInheritedType : all attr. SimpleInheritedF Type attr
+  sem simpleInheritedType st here openAttr = | addHere ->
+    match here with (ty, attr) in
+    match willRead st (openAttr attr) with (st, readHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, writes) in
+      match willWrite st (openAttr (getAttr x)) with (st, write) in
+      (st, snoc writes write) in
+    let acc = (st, []) in
+    let acc = sfold_Type_Type (f (getAttrType attr)) acc ty in
+    match acc with (st, writes) in
+    ( st
+    , lam.
+      let data = addHere (readHere ()) in
+      for_ writes (lam w. w data)
+    )
+
+  sem simpleInheritedPat : all attr. SimpleInheritedF Pat attr
+  sem simpleInheritedPat st here openAttr = | addHere ->
+    match here with (pat, attr) in
+    match willRead st (openAttr attr) with (st, readHere) in
+    let f = lam getAttr. lam acc. lam x.
+      match acc with (st, writes) in
+      match willWrite st (openAttr (getAttr x)) with (st, write) in
+      (st, snoc writes write) in
+    let acc = (st, []) in
+    let acc = sfold_Pat_Pat (f (getAttrPat attr)) acc pat in
+    match acc with (st, writes) in
+    ( st
+    , lam.
+      let data = addHere (readHere ()) in
+      for_ writes (lam w. w data)
+    )
+
+  -- === Internals ===
+
+  syn Expr = | TmWithEnv {env : Ref (InvEnv Loc), label : Lazy String}
+  syn Decl = | DeclWithEnv {env : Ref (InvEnv Loc), label : Lazy String}
+  syn Type = | TyWithEnv {env : Ref (InvEnv Loc), label : Lazy String}
+  syn Pat = | PatWithEnv {env : Ref (InvEnv Loc), label : Lazy String}
+
+  sem pprintCode indent env = | TmWithEnv x -> (env, join ["<omitted tm, ", lazyForce x.label, ">"])
+  sem getTypeStringCode indent env = | TyWithEnv x -> (env, join ["<omitted ty, ", lazyForce x.label, ">"])
+  sem getPatStringCode indent env = | PatWithEnv x -> (env, join ["<omitted pat, ", lazyForce x.label, ">"])
+  sem pprintDeclCode indent env = | DeclWithEnv x -> (env, join ["<omitted decl, ", lazyForce x.label, ">"])
+
+  -- sem infoTm = | TmWithEnv _ -> NoInfo ()
+  -- sem infoTy = | TyWithEnv _ -> NoInfo ()
+  -- sem infoDecl = | DeclWithEnv _ -> NoInfo ()
+  -- sem infoPat = | PatWithEnv _ -> NoInfo ()
+
+  sem processExpr : InvEnv Loc -> Expr -> ()
+  sem processExpr env = | tm ->
+    let loc = LocExpr tm in
+    -- NOTE(vipa, 2026-02-25): Prepare, insert environments in place
+    -- of expressions, prepare closures for the recursive calls
+    let toCall = [] in
+
+    let prepareDecl = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processDecl (deref localEnv) x)
+      , DeclWithEnv {label = lazy (lam. decl2str x), env = localEnv}
+      ) in
+    -- NOTE(vipa, 2026-03-02): This takes the place of an explicit
+    -- smapAccumL_Expr_Decl. Note also that it swaps out the `Decl`
+    -- for one that has no children, thus the default
+    -- `smapAccumL_Expr_*` for `TmDecl` (which traverses through the
+    -- corresponding `smapAccumL_Decl_*`) doesn't apply after this,
+    -- i.e., it's important we deal with `Decl` *first*.
+    match
+      match tm with TmDecl x then
+        match prepareDecl toCall x.decl with (toCall, decl) in
+        (toCall, TmDecl {x with decl = decl})
+      else (toCall, tm)
+    with (toCall, tm) in
+
+    let prepareExpr = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processExpr (deref localEnv) x)
+      , TmWithEnv {label = lazy (lam. expr2str x), env = localEnv}
+      ) in
+    match smapAccumL_Expr_Expr prepareExpr toCall tm with (toCall, tm) in
+
+    let prepareType = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processType (deref localEnv) x)
+      , TyWithEnv {label = lazy (lam. type2str x), env = localEnv}
+      ) in
+    match smapAccumL_Expr_Type prepareType toCall tm with (toCall, tm) in
+
+    let preparePat = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processPat (deref localEnv) x)
+      , PatWithEnv {label = lazy (lam. pat2str x), env = localEnv}
+      ) in
+    match smapAccumL_Expr_Pat preparePat toCall tm with (toCall, tm) in
+
+    -- NOTE(vipa, 2026-02-25): Do processing of attributes here
+    let st = {willWrite = []} in
+    let fsPerAttr = mapMap (lam attr. processAttrExpr env st loc (tm, attr)) env in
+
+    -- NOTE(vipa, 2026-02-25): Record connections between thunks and
+    -- their update functions
+    let f = lam pair.
+      match pair with (st, f) in
+      let f = lam.
+        for_ st.willWrite (lam ww. ww.blackhole ());
+        f () in
+      for_ st.willWrite (lam ww. ww.lazy f) in
+    mapMap f fsPerAttr;
+
+    -- NOTE(vipa, 2026-02-25): Do recursive calls
+    for_ toCall (lam f. f ())
+
+  sem processDecl : InvEnv Loc -> Decl -> ()
+  sem processDecl env = | decl ->
+    let loc = LocDecl decl in
+    -- NOTE(vipa, 2026-02-25): Prepare, insert environments in place
+    -- of expressions, prepare closures for the recursive calls
+    let toCall = [] in
+
+    let prepareExpr = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processExpr (deref localEnv) x)
+      , TmWithEnv {label = lazy (lam. expr2str x), env = localEnv}
+      ) in
+    match smapAccumL_Decl_Expr prepareExpr toCall decl with (toCall, decl) in
+
+    let prepareType = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processType (deref localEnv) x)
+      , TyWithEnv {label = lazy (lam. type2str x), env = localEnv}
+      ) in
+    match smapAccumL_Decl_Type prepareType toCall decl with (toCall, decl) in
+
+    -- NOTE(vipa, 2026-02-25): Do processing of attributes here
+    let st = {willWrite = []} in
+    let fsPerAttr = mapMap (lam attr. processAttrDecl env st loc (decl, attr)) env in
+
+    -- NOTE(vipa, 2026-02-25): Record connections between thunks and
+    -- their update functions
+    let f = lam pair.
+      match pair with (st, f) in
+      let f = lam.
+        for_ st.willWrite (lam ww. ww.blackhole ());
+        f () in
+      for_ st.willWrite (lam ww. ww.lazy f) in
+    mapMap f fsPerAttr;
+
+    -- NOTE(vipa, 2026-02-25): Do recursive calls
+    for_ toCall (lam f. f ())
+
+  sem processType : InvEnv Loc -> Type -> ()
+  sem processType env = | ty ->
+    let loc = LocType ty in
+    -- NOTE(vipa, 2026-02-25): Prepare, insert environments in place
+    -- of expressions, prepare closures for the recursive calls
+    let toCall = [] in
+
+    let prepareType = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processType (deref localEnv) x)
+      , TyWithEnv {label = lazy (lam. type2str x), env = localEnv}
+      ) in
+    match smapAccumL_Type_Type prepareType toCall ty with (toCall, ty) in
+
+    -- NOTE(vipa, 2026-02-25): Do processing of attributes here
+    let st = {willWrite = []} in
+    let fsPerAttr = mapMap (lam attr. processAttrType env st loc (ty, attr)) env in
+
+    -- NOTE(vipa, 2026-02-25): Record connections between thunks and
+    -- their update functions
+    let f = lam pair.
+      match pair with (st, f) in
+      let f = lam.
+        for_ st.willWrite (lam ww. ww.blackhole ());
+        f () in
+      for_ st.willWrite (lam ww. ww.lazy f) in
+    mapMap f fsPerAttr;
+
+    -- NOTE(vipa, 2026-02-25): Do recursive calls
+    for_ toCall (lam f. f ())
+
+  sem processPat : InvEnv Loc -> Pat -> ()
+  sem processPat env = | pat ->
+    let loc = LocPat pat in
+    -- NOTE(vipa, 2026-02-25): Prepare, insert environments in place
+    -- of expressions, prepare closures for the recursive calls
+    let toCall = [] in
+
+    let preparePat = lam toCall. lam x.
+      let localEnv = ref (mapEmpty subi) in
+      ( snoc toCall (lam. processPat (deref localEnv) x)
+      , PatWithEnv {label = lazy (lam. pat2str x), env = localEnv}
+      ) in
+    match smapAccumL_Pat_Pat preparePat toCall pat with (toCall, pat) in
+
+    -- NOTE(vipa, 2026-02-25): Do processing of attributes here
+    let st = {willWrite = []} in
+    let fsPerAttr = mapMap (lam attr. processAttrPat env st loc (pat, attr)) env in
+
+    -- NOTE(vipa, 2026-02-25): Record connections between thunks and
+    -- their update functions
+    let f = lam pair.
+      match pair with (st, f) in
+      let f = lam.
+        for_ st.willWrite (lam ww. ww.blackhole ());
+        f () in
+      for_ st.willWrite (lam ww. ww.lazy f) in
+    mapMap f fsPerAttr;
+
+    -- NOTE(vipa, 2026-02-25): Do recursive calls
+    for_ toCall (lam f. f ())
+end
+
+lang CountAttr = AttributeGrammar + MExprAst
+  type CountAttr loc =
+    { tm : Int
+    , decl : Int
+    , ty : Int
+    , pat : Int
+    }
+
+  syn Attr loc =
+  | CountAttr (Thunk (CountAttr loc))
+
+  sem newAttr label =
+  | CountAttr _ -> CountAttr (mkThunk label)
+
+  sem attrKindToString =
+  | CountAttr _ -> "CountAttr"
+
+  sem openCountAttr : all loc. Attr loc -> Thunk (CountAttr loc)
+  sem openCountAttr =
+  | CountAttr x -> x
+
+  sem mergeCount : all loc. CountAttr loc -> CountAttr loc -> CountAttr loc
+  sem mergeCount a = | b ->
+    { tm = addi a.tm b.tm
+    , decl = addi a.decl b.decl
+    , ty = addi a.ty b.ty
+    , pat = addi a.pat b.pat
+    }
+
+  sem processAttrDecl env st loc =
+  | pair & (_, CountAttr _) ->
+    simpleSynthesizedDecl st
+      pair
+      openCountAttr
+      {tm = 0, decl = 0, ty = 0, pat = 0}
+      mergeCount
+      (lam x. {x with decl = addi x.decl 1})
+
+  sem processAttrExpr env st loc =
+  | pair & (_, CountAttr _) ->
+    simpleSynthesizedExpr st
+      pair
+      openCountAttr
+      {tm = 0, decl = 0, ty = 0, pat = 0}
+      mergeCount
+      (lam x. {x with tm = addi x.tm 1})
+
+  sem processAttrType env st loc =
+  | pair & (_, CountAttr _) ->
+    simpleSynthesizedType st
+      pair
+      openCountAttr
+      {tm = 0, decl = 0, ty = 0, pat = 0}
+      mergeCount
+      (lam x. {x with ty = addi x.ty 1})
+
+  sem processAttrPat env st loc =
+  | pair & (_, CountAttr _) ->
+    simpleSynthesizedPat st
+      pair
+      openCountAttr
+      {tm = 0, decl = 0, ty = 0, pat = 0}
+      mergeCount
+      (lam x. {x with pat = addi x.pat 1})
+end
+
+mexpr
+
+use CountAttr in
+
+let count = lam ast.
+  match getAttrEnv (CountAttr noThunk) (processAst [CountAttr (mkThunk (lazyPure "CountAttr#root"))] ast)
+    with CountAttr thunk in
+  thunk.read () in
+
+utest count unit_ with {decl = 0, pat = 0, ty = 0, tm = 1} in
+utest count (ulam_ "a" (var_ "a")) with {decl = 0, pat = 0, ty = 1, tm = 2} in
+utest count (match_ (int_ 1) (pint_ 2) true_ false_) with {decl = 0, pat = 1, ty = 0, tm = 4} in
+utest count (bind_ (ulet_ "x" (int_ 1)) (var_ "x")) with {decl = 1, pat = 0, ty = 1, tm = 3} in
+
+()

--- a/src/stdlib/mexpr/invariants.mc
+++ b/src/stdlib/mexpr/invariants.mc
@@ -1,0 +1,15 @@
+include "mexpr/attribute-grammar.mc"
+
+lang Invariant = AttributeGrammar
+  sem printInvariantSummary : Attr Loc -> ()
+  sem printInvariantSummary =
+  | _ -> ()
+
+  sem checkInvariants : [Attr Loc] -> Expr -> ()
+  sem checkInvariants attrs = | ast ->
+    let start = wallTimeMs () in
+    let res = processAst attrs ast in
+    let timeMs = subf (wallTimeMs ()) start in
+    printLn (join ["  Invariants: associated attributes in ", float2string timeMs, "ms."]);
+    mapFoldWithKey (lam. lam. lam attr. printInvariantSummary attr) () res
+end

--- a/src/stdlib/mexpr/invariants/definitions.mc
+++ b/src/stdlib/mexpr/invariants/definitions.mc
@@ -1,0 +1,172 @@
+-- This file provides attributes (see `mexpr/attribute-grammar.mc`)
+-- for finding all places where each `Name` is defined in the AST.
+--
+-- To use, supply a `DefinedAttr (mkThunk "DefinedAttr#root")`
+-- to `processAst`, then read from it afterwards.
+
+include "mexpr/ast.mc"
+include "mexpr/invariants.mc"
+include "mexpr/invariants/in-scope.mc"
+
+include "mexpr/cmp.mc"
+
+lang DefinedAttr = Invariant + MExprAst + DeclaredHereAttr
+  type DefinedAttr loc = Map Name [loc]
+  syn Attr loc =
+  | DefinedAttr (Thunk (DefinedAttr loc))
+
+  sem newAttr label =
+  | DefinedAttr _ -> DefinedAttr (mkThunk label)
+
+  sem attrKindToString =
+  | DefinedAttr _ -> "DefinedAttr"
+
+  sem printInvariantSummary =
+  | DefinedAttr x ->
+    let start = wallTimeMs () in
+    let x = x.read () in
+    let timeMs = subf (wallTimeMs ()) start in
+    let numNoSym =
+      mapFoldWithKey (lam n. lam k. lam. if nameHasSym k then n else addi n 1) 0 x in
+    let numMultiDef = mapFoldWithKey
+      (lam n. lam. lam defs. match defs with [_, _] ++ _ then addi n 1 else n) 0 x in
+    printLn (join
+      [ "  Definitions: ", int2string numNoSym, " names without symbols, "
+      , int2string numMultiDef, " with multiple definitions ("
+      , float2string timeMs, "ms)."
+      ])
+
+  sem openDefinedAttr : all loc. Attr loc -> Thunk (DefinedAttr loc)
+  sem openDefinedAttr = | DefinedAttr x -> x
+
+  sem addDefinitions : all loc. loc -> InScopeAttr loc -> DefinedAttr loc -> DefinedAttr loc
+  sem addDefinitions loc scope = | x ->
+    let f = lam x. lam n. mapInsertWith concat n [loc] x in
+    let x = setFold f x scope.values in
+    let x = setFold f x scope.constructors in
+    let x = setFold f x scope.tyValues in
+    let x = setFold f x scope.tyConstructors in
+    x
+
+  sem processDefinedExpr : all loc. InvEnv loc -> InvState -> loc -> Expr -> (InvState, DefinedAttr loc -> DefinedAttr loc)
+  sem processDefinedExpr env st loc =
+  | TmLam x -> (st, mapInsertWith concat x.ident [loc])
+  | TmDecl x ->
+    match willRead st (openInScopeAttr (getAttrDecl (DeclaredHere noThunk) x.decl)) with (st, readDecl) in
+    ( st
+    , lam definitions.
+      let res = readDecl () in
+      addDefinitions loc res definitions
+    )
+  | _ -> (st, lam x. x)
+
+  sem processDefinedType : all loc. loc -> Type -> DefinedAttr loc -> DefinedAttr loc
+  sem processDefinedType loc =
+  | TyAll x -> mapInsertWith concat x.ident [loc]
+  | _ -> lam x. x
+
+  sem processAttrDecl env st loc =
+  | pair & (_, DefinedAttr _) ->
+    simpleSynthesizedDecl st
+      pair
+      openDefinedAttr
+      (mapEmpty nameCmp)
+      (mapUnionWith concat)
+      (lam x. x)
+
+  sem processAttrExpr env st loc =
+  | (TmMatch x, attr & DefinedAttr here) ->
+    match willWrite st here with (st, writeHere) in
+    match willRead st (openDefinedAttr (getAttrExpr attr x.target)) with (st, readTarget) in
+    match willRead st (openInScopeAttr (getAttrPat (DeclaredHere noThunk) x.pat)) with (st, readPat) in
+    match willRead st (openDefinedAttr (getAttrExpr attr x.thn)) with (st, readThn) in
+    match willRead st (openDefinedAttr (getAttrExpr attr x.els)) with (st, readEls) in
+    ( st
+    , lam.
+      let res = mapUnionWith concat (readTarget ()) (readThn ()) in
+      let res = mapUnionWith concat res (readEls ()) in
+      let res = addDefinitions loc (readPat ()) res in
+      writeHere res
+    )
+  | pair & (tm, DefinedAttr _) ->
+    match processDefinedExpr env st loc tm with (st, addHere) in
+    simpleSynthesizedExpr st
+      pair
+      openDefinedAttr
+      (mapEmpty nameCmp)
+      (mapUnionWith concat)
+      addHere
+
+  sem processAttrType env st loc =
+  | pair & (ty, DefinedAttr _) ->
+    simpleSynthesizedType st
+      pair
+      openDefinedAttr
+      (mapEmpty nameCmp)
+      (mapUnionWith concat)
+      (processDefinedType loc ty)
+end
+
+lang TestLang = DefinedAttr + MExprCmp
+end
+
+mexpr
+
+use TestLang in
+
+-- NOTE(vipa, 2026-03-04): We check info fields of the top node as
+-- well, so we're able to distinguish sub-trees that are otherwise
+-- identical
+let locEq = lam a. lam b. switch (a, b)
+  case (LocExpr a, LocExpr b) then
+    if eqi 0 (cmpExpr a b)
+    then eqi 0 (infoCmp (infoTm a) (infoTm b))
+    else false
+  case (LocDecl a, LocDecl b) then
+    if eqi 0 (cmpDecl a b)
+    then eqi 0 (infoCmp (infoDecl a) (infoDecl b))
+    else false
+  case (LocType a, LocType b) then
+    if eqi 0 (cmpType a b)
+    then eqi 0 (infoCmp (infoTy a) (infoTy b))
+    else false
+  case (LocPat a, LocPat b) then
+    if eqi 0 (cmpPat a b)
+    then eqi 0 (infoCmp (infoPat a) (infoPat b))
+    else false
+  end in
+let eq = eqSeq (tupleEq2 nameEq (eqSeq locEq)) in
+
+-- NOTE(vipa, 2026-03-04): Two helpers for attaching two distinct info
+-- fields to each kind of node
+let itm = withInfo (infoVal "i" 0 0 0 0) in
+let jtm = withInfo (infoVal "j" 0 0 0 0) in
+let ity = tyWithInfo (infoVal "i" 0 0 0 0) in
+let jty = tyWithInfo (infoVal "j" 0 0 0 0) in
+let idecl = declWithInfo (infoVal "i" 0 0 0 0) in
+let jdecl = declWithInfo (infoVal "j" 0 0 0 0) in
+let ipat = withInfoPat (infoVal "i" 0 0 0 0) in
+let jpat = withInfoPat (infoVal "j" 0 0 0 0) in
+
+let check = lam ast.
+  let attrs = [DefinedAttr (mkThunk (lazyPure "DefinedAttr#root"))] in
+  let res = processAst attrs ast in
+  match getAttrEnv (DefinedAttr noThunk) res with DefinedAttr thunk in
+  mapBindings (thunk.read ()) in
+
+
+-- === Actual tests ===
+
+utest check (bindall_ [ulet_ "x" unit_, ulet_ "x" (int_ 1)] unit_) with
+  [ ( nameNoSym "x"
+    , [ LocExpr (bindall_ [ulet_ "x" (int_ 1)] unit_)
+      , LocExpr (bindall_ [ulet_ "x" unit_, ulet_ "x" (int_ 1)] unit_)
+      ]
+    )
+  ] using eq in
+utest check (match_ unit_ (por_ (pvar_ "x") pvarw_) unit_ unit_) with [] using eq in
+utest check (match_ unit_ (por_ (pvar_ "x") (pvar_ "x")) unit_ unit_) with
+  [ (nameNoSym "x", [LocExpr (match_ unit_ (por_ (pvar_ "x") (pvar_ "x")) unit_ unit_)])
+  ] using eq in
+
+()

--- a/src/stdlib/mexpr/invariants/in-scope.mc
+++ b/src/stdlib/mexpr/invariants/in-scope.mc
@@ -1,0 +1,473 @@
+-- This file provides attributes (see `mexpr/attribute-grammar.mc`)
+-- for checking if names used are actually bound and in scope.
+--
+-- To use, supply a `InScopeAttr (filledThunk <initial-environment>)`
+-- and `UnboundErrorAttr (mkThunk "UnboundErrorAttr#root")` to
+-- `processAst`, then read from the `UnboundErrorAttr` afterwards.
+
+include "mexpr/ast.mc"
+include "mexpr/invariants.mc"
+
+include "mexpr/cmp.mc"
+include "tuple.mc"
+
+-- The `DeclaredHere` attribute is a helper attribute, and is used to
+-- compute declarations that can "float upwards":
+-- * Names introduced by `Decl`s flow up to the containing `TmDecl`,
+--   then on to its `inexpr`.
+-- * Names introduced by `Pat`s flow up to the containing `TmMatch`,
+--   then on to its `thn`.
+-- * Names introduced by (potentially nested) `TyAll`s that are
+--   top-most in a type signature of a `let` flow to the body of the
+--   `let`
+lang DeclaredHereAttr = AttributeGrammar + MExprAst
+  -- TODO(vipa, 2026-03-02): Make something extensible that can attach attributes to each name
+  type InScopeAttr loc =
+    { values : Set Name
+    , constructors : Set Name
+    , tyValues : Set Name
+    , tyConstructors : Set Name
+    }
+
+  sem _scopeMerge : all loc. InScopeAttr loc -> InScopeAttr loc -> InScopeAttr loc
+  sem _scopeMerge a = | b ->
+    { values = mapUnion a.values b.values
+    , constructors = mapUnion a.constructors b.constructors
+    , tyValues = mapUnion a.tyValues b.tyValues
+    , tyConstructors = mapUnion a.tyConstructors b.tyConstructors
+    }
+
+  sem _scopeIntersect : all loc. InScopeAttr loc -> InScopeAttr loc -> InScopeAttr loc
+  sem _scopeIntersect a = | b ->
+    { values = mapIntersectWith (lam a. lam. a) a.values b.values
+    , constructors = mapIntersectWith (lam a. lam. a) a.constructors b.constructors
+    , tyValues = mapIntersectWith (lam a. lam. a) a.tyValues b.tyValues
+    , tyConstructors = mapIntersectWith (lam a. lam. a) a.tyConstructors b.tyConstructors
+    }
+
+  sem _scopeValues : all loc. [Name] -> InScopeAttr loc
+  sem _scopeValues = | names ->
+    { values = setOfSeq nameCmp names
+    , constructors = setEmpty nameCmp
+    , tyValues = setEmpty nameCmp
+    , tyConstructors = setEmpty nameCmp
+    }
+
+  sem _scopeConstructors : all loc. [Name] -> InScopeAttr loc
+  sem _scopeConstructors = | names ->
+    { values = setEmpty nameCmp
+    , constructors = setOfSeq nameCmp names
+    , tyValues = setEmpty nameCmp
+    , tyConstructors = setEmpty nameCmp
+    }
+
+  sem _scopeTyValues : all loc. [Name] -> InScopeAttr loc
+  sem _scopeTyValues = | names ->
+    { values = setEmpty nameCmp
+    , constructors = setEmpty nameCmp
+    , tyValues = setOfSeq nameCmp names
+    , tyConstructors = setEmpty nameCmp
+    }
+
+  sem _scopeTyConstructors : all loc. [Name] -> InScopeAttr loc
+  sem _scopeTyConstructors = | names ->
+    { values = setEmpty nameCmp
+    , constructors = setEmpty nameCmp
+    , tyValues = setEmpty nameCmp
+    , tyConstructors = setOfSeq nameCmp names
+    }
+
+  sem _scopeEmpty : all loc. () -> InScopeAttr loc
+  sem _scopeEmpty = | _ ->
+    { values = setEmpty nameCmp
+    , constructors = setEmpty nameCmp
+    , tyValues = setEmpty nameCmp
+    , tyConstructors = setEmpty nameCmp
+    }
+
+  syn Attr loc =
+  | DeclaredHere (Thunk (InScopeAttr loc))
+
+  sem newAttr label =
+  | DeclaredHere _ -> DeclaredHere (mkThunk label)
+
+  sem attrKindToString =
+  | DeclaredHere _ -> "DeclaredHere"
+
+  sem openInScopeAttr : all loc. Attr loc -> Thunk (InScopeAttr loc)
+  sem openInScopeAttr =
+  | DeclaredHere x -> x
+
+  sem processAttrDecl env st loc =
+  | (DeclLet x, DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    (st, lam. writeHere (_scopeValues [x.ident]))
+  | (DeclRecLets x, DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    (st, lam. writeHere (_scopeValues (map (lam b. b.ident) x.bindings)))
+  | (DeclType x, DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    (st, lam. writeHere (_scopeTyConstructors [x.ident]))
+  | (DeclConDef x, DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    (st, lam. writeHere (_scopeConstructors [x.ident]))
+  | (DeclExt x, DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    (st, lam. writeHere (_scopeValues [x.ident]))
+  | (DeclUtest _, DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    (st, lam. writeHere (_scopeEmpty ()))
+
+  sem processDeclaredHerePat : all loc. loc -> Pat -> InScopeAttr loc -> InScopeAttr loc
+  sem processDeclaredHerePat loc =
+  | PatNamed {ident = PName n}
+  | PatSeqEdge {middle = PName n} -> lam scope. _scopeMerge scope (_scopeValues [n])
+  | PatNamed {ident = PWildcard _}
+  | PatSeqTot _
+  | PatSeqEdge {middle = PWildcard _}
+  | PatRecord _
+  | PatCon _
+  | PatInt _
+  | PatChar _
+  | PatBool _
+  | PatAnd _
+  | PatNot _ -> lam x. x
+
+  sem processAttrPat env st loc =
+  | pair & (PatOr x, attr & DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    match willRead st (openInScopeAttr (getAttrPat attr x.lpat)) with (st, readL) in
+    match willRead st (openInScopeAttr (getAttrPat attr x.rpat)) with (st, readR) in
+    ( st
+    , lam.
+      writeHere (_scopeIntersect (readL ()) (readR ()))
+    )
+  | pair & (pat, DeclaredHere _) ->
+    simpleSynthesizedPat st
+      pair
+      openInScopeAttr
+      (_scopeEmpty ())
+      _scopeMerge
+      (processDeclaredHerePat loc pat)
+
+  sem processAttrType env st loc =
+  | (TyAll x, attr & DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    match willRead st (openInScopeAttr (getAttrType attr x.ty)) with (st, readTy) in
+    ( st
+    , lam.
+      writeHere (_scopeMerge (readTy ()) (_scopeTyValues [x.ident]))
+    )
+  -- TODO(vipa, 2026-03-02): TyMeta and TyAlias?
+  | (_, DeclaredHere here) ->
+    match willWrite st here with (st, writeHere) in
+    (st, lam. writeHere (_scopeEmpty ()))
+end
+
+lang InScopeAttr = AttributeGrammar + DeclaredHereAttr
+  syn Attr loc =
+  | InScopeAttr (Thunk (InScopeAttr loc))
+
+  sem newAttr label =
+  | InScopeAttr _ -> InScopeAttr (mkThunk label)
+
+  sem attrKindToString =
+  | InScopeAttr _ -> "InScopeAttr"
+
+  sem openInScopeAttr =
+  | InScopeAttr x -> x
+
+  sem processAttrExpr env st loc =
+  | (TmLam x, attr & InScopeAttr here) ->
+    match willRead st here with (st, readHere) in
+    match willWrite st (openInScopeAttr (getAttrType attr x.tyAnnot)) with (st, writeTyAnnot) in
+    match willWrite st (openInScopeAttr (getAttrExpr attr x.body)) with (st, writeBody) in
+    ( st
+    , lam.
+      let here = readHere () in
+      writeTyAnnot here;
+      writeBody (_scopeMerge here (_scopeValues [x.ident]))
+    )
+  | (TmDecl x, attr & InScopeAttr here) ->
+    match willRead st here with (st, readHere) in
+    match willRead st (openInScopeAttr (getAttrDecl (DeclaredHere noThunk) x.decl)) with (st, readDecl) in
+    match willWrite st (openInScopeAttr (getAttrDecl attr x.decl)) with (st, writeDecl) in
+    match willWrite st (openInScopeAttr (getAttrExpr attr x.inexpr)) with (st, writeInexpr) in
+    ( st
+    , lam.
+      let here = readHere () in
+      writeDecl here;
+      writeInexpr (_scopeMerge here (readDecl ()))
+    )
+  | (TmMatch x, attr & InScopeAttr here) ->
+    match willRead st here with (st, readHere) in
+    match willRead st (openInScopeAttr (getAttrPat (DeclaredHere noThunk) x.pat)) with (st, readPat) in
+    match willWrite st (openInScopeAttr (getAttrPat attr x.pat)) with (st, writePat) in
+    match willWrite st (openInScopeAttr (getAttrExpr attr x.thn)) with (st, writeThn) in
+    match willWrite st (openInScopeAttr (getAttrExpr attr x.target)) with (st, writeTarget) in
+    match willWrite st (openInScopeAttr (getAttrExpr attr x.els)) with (st, writeEls) in
+    ( st
+    , lam.
+      let here = readHere () in
+      writePat here;
+      writeEls here;
+      writeTarget here;
+      writeThn (_scopeMerge here (readPat ()))
+    )
+  | pair & (_, InScopeAttr _) ->
+    simpleInheritedExpr st pair openInScopeAttr (lam x. x)
+
+  sem processAttrDecl env st loc =
+  | (DeclLet x, attr & InScopeAttr here) ->
+    match willRead st here with (st, readHere) in
+    match willRead st (openInScopeAttr (getAttrType (DeclaredHere noThunk) x.tyAnnot)) with (st, readTyAnnot) in
+    match willWrite st (openInScopeAttr (getAttrType attr x.tyAnnot)) with (st, writeTyAnnot) in
+    match willWrite st (openInScopeAttr (getAttrExpr attr x.body)) with (st, writeBody) in
+    ( st
+    , lam.
+      let here = readHere () in
+      writeTyAnnot here;
+      writeBody (_scopeMerge here (readTyAnnot ()))
+    )
+  | (DeclRecLets x, attr & InScopeAttr here) ->
+    match willRead st here with (st, readHere) in
+    match willRead st (openInScopeAttr (getAttrEnv (DeclaredHere noThunk) env)) with (st, readDeclaredHere) in
+    let f = lam st. lam b.
+      match willRead st (openInScopeAttr (getAttrType (DeclaredHere noThunk) b.tyAnnot)) with (st, readTyAnnot) in
+      match willWrite st (openInScopeAttr (getAttrType attr b.tyAnnot)) with (st, writeTyAnnot) in
+      match willWrite st (openInScopeAttr (getAttrExpr attr b.body)) with (st, writeBody) in
+      (st, {readTyAnnot = readTyAnnot, writeTyAnnot = writeTyAnnot, writeBody = writeBody}) in
+    match mapAccumL f st x.bindings with (st, bs) in
+    ( st
+    , lam.
+      let here = _scopeMerge (readHere ()) (readDeclaredHere ()) in
+      for_ bs (lam b. b.writeTyAnnot here; b.writeBody (_scopeMerge here (b.readTyAnnot ())))
+    )
+  | (DeclType x, attr & InScopeAttr here) ->
+    match willRead st here with (st, readHere) in
+    match willWrite st (openInScopeAttr (getAttrType attr x.tyIdent)) with (st, writeTyIdent) in
+    ( st
+    , lam.
+      writeTyIdent (_scopeMerge (readHere ()) (_scopeTyValues x.params))
+    )
+  | pair & (DeclConDef _ | DeclUtest _ | DeclExt _, InScopeAttr _) ->
+    simpleInheritedDecl st pair openInScopeAttr (lam x. x)
+
+  sem processAttrPat env st loc =
+  | pair & (_, InScopeAttr _) ->
+    simpleInheritedPat st pair openInScopeAttr (lam x. x)
+
+  sem processInScopeAttrType : all loc. loc -> Type -> InScopeAttr loc -> InScopeAttr loc
+  sem processInScopeAttrType loc =
+  | TyAll x -> lam scope. _scopeMerge scope (_scopeTyValues [x.ident])
+  | _ -> lam x. x
+
+  sem processAttrType env st loc =
+  | pair & (ty, InScopeAttr _) ->
+    simpleInheritedType st pair openInScopeAttr (processInScopeAttrType loc ty)
+end
+
+lang UnboundErrorAttr = Invariant + InScopeAttr
+  type UnboundErrorAttr loc = Map Name [loc]
+  syn Attr loc =
+  | UnboundErrorAttr (Thunk (UnboundErrorAttr loc))
+
+  sem newAttr label =
+  | UnboundErrorAttr _ -> UnboundErrorAttr (mkThunk label)
+
+  sem attrKindToString =
+  | UnboundErrorAttr _ -> "UnboundErrorAttr"
+
+  sem printInvariantSummary =
+  | UnboundErrorAttr x ->
+    let start = wallTimeMs () in
+    let x = x.read () in
+    let timeMs = subf (wallTimeMs ()) start in
+    let numUnbound = mapSize x in
+    let numLocations = mapFoldWithKey (lam n. lam. lam locs. addi n (length locs)) 0 x in
+    let examples =
+      match mapFoldWithKey (lam acc. lam n. lam. if gti (length acc) 5 then acc else snoc acc n) [] x
+      with names & ![] then join [" (e.g. ", seq2string nameGetStr names, ")"]
+      else "" in
+    printLn (join
+      [ "  Unbound: ", int2string numUnbound, " unbound in "
+      , int2string numLocations, " locations", examples
+      , " (", float2string timeMs , "ms)."
+      ])
+
+  sem openUnboundErrorAttr : all loc. Attr loc -> Thunk (UnboundErrorAttr loc)
+  sem openUnboundErrorAttr = | UnboundErrorAttr x -> x
+
+  sem processUnboundErrorAttrExpr : all loc. InvEnv loc -> InvState -> loc -> Expr -> (InvState, UnboundErrorAttr loc -> UnboundErrorAttr loc)
+  sem processUnboundErrorAttrExpr env st loc =
+  | TmVar x ->
+    match willRead st (openInScopeAttr (getAttrEnv (InScopeAttr noThunk) env)) with (st, readScope) in
+    ( st
+    , lam scope.
+      if setMem x.ident (readScope ()).values
+      then scope
+      else mapInsertWith concat x.ident [loc] scope
+    )
+  | TmConApp x ->
+    match willRead st (openInScopeAttr (getAttrEnv (InScopeAttr noThunk) env)) with (st, readScope) in
+    ( st
+    , lam scope.
+      if setMem x.ident (readScope ()).constructors
+      then scope
+      else mapInsertWith concat x.ident [loc] scope
+    )
+  | _ -> (st, lam x. x)
+
+  sem processUnboundErrorAttrType : all loc. InvEnv loc -> InvState -> loc -> Type -> (InvState, UnboundErrorAttr loc -> UnboundErrorAttr loc)
+  sem processUnboundErrorAttrType env st loc =
+  | TyCon x ->
+    match willRead st (openInScopeAttr (getAttrEnv (InScopeAttr noThunk) env)) with (st, readScope) in
+    ( st
+    , lam scope.
+      if setMem x.ident (readScope ()).tyConstructors
+      then scope
+      else mapInsertWith concat x.ident [loc] scope
+    )
+  | TyVar x ->
+    match willRead st (openInScopeAttr (getAttrEnv (InScopeAttr noThunk) env)) with (st, readScope) in
+    ( st
+    , lam scope.
+      if setMem x.ident (readScope ()).tyValues
+      then scope
+      else mapInsertWith concat x.ident [loc] scope
+    )
+  -- TODO(vipa, 2026-03-04): TyData and TyVariant?
+  | _ -> (st, lam x. x)
+
+  sem processUnboundErrorAttrPat : all loc. InvEnv loc -> InvState -> loc -> Pat -> (InvState, UnboundErrorAttr loc -> UnboundErrorAttr loc)
+  sem processUnboundErrorAttrPat env st loc =
+  | PatCon x ->
+    match willRead st (openInScopeAttr (getAttrEnv (InScopeAttr noThunk) env)) with (st, readScope) in
+    ( st
+    , lam scope.
+      if setMem x.ident (readScope ()).constructors
+      then scope
+      else mapInsertWith concat x.ident [loc] scope
+    )
+  | _ -> (st, lam x. x)
+
+  sem processAttrDecl env st loc =
+  | pair & (x, UnboundErrorAttr _) ->
+    simpleSynthesizedDecl st
+      pair
+      openUnboundErrorAttr
+      (mapEmpty nameCmp)
+      (mapUnionWith concat)
+      (lam x. x)
+
+  sem processAttrExpr env st loc =
+  | pair & (x, UnboundErrorAttr _) ->
+    match processUnboundErrorAttrExpr env st loc x with (st, addHere) in
+    simpleSynthesizedExpr st
+      pair
+      openUnboundErrorAttr
+      (mapEmpty nameCmp)
+      (mapUnionWith concat)
+      addHere
+
+  sem processAttrType env st loc =
+  | pair & (x, UnboundErrorAttr _) ->
+    match processUnboundErrorAttrType env st loc x with (st, addHere) in
+    simpleSynthesizedType st
+      pair
+      openUnboundErrorAttr
+      (mapEmpty nameCmp)
+      (mapUnionWith concat)
+      addHere
+
+  sem processAttrPat env st loc =
+  | pair & (x, UnboundErrorAttr _) ->
+    match processUnboundErrorAttrPat env st loc x with (st, addHere) in
+    simpleSynthesizedPat st
+      pair
+      openUnboundErrorAttr
+      (mapEmpty nameCmp)
+      (mapUnionWith concat)
+      addHere
+end
+
+lang TestLang = UnboundErrorAttr + MExprCmp
+end
+
+mexpr
+
+use TestLang in
+
+-- NOTE(vipa, 2026-03-04): We check info fields of the top node as
+-- well, so we're able to distinguish sub-trees that are otherwise
+-- identical
+let locEq = lam a. lam b. switch (a, b)
+  case (LocExpr a, LocExpr b) then
+    if eqi 0 (cmpExpr a b)
+    then eqi 0 (infoCmp (infoTm a) (infoTm b))
+    else false
+  case (LocDecl a, LocDecl b) then
+    if eqi 0 (cmpDecl a b)
+    then eqi 0 (infoCmp (infoDecl a) (infoDecl b))
+    else false
+  case (LocType a, LocType b) then
+    if eqi 0 (cmpType a b)
+    then eqi 0 (infoCmp (infoTy a) (infoTy b))
+    else false
+  case (LocPat a, LocPat b) then
+    if eqi 0 (cmpPat a b)
+    then eqi 0 (infoCmp (infoPat a) (infoPat b))
+    else false
+  end in
+let eq = eqSeq (tupleEq2 nameEq (eqSeq locEq)) in
+
+-- NOTE(vipa, 2026-03-04): Two helpers for attaching two distinct info
+-- fields to each kind of node
+let itm = withInfo (infoVal "i" 0 0 0 0) in
+let jtm = withInfo (infoVal "j" 0 0 0 0) in
+let ity = tyWithInfo (infoVal "i" 0 0 0 0) in
+let jty = tyWithInfo (infoVal "j" 0 0 0 0) in
+let idecl = declWithInfo (infoVal "i" 0 0 0 0) in
+let jdecl = declWithInfo (infoVal "j" 0 0 0 0) in
+let ipat = withInfoPat (infoVal "i" 0 0 0 0) in
+let jpat = withInfoPat (infoVal "j" 0 0 0 0) in
+
+let check = lam ast.
+  let attrs = [InScopeAttr (filledThunk (_scopeEmpty ())), UnboundErrorAttr (mkThunk (lazyPure "UnboundErrorAttr#root"))] in
+  let res = processAst attrs ast in
+  match getAttrEnv (UnboundErrorAttr noThunk) res with UnboundErrorAttr thunk in
+  mapBindings (thunk.read ()) in
+
+
+-- === Actual tests ===
+
+utest check (utuple_ [var_ "x", conapp_ "C" unit_]) with
+  [ (nameNoSym "C", [LocExpr (conapp_ "C" unit_)])
+  , (nameNoSym "x", [LocExpr (var_ "x")])
+  ] using eq in
+utest check (bind_ (ulet_ "x" unit_) (conapp_ "x" (var_ "x"))) with
+  [ (nameNoSym "x", [LocExpr (conapp_ "x" (var_ "x"))])
+  ] using eq in
+utest check
+  (bind_
+    (let_ "x" (tytuple_ [ity (tyvar_ "t"), tycon_ "T", tyall_ "t" (jty (tyvar_ "t"))])
+      unit_)
+    unit_)
+with
+  [ (nameNoSym "T", [LocType (tycon_ "T")])
+  , (nameNoSym "t", [LocType (ity (tyvar_ "t"))])
+  ] using eq in
+utest check (match_ unit_ (pvar_ "x") (itm (var_ "x")) (jtm (var_ "x"))) with
+  [ (nameNoSym "x", [LocExpr (jtm (var_ "x"))])
+  ] using eq in
+utest check
+  (match_ unit_
+    (por_ (pvar_ "x") (pvar_ "y"))
+    (utuple_ [itm (var_ "x"), itm (var_ "y")])
+    (utuple_ [jtm (var_ "x"), jtm (var_ "y")]))
+with
+  [ (nameNoSym "x", [LocExpr (itm (var_ "x")), LocExpr (jtm (var_ "x"))])
+  , (nameNoSym "y", [LocExpr (itm (var_ "y")), LocExpr (jtm (var_ "y"))])
+  ] using eq in
+
+()

--- a/src/stdlib/mexpr/invariants/info.mc
+++ b/src/stdlib/mexpr/invariants/info.mc
@@ -1,0 +1,178 @@
+-- This file provides attributes (see `mexpr/attribute-grammar.mc`)
+-- for finding nodes in the AST that do not have an info field set.
+--
+-- To use, supply a `WithoutInfoAttr (mkThunk "WithoutInfoAttr#root")`
+-- to `processAst`, then read from it afterwards.
+
+include "mexpr/ast.mc"
+include "mexpr/invariants.mc"
+
+include "mexpr/cmp.mc"
+
+lang WithoutInfoAttr = Invariant
+  type WithoutInfoAttr loc = [loc]
+  syn Attr loc =
+  | WithoutInfoAttr (Thunk (WithoutInfoAttr loc))
+
+  sem newAttr label =
+  | WithoutInfoAttr _ -> WithoutInfoAttr (mkThunk label)
+
+  sem attrKindToString =
+  | WithoutInfoAttr _ -> "WithoutInfoAttr"
+
+  sem printInvariantSummary =
+  | WithoutInfoAttr x ->
+    let start = wallTimeMs () in
+    let x = x.read () in
+    let timeMs = subf (wallTimeMs ()) start in
+    let numMissing = length x in
+    let example =
+      match x with [example] ++ _ then
+        let lines = strSplit "\n" (loc2str example) in
+        let lines = match lines with [l1, l2, l3, _, _] ++ _ ++ [r1, r2, r3]
+          then [l1, l2, l3, "...elided...", r1, r2, r3]
+          else lines in
+        join [" Example:\n    ", strJoin "\n    " lines]
+      else "" in
+    printLn (join
+      [ "  NoInfo: ", int2string numMissing, " missing Info fields ("
+      , float2string timeMs, "ms).", example
+      ])
+
+  sem openWithoutInfoAttr : all loc. Attr loc -> Thunk (WithoutInfoAttr loc)
+  sem openWithoutInfoAttr = | WithoutInfoAttr x -> x
+
+  sem processAttrDecl env st loc =
+  | pair & (decl, WithoutInfoAttr _) ->
+    simpleSynthesizedDecl st
+      pair
+      openWithoutInfoAttr
+      []
+      concat
+      (match infoDecl decl with NoInfo _ then cons loc else lam x. x)
+
+  sem processAttrExpr env st loc =
+  | pair & (tm, WithoutInfoAttr _) ->
+    simpleSynthesizedExpr st
+      pair
+      openWithoutInfoAttr
+      []
+      concat
+      (match infoTm tm with NoInfo _ then cons loc else lam x. x)
+
+  sem processAttrType env st loc =
+  | pair & (TyAlias _, WithoutInfoAttr _) ->
+    simpleSynthesizedType st
+      pair
+      openWithoutInfoAttr
+      []
+      concat
+      (lam x. x)
+  | pair & (ty, WithoutInfoAttr _) ->
+    simpleSynthesizedType st
+      pair
+      openWithoutInfoAttr
+      []
+      concat
+      (match infoTy ty with NoInfo _ then cons loc else lam x. x)
+
+  sem processAttrPat env st loc =
+  | pair & (pat, WithoutInfoAttr _) ->
+    simpleSynthesizedPat st
+      pair
+      openWithoutInfoAttr
+      []
+      concat
+      (match infoPat pat with NoInfo _ then cons loc else lam x. x)
+end
+
+lang TestLang = WithoutInfoAttr + MExprAst + MExprCmp
+end
+
+mexpr
+
+use TestLang in
+
+-- NOTE(vipa, 2026-03-04): We check info fields of the top node as
+-- well, so we're able to distinguish sub-trees that are otherwise
+-- identical
+let locEq = lam a. lam b. switch (a, b)
+  case (LocExpr a, LocExpr b) then
+    if eqi 0 (cmpExpr a b)
+    then eqi 0 (infoCmp (infoTm a) (infoTm b))
+    else false
+  case (LocDecl a, LocDecl b) then
+    if eqi 0 (cmpDecl a b)
+    then eqi 0 (infoCmp (infoDecl a) (infoDecl b))
+    else false
+  case (LocType a, LocType b) then
+    if eqi 0 (cmpType a b)
+    then eqi 0 (infoCmp (infoTy a) (infoTy b))
+    else false
+  case (LocPat a, LocPat b) then
+    if eqi 0 (cmpPat a b)
+    then eqi 0 (infoCmp (infoPat a) (infoPat b))
+    else false
+  end in
+let eq = eqSeq locEq in
+
+-- NOTE(vipa, 2026-03-04): Helper for attaching an arbitrary info
+-- field to a node
+let itm = withInfo (infoVal "i" 0 0 0 0) in
+let ity = tyWithInfo (infoVal "i" 0 0 0 0) in
+let idecl = declWithInfo (infoVal "i" 0 0 0 0) in
+let ipat = withInfoPat (infoVal "i" 0 0 0 0) in
+
+let check = lam ast.
+  let attrs = [WithoutInfoAttr (mkThunk (lazyPure "WithoutInfoAttr#root"))] in
+  let res = processAst attrs ast in
+  match getAttrEnv (WithoutInfoAttr noThunk) res with WithoutInfoAttr thunk in
+  thunk.read () in
+
+
+-- === Actual tests ===
+
+utest check (utuple_ [var_ "x", conapp_ "C" unit_]) with
+  [ LocExpr (utuple_ [var_ "x", conapp_ "C" unit_])
+  , LocExpr (var_ "x")
+  , LocExpr (conapp_ "C" unit_)
+  , LocExpr (unit_)
+  ] using eq in
+
+utest check (utuple_ [itm (var_ "x"), conapp_ "C" unit_]) with
+  [ LocExpr (utuple_ [var_ "x", conapp_ "C" unit_])
+  , LocExpr (conapp_ "C" unit_)
+  , LocExpr (unit_)
+  ] using eq in
+
+utest check (itm (utuple_ [itm (var_ "x"), conapp_ "C" unit_])) with
+  [ LocExpr (conapp_ "C" unit_)
+  , LocExpr (unit_)
+  ] using eq in
+
+utest check (itm (utuple_ [itm (var_ "x"), itm (conapp_ "C" unit_)])) with
+  [ LocExpr (unit_)
+  ] using eq in
+
+utest check (itm (utuple_ [itm (var_ "x"), itm (conapp_ "C" (itm unit_))])) with
+  [] using eq in
+
+utest check (itm (bind_ (let_ "x" tyunit_ (itm unit_)) (itm (match_ (itm (var_ "x")) (pvar_ "y") (itm unit_) (itm unit_))))) with
+  [ LocDecl (let_ "x" tyunit_ (itm unit_))
+  , LocType tyunit_
+  , LocPat (pvar_ "y")
+  ] using eq in
+
+utest check (itm (bind_ (idecl (let_ "x" tyunit_ (itm unit_))) (itm (match_ (itm (var_ "x")) (pvar_ "y") (itm unit_) (itm unit_))))) with
+  [ LocType tyunit_
+  , LocPat (pvar_ "y")
+  ] using eq in
+
+utest check (itm (bind_ (idecl (let_ "x" (ity tyunit_) (itm unit_))) (itm (match_ (itm (var_ "x")) (pvar_ "y") (itm unit_) (itm unit_))))) with
+  [ LocPat (pvar_ "y")
+  ] using eq in
+
+utest check (itm (bind_ (idecl (let_ "x" (ity tyunit_) (itm unit_))) (itm (match_ (itm (var_ "x")) (ipat (pvar_ "y")) (itm unit_) (itm unit_))))) with
+  [] using eq in
+
+()

--- a/src/stdlib/mexpr/phase-stats.mc
+++ b/src/stdlib/mexpr/phase-stats.mc
@@ -3,14 +3,16 @@ include "ast.mc"
 include "basic-types.mc"
 include "either.mc"
 include "json-debug.mc"
+include "invariants.mc"
 
 include "mlang/ast.mc"
 
-lang PhaseStats = Ast + MLangTopLevel + AstToJson + MLangProgramToJson
+lang PhaseStats = Ast + MLangTopLevel + AstToJson + MLangProgramToJson + Invariant
   type StatState =
     { lastPhaseEnd : Ref Float
     , log : Bool
     , jsonDumpPhases : Set String
+    , mkAttrs : () -> [Attr Loc]
     }
 
   sem endPhaseStatsExpr : StatState -> String -> Expr -> ()
@@ -35,7 +37,12 @@ lang PhaseStats = Ast + MLangTopLevel + AstToJson + MLangProgramToJson
         case Right prog then countProgNodes prog
       end) in
       let postTraverse = wallTimeMs () in
-      printLn (join ["  Ast size: ", int2string size, " (Traversal takes ~", float2string (subf postTraverse preTraverse), "ms)"])
+      printLn (join ["  Ast size: ", int2string size, " (Traversal takes ~", float2string (subf postTraverse preTraverse), "ms)"]);
+      match e with Left e then
+        match state.mkAttrs () with attrs & ![] then
+          checkInvariants attrs e
+        else ()
+      else ()
      else ());
 
     (if setMem phaseLabel state.jsonDumpPhases then
@@ -48,10 +55,11 @@ lang PhaseStats = Ast + MLangTopLevel + AstToJson + MLangProgramToJson
     let newNow = wallTimeMs () in
     modref state.lastPhaseEnd newNow
 
-  sem mkPhaseLogState : Set String -> Bool -> StatState
-  sem mkPhaseLogState jsonDumpPhases = | log ->
+  sem mkPhaseLogState : Set String -> Bool -> (() -> [Attr Loc]) -> StatState
+  sem mkPhaseLogState jsonDumpPhases log = | mkAttrs ->
     { lastPhaseEnd = ref (wallTimeMs ())
     , jsonDumpPhases = jsonDumpPhases
     , log = log
+    , mkAttrs = mkAttrs
     }
 end

--- a/src/stdlib/mlang/main.mc
+++ b/src/stdlib/mlang/main.mc
@@ -40,7 +40,7 @@ lang MLangPipeline = MLangCompiler + BootParserMLang +
 
   -- TODO: add node count for MLang programs to phase-stats
   sem compileMLangToOcaml options runner =| filepath ->
-    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases in
+    let log = mkPhaseLogState options.debugDumpPhases options.debugPhases (lam. []) in
 
     let p = parseAndHandleIncludes filepath in
     endPhaseStatsProg log "parsing-include-handling" p;


### PR DESCRIPTION
Builds on #978 and #979, will be rebased once those are merged. First, this PR adds an interface for computing data over an AST with an attribute grammar-like form of dependencies. Second, it adds a few attributes that check invariants we'd like to have on the AST, and then uses them in `--debug-phases` to provide some diagnostics.

<details>

<summary>Example output of `--debug-phases`.</summary>

```
parsing
  Phase duration: 10594.7949219ms
  Ast size: 1135724 (Traversal takes ~105.069091797ms)
  Invariants: associated attributes in 1653.57397461ms.
  Unbound: 3 unbound in 172 locations (e.g. [Ref, Symbol, BootParseTree]) (848.055175781ms).
  Definitions: 8124 names without symbols, 1706 with multiple definitions (394.21484375ms).
  NoInfo: 0 missing Info fields (296.331054688ms).
make-keywords
  Phase duration: 167.530029297ms
  Ast size: 1135724 (Traversal takes ~101.227050781ms)
  Invariants: associated attributes in 1507.76977539ms.
  Unbound: 3 unbound in 172 locations (e.g. [Ref, Symbol, BootParseTree]) (772.652832031ms).
  Definitions: 8124 names without symbols, 1706 with multiple definitions (355.66796875ms).
  NoInfo: 0 missing Info fields (268.153076172ms).
tuning
  Phase duration: 99.8671875ms
  Ast size: 1135724 (Traversal takes ~106.269287109ms)
  Invariants: associated attributes in 1826.25512695ms.
  Unbound: 3 unbound in 172 locations (e.g. [Ref, Symbol, BootParseTree]) (823.592041016ms).
  Definitions: 8124 names without symbols, 1706 with multiple definitions (365.838867188ms).
  NoInfo: 0 missing Info fields (275.366943359ms).
instrument-profiling
  Phase duration: 0.0009765625ms
  Ast size: 1135724 (Traversal takes ~100.247070312ms)
  Invariants: associated attributes in 1727.84521484ms.
  Unbound: 3 unbound in 172 locations (e.g. [Ref, Symbol, BootParseTree]) (810.317871094ms).
  Definitions: 8124 names without symbols, 1706 with multiple definitions (377.839111328ms).
  NoInfo: 0 missing Info fields (282.641113281ms).
symbolize
  Phase duration: 304.658935547ms
  Ast size: 1135724 (Traversal takes ~95.7219238281ms)
  Invariants: associated attributes in 1849.94799805ms.
  Unbound: 0 unbound in 0 locations (612.278076172ms).
  Definitions: 0 names without symbols, 0 with multiple definitions (308.386962891ms).
  NoInfo: 0 missing Info fields (269.633056641ms).
type-check
  Phase duration: 2827.375ms
  Ast size: 26989429 (Traversal takes ~1056.61889648ms)
  Invariants: associated attributes in 4732.56396484ms.
  Unbound: 0 unbound in 0 locations (1577.91796875ms).
  Definitions: 0 names without symbols, 24 with multiple definitions (918.761962891ms).
  NoInfo: 0 missing Info fields (870.245849609ms).
runtime-checks
  Phase duration: 41.5771484375ms
  Ast size: 26989429 (Traversal takes ~1050.33691406ms)
  Invariants: associated attributes in 4867.5559082ms.
  Unbound: 0 unbound in 0 locations (1493.53320312ms).
  Definitions: 0 names without symbols, 24 with multiple definitions (844.036865234ms).
  NoInfo: 0 missing Info fields (833.691894531ms).
generate-utest
  Phase duration: 58.701171875ms
  Ast size: 26989429 (Traversal takes ~1073.26391602ms)
  Invariants: associated attributes in 4635.07788086ms.
  Unbound: 0 unbound in 0 locations (1493.06298828ms).
  Definitions: 0 names without symbols, 24 with multiple definitions (880.491210938ms).
  NoInfo: 0 missing Info fields (857.000976562ms).
constant folding
  Phase duration: 0.0009765625ms
  Ast size: 26989429 (Traversal takes ~1065.56689453ms)
  Invariants: associated attributes in 4423.59985352ms.
  Unbound: 0 unbound in 0 locations (1475.38085938ms).
  Definitions: 0 names without symbols, 24 with multiple definitions (868.061035156ms).
  NoInfo: 0 missing Info fields (832.692871094ms).
pattern-lowering
  Phase duration: 201.944091797ms
  Ast size: 28975588 (Traversal takes ~1100.78076172ms)
  Invariants: associated attributes in 5630.84887695ms.
  Unbound: 0 unbound in 0 locations (2029.45410156ms).
  Definitions: 1 names without symbols, 102 with multiple definitions (1160.07885742ms).
  NoInfo: 397073 missing Info fields (1093.89892578ms). Example:
    let _elsBranch =
      lam #var"".
        let _elsBranch1 = lam #var"".
            false in
        let _target1 = (o1, o2) in
        let matchBody1 = lam #var"".
            true in
        match _target1 with (field2, field3)
        in
        match field2 with None carried2
        then
          match field3 with None carried3
          then
            match carried2 with {}
            in
            match carried3 with {}
            in
            matchBody1 {}
          else
            _elsBranch1 {}
        else
          _elsBranch1 {}
    in
    let _target = (o1, o2) in
    let matchBody = lam v1.
        lam v2.
          lam #var"".
            eq v1 v2
    in
    match _target with (field, field1)
    in
    match field with Some carried
    then
      match field1 with Some carried1
      then
        matchBody carried carried1 {}
      else
        _elsBranch {}
    else
      _elsBranch {}
dprintToPprint
  Phase duration: 0.0009765625ms
  Ast size: 28975588 (Traversal takes ~1079.67285156ms)
  Invariants: associated attributes in 5749.99609375ms.
  Unbound: 0 unbound in 0 locations (1940.36108398ms).
  Definitions: 1 names without symbols, 102 with multiple definitions (1137.625ms).
  NoInfo: 397073 missing Info fields (1054.79785156ms). Example:
    let _elsBranch =
      lam #var"".
        let _elsBranch1 = lam #var"".
            false in
        let _target1 = (o1, o2) in
        let matchBody1 = lam #var"".
            true in
        match _target1 with (field2, field3)
        in
        match field2 with None carried2
        then
          match field3 with None carried3
          then
            match carried2 with {}
            in
            match carried3 with {}
            in
            matchBody1 {}
          else
            _elsBranch1 {}
        else
          _elsBranch1 {}
    in
    let _target = (o1, o2) in
    let matchBody = lam v1.
        lam v2.
          lam #var"".
            eq v1 v2
    in
    match _target with (field, field1)
    in
    match field with Some carried
    then
      match field1 with Some carried1
      then
        matchBody carried carried1 {}
      else
        _elsBranch {}
    else
      _elsBranch {}
type-annot
  Phase duration: 696.126708984ms
  Ast size: 16972065 (Traversal takes ~572.531005859ms)
  Invariants: associated attributes in 5703.65307617ms.
  Unbound: 0 unbound in 0 locations (1858.82910156ms).
  Definitions: 1 names without symbols, 102 with multiple definitions (1081.14990234ms).
  NoInfo: 397073 missing Info fields (1019.86010742ms). Example:
    let _elsBranch =
      lam #var"".
        let _elsBranch1 = lam #var"".
            false in
        let _target1 = (o1, o2) in
        let matchBody1 = lam #var"".
            true in
        match _target1 with (field2, field3)
        in
        match field2 with None carried2
        then
          match field3 with None carried3
          then
            match carried2 with {}
            in
            match carried3 with {}
            in
            matchBody1 {}
          else
            _elsBranch1 {}
        else
          _elsBranch1 {}
    in
    let _target = (o1, o2) in
    let matchBody = lam v1.
        lam v2.
          lam #var"".
            eq v1 v2
    in
    match _target with (field, field1)
    in
    match field with Some carried
    then
      match field1 with Some carried1
      then
        matchBody carried carried1 {}
      else
        _elsBranch {}
    else
      _elsBranch {}
backend
  Phase duration: 16402.7600098ms
  Ast size: 28975588 (Traversal takes ~1087.10107422ms)
  Invariants: associated attributes in 4977.20019531ms.
  Unbound: 0 unbound in 0 locations (2198.00292969ms).
  Definitions: 1 names without symbols, 102 with multiple definitions (1137.31982422ms).
  NoInfo: 397073 missing Info fields (1085.54614258ms). Example:
    let _elsBranch =
      lam #var"".
        let _elsBranch1 = lam #var"".
            false in
        let _target1 = (o1, o2) in
        let matchBody1 = lam #var"".
            true in
        match _target1 with (field2, field3)
        in
        match field2 with None carried2
        then
          match field3 with None carried3
          then
            match carried2 with {}
            in
            match carried3 with {}
            in
            matchBody1 {}
          else
            _elsBranch1 {}
        else
          _elsBranch1 {}
    in
    let _target = (o1, o2) in
    let matchBody = lam v1.
        lam v2.
          lam #var"".
            eq v1 v2
    in
    match _target with (field, field1)
    in
    match field with Some carried
    then
      match field1 with Some carried1
      then
        matchBody carried carried1 {}
      else
        _elsBranch {}
    else
      _elsBranch {}
```

</details>
