### PR TITLE
Update flake and ocamlformat

### DIFF
--- a/misc/packaging/flake.lock
+++ b/misc/packaging/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {

--- a/misc/packaging/flake.nix
+++ b/misc/packaging/flake.nix
@@ -20,7 +20,7 @@
           devShells.default = pkgs.mkShell {
             name = "Miking dev shell";
             inputsFrom = [ packages.miking-lib packages.miking-unwrapped ];
-            buildInputs = [ pkgs.tup pkgs.ocamlformat_0_29_0 pkgs.ocamlPackages.owl pkgs.ocamlPackages.utop pkgs.gdb ];
+            buildInputs = with pkgs; [ tup ocamlformat_0_29_0 ocamlPackages.owl ocamlPackages.utop gdb ];
           };
         };
     in

--- a/misc/packaging/flake.nix
+++ b/misc/packaging/flake.nix
@@ -20,7 +20,7 @@
           devShells.default = pkgs.mkShell {
             name = "Miking dev shell";
             inputsFrom = [ packages.miking-lib packages.miking-unwrapped ];
-            buildInputs = [ pkgs.tup pkgs.ocamlformat_0_24_1 ];
+            buildInputs = [ pkgs.tup pkgs.ocamlformat_0_29_0 pkgs.ocamlPackages.owl pkgs.ocamlPackages.utop pkgs.gdb ];
           };
         };
     in

--- a/src/boot/.ocamlformat
+++ b/src/boot/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.24.1
+version=0.29.0
 profile=ocamlformat
 margin=79

--- a/src/boot/boot.ml
+++ b/src/boot/boot.ml
@@ -28,7 +28,7 @@ let files_of_folders lst =
         |> List.map (fun x -> add_slash v ^ x)
         |> List.filter (fun x -> not (Sys.is_directory x))
         |> List.filter (fun x ->
-               not (String.contains x '#' || String.contains x '~') ) )
+            not (String.contains x '#' || String.contains x '~') ) )
         @ a
       else v :: a )
     [] lst

--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -523,16 +523,16 @@ let smap_accum_left_tm_tm (f : 'a -> tm -> 'a * tm) (acc : 'a) : tm -> 'a * tm
       f acc t2
       |> fun (acc, t2') ->
       ( match tusing with
-      | Some tusing' ->
-          f acc tusing' |> fun (acc, tusing'') -> (acc, Some tusing'')
-      | None ->
-          (acc, tusing) )
+        | Some tusing' ->
+            f acc tusing' |> fun (acc, tusing'') -> (acc, Some tusing'')
+        | None ->
+            (acc, tusing) )
       |> fun (acc, tusing') ->
       ( match tonfail with
-      | Some tonfail' ->
-          f acc tonfail' |> fun (acc, tonfail'') -> (acc, Some tonfail'')
-      | None ->
-          (acc, tonfail) )
+        | Some tonfail' ->
+            f acc tonfail' |> fun (acc, tonfail'') -> (acc, Some tonfail'')
+        | None ->
+            (acc, tonfail) )
       |> fun (acc, onfail') ->
       f acc tnext
       |> fun (acc, tnext') ->

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -101,10 +101,10 @@ let builtin =
         ( NoInfo
         , argv_prog |> Mseq.Helpers.of_array
           |> Mseq.map (fun s ->
-                 TmSeq
-                   ( NoInfo
-                   , s |> us |> Mseq.Helpers.of_ustring
-                     |> Mseq.map (fun x -> TmConst (NoInfo, CChar x)) ) ) ) )
+              TmSeq
+                ( NoInfo
+                , s |> us |> Mseq.Helpers.of_ustring
+                  |> Mseq.map (fun x -> TmConst (NoInfo, CChar x)) ) ) ) )
   ; ("readFile", f CreadFile)
   ; ("writeFile", f (CwriteFile None))
   ; ("fileExists", f CfileExists)

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -514,12 +514,12 @@ module T = struct
       int Mseq.t =
     let el2str x = Mseq.Helpers.to_ustring (el2str x) in
     ( match t with
-    | TInt t' ->
-        Tensor.Uop_barray.to_ustring el2str t'
-    | TFloat t' ->
-        Tensor.Uop_barray.to_ustring el2str t'
-    | TGen t' ->
-        Tensor.Uop_generic.to_ustring el2str t' )
+      | TInt t' ->
+          Tensor.Uop_barray.to_ustring el2str t'
+      | TFloat t' ->
+          Tensor.Uop_barray.to_ustring el2str t'
+      | TGen t' ->
+          Tensor.Uop_generic.to_ustring el2str t' )
     |> Mseq.Helpers.of_ustring
 
   module Helpers = struct
@@ -704,7 +704,7 @@ module MSys = struct
   let argv =
     Sys.argv |> Mseq.Helpers.of_array
     |> Mseq.map (fun a ->
-           a |> Ustring.from_utf8 |> Ustring.to_uchars |> Mseq.Helpers.of_array )
+        a |> Ustring.from_utf8 |> Ustring.to_uchars |> Mseq.Helpers.of_array )
 
   let command s = Sys.command (s |> Mseq.Helpers.to_ustring |> Ustring.to_utf8)
 end

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -697,8 +697,7 @@ let getData = function
       let lst =
         List.map
           (fun x ->
-            match x with CDecl (fi, params, con, ty) -> (fi, params, con, ty)
-            )
+            match x with CDecl (fi, params, con, ty) -> (fi, params, con, ty) )
           decls
       in
       let allStr = List.map (fun (_, _, con, _) -> con) lst in
@@ -726,8 +725,7 @@ let getData = function
       let lst =
         List.map
           (fun x ->
-            match x with CDecl (fi, params, con, ty) -> (fi, params, con, ty)
-            )
+            match x with CDecl (fi, params, con, ty) -> (fi, params, con, ty) )
           decls
       in
       let allStr = List.map (fun (_, _, con, _) -> con) lst in
@@ -2242,7 +2240,10 @@ and delta (apply : info -> tm -> tm -> tm) fi c v =
         let tmseq = int_seq2int_tm_seq (tm_info tm) is in
         apply tm tmseq
         |> function
-        | TmConst (_, CInt n) -> n | _ -> raise_error fi "Expected integer"
+        | TmConst (_, CInt n) ->
+            n
+        | _ ->
+            raise_error fi "Expected integer"
       in
       T.create_int shape f |> fun t -> TmTensor (fi, T.TBootInt t)
   | CtensorCreateCArrayInt _, _ ->
@@ -2255,7 +2256,10 @@ and delta (apply : info -> tm -> tm -> tm) fi c v =
         let tmseq = int_seq2int_tm_seq (tm_info tm) is in
         apply tm tmseq
         |> function
-        | TmConst (_, CFloat r) -> r | _ -> raise_error fi "Expected float"
+        | TmConst (_, CFloat r) ->
+            r
+        | _ ->
+            raise_error fi "Expected float"
       in
       T.create_float shape f |> fun t -> TmTensor (fi, T.TBootFloat t)
   | CtensorCreateCArrayFloat _, _ ->
@@ -2546,16 +2550,16 @@ and delta (apply : info -> tm -> tm -> tm) fi c v =
       in
       let el2str x = apply el2str x |> to_ustring in
       ( match t with
-      | T.TBootInt t' ->
-          Tensor.Uop_barray.to_ustring
-            (fun x -> TmConst (fi, CInt x) |> el2str)
-            t'
-      | T.TBootFloat t' ->
-          Tensor.Uop_barray.to_ustring
-            (fun x -> TmConst (fi, CFloat x) |> el2str)
-            t'
-      | T.TBootGen t' ->
-          Tensor.Uop_generic.to_ustring el2str t' )
+        | T.TBootInt t' ->
+            Tensor.Uop_barray.to_ustring
+              (fun x -> TmConst (fi, CInt x) |> el2str)
+              t'
+        | T.TBootFloat t' ->
+            Tensor.Uop_barray.to_ustring
+              (fun x -> TmConst (fi, CFloat x) |> el2str)
+              t'
+        | T.TBootGen t' ->
+            Tensor.Uop_generic.to_ustring el2str t' )
       |> fun str -> TmSeq (fi, ustring2tmseq fi str)
   | Ctensor2string _, _ ->
       fail_constapp fi
@@ -2596,8 +2600,7 @@ and delta (apply : info -> tm -> tm -> tm) fi c v =
           let externals_exclude =
             Mseq.map
               (function
-                | TmSeq (_, s) -> tmseq2seq_of_int fi s | _ -> fail_constapp fi
-                )
+                | TmSeq (_, s) -> tmseq2seq_of_int fi s | _ -> fail_constapp fi )
               externals_exclude
           in
           TmConst
@@ -2964,11 +2967,11 @@ and eval (env : (Symb.t * tm) list) (pe : peval) (t : tm) =
   | TmConApp (fi, x, s, t) ->
       let rhs = eval env pe t in
       ( if !enable_debug_con_shape then
-        let shape = shape_str rhs in
-        let sym = ustring_of_var ~symbol:!enable_debug_symbol_print x s in
-        let info = info2str fi in
-        Printf.eprintf "%s:\t%s\t(%s)\n" (Ustring.to_utf8 sym)
-          (Ustring.to_utf8 shape) (Ustring.to_utf8 info) ) ;
+          let shape = shape_str rhs in
+          let sym = ustring_of_var ~symbol:!enable_debug_symbol_print x s in
+          let info = info2str fi in
+          Printf.eprintf "%s:\t%s\t(%s)\n" (Ustring.to_utf8 sym)
+            (Ustring.to_utf8 shape) (Ustring.to_utf8 info) ) ;
       TmConApp (fi, x, s, rhs)
   (* Match *)
   | TmMatch (fi, t1, p, t2, t3) -> (

--- a/src/boot/lib/mlang.ml
+++ b/src/boot/lib/mlang.ml
@@ -945,7 +945,7 @@ let wrap_aliases : mlang_env -> lang_data -> tm -> tm =
   |> Seq.filter (fun (alias : alias_data) -> alias.def_here)
   |> List.of_seq
   |> List.sort (fun (a : alias_data) (b : alias_data) ->
-         Symb.compare a.id b.id )
+      Symb.compare a.id b.id )
   |> fun aliases -> List.fold_right wrap_alias aliases tm
 
 let wrap_cons : mlang_env -> lang_data -> tm -> tm =

--- a/src/boot/lib/parserutils.ml
+++ b/src/boot/lib/parserutils.ml
@@ -120,18 +120,22 @@ let prune_external_utests ?(enable = true) ?(warn = true)
         recur (sm, ntests, hasref') t2
         |> fun ((sm, ntests, hasref'), t2') ->
         ( match t3 with
-        | Some t3' ->
-            let (sm, ntests, hasref'), t3' = recur (sm, ntests, hasref') t3' in
-            ((sm, ntests, hasref'), Some t3')
-        | None ->
-            ((sm, ntests, hasref'), t3) )
+          | Some t3' ->
+              let (sm, ntests, hasref'), t3' =
+                recur (sm, ntests, hasref') t3'
+              in
+              ((sm, ntests, hasref'), Some t3')
+          | None ->
+              ((sm, ntests, hasref'), t3) )
         |> fun ((sm, ntests, hasref'), t3') ->
         ( match t4 with
-        | Some t4' ->
-            let (sm, ntests, hasref'), t4' = recur (sm, ntests, hasref') t4' in
-            ((sm, ntests, hasref'), Some t4')
-        | None ->
-            ((sm, ntests, hasref'), t4) )
+          | Some t4' ->
+              let (sm, ntests, hasref'), t4' =
+                recur (sm, ntests, hasref') t4'
+              in
+              ((sm, ntests, hasref'), Some t4')
+          | None ->
+              ((sm, ntests, hasref'), t4) )
         |> fun ((sm, ntests, hasref'), t4') ->
         recur (sm, ntests, false) t5
         |> fun ((sm, ntests, hasref''), t5') ->
@@ -339,7 +343,7 @@ let rec merge_includes root visited = function
       let included_tops =
         included
         |> List.map (function Program (_, tops, _) ->
-               List.filter not_test tops )
+            List.filter not_test tops )
         |> List.concat
       in
       Program (includes, included_tops @ tops, tm)

--- a/src/boot/lib/patterns.ml
+++ b/src/boot/lib/patterns.ml
@@ -269,7 +269,7 @@ let rec list_complement (constr : npat list -> npat) (l : npat list) : normpat
        normpat (since it's a set) up to the top-most list, which we can do using `traverse`
        in the list monad. *)
     |> concat_map ~f:(fun np_list ->
-           traverse NPatSet.elements np_list |> List.map constr )
+        traverse NPatSet.elements np_list |> List.map constr )
     |> NPatSet.of_list
   else
     (* NOTE(vipa, 2021-08-18):
@@ -319,8 +319,7 @@ and npat_complement : npat -> normpat = function
       let with_forbidden_labels =
         UstringSet.elements neg_labels
         |> List.map (fun label ->
-               SNPat
-                 (NPatRecord (Record.add label wildpat pats, UstringSet.empty)) )
+            SNPat (NPatRecord (Record.add label wildpat pats, UstringSet.empty)) )
         |> NPatSet.of_list
       in
       let labels, pats = Record.bindings pats |> List.split in
@@ -334,7 +333,7 @@ and npat_complement : npat -> normpat = function
       let missing_labels =
         labels
         |> List.map (fun label ->
-               SNPat (NPatRecord (Record.empty, UstringSet.singleton label)) )
+            SNPat (NPatRecord (Record.empty, UstringSet.singleton label)) )
         |> NPatSet.of_list
       in
       NPatSet.union complemented_product missing_labels
@@ -364,18 +363,18 @@ and npat_complement : npat -> normpat = function
   | NPatNot cons ->
       ConSet.elements cons
       |> List.map (function
-           | IntCon i ->
-               SNPat (NPatInt i)
-           | CharCon c ->
-               SNPat (NPatChar c)
-           | BoolCon b ->
-               SNPat (NPatBool b)
-           | ConCon c ->
-               SNPat (NPatCon (c, wildpat))
-           | SeqCon ->
-               SNPat (NPatSeqEdge ([], IntSet.empty, []))
-           | RecCon ->
-               SNPat (NPatRecord (Record.empty, UstringSet.empty)) )
+        | IntCon i ->
+            SNPat (NPatInt i)
+        | CharCon c ->
+            SNPat (NPatChar c)
+        | BoolCon b ->
+            SNPat (NPatBool b)
+        | ConCon c ->
+            SNPat (NPatCon (c, wildpat))
+        | SeqCon ->
+            SNPat (NPatSeqEdge ([], IntSet.empty, []))
+        | RecCon ->
+            SNPat (NPatRecord (Record.empty, UstringSet.empty)) )
       |> NPatSet.of_list
 
 and npat_intersect (a : npat) (b : npat) : normpat =
@@ -414,7 +413,7 @@ and npat_intersect (a : npat) (b : npat) : normpat =
           Record.merge merge_f r1 r2 |> Record.bindings
           |> traverse (fun (k, vs) -> List.map (fun v -> (k, v)) vs)
           |> List.map (fun bindings ->
-                 SNPat (NPatRecord (List.to_seq bindings |> Record.of_seq, neg)) )
+              SNPat (NPatRecord (List.to_seq bindings |> Record.of_seq, neg)) )
           |> NPatSet.of_list
     | NPatSeqTot pats1, NPatSeqTot pats2 ->
         if List.length pats1 <> List.length pats2 then NPatSet.empty
@@ -434,8 +433,8 @@ and npat_intersect (a : npat) (b : npat) : normpat =
           let post = List.rev (include_tail NPatSet.singleton rev_post) in
           pre @ post |> traverse NPatSet.elements
           |> List.map (fun pats ->
-                 let pre, post = split_at (List.length pre) pats in
-                 SNPat (NPatSeqEdge (pre, lens, post)) )
+              let pre, post = split_at (List.length pre) pats in
+              SNPat (NPatSeqEdge (pre, lens, post)) )
           |> NPatSet.of_list
         in
         (* NOTE(vipa, 2021-08-23): We need to consider when the
@@ -511,17 +510,17 @@ let rec pat_to_normpat = function
       Mseq.concat pre post |> Mseq.Helpers.to_list
       |> traverse (fun p -> pat_to_normpat p |> NPatSet.elements)
       |> List.map (fun pats ->
-             let pre, post = split_at (Mseq.length pre) pats in
-             SNPat (NPatSeqEdge (pre, IntSet.empty, post)) )
+          let pre, post = split_at (Mseq.length pre) pats in
+          SNPat (NPatSeqEdge (pre, IntSet.empty, post)) )
       |> NPatSet.of_list
   | PatRecord (_, r) ->
       Record.bindings r
       |> traverse (fun (k, p) ->
-             pat_to_normpat p |> NPatSet.elements |> List.map (fun p -> (k, p)) )
+          pat_to_normpat p |> NPatSet.elements |> List.map (fun p -> (k, p)) )
       |> List.map (fun bindings ->
-             SNPat
-               (NPatRecord
-                  (List.to_seq bindings |> Record.of_seq, UstringSet.empty) ) )
+          SNPat
+            (NPatRecord
+               (List.to_seq bindings |> Record.of_seq, UstringSet.empty) ) )
       |> NPatSet.of_list
   | PatCon (_, c, _, p) ->
       pat_to_normpat p |> NPatSet.map (fun p -> SNPat (NPatCon (c, p)))
@@ -555,7 +554,7 @@ let pat_example normpat =
         let pos = PatRecord (NoInfo, Record.map npat_to_pat r) in
         UstringSet.elements neg
         |> List.map (fun label ->
-               PatRecord (NoInfo, Record.singleton label wildpat) )
+            PatRecord (NoInfo, Record.singleton label wildpat) )
         |> function
         | [] ->
             pos
@@ -586,18 +585,18 @@ let pat_example normpat =
         let cons =
           ConSet.elements cons
           |> List.map (function
-               | IntCon i ->
-                   PatInt (NoInfo, i)
-               | CharCon c ->
-                   PatChar (NoInfo, c)
-               | BoolCon b ->
-                   PatBool (NoInfo, b)
-               | ConCon str ->
-                   PatCon (NoInfo, str, Symb.Helpers.nosym, wildpat)
-               | SeqCon ->
-                   PatSeqEdge (NoInfo, Mseq.empty, NameWildcard, Mseq.empty)
-               | RecCon ->
-                   PatRecord (NoInfo, Record.empty) )
+            | IntCon i ->
+                PatInt (NoInfo, i)
+            | CharCon c ->
+                PatChar (NoInfo, c)
+            | BoolCon b ->
+                PatBool (NoInfo, b)
+            | ConCon str ->
+                PatCon (NoInfo, str, Symb.Helpers.nosym, wildpat)
+            | SeqCon ->
+                PatSeqEdge (NoInfo, Mseq.empty, NameWildcard, Mseq.empty)
+            | RecCon ->
+                PatRecord (NoInfo, Record.empty) )
         in
         match cons with
         | [] ->

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -143,7 +143,7 @@ let ustring_of_pat p =
         let ps =
           Record.bindings ps
           |> List.map (fun (label, p) ->
-                 pprint_label_str label ^. us " = " ^. ppp p )
+              pprint_label_str label ^. us " = " ^. ppp p )
           |> Ustring.concat (us ",")
         in
         us "{" ^. ps ^. us "}"

--- a/src/boot/lib/rope.ml
+++ b/src/boot/lib/rope.ml
@@ -92,10 +92,12 @@ let set_array (s : 'a t) (idx : int) (v : 'a) : 'a t =
     match s with
     | Leaf a ->
         let a' = Array.copy a in
-        a'.(i) <- v ; Leaf a'
+        a'.(i) <- v ;
+        Leaf a'
     | Slice {v= value; off; len} ->
         let a' = Array.sub value off len in
-        a'.(i) <- v ; Leaf a'
+        a'.(i) <- v ;
+        Leaf a'
     | Concat {lhs; rhs; len} ->
         let n = _length_array lhs in
         if i < n then Concat {lhs= helper lhs i; rhs; len}


### PR DESCRIPTION
When setting up a new test environment on a new computer I wanted to give it a later version of OCaml. Unfortunately this makes it difficult to install the version of `ocamlformat` we require, so this PR updates that. It also updates the nix flake, since that was required to install the new version of `ocamlformat`.