### PR TITLE
More explicit decision-making on whether a value is considered "simple" enough for inlining

### DIFF
--- a/src/stdlib/mexpr/inline-single-use-simple.mc
+++ b/src/stdlib/mexpr/inline-single-use-simple.mc
@@ -78,6 +78,12 @@ lang InlineSingleUse = DeclAst + LetDeclAst + RecLetsDeclAst + VarAst + TempLamA
     ({st with useCounts = mapInsertWith addi x.ident 1 st.useCounts}, tm)
   | tm -> smapAccumL_Expr_Expr collectSingleUses st tm
 
+  sem isSimpleInline : Expr -> Bool
+  sem isSimpleInline =
+  | TmConst _ -> true
+  | TmVar _ -> true
+  | _ -> false
+
   sem mkInlineable : Map Name Int -> Expr -> InlineMap -> Expr
   sem mkInlineable useCounts =
   | TmLam x ->
@@ -93,8 +99,7 @@ lang InlineSingleUse = DeclAst + LetDeclAst + RecLetsDeclAst + VarAst + TempLamA
       TempLam {f = f, info = x.info, ty = x.ty}
     case _ then lam st.
       let f = lam arg.
-        let isSimple = sfold_Expr_Expr (lam. lam. false) true arg in
-        if isSimple then
+        if isSimpleInline arg then
           match st with InlineMap toInline in
           let toInline = mapInsert x.ident (lam. arg) toInline in
           mkInlineable useCounts x.body (InlineMap toInline)


### PR DESCRIPTION
Previously, the `inline-single-use-simple.mc` pass would consider a term to be simple enough to inline even if used more than once if it had zero children. The actual choice _should_ be made based on whether a) there is any computation, and b) if the inlined thing is large code-wise, but this proxy only looked at the latter. There is now an explicit `sem` for making the decision instead, making it a bit less accidental what gets inlined.