### PR TITLE
Some file and system utilities updates.

### DIFF
--- a/src/stdlib/fileutils.mc
+++ b/src/stdlib/fileutils.mc
@@ -16,11 +16,38 @@ let dirname : String -> String = lam filepath.
   match findiLast (eqc '/') filepath with Some i then
     subsequence filepath 0 i
   else
-    ""
+    "."
 
-utest dirname "foo.mc" with ""
+utest dirname "foo.mc" with "."
 utest dirname "a/b/c/foo.mc" with "a/b/c"
 utest dirname "a/b/c/../foo.mc" with "a/b/c/.."
+
+let basename : String -> String = lam filepath.
+  match findiLast (eqc '/') filepath with Some i then
+    subsequence filepath (addi i 1) (subi (length filepath) (addi i 1))
+  else
+    filepath
+
+utest basename "foo.mc" with "foo.mc"
+utest basename "a/b/c/foo.mc" with "foo.mc"
+utest basename "a/b/c/../foo.mc" with "foo.mc"
+
+let withExtension : String -> String -> String = lam ext. lam path.
+  let path =
+    match findiLast (eqc '.') path with Some i then
+      let isExt = if eqi i 0
+        then false
+        else not (eqc '/' (get path (subi i 1))) in
+      if isExt
+      then subsequence path 0 i
+      else path
+    else path in
+  concat path ext
+
+utest withExtension ".test" "file.blub" with "file.test"
+utest withExtension ".test" "dir/file.blub" with "dir/file.test"
+utest withExtension ".test" ".blub" with ".blub.test"
+utest withExtension ".test" "dir/.blub" with "dir/.blub.test"
 
 let fileutilsNormalize : String -> String = lam path.
   recursive let recur = lam zipper : ([String], [String]).

--- a/src/stdlib/sys.mc
+++ b/src/stdlib/sys.mc
@@ -7,6 +7,15 @@ let _pathSep = "/"
 let _tempBase = "/tmp"
 let _null = "/dev/null"
 
+-- Ensures the given string can be passed to a shell (e.g., `sh` or
+-- `bash`) as a single argument without being split by whitespace.
+let sysShellQuote : String -> String = lam str.
+  snoc (cons '\'' (strReplace "'" "'\"'\"'" str)) '\''
+
+utest sysShellQuote "foo" with "'foo'"
+utest sysShellQuote "foo bar" with "'foo bar'"
+utest sysShellQuote "foo 'and bar'" with "'foo '\"'\"'and bar'\"'\"''"
+
 let sysCommandExists : String -> Bool = lam cmd.
   eqi 0 (command (join ["command -v ", cmd, " >/dev/null 2>&1"]))
 
@@ -49,6 +58,9 @@ let sysDeleteDir = lam dir.
 
 let sysChmodWriteAccessFile = lam file.
   _commandList ["chmod", "+w", file]
+
+let sysChmodExecuteFile = lam file.
+  _commandList ["chmod", "+x", file]
 
 let sysJoinPath = lam p1. lam p2.
   strJoin _pathSep [p1, p2]


### PR DESCRIPTION
I needed some more utilities for working with paths and files.

- `dirname` called on, e.g., `foo.mc` returns `"."` instead of `""`, which was probably a bad idea in the first place.
- `basename` removes the directory part of a path.
- `withExtension newExt` replaces the extension part of a path (roughly the last `.` and everything after it`) with `newExt`.
- `sysShellQuote` ensures that a string will be interpreted as a single argument when put on the commandline.
- `sysChmodExecuteFile` makes a file executable via `chmod +x`.