### PR TITLE
Tm opaque

### DIFF
--- a/src/main/compile.mc
+++ b/src/main/compile.mc
@@ -36,6 +36,7 @@ lang MCoreCompile =
   BootParser +
   MExprHoles +
   MExprCmp +
+  KeywordMakerOpaque +
   MExprSym + MExprRemoveTypeAscription + MExprTypeCheck +
   MExprUtestGenerate + MExprRuntimeCheck + MExprProfileInstrument + MExprTypeAnnot +
   MExprPrettyPrint +

--- a/src/stdlib/ext/arr-ext.mc
+++ b/src/stdlib/ext/arr-ext.mc
@@ -199,10 +199,15 @@ utest
 
 -- Creates an external array from a sequence.
 let extArrOfSeq : all a. ExtArrKind a -> [a] -> ExtArr a
-  = lam kind. lam seq.
-    let a = externalExtArrMakeUninit kind (length seq) in
-    iteri (externalExtArrSet a) seq;
-    a
+  = lam kind. lam seq. tmOpaque
+    (let len = length seq in
+    let a = externalExtArrMakeUninit kind len in
+    recursive let work = lam i.
+      if eqi i len
+      then ()
+      else externalExtArrSet a i (get seq i); work (addi i 1) in
+    work 0;
+    a)
 
 -- Creates a sequence from an external array.
 let extArrToSeq : all a. ExtArr a -> [a]
@@ -235,10 +240,10 @@ utest
 
 -- Creates an external array.
 let extArrMake : all a . ExtArrKind a -> Int -> a -> ExtArr a
-  = lam kind. lam n. lam v.
-    let a = externalExtArrMakeUninit kind n in
+  = lam kind. lam n. lam v. tmOpaque
+    (let a = externalExtArrMakeUninit kind n in
     externalExtArrFill a v;
-    a
+    a)
 
 utest
   let a  = extArrMake extArrKindFloat64 3 1. in
@@ -263,7 +268,3 @@ utest
   utest extArrGetExn bA 1 with 2. in
   utest extArrGetExn bA 2 with 3. in
   () with ()
-
-
-
-

--- a/src/stdlib/ext/mat-ext.mc
+++ b/src/stdlib/ext/mat-ext.mc
@@ -105,8 +105,10 @@ utest
 let matCopy : all a. Mat a -> Mat a
   = lam a.
     let mn = muli a.m a.n in
-    let b = extArrMakeUninit (externalExtArrKind a.arr) mn in
-    externalCblasCopy mn a.arr 1 b 1;
+    let b = tmOpaque
+      (let b = extArrMakeUninit (externalExtArrKind a.arr) mn in
+      externalCblasCopy mn a.arr 1 b 1;
+      b) in
     { a with arr = b }
 
 utest
@@ -263,10 +265,10 @@ utest
 
 -- Returns the transpose of a matrix as a fresh matrix.
 let matTranspose : Mat Float -> Mat Float
-  = lam a.
+  = lam a. tmOpaque (
     let b = matMakeUninit (externalExtArrKind a.arr) a.n a.m in
     matTranposeNoAlloc a b;
-    b
+    b)
 
 utest
   let test = lam kind.
@@ -287,9 +289,10 @@ utest
 let matElemMul : Mat Float -> Mat Float -> Either MatError (Mat Float)
   = lam a. lam b.
     if matHasSameShape2 a b then
-      let c = matMakeUninit (externalExtArrKind a.arr) a.m a.n in
-      matElemMulNoAlloc a b c;
-      Right c
+      Right (tmOpaque (
+        let c = matMakeUninit (externalExtArrKind a.arr) a.m a.n in
+        matElemMulNoAlloc a b c;
+        c))
     else Left (DimensionMismatch ())
 
 let matElemMulExn : Mat Float -> Mat Float -> Mat Float
@@ -317,10 +320,10 @@ utest
 
 -- General matrix element-wise exp. Returns a fresh matrix.
 let matElemExp : Mat Float -> Mat Float
-  = lam a.
+  = lam a. tmOpaque (
     let b = matMakeUninit (externalExtArrKind a.arr) a.m a.n in
     matElemExpInplace a b;
-    b
+    b)
 
 utest
   let test = lam kind.
@@ -339,10 +342,10 @@ utest
 
 -- General matrix element-wise log. Returns a fresh matrix.
 let matElemLog : Mat Float -> Mat Float
-  = lam a.
+  = lam a. tmOpaque (
     let b = matMakeUninit (externalExtArrKind a.arr) a.m a.n in
     matElemLogInplace a b;
-    b
+    b)
 
 utest
   let test = lam kind.
@@ -365,11 +368,12 @@ let matAdd : Mat Float -> Mat Float -> Either MatError (Mat Float)
     if matHasSameShape2 a b then
       let m = a.m in
       let n = a.n in
-      let c = matMakeUninit (externalExtArrKind b.arr) m n in
-      let mn = muli m n in
-      externalCblasCopy mn b.arr 1 c.arr 1;
-      externalCblasAxpy mn 1. a.arr 1 c.arr 1;
-      Right c
+      Right (tmOpaque (
+        let c = matMakeUninit (externalExtArrKind b.arr) m n in
+        let mn = muli m n in
+        externalCblasCopy mn b.arr 1 c.arr 1;
+        externalCblasAxpy mn 1. a.arr 1 c.arr 1;
+        c))
     else Left (DimensionMismatch ())
 
 let matAddExn : Mat Float -> Mat Float -> Mat Float
@@ -400,11 +404,12 @@ let matScale : Float -> Mat Float -> Mat Float
   = lam s. lam a.
     let m = a.m in
     let n = a.n in
-    let b = matMakeUninit (externalExtArrKind a.arr) m n in
     let mn = muli m n in
-    externalCblasCopy mn a.arr 1 b.arr 1;
-    externalCblasScal mn s b.arr 1;
-    b
+    tmOpaque
+      (let b = matMakeUninit (externalExtArrKind a.arr) m n in
+      externalCblasCopy mn a.arr 1 b.arr 1;
+      externalCblasScal mn s b.arr 1;
+      b)
 
 utest
   let test = lam kind.
@@ -428,16 +433,17 @@ let matMul : Mat Float -> Mat Float -> Either MatError (Mat Float)
     let n = b.n in
     let k = a.n in
     if eqi k b.m then
-      let c = matMakeUninit (externalExtArrKind b.arr) m n in
-      externalCblasGemm
-        cblasRowMajor cblasNoTrans cblasNoTrans
-        m n k
-        1.
-        a.arr k
-        b.arr n
-        0.
-        c.arr n;
-      Right c
+      Right (tmOpaque (
+        let c = matMakeUninit (externalExtArrKind b.arr) m n in
+        externalCblasGemm
+          cblasRowMajor cblasNoTrans cblasNoTrans
+          m n k
+          1.
+          a.arr k
+          b.arr n
+          0.
+          c.arr n;
+        c))
     else Left (DimensionMismatch ())
 
 let matMulExn : Mat Float -> Mat Float -> Mat Float

--- a/src/stdlib/mexpr/ast.mc
+++ b/src/stdlib/mexpr/ast.mc
@@ -353,6 +353,12 @@ lang OpaqueAst = Ast
     printError "Compiler error: called `smap` or `smapAccumL` on a `TmOpaque`, but it must be special-cased since transformation isn't allowed.\n";
     flushStderr ();
     never
+
+  sem mapPre_Expr_Expr f =
+  | tm & TmOpaque _ -> tm
+
+  sem mapPost_Expr_Expr f =
+  | tm & TmOpaque _ -> tm
 end
 
 -- TmVar --

--- a/src/stdlib/mexpr/ast.mc
+++ b/src/stdlib/mexpr/ast.mc
@@ -313,6 +313,48 @@ lang Ast
     count
 end
 
+-- TmOpaque
+lang OpaqueAst = Ast
+  -- NOTE(vipa, 2026-02-05): TmOpaque is special, in the sense that
+  -- its body should never be transformed by the compiler, with a
+  -- small set of exceptions. This means that whatever code is put in
+  -- an opaque block must already be transformed to a sufficiently
+  -- low-level form that whatever backend is in use can compile
+  -- it. Analysis is allowed however, which means that `sfold` works
+  -- as expected, but `smap` and `smapAccumL` will explicitly crash.
+  --
+  -- Transformations that are allowed:
+  -- * Renaming to something alpha-equivalent
+  -- * Attaching results of type inference
+  syn Expr =
+  | TmOpaque
+    { body : Expr
+    , info : Info
+    , ty : Type
+    }
+
+  sem infoTm =
+  | TmOpaque x -> x.info
+
+  sem withInfo info =
+  | TmOpaque x -> TmOpaque {x with info = info}
+
+  sem tyTm =
+  | TmOpaque x -> x.ty
+
+  sem withType ty =
+  | TmOpaque x -> TmOpaque {x with ty = ty}
+
+  sem sfold_Expr_Expr f acc =
+  | TmOpaque x -> f acc x.body
+
+  sem smapAccumL_Expr_Expr f acc =
+  | TmOpaque x ->
+    printError "Compiler error: called `smap` or `smapAccumL` on a `TmOpaque`, but it must be special-cased since transformation isn't allowed.\n";
+    flushStderr ();
+    never
+end
+
 -- TmVar --
 lang VarAst = Ast
   syn Expr =
@@ -1632,7 +1674,7 @@ lang MExprAst =
 
   -- Terms
   VarAst + AppAst + LamAst + RecordAst + ConstAst + DataAst + MatchAst +
-  SeqAst + NeverAst + PlaceholderAst +
+  SeqAst + NeverAst + PlaceholderAst + OpaqueAst +
 
   -- Decls
   LetDeclAst + TypeDeclAst + RecLetsDeclAst + DataDeclAst + UtestDeclAst +

--- a/src/stdlib/mexpr/attribute-grammar.mc
+++ b/src/stdlib/mexpr/attribute-grammar.mc
@@ -415,7 +415,12 @@ lang AttributeGrammar = Ast + DeclAst + PrettyPrint
       ( snoc toCall (lam. processExpr (deref localEnv) x)
       , TmWithEnv {label = lazy (lam. expr2str x), env = localEnv}
       ) in
-    match smapAccumL_Expr_Expr prepareExpr toCall tm with (toCall, tm) in
+    match
+      match tm with TmOpaque x then
+        match prepareExpr toCall x.body with (toCall, body) in
+        (toCall, TmOpaque {x with body = body})
+      else smapAccumL_Expr_Expr prepareExpr toCall tm
+    with (toCall, tm) in
 
     let prepareType = lam toCall. lam x.
       let localEnv = ref (mapEmpty subi) in

--- a/src/stdlib/mexpr/constant-fold.mc
+++ b/src/stdlib/mexpr/constant-fold.mc
@@ -8,6 +8,7 @@ include "pprint.mc"
 include "symbolize.mc"
 include "type-check.mc"
 include "ast-builder.mc"
+include "free-vars.mc"
 
 /-
   This file implements constant folding and constant propagation
@@ -50,6 +51,15 @@ lang ConstantFold = Eval + Ast
   sem countNodesH : Int -> Expr -> Int
   sem countNodesH n =| t ->
     let n = addi n 1 in sfold_Expr_Expr countNodesH n t
+end
+
+lang OpaqueConstantFold = ConstantFold + OpaqueAst + FreeVars
+  sem readback =
+  | tm & TmOpaque _ -> tm
+  sem constantFoldExpr ctx =
+  | tm & TmOpaque x ->
+    let referenced = freeVars x.body in
+    listFoldl (lam tm. lam pair. if setMem pair.0 referenced then bind_ (nulet_ pair.0 pair.1) tm else tm) tm ctx.env
 end
 
 lang VarConstantFold = ConstantFold + VarAst
@@ -314,6 +324,7 @@ lang MExprConstantFold = MExprAst +
   -- Terms
   VarConstantFold + AppConstantFold + LamAppConstantFold + LetConstantFold +
   RecordConstantFold + ConstConstantFold + MatchConstantFold + SeqConstantFold +
+  OpaqueConstantFold +
 
   -- Constant operations
   ArithIntConstantFold + ArithFloatConstantFold + SeqOpConstantFoldFirstOrder +

--- a/src/stdlib/mexpr/deadcode.mc
+++ b/src/stdlib/mexpr/deadcode.mc
@@ -100,6 +100,11 @@ lang MExprDeadcodeEliminationVar = DeadcodeElimination + VarAst
     (nmap, setInsert t.ident free)
 end
 
+lang MExprDeadcodeEliminationOpaque = DeadcodeElimination + OpaqueAst
+  sem removeLets nmap =
+  | tm & TmOpaque _ -> tm
+end
+
 lang MExprDeadcodeEliminationApp = DeadcodeElimination + AppAst
   sem lambdasLeft : NMap -> Int -> Bool -> Expr -> (Int, Bool)
   sem lambdasLeft nmap n se =
@@ -117,7 +122,7 @@ end
 
 lang MExprDeadcodeEliminationLam = DeadcodeElimination + LamAst
   sem lamCounts : Int -> NMap -> Expr -> Int
-  sem lamCounts n nmap = 
+  sem lamCounts n nmap =
   | TmLam t ->
     lamCounts (addi n 1) nmap t.body
 
@@ -236,7 +241,7 @@ lang MExprDeadcodeElimination =
   MExprDeadcodeEliminationConst + MExprDeadcodeEliminationLam +
   MExprDeadcodeEliminationDecl + MExprDeadcodeEliminationLetDecl +
   MExprDeadcodeEliminationRecLetsDecl + MExprDeadcodeEliminationExtDecl +
-  MExprDeadcodeEliminationFunType
+  MExprDeadcodeEliminationFunType + MExprDeadcodeEliminationOpaque
 
   sem tmHasSideEffect : NMap -> Bool -> Expr -> Bool
   sem tmHasSideEffect nmap acc =

--- a/src/stdlib/mexpr/demote-recursive.mc
+++ b/src/stdlib/mexpr/demote-recursive.mc
@@ -14,6 +14,7 @@ include "digraph.mc"
 lang MExprDemoteRecursive = MExprAst + MExprFreeVars
   sem demoteRecursive : Expr -> Expr
   sem demoteRecursive =
+  | tm & TmOpaque _ -> tm
   | tm -> smap_Expr_Expr demoteRecursive tm
   | TmDecl (x & {decl = DeclRecLets t}) ->
     let f = lam acc. lam binding.

--- a/src/stdlib/mexpr/desugar.mc
+++ b/src/stdlib/mexpr/desugar.mc
@@ -1,13 +1,14 @@
 include "mexpr/ast.mc"
 include "mlang/loader.mc"
 
-lang Desugar = Ast
+lang Desugar = Ast + OpaqueAst
   sem desugarExpr: Expr -> Expr
   sem desugarExpr =
+  | tm & TmOpaque _ -> tm
   | tm -> smap_Expr_Expr desugarExpr tm
 end
 
-lang DesugarLoader = Ast + MCoreLoader
+lang DesugarLoader = Ast + MCoreLoader + OpaqueAst
   syn Hook =
   | DesugarHook ()
 
@@ -16,7 +17,9 @@ lang DesugarLoader = Ast + MCoreLoader
     smapAccumL_Decl_Expr desugarExpr loader decl
 
   sem desugarExpr : Loader -> Expr -> (Loader, Expr)
-  sem desugarExpr loader = | expr ->
+  sem desugarExpr loader =
+  | expr & TmOpaque _ -> (loader, expr)
+  | expr ->
     smapAccumL_Expr_Expr desugarExpr loader expr
 
   sem enableDesugar : Loader -> Loader

--- a/src/stdlib/mexpr/duplicate-code-elimination.mc
+++ b/src/stdlib/mexpr/duplicate-code-elimination.mc
@@ -159,6 +159,7 @@ lang MExprEliminateDuplicateCode = MExprAst
     match eliminateDuplicateCodeType env replaced x.ty with (replaced, ty) in
     ( replaced
     , TmDecl {x with decl = DeclRecLets {t with bindings = reverse bindings}, inexpr = inexpr, ty = ty} )
+  | t & TmOpaque _ -> (replaced, t)
   | t ->
     match smapAccumL_Expr_Expr (eliminateDuplicateCodeExpr env) replaced t with (replaced, t) in
     match smapAccumL_Expr_Type (eliminateDuplicateCodeType env) replaced t with (replaced, t) in

--- a/src/stdlib/mexpr/eq.mc
+++ b/src/stdlib/mexpr/eq.mc
@@ -147,6 +147,14 @@ lang Eq = ConstAst
   sem eqDeclH env free lhs =
 end
 
+lang OpaqueEq = Eq + OpaqueAst
+  sem eqExprH env free lhs =
+  | TmOpaque l ->
+    match lhs with TmOpaque r then
+      eqExprH env free l.body r.body
+    else None ()
+end
+
 lang VarEq = Eq + VarAst
   sem eqExprH (env : EqEnv) (free : EqEnv) (lhs : Expr) =
   | TmVar r ->
@@ -744,7 +752,8 @@ lang MExprEq =
 
   -- Terms
   + VarEq + AppEq + LamEq + RecordEq + LetEq + RecLetsEq + ConstEq + DataEq +
-  TypeEq + MatchEq + UtestEq + SeqEq + NeverEq + ExtEq + DeclAst + DeclEq
+  TypeEq + MatchEq + UtestEq + SeqEq + NeverEq + ExtEq + DeclAst + DeclEq +
+  OpaqueEq
 
   -- Constants
   + IntEq + FloatEq + BoolEq + CharEq + SymbEq

--- a/src/stdlib/mexpr/generate-pprint.mc
+++ b/src/stdlib/mexpr/generate-pprint.mc
@@ -277,8 +277,8 @@ lang DPrintViaPprintLoader = GeneratePprintLoader + IOAst
     loader
 
   sem _postTypecheck loader decl = | DPrintViaPprintHook _ ->
-    recursive let work = lam loader. lam tm.
-      match tm with TmConst {val = CDPrint _, ty = ty} then
+    recursive let work = lam loader. lam tm. switch tm
+      case TmConst {val = CDPrint _, ty = ty} then
         match unwrapType ty with TyArrow {from = from} in
         match pprintFunctionsFor [from] loader with (loader, [pprint]) in
         let x = nameSym "x" in
@@ -286,7 +286,9 @@ lang DPrintViaPprintLoader = GeneratePprintLoader + IOAst
           (printError_ (app_ pprint (nvar_ x)))
           (flushStderr_ unit_)) in
         (loader, pprint)
-      else smapAccumL_Expr_Expr work loader tm
+      case TmOpaque _ then (loader, tm)
+      case tm then smapAccumL_Expr_Expr work loader tm
+      end
     in smapAccumL_Decl_Expr work loader decl
 end
 

--- a/src/stdlib/mexpr/generate-utest.mc
+++ b/src/stdlib/mexpr/generate-utest.mc
@@ -3,13 +3,14 @@ include "generate-eq.mc"
 
 include "mlang/loader.mc"
 
-lang StripUtestLoader = MCoreLoader + UtestDeclAst
+lang StripUtestLoader = MCoreLoader + UtestDeclAst + OpaqueAst
   syn Hook =
   | StripUtestHook ()
 
   sem stripUtests : Expr -> Expr
   sem stripUtests =
   | TmDecl (t & {decl = DeclUtest _}) -> stripUtests t.inexpr
+  | t & TmOpaque _ -> t
   | t -> smap_Expr_Expr stripUtests t
 
   sem _postTypecheck loader decl = | StripUtestHook _ ->
@@ -94,6 +95,7 @@ lang UtestLoader = MCoreLoader + GenerateEqLoader + GeneratePprintLoader + Strip
 
   sem replaceUtests hook static loader =
   | tm & TmLam _ -> smapAccumL_Expr_Expr (replaceUtests hook false) loader tm
+  | tm & TmOpaque _ -> (loader, tm)
   | tm -> smapAccumL_Expr_Expr (replaceUtests hook static) loader tm
   | TmDecl (x & {decl = DeclUtest t}) ->
     if hook.includeUtestIf {static = static, info = t.info} then

--- a/src/stdlib/mexpr/hoas.mc
+++ b/src/stdlib/mexpr/hoas.mc
@@ -23,7 +23,7 @@
 include "mexpr/ast.mc"
 include "mexpr/pprint.mc"
 
-lang TempLamAst = Ast + PrettyPrint
+lang TempLamAst = Ast + PrettyPrint + OpaqueAst
   type TempFixRec =
     { canMakeProgress : Expr -> Bool
     , f : (Expr -> Expr) -> Expr -> Expr
@@ -115,6 +115,7 @@ lang TempLamAst = Ast + PrettyPrint
     let decl = smap_Decl_Expr stripTempLam x.decl in
     let inexpr = _stripTempLam (args, x.inexpr) in
     TmDecl {x with decl = decl, inexpr = inexpr}
+  | (args, tm & TmOpaque _) -> appSeq_ tm args
   | (args, tm) -> appSeq_ (smap_Expr_Expr stripTempLam tm) args
 
   sem maybeEtaExpand : Expr -> {ident : Name, tyAnnot : Type, tyParam : Type, body : Expr, ty : Type, info : Info}

--- a/src/stdlib/mexpr/inline-single-use-simple.mc
+++ b/src/stdlib/mexpr/inline-single-use-simple.mc
@@ -66,6 +66,14 @@ lang InlineSingleUse = DeclAst + LetDeclAst + RecLetsDeclAst + VarAst + TempLamA
     match filterOption bindings with bindings & ![]
     then (st, TmDecl {x with decl = DeclRecLets {l with bindings = bindings}, inexpr = inexpr})
     else (st, inexpr)
+  | tm & TmOpaque x ->
+    -- NOTE(vipa, 2026-02-06): We may not modify the contents of a
+    -- TmOpaque, nor may we remove definitions it uses. This branch
+    -- thus only finds uses, ensures that any use counts as more than
+    -- 1, then returns the same TmOpaque unchanged.
+    let used = (collectSingleUses {useCounts = mapEmpty nameCmp, toInline = mapEmpty nameCmp} x.body).0 in
+    let st = {st with useCounts = mapUnionWith addi st.useCounts (mapMap (muli 2) used.useCounts)} in
+    (st, tm)
   | tm & TmVar x ->
     ({st with useCounts = mapInsertWith addi x.ident 1 st.useCounts}, tm)
   | tm -> smapAccumL_Expr_Expr collectSingleUses st tm
@@ -122,5 +130,15 @@ lang InlineSingleUse = DeclAst + LetDeclAst + RecLetsDeclAst + VarAst + TempLamA
   | tm & TmVar x ->
     match st with InlineMap toInline in
     optionGetOr tm (optionMap (lam f. f st) (mapLookup x.ident toInline))
+  | TmOpaque x ->
+    -- NOTE(vipa, 2026-02-06): We may need to rename variables inside
+    -- a `TmOpaque` because some surrounding variable has been
+    -- renamed, and that's done via `insertSingleUses`. Because of
+    -- what `collectSingleUses` does for `TmOpaque` we know that
+    -- nothing inside is counted as single use, thus the only thing
+    -- being inserted is what's considered as "simple" by `isSimple`
+    -- above. That's _technically_ not just `TmVar`s, it could also be
+    -- constants or literals, but I'm counting it good enough for now.
+    TmOpaque {x with body = insertSingleUses st x.body}
   | tm -> smap_Expr_Expr (insertSingleUses st) tm
 end

--- a/src/stdlib/mexpr/json-debug.mc
+++ b/src/stdlib/mexpr/json-debug.mc
@@ -158,6 +158,16 @@ lang MatchToJson = AstToJson + MatchAst
     ] )
 end
 
+lang OpaqueToJson = AstToJson + OpaqueAst
+  sem exprToJson =
+  | TmOpaque x -> JsonObject (mapFromSeq cmpString
+    [ ("con", JsonString "TmOpaque")
+    , ("body", exprToJson x.body)
+    , ("ty", typeToJson x.ty)
+    , ("info", infoToJson x.info)
+    ] )
+end
+
 lang NeverToJson = AstToJson + NeverAst
   sem exprToJson =
   | TmNever x -> JsonObject (mapFromSeq cmpString
@@ -642,6 +652,7 @@ lang MExprToJson
   + UtestToJson
   + ExtToJson
   + MetaVarToJson
+  + OpaqueToJson
 end
 
 mexpr

--- a/src/stdlib/mexpr/keyword-maker.mc
+++ b/src/stdlib/mexpr/keyword-maker.mc
@@ -40,11 +40,11 @@ lang KeywordMakerBase = VarAst + AppAst + ConTypeAst + AppTypeAst
   sem makeKeywords : Expr -> Expr
   sem makeKeywords =
   | expr ->
-    let expr = makeExprKeywords [] expr in
     let expr = mapPre_Expr_Expr (lam expr.
         smap_Expr_Type (makeTypeKeywords []) expr
-      ) expr
-    in expr
+      ) expr in
+    let expr = makeExprKeywords [] expr in
+    expr
 
   sem makeExprKeywords (args: [Expr]) =
   | TmApp r ->
@@ -162,6 +162,14 @@ end
 -- The keyword maker fragment, that includes all checks
 lang KeywordMaker = KeywordMakerBase + KeywordMakerLam + KeywordMakerLet +
                     KeywordMakerMatch + KeywordMakerData + KeywordMakerType
+end
+
+lang KeywordMakerOpaque = KeywordMakerBase + OpaqueAst + UnknownTypeAst
+  sem matchKeywordString info =
+  | "tmOpaque" -> Some (1, lam args. TmOpaque {body = head args, info = mergeInfo info (infoTm (head args)), ty = TyUnknown {info = NoInfo ()}})
+
+  sem isKeyword =
+  | TmOpaque _ -> true
 end
 
 -- A test fragment that is used to test the approach. This

--- a/src/stdlib/mexpr/keywords.mc
+++ b/src/stdlib/mexpr/keywords.mc
@@ -4,6 +4,8 @@ let mexprBuiltInKeywords = [
   "mexpr", "include", "never", "using", "external", "switch", "case", "all"
 ]
 
+let opaqueKeywords = ["tmOpaque"]
+
 let holeKeywords = ["hole", "Boolean", "IntRange", "independent"]
 
 let accelerateKeywords = [
@@ -12,5 +14,4 @@ let accelerateKeywords = [
 
 let specializeKeywords = ["specialize"]
 
-let mexprExtendedKeywords = concat specializeKeywords (
-                              concat holeKeywords accelerateKeywords)
+let mexprExtendedKeywords = foldl concat [] [opaqueKeywords, specializeKeywords, holeKeywords, accelerateKeywords]

--- a/src/stdlib/mexpr/lamlift.mc
+++ b/src/stdlib/mexpr/lamlift.mc
@@ -83,6 +83,7 @@ lang LambdaLiftNameAnonymous = MExprAst
   sem nameAnonymousLambdasWork : Bool -> Expr -> Expr
   sem nameAnonymousLambdasWork named =
   | tm -> smap_Expr_Expr (nameAnonymousLambdasWork false) tm
+  | tm & TmOpaque _ -> tm
   | tm & TmLam t ->
     let tm = smap_Expr_Expr (nameAnonymousLambdasWork true) tm in
     if named then tm else
@@ -311,6 +312,25 @@ lang LambdaLiftInsertFreeVariables = MExprAst + UpdateDefinitionsAndUses
   sem insertFreeVariablesH solutions subMap =
   | tm & TmVar t ->
     optionMapOr tm (lam f. f t) (mapLookup t.ident subMap)
+  | TmOpaque x ->
+    recursive let updateFree : Map Name (Name, Expr) -> Expr -> (Map Name (Name, Expr), Expr) = lam acc. lam tm.
+      switch tm
+      case TmOpaque x then
+        match updateFree acc x.body with (acc, body) in
+        (acc, TmOpaque {x with body = body})
+      case TmVar x then
+        match mapLookup x.ident acc with Some (n, _) then
+          (acc, TmVar {x with ident = n})
+        else match mapLookup x.ident subMap with Some f then
+          let n = nameSetNewSym x.ident in
+          let acc = mapInsert x.ident (n, f x) acc in
+          (acc, TmVar {x with ident = n})
+        else (acc, tm)
+      case tm then
+        smapAccumL_Expr_Expr updateFree acc tm
+      end in
+    match updateFree (mapEmpty nameCmp) x.body with (acc, body) in
+    mapFoldWithKey (lam tm. lam. lam pair. bind_ (nulet_ pair.0 pair.1) tm) (TmOpaque {x with body = body}) acc
   | TmDecl (x & {decl = DeclLet (t & {body = TmLam _})}) ->
     match mapLookup t.ident solutions with Some sol then
       let sol = _orderSolution sol in
@@ -387,6 +407,7 @@ lang LambdaLiftLiftGlobal = MExprAst
   sem liftGlobalH : [Decl] -> Expr -> ([Decl], Expr)
   sem liftGlobalH lifted =
   | t -> smapAccumL_Expr_Expr liftGlobalH lifted t
+  | t & TmOpaque _ -> (lifted, t)
   | TmDecl (x & {decl = DeclType _ | DeclConDef _ | DeclExt _}) ->
     liftGlobalH (snoc lifted x.decl) x.inexpr
   | TmDecl (x & {decl = DeclLet t}) ->
@@ -451,6 +472,12 @@ lang LambdaLiftReplaceCapturedParameters = MExprAst + MExprSubstitute
     {x with decl = DeclRecLets {t with bindings = bindings}
     , inexpr = replaceCapturedParametersH subMap x.inexpr
     }
+  | TmOpaque x ->
+    -- NOTE(vipa, 2026-04-28): This will make sure we actually refer
+    -- to the parameters standing in for captured variables, rather
+    -- than the variables themselves, which notably should be a
+    -- semantics preserving rename, which is allowed under TmOpaque
+    TmOpaque {x with body = replaceCapturedParametersH subMap x.body}
   | t -> smap_Expr_Expr (replaceCapturedParametersH subMap) t
 end
 
@@ -1028,4 +1055,36 @@ let nestedUtest = preprocess (bindall_ [
     (addi_ (var_ "x") (int_ 1))))
 ] unit_) in
 utest liftLambdas nestedUtest with nestedUtest using eqExpr in
+
+
+let lhs = preprocess
+  (bindall_
+    [ ulet_ "x" (int_ 1)
+    , ulet_ "foo" (ulam_ "y" (addi_ (var_ "x") (var_ "y")))
+    ]
+    (TmOpaque {info = NoInfo (), ty = tyunknown_, body = app_ (var_ "foo") (int_ 2)})) in
+let rhs = preprocess
+  (bindall_
+    [ ulet_ "x" (int_ 1)
+    , ulet_ "foo" (ulam_ "x1" (ulam_ "y" (addi_ (var_ "x1") (var_ "y"))))
+    , ulet_ "foo1" (app_ (var_ "foo") (var_ "x"))
+    ]
+    (TmOpaque {info = NoInfo (), ty = tyunknown_, body = app_ (var_ "foo1") (int_ 2)})) in
+utest liftLambdas lhs with rhs using eqExpr in
+
+let lhs = preprocess
+  (bindall_
+    [ ulet_ "x" (int_ 1)
+    , ulet_ "foo" (ulam_ "y" (TmOpaque {body = addi_ (var_ "x") (var_ "y"), ty = tyunknown_, info = NoInfo ()}))
+    ]
+    (app_ (var_ "foo") (int_ 2))) in
+let rhs = preprocess
+  (bindall_
+    [ ulet_ "x" (int_ 1)
+    , ulet_ "foo" (ulam_ "x1" (ulam_ "y" (TmOpaque {body = addi_ (var_ "x1") (var_ "y"), ty = tyunknown_, info = NoInfo ()})))
+    ]
+    (appf2_ (var_ "foo") (var_ "x") (int_ 2))) in
+utest liftLambdas lhs with rhs using eqExpr in
+
+
 ()

--- a/src/stdlib/mexpr/pprint.mc
+++ b/src/stdlib/mexpr/pprint.mc
@@ -308,6 +308,16 @@ lang PrettyPrint = IdentifierPrettyPrint + MExprAst
     else (env, join ["(", str, ")"])
 end
 
+lang OpaquePrettyPrint = PrettyPrint + OpaqueAst
+  sem isAtomic =
+  | TmOpaque _ -> false
+
+  sem pprintCode indent env =
+  | TmOpaque x ->
+    match printParen indent env x.body with (env, body) in
+    (env, join ["tmOpaque ", body])
+end
+
 lang VarPrettyPrint = PrettyPrint + MExprIdentifierPrettyPrint + VarAst
   sem isAtomic =
   | TmVar _ -> true
@@ -1433,7 +1443,7 @@ lang MExprPrettyPrint =
   -- Terms
   VarPrettyPrint + AppPrettyPrint + LamPrettyPrint + RecordPrettyPrint +
   DeclPrettyPrint + ConstPrettyPrint + DataPrettyPrint + MatchPrettyPrint +
-  SeqPrettyPrint + NeverPrettyPrint +
+  SeqPrettyPrint + NeverPrettyPrint + OpaquePrettyPrint +
 
   -- Decls
   LetPrettyPrint + TypePrettyPrint + RecLetsPrettyPrint + DataDeclPrettyPrint +

--- a/src/stdlib/mexpr/remove-ascription.mc
+++ b/src/stdlib/mexpr/remove-ascription.mc
@@ -9,6 +9,7 @@ lang MExprRemoveTypeAscription = MExprAst
     if nameEq idLet idExpr then
       removeTypeAscription body
     else smap_Expr_Expr removeTypeAscription letexpr
+  | expr & TmOpaque _ -> expr
   | expr -> smap_Expr_Expr removeTypeAscription expr
 end
 

--- a/src/stdlib/mexpr/resymbolize.mc
+++ b/src/stdlib/mexpr/resymbolize.mc
@@ -20,6 +20,14 @@ lang Resymbolize = Ast
   sem resymbolizeType : Map Name Name -> Type -> Type
 end
 
+lang ResymbolizeOpaque = Resymbolize + OpaqueAst
+  sem resymbolizeExpr nameMap =
+  | TmOpaque x -> TmOpaque
+    { x with body = resymbolizeExpr nameMap x.body
+    , ty = resymbolizeType nameMap x.ty
+    }
+end
+
 lang ResymbolizeVar = Resymbolize + VarAst
   sem resymbolizeExpr : Map Name Name -> Expr -> Expr
   sem resymbolizeExpr nameMap =
@@ -192,6 +200,7 @@ end
 lang MExprResymbolize =
   -- Expr
   ResymbolizeVar + ResymbolizeLam + ResymbolizeConApp + ResymbolizeMatch + ResymbolizeDecl +
+  ResymbolizeOpaque +
 
   -- Decl
   ResymbolizeLetDecl + ResymbolizeRecLetsDecl + ResymbolizeTypeDecl + ResymbolizeConDefDecl +

--- a/src/stdlib/mexpr/shallow-patterns.mc
+++ b/src/stdlib/mexpr/shallow-patterns.mc
@@ -774,9 +774,11 @@ lang CollectBranches = MatchAst + VarAst + NamedPat + AndPat + OrPat + NotPat
   | _ -> None ()
 end
 
-lang LowerNestedPatterns = CollectBranches + ShallowBase
+lang LowerNestedPatterns = CollectBranches + ShallowBase + OpaqueAst
   sem lowerAll : Expr -> Expr
-  sem lowerAll = | t ->
+  sem lowerAll =
+  | t & TmOpaque _ -> t
+  | t ->
     let f = lam pair. (pair.0, lowerAll pair.1) in
     match collectBranches t with Some (target, branches, fallthrough)
     then

--- a/src/stdlib/mexpr/symbolize.mc
+++ b/src/stdlib/mexpr/symbolize.mc
@@ -257,6 +257,12 @@ lang Sym = Ast + SymLookup
   | _ -> env
 end
 
+lang OpaqueSym = Sym + OpaqueAst
+  sem symbolizeExpr env =
+  | TmOpaque x ->
+    TmOpaque {x with body = symbolizeExpr env x.body}
+end
+
 lang VarSym = Sym + VarAst
   sem symbolizeExpr (env : SymEnv) =
   | TmVar t ->
@@ -671,7 +677,7 @@ lang MExprSym =
   SeqTotPat + RecordPat + IntPat + CharPat + BoolPat + AndPat + OrPat +
 
   -- Non-default implementations (Terms)
-  VarSym + LamSym + DataSym + MatchSym + DeclSym +
+  VarSym + LamSym + DataSym + MatchSym + DeclSym + OpaqueSym +
 
   -- Non-default implementations (Decls)
   LetSym + ExtSym + TypeSym + RecLetsSym +

--- a/src/stdlib/mexpr/type-annot.mc
+++ b/src/stdlib/mexpr/type-annot.mc
@@ -228,6 +228,11 @@ lang TypeAnnot = CompatibleType
     typeAnnotExpr env expr
 end
 
+lang OpaqueTypeAnnot = TypeAnnot + OpaqueAst
+  sem typeAnnotExpr env =
+  | tm & TmOpaque _ -> tm
+end
+
 lang VarTypeAnnot = TypeAnnot + VarAst
   sem typeAnnotExpr (env : TypeEnv) =
   | TmVar t ->
@@ -773,7 +778,7 @@ lang MExprTypeAnnot =
   VarTypeAnnot + AppTypeAnnot + LamTypeAnnot + RecordTypeAnnot + LetTypeAnnot +
   TypeTypeAnnot + RecLetsTypeAnnot + ConstTypeAnnot + DataTypeAnnot +
   MatchTypeAnnot + UtestTypeAnnot + SeqTypeAnnot + NeverTypeAnnot +
-  ExpTypeAnnot + PlaceHolderTypeAnnotation +
+  ExpTypeAnnot + PlaceHolderTypeAnnotation + OpaqueTypeAnnot +
 
   -- Patterns
   NamedPatTypeAnnot + SeqTotPatTypeAnnot + SeqEdgePatTypeAnnot +

--- a/src/stdlib/mexpr/type-check.mc
+++ b/src/stdlib/mexpr/type-check.mc
@@ -721,7 +721,7 @@ lang SubstituteNewReprs = ReprTypeAst + RepTypesHelpers
   | ty -> smap_Type_Type (substituteNewReprs env) ty
 end
 
-lang RemoveMetaVar = MetaVarTypeAst + UnknownTypeAst + RecordTypeAst + RecordKindAst
+lang RemoveMetaVar = MetaVarTypeAst + UnknownTypeAst + RecordTypeAst + RecordKindAst + OpaqueAst
   sem removeMetaVarType =
   | TyMetaVar t ->
     switch deref t.contents
@@ -734,6 +734,10 @@ lang RemoveMetaVar = MetaVarTypeAst + UnknownTypeAst + RecordTypeAst + RecordKin
     smap_Type_Type removeMetaVarType ty
 
   sem removeMetaVarExpr =
+  | TmOpaque x ->
+    let body = removeMetaVarExpr x.body in
+    let ty = removeMetaVarType x.ty in
+    TmOpaque {x with body = body, ty = ty}
   | tm ->
     let tm = smap_Expr_TypeLabel removeMetaVarType tm in
     let tm = smap_Expr_Type removeMetaVarType tm in
@@ -999,6 +1003,13 @@ lang IsEmpty =
     in
     match foldl merge (0, []) ms with (_, [m]) then Some m
     else None ()
+end
+
+lang OpaqueTypeCheck = TypeCheck + OpaqueAst
+  sem typeCheckExpr env =
+  | TmOpaque x ->
+    let body = typeCheckExpr env x.body in
+    TmOpaque {x with ty = tyTm body, body = body}
 end
 
 lang VarTypeCheck = TypeCheck + VarAst
@@ -1797,6 +1808,7 @@ lang MExprTypeCheckMost =
   AppTypeCheck + MatchTypeCheck + ConstTypeCheck + SeqTypeCheck +
   RecordTypeCheck + TypeTypeCheck + DataTypeCheck + UtestTypeCheck +
   NeverTypeCheck + ExtTypeCheck + PlaceholderTypeCheck + DeclTypeCheck +
+  OpaqueTypeCheck +
 
   -- Patterns
   NamedPatTypeCheck + SeqTotPatTypeCheck + SeqEdgePatTypeCheck +

--- a/src/stdlib/mexpr/uncurried.mc
+++ b/src/stdlib/mexpr/uncurried.mc
@@ -84,9 +84,10 @@ lang UncurriedAst = Ast
     (acc, TyUncurriedArrow {x with positional = positional, ret = ret})
 end
 
-lang LowerUncurried = UncurriedAst + LamAst
+lang LowerUncurried = UncurriedAst + LamAst + OpaqueAst
   sem lowerUncurried : Expr -> Expr
   sem lowerUncurried =
+  | tm & TmOpaque _ -> tm
   | tm ->
     let tm = smap_Expr_Expr lowerUncurried tm in
     let tm = smap_Expr_Type lowerUncurriedType tm in

--- a/src/stdlib/mexpr/utest-generate.mc
+++ b/src/stdlib/mexpr/utest-generate.mc
@@ -1013,6 +1013,7 @@ lang MExprUtestGenerate =
     match mapAccumL replaceBinding env t.bindings with (_, bindings) in
     match replaceUtests env x.inexpr with (env, inexpr) in
     (env, TmDecl {x with decl = DeclRecLets {t with bindings = bindings}, inexpr = inexpr})
+  | t & TmOpaque _ -> (env, t)
   | t -> smapAccumL_Expr_Expr replaceUtests env t
 
   -- Inserts utest runtime code at the tail of the program. In case any test
@@ -1033,6 +1034,7 @@ lang MExprUtestGenerate =
   sem stripUtests : Expr -> Expr
   sem stripUtests =
   | TmDecl (x & {decl = DeclUtest _}) -> stripUtests x.inexpr
+  | t & TmOpaque _ -> t
   | t -> smap_Expr_Expr stripUtests t
 
   sem generateUtest : Bool -> Expr -> Expr

--- a/src/stdlib/mexpr/utils.mc
+++ b/src/stdlib/mexpr/utils.mc
@@ -40,27 +40,34 @@ lang MExprSubstitute = MExprAst
     let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
-    withType (substituteIdentifiersType replacements (tyTm ast)) ast
+    ast
   | TmLam t ->
     let ast = TmLam {t with ident = subIdent replacements t.ident} in
     let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
     let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
-    withType (substituteIdentifiersType replacements (tyTm ast)) ast
+    ast
   | TmDecl x ->
     let ast = TmDecl {x with decl = substituteIdentifiersSDecl replacements x.decl} in
     let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
     let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
-    withType (substituteIdentifiersType replacements (tyTm ast)) ast
+    ast
+  | TmOpaque x ->
+    let ast = TmOpaque {x with body = substituteIdentifiersExpr replacements x.body} in
+    let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
+    let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
+    let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
+    ast
   | ast ->
     let ast = smap_Expr_Expr (substituteIdentifiersExpr replacements) ast in
     let ast = smap_Expr_Type (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_TypeLabel (substituteIdentifiersType replacements) ast in
     let ast = smap_Expr_Pat (substituteIdentifiersPat replacements) ast in
-    withType (substituteIdentifiersType replacements (tyTm ast)) ast
+    ast
 
   sem substituteIdentifiersType : Map Name Name -> Type -> Type
   sem substituteIdentifiersType replacements =

--- a/src/stdlib/mlang/loader.mc
+++ b/src/stdlib/mlang/loader.mc
@@ -22,6 +22,7 @@ include "symbolize.mc"
 include "type-check.mc"
 include "pprint.mc"
 include "mexpr/json-debug.mc"
+include "mexpr/keyword-maker.mc"
 
 lang SymGetters = Sym
   -- Helpers for looking up names from known symbolization
@@ -140,6 +141,9 @@ lang MCorePathResolution = MCoreLoader
     ({path = resolved, env = env}, loader)
 end
 
+lang MCoreKeywordMaker = KeywordMaker + KeywordMakerOpaque
+end
+
 lang BootParserLoader = MCorePathResolution + DeclAst + BootParser
   + LetDeclAst + RecLetsDeclAst + TypeDeclAst + DataDeclAst + ExtDeclAst
   + MLangPrettyPrint + AstToJson
@@ -213,6 +217,7 @@ lang BootParserLoader = MCorePathResolution + DeclAst + BootParser
       , allowFree = true
       } in
     let ast = parseMCoreFile args path in
+    let ast = use MCoreKeywordMaker in makeKeywords ast in
     recursive let f = lam decls. lam ast.
       match ast with TmDecl {decl = decl, inexpr = ast}
       then f (snoc decls decl) ast

--- a/src/stdlib/ocaml/mcore.mc
+++ b/src/stdlib/ocaml/mcore.mc
@@ -44,6 +44,11 @@ lang MCoreCompileLang =
   sem compileMCore : all a. Expr -> Hooks a -> a
   sem compileMCore ast =
   | hooks ->
+    recursive let removeOpaque = lam tm.
+      match tm with TmOpaque x
+      then removeOpaque x.body
+      else smap_Expr_Expr removeOpaque tm in
+    let ast = removeOpaque ast in
     let ast = removeTypeAscription ast in
 
     match typeLift ast with (env, ast) in

--- a/src/stdlib/tuning/ast.mc
+++ b/src/stdlib/tuning/ast.mc
@@ -40,6 +40,7 @@ lang HoleAstBase = IntAst + ANF + KeywordMaker + TypeCheck + Sym
 
   sem default =
   | TmHole {default = default} -> default
+  | t & TmOpaque _ -> t
   | t -> smap_Expr_Expr default t
 
   sem isAtomic =
@@ -275,8 +276,9 @@ lang HoleIntRangeAst = IntAst + HoleAstBase + IntTypeAst
 
 end
 
-lang HoleAnnotation = Ast
+lang HoleAnnotation = Ast + OpaqueAst
   sem stripTuneAnnotations =
+  | t & TmOpaque _ -> t
   | t -> smap_Expr_Expr stripTuneAnnotations t
 end
 


### PR DESCRIPTION
This PR adds `TmOpaque` in the shape we discussed it last (I think): something that may be examined, but not altered, by compiler passes. The same exceptions apply as before; the compiler may make alpha-equivalent renames (e.g., symbolize) and attach inferred type information (so the backend has what it needs to compile).

The current primary use-case for `TmOpaque` is for ensuring inference transformation passes in miking-dppl do not touch  particular pieces of code, right now just matrix implementations (which are externally immutable, but internally use mutability), but in the future custom distributions.

Other points of note:
- I have implemented `sfold` explicitly, but made `smapAccumL` (and thus also `smap`) crash with an error. This seemed safest to me, to ensure we've actually considered how each pass should handle `TmOpaque` properly if it normally would make changes to the AST.
- That also means I have removed the full-tree traversal functions (`mapPre`, `mapPost`, etc.), since they can't know what to do when they encounter a `TmOpaque`.