### PR TITLE
Make `test-spec.mc` use `xargs` to work around really long command lines

### DIFF
--- a/src/stdlib/test-spec.mc
+++ b/src/stdlib/test-spec.mc
@@ -473,7 +473,13 @@ lang TestSpec
     let keepGoing = if flags.keepGoing
       then " -k"
       else "" in
-    command (join ["exec tup", parallel, keepGoing, " ", formatTupFilter rules])
+    sysWithTempFile (lam file.
+      writeFile file (formatTupFilter rules);
+      -- NOTE(vipa, 2026-05-06): Something about the way OCaml's
+      -- Sys.command handles really, really long commands makes it
+      -- break to run `tup` directly. Putting the arguments in a file
+      -- and using xargs appears to work, however.
+      command (join ["xargs tup", parallel, keepGoing, " < ", file]))
 
   sem runStats : [Rule] -> [Rule] -> Int
   sem runStats selectedRules = | allRules ->


### PR DESCRIPTION
This PR fixes a bug that _seems_ to be due to some peculiarity of OCaml's `Sys.command` function, that makes it fail if you give it a _very_ long command line. The error occurs because `test-spec.mc` will give a list of all targets that need to be run, which ends up being a lot in our projects. The error affects `tup` but not `make` because they're run in different ways:

- `tup` is run through `tup target1 target2 target3...`, where we often end up with 1000-2000 targets in a bare `misc/test` run.
- `make` is run through `make -f generated-file.mk`, where `generated-file.mk` contains instructions for exactly the targets to run this time, and no other targets.

Notably we don't want to use the `make` approach for `tup` because `tup` aggressively makes sure that only defined targets exist/are remembered, so if we generated a new `Tupfile` for only the desired targets, then the third run in `misc/test; misc/test src/stdlib/bool.mc; misc/test` would rerun all tests except `src/stdlib/bool.mc`, even though they've already been run in the first command.

The solution is using `xargs`, because we can write all the targets to a file just fine.