### PR TITLE
First steps on the new parser

### DIFF
--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -7,10 +7,12 @@ include "mexpr/json-debug.mc"
 include "json.mc"
 include "seq.mc"
 include "parser/breakable.mc"
+include "name.mc"
 
 type BreakableOp lstyle rstyle
-con OpAtom: all self. self -> BreakableOp LClosed RClosed
-con OpNeg: all self. self -> BreakableOp LClosed ROpen
+con OpAtom: use Ast in Expr -> BreakableOp LClosed RClosed
+con OpNeg: Info -> BreakableOp LClosed ROpen
+con OpApp: Info -> BreakableOp LClosed ROpen
 
 lang AstParserBase = Lexer
   sem config: () -> Config BreakableOp
@@ -21,7 +23,7 @@ lang AstParserBase = Lexer
   sem parenAllowed: ParenAllowedFunc BreakableOp
   sem groupingsAllowed: GroupingsAllowedFunc BreakableOp
 
-  sem constructPrefix: BreakableOp LClosed ROpen -> Expr -> Expr
+  sem constructPrefix: (BreakableOp LClosed ROpen, Expr) -> Expr
 
   sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
   sem parseExprRClosed : State BreakableOp RClosed -> NextTokenResult -> (Expr, NextTokenResult)
@@ -74,7 +76,7 @@ lang AstParserBase = Lexer
       let expr = breakableConstructSimple {
         constructAtom = lam op. match op with OpAtom expr in expr,
         constructInfix = lam op. lam l. never,
-        constructPrefix = constructPrefix,
+        constructPrefix = lam op. lam rhs. constructPrefix (op, rhs),
         constructPostfix = lam op. lam l. never
       } sppf in
       (expr, next)
@@ -112,35 +114,47 @@ lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
     parseExprROpen state (nextToken stream)
 
   sem constructPrefix =
-  | OpNeg info -> lam r.
-    switch r
-      case TmConst { val = CInt { val = val }, info = info2 } then
-        let info = mergeInfo info info2 in
-        TmConst {
-          val = CInt { val = negi val },
-          ty = ityunknown_ info,
-          info = info
-        }
-      case TmConst { val = CFloat { val = val }, info = info2 } then
-        let info = mergeInfo info info2 in
-        TmConst {
-          val = CFloat { val = negf val },
-          ty = ityunknown_ info,
-          info = info
-        }
-      case expr then
-        let info2 = mergeInfo info (infoTm expr) in
-        TmApp {
-          lhs = TmConst {
-            val = CNegi {},
-            ty = ityunknown_ info,
-            info = info
-          },
-          rhs = expr,
-          ty = ityunknown_ info2,
-          info = info2
-        }
-    end
+  | (OpNeg info, TmConst { val = CInt { val = val }, info = info2 }) ->
+    let info = mergeInfo info info2 in
+    TmConst {
+      val = CInt { val = negi val },
+      ty = ityunknown_ info,
+      info = info
+    }
+
+  | (OpNeg info, TmConst { val = CFloat { val = val }, info = info2 }) ->
+    let info = mergeInfo info info2 in
+    TmConst {
+      val = CFloat { val = negf val },
+      ty = ityunknown_ info,
+      info = info
+    }
+
+  | (OpNeg info, rhs) ->
+    let info2 = mergeInfo info (infoTm rhs) in
+    TmApp {
+      lhs = TmConst {
+        val = CNegi {},
+        ty = ityunknown_ info,
+        info = info
+      },
+      rhs = rhs,
+      ty = ityunknown_ info2,
+      info = info2
+    }
+end
+
+lang VarParser = AstParserBase + VarAst
+  sem parseExprROpen state =
+  | { token = LIdentTok { val = val, info = info }, stream = stream } ->
+    let expr = TmVar {
+      ident = nameNoSym val,
+      ty = ityunknown_ info,
+      info = info,
+      frozen = false -- TODO
+    } in
+    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    parseExprRClosed state (nextToken stream)
 end
 
 lang BoolParser = AstParserBase + BoolAst
@@ -205,6 +219,7 @@ lang AstParser =
   + CharParser
   + StringParser
   + NegParser
+  + VarParser
 end
 
 lang TestParser =
@@ -223,7 +238,7 @@ use BootParser in
 let lex = lam str. nextToken {pos = initPos "internal", str = str} in
 let parse = lam str. match parseExpr (lex str) with (expr, next) in expr in
 
-let bootArg = _defaultBootParserParseMExprStringArg () in
+let bootArg = { _defaultBootParserParseMExprStringArg () with builtin = [] } in
 let parseBoot = lam str.
   match parseMExprString bootArg str with (ResultOk { value = bootExpr}) in bootExpr in
 
@@ -234,7 +249,9 @@ let compare = lam str. eqString (jsonStr (parse str)) (jsonStr (parseBoot str)) 
 
 let printAst = lam expr. printLn (jsonStr expr) in
 
--- printAst (parseBoot "\"test\"");
+-- printLn "";
+-- printAst (parseBoot "addi 1 2");
+-- printAst (parse "addi 1 2");
 
 utest compare "0" with true in
 utest compare "1" with true in
@@ -251,5 +268,7 @@ utest compare "'a'" with true in
 utest compare "'😊'" with true in
 
 utest compare "\"test\"" with true in
+
+utest compare "addi 1 2" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -14,6 +14,11 @@ con OpAtom: use Ast in Expr -> BreakableOp LClosed RClosed
 con OpNeg: Info -> BreakableOp LClosed ROpen
 con OpApp: Info -> BreakableOp LOpen ROpen
 
+type ParseResult a = Result (Info, String) (Info, String) a
+
+let parseOk:  all a. a              -> ParseResult a = lam a. result.ok a
+let parseErr: all a. (Info, String) -> ParseResult a = lam e. result.err e
+
 lang AstParserBase = Lexer
   sem config: () -> Config BreakableOp
 
@@ -29,15 +34,15 @@ lang AstParserBase = Lexer
 
   sem canStartExpr: NextTokenResult -> Bool
 
-  sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
-  sem parseExprRClosed : State BreakableOp RClosed -> NextTokenResult -> (Expr, NextTokenResult)
-  sem parseExprROpen : State BreakableOp ROpen -> NextTokenResult -> (Expr, NextTokenResult)
-  sem finalizeParseExpr : State BreakableOp RClosed -> NextTokenResult -> (Expr, NextTokenResult)
+  sem parseExpr: NextTokenResult -> ParseResult (Expr, NextTokenResult)
+  sem parseExprRClosed:  State BreakableOp RClosed -> NextTokenResult -> ParseResult (Expr, NextTokenResult)
+  sem parseExprROpen:    State BreakableOp ROpen   -> NextTokenResult -> ParseResult (Expr, NextTokenResult)
+  sem finalizeParseExpr: State BreakableOp RClosed -> NextTokenResult -> ParseResult (Expr, NextTokenResult)
 
-  sem parseDecl: NextTokenResult -> (Decl, NextTokenResult)
-  sem parseType: NextTokenResult -> (Type, NextTokenResult)
-  sem parseKind: NextTokenResult -> (Kind, NextTokenResult)
-  sem parsePat:  NextTokenResult -> (Pat,  NextTokenResult)
+  sem parseDecl: NextTokenResult -> ParseResult (Decl, NextTokenResult)
+  sem parseType: NextTokenResult -> ParseResult (Type, NextTokenResult)
+  sem parseKind: NextTokenResult -> ParseResult (Kind, NextTokenResult)
+  sem parsePat:  NextTokenResult -> ParseResult (Pat,  NextTokenResult)
 
   sem config =
   | _ ->
@@ -87,8 +92,9 @@ lang AstParserBase = Lexer
         constructPrefix = lam op. lam rhs. constructPrefix (op, rhs),
         constructPostfix = lam op. lam lhs. constructPostfix (op, lhs)
       } sppf in
-      (expr, next)
-    else error "Breakable parse error"
+      parseOk (expr, next)
+    else
+      parseErr (next.info, "Breakable parse error")
 end
 
 lang IntParser = AstParserBase + IntAst
@@ -172,7 +178,7 @@ lang AppParser = AstParserBase + AppAst
       match breakableAddInfix (config ()) (OpApp info) state with Some(state) then
         parseExprROpen state next
       else
-        error "Breakable add infix error"
+        parseErr (info, "Breakable add infix error")
     else
       finalizeParseExpr state next
 
@@ -193,12 +199,14 @@ lang ParenParser = AstParserBase
 
   sem parseExprROpen state =
   | { token = LParenTok {}, stream = stream } ->
-    match parseExpr (nextToken stream) with (expr, next) in
-    match next with { token = RParenTok {}, stream = stream } then
-      let state = breakableAddAtom (config ()) (OpAtom expr) state in
-      parseExprRClosed state (nextToken stream)
-    else
-      error "Missing closing parenthesis"
+    result.bind (parseExpr (nextToken stream)) (lam a.
+      match a with (expr, next) in
+      match next with { token = RParenTok {}, stream = stream } then
+        let state = breakableAddAtom (config ()) (OpAtom expr) state in
+        parseExprRClosed state (nextToken stream)
+      else
+        parseErr (next.info, "Missing closing parenthesis")
+    )
 end
 
 lang BoolParser = AstParserBase + BoolAst
@@ -251,9 +259,9 @@ end
 
 lang NotImplementedParser = AstParserBase
   sem parseExprROpen state =
-  | { token = token } ->
-    let str = concat "Not implemented: " (tokToStr token) in
-    error str
+  | next ->
+    let str = concat "Not implemented: " (tokToStr next.token) in
+    parseErr (next.info, str)
 end
 
 lang AstParser =
@@ -282,16 +290,22 @@ use TestParser in
 use BootParser in
 
 let lex = lam str. nextToken {pos = initPos "internal", str = str} in
-let parse = lam str. match parseExpr (lex str) with (expr, next) in expr in
+let parse = lam str. result.map (lam a. a.0) (parseExpr (lex str)) in
 
 let bootArg = { _defaultBootParserParseMExprStringArg () with builtin = [] } in
-let parseBoot = lam str.
-  match parseMExprString bootArg str with (ResultOk { value = bootExpr}) in bootExpr in
+let parseBoot = lam str. parseMExprString bootArg str in
 
 let jsonStr = lam expr. json2string (exprToJson expr) in
 
--- let compare = lam str. eqExpr (parse str) (parseBoot str) in -- does not compare info
-let compare = lam str. eqString (jsonStr (parse str)) (jsonStr (parseBoot str)) in -- compares info
+let compare = lam str.
+  let a = parse str in
+  let b = parseBoot str in
+
+  match (result.toOption a, result.toOption b) with (Some a, Some b) then
+    eqString (jsonStr a) (jsonStr b)
+  else
+    false
+  in
 
 let printAst = lam expr. printLn (jsonStr expr) in
 

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -504,6 +504,73 @@ lang StringParser = AstParserBase + SeqAst + CharAst
     parseTypeRClosed state (nextToken cur.stream)
 end
 
+lang SeqParser = AstParserBase + SeqAst + SeqTypeAst
+  sem canStartAppArgExpr =
+  | { token = LBracketTok { } } -> true
+  | { token = RBracketTok { } } -> false
+  | { token = CommaTok { } } -> false
+
+  sem canStartAppArgType =
+  | { token = LBracketTok { } } -> true
+  | { token = RBracketTok { } } -> false
+
+  sem parseExprROpen state =
+  | { token = LBracketTok { } } & toklb ->
+    recursive let parseItems = lam acc. lam cur.
+      result.bind (parseExpr cur) (lam expr.
+        match expr with (expr, cur) in
+        let acc = snoc acc expr in
+        switch cur
+          case { token = RBracketTok { } } then
+            parseOk (cur, acc)
+          case { token = CommaTok { } } then
+            let cur = nextToken cur.stream in
+            parseItems acc cur
+          case _ then
+            parseErr (cur.info, "Unexpected token in sequence")
+        end
+      )
+    in
+
+    let cur = nextToken toklb.stream in
+    let res = switch cur
+      case { token = RBracketTok { } } then
+        parseOk (cur, [])
+      case _ then
+        parseItems [] cur
+    end in
+
+    result.bind res (lam res.
+      match res with (tokrb, tms) in
+      let info = mergeInfo toklb.info tokrb.info in
+      let expr = TmSeq {
+        tms = tms,
+        ty = ityunknown_ info,
+        info = info
+      } in
+      let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
+      parseExprRClosed state (nextToken cur.stream)
+    )
+
+  sem parseTypeROpen state =
+  | { token = LBracketTok { } } & toklb ->
+    let cur = nextToken toklb.stream in
+    result.bind (parseType cur) (lam res.
+      match res with (ty, cur) in
+      match cur with { token = RBracketTok {} } & tokrb then
+        let info = mergeInfo toklb.info tokrb.info in
+        let typ = TySeq {
+          ty = ty,
+          info = info
+        } in
+        let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+        parseTypeRClosed state (nextToken cur.stream)
+      else
+        parseErr (cur.info, "Missing right bracket")
+    )
+
+end
+
 lang LetDeclParser = AstParserBase + LetDeclAst
   sem canStartAppArgExpr =
   | { token = LIdentTok { val = "let" } } -> false
@@ -631,6 +698,7 @@ lang AstParser =
   + BoolParser
   + CharParser
   + StringParser
+  + SeqParser
   + NegParser
   + VarParser
   + AppParser
@@ -690,7 +758,7 @@ let printAst = lam expr.
   end
 in
 
--- let str = "-5" in
+-- let str = "let a: [Int] = () in a" in
 -- printLn "\nBoot:";
 -- printAst (parseBoot str);
 -- printLn "Native:";
@@ -736,5 +804,13 @@ utest compareWithoutInfo "let a: Int Int = 1 1 in a" with true in
 
 utest compareWithoutInfo "let a: Int -> Int = addi 1 in a" with true in
 utest compareWithoutInfo "let a: Int Int -> Int = addi in a" with true in
+
+utest compare "[]" with true in
+utest compare "[1]" with true in
+utest compare "[1, 2]" with true in
+utest compare "cons 0 [1, 2]" with true in
+
+utest compareWithoutInfo "let a: [Int] = () in a" with true in
+utest compareWithoutInfo "let a: [[Int]] = () in a" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -23,10 +23,15 @@ include "map.mc"
 include "parser/breakable.mc"
 include "name.mc"
 
-type BreakableOp lstyle rstyle
-con OpAtom: use Ast in Expr -> BreakableOp LClosed RClosed
-con OpNeg: Info -> BreakableOp LClosed ROpen
-con OpApp: Info -> BreakableOp LOpen ROpen
+type BrkOpExpr lstyle rstyle
+con OpExprAtom: use Ast in Expr -> BrkOpExpr LClosed RClosed
+con OpExprNeg: Info -> BrkOpExpr LClosed ROpen
+con OpExprApp: Info -> BrkOpExpr LOpen ROpen
+
+type BrkOpType lstyle rstyle
+con OpTypeAtom: use Ast in Type -> BrkOpType LClosed RClosed
+con OpTypeApp: Info -> BrkOpType LOpen ROpen
+con OpTypeArrow: Info -> BrkOpType LOpen ROpen
 
 type ParseResult w a = Result w (Info, String) a
 
@@ -36,67 +41,56 @@ let parseErrs: all w. all a. [(Info, String)] -> ParseResult w a = lam errs.
   foldl1 result.withAnnotations (map result.err errs)
 
 lang AstParserBase = Lexer + Ast
-  -- breakable related stuff
-  sem config: () -> Config BreakableOp
-  sem topAllowed: TopAllowedFunc BreakableOp
-  sem leftAllowed: LeftAllowedFunc BreakableOp
-  sem rightAllowed: RightAllowedFunc BreakableOp
-  sem parenAllowed: ParenAllowedFunc BreakableOp
-  sem groupingsAllowed: GroupingsAllowedFunc BreakableOp
-  sem terminalInfos: all lstyle. all rstyle. BreakableOp lstyle rstyle -> [Info]
-  sem getInfo: all lstyle. all rstyle. BreakableOp lstyle rstyle -> Info
-  sem constructPrefix: (BreakableOp LClosed ROpen, Expr) -> Expr
-  sem constructInfix: (BreakableOp LOpen ROpen, Expr, Expr) -> Expr
-  sem constructPostfix: (BreakableOp LOpen RClosed, Expr) -> Expr
-
-  -- used to deal with function applications
-  sem canStartExpr: NextTokenResult -> Bool
-
   sem parseExpr: all w. NextTokenResult -> ParseResult w (Expr, NextTokenResult)
-  sem parseExprRClosed:  all w. State BreakableOp RClosed -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
-  sem parseExprROpen:    all w. State BreakableOp ROpen   -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
-  sem finalizeParseExpr: all w. State BreakableOp RClosed -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
-
   sem parseDecl: all w. NextTokenResult -> ParseResult w (Decl, NextTokenResult)
   sem parseType: all w. NextTokenResult -> ParseResult w (Type, NextTokenResult)
   sem parseKind: all w. NextTokenResult -> ParseResult w (Kind, NextTokenResult)
   sem parsePat:  all w. NextTokenResult -> ParseResult w (Pat,  NextTokenResult)
 
-  sem config =
-  | _ ->
-    {
-      topAllowed = #frozen"topAllowed",
-      leftAllowed = #frozen"leftAllowed",
-      rightAllowed = #frozen"rightAllowed",
-      parenAllowed = #frozen"parenAllowed",
-      groupingsAllowed = #frozen"groupingsAllowed"
-    }
+  sem parseExprRClosed:  all w. State BrkOpExpr RClosed -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
+  sem parseTypeRClosed:  all w. State BrkOpType RClosed -> NextTokenResult -> ParseResult w (Type, NextTokenResult)
 
+  sem parseExprROpen:    all w. State BrkOpExpr ROpen   -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
+  sem parseTypeROpen:    all w. State BrkOpType ROpen   -> NextTokenResult -> ParseResult w (Type, NextTokenResult)
 
-  -- Default breakable config
+  sem finalizeParseExpr: all w. State BrkOpExpr RClosed -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
+  sem finalizeParseType: all w. State BrkOpType RClosed -> NextTokenResult -> ParseResult w (Type, NextTokenResult)
 
-  sem topAllowed =
-  | _ -> true
+  sem canAppExpr: NextTokenResult -> Bool
+  sem canAppType: NextTokenResult -> Bool
 
-  sem leftAllowed =
-  | _ -> true
+  sem constructPrefixExpr: (BrkOpExpr LClosed ROpen, Expr) -> Expr
+  sem constructPrefixType: (BrkOpType LClosed ROpen, Type) -> Type
 
-  sem rightAllowed =
-  | _ -> true
+  sem constructInfixExpr: (BrkOpExpr LOpen ROpen, Expr, Expr) -> Expr
+  sem constructInfixType: (BrkOpType LOpen ROpen, Type, Type) -> Type
 
-  sem parenAllowed =
-  | _ -> GEither ()
+  sem constructPostfixExpr: (BrkOpExpr LOpen RClosed, Expr) -> Expr
+  sem constructPostfixType: (BrkOpType LOpen RClosed, Type) -> Type
 
-  sem groupingsAllowed =
-  | _ -> GLeft ()
+  sem configExpr: () -> Config BrkOpExpr
+  sem configType: () -> Config BrkOpType
 
-  sem terminalInfos =
-  | op -> [getInfo op]
+  sem topAllowedExpr: TopAllowedFunc BrkOpExpr
+  sem topAllowedType: TopAllowedFunc BrkOpType
 
-  sem canStartExpr =
-  | { token = EOFTok {} } -> false
-  | _ -> true
+  sem leftAllowedExpr: LeftAllowedFunc BrkOpExpr
+  sem leftAllowedType: LeftAllowedFunc BrkOpType
 
+  sem rightAllowedExpr: RightAllowedFunc BrkOpExpr
+  sem rightAllowedType: RightAllowedFunc BrkOpType
+
+  sem parenAllowedExpr: ParenAllowedFunc BrkOpExpr
+  sem parenAllowedType: ParenAllowedFunc BrkOpType
+
+  sem groupingsAllowedExpr: GroupingsAllowedFunc BrkOpExpr
+  sem groupingsAllowedType: GroupingsAllowedFunc BrkOpType
+
+  sem terminalInfosExpr: all lstyle. all rstyle. BrkOpExpr lstyle rstyle -> [Info]
+  sem terminalInfosType: all lstyle. all rstyle. BrkOpType lstyle rstyle -> [Info]
+
+  sem getInfoExpr: all lstyle. all rstyle. BrkOpExpr lstyle rstyle -> Info
+  sem getInfoType: all lstyle. all rstyle. BrkOpType lstyle rstyle -> Info
 
   -- The main entry point
   sem parseExpr =
@@ -104,18 +98,27 @@ lang AstParserBase = Lexer + Ast
     let state = breakableInitState () in
     parseExprROpen state cur
 
+  sem parseType =
+  | cur ->
+    let state = breakableInitState () in
+    parseTypeROpen state cur
+
   sem parseExprRClosed state =
   | cur ->
     finalizeParseExpr state cur
 
+  sem parseTypeRClosed state =
+  | cur ->
+    finalizeParseType state cur
+
   sem finalizeParseExpr state =
   | cur ->
-    match breakableFinalizeParse (config ()) state with Some sppf then
-      let config: BreakableErrorHighlightConfig BreakableOp = {
-        parenAllowed = #frozen"parenAllowed",
-        topAllowed = #frozen"topAllowed",
-        terminalInfos = #frozen"terminalInfos",
-        getInfo = #frozen"getInfo",
+    match breakableFinalizeParse (configExpr ()) state with Some sppf then
+      let config: BreakableErrorHighlightConfig BrkOpExpr = {
+        parenAllowed = #frozen"parenAllowedExpr",
+        topAllowed = #frozen"topAllowedExpr",
+        terminalInfos = #frozen"terminalInfosExpr",
+        getInfo = #frozen"getInfoExpr",
         lpar = "(",
         rpar = ")"
       } in
@@ -124,14 +127,111 @@ lang AstParserBase = Lexer + Ast
         parseErrs errs
       else
         let expr = breakableConstructSimple {
-          constructAtom = lam op. match op with OpAtom expr in expr,
-          constructInfix = lam op. lam lhs. lam rhs. constructInfix (op, lhs, rhs),
-          constructPrefix = lam op. lam rhs. constructPrefix (op, rhs),
-          constructPostfix = lam op. lam lhs. constructPostfix (op, lhs)
+          constructAtom = lam op. match op with OpExprAtom expr in expr,
+          constructInfix = lam op. lam lhs. lam rhs. constructInfixExpr (op, lhs, rhs),
+          constructPrefix = lam op. lam rhs. constructPrefixExpr (op, rhs),
+          constructPostfix = lam op. lam lhs. constructPostfixExpr (op, lhs)
         } sppf in
         parseOk (expr, cur)
     else
       parseErr (cur.info, "Breakable parse error")
+
+  sem finalizeParseType state =
+  | cur ->
+    match breakableFinalizeParse (configType ()) state with Some sppf then
+      let config: BreakableErrorHighlightConfig BrkOpType = {
+        parenAllowed = #frozen"parenAllowedType",
+        topAllowed = #frozen"topAllowedType",
+        terminalInfos = #frozen"terminalInfosType",
+        getInfo = #frozen"getInfoType",
+        lpar = "(",
+        rpar = ")"
+      } in
+      let errs = breakableDefaultHighlight config cur.stream.str sppf in
+      match errs with [first] ++ _ then
+        parseErrs errs
+      else
+        let typ = breakableConstructSimple {
+          constructAtom = lam op. match op with OpTypeAtom typ in typ,
+          constructInfix = lam op. lam lhs. lam rhs. constructInfixType (op, lhs, rhs),
+          constructPrefix = lam op. lam rhs. constructPrefixType (op, rhs),
+          constructPostfix = lam op. lam lhs. constructPostfixType (op, lhs)
+        } sppf in
+        parseOk (typ, cur)
+    else
+      parseErr (cur.info, "Breakable parse error")
+
+  sem canAppExpr =
+  | { token = EOFTok {} } -> false
+  | _ -> true
+
+  sem canAppType =
+  | { token = EOFTok {} } -> false
+  | _ -> true
+
+  sem configExpr =
+  | _ ->
+    {
+      topAllowed = #frozen"topAllowedExpr",
+      leftAllowed = #frozen"leftAllowedExpr",
+      rightAllowed = #frozen"rightAllowedExpr",
+      parenAllowed = #frozen"parenAllowedExpr",
+      groupingsAllowed = #frozen"groupingsAllowedExpr"
+    }
+
+  sem configType =
+  | _ ->
+    {
+      topAllowed = #frozen"topAllowedType",
+      leftAllowed = #frozen"leftAllowedType",
+      rightAllowed = #frozen"rightAllowedType",
+      parenAllowed = #frozen"parenAllowedType",
+      groupingsAllowed = #frozen"groupingsAllowedType"
+    }
+
+  sem topAllowedExpr =
+  | _ -> true
+
+  sem topAllowedType =
+  | _ -> true
+
+  sem leftAllowedExpr =
+  | _ -> true
+
+  sem leftAllowedType =
+  | _ -> true
+
+  sem rightAllowedExpr =
+  | _ -> true
+
+  sem rightAllowedType =
+  | _ -> true
+
+  sem parenAllowedExpr =
+  | _ -> GEither ()
+
+  sem parenAllowedType =
+  | _ -> GEither ()
+
+  sem groupingsAllowedExpr =
+  | _ -> GLeft ()
+
+  sem groupingsAllowedType =
+  | _ -> GLeft ()
+
+  sem terminalInfosExpr =
+  | op -> [getInfoExpr op]
+
+  sem terminalInfosType =
+  | op -> [getInfoType op]
+
+  sem getInfoExpr =
+  | op ->
+    never -- TODO
+
+  sem getInfoType =
+  | op ->
+    never -- TODO
 end
 
 lang IntParser = AstParserBase + IntAst
@@ -142,13 +242,14 @@ lang IntParser = AstParserBase + IntAst
       ty = ityunknown_ cur.info,
       info = cur.info
     } in
-    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
 
-  sem parseType =
+  sem parseTypeROpen state =
   | { token = UIdentTok { val = "Int" } } & cur ->
     let typ = ityint_ cur.info in
-    parseOk (typ, nextToken cur.stream)
+    let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+    parseTypeRClosed state (nextToken cur.stream)
 end
 
 lang FloatParser = AstParserBase + FloatAst
@@ -159,19 +260,19 @@ lang FloatParser = AstParserBase + FloatAst
       ty = ityunknown_ cur.info,
       info = cur.info
     } in
-    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
 end
 
 lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
   sem parseExprROpen state =
   | { token = OperatorTok { val = "-" } } & cur ->
-    let state = breakableAddPrefix (config ()) (OpNeg cur.info) state in
+    let state = breakableAddPrefix (configExpr ()) (OpExprNeg cur.info) state in
     parseExprROpen state (nextToken cur.stream)
 
   -- Two special cases if the rhs is a constant int or float
-  sem constructPrefix =
-  | (OpNeg info, TmConst { val = CInt { val = val } } & expr) ->
+  sem constructPrefixExpr =
+  | (OpExprNeg info, TmConst { val = CInt { val = val } } & expr) ->
     let info = mergeInfo info (infoTm expr) in
     TmConst {
       val = CInt { val = negi val },
@@ -179,7 +280,7 @@ lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
       info = info
     }
 
-  | (OpNeg info, TmConst { val = CFloat { val = val } } & expr) ->
+  | (OpExprNeg info, TmConst { val = CFloat { val = val } } & expr) ->
     let info = mergeInfo info (infoTm expr) in
     TmConst {
       val = CFloat { val = negf val },
@@ -188,7 +289,7 @@ lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
     }
 
   -- Normal case
-  | (OpNeg info, rhs) ->
+  | (OpExprNeg info, rhs) ->
     let info2 = mergeInfo info (infoTm rhs) in
     TmApp {
       lhs = TmConst {
@@ -211,24 +312,35 @@ lang VarParser = AstParserBase + VarAst
       info = cur.info,
       frozen = false -- TODO: Always false?
     } in
-    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
 end
 
-lang AppParser = AstParserBase + AppAst
+lang AppParser = AstParserBase + AppAst + AppTypeAst
   sem parseExprRClosed state =
   | { token = token } & cur ->
     -- check if the next token can be part of the current expression.
-    match canStartExpr cur with true then
-      match breakableAddInfix (config ()) (OpApp cur.info) state with Some(state) then
+    match canAppExpr cur with true then
+      match breakableAddInfix (configExpr ()) (OpExprApp cur.info) state with Some(state) then
         parseExprROpen state cur
       else
         parseErr (cur.info, "Breakable add infix error")
     else
       finalizeParseExpr state cur
 
-  sem constructInfix =
-  | (OpApp info, lhs, rhs) ->
+  sem parseTypeRClosed state =
+  | { token = token } & cur ->
+    -- check if the next token can be part of the current type.
+    match canAppType cur with true then
+      match breakableAddInfix (configType ()) (OpTypeApp cur.info) state with Some(state) then
+        parseTypeROpen state cur
+      else
+        parseErr (cur.info, "Breakable add infix error")
+    else
+      finalizeParseType state cur
+
+  sem constructInfixExpr =
+  | (OpExprApp info, lhs, rhs) ->
     let info = mergeInfo (infoTm lhs) (infoTm rhs) in
     TmApp {
       lhs = lhs,
@@ -236,10 +348,22 @@ lang AppParser = AstParserBase + AppAst
       ty = ityunknown_ info,
       info = info
     }
+
+  sem constructInfixType =
+  | (OpTypeApp info, lhs, rhs) ->
+    let info = mergeInfo (infoTy lhs) (infoTy rhs) in
+    TyApp {
+      lhs = lhs,
+      rhs = rhs,
+      info = info
+    }
 end
 
-lang ParenParser = AstParserBase + RecordAst
-  sem canStartExpr =
+lang ParenParser = AstParserBase + RecordAst + RecordTypeAst
+  sem canAppExpr =
+  | { token = RParenTok {} } -> false
+
+  sem canAppType =
   | { token = RParenTok {} } -> false
 
   sem parseExprROpen state =
@@ -252,7 +376,7 @@ lang ParenParser = AstParserBase + RecordAst
         ty = ityunknown_ info,
         info = info
       } in
-      let state = breakableAddAtom (config ()) (OpAtom expr) state in
+      let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
       parseExprRClosed state (nextToken close.stream)
     else
       -- start parsing a new expression at (
@@ -260,8 +384,31 @@ lang ParenParser = AstParserBase + RecordAst
         match expr with (expr, cur) in
         -- and check for a following )
         match cur with { token = RParenTok {} } & close then
-          let state = breakableAddAtom (config ()) (OpAtom expr) state in
+          let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
           parseExprRClosed state (nextToken close.stream)
+        else
+          parseErr (cur.info, "Missing closing parenthesis")
+      )
+
+  sem parseTypeROpen state =
+  | { token = LParenTok {} } & open ->
+    match (nextToken open.stream) with { token = RParenTok {} } & close then
+      -- this is a unit
+      let info = mergeInfo open.info close.info in
+      let typ = TyRecord {
+        fields = mapEmpty cmpSID,
+        info = info
+      } in
+      let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+      parseTypeRClosed state (nextToken close.stream)
+    else
+      -- start parsing a new type at (
+      result.bind (parseType (nextToken open.stream)) (lam typ.
+        match typ with (typ, cur) in
+        -- and check for a following )
+        match cur with { token = RParenTok {} } & close then
+          let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+          parseTypeRClosed state (nextToken close.stream)
         else
           parseErr (cur.info, "Missing closing parenthesis")
       )
@@ -275,7 +422,7 @@ lang BoolParser = AstParserBase + BoolAst
       ty = ityunknown_ cur.info,
       info = cur.info
     } in
-    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
   | { token = LIdentTok { val = "false" } } & cur ->
     let expr = TmConst {
@@ -283,7 +430,7 @@ lang BoolParser = AstParserBase + BoolAst
       ty = ityunknown_ cur.info,
       info = cur.info
     } in
-    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
 end
 
@@ -295,7 +442,7 @@ lang CharParser = AstParserBase + CharAst
       ty = ityunknown_ cur.info,
       info = cur.info
     } in
-    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
 end
 
@@ -311,17 +458,46 @@ lang StringParser = AstParserBase + SeqAst + CharAst
       ty = ityunknown_ cur.info,
       info = cur.info
     } in
-    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
 end
 
 lang LetDeclParser = AstParserBase + LetDeclAst
-  sem canStartExpr =
+  sem canAppExpr =
   | { token = LIdentTok { val = "let" } } -> false
   | { token = OperatorTok { val = "="} } -> false
   | { token = LIdentTok { val = "in"} } -> false
 
+  sem canAppType =
+  | { token = OperatorTok { val = "="} } -> false
+
   sem parseExprROpen state =
+  | { token = LIdentTok { val = "let" } } & toklet ->
+    result.bind (parseDecl toklet) (lam decl.
+      match decl with (decl, cur) in
+
+      match cur with { token = LIdentTok { val = "in" } } & tokin then
+        let cur = nextToken tokin.stream in
+
+        result.bind (parseExpr cur) (lam inexpr.
+          match inexpr with (inexpr, cur) in
+
+          let info = mergeInfo toklet.info tokin.info in
+          let expr = TmDecl {
+            decl = decl,
+            inexpr = inexpr,
+            ty = ityunknown_ info,
+            info = info
+          } in
+          let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
+          parseExprRClosed state (nextToken cur.stream)
+        )
+
+      else
+        parseErr (cur.info, "Missing in expression")
+    )
+
+  sem parseDecl =
   | { token = LIdentTok { val = "let" } } & toklet ->
     let cur = nextToken toklet.stream in
 
@@ -345,33 +521,16 @@ lang LetDeclParser = AstParserBase + LetDeclAst
           result.bind (parseExpr cur) (lam body.
             match body with (body, cur) in
 
-            match cur with { token = LIdentTok { val = "in" } } & tokin then
-              let cur = nextToken tokin.stream in
-
-              result.bind (parseExpr cur) (lam inexpr.
-                match inexpr with (inexpr, cur) in
-
-                let info = mergeInfo toklet.info tokin.info in
-                let expr = TmDecl {
-                  decl = DeclLet {
-                    ident = nameNoSym ident,
-                    tyAnnot = tyAnnot,
-                    tyBody = ityunknown_ info,
-                    body = body,
-                    info = info
-                  },
-                  inexpr = inexpr,
-                  ty = ityunknown_ info,
-                  info = info
-                } in
-                let state = breakableAddAtom (config ()) (OpAtom expr) state in
-                parseExprRClosed state (nextToken cur.stream)
-              )
-
-            else
-              parseErr (cur.info, "Missing in expression")
+            let info = mergeInfo toklet.info (infoTm body) in
+            let decl = DeclLet {
+              ident = nameNoSym ident,
+              tyAnnot = tyAnnot,
+              tyBody = ityunknown_ info,
+              body = body,
+              info = info
+            } in
+            parseOk (decl, cur)
           )
-
         else
           parseErr (cur.info, "Missing assignment")
       )
@@ -390,7 +549,7 @@ lang UnexpectedTokenParser = AstParserBase
     let str = concat "Unexpexted token while parsing decl: " (tokToStr cur.token) in
     parseErr (cur.info, str)
 
-  sem parseType =
+  sem parseTypeROpen state =
   | cur ->
     let str = concat "Unexpexted token while parsing type: " (tokToStr cur.token) in
     parseErr (cur.info, str)
@@ -470,7 +629,7 @@ let printAst = lam expr.
   end
 in
 
--- let str = "let a: Int = 1 in a" in
+-- let str = "let a: () () = 1 in a" in
 -- printLn "";
 -- printAst (parseBoot str);
 -- printAst (parse str);
@@ -502,8 +661,10 @@ utest compareWithoutInfo "(())" with true in
 utest compareWithoutInfo "addi () ()" with true in
 utest compareWithoutInfo "(addi ()) ()" with true in
 
-utest compare "let a = 1 in a" with true in
-utest compare "let a = 1 in let b = 2 in addi a b" with true in
-utest compare "let a: Int = 1 in a" with true in
+utest compareWithoutInfo "let a = 1 in a" with true in
+utest compareWithoutInfo "let a = 1 in let b = 2 in addi a b" with true in
+utest compareWithoutInfo "let a: Int = 1 in a" with true in
+
+utest compareWithoutInfo "let a: Int Int = 1 1 in a" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -23,15 +23,6 @@ include "map.mc"
 include "parser/breakable.mc"
 include "name.mc"
 
-type BrkOpExpr lstyle rstyle
-con OpExprAtom: use Ast in Expr -> BrkOpExpr LClosed RClosed
-con OpExprApp: Info -> BrkOpExpr LOpen ROpen
-
-type BrkOpType lstyle rstyle
-con OpTypeAtom: use Ast in Type -> BrkOpType LClosed RClosed
-con OpTypeApp: Info -> BrkOpType LOpen ROpen
-con OpTypeArrow: Info -> BrkOpType LOpen ROpen
-
 type ParseResult w a = Result w (Info, String) a
 
 let parseOk:  all w. all a. a              -> ParseResult w a = lam a. result.ok a
@@ -40,6 +31,12 @@ let parseErrs: all w. all a. [(Info, String)] -> ParseResult w a = lam errs.
   foldl1 result.withAnnotations (map result.err errs)
 
 lang AstParserBase = Lexer + Ast
+  syn BrkOpExpr lstyle rstyle =
+  | OpExprAtom Expr
+
+  syn BrkOpType lstyle rstyle =
+  | OpTypeAtom Type
+
   sem parseExpr: all w. NextTokenResult -> ParseResult w (Expr, NextTokenResult)
   sem parseDecl: all w. NextTokenResult -> ParseResult w (Decl, NextTokenResult)
   sem parseType: all w. NextTokenResult -> ParseResult w (Type, NextTokenResult)
@@ -113,7 +110,8 @@ lang AstParserBase = Lexer + Ast
         lpar = "(",
         rpar = ")"
       } in
-      let errs = breakableDefaultHighlight config cur.stream.str sppf in
+      -- TODO use correct src string
+      let errs = breakableDefaultHighlight config "" sppf in
       match errs with [first] ++ _ then
         parseErrs errs
       else
@@ -203,10 +201,10 @@ lang AstParserBase = Lexer + Ast
   | _ -> GEither ()
 
   sem groupingsAllowedExpr =
-  | _ -> GLeft ()
+  | _ -> GEither ()
 
   sem groupingsAllowedType =
-  | _ -> GLeft ()
+  | _ -> GEither ()
 
   sem terminalInfosExpr =
   | op -> [getInfoExpr op]
@@ -215,12 +213,12 @@ lang AstParserBase = Lexer + Ast
   | op -> [getInfoType op]
 
   sem getInfoExpr =
-  | op ->
-    never -- TODO
+  | OpExprAtom expr ->
+    infoTm expr
 
   sem getInfoType =
-  | op ->
-    never -- TODO
+  | OpTypeAtom typ ->
+    infoTy typ
 end
 
 lang IntParser = AstParserBase + IntAst
@@ -320,6 +318,20 @@ lang VarParser = AstParserBase + VarAst
 end
 
 lang AppParser = AstParserBase + AppAst + AppTypeAst
+  syn BrkOpExpr lstyle rstyle =
+  | OpExprApp Info
+
+  syn BrkOpType lstyle rstyle =
+  | OpTypeApp Info
+
+  sem getInfoExpr =
+  | OpExprApp info ->
+    info
+
+  sem getInfoType =
+  | OpTypeApp info ->
+    info
+
   sem parseExprRClosed state =
   | cur ->
     -- check if the next token can be part of the current expression.
@@ -572,6 +584,13 @@ lang SeqParser = AstParserBase + SeqAst + SeqTypeAst
 end
 
 lang LetDeclParser = AstParserBase + LetDeclAst
+  syn BrkOpExpr lstyle rstyle =
+  | OpExprLet Decl
+
+  sem getInfoExpr =
+  | OpExprLet decl ->
+    infoDecl decl
+
   sem canStartAppArgExpr =
   | { token = LIdentTok { val = "let" } } -> false
   | { token = LIdentTok { val = "in"} } -> false
@@ -581,23 +600,11 @@ lang LetDeclParser = AstParserBase + LetDeclAst
     result.bind (parseDecl toklet) (lam decl.
       match decl with (decl, cur) in
 
+      let state = breakableAddPrefix (configExpr ()) (OpExprLet decl) state in
+
       match cur with { token = LIdentTok { val = "in" } } & tokin then
         let cur = nextToken tokin.stream in
-
-        result.bind (parseExpr cur) (lam inexpr.
-          match inexpr with (inexpr, cur) in
-
-          let info = mergeInfo toklet.info tokin.info in
-          let expr = TmDecl {
-            decl = decl,
-            inexpr = inexpr,
-            ty = ityunknown_ info,
-            info = info
-          } in
-          let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
-          parseExprRClosed state (nextToken cur.stream)
-        )
-
+        parseExprROpen state cur
       else
         parseErr (cur.info, "Missing in expression")
     )
@@ -614,7 +621,7 @@ lang LetDeclParser = AstParserBase + LetDeclAst
           let cur = nextToken tokcol.stream in
           parseType cur
         else
-          parseOk (ityunknown_ toklet.info, cur)
+          parseOk (ityunknown_ tokident.info, cur)
       in
 
       result.bind tyAnnot (lam tyAnnot.
@@ -641,11 +648,67 @@ lang LetDeclParser = AstParserBase + LetDeclAst
       )
     else
       parseErr (cur.info, "Missing identifier")
+
+  sem constructPrefixExpr =
+  | (OpExprLet decl, inexpr) ->
+    let info = infoDecl decl in
+    TmDecl {
+      decl = decl,
+      inexpr = inexpr,
+      ty = ityunknown_ info,
+      info = info
+    }
 end
 
-lang ArrowParser = AstParserBase + FunTypeAst
+lang LamParser = AstParserBase + LamAst + FunTypeAst
+  syn BrkOpExpr lstyle rstyle =
+  | OpExprLam (Info, String, Type, Type)
+
+  syn BrkOpType lstyle rstyle =
+  | OpTypeArrow Info
+
+  sem getInfoExpr =
+  | OpExprLam (info, _, _, _) -> info
+
+  sem getInfoType =
+  | OpTypeArrow info -> info
+
+  sem canStartAppArgExpr =
+  | { token = LIdentTok { val = "lam" } } -> false
+  | { token = OperatorTok { val = "." } } -> false
+
   sem canStartAppArgType =
   | { token = OperatorTok { val = "->" } } -> false
+
+  sem parseExprROpen state =
+  | { token = LIdentTok { val = "lam" } } & toklam ->
+    let cur = nextToken toklam.stream in
+
+    match match cur with { token = LIdentTok { val = ident } } & tokident then
+      let cur = nextToken tokident.stream in
+      let tyAnnot =
+        match cur with { token = OperatorTok { val = ":" } } & tokcol then
+          let cur = nextToken tokcol.stream in
+          parseType cur
+        else
+          parseOk (tyunknown_, cur)
+      in
+      (ident, ityunknown_ tokident.info, tyAnnot)
+    else
+      ("", tyunknown_, parseOk (tyunknown_, cur))
+    with (ident, tyParam, tyAnnot) in
+
+    result.bind tyAnnot (lam res.
+      match res with (tyAnnot, cur) in
+
+      let state = breakableAddPrefix (configExpr ()) (OpExprLam (toklam.info, ident, tyParam, tyAnnot)) state in
+
+      match cur with { token = OperatorTok { val = "." } } & tokdot then
+        let cur = nextToken tokdot.stream in
+        parseExprROpen state cur
+      else
+        parseErr (cur.info, "Missing period")
+    )
 
   sem parseTypeRClosed state =
   | { token = OperatorTok { val = "->" } } & cur ->
@@ -655,6 +718,18 @@ lang ArrowParser = AstParserBase + FunTypeAst
     else
       parseErr (cur.info, "Breakable add infix error")
 
+  sem constructPrefixExpr =
+  | (OpExprLam (beginInfo, ident, tyParam, tyAnnot), body) ->
+    let info = mergeInfo beginInfo (infoTm body) in
+    TmLam {
+      ident = nameNoSym ident,
+      tyAnnot = tyAnnot,
+      tyParam = tyParam,
+      body = body,
+      ty = ityunknown_ info,
+      info = info
+    }
+
   sem constructInfixType =
   | (OpTypeArrow info, from, to) ->
     let info = mergeInfo (infoTy from) (infoTy to) in
@@ -663,6 +738,20 @@ lang ArrowParser = AstParserBase + FunTypeAst
       to = to,
       info = info
     }
+end
+
+-- TODO: Better solution
+lang PrecedenceParser = AppParser + LamParser + LetDeclParser
+  sem groupingsAllowedExpr =
+  | (OpExprApp _, OpExprApp _) -> GLeft ()
+  | (OpExprLet _, OpExprApp _) -> GRight ()
+  | (OpExprLam _, OpExprApp _) -> GRight ()
+
+  sem groupingsAllowedType =
+  | (OpTypeApp _, OpTypeApp _)  -> GLeft ()
+  | (OpTypeArrow _, OpTypeArrow _) -> GLeft ()
+  | (OpTypeApp _, OpTypeArrow _) -> GLeft ()
+  | (OpTypeArrow _, OpTypeApp _) -> GRight ()
 end
 
 lang UnexpectedTokenParser = AstParserBase
@@ -704,7 +793,8 @@ lang AstParser =
   + AppParser
   + ParenParser
   + LetDeclParser
-  + ArrowParser
+  + LamParser
+  + PrecedenceParser
   + UnexpectedTokenParser
 end
 
@@ -758,7 +848,7 @@ let printAst = lam expr.
   end
 in
 
--- let str = "let a: [Int] = () in a" in
+-- let str = "let a = 1 in let b = 2 in addi a b" in
 -- printLn "\nBoot:";
 -- printAst (parseBoot str);
 -- printLn "Native:";
@@ -812,5 +902,11 @@ utest compare "cons 0 [1, 2]" with true in
 
 utest compareWithoutInfo "let a: [Int] = () in a" with true in
 utest compareWithoutInfo "let a: [[Int]] = () in a" with true in
+
+utest compareWithoutInfo "lam. ()" with true in
+utest compareWithoutInfo "lam a. a" with true in
+utest compareWithoutInfo "lam a: Int. a" with true in
+utest compareWithoutInfo "lam. lam. ()" with true in
+utest compareWithoutInfo "lam a. lam b. addi a b" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -100,16 +100,16 @@ lang AstParserBase = Lexer + Ast
 
   -- The main entry point
   sem parseExpr =
-  | next ->
+  | cur ->
     let state = breakableInitState () in
-    parseExprROpen state next
+    parseExprROpen state cur
 
   sem parseExprRClosed state =
-  | next ->
-    finalizeParseExpr state next
+  | cur ->
+    finalizeParseExpr state cur
 
   sem finalizeParseExpr state =
-  | next ->
+  | cur ->
     match breakableFinalizeParse (config ()) state with Some sppf then
       let config: BreakableErrorHighlightConfig BreakableOp = {
         parenAllowed = #frozen"parenAllowed",
@@ -119,7 +119,7 @@ lang AstParserBase = Lexer + Ast
         lpar = "(",
         rpar = ")"
       } in
-      let errs = breakableDefaultHighlight config next.stream.str sppf in
+      let errs = breakableDefaultHighlight config cur.stream.str sppf in
       match errs with [first] ++ _ then
         parseErrs errs
       else
@@ -129,53 +129,58 @@ lang AstParserBase = Lexer + Ast
           constructPrefix = lam op. lam rhs. constructPrefix (op, rhs),
           constructPostfix = lam op. lam lhs. constructPostfix (op, lhs)
         } sppf in
-        parseOk (expr, next)
+        parseOk (expr, cur)
     else
-      parseErr (next.info, "Breakable parse error")
+      parseErr (cur.info, "Breakable parse error")
 end
 
 lang IntParser = AstParserBase + IntAst
   sem parseExprROpen state =
-  | { token = IntTok { val = val, info = info }, stream = stream } ->
+  | { token = IntTok { val = val } } & cur ->
     let expr = TmConst {
       val = CInt { val = val },
-      ty = ityunknown_ info,
-      info = info
+      ty = ityunknown_ cur.info,
+      info = cur.info
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
-    parseExprRClosed state (nextToken stream)
+    parseExprRClosed state (nextToken cur.stream)
+
+  sem parseType =
+  | { token = UIdentTok { val = "Int" } } & cur ->
+    let typ = ityint_ cur.info in
+    parseOk (typ, nextToken cur.stream)
 end
 
 lang FloatParser = AstParserBase + FloatAst
   sem parseExprROpen state =
-  | { token = FloatTok { val = val, info = info }, stream = stream } ->
+  | { token = FloatTok { val = val } } & cur ->
     let expr = TmConst {
       val = CFloat { val = val },
-      ty = ityunknown_ info,
-      info = info
+      ty = ityunknown_ cur.info,
+      info = cur.info
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
-    parseExprRClosed state (nextToken stream)
+    parseExprRClosed state (nextToken cur.stream)
 end
 
 lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
   sem parseExprROpen state =
-  | { token = OperatorTok { val = "-", info = info }, stream = stream } ->
-    let state = breakableAddPrefix (config ()) (OpNeg info) state in
-    parseExprROpen state (nextToken stream)
+  | { token = OperatorTok { val = "-" } } & cur ->
+    let state = breakableAddPrefix (config ()) (OpNeg cur.info) state in
+    parseExprROpen state (nextToken cur.stream)
 
   -- Two special cases if the rhs is a constant int or float
   sem constructPrefix =
-  | (OpNeg info, TmConst { val = CInt { val = val }, info = info2 }) ->
-    let info = mergeInfo info info2 in
+  | (OpNeg info, TmConst { val = CInt { val = val } } & expr) ->
+    let info = mergeInfo info (infoTm expr) in
     TmConst {
       val = CInt { val = negi val },
       ty = ityunknown_ info,
       info = info
     }
 
-  | (OpNeg info, TmConst { val = CFloat { val = val }, info = info2 }) ->
-    let info = mergeInfo info info2 in
+  | (OpNeg info, TmConst { val = CFloat { val = val } } & expr) ->
+    let info = mergeInfo info (infoTm expr) in
     TmConst {
       val = CFloat { val = negf val },
       ty = ityunknown_ info,
@@ -199,28 +204,28 @@ end
 
 lang VarParser = AstParserBase + VarAst
   sem parseExprROpen state =
-  | { token = LIdentTok { val = val, info = info }, stream = stream } ->
+  | { token = LIdentTok { val = val } } & cur ->
     let expr = TmVar {
       ident = nameNoSym val,
-      ty = ityunknown_ info,
-      info = info,
+      ty = ityunknown_ cur.info,
+      info = cur.info,
       frozen = false -- TODO: Always false?
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
-    parseExprRClosed state (nextToken stream)
+    parseExprRClosed state (nextToken cur.stream)
 end
 
 lang AppParser = AstParserBase + AppAst
   sem parseExprRClosed state =
-  | { token = token, info = info } & next ->
+  | { token = token } & cur ->
     -- check if the next token can be part of the current expression.
-    match canStartExpr next with true then
-      match breakableAddInfix (config ()) (OpApp info) state with Some(state) then
-        parseExprROpen state next
+    match canStartExpr cur with true then
+      match breakableAddInfix (config ()) (OpApp cur.info) state with Some(state) then
+        parseExprROpen state cur
       else
-        parseErr (info, "Breakable add infix error")
+        parseErr (cur.info, "Breakable add infix error")
     else
-      finalizeParseExpr state next
+      finalizeParseExpr state cur
 
   sem constructInfix =
   | (OpApp info, lhs, rhs) ->
@@ -238,84 +243,167 @@ lang ParenParser = AstParserBase + RecordAst
   | { token = RParenTok {} } -> false
 
   sem parseExprROpen state =
-  | { token = LParenTok {}, info = info, stream = stream } ->
-    let next = nextToken stream in
-    match next with { token = RParenTok {}, info = info2, stream = stream } then
+  | { token = LParenTok {} } & open ->
+    match (nextToken open.stream) with { token = RParenTok {} } & close then
       -- this is a unit
-      let info = mergeInfo info info2 in
+      let info = mergeInfo open.info close.info in
       let expr = TmRecord {
         bindings = mapEmpty cmpSID,
         ty = ityunknown_ info,
         info = info
       } in
       let state = breakableAddAtom (config ()) (OpAtom expr) state in
-      parseExprRClosed state (nextToken stream)
+      parseExprRClosed state (nextToken close.stream)
     else
       -- start parsing a new expression at (
-      result.bind (parseExpr (nextToken stream)) (lam a.
-        match a with (expr, next) in
+      result.bind (parseExpr (nextToken open.stream)) (lam expr.
+        match expr with (expr, cur) in
         -- and check for a following )
-        match next with { token = RParenTok {}, stream = stream } then
+        match cur with { token = RParenTok {} } & close then
           let state = breakableAddAtom (config ()) (OpAtom expr) state in
-          parseExprRClosed state (nextToken stream)
+          parseExprRClosed state (nextToken close.stream)
         else
-          parseErr (next.info, "Missing closing parenthesis")
+          parseErr (cur.info, "Missing closing parenthesis")
       )
 end
 
 lang BoolParser = AstParserBase + BoolAst
   sem parseExprROpen state =
-  | { token = LIdentTok { val = "true", info = info}, stream = stream} ->
+  | { token = LIdentTok { val = "true" } } & cur ->
     let expr = TmConst {
       val = CBool { val = true },
-      ty = ityunknown_ info,
-      info = info
+      ty = ityunknown_ cur.info,
+      info = cur.info
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
-    parseExprRClosed state (nextToken stream)
-  | { token = LIdentTok { val = "false", info = info}, stream = stream} ->
+    parseExprRClosed state (nextToken cur.stream)
+  | { token = LIdentTok { val = "false" } } & cur ->
     let expr = TmConst {
       val = CBool { val = false },
-      ty = ityunknown_ info,
-      info = info
+      ty = ityunknown_ cur.info,
+      info = cur.info
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
-    parseExprRClosed state (nextToken stream)
+    parseExprRClosed state (nextToken cur.stream)
 end
 
 lang CharParser = AstParserBase + CharAst
   sem parseExprROpen state =
-  | { token = CharTok { val = val, info = info }, stream = stream } ->
+  | { token = CharTok { val = val } } & cur ->
     let expr = TmConst {
       val = CChar { val = val },
-      ty = ityunknown_ info,
-      info = info
+      ty = ityunknown_ cur.info,
+      info = cur.info
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
-    parseExprRClosed state (nextToken stream)
+    parseExprRClosed state (nextToken cur.stream)
 end
 
 lang StringParser = AstParserBase + SeqAst + CharAst
   sem parseExprROpen state =
-  | { token = StringTok { val = val, info = info }, stream = stream } ->
+  | { token = StringTok { val = val } } & cur ->
     let expr = TmSeq {
       tms = map (lam ch. TmConst {
         val = CChar { val = ch },
-        ty = ityunknown_ info,
-        info = info
+        ty = ityunknown_ cur.info,
+        info = cur.info
       }) val,
-      ty = ityunknown_ info,
-      info = info
+      ty = ityunknown_ cur.info,
+      info = cur.info
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
-    parseExprRClosed state (nextToken stream)
+    parseExprRClosed state (nextToken cur.stream)
 end
 
-lang NotImplementedParser = AstParserBase
+lang LetDeclParser = AstParserBase + LetDeclAst
+  sem canStartExpr =
+  | { token = LIdentTok { val = "let" } } -> false
+  | { token = OperatorTok { val = "="} } -> false
+  | { token = LIdentTok { val = "in"} } -> false
+
   sem parseExprROpen state =
-  | next ->
-    let str = concat "Not implemented: " (tokToStr next.token) in
-    parseErr (next.info, str)
+  | { token = LIdentTok { val = "let" } } & toklet ->
+    let cur = nextToken toklet.stream in
+
+    match cur with { token = LIdentTok { val = ident } } & tokident then
+      let cur = nextToken tokident.stream in
+
+      let tyAnnot =
+        match cur with { token = OperatorTok { val = ":" } } & tokcol then
+          let cur = nextToken tokcol.stream in
+          parseType cur
+        else
+          parseOk (ityunknown_ toklet.info, cur)
+      in
+
+      result.bind tyAnnot (lam tyAnnot.
+        match tyAnnot with (tyAnnot, cur) in
+
+        match cur with { token = OperatorTok { val = "=" } } & tokeq then
+          let cur = nextToken tokeq.stream in
+
+          result.bind (parseExpr cur) (lam body.
+            match body with (body, cur) in
+
+            match cur with { token = LIdentTok { val = "in" } } & tokin then
+              let cur = nextToken tokin.stream in
+
+              result.bind (parseExpr cur) (lam inexpr.
+                match inexpr with (inexpr, cur) in
+
+                let info = mergeInfo toklet.info tokin.info in
+                let expr = TmDecl {
+                  decl = DeclLet {
+                    ident = nameNoSym ident,
+                    tyAnnot = tyAnnot,
+                    tyBody = ityunknown_ info,
+                    body = body,
+                    info = info
+                  },
+                  inexpr = inexpr,
+                  ty = ityunknown_ info,
+                  info = info
+                } in
+                let state = breakableAddAtom (config ()) (OpAtom expr) state in
+                parseExprRClosed state (nextToken cur.stream)
+              )
+
+            else
+              parseErr (cur.info, "Missing in expression")
+          )
+
+        else
+          parseErr (cur.info, "Missing assignment")
+      )
+    else
+      parseErr (cur.info, "Missing identifier")
+end
+
+lang UnexpectedTokenParser = AstParserBase
+  sem parseExprROpen state =
+  | cur ->
+    let str = concat "Unexpexted token while parsing expr: " (tokToStr cur.token) in
+    parseErr (cur.info, str)
+
+  sem parseDecl =
+  | cur ->
+    let str = concat "Unexpexted token while parsing decl: " (tokToStr cur.token) in
+    parseErr (cur.info, str)
+
+  sem parseType =
+  | cur ->
+    let str = concat "Unexpexted token while parsing type: " (tokToStr cur.token) in
+    parseErr (cur.info, str)
+
+  sem parseKind =
+  | cur ->
+    let str = concat "Unexpexted token while parsing kind: " (tokToStr cur.token) in
+    parseErr (cur.info, str)
+
+  sem parsePat =
+  | cur ->
+    let str = concat "Unexpexted token while parsing pat: " (tokToStr cur.token) in
+    parseErr (cur.info, str)
 end
 
 lang AstParser =
@@ -328,11 +416,12 @@ lang AstParser =
   + VarParser
   + AppParser
   + ParenParser
+  + LetDeclParser
+  + UnexpectedTokenParser
 end
 
 lang TestParser =
     AstParser
-  + NotImplementedParser
   + MExprPrettyPrint
   + MExprEq
   + MExprToJson
@@ -381,9 +470,10 @@ let printAst = lam expr.
   end
 in
 
+-- let str = "let a: Int = 1 in a" in
 -- printLn "";
--- printAst (parseBoot "(())");
--- printAst (parse "(())");
+-- printAst (parseBoot str);
+-- printAst (parse str);
 
 utest compare "0" with true in
 utest compare "1" with true in
@@ -411,5 +501,9 @@ utest compareWithoutInfo "()" with true in
 utest compareWithoutInfo "(())" with true in
 utest compareWithoutInfo "addi () ()" with true in
 utest compareWithoutInfo "(addi ()) ()" with true in
+
+utest compare "let a = 1 in a" with true in
+utest compare "let a = 1 in let b = 2 in addi a b" with true in
+utest compare "let a: Int = 1 in a" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -5,6 +5,7 @@ include "mexpr/ast-builder.mc"
 include "mexpr/boot-parser.mc"
 include "mexpr/json-debug.mc"
 include "json.mc"
+include "seq.mc"
 
 lang AstParserBase = Lexer
   sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
@@ -86,7 +87,11 @@ lang StringParser = AstParserBase + SeqAst + CharAst
   sem parseExpr =
   | { token = StringTok { val = val, info = info }, stream = stream } ->
     let expr = TmSeq {
-      tms = [], -- TODO
+      tms = map (lam ch. TmConst {
+        val = CChar { val = ch },
+        ty = ityunknown_ info,
+        info = info
+      }) val,
       ty = ityunknown_ info,
       info = info
     } in

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -1,3 +1,16 @@
+/-
+
+This will be a parser for MCore.
+It is work in progress.
+
+The parser is designed to be as extensible as possible.
+It is built on top of the breakable libarary.
+
+The new parser is simply tested against the ocaml boot parser.
+The tests checks that the parsed AST is identical.
+
+-/
+
 include "lexer.mc"
 include "mexpr/info.mc"
 include "mexpr/eq.mc"
@@ -14,35 +27,37 @@ con OpAtom: use Ast in Expr -> BreakableOp LClosed RClosed
 con OpNeg: Info -> BreakableOp LClosed ROpen
 con OpApp: Info -> BreakableOp LOpen ROpen
 
-type ParseResult a = Result (Info, String) (Info, String) a
+type ParseResult w a = Result w (Info, String) a
 
-let parseOk:  all a. a              -> ParseResult a = lam a. result.ok a
-let parseErr: all a. (Info, String) -> ParseResult a = lam e. result.err e
+let parseOk:  all w. all a. a              -> ParseResult w a = lam a. result.ok a
+let parseErr: all w. all a. (Info, String) -> ParseResult w a = lam e. result.err e
 
-lang AstParserBase = Lexer
+lang AstParserBase = Lexer + Ast
+  -- breakable related stuff
   sem config: () -> Config BreakableOp
-
   sem topAllowed: TopAllowedFunc BreakableOp
   sem leftAllowed: LeftAllowedFunc BreakableOp
   sem rightAllowed: RightAllowedFunc BreakableOp
   sem parenAllowed: ParenAllowedFunc BreakableOp
   sem groupingsAllowed: GroupingsAllowedFunc BreakableOp
-
+  sem terminalInfos: all lstyle. all rstyle. BreakableOp lstyle rstyle -> [Info]
+  sem getInfo: all lstyle. all rstyle. BreakableOp lstyle rstyle -> Info
   sem constructPrefix: (BreakableOp LClosed ROpen, Expr) -> Expr
   sem constructInfix: (BreakableOp LOpen ROpen, Expr, Expr) -> Expr
   sem constructPostfix: (BreakableOp LOpen RClosed, Expr) -> Expr
 
+  -- used to deal with function applications
   sem canStartExpr: NextTokenResult -> Bool
 
-  sem parseExpr: NextTokenResult -> ParseResult (Expr, NextTokenResult)
-  sem parseExprRClosed:  State BreakableOp RClosed -> NextTokenResult -> ParseResult (Expr, NextTokenResult)
-  sem parseExprROpen:    State BreakableOp ROpen   -> NextTokenResult -> ParseResult (Expr, NextTokenResult)
-  sem finalizeParseExpr: State BreakableOp RClosed -> NextTokenResult -> ParseResult (Expr, NextTokenResult)
+  sem parseExpr: all w. NextTokenResult -> ParseResult w (Expr, NextTokenResult)
+  sem parseExprRClosed:  all w. State BreakableOp RClosed -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
+  sem parseExprROpen:    all w. State BreakableOp ROpen   -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
+  sem finalizeParseExpr: all w. State BreakableOp RClosed -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
 
-  sem parseDecl: NextTokenResult -> ParseResult (Decl, NextTokenResult)
-  sem parseType: NextTokenResult -> ParseResult (Type, NextTokenResult)
-  sem parseKind: NextTokenResult -> ParseResult (Kind, NextTokenResult)
-  sem parsePat:  NextTokenResult -> ParseResult (Pat,  NextTokenResult)
+  sem parseDecl: all w. NextTokenResult -> ParseResult w (Decl, NextTokenResult)
+  sem parseType: all w. NextTokenResult -> ParseResult w (Type, NextTokenResult)
+  sem parseKind: all w. NextTokenResult -> ParseResult w (Kind, NextTokenResult)
+  sem parsePat:  all w. NextTokenResult -> ParseResult w (Pat,  NextTokenResult)
 
   sem config =
   | _ ->
@@ -54,6 +69,9 @@ lang AstParserBase = Lexer
       groupingsAllowed = #frozen"groupingsAllowed"
     }
 
+
+  -- Default breakable config
+
   sem topAllowed =
   | _ -> true
 
@@ -64,15 +82,20 @@ lang AstParserBase = Lexer
   | _ -> true
 
   sem parenAllowed =
-  | _ -> GNeither ()
+  | _ -> GEither ()
 
   sem groupingsAllowed =
   | _ -> GLeft ()
+
+  sem terminalInfos =
+  | op -> [getInfo op]
 
   sem canStartExpr =
   | { token = EOFTok {} } -> false
   | _ -> true
 
+
+  -- The main entry point
   sem parseExpr =
   | next ->
     let state = breakableInitState () in
@@ -85,14 +108,25 @@ lang AstParserBase = Lexer
   sem finalizeParseExpr state =
   | next ->
     match breakableFinalizeParse (config ()) state with Some sppf then
-      -- breakableReportAmbiguities ?
-      let expr = breakableConstructSimple {
-        constructAtom = lam op. match op with OpAtom expr in expr,
-        constructInfix = lam op. lam lhs. lam rhs. constructInfix (op, lhs, rhs),
-        constructPrefix = lam op. lam rhs. constructPrefix (op, rhs),
-        constructPostfix = lam op. lam lhs. constructPostfix (op, lhs)
-      } sppf in
-      parseOk (expr, next)
+      let config: BreakableErrorHighlightConfig BreakableOp = {
+        parenAllowed = #frozen"parenAllowed",
+        topAllowed = #frozen"topAllowed",
+        terminalInfos = #frozen"terminalInfos",
+        getInfo = #frozen"getInfo",
+        lpar = "(",
+        rpar = ")"
+      } in
+      let errs = breakableDefaultHighlight config next.stream.str sppf in
+      match errs with [first] ++ _ then
+        parseErr first -- TODO: Report all errs
+      else
+        let expr = breakableConstructSimple {
+          constructAtom = lam op. match op with OpAtom expr in expr,
+          constructInfix = lam op. lam lhs. lam rhs. constructInfix (op, lhs, rhs),
+          constructPrefix = lam op. lam rhs. constructPrefix (op, rhs),
+          constructPostfix = lam op. lam lhs. constructPostfix (op, lhs)
+        } sppf in
+        parseOk (expr, next)
     else
       parseErr (next.info, "Breakable parse error")
 end
@@ -127,6 +161,7 @@ lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
     let state = breakableAddPrefix (config ()) (OpNeg info) state in
     parseExprROpen state (nextToken stream)
 
+  -- Two special cases if the rhs is a constant int or float
   sem constructPrefix =
   | (OpNeg info, TmConst { val = CInt { val = val }, info = info2 }) ->
     let info = mergeInfo info info2 in
@@ -144,11 +179,12 @@ lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
       info = info
     }
 
+  -- Normal case
   | (OpNeg info, rhs) ->
     let info2 = mergeInfo info (infoTm rhs) in
     TmApp {
       lhs = TmConst {
-        val = CNegi {},
+        val = CNegi {}, -- TODO: What about CNegf?
         ty = ityunknown_ info,
         info = info
       },
@@ -165,7 +201,7 @@ lang VarParser = AstParserBase + VarAst
       ident = nameNoSym val,
       ty = ityunknown_ info,
       info = info,
-      frozen = false -- TODO
+      frozen = false -- TODO: Always false?
     } in
     let state = breakableAddAtom (config ()) (OpAtom expr) state in
     parseExprRClosed state (nextToken stream)
@@ -174,6 +210,7 @@ end
 lang AppParser = AstParserBase + AppAst
   sem parseExprRClosed state =
   | { token = token, info = info } & next ->
+    -- check if the next token can be part of the current expression.
     match canStartExpr next with true then
       match breakableAddInfix (config ()) (OpApp info) state with Some(state) then
         parseExprROpen state next
@@ -199,8 +236,10 @@ lang ParenParser = AstParserBase
 
   sem parseExprROpen state =
   | { token = LParenTok {}, stream = stream } ->
+    -- start parsing a new expression at (
     result.bind (parseExpr (nextToken stream)) (lam a.
       match a with (expr, next) in
+      -- and check for a following )
       match next with { token = RParenTok {}, stream = stream } then
         let state = breakableAddAtom (config ()) (OpAtom expr) state in
         parseExprRClosed state (nextToken stream)
@@ -302,7 +341,7 @@ let compare = lam str.
   let b = parseBoot str in
 
   match (result.toOption a, result.toOption b) with (Some a, Some b) then
-    eqString (jsonStr a) (jsonStr b)
+    eqString (jsonStr a) (jsonStr b) -- By comparing strings we also take info filed into account.
   else
     false
   in

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -55,8 +55,8 @@ lang AstParserBase = Lexer + Ast
   sem finalizeParseExpr: all w. State BrkOpExpr RClosed -> NextTokenResult -> ParseResult w (Expr, NextTokenResult)
   sem finalizeParseType: all w. State BrkOpType RClosed -> NextTokenResult -> ParseResult w (Type, NextTokenResult)
 
-  sem canAppExpr: NextTokenResult -> Bool
-  sem canAppType: NextTokenResult -> Bool
+  sem canStartAppArgExpr: NextTokenResult -> Bool
+  sem canStartAppArgType: NextTokenResult -> Bool
 
   sem constructPrefixExpr: (BrkOpExpr LClosed ROpen, Expr) -> Expr
   sem constructPrefixType: (BrkOpType LClosed ROpen, Type) -> Type
@@ -152,13 +152,11 @@ lang AstParserBase = Lexer + Ast
     else
       parseErr (cur.info, "Breakable parse error")
 
-  sem canAppExpr =
-  | { token = EOFTok {} } -> false
-  | _ -> true
+  sem canStartAppArgExpr =
+  | _ -> false
 
-  sem canAppType =
-  | { token = EOFTok {} } -> false
-  | _ -> true
+  sem canStartAppArgType =
+  | _ -> false
 
   sem configExpr =
   | _ ->
@@ -226,6 +224,12 @@ lang AstParserBase = Lexer + Ast
 end
 
 lang IntParser = AstParserBase + IntAst
+  sem canStartAppArgExpr =
+  | { token = IntTok { } } -> true
+
+  sem canStartAppArgType =
+  | { token = UIdentTok { val = "Int" } } -> true
+
   sem parseExprROpen state =
   | { token = IntTok { val = val } } & cur ->
     let expr = TmConst {
@@ -244,6 +248,12 @@ lang IntParser = AstParserBase + IntAst
 end
 
 lang FloatParser = AstParserBase + FloatAst
+  sem canStartAppArgExpr =
+  | { token = FloatTok { } } -> true
+
+  sem canStartAppArgType =
+  | { token = UIdentTok { val = "Float" } } -> true
+
   sem parseExprROpen state =
   | { token = FloatTok { val = val } } & cur ->
     let expr = TmConst {
@@ -262,6 +272,9 @@ lang FloatParser = AstParserBase + FloatAst
 end
 
 lang NegParser = AstParserBase + IntAst + FloatAst
+  sem canStartAppArgExpr =
+  | { token = OperatorTok { val = "-" } } -> true
+
   sem parseExprROpen state =
   | { token = OperatorTok { val = "-" } } & tokneg ->
     let cur = nextToken tokneg.stream in
@@ -291,6 +304,9 @@ lang NegParser = AstParserBase + IntAst + FloatAst
 end
 
 lang VarParser = AstParserBase + VarAst
+  sem canStartAppArgExpr =
+  | { token = LIdentTok { } } -> true
+
   sem parseExprROpen state =
   | { token = LIdentTok { val = val } } & cur ->
     let expr = TmVar {
@@ -307,7 +323,7 @@ lang AppParser = AstParserBase + AppAst + AppTypeAst
   sem parseExprRClosed state =
   | cur ->
     -- check if the next token can be part of the current expression.
-    match canAppExpr cur with true then
+    match canStartAppArgExpr cur with true then
       match breakableAddInfix (configExpr ()) (OpExprApp cur.info) state with Some(state) then
         parseExprROpen state cur
       else
@@ -318,7 +334,7 @@ lang AppParser = AstParserBase + AppAst + AppTypeAst
   sem parseTypeRClosed state =
   | cur ->
     -- check if the next token can be part of the current type.
-    match canAppType cur with true then
+    match canStartAppArgType cur with true then
       match breakableAddInfix (configType ()) (OpTypeApp cur.info) state with Some(state) then
         parseTypeROpen state cur
       else
@@ -347,10 +363,12 @@ lang AppParser = AstParserBase + AppAst + AppTypeAst
 end
 
 lang ParenParser = AstParserBase + RecordAst + RecordTypeAst
-  sem canAppExpr =
+  sem canStartAppArgExpr =
+  | { token = LParenTok {} } -> true
   | { token = RParenTok {} } -> false
 
-  sem canAppType =
+  sem canStartAppArgType =
+  | { token = LParenTok {} } -> true
   | { token = RParenTok {} } -> false
 
   sem parseExprROpen state =
@@ -402,6 +420,13 @@ lang ParenParser = AstParserBase + RecordAst + RecordTypeAst
 end
 
 lang BoolParser = AstParserBase + BoolAst
+  sem canStartAppArgExpr =
+  | { token = LIdentTok { val = "true" } } -> true
+  | { token = LIdentTok { val = "false" } } -> true
+
+  sem canStartAppArgType =
+  | { token = UIdentTok { val = "Bool" } } -> true
+
   sem parseExprROpen state =
   | { token = LIdentTok { val = "true" } } & cur ->
     let expr = TmConst {
@@ -428,6 +453,12 @@ lang BoolParser = AstParserBase + BoolAst
 end
 
 lang CharParser = AstParserBase + CharAst
+  sem canStartAppArgExpr =
+  | { token = CharTok { } } -> true
+
+  sem canStartAppArgType =
+  | { token = UIdentTok { val = "Char" } } -> true
+
   sem parseExprROpen state =
   | { token = CharTok { val = val } } & cur ->
     let expr = TmConst {
@@ -446,6 +477,12 @@ lang CharParser = AstParserBase + CharAst
 end
 
 lang StringParser = AstParserBase + SeqAst + CharAst
+  sem canStartAppArgExpr =
+  | { token = StringTok { } } -> true
+
+  sem canStartAppArgType =
+  | { token = UIdentTok { val = "String" } } -> true
+
   sem parseExprROpen state =
   | { token = StringTok { val = val } } & cur ->
     let expr = TmSeq {
@@ -468,13 +505,9 @@ lang StringParser = AstParserBase + SeqAst + CharAst
 end
 
 lang LetDeclParser = AstParserBase + LetDeclAst
-  sem canAppExpr =
+  sem canStartAppArgExpr =
   | { token = LIdentTok { val = "let" } } -> false
-  | { token = OperatorTok { val = "="} } -> false
   | { token = LIdentTok { val = "in"} } -> false
-
-  sem canAppType =
-  | { token = OperatorTok { val = "="} } -> false
 
   sem parseExprROpen state =
   | { token = LIdentTok { val = "let" } } & toklet ->
@@ -544,7 +577,7 @@ lang LetDeclParser = AstParserBase + LetDeclAst
 end
 
 lang ArrowParser = AstParserBase + FunTypeAst
-  sem canAppType =
+  sem canStartAppArgType =
   | { token = OperatorTok { val = "->" } } -> false
 
   sem parseTypeRClosed state =

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -12,7 +12,7 @@ include "name.mc"
 type BreakableOp lstyle rstyle
 con OpAtom: use Ast in Expr -> BreakableOp LClosed RClosed
 con OpNeg: Info -> BreakableOp LClosed ROpen
-con OpApp: Info -> BreakableOp LClosed ROpen
+con OpApp: Info -> BreakableOp LOpen ROpen
 
 lang AstParserBase = Lexer
   sem config: () -> Config BreakableOp
@@ -24,6 +24,10 @@ lang AstParserBase = Lexer
   sem groupingsAllowed: GroupingsAllowedFunc BreakableOp
 
   sem constructPrefix: (BreakableOp LClosed ROpen, Expr) -> Expr
+  sem constructInfix: (BreakableOp LOpen ROpen, Expr, Expr) -> Expr
+  sem constructPostfix: (BreakableOp LOpen RClosed, Expr) -> Expr
+
+  sem canStartExpr: NextTokenResult -> Bool
 
   sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
   sem parseExprRClosed : State BreakableOp RClosed -> NextTokenResult -> (Expr, NextTokenResult)
@@ -60,6 +64,10 @@ lang AstParserBase = Lexer
   sem groupingsAllowed =
   | _ -> GLeft ()
 
+  sem canStartExpr =
+  | { token = EOFTok {} } -> false
+  | _ -> true
+
   sem parseExpr =
   | next ->
     let state = breakableInitState () in
@@ -75,9 +83,9 @@ lang AstParserBase = Lexer
       -- breakableReportAmbiguities ?
       let expr = breakableConstructSimple {
         constructAtom = lam op. match op with OpAtom expr in expr,
-        constructInfix = lam op. lam l. never,
+        constructInfix = lam op. lam lhs. lam rhs. constructInfix (op, lhs, rhs),
         constructPrefix = lam op. lam rhs. constructPrefix (op, rhs),
-        constructPostfix = lam op. lam l. never
+        constructPostfix = lam op. lam lhs. constructPostfix (op, lhs)
       } sppf in
       (expr, next)
     else error "Breakable parse error"
@@ -157,6 +165,42 @@ lang VarParser = AstParserBase + VarAst
     parseExprRClosed state (nextToken stream)
 end
 
+lang AppParser = AstParserBase + AppAst
+  sem parseExprRClosed state =
+  | { token = token, info = info } & next ->
+    match canStartExpr next with true then
+      match breakableAddInfix (config ()) (OpApp info) state with Some(state) then
+        parseExprROpen state next
+      else
+        error "Breakable add infix error"
+    else
+      finalizeParseExpr state next
+
+  sem constructInfix =
+  | (OpApp info, lhs, rhs) ->
+    let info = mergeInfo (infoTm lhs) (infoTm rhs) in
+    TmApp {
+      lhs = lhs,
+      rhs = rhs,
+      ty = ityunknown_ info,
+      info = info
+    }
+end
+
+lang ParenParser = AstParserBase
+  sem canStartExpr =
+  | { token = RParenTok {} } -> false
+
+  sem parseExprROpen state =
+  | { token = LParenTok {}, stream = stream } ->
+    match parseExpr (nextToken stream) with (expr, next) in
+    match next with { token = RParenTok {}, stream = stream } then
+      let state = breakableAddAtom (config ()) (OpAtom expr) state in
+      parseExprRClosed state (nextToken stream)
+    else
+      error "Missing closing parenthesis"
+end
+
 lang BoolParser = AstParserBase + BoolAst
   sem parseExprROpen state =
   | { token = LIdentTok { val = "true", info = info}, stream = stream} ->
@@ -220,6 +264,8 @@ lang AstParser =
   + StringParser
   + NegParser
   + VarParser
+  + AppParser
+  + ParenParser
 end
 
 lang TestParser =
@@ -250,8 +296,8 @@ let compare = lam str. eqString (jsonStr (parse str)) (jsonStr (parseBoot str)) 
 let printAst = lam expr. printLn (jsonStr expr) in
 
 -- printLn "";
--- printAst (parseBoot "addi 1 2");
--- printAst (parse "addi 1 2");
+-- printAst (parseBoot "addi (addi 1 2) 3");
+-- printAst (parse "addi (addi 1 2) 3");
 
 utest compare "0" with true in
 utest compare "1" with true in
@@ -270,5 +316,9 @@ utest compare "'😊'" with true in
 utest compare "\"test\"" with true in
 
 utest compare "addi 1 2" with true in
+utest compare "addi 1 2 3" with true in
+utest compare "addi addi 1 2 3" with true in
+utest compare "addi (addi 1 2) 3" with true in
+utest compare "addi 1 (addi 2 3)" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -25,7 +25,6 @@ include "name.mc"
 
 type BrkOpExpr lstyle rstyle
 con OpExprAtom: use Ast in Expr -> BrkOpExpr LClosed RClosed
-con OpExprNeg: Info -> BrkOpExpr LClosed ROpen
 con OpExprApp: Info -> BrkOpExpr LOpen ROpen
 
 type BrkOpType lstyle rstyle
@@ -262,43 +261,33 @@ lang FloatParser = AstParserBase + FloatAst
     parseTypeRClosed state (nextToken cur.stream)
 end
 
-lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
+lang NegParser = AstParserBase + IntAst + FloatAst
   sem parseExprROpen state =
-  | { token = OperatorTok { val = "-" } } & cur ->
-    let state = breakableAddPrefix (configExpr ()) (OpExprNeg cur.info) state in
-    parseExprROpen state (nextToken cur.stream)
+  | { token = OperatorTok { val = "-" } } & tokneg ->
+    let cur = nextToken tokneg.stream in
 
-  -- Two special cases if the rhs is a constant int or float
-  sem constructPrefixExpr =
-  | (OpExprNeg info, TmConst { val = CInt { val = val } } & expr) ->
-    let info = mergeInfo info (infoTm expr) in
-    TmConst {
-      val = CInt { val = negi val },
-      ty = ityunknown_ info,
-      info = info
-    }
-
-  | (OpExprNeg info, TmConst { val = CFloat { val = val } } & expr) ->
-    let info = mergeInfo info (infoTm expr) in
-    TmConst {
-      val = CFloat { val = negf val },
-      ty = ityunknown_ info,
-      info = info
-    }
-
-  -- Normal case
-  | (OpExprNeg info, rhs) ->
-    let info2 = mergeInfo info (infoTm rhs) in
-    TmApp {
-      lhs = TmConst {
-        val = CNegi {}, -- TODO: What about CNegf?
-        ty = ityunknown_ info,
-        info = info
-      },
-      rhs = rhs,
-      ty = ityunknown_ info2,
-      info = info2
-    }
+    switch cur
+      case { token = IntTok { val = val } } then
+        let info = mergeInfo tokneg.info cur.info in
+        let expr = TmConst {
+          val = CInt { val = negi val },
+          ty = ityunknown_ info,
+          info = info
+        } in
+        let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
+        parseExprRClosed state (nextToken cur.stream)
+      case { token = FloatTok { val = val } } then
+        let info = mergeInfo tokneg.info cur.info in
+        let expr = TmConst {
+          val = CFloat { val = negf val },
+          ty = ityunknown_ info,
+          info = info
+        } in
+        let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
+        parseExprRClosed state (nextToken cur.stream)
+      case _ then
+        parseErr (cur.info, "Expected a number")
+    end
 end
 
 lang VarParser = AstParserBase + VarAst
@@ -668,9 +657,10 @@ let printAst = lam expr.
   end
 in
 
--- let str = "let a: Int -> Int = addi 1 in a" in
--- printLn "";
+-- let str = "-5" in
+-- printLn "\nBoot:";
 -- printAst (parseBoot str);
+-- printLn "Native:";
 -- printAst (parse str);
 
 utest compare "0" with true in

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -33,6 +33,7 @@ let parseErrs: all w. all a. [(Info, String)] -> ParseResult w a = lam errs.
 lang AstParserBase = Lexer + Ast
   syn BrkOpExpr lstyle rstyle =
   | OpExprAtom Expr
+  | OpExprDecl Decl
 
   syn BrkOpType lstyle rstyle =
   | OpTypeAtom Type
@@ -213,12 +214,11 @@ lang AstParserBase = Lexer + Ast
   | op -> [getInfoType op]
 
   sem getInfoExpr =
-  | OpExprAtom expr ->
-    infoTm expr
+  | OpExprAtom expr -> infoTm expr
+  | OpExprDecl decl -> infoDecl decl
 
   sem getInfoType =
-  | OpTypeAtom typ ->
-    infoTy typ
+  | OpTypeAtom typ -> infoTy typ
 end
 
 lang IntParser = AstParserBase + IntAst
@@ -311,10 +311,20 @@ lang VarParser = AstParserBase + VarAst
       ident = nameNoSym val,
       ty = ityunknown_ cur.info,
       info = cur.info,
-      frozen = false -- TODO: Always false?
+      frozen = false
     } in
     let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
+
+  | { token = HashStringTok { hash = "frozen", val = val } } & cur ->
+    let expr = TmVar {
+        ident = nameNoSym val,
+        ty = ityunknown_ cur.info,
+        info = cur.info,
+        frozen = true
+      } in
+      let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
+      parseExprRClosed state (nextToken cur.stream)
 end
 
 lang AppParser = AstParserBase + AppAst + AppTypeAst
@@ -377,11 +387,9 @@ end
 lang ParenParser = AstParserBase + RecordAst + RecordTypeAst
   sem canStartAppArgExpr =
   | { token = LParenTok {} } -> true
-  | { token = RParenTok {} } -> false
 
   sem canStartAppArgType =
   | { token = LParenTok {} } -> true
-  | { token = RParenTok {} } -> false
 
   sem parseExprROpen state =
   | { token = LParenTok {} } & open ->
@@ -433,8 +441,7 @@ end
 
 lang BoolParser = AstParserBase + BoolAst
   sem canStartAppArgExpr =
-  | { token = LIdentTok { val = "true" } } -> true
-  | { token = LIdentTok { val = "false" } } -> true
+  | { token = LIdentTok { val = "true" | "false" } } -> true
 
   sem canStartAppArgType =
   | { token = UIdentTok { val = "Bool" } } -> true
@@ -584,23 +591,15 @@ lang SeqParser = AstParserBase + SeqAst + SeqTypeAst
 end
 
 lang LetDeclParser = AstParserBase + LetDeclAst
-  syn BrkOpExpr lstyle rstyle =
-  | OpExprLet Decl
-
-  sem getInfoExpr =
-  | OpExprLet decl ->
-    infoDecl decl
-
   sem canStartAppArgExpr =
-  | { token = LIdentTok { val = "let" } } -> false
-  | { token = LIdentTok { val = "in"} } -> false
+  | { token = LIdentTok { val = "let" | "in" } } -> false
 
   sem parseExprROpen state =
   | { token = LIdentTok { val = "let" } } & toklet ->
     result.bind (parseDecl toklet) (lam decl.
       match decl with (decl, cur) in
 
-      let state = breakableAddPrefix (configExpr ()) (OpExprLet decl) state in
+      let state = breakableAddPrefix (configExpr ()) (OpExprDecl decl) state in
 
       match cur with { token = LIdentTok { val = "in" } } & tokin then
         let cur = nextToken tokin.stream in
@@ -650,7 +649,7 @@ lang LetDeclParser = AstParserBase + LetDeclAst
       parseErr (cur.info, "Missing identifier")
 
   sem constructPrefixExpr =
-  | (OpExprLet decl, inexpr) ->
+  | (OpExprDecl decl, inexpr) ->
     let info = infoDecl decl in
     TmDecl {
       decl = decl,
@@ -744,7 +743,7 @@ end
 lang PrecedenceParser = AppParser + LamParser + LetDeclParser
   sem groupingsAllowedExpr =
   | (OpExprApp _, OpExprApp _) -> GLeft ()
-  | (OpExprLet _, OpExprApp _) -> GRight ()
+  | (OpExprDecl _, OpExprApp _) -> GRight ()
   | (OpExprLam _, OpExprApp _) -> GRight ()
 
   sem groupingsAllowedType =
@@ -875,6 +874,9 @@ utest compare "addi 1 2 3" with true in
 utest compare "addi addi 1 2 3" with true in
 utest compare "addi (addi 1 2) 3" with true in
 utest compare "addi 1 (addi 2 3)" with true in
+
+utest compare "a" with true in
+utest compare "#frozen\"a\"" with true in
 
 utest compareWithoutInfo "()" with true in
 utest compareWithoutInfo "(())" with true in

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -1,0 +1,77 @@
+include "lexer.mc"
+include "mexpr/info.mc"
+include "mexpr/eq.mc"
+include "mexpr/ast-builder.mc"
+include "mexpr/boot-parser.mc"
+
+lang AstParser = Lexer
+  sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
+  sem parseDecl: NextTokenResult -> (Decl, NextTokenResult)
+  sem parseType: NextTokenResult -> (Type, NextTokenResult)
+  sem parseKind: NextTokenResult -> (Kind, NextTokenResult)
+  sem parsePat:  NextTokenResult -> (Pat,  NextTokenResult)
+end
+
+lang IntParser = AstParser + IntAst
+  sem parseExpr =
+  | { token = IntTok { val = val, info = info }, stream = stream } ->
+    let expr = TmConst {
+      val = CInt { val = val },
+      ty = tyint_,
+      info = info
+    } in
+    (expr, nextToken stream)
+end
+
+lang BoolParser = AstParser + BoolAst
+  sem parseExpr =
+  | { token = LIdentTok { val = "true", info = info}, stream = stream} ->
+    let expr = TmConst {
+      val = CBool { val = true },
+      ty = tybool_,
+      info = info
+    } in
+    (expr, nextToken stream)
+  | { token = LIdentTok { val = "false", info = info}, stream = stream} ->
+    let expr = TmConst {
+      val = CBool { val = false },
+      ty = tybool_,
+      info = info
+    } in
+    (expr, nextToken stream)
+end
+
+
+lang TestParser = IntParser + BoolParser + MExprPrettyPrint + Eq end
+
+mexpr
+
+use TestParser in
+
+let lex = lam str. nextToken {pos = initPos "test", str = str} in
+let parse = lam str. match parseExpr (lex str) with (expr, next) in expr in
+
+let expr = parse "5" in
+
+utest match expr with TmConst { val = CInt { val = val }} in val with 5 in
+utest match expr with TmConst { info = info} in info with infoVal "test" 1 0 1 1 in
+
+match parseExpr (lex "true") with (expr, next) in
+utest match expr with TmConst { val = CBool { val = val }} in val with true in
+
+match parseExpr (lex "false") with (expr, next) in
+utest match expr with TmConst { val = CBool { val = val }} in val with false in
+
+
+use BootParser in
+
+let bootArg = _defaultBootParserParseMExprStringArg () in
+let parseBoot = lam str.
+  match parseMExprString bootArg str with (ResultOk { value = bootExpr}) in bootExpr in
+
+let expr = parse "5" in
+let bootExpr = parseBoot "5" in
+
+utest expr with bootExpr using eqExpr in
+
+()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -27,10 +27,10 @@ con OpAtom: use Ast in Expr -> BreakableOp LClosed RClosed
 con OpNeg: Info -> BreakableOp LClosed ROpen
 con OpApp: Info -> BreakableOp LOpen ROpen
 
-type ParseResult w a = Result w (Info, String) a
+type ParseResult w a = Result w [(Info, String)] a
 
 let parseOk:  all w. all a. a              -> ParseResult w a = lam a. result.ok a
-let parseErr: all w. all a. (Info, String) -> ParseResult w a = lam e. result.err e
+let parseErr: all w. all a. [(Info, String)] -> ParseResult w a = lam e. result.err e
 
 lang AstParserBase = Lexer + Ast
   -- breakable related stuff
@@ -118,7 +118,7 @@ lang AstParserBase = Lexer + Ast
       } in
       let errs = breakableDefaultHighlight config next.stream.str sppf in
       match errs with [first] ++ _ then
-        parseErr first -- TODO: Report all errs
+        parseErr errs -- TODO: Report all errs
       else
         let expr = breakableConstructSimple {
           constructAtom = lam op. match op with OpAtom expr in expr,
@@ -128,7 +128,7 @@ lang AstParserBase = Lexer + Ast
         } sppf in
         parseOk (expr, next)
     else
-      parseErr (next.info, "Breakable parse error")
+      parseErr [(next.info, "Breakable parse error")]
 end
 
 lang IntParser = AstParserBase + IntAst
@@ -215,7 +215,7 @@ lang AppParser = AstParserBase + AppAst
       match breakableAddInfix (config ()) (OpApp info) state with Some(state) then
         parseExprROpen state next
       else
-        parseErr (info, "Breakable add infix error")
+        parseErr [(info, "Breakable add infix error")]
     else
       finalizeParseExpr state next
 
@@ -244,7 +244,7 @@ lang ParenParser = AstParserBase
         let state = breakableAddAtom (config ()) (OpAtom expr) state in
         parseExprRClosed state (nextToken stream)
       else
-        parseErr (next.info, "Missing closing parenthesis")
+        parseErr [(next.info, "Missing closing parenthesis")]
     )
 end
 
@@ -300,7 +300,7 @@ lang NotImplementedParser = AstParserBase
   sem parseExprROpen state =
   | next ->
     let str = concat "Not implemented: " (tokToStr next.token) in
-    parseErr (next.info, str)
+    parseErr [(next.info, str)]
 end
 
 lang AstParser =

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -3,8 +3,10 @@ include "mexpr/info.mc"
 include "mexpr/eq.mc"
 include "mexpr/ast-builder.mc"
 include "mexpr/boot-parser.mc"
+include "mexpr/json-debug.mc"
+include "json.mc"
 
-lang AstParser = Lexer
+lang AstParserBase = Lexer
   sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
   sem parseDecl: NextTokenResult -> (Decl, NextTokenResult)
   sem parseType: NextTokenResult -> (Type, NextTokenResult)
@@ -12,66 +14,131 @@ lang AstParser = Lexer
   sem parsePat:  NextTokenResult -> (Pat,  NextTokenResult)
 end
 
-lang IntParser = AstParser + IntAst
+lang IntParser = AstParserBase + IntAst
   sem parseExpr =
   | { token = IntTok { val = val, info = info }, stream = stream } ->
     let expr = TmConst {
       val = CInt { val = val },
-      ty = tyint_,
+      ty = ityunknown_ info,
       info = info
     } in
     (expr, nextToken stream)
 end
 
-lang BoolParser = AstParser + BoolAst
+lang FloatParser = AstParserBase + FloatAst
+  sem parseExpr =
+  | { token = FloatTok { val = val, info = info }, stream = stream } ->
+    let expr = TmConst {
+      val = CFloat { val = val },
+      ty = ityunknown_ info,
+      info = info
+    } in
+    (expr, nextToken stream)
+end
+
+lang NegParser = AstParserBase + IntAst + FloatAst
+  sem parseExpr =
+  | { token = OperatorTok { val = "-", info = info }, stream = stream } ->
+    match parseExpr (nextToken stream) with (expr, next) in
+    let val = switch expr
+      case TmConst { val = CInt { val = val } } then CInt { val = negi val }
+      case TmConst { val = CFloat { val = val } } then CFloat { val = negf val }
+    end in
+    let info = mergeInfo info (infoTm expr) in
+    let expr = TmConst {
+      val = val,
+      ty = ityunknown_ info,
+      info = info
+    } in
+    (expr, nextToken next.stream)
+end
+
+lang BoolParser = AstParserBase + BoolAst
   sem parseExpr =
   | { token = LIdentTok { val = "true", info = info}, stream = stream} ->
     let expr = TmConst {
       val = CBool { val = true },
-      ty = tybool_,
+      ty = ityunknown_ info,
       info = info
     } in
     (expr, nextToken stream)
   | { token = LIdentTok { val = "false", info = info}, stream = stream} ->
     let expr = TmConst {
       val = CBool { val = false },
-      ty = tybool_,
+      ty = ityunknown_ info,
       info = info
     } in
     (expr, nextToken stream)
 end
 
+lang CharParser = AstParserBase + CharAst
+  sem parseExpr =
+  | { token = CharTok { val = val, info = info }, stream = stream } ->
+    let expr = TmConst {
+      val = CChar { val = val },
+      ty = ityunknown_ info,
+      info = info
+    } in
+    (expr, nextToken stream)
+end
 
-lang TestParser = IntParser + BoolParser + MExprPrettyPrint + Eq end
+lang StringParser = AstParserBase + SeqAst + CharAst
+  sem parseExpr =
+  | { token = StringTok { val = val, info = info }, stream = stream } ->
+    let expr = TmSeq {
+      tms = [], -- TODO
+      ty = ityunknown_ info,
+      info = info
+    } in
+    (expr, nextToken stream)
+end
+
+lang NotImplementedParser = AstParserBase
+  sem parseExpr =
+  | { token = token } ->
+    let str = concat "Not implemented: " (tokToStr token) in
+    error str
+end
+
+lang AstParser = IntParser + FloatParser + BoolParser + CharParser + StringParser + NegParser end
+
+lang TestParser = AstParser + NotImplementedParser + MExprPrettyPrint + MExprEq + MExprToJson end
 
 mexpr
 
 use TestParser in
-
-let lex = lam str. nextToken {pos = initPos "test", str = str} in
-let parse = lam str. match parseExpr (lex str) with (expr, next) in expr in
-
-let expr = parse "5" in
-
-utest match expr with TmConst { val = CInt { val = val }} in val with 5 in
-utest match expr with TmConst { info = info} in info with infoVal "test" 1 0 1 1 in
-
-match parseExpr (lex "true") with (expr, next) in
-utest match expr with TmConst { val = CBool { val = val }} in val with true in
-
-match parseExpr (lex "false") with (expr, next) in
-utest match expr with TmConst { val = CBool { val = val }} in val with false in
-
-
 use BootParser in
+
+let lex = lam str. nextToken {pos = initPos "internal", str = str} in
+let parse = lam str. match parseExpr (lex str) with (expr, next) in expr in
 
 let bootArg = _defaultBootParserParseMExprStringArg () in
 let parseBoot = lam str.
   match parseMExprString bootArg str with (ResultOk { value = bootExpr}) in bootExpr in
 
-let expr = parse "5" in
-let bootExpr = parseBoot "5" in
+let jsonStr = lam expr. json2string (exprToJson expr) in
 
-utest expr with bootExpr using eqExpr in
+-- let compare = lam str. eqExpr (parse str) (parseBoot str) in
+let compare = lam str. eqString (jsonStr (parse str)) (jsonStr (parseBoot str)) in
+
+let printAst = lam expr. printLn (jsonStr expr) in
+
+-- printAst (parseBoot "\"test\"");
+
+utest compare "0" with true in
+utest compare "1" with true in
+utest compare "-1" with true in
+
+utest compare "0.0" with true in
+utest compare "1.0" with true in
+utest compare "-1.0" with true in
+
+utest compare "true" with true in
+utest compare "false" with true in
+
+utest compare "'a'" with true in
+utest compare "'😊'" with true in
+
+utest compare "\"test\"" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -103,14 +103,6 @@ lang AstParserBase = Lexer + Ast
     let state = breakableInitState () in
     parseTypeROpen state cur
 
-  sem parseExprRClosed state =
-  | cur ->
-    finalizeParseExpr state cur
-
-  sem parseTypeRClosed state =
-  | cur ->
-    finalizeParseType state cur
-
   sem finalizeParseExpr state =
   | cur ->
     match breakableFinalizeParse (configExpr ()) state with Some sppf then
@@ -262,6 +254,12 @@ lang FloatParser = AstParserBase + FloatAst
     } in
     let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
+
+  sem parseTypeROpen state =
+  | { token = UIdentTok { val = "Float" } } & cur ->
+    let typ = ityfloat_ cur.info in
+    let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+    parseTypeRClosed state (nextToken cur.stream)
 end
 
 lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
@@ -318,7 +316,7 @@ end
 
 lang AppParser = AstParserBase + AppAst + AppTypeAst
   sem parseExprRClosed state =
-  | { token = token } & cur ->
+  | cur ->
     -- check if the next token can be part of the current expression.
     match canAppExpr cur with true then
       match breakableAddInfix (configExpr ()) (OpExprApp cur.info) state with Some(state) then
@@ -329,7 +327,7 @@ lang AppParser = AstParserBase + AppAst + AppTypeAst
       finalizeParseExpr state cur
 
   sem parseTypeRClosed state =
-  | { token = token } & cur ->
+  | cur ->
     -- check if the next token can be part of the current type.
     match canAppType cur with true then
       match breakableAddInfix (configType ()) (OpTypeApp cur.info) state with Some(state) then
@@ -432,6 +430,12 @@ lang BoolParser = AstParserBase + BoolAst
     } in
     let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
+
+  sem parseTypeROpen state =
+  | { token = UIdentTok { val = "Bool" } } & cur ->
+    let typ = itybool_ cur.info in
+    let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+    parseTypeRClosed state (nextToken cur.stream)
 end
 
 lang CharParser = AstParserBase + CharAst
@@ -444,6 +448,12 @@ lang CharParser = AstParserBase + CharAst
     } in
     let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
+
+  sem parseTypeROpen state =
+  | { token = UIdentTok { val = "Char" } } & cur ->
+    let typ = itychar_ cur.info in
+    let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+    parseTypeRClosed state (nextToken cur.stream)
 end
 
 lang StringParser = AstParserBase + SeqAst + CharAst
@@ -460,6 +470,12 @@ lang StringParser = AstParserBase + SeqAst + CharAst
     } in
     let state = breakableAddAtom (configExpr ()) (OpExprAtom expr) state in
     parseExprRClosed state (nextToken cur.stream)
+
+  sem parseTypeROpen state =
+  | { token = UIdentTok { val = "String" } } & cur ->
+    let typ = itystr_ cur.info in
+    let state = breakableAddAtom (configType ()) (OpTypeAtom typ) state in
+    parseTypeRClosed state (nextToken cur.stream)
 end
 
 lang LetDeclParser = AstParserBase + LetDeclAst
@@ -538,6 +554,28 @@ lang LetDeclParser = AstParserBase + LetDeclAst
       parseErr (cur.info, "Missing identifier")
 end
 
+lang ArrowParser = AstParserBase + FunTypeAst
+  sem canAppType =
+  | { token = OperatorTok { val = "->" } } -> false
+
+  sem parseTypeRClosed state =
+  | { token = OperatorTok { val = "->" } } & cur ->
+    match breakableAddInfix (configType ()) (OpTypeArrow cur.info) state with Some(state) then
+      let cur = nextToken cur.stream in
+      parseTypeROpen state cur
+    else
+      parseErr (cur.info, "Breakable add infix error")
+
+  sem constructInfixType =
+  | (OpTypeArrow info, from, to) ->
+    let info = mergeInfo (infoTy from) (infoTy to) in
+    TyArrow {
+      from = from,
+      to = to,
+      info = info
+    }
+end
+
 lang UnexpectedTokenParser = AstParserBase
   sem parseExprROpen state =
   | cur ->
@@ -576,6 +614,7 @@ lang AstParser =
   + AppParser
   + ParenParser
   + LetDeclParser
+  + ArrowParser
   + UnexpectedTokenParser
 end
 
@@ -629,7 +668,7 @@ let printAst = lam expr.
   end
 in
 
--- let str = "let a: () () = 1 in a" in
+-- let str = "let a: Int -> Int = addi 1 in a" in
 -- printLn "";
 -- printAst (parseBoot str);
 -- printAst (parse str);
@@ -663,8 +702,16 @@ utest compareWithoutInfo "(addi ()) ()" with true in
 
 utest compareWithoutInfo "let a = 1 in a" with true in
 utest compareWithoutInfo "let a = 1 in let b = 2 in addi a b" with true in
+
 utest compareWithoutInfo "let a: Int = 1 in a" with true in
+utest compareWithoutInfo "let a: Float = 1.0 in a" with true in
+utest compareWithoutInfo "let a: Bool = true in a" with true in
+utest compareWithoutInfo "let a: Char = 'a' in a" with true in
+utest compareWithoutInfo "let a: String = \"test\" in a" with true in
 
 utest compareWithoutInfo "let a: Int Int = 1 1 in a" with true in
+
+utest compareWithoutInfo "let a: Int -> Int = addi 1 in a" with true in
+utest compareWithoutInfo "let a: Int Int -> Int = addi in a" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -19,6 +19,7 @@ include "mexpr/boot-parser.mc"
 include "mexpr/json-debug.mc"
 include "json.mc"
 include "seq.mc"
+include "map.mc"
 include "parser/breakable.mc"
 include "name.mc"
 
@@ -27,10 +28,12 @@ con OpAtom: use Ast in Expr -> BreakableOp LClosed RClosed
 con OpNeg: Info -> BreakableOp LClosed ROpen
 con OpApp: Info -> BreakableOp LOpen ROpen
 
-type ParseResult w a = Result w [(Info, String)] a
+type ParseResult w a = Result w (Info, String) a
 
 let parseOk:  all w. all a. a              -> ParseResult w a = lam a. result.ok a
-let parseErr: all w. all a. [(Info, String)] -> ParseResult w a = lam e. result.err e
+let parseErr: all w. all a. (Info, String) -> ParseResult w a = lam e. result.err e
+let parseErrs: all w. all a. [(Info, String)] -> ParseResult w a = lam errs.
+  foldl1 result.withAnnotations (map result.err errs)
 
 lang AstParserBase = Lexer + Ast
   -- breakable related stuff
@@ -118,7 +121,7 @@ lang AstParserBase = Lexer + Ast
       } in
       let errs = breakableDefaultHighlight config next.stream.str sppf in
       match errs with [first] ++ _ then
-        parseErr errs -- TODO: Report all errs
+        parseErrs errs
       else
         let expr = breakableConstructSimple {
           constructAtom = lam op. match op with OpAtom expr in expr,
@@ -128,7 +131,7 @@ lang AstParserBase = Lexer + Ast
         } sppf in
         parseOk (expr, next)
     else
-      parseErr [(next.info, "Breakable parse error")]
+      parseErr (next.info, "Breakable parse error")
 end
 
 lang IntParser = AstParserBase + IntAst
@@ -215,7 +218,7 @@ lang AppParser = AstParserBase + AppAst
       match breakableAddInfix (config ()) (OpApp info) state with Some(state) then
         parseExprROpen state next
       else
-        parseErr [(info, "Breakable add infix error")]
+        parseErr (info, "Breakable add infix error")
     else
       finalizeParseExpr state next
 
@@ -230,22 +233,34 @@ lang AppParser = AstParserBase + AppAst
     }
 end
 
-lang ParenParser = AstParserBase
+lang ParenParser = AstParserBase + RecordAst
   sem canStartExpr =
   | { token = RParenTok {} } -> false
 
   sem parseExprROpen state =
-  | { token = LParenTok {}, stream = stream } ->
-    -- start parsing a new expression at (
-    result.bind (parseExpr (nextToken stream)) (lam a.
-      match a with (expr, next) in
-      -- and check for a following )
-      match next with { token = RParenTok {}, stream = stream } then
-        let state = breakableAddAtom (config ()) (OpAtom expr) state in
-        parseExprRClosed state (nextToken stream)
-      else
-        parseErr [(next.info, "Missing closing parenthesis")]
-    )
+  | { token = LParenTok {}, info = info, stream = stream } ->
+    let next = nextToken stream in
+    match next with { token = RParenTok {}, info = info2, stream = stream } then
+      -- this is a unit
+      let info = mergeInfo info info2 in
+      let expr = TmRecord {
+        bindings = mapEmpty cmpSID,
+        ty = ityunknown_ info,
+        info = info
+      } in
+      let state = breakableAddAtom (config ()) (OpAtom expr) state in
+      parseExprRClosed state (nextToken stream)
+    else
+      -- start parsing a new expression at (
+      result.bind (parseExpr (nextToken stream)) (lam a.
+        match a with (expr, next) in
+        -- and check for a following )
+        match next with { token = RParenTok {}, stream = stream } then
+          let state = breakableAddAtom (config ()) (OpAtom expr) state in
+          parseExprRClosed state (nextToken stream)
+        else
+          parseErr (next.info, "Missing closing parenthesis")
+      )
 end
 
 lang BoolParser = AstParserBase + BoolAst
@@ -300,7 +315,7 @@ lang NotImplementedParser = AstParserBase
   sem parseExprROpen state =
   | next ->
     let str = concat "Not implemented: " (tokToStr next.token) in
-    parseErr [(next.info, str)]
+    parseErr (next.info, str)
 end
 
 lang AstParser =
@@ -339,18 +354,36 @@ let jsonStr = lam expr. json2string (exprToJson expr) in
 let compare = lam str.
   let a = parse str in
   let b = parseBoot str in
-
   match (result.toOption a, result.toOption b) with (Some a, Some b) then
-    eqString (jsonStr a) (jsonStr b) -- By comparing strings we also take info filed into account.
+    eqString (jsonStr a) (jsonStr b) -- By comparing strings we also take info fieled into account.
   else
     false
   in
 
-let printAst = lam expr. printLn (jsonStr expr) in
+let compareWithoutInfo = lam str.
+  let a = parse str in
+  let b = parseBoot str in
+  match (result.toOption a, result.toOption b) with (Some a, Some b) then
+    eqExpr a b
+  else
+    false
+  in
+
+let printAst = lam expr.
+  switch result.consume expr
+  case (w, Left e) then
+    printLn "Parse error:";
+    iter (lam e.
+      match e with (info, msg) in printLn (infoErrorString info msg)
+    ) e
+  case (w, Right expr) then
+    printLn (jsonStr expr)
+  end
+in
 
 -- printLn "";
--- printAst (parseBoot "addi (addi 1 2) 3");
--- printAst (parse "addi (addi 1 2) 3");
+-- printAst (parseBoot "(())");
+-- printAst (parse "(())");
 
 utest compare "0" with true in
 utest compare "1" with true in
@@ -373,5 +406,10 @@ utest compare "addi 1 2 3" with true in
 utest compare "addi addi 1 2 3" with true in
 utest compare "addi (addi 1 2) 3" with true in
 utest compare "addi 1 (addi 2 3)" with true in
+
+utest compareWithoutInfo "()" with true in
+utest compareWithoutInfo "(())" with true in
+utest compareWithoutInfo "addi () ()" with true in
+utest compareWithoutInfo "(addi ()) ()" with true in
 
 ()

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -14,11 +14,14 @@ con OpNeg: all self. self -> BreakableOp LClosed ROpen
 
 lang AstParserBase = Lexer
   sem config: () -> Config BreakableOp
+
   sem topAllowed: TopAllowedFunc BreakableOp
   sem leftAllowed: LeftAllowedFunc BreakableOp
   sem rightAllowed: RightAllowedFunc BreakableOp
   sem parenAllowed: ParenAllowedFunc BreakableOp
   sem groupingsAllowed: GroupingsAllowedFunc BreakableOp
+
+  sem constructPrefix: BreakableOp LClosed ROpen -> Expr -> Expr
 
   sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
   sem parseExprRClosed : State BreakableOp RClosed -> NextTokenResult -> (Expr, NextTokenResult)
@@ -32,11 +35,12 @@ lang AstParserBase = Lexer
 
   sem config =
   | _ ->
-    { topAllowed = #frozen"topAllowed"
-    , leftAllowed = #frozen"leftAllowed"
-    , rightAllowed = #frozen"rightAllowed"
-    , parenAllowed = #frozen"parenAllowed"
-    , groupingsAllowed = #frozen"groupingsAllowed"
+    {
+      topAllowed = #frozen"topAllowed",
+      leftAllowed = #frozen"leftAllowed",
+      rightAllowed = #frozen"rightAllowed",
+      parenAllowed = #frozen"parenAllowed",
+      groupingsAllowed = #frozen"groupingsAllowed"
     }
 
   sem topAllowed =
@@ -70,7 +74,7 @@ lang AstParserBase = Lexer
       let expr = breakableConstructSimple {
         constructAtom = lam op. match op with OpAtom expr in expr,
         constructInfix = lam op. lam l. never,
-        constructPrefix = lam op. lam r. never,
+        constructPrefix = constructPrefix,
         constructPostfix = lam op. lam l. never
       } sppf in
       (expr, next)
@@ -101,32 +105,41 @@ lang FloatParser = AstParserBase + FloatAst
     parseExprRClosed state (nextToken stream)
 end
 
-lang NegParser = AstParserBase + IntAst + FloatAst
+lang NegParser = AstParserBase + ArithIntAst + ArithFloatAst + AppAst
   sem parseExprROpen state =
   | { token = OperatorTok { val = "-", info = info }, stream = stream } ->
-    match parseExpr (nextToken stream) with (expr, next) in
-    switch expr
-      case TmConst { val = CInt { val = val } } then
-        let info = mergeInfo info (infoTm expr) in
-        let expr = TmConst {
+    let state = breakableAddPrefix (config ()) (OpNeg info) state in
+    parseExprROpen state (nextToken stream)
+
+  sem constructPrefix =
+  | OpNeg info -> lam r.
+    switch r
+      case TmConst { val = CInt { val = val }, info = info2 } then
+        let info = mergeInfo info info2 in
+        TmConst {
           val = CInt { val = negi val },
           ty = ityunknown_ info,
           info = info
-        } in
-        let state = breakableAddAtom (config ()) (OpAtom expr) state in
-        parseExprRClosed state (nextToken stream)
-      case TmConst { val = CFloat { val = val } } then
-        let info = mergeInfo info (infoTm expr) in
-        let expr = TmConst {
+        }
+      case TmConst { val = CFloat { val = val }, info = info2 } then
+        let info = mergeInfo info info2 in
+        TmConst {
           val = CFloat { val = negf val },
           ty = ityunknown_ info,
           info = info
-        } in
-        let state = breakableAddAtom (config ()) (OpAtom expr) state in
-        parseExprRClosed state (nextToken stream)
-      case _ then
-        let state = breakableAddPrefix (config ()) (OpNeg info) state in
-        parseExprROpen state (nextToken stream)
+        }
+      case expr then
+        let info2 = mergeInfo info (infoTm expr) in
+        TmApp {
+          lhs = TmConst {
+            val = CNegi {},
+            ty = ityunknown_ info,
+            info = info
+          },
+          rhs = expr,
+          ty = ityunknown_ info2,
+          info = info2
+        }
     end
 end
 

--- a/src/stdlib/parser/parser.mc
+++ b/src/stdlib/parser/parser.mc
@@ -6,85 +6,164 @@ include "mexpr/boot-parser.mc"
 include "mexpr/json-debug.mc"
 include "json.mc"
 include "seq.mc"
+include "parser/breakable.mc"
+
+type BreakableOp lstyle rstyle
+con OpAtom: all self. self -> BreakableOp LClosed RClosed
+con OpNeg: all self. self -> BreakableOp LClosed ROpen
 
 lang AstParserBase = Lexer
+  sem config: () -> Config BreakableOp
+  sem topAllowed: TopAllowedFunc BreakableOp
+  sem leftAllowed: LeftAllowedFunc BreakableOp
+  sem rightAllowed: RightAllowedFunc BreakableOp
+  sem parenAllowed: ParenAllowedFunc BreakableOp
+  sem groupingsAllowed: GroupingsAllowedFunc BreakableOp
+
   sem parseExpr: NextTokenResult -> (Expr, NextTokenResult)
+  sem parseExprRClosed : State BreakableOp RClosed -> NextTokenResult -> (Expr, NextTokenResult)
+  sem parseExprROpen : State BreakableOp ROpen -> NextTokenResult -> (Expr, NextTokenResult)
+  sem finalizeParseExpr : State BreakableOp RClosed -> NextTokenResult -> (Expr, NextTokenResult)
+
   sem parseDecl: NextTokenResult -> (Decl, NextTokenResult)
   sem parseType: NextTokenResult -> (Type, NextTokenResult)
   sem parseKind: NextTokenResult -> (Kind, NextTokenResult)
   sem parsePat:  NextTokenResult -> (Pat,  NextTokenResult)
+
+  sem config =
+  | _ ->
+    { topAllowed = #frozen"topAllowed"
+    , leftAllowed = #frozen"leftAllowed"
+    , rightAllowed = #frozen"rightAllowed"
+    , parenAllowed = #frozen"parenAllowed"
+    , groupingsAllowed = #frozen"groupingsAllowed"
+    }
+
+  sem topAllowed =
+  | _ -> true
+
+  sem leftAllowed =
+  | _ -> true
+
+  sem rightAllowed =
+  | _ -> true
+
+  sem parenAllowed =
+  | _ -> GNeither ()
+
+  sem groupingsAllowed =
+  | _ -> GLeft ()
+
+  sem parseExpr =
+  | next ->
+    let state = breakableInitState () in
+    parseExprROpen state next
+
+  sem parseExprRClosed state =
+  | next ->
+    finalizeParseExpr state next
+
+  sem finalizeParseExpr state =
+  | next ->
+    match breakableFinalizeParse (config ()) state with Some sppf then
+      -- breakableReportAmbiguities ?
+      let expr = breakableConstructSimple {
+        constructAtom = lam op. match op with OpAtom expr in expr,
+        constructInfix = lam op. lam l. never,
+        constructPrefix = lam op. lam r. never,
+        constructPostfix = lam op. lam l. never
+      } sppf in
+      (expr, next)
+    else error "Breakable parse error"
 end
 
 lang IntParser = AstParserBase + IntAst
-  sem parseExpr =
+  sem parseExprROpen state =
   | { token = IntTok { val = val, info = info }, stream = stream } ->
     let expr = TmConst {
       val = CInt { val = val },
       ty = ityunknown_ info,
       info = info
     } in
-    (expr, nextToken stream)
+    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    parseExprRClosed state (nextToken stream)
 end
 
 lang FloatParser = AstParserBase + FloatAst
-  sem parseExpr =
+  sem parseExprROpen state =
   | { token = FloatTok { val = val, info = info }, stream = stream } ->
     let expr = TmConst {
       val = CFloat { val = val },
       ty = ityunknown_ info,
       info = info
     } in
-    (expr, nextToken stream)
+    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    parseExprRClosed state (nextToken stream)
 end
 
 lang NegParser = AstParserBase + IntAst + FloatAst
-  sem parseExpr =
+  sem parseExprROpen state =
   | { token = OperatorTok { val = "-", info = info }, stream = stream } ->
     match parseExpr (nextToken stream) with (expr, next) in
-    let val = switch expr
-      case TmConst { val = CInt { val = val } } then CInt { val = negi val }
-      case TmConst { val = CFloat { val = val } } then CFloat { val = negf val }
-    end in
-    let info = mergeInfo info (infoTm expr) in
-    let expr = TmConst {
-      val = val,
-      ty = ityunknown_ info,
-      info = info
-    } in
-    (expr, nextToken next.stream)
+    switch expr
+      case TmConst { val = CInt { val = val } } then
+        let info = mergeInfo info (infoTm expr) in
+        let expr = TmConst {
+          val = CInt { val = negi val },
+          ty = ityunknown_ info,
+          info = info
+        } in
+        let state = breakableAddAtom (config ()) (OpAtom expr) state in
+        parseExprRClosed state (nextToken stream)
+      case TmConst { val = CFloat { val = val } } then
+        let info = mergeInfo info (infoTm expr) in
+        let expr = TmConst {
+          val = CFloat { val = negf val },
+          ty = ityunknown_ info,
+          info = info
+        } in
+        let state = breakableAddAtom (config ()) (OpAtom expr) state in
+        parseExprRClosed state (nextToken stream)
+      case _ then
+        let state = breakableAddPrefix (config ()) (OpNeg info) state in
+        parseExprROpen state (nextToken stream)
+    end
 end
 
 lang BoolParser = AstParserBase + BoolAst
-  sem parseExpr =
+  sem parseExprROpen state =
   | { token = LIdentTok { val = "true", info = info}, stream = stream} ->
     let expr = TmConst {
       val = CBool { val = true },
       ty = ityunknown_ info,
       info = info
     } in
-    (expr, nextToken stream)
+    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    parseExprRClosed state (nextToken stream)
   | { token = LIdentTok { val = "false", info = info}, stream = stream} ->
     let expr = TmConst {
       val = CBool { val = false },
       ty = ityunknown_ info,
       info = info
     } in
-    (expr, nextToken stream)
+    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    parseExprRClosed state (nextToken stream)
 end
 
 lang CharParser = AstParserBase + CharAst
-  sem parseExpr =
+  sem parseExprROpen state =
   | { token = CharTok { val = val, info = info }, stream = stream } ->
     let expr = TmConst {
       val = CChar { val = val },
       ty = ityunknown_ info,
       info = info
     } in
-    (expr, nextToken stream)
+    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    parseExprRClosed state (nextToken stream)
 end
 
 lang StringParser = AstParserBase + SeqAst + CharAst
-  sem parseExpr =
+  sem parseExprROpen state =
   | { token = StringTok { val = val, info = info }, stream = stream } ->
     let expr = TmSeq {
       tms = map (lam ch. TmConst {
@@ -95,19 +174,33 @@ lang StringParser = AstParserBase + SeqAst + CharAst
       ty = ityunknown_ info,
       info = info
     } in
-    (expr, nextToken stream)
+    let state = breakableAddAtom (config ()) (OpAtom expr) state in
+    parseExprRClosed state (nextToken stream)
 end
 
 lang NotImplementedParser = AstParserBase
-  sem parseExpr =
+  sem parseExprROpen state =
   | { token = token } ->
     let str = concat "Not implemented: " (tokToStr token) in
     error str
 end
 
-lang AstParser = IntParser + FloatParser + BoolParser + CharParser + StringParser + NegParser end
+lang AstParser =
+    IntParser
+  + FloatParser
+  + BoolParser
+  + CharParser
+  + StringParser
+  + NegParser
+end
 
-lang TestParser = AstParser + NotImplementedParser + MExprPrettyPrint + MExprEq + MExprToJson end
+lang TestParser =
+    AstParser
+  + NotImplementedParser
+  + MExprPrettyPrint
+  + MExprEq
+  + MExprToJson
+end
 
 mexpr
 
@@ -123,8 +216,8 @@ let parseBoot = lam str.
 
 let jsonStr = lam expr. json2string (exprToJson expr) in
 
--- let compare = lam str. eqExpr (parse str) (parseBoot str) in
-let compare = lam str. eqString (jsonStr (parse str)) (jsonStr (parseBoot str)) in
+-- let compare = lam str. eqExpr (parse str) (parseBoot str) in -- does not compare info
+let compare = lam str. eqString (jsonStr (parse str)) (jsonStr (parseBoot str)) in -- compares info
 
 let printAst = lam expr. printLn (jsonStr expr) in
 


### PR DESCRIPTION
The parser is designed to be as extensible as possible.
It is built on top of the breakable library.

This is a new self-contained file, should not affect anything else.
The parser is still very much work in progress but it works with limited functionality.

Currently the parser is tested for equivalence with the boot parser.

Known issues as of now.
* Much is not implemented
* Ambiguity error reporting does not use the correct source string.
* Precedence handling (groupingsAllowed) will need a new solution.
* No tests for parsing that should fail.