### PR TITLE
Make ocaml generate merely warn if it cannot determine if a match is exhaustive

### DIFF
--- a/src/stdlib/ocaml/generate.mc
+++ b/src/stdlib/ocaml/generate.mc
@@ -433,11 +433,15 @@ lang OCamlMatchGenerate = MExprAst + OCamlAst + OCamlTopGenerate
     -- lost at this stage, but the pattern contains the correct type
     -- information.
     let ty = unwrapType (tyPat t.pat) in
-    match ty with TyCon {ident = ident} then
+    switch ty
+    case TyCon {ident = ident} then
       match mapLookup ident env.variants with Some constrs then
         eqi (length arms) (mapSize constrs)
       else errorSingle [infoPat t.pat] "env.variants lookup failed"
-    else errorSingle [infoPat t.pat] "expected TyCon"
+    case TyUnknown _ then
+      warnSingle [infoPat t.pat] "Compiler warning: this pattern should have a TyCon attached, but had TyUnknown"; false
+    case _ then errorSingle [infoPat t.pat] "expected TyCon or TyUnknown"
+    end
 
   sem casesReferToDefault : GenerateEnv -> Name -> [(Pat, Expr)] -> Bool
   sem casesReferToDefault env id =


### PR DESCRIPTION
It is quite difficult to generate appropriate type annotations for matches on constructors in the `idealized-transform.mc` that is part of the automated graph transformation. This is for two reasons:

1. The transformation essentially uses structural types internally, meaning it currently has no explicit reference to the named type the constructors belonged to.
2. The transformation actually changes the types of said constructors and their types, to make them flexible enough to carry both wrapped and unwrapped values.

The latter would probably make the annotated types incompatible with what we think the types look like in the rest of the program, so it's not obvious how the annotation should be made.

However, for now it appears to work to just turn this (compiler) error into a warning, the generated code still does the right thing.