### PR TITLE
Make test-spec --watch slightly less aggressive

### DIFF
--- a/src/stdlib/test-spec.mc
+++ b/src/stdlib/test-spec.mc
@@ -523,7 +523,7 @@ lang TestSpec
       else printWatchList in
     let runEntr =
       let args = filter (lam str. not (eqString "--watch" str)) (tail argv) in
-      join ["entr -rccdd ", sysShellQuote (head argv), " ", strJoin " " (map sysShellQuote args)] in
+      join ["entr -rccd ", sysShellQuote (head argv), " ", strJoin " " (map sysShellQuote args)] in
     let cmd = join ["set -o pipefail; { ", printWatchList, "; } | ", runEntr] in
     recursive let work = lam.
       -- NOTE(vipa, 2026-04-10): 'entr' will exit with '2' if a new


### PR DESCRIPTION
The `--watch` flag of `test-spec.mc` would rerun tests as soon as I start editing files, because Emacs would write to some otherwise invisible file in the repository when a buffer gets dirty, even though I've (as far as I can tell) told it to do all such writes elsewhere. Telling `entr` to ignore newly created hidden files fixes this issue.