### PR TITLE
Add new intrinsic `exec`

### DIFF
--- a/src/boot/lib/ast.ml
+++ b/src/boot/lib/ast.ml
@@ -168,6 +168,7 @@ and const =
   | CfileExists
   | CdeleteFile
   | Ccommand
+  | Cexec of int Mseq.t option
   | Cerror
   | Cexit
   | CflushStdout
@@ -892,6 +893,7 @@ let const_has_side_effect = function
   | CfileExists
   | CdeleteFile
   | Ccommand
+  | Cexec _
   | Cerror
   | Cexit
   | CflushStdout

--- a/src/boot/lib/builtin.ml
+++ b/src/boot/lib/builtin.ml
@@ -110,6 +110,7 @@ let builtin =
   ; ("fileExists", f CfileExists)
   ; ("deleteFile", f CdeleteFile)
   ; ("command", f Ccommand)
+  ; ("exec", f (Cexec None))
   ; ("error", f Cerror)
   ; ("exit", f Cexit)
   ; ("flushStdout", f CflushStdout)

--- a/src/boot/lib/intrinsics.ml
+++ b/src/boot/lib/intrinsics.ml
@@ -707,6 +707,12 @@ module MSys = struct
         a |> Ustring.from_utf8 |> Ustring.to_uchars |> Mseq.Helpers.of_array )
 
   let command s = Sys.command (s |> Mseq.Helpers.to_ustring |> Ustring.to_utf8)
+
+  let exec p args =
+    Unix.execvp (Mseq.Helpers.to_utf8 p)
+      ( Mseq.cons p args
+      |> Mseq.map Mseq.Helpers.to_utf8
+      |> Mseq.Helpers.to_array )
 end
 
 module Time = struct

--- a/src/boot/lib/intrinsics.mli
+++ b/src/boot/lib/intrinsics.mli
@@ -424,6 +424,8 @@ module MSys : sig
   val argv : int Mseq.t Mseq.t
 
   val command : int Mseq.t -> int
+
+  val exec : int Mseq.t -> int Mseq.t Mseq.t -> 'a
 end
 
 module Time : sig

--- a/src/boot/lib/mexpr.ml
+++ b/src/boot/lib/mexpr.ml
@@ -1161,6 +1161,10 @@ let arity = function
       1
   | Ccommand ->
       1
+  | Cexec (Some _) ->
+      1
+  | Cexec None ->
+      2
   | Cerror ->
       1
   | Cexit ->
@@ -2166,6 +2170,18 @@ and delta (apply : info -> tm -> tm -> tm) fi c v =
   | Ccommand, TmSeq (_, lst) ->
       TmConst (fi, CInt (Intrinsics.MSys.command (tm_seq2int_seq fi lst)))
   | Ccommand, _ ->
+      fail_constapp fi
+  | Cexec None, TmSeq (fi, l) ->
+      TmConst (fi, Cexec (Some (tm_seq2int_seq fi l)))
+  | Cexec (Some program), TmSeq (fi, args) ->
+      let conv = function
+        | TmSeq (_, xs) ->
+            tm_seq2int_seq fi xs
+        | _ ->
+            fail_constapp fi
+      in
+      Intrinsics.MSys.exec program (Mseq.map conv args)
+  | Cexec _, _ ->
       fail_constapp fi
   | Cerror, TmSeq (fiseq, lst) ->
       tmseq2ustring fiseq lst |> Ustring.to_utf8 |> raise_error fi

--- a/src/boot/lib/pprint.ml
+++ b/src/boot/lib/pprint.ml
@@ -458,6 +458,8 @@ let rec print_const fmt = function
       fprintf fmt "deleteFile"
   | Ccommand ->
       fprintf fmt "command"
+  | Cexec _ ->
+      fprintf fmt "exec"
   | Cerror ->
       fprintf fmt "error"
   | Cexit ->

--- a/src/stdlib/mexpr/ast.mc
+++ b/src/stdlib/mexpr/ast.mc
@@ -1013,6 +1013,7 @@ lang SysAst = ConstAst
   | CError {}
   | CArgv {}
   | CCommand {}
+  | CExec {}
 end
 
 lang TimeAst = ConstAst

--- a/src/stdlib/mexpr/builtin.mc
+++ b/src/stdlib/mexpr/builtin.mc
@@ -88,6 +88,7 @@ let builtin = use MExprAst in
   , ("fileExists", CFileExists ())
   , ("deleteFile", CFileDelete ())
   , ("command", CCommand ())
+  , ("exec", CExec ())
   , ("error", CError ())
   , ("exit", CExit ())
   -- Constructor tags

--- a/src/stdlib/mexpr/const-arity.mc
+++ b/src/stdlib/mexpr/const-arity.mc
@@ -171,6 +171,7 @@ lang SysArity = ConstArity + SysAst
   | CError _ -> 1
   | CArgv _ -> 0
   | CCommand _ -> 1
+  | CExec _ -> 2
 end
 
 lang TimeArity = ConstArity + TimeAst

--- a/src/stdlib/mexpr/const-types.mc
+++ b/src/stdlib/mexpr/const-types.mc
@@ -212,6 +212,7 @@ lang SysTypeAst = TyConst + SysAst
   | CError _ -> mktyall_ "a" (lam a. tyarrow_ tystr_ a)
   | CArgv _ -> tyseq_ tystr_
   | CCommand _ -> tyarrow_ tystr_ tyint_
+  | CExec _ -> mktyall_ "a" (lam a. tyarrows_ [tystr_, tyseq_ tystr_, a])
 end
 
 lang TimeTypeAst = TyConst + TimeAst

--- a/src/stdlib/mexpr/eval.mc
+++ b/src/stdlib/mexpr/eval.mc
@@ -689,6 +689,11 @@ lang SysEval = ConstDelta + SysAst + SeqAst + IntAst + CharAst + SysArity
       val = CInt {val = command (_evalSeqOfCharsToString info s.tms)},
       ty = tyunknown_, info = NoInfo ()
     }
+  | (CExec _, [TmSeq p, TmSeq args]) ->
+    let f = lam tm. match tm with TmSeq arg
+      then _evalSeqOfCharsToString info arg.tms
+      else errorSingle [info] "Expected sequence of characters" in
+    exec (_evalSeqOfCharsToString info p.tms) (map f args.tms)
 end
 
 lang TimeEval = ConstDelta + TimeAst + IntAst + TimeArity

--- a/src/stdlib/mexpr/pprint.mc
+++ b/src/stdlib/mexpr/pprint.mc
@@ -916,6 +916,7 @@ lang SysPrettyPrint = SysAst + ConstPrettyPrint
   | CError _ -> "error"
   | CArgv _ -> "argv"
   | CCommand _ -> "command"
+  | CExec _ -> "exec"
 end
 
 lang TimePrettyPrint = TimeAst + ConstPrettyPrint

--- a/src/stdlib/mexpr/side-effect.mc
+++ b/src/stdlib/mexpr/side-effect.mc
@@ -84,7 +84,7 @@ lang ConstSideEffect = ConstSideEffectBase + MExprAst
   | CPrint _ | CPrintError _ | CDPrint _ | CFlushStdout _ | CFlushStderr _
   | CReadLine _ | CReadBytesAsString _ -> true
   | CRandIntU _ | CRandSetSeed _ -> true
-  | CExit _ | CError _ | CArgv _ | CCommand _ -> true
+  | CExit _ | CError _ | CArgv _ | CCommand _ | CExec _ -> true
   | CWallTimeMs _ | CSleepMs _ -> true
   | CConstructorTag _ -> true
   | CRef _ | CModRef _ | CDeRef _ -> true

--- a/src/stdlib/ocaml/pprint.mc
+++ b/src/stdlib/ocaml/pprint.mc
@@ -265,6 +265,7 @@ lang OCamlPrettyPrint =
   | CError _ -> intrinsicOpSys "error"
   | CExit _ -> intrinsicOpSys "exit"
   | CCommand _ -> intrinsicOpSys "command"
+  | CExec _ -> intrinsicOpSys "exec"
   | CEqsym _ -> intrinsicOpSymb "eqsym"
   | CGensym _ -> intrinsicOpSymb "gensym"
   | CSym2hash _ -> intrinsicOpSymb "hash"


### PR DESCRIPTION
This PR adds a new intrinsic `exec` that does a Unix-style `exec`, i.e., it replaces the currently running program with the launched program. This ends up being very convenient for `test-spec.mc`.

We could consider if this should be an intrinsic or if it should be an external.