### PR TITLE
Make js tests not use dprint

### DIFF
--- a/src/test/js/foldl.mc
+++ b/src/test/js/foldl.mc
@@ -1,5 +1,6 @@
 include "common.mc"
+include "string.mc"
 
 mexpr
 	let l = [1, 2, 3, 4, 5] in
-	dprintLn (foldl (addi) 0 l)
+  printLn (int2string (foldl addi 0 l))

--- a/src/test/js/lam.mc
+++ b/src/test/js/lam.mc
@@ -1,9 +1,9 @@
 include "common.mc"
+include "string.mc"
 
 mexpr
     let f = lam x. lam y. addi (addi x (muli y 2)) 5 in
     let g = (f 3) in
     let h = (g 4) in
-    -- print (int2string h)
-    dprintLn h;
-    dprintLn (f 3 4)
+    printLn (int2string h);
+    printLn (int2string (f 3 4))

--- a/src/test/js/match_list.mc
+++ b/src/test/js/match_list.mc
@@ -3,40 +3,43 @@ include "common.mc"
 
 mexpr
 	let s = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] in
+  -- let printInt = lam x. printLn (int2string x) in
+  -- let printSeq = lam x. printLn (seq2string int2string x) in
+  -- let printSeqSeq = lam x. printLn (seq2string (seq2string int2string) x) in
 
   (match s with [x, y, _] ++ mid ++ [_, z, _] then
-    dprintLn x;
-    dprintLn y;
-    -- dprintLn mid; -- Should be [3, 4, 5, 6] BREAKS TESTS
-    dprintLn z;
+    printLn (int2string x);
+    printLn (int2string y);
+    -- printLn (seq2string int2string mid); -- Should be [3, 4, 5, 6] BREAKS TESTS
+    printLn (int2string z);
     0
   else match s with [h] ++ t then
-    dprintLn h;
-    dprintLn t;
+    printLn (int2string h);
+    -- printLn (seq2string int2string t);
     1
   else match s with rest ++ [a, b] then
-    dprintLn a;
-    dprintLn b;
-    dprintLn rest;
+    printLn (int2string a);
+    printLn (int2string b);
+    -- printLn (seq2string int2string rest);
     2
   else match s with [a, b, c] then
-    dprintLn a;
-    dprintLn b;
-    dprintLn c;
+    printLn (int2string a);
+    printLn (int2string b);
+    printLn (int2string c);
     3
   else 4);
 
   (let u = [ [0, 1, 2], [3, 4, 5], [6, 7, 8] ] in
   match u with [ [hd] ++ tl ] ++ rest then
-    dprintLn hd;
-    dprintLn tl;
+    printLn (int2string hd);
+    -- printLn (seq2string int2string tl);
     5
   else match u with [ [hd, mdl] ++ tl, [last] ] ++ rest then
-    dprintLn hd;
-    dprintLn mdl;
-    dprintLn tl;
-    dprintLn last;
-    dprintLn rest;
+    printLn (int2string hd);
+    printLn (int2string mdl);
+    -- printLn (seq2string int2string tl);
+    printLn (int2string last);
+    -- printSeqSeq rest;
     6
   else
     printLn "nothing";

--- a/src/test/js/rec_let.mc
+++ b/src/test/js/rec_let.mc
@@ -9,9 +9,9 @@ mexpr
     else _fact (muli n acc) (subi n 1)
   in
   let fact = lam n. _fact 1 n in
-  dprintLn (fact 5);
-  dprintLn (fact 10);
-  dprintLn (fact 20);
+  printLn (int2string (fact 5));
+  printLn (int2string (fact 10));
+  printLn (int2string (fact 20));
   -- dprintLn (fact 40);
   recursive
       let isEven = lam n.
@@ -21,10 +21,10 @@ mexpr
         if eqi n 0 then false
         else isEven (subi n 1)
   in
-  dprintLn (isEven 10);
-  dprintLn (isOdd 10);
-  dprintLn (isEven 15);
-  dprintLn (isOdd 15);
+  printLn (bool2string (isEven 10));
+  printLn (bool2string (isOdd 10));
+  printLn (bool2string (isEven 15));
+  printLn (bool2string (isOdd 15));
 
   let wrapper = lam n.
     recursive let work = lam a. lam b.
@@ -34,7 +34,7 @@ mexpr
     in
     work
   in
-  dprintLn (wrapper 1 4 2);
-  dprintLn (wrapper 2 3 4);
-  dprintLn ((wrapper 10) 50 2);
+  printLn (int2string (wrapper 1 4 2));
+  printLn (int2string (wrapper 2 3 4));
+  printLn (int2string ((wrapper 10) 50 2));
   ()


### PR DESCRIPTION
Some of the JS tests did not survive the test system transition (#738), namely those that tested output of running a program with the OCaml backend and the JS backend, making sure they are equal, because the build system did not support steps with multiple inputs. I'm fixing this now, and ran into an issue where the JS tests used `dprint`. This is an issue because we haven't fully specified what exactly `dprint` should do, it's kind of best-effort (`mi eval` does nothing, `mi compile` prints a debug formatting of OCaml internals, `mi compile --debug-dprint` pretty prints values, etc.), meaning that those tests fail.

This PR thus changes the tests to use fully specified printing functions, i.e., `printLn`, `int2string`, and `seq2string`.